### PR TITLE
Add Travis build badges for both master and develop against python 2.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
-# NetBox [![Build Status](https://travis-ci.org/digitalocean/netbox.svg?branch=master)](https://travis-ci.org/digitalocean/netbox)
+# NetBox
 
 NetBox is an IP address management (IPAM) and data center infrastructure management (DCIM) tool. Initially conceived by the network engineering team at [DigitalOcean](https://www.digitalocean.com/), NetBox was developed specifically to address the needs of network and infrastructure engineers.
 
 NetBox runs as a web application atop the [Django](https://www.djangoproject.com/) Python framework with a [PostgreSQL](http://www.postgresql.org/) database. For a complete list of requirements, see `requirements.txt`. The code is available [on GitHub](https://github.com/digitalocean/netbox).
 
 Questions? Comments? Please join us on IRC in **#netbox** on **irc.freenode.net**!
+
+### Build Status
+
+|             | python 2.7 |
+|-------------|------------|
+| **master** | [![Build Status](https://travis-ci.org/digitalocean/netbox.svg?branch=master)](https://travis-ci.org/digitalocean/netbox) |
+| **develop** | [![Build Status](https://travis-ci.org/digitalocean/netbox.svg?branch=develop)](https://travis-ci.org/digitalocean/netbox) |
+
+## Screenshots
 
 ![Screenshot of main page](docs/screenshot1.png "Main page")
 


### PR DESCRIPTION
This way, we should be able to extend this table in the future to show the build status of multiple different branches against different versions of python, if this functionality is supported.
