### PR TITLE
Replace pydot by graphviz

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ django-filter==0.13.0
 django-rest-swagger==0.3.7
 django-tables2==1.2.1
 djangorestframework==3.3.3
+graphviz==0.4.10
 Markdown==2.6.6
 ncclient==0.4.7
 netaddr==0.7.18
@@ -12,6 +13,5 @@ paramiko==2.0.0
 psycopg2==2.6.1
 py-gfm==0.1.3
 pycrypto==2.6.1
-pydot==1.0.2
 sqlparse==0.1.19
 xmltodict==0.10.2


### PR DESCRIPTION
This is in an effort to support Python 3 in the future: pydot is not compatible with Python 3, while graphviz is.

From some limited testing I have done, the resulting PNGs were absolutely identical. Additionally, this should make #71 obsolete, since graphviz automatically includes empty double quotes (`label=""`) if the supplied string was empty.

---

As for Python 3 compatibility: AFAICT `ncclient` is currently the only other dependency that is incompatible with Python 3. There is an updated version [0.5.0 available on PyPi-test](https://testpypi.python.org/pypi/ncclient/0.5.0) which supports Python 3, but the full release to PyPi has not happened yet (there is at least [one issue](https://github.com/ncclient/ncclient/issues/138) asking for the release).

As soon as `ncclient==0.5.0` is released, one should be able to make NetBox compatible with Python 3 in addition to Python 2.7.
