### PR TITLE
Fixes #246 - Add build directive to docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
             POSTGRES_PASSWORD: J5brHrAXFLQSif0K
             POSTGRES_DB: netbox
     netbox:
+        build: .
         image: digitalocean/netbox
         links:
         - postgres


### PR DESCRIPTION
Making a PR related to #246. This adds a build directive to docker-compose until we can get an image on docker hub to download. Alternatively, we could leave `docker-compose.yml` as is and add a step to the docs to `docker build -t digitalocean/netbox .`. Whichever works best.
