### PR TITLE
Potential quick fix for Rack view broken when viewport less than 992px wide

### DIFF
--- a/netbox/templates/dcim/rack.html
+++ b/netbox/templates/dcim/rack.html
@@ -154,17 +154,19 @@
             </div>
         </div>
 	</div>
-    <div class="col-md-3">
-        <div class="rack_header">
+    <div class="row col-md-6">
+       <div class="col-md-6 col-sm-6 col-xs-12">
+          <div class="rack_header">
             <h4>Front</h4>
-        </div>
-        {% include 'dcim/_rack_elevation.html' with primary_face=front_elevation secondary_face=rear_elevation face_id=0 %}
-    </div>
-    <div class="col-md-3">
+          </div>
+          {% include 'dcim/_rack_elevation.html' with primary_face=front_elevation secondary_face=rear_elevation face_id=0 %}
+      </div>
+      <div class="col-md-6 col-sm-6 col-xs-12">
         <div class="rack_header">
             <h4>Rear</h4>
         </div>
         {% include 'dcim/_rack_elevation.html' with primary_face=rear_elevation secondary_face=front_elevation face_id=1 %}
+      </div>
     </div>
 </div>
 {% endblock %}


### PR DESCRIPTION
Proper fix is to redo the grid layout for the whole page so that its fully responsive.
It is only partial responsive. 
