### PR TITLE
possible fix for #243 generic sorting for device bays

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1,4 +1,5 @@
 import re
+from operator import attrgetter
 
 from django.contrib import messages
 from django.contrib.auth.decorators import permission_required
@@ -11,6 +12,8 @@ from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.http import urlencode
 from django.views.generic import View
+
+from natsort import natsorted
 
 from ipam.models import Prefix, IPAddress, VLAN
 from circuits.models import Circuit
@@ -520,7 +523,10 @@ def device(request, pk):
         .select_related('connected_as_a', 'connected_as_b', 'circuit')
     mgmt_interfaces = Interface.objects.filter(device=device, mgmt_only=True)\
         .select_related('connected_as_a', 'connected_as_b', 'circuit')
-    device_bays = DeviceBay.objects.filter(device=device).select_related('installed_device__device_type__manufacturer')
+    device_bays = natsorted(
+        DeviceBay.objects.filter(device=device).select_related('installed_device__device_type__manufacturer'),
+        key=attrgetter("name")
+    )
 
     # Gather any secrets which belong to this device
     secrets = device.secrets.all()

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ py-gfm==0.1.3
 pycrypto==2.6.1
 sqlparse==0.1.19
 xmltodict==0.10.2
+natsort>=5.0.0


### PR DESCRIPTION
As mentioned in issue #9 the natsort library handles this kind of thing easily on its own. If the additional library requirement is not desired then this obviously isnt the way to go.
