### PR TITLE
Use overflow-y: scoll on html element 

### DIFF
--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -2,6 +2,9 @@
 * {
     margin: 0;
 }
+html {
+    overflow-y: scroll;
+}
 html, body {
     height: 100%;
 }


### PR DESCRIPTION
Use overflow-y: scoll on html element to avoid jumping around when the previous/next page adds a vertical scrollbar.
