### PR TITLE
Topology view: remove empty label in generated dot file.

### DIFF
--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -55,7 +55,7 @@ class TopologyMapView(APIView):
             subgraph = pydot.Subgraph('sg{}'.format(i), rank='same')
 
             # Add a pseudonode for each device_set to enforce hierarchical layout
-            subgraph.add_node(pydot.Node('set{}'.format(i), shape='none', width='0', label=''))
+            subgraph.add_node(pydot.Node('set{}'.format(i), shape='none', width='0'))
             if i:
                 graph.add_edge(pydot.Edge('set{}'.format(i - 1), 'set{}'.format(i), style='invis'))
 


### PR DESCRIPTION
Example line from generated dot file:
set0 [width=0, shape=none, label=];

This is not accepted by graphviz v2.38.0.
