### PR TITLE
Support VLAN in Import Prefixes, Add VLAN column to Prefixes page

### DIFF
--- a/netbox/ipam/forms.py
+++ b/netbox/ipam/forms.py
@@ -192,13 +192,15 @@ class PrefixFromCSVForm(forms.ModelForm):
                                  error_messages={'invalid_choice': 'VRF not found.'})
     site = forms.ModelChoiceField(queryset=Site.objects.all(), required=False, to_field_name='name',
                                   error_messages={'invalid_choice': 'Site not found.'})
+    vlan = forms.ModelChoiceField(queryset=VLAN.objects.all(), required=False, to_field_name='name',
+                                  error_messages={'invalid_choice': 'VLAN not found.'})
     status_name = forms.ChoiceField(choices=[(s[1], s[0]) for s in PREFIX_STATUS_CHOICES])
     role = forms.ModelChoiceField(queryset=Role.objects.all(), required=False, to_field_name='name',
                                   error_messages={'invalid_choice': 'Invalid role.'})
 
     class Meta:
         model = Prefix
-        fields = ['prefix', 'vrf', 'site', 'status_name', 'role', 'description']
+        fields = ['prefix', 'vrf', 'site', 'vlan', 'status_name', 'role', 'description']
 
     def save(self, *args, **kwargs):
         m = super(PrefixFromCSVForm, self).save(commit=False)
@@ -238,6 +240,9 @@ def prefix_site_choices():
     site_choices = Site.objects.annotate(prefix_count=Count('prefixes'))
     return [(s.slug, '{} ({})'.format(s.name, s.prefix_count)) for s in site_choices]
 
+def prefix_vlan_choices():
+    vlan_choices = VLAN.objects.annotate(prefix_count=Count('prefixes'))
+    return [(v.id, '{} ({})'.format(v.display_name, v.prefix_count)) for v in vlan_choices]
 
 def prefix_status_choices():
     status_counts = {}
@@ -256,9 +261,11 @@ class PrefixFilterForm(forms.Form, BootstrapMixin):
     vrf = forms.ChoiceField(required=False, choices=prefix_vrf_choices, label='VRF')
     status = forms.MultipleChoiceField(required=False, choices=prefix_status_choices)
     site = forms.MultipleChoiceField(required=False, choices=prefix_site_choices,
-                                     widget=forms.SelectMultiple(attrs={'size': 8}))
+                                     widget=forms.SelectMultiple(attrs={'size': 6}))
+    vlan_id = forms.MultipleChoiceField(required=False, choices=prefix_vlan_choices, label='VLAN',
+				     widget=forms.SelectMultiple(attrs={'size': 8}))
     role = forms.MultipleChoiceField(required=False, choices=prefix_role_choices,
-                                     widget=forms.SelectMultiple(attrs={'size': 8}))
+                                     widget=forms.SelectMultiple(attrs={'size': 6}))
     expand = forms.BooleanField(required=False, label='Expand prefix hierarchy')
 
 

--- a/netbox/ipam/forms.py
+++ b/netbox/ipam/forms.py
@@ -240,9 +240,11 @@ def prefix_site_choices():
     site_choices = Site.objects.annotate(prefix_count=Count('prefixes'))
     return [(s.slug, '{} ({})'.format(s.name, s.prefix_count)) for s in site_choices]
 
+
 def prefix_vlan_choices():
     vlan_choices = VLAN.objects.annotate(prefix_count=Count('prefixes'))
     return [(v.id, '{} ({})'.format(v.display_name, v.prefix_count)) for v in vlan_choices]
+
 
 def prefix_status_choices():
     status_counts = {}
@@ -262,8 +264,8 @@ class PrefixFilterForm(forms.Form, BootstrapMixin):
     status = forms.MultipleChoiceField(required=False, choices=prefix_status_choices)
     site = forms.MultipleChoiceField(required=False, choices=prefix_site_choices,
                                      widget=forms.SelectMultiple(attrs={'size': 6}))
-    vlan_id = forms.MultipleChoiceField(required=False, choices=prefix_vlan_choices, label='VLAN',
-				     widget=forms.SelectMultiple(attrs={'size': 8}))
+    vlan_id = forms.MultipleChoiceField(required=False, choices=prefix_vlan_choices,
+                                        label='VLAN', widget=forms.SelectMultiple(attrs={'size': 8}))
     role = forms.MultipleChoiceField(required=False, choices=prefix_role_choices,
                                      widget=forms.SelectMultiple(attrs={'size': 6}))
     expand = forms.BooleanField(required=False, label='Expand prefix hierarchy')

--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -127,12 +127,13 @@ class PrefixTable(BaseTable):
     prefix = tables.TemplateColumn(PREFIX_LINK, verbose_name='Prefix')
     vrf = tables.Column(orderable=False, default='Global', verbose_name='VRF')
     site = tables.LinkColumn('dcim:site', args=[Accessor('site.slug')], verbose_name='Site')
+    vlan = tables.Column(accessor='vlan.display_name', verbose_name='VLAN')
     role = tables.Column(verbose_name='Role')
     description = tables.Column(orderable=False, verbose_name='Description')
 
     class Meta(BaseTable.Meta):
         model = Prefix
-        fields = ('pk', 'prefix', 'status', 'vrf', 'site', 'role', 'description')
+        fields = ('pk', 'prefix', 'status', 'vrf', 'site', 'vlan', 'role', 'description')
 
 
 class PrefixBriefTable(BaseTable):

--- a/netbox/templates/ipam/prefix_bulk_edit.html
+++ b/netbox/templates/ipam/prefix_bulk_edit.html
@@ -9,6 +9,7 @@
             <td><a href="{% url 'ipam:prefix' pk=prefix.pk %}">{{ prefix }}</a></td>
             <td>{{ prefix.vrf|default:"Global" }}</td>
             <td>{{ prefix.site }}</td>
+            <td>{{ prefix.vlan }}</td>
             <td>{{ prefix.status }}</td>
             <td>{{ prefix.role }}</td>
             <td>{{ prefix.description }}</td>

--- a/netbox/templates/ipam/prefix_import.html
+++ b/netbox/templates/ipam/prefix_import.html
@@ -44,6 +44,11 @@
 					<td>HQ</td>
 				</tr>
 				<tr>
+					<td>VLAN</td>
+					<td>VLAN Name (optional)</td>
+					<td>Security</td>
+				</tr>
+				<tr>
 					<td>Status</td>
 					<td>Current status</td>
 					<td>Active</td>
@@ -61,7 +66,7 @@
 			</tbody>
 		</table>
 		<h4>Example</h4>
-		<pre>192.168.42.0/24,65000:123,HQ,Active,Customer,7th floor WiFi</pre>
+		<pre>192.168.42.0/24,65000:123,HQ,Security,Active,Customer,7th floor WiFi</pre>
 	</div>
 </div>
 {% endblock %}

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -247,10 +247,10 @@ class BulkImportForm(forms.Form):
         for i, record in enumerate(records, start=1):
             obj_form = self.fields['csv'].csv_form(data=record)
             try:
-                 if obj_form.is_valid():
+                if obj_form.is_valid():
                     obj = obj_form.save(commit=False)
                     obj_list.append(obj)
-                 else:
+                else:
                     for field, errors in obj_form.errors.items():
                         for e in errors:
                             if field == '__all__':


### PR DESCRIPTION
Addresses #42 

This commit adds support for including the VLAN Name when importing prefixes. This also adds the VLAN Display Name to the prefixes view. I've changed the size on the site and role choice fields in in order to save some space because most people will have more VLANs than sites or roles.

The import will throw an error if you have a VLAN with the same VID and name. Its not super descriptive but if anyone has suggestions on how to pull the VLAN Name out of the exception information please let me know.

Screenshot of above described error and other changes to the page's examples
<img width="1361" alt="screen shot 2016-07-06 at 2 12 46 am" src="https://cloud.githubusercontent.com/assets/422752/16610188/4c08ce42-431f-11e6-9ce5-c52d21311841.png">

Screenshot of new view on Prefixes page
<img width="888" alt="screen shot 2016-07-06 at 2 13 35 am" src="https://cloud.githubusercontent.com/assets/422752/16610197/5e27dd66-431f-11e6-9a37-91e4a9499ed4.png">
