### PR TITLE
Add icons to panel headers

### DIFF
--- a/netbox/templates/500.html
+++ b/netbox/templates/500.html
@@ -12,6 +12,7 @@
         <div class="col-md-4 col-md-offset-4">
             <div class="panel panel-danger" style="margin-top: 200px">
                 <div class="panel-heading">
+                    <i class="fa fa-fw fa-exclamation-triangle"></i> 
                     <strong>Server Error</strong>
                 </div>
                 <div class="panel-body">

--- a/netbox/templates/circuits/circuit.html
+++ b/netbox/templates/circuits/circuit.html
@@ -44,6 +44,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-arrows-h"></i> 
                 <strong>Circuit</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -107,6 +108,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-commenting"></i> 
                 <strong>Comments</strong>
             </div>
             <div class="panel-body">

--- a/netbox/templates/circuits/circuit_edit.html
+++ b/netbox/templates/circuits/circuit_edit.html
@@ -17,7 +17,9 @@
         </div>
     </div>
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Termination</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-stop-circle"></i> 
+            <strong>Termination</strong></div>
         <div class="panel-body">
             {% render_field form.site %}
             <ul class="nav nav-tabs" role="tablist">
@@ -37,7 +39,9 @@
         </div>
     </div>
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Comments</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-commenting"></i> 
+            <strong>Comments</strong></div>
         <div class="panel-body">
             {% render_field form.comments %}
         </div>

--- a/netbox/templates/circuits/circuit_list.html
+++ b/netbox/templates/circuits/circuit_list.html
@@ -21,6 +21,7 @@
     <div class="col-md-3">
 		<div class="panel panel-default">
 			<div class="panel-heading">
+				<span class="glyphicon glyphicon-search" aria-hidden="true"></span> 
 				<strong>Search</strong>
 			</div>
 			<div class="panel-body">

--- a/netbox/templates/circuits/provider.html
+++ b/netbox/templates/circuits/provider.html
@@ -36,6 +36,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-building"></i> 
                 <strong>Provider</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -73,6 +74,7 @@
         </div>
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-commenting"></i> 
                 <strong>Comments</strong>
             </div>
             <div class="panel-body">
@@ -87,6 +89,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	Circuit: <i class="fa fa-fw fa-arrows-h"></i> 
                 <strong>Circuits</strong>
             </div>
             <table class="table table-hover panel-body">

--- a/netbox/templates/circuits/provider_edit.html
+++ b/netbox/templates/circuits/provider_edit.html
@@ -3,7 +3,9 @@
 
 {% block form %}
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Provider</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-building"></i> 
+            <strong>Provider</strong></div>
         <div class="panel-body">
             {% render_field form.name %}
             {% render_field form.slug %}
@@ -11,7 +13,9 @@
         </div>
     </div>
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Support Info</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-life-ring"></i> 
+            <strong>Support Info</strong></div>
         <div class="panel-body">
             {% render_field form.account %}
             {% render_field form.portal_url %}
@@ -20,7 +24,9 @@
         </div>
     </div>
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Comments</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-commenting"></i> 
+            <strong>Comments</strong></div>
         <div class="panel-body">
             {% render_field form.comments %}
         </div>

--- a/netbox/templates/dcim/component_template_add.html
+++ b/netbox/templates/dcim/component_template_add.html
@@ -18,6 +18,7 @@
             {% endif %}
             <div class="panel panel-default">
                 <div class="panel-heading">
+                    <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> 
                     <strong>New {{ component_type }}</strong>
                 </div>
                 <div class="panel-body">

--- a/netbox/templates/dcim/consoleport_connect.html
+++ b/netbox/templates/dcim/consoleport_connect.html
@@ -18,7 +18,9 @@
                 </div>
             {% endif %}
             <div class="panel panel-default">
-                <div class="panel-heading">Connect {{ consoleport.device }} {{ consoleport }}</div>
+                <div class="panel-heading">
+                    <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> 
+                    Connect {{ consoleport.device }} {{ consoleport }}</div>
                 <div class="panel-body">
                     <ul class="nav nav-tabs" role="tablist">
                         <li role="presentation" class="active"><a href="#search" aria-controls="search" role="tab" data-toggle="tab">Search</a></li>

--- a/netbox/templates/dcim/consoleport_edit.html
+++ b/netbox/templates/dcim/consoleport_edit.html
@@ -19,8 +19,10 @@
             <div class="panel panel-default">
                 <div class="panel-heading">
                     {% if consoleport.pk %}
+                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> 
                         <strong>Editing {{ consoleport }}</strong>
                     {% else %}
+                        <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> 
                         <strong>Add a Console Port</strong>
                     {% endif %}
                 </div>

--- a/netbox/templates/dcim/consoleserverport_connect.html
+++ b/netbox/templates/dcim/consoleserverport_connect.html
@@ -18,7 +18,9 @@
                 </div>
             {% endif %}
             <div class="panel panel-default">
-                <div class="panel-heading">Connect {{ consoleserverport.device }} {{ consoleserverport }}</div>
+                <div class="panel-heading">
+                    <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> 
+                    Connect {{ consoleserverport.device }} {{ consoleserverport }}</div>
                 <div class="panel-body">
                     <ul class="nav nav-tabs" role="tablist">
                         <li role="presentation" class="active"><a href="#search" aria-controls="search" role="tab" data-toggle="tab">Search</a></li>

--- a/netbox/templates/dcim/consoleserverport_edit.html
+++ b/netbox/templates/dcim/consoleserverport_edit.html
@@ -19,8 +19,10 @@
             <div class="panel panel-default">
                 <div class="panel-heading">
                     {% if consoleserverport.pk %}
+                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> 
                         <strong>Editing {{ consoleserverport }}</strong>
                     {% else %}
+                    <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> 
                         <strong>Add a Console Server Port</strong>
                     {% endif %}
                 </div>

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -11,6 +11,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-server"></i> 
                 <strong>Device</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -71,6 +72,7 @@
         </div>
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-cogs"></i> 
                 <strong>Management</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -135,6 +137,7 @@
         {% if request.user.is_authenticated %}
             <div class="panel panel-default">
                 <div class="panel-heading">
+                    <i class="fa fa-fw fa-user-secret"></i> 	
                     <strong>Secrets</strong>
                 </div>
                 {% if secrets %}
@@ -163,6 +166,7 @@
         {% endif %}
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-map-signs"></i> 
                 <strong>IP Addresses</strong>
             </div>
             {% if ip_addresses %}
@@ -187,6 +191,7 @@
         </div>
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-times-circle"></i> 
                 <strong>Critical Connections</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -254,6 +259,7 @@
         </div>
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-commenting"></i> 
                 <strong>Comments</strong>
             </div>
             <div class="panel-body">
@@ -266,6 +272,7 @@
         </div>
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-share-alt"></i> 
                 <strong>Related Devices</strong>
             </div>
             {% if related_devices %}
@@ -291,6 +298,7 @@
         {% if device_bays or device.device_type.is_parent_device %}
             <div class="panel panel-default">
                 <div class="panel-heading">
+                   <i class="fa fa-fw fa-puzzle-piece"></i> 
                     <strong>Device Bays</strong>
                 </div>
                 <table class="table table-hover panel-body">
@@ -315,6 +323,7 @@
         {% if interfaces or device.device_type.is_network_device %}
             <div class="panel panel-default">
                 <div class="panel-heading">
+                    <i class="fa fa-fw fa-exchange"></i> 
                     <strong>Interfaces</strong>
                 </div>
                 <table class="table table-hover panel-body">
@@ -339,6 +348,7 @@
         {% if cs_ports or device.device_type.is_console_server %}
             <div class="panel panel-default">
                 <div class="panel-heading">
+                    <i class="fa fa-fw fa-desktop"></i> 
                     <strong>Console Server Ports</strong>
                 </div>
                 <table class="table table-hover panel-body">
@@ -363,6 +373,7 @@
         {% if power_outlets or device.device_type.is_pdu %}
             <div class="panel panel-default">
                 <div class="panel-heading">
+                    <i class="fa fa-fw fa-plug"></i> 
                     <strong>Power Outlets</strong>
                 </div>
                 <table class="table table-hover panel-body">

--- a/netbox/templates/dcim/device_edit.html
+++ b/netbox/templates/dcim/device_edit.html
@@ -3,14 +3,18 @@
 
 {% block form %}
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Device</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-server"></i> 
+            <strong>Device</strong></div>
         <div class="panel-body">
             {% render_field form.name %}
             {% render_field form.device_role %}
         </div>
     </div>
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Hardware</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-server"></i> 
+            <strong>Hardware</strong></div>
         <div class="panel-body">
             {% render_field form.manufacturer %}
             {% render_field form.device_type %}
@@ -18,7 +22,9 @@
         </div>
     </div>
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Location</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-map-marker"></i> 
+            <strong>Location</strong></div>
         <div class="panel-body">
             {% render_field form.site %}
             {% render_field form.rack %}
@@ -27,7 +33,9 @@
         </div>
     </div>
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Management</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-cogs"></i> 
+            <strong>Management</strong></div>
         <div class="panel-body">
             {% render_field form.platform %}
             {% render_field form.status %}
@@ -38,7 +46,9 @@
         </div>
     </div>
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Comments</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-commenting"></i> 
+            <strong>Comments</strong></div>
         <div class="panel-body">
             {% render_field form.comments %}
         </div>

--- a/netbox/templates/dcim/device_inventory.html
+++ b/netbox/templates/dcim/device_inventory.html
@@ -8,6 +8,7 @@
     <div class="col-md-4">
         <div class="panel panel-default">
             <div class="panel-heading">
+                <i class="fa fa-fw fa-hdd-o"></i> 
                 <strong>Chassis</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -25,6 +26,7 @@
     <div class="col-md-8">
         <div class="panel panel-default">
             <div class="panel-heading">
+                <i class="fa fa-fw fa-server"></i> 
                 <strong>Hardware</strong>
             </div>
             <table class="table table-hover table-condensed panel-body" id="hardware">

--- a/netbox/templates/dcim/device_lldp_neighbors.html
+++ b/netbox/templates/dcim/device_lldp_neighbors.html
@@ -6,6 +6,7 @@
 {% include 'dcim/inc/_device_header.html' with active_tab='lldp-neighbors' %}
 <div class="panel panel-default">
     <div class="panel-heading">
+        <i class="fa fa-fw fa-sitemap"></i> 
         <strong>LLDP Neighbors</strong>
     </div>
     <table class="table table-hover panel-body">

--- a/netbox/templates/dcim/device_lldp_neighbors.html
+++ b/netbox/templates/dcim/device_lldp_neighbors.html
@@ -22,7 +22,7 @@
         <tbody>
             {% for iface in interfaces %}
                 <tr id="{{ iface }}">
-                    <td>{{ iface }}</td>
+                    <td><i class="fa fa-fw fa-exchange"></i> {{ iface }}</td>
                     {% if iface.connection %}
                         {% with iface.get_connected_interface as connected_iface %}
                             <td class="configured_device" data="{{ connected_iface.device }}">

--- a/netbox/templates/dcim/devicebay_edit.html
+++ b/netbox/templates/dcim/devicebay_edit.html
@@ -19,8 +19,10 @@
             <div class="panel panel-default">
                 <div class="panel-heading">
                     {% if poweroutlet.pk %}
+                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> 
                         <strong>Editing {{ devicebay }}</strong>
                     {% else %}
+                        <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> 
                         <strong>Add a Device Bay</strong>
                     {% endif %}
                 </div>

--- a/netbox/templates/dcim/devicebay_populate.html
+++ b/netbox/templates/dcim/devicebay_populate.html
@@ -17,7 +17,9 @@
                 </div>
             {% endif %}
             <div class="panel panel-default">
-                <div class="panel-heading">Populate {{ device_bay }}</div>
+                <div class="panel-heading">
+                	<span class="glyphicon glyphicon-plus" aria-hidden="true"></span> 
+                	Populate {{ device_bay }}</div>
                 <div class="panel-body">
                     <div class="form-group">
                         <label class="col-md-3 control-label required">Parent Device</label>

--- a/netbox/templates/dcim/devicetype.html
+++ b/netbox/templates/dcim/devicetype.html
@@ -37,6 +37,7 @@
     <div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+                <i class="fa fa-fw fa-hdd-o"></i> 
                 <strong>Chassis</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -60,6 +61,7 @@
         </div>
         <div class="panel panel-default">
             <div class="panel-heading">
+                <i class="fa fa-fw fa-cog"></i> 
                 <strong>Function</strong>
             </div>
             <table class="table table-hover panel-body">

--- a/netbox/templates/dcim/devicetype.html
+++ b/netbox/templates/dcim/devicetype.html
@@ -79,21 +79,21 @@
                 </tr>
             </table>
         </div>
-        {% include 'dcim/inc/devicetype_component_table.html' with table=consoleport_table title='Console Ports' add_url='dcim:devicetype_add_consoleport' delete_url='dcim:devicetype_delete_consoleport' %}
-        {% include 'dcim/inc/devicetype_component_table.html' with table=powerport_table title='Power Ports' add_url='dcim:devicetype_add_powerport' delete_url='dcim:devicetype_delete_powerport' %}
+        {% include 'dcim/inc/devicetype_component_table.html' with table=consoleport_table title='Console Ports' icon='desktop' add_url='dcim:devicetype_add_consoleport' delete_url='dcim:devicetype_delete_consoleport' %}
+        {% include 'dcim/inc/devicetype_component_table.html' with table=powerport_table title='Power Ports' icon='plug' add_url='dcim:devicetype_add_powerport' delete_url='dcim:devicetype_delete_powerport' %}
     </div>
     <div class="col-md-6">
         {% if devicetype.is_parent_device %}
-            {% include 'dcim/inc/devicetype_component_table.html' with table=devicebay_table title='Device Bays' add_url='dcim:devicetype_add_devicebay' delete_url='dcim:devicetype_delete_devicebay' %}
+            {% include 'dcim/inc/devicetype_component_table.html' with table=devicebay_table title='Device Bays' icon='puzzle-piece' add_url='dcim:devicetype_add_devicebay' delete_url='dcim:devicetype_delete_devicebay' %}
         {% endif %}
         {% if devicetype.is_network_device %}
-            {% include 'dcim/inc/devicetype_component_table.html' with table=interface_table title='Interfaces' add_url='dcim:devicetype_add_interface' delete_url='dcim:devicetype_delete_interface' %}
+            {% include 'dcim/inc/devicetype_component_table.html' with table=interface_table title='Interfaces' icon='exchange' add_url='dcim:devicetype_add_interface' delete_url='dcim:devicetype_delete_interface' %}
         {% endif %}
         {% if devicetype.is_console_server %}
-            {% include 'dcim/inc/devicetype_component_table.html' with table=consoleserverport_table title='Console Server Ports' add_url='dcim:devicetype_add_consoleserverport' delete_url='dcim:devicetype_delete_consoleserverport' %}
+            {% include 'dcim/inc/devicetype_component_table.html' with table=consoleserverport_table title='Console Server Ports' icon='desktop' add_url='dcim:devicetype_add_consoleserverport' delete_url='dcim:devicetype_delete_consoleserverport' %}
         {% endif %}
         {% if devicetype.is_pdu %}
-            {% include 'dcim/inc/devicetype_component_table.html' with table=poweroutlet_table title='Power Outlets' add_url='dcim:devicetype_add_poweroutlet' delete_url='dcim:devicetype_delete_poweroutlet' %}
+            {% include 'dcim/inc/devicetype_component_table.html' with table=poweroutlet_table title='Power Outlets' icon='plug' add_url='dcim:devicetype_add_poweroutlet' delete_url='dcim:devicetype_delete_poweroutlet' %}
         {% endif %}
     </div>
 </div>

--- a/netbox/templates/dcim/inc/devicetype_component_table.html
+++ b/netbox/templates/dcim/inc/devicetype_component_table.html
@@ -5,6 +5,7 @@
         <div class="panel panel-default">
             <div class="panel-heading">
                 <a href="{% url add_url pk=devicetype.pk %}" class="btn btn-primary btn-xs pull-right"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Add {{ title }}</a>
+                <i class="fa fa-fw fa-{{ icon }}"></i> 
                 <strong>{{ title }}</strong>
             </div>
             {% render_table table 'table.html' %}
@@ -20,6 +21,7 @@
 {% else %}
     <div class="panel panel-default">
         <div class="panel-heading">
+            <i class="fa fa-fw fa-{{ icon }}"></i> 
             <strong>{{ title }}</strong>
         </div>
         {% render_table table 'table.html' %}

--- a/netbox/templates/dcim/interface_edit.html
+++ b/netbox/templates/dcim/interface_edit.html
@@ -19,8 +19,10 @@
             <div class="panel panel-default">
                 <div class="panel-heading">
                     {% if interface.pk %}
+                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> 
                         <strong>Editing {{ interface }}</strong>
                     {% else %}
+                        <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> 
                         <strong>Add an Interface</strong>
                     {% endif %}
                 </div>

--- a/netbox/templates/dcim/interfaceconnection_edit.html
+++ b/netbox/templates/dcim/interfaceconnection_edit.html
@@ -24,6 +24,7 @@
 	<div class="col-md-5">
         <div class="panel panel-default">
             <div class="panel-heading text-center">
+            	<span class="glyphicon chevron-right" aria-hidden="true"></span> 
                 <strong>A Side</strong>
             </div>
             <div class="panel-body">
@@ -49,6 +50,7 @@
 	<div class="col-md-5">
         <div class="panel panel-default">
             <div class="panel-heading text-center">
+            	<span class="glyphicon chevron-left" aria-hidden="true"></span> 
                 <strong>B Side</strong>
             </div>
             <div class="panel-body">

--- a/netbox/templates/dcim/ipaddress_assign.html
+++ b/netbox/templates/dcim/ipaddress_assign.html
@@ -18,6 +18,7 @@
             {% endif %}
             <div class="panel panel-default">
                 <div class="panel-heading">
+                    <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> 
                     Add an IP Address
                 </div>
                 <div class="panel-body">

--- a/netbox/templates/dcim/module_edit.html
+++ b/netbox/templates/dcim/module_edit.html
@@ -18,7 +18,7 @@
             {% endif %}
             <div class="panel panel-default">
                 <div class="panel-heading">
-                    <strong>{% if module %}Editing {{ module.device }} {{ module }}{% else %}Add a Module to {{ device }}{% endif %}</strong>
+                    <strong>{% if module %}<span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Editing {{ module.device }} {{ module }}{% else %}<span class="glyphicon glyphicon-plus" aria-hidden="true"></span> Add a Module to {{ device }}{% endif %}</strong>
                 </div>
                 <div class="panel-body">
                     <div class="form-group">

--- a/netbox/templates/dcim/poweroutlet_connect.html
+++ b/netbox/templates/dcim/poweroutlet_connect.html
@@ -18,7 +18,9 @@
                 </div>
             {% endif %}
             <div class="panel panel-default">
-                <div class="panel-heading">Connect {{ poweroutlet.device }} {{ poweroutlet }}</div>
+                <div class="panel-heading">
+                    <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> 
+                    Connect {{ poweroutlet.device }} {{ poweroutlet }}</div>
                 <div class="panel-body">
                     <ul class="nav nav-tabs" role="tablist">
                         <li role="presentation" class="active"><a href="#search" aria-controls="search" role="tab" data-toggle="tab">Search</a></li>

--- a/netbox/templates/dcim/poweroutlet_edit.html
+++ b/netbox/templates/dcim/poweroutlet_edit.html
@@ -19,8 +19,10 @@
             <div class="panel panel-default">
                 <div class="panel-heading">
                     {% if poweroutlet.pk %}
+                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> 
                         <strong>Editing {{ poweroutlet }}</strong>
                     {% else %}
+                        <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> 
                         <strong>Add a Power Outlet</strong>
                     {% endif %}
                 </div>

--- a/netbox/templates/dcim/powerport_connect.html
+++ b/netbox/templates/dcim/powerport_connect.html
@@ -18,7 +18,9 @@
                 </div>
             {% endif %}
             <div class="panel panel-default">
-                <div class="panel-heading">Connect {{ powerport.device }} {{ powerport }}</div>
+                <div class="panel-heading">
+                	<span class="glyphicon glyphicon-plus" aria-hidden="true"></span> 
+                	Connect {{ powerport.device }} {{ powerport }}</div>
                 <div class="panel-body">
                     <ul class="nav nav-tabs" role="tablist">
                         <li role="presentation" class="active"><a href="#search" aria-controls="search" role="tab" data-toggle="tab">Search</a></li>

--- a/netbox/templates/dcim/powerport_edit.html
+++ b/netbox/templates/dcim/powerport_edit.html
@@ -19,8 +19,10 @@
             <div class="panel panel-default">
                 <div class="panel-heading">
                     {% if powerport.pk %}
+                        <span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> 
                         <strong>Editing {{ powerport }}</strong>
                     {% else %}
+                        <span class="glyphicon glyphicon-plus" aria-hidden="true"></span> 
                         <strong>Add a Power Port</strong>
                     {% endif %}
                 </div>

--- a/netbox/templates/dcim/rack.html
+++ b/netbox/templates/dcim/rack.html
@@ -57,6 +57,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-align-justify"></i> 
                 <strong>Rack</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -108,6 +109,7 @@
         </div>
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<span class="glyphicon glyphicon-full-screen" aria-hidden="true"></span> 
                 <strong>Non-Racked Devices</strong>
             </div>
             {% if nonracked_devices %}
@@ -143,6 +145,7 @@
         </div>
         <div class="panel panel-default">
             <div class="panel-heading">
+            	Comments: <i class="fa fa-fw fa-commenting"></i> 
                 <strong>Comments</strong>
             </div>
             <div class="panel-body">

--- a/netbox/templates/dcim/rack_edit.html
+++ b/netbox/templates/dcim/rack_edit.html
@@ -3,7 +3,9 @@
 
 {% block form %}
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Rack</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-align-justify"></i> 
+            <strong>Rack</strong></div>
         <div class="panel-body">
             {% render_field form.site %}
             {% render_field form.group %}
@@ -13,7 +15,9 @@
         </div>
     </div>
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Comments</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-commenting"></i> 
+            <strong>Comments</strong></div>
         <div class="panel-body">
             {% render_field form.comments %}
         </div>

--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -49,6 +49,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-building"></i> 
                 <strong>Site</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -95,6 +96,7 @@
         </div>
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-commenting"></i> 
                 <strong>Comments</strong>
             </div>
             <div class="panel-body">
@@ -109,6 +111,7 @@
     <div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-area-chart"></i> 
                 <strong>Stats</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -146,6 +149,7 @@
         </div>
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-object-group"></i> 
                 <strong>Rack Groups</strong>
             </div>
             {% if rack_groups %}
@@ -165,6 +169,7 @@
         </div>
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-map"></i> 
                 <strong>Topology Maps</strong>
             </div>
             {% if topology_maps %}

--- a/netbox/templates/dcim/site_edit.html
+++ b/netbox/templates/dcim/site_edit.html
@@ -3,7 +3,9 @@
 
 {% block form %}
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Site</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-map-marker"></i> 
+            <strong>Site</strong></div>
         <div class="panel-body">
             {% render_field form.name %}
             {% render_field form.slug %}
@@ -14,7 +16,9 @@
         </div>
     </div>
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>Comments</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-commenting"></i> 
+            <strong>Comments</strong></div>
         <div class="panel-body">
             {% render_field form.comments %}
         </div>

--- a/netbox/templates/home.html
+++ b/netbox/templates/home.html
@@ -50,6 +50,7 @@
     <div class="col-md-4">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-building"></i> 
                 <strong>DCIM</strong>
             </div>
             <div class="list-group">
@@ -82,6 +83,7 @@
         {% if perms.secrets %}
             <div class="panel panel-default">
                 <div class="panel-heading">
+                    <i class="fa fa-fw fa-user-secret"></i> 
                     <strong>Secrets</strong>
                 </div>
                 <div class="list-group">
@@ -97,6 +99,7 @@
     <div class="col-md-4">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-exchange"></i> 
                 <strong>IPAM</strong>
             </div>
             <div class="list-group">
@@ -124,6 +127,7 @@
         </div>
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-arrows-h"></i> 
                 <strong>Circuits</strong>
             </div>
             <div class="list-group">
@@ -143,6 +147,7 @@
     <div class="col-md-4">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-clock-o"></i> 
                 <strong>Recent Activity</strong>
             </div>
             <div class="list-group">

--- a/netbox/templates/ipam/aggregate.html
+++ b/netbox/templates/ipam/aggregate.html
@@ -32,6 +32,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-cube"></i> 
                 <strong>Aggregate</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -79,7 +80,7 @@
 </div>
 <div class="row">
     <div class="col-md-12">
-        {% include 'utilities/obj_table.html' with table=prefix_table table_template='panel_table.html' heading='Child Prefixes' bulk_edit_url='ipam:prefix_bulk_edit' bulk_delete_url='ipam:prefix_bulk_delete' %}
+        {% include 'utilities/obj_table.html' with table=prefix_table table_template='panel_table.html' heading='Child Prefixes' icon='cubes' bulk_edit_url='ipam:prefix_bulk_edit' bulk_delete_url='ipam:prefix_bulk_delete' %}
 	</div>
 </div>
 {% endblock %}

--- a/netbox/templates/ipam/ipaddress.html
+++ b/netbox/templates/ipam/ipaddress.html
@@ -47,6 +47,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-map-signs"></i> 
                 <strong>IP Address</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -119,15 +120,15 @@
         </div>
 	</div>
 	<div class="col-md-6">
-        {% with heading='Parent Prefixes' %}
+        {% with heading='Parent Prefixes' icon='cube' %}
             {% render_table parent_prefixes_table 'panel_table.html' %}
         {% endwith %}
         {% if duplicate_ips_table.rows %}
-            {% with heading='Duplicate IP Addresses' panel_class='danger' %}
+            {% with heading='Duplicate IP Addresses' icon='exclamation-traingle' panel_class='danger' %}
                 {% render_table duplicate_ips_table 'panel_table.html' %}
             {% endwith %}
         {% endif %}
-        {% with heading='Related IP Addresses' %}
+        {% with heading='Related IP Addresses' icon=share-alt' %}
             {% render_table related_ips_table 'panel_table.html' %}
         {% endwith %}
 	</div>

--- a/netbox/templates/ipam/ipaddress_edit.html
+++ b/netbox/templates/ipam/ipaddress_edit.html
@@ -32,7 +32,9 @@
         </div>
     </div>
     <div class="panel panel-default">
-        <div class="panel-heading"><strong>NAT IP (Inside)</strong></div>
+        <div class="panel-heading">
+            <i class="fa fa-fw fa-arrows-alt"></i> 
+            <strong>NAT IP (Inside)</strong></div>
         <div class="panel-body">
             <ul class="nav nav-tabs" role="tablist">
                 <li role="presentation" class="active"><a href="#select" aria-controls="home" role="tab" data-toggle="tab">By Device</a></li>

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -9,6 +9,7 @@
 	<div class="col-md-5">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-cube"></i> 
                 <strong>Prefix</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -93,11 +94,11 @@
 	</div>
 	<div class="col-md-7">
         {% if duplicate_prefix_table.rows %}
-            {% with heading='Duplicate Prefixes' panel_class='danger' %}
+            {% with heading='Duplicate Prefixes' icon='exclamation-triangle' panel_class='danger' %}
                 {% render_table duplicate_prefix_table 'panel_table.html' %}
             {% endwith %}
         {% endif %}
-        {% with heading='Parent Prefixes' %}
+        {% with heading='Parent Prefixes' icon='cube' %}
             {% render_table parent_prefix_table 'panel_table.html' %}
         {% endwith %}
 	</div>
@@ -105,7 +106,7 @@
 <div class="row">
 	<div class="col-md-12">
         {% if child_prefix_table.rows %}
-            {% include 'utilities/obj_table.html' with table=child_prefix_table table_template='panel_table.html' heading='Child Prefixes' parent=prefix bulk_edit_url='ipam:prefix_bulk_edit' bulk_delete_url='ipam:prefix_bulk_delete' %}
+            {% include 'utilities/obj_table.html' with table=child_prefix_table table_template='panel_table.html' heading='Child Prefixes' icon='cubes' parent=prefix bulk_edit_url='ipam:prefix_bulk_edit' bulk_delete_url='ipam:prefix_bulk_delete' %}
         {% elif prefix.new_subnet %}
             <a href="{% url 'ipam:prefix_add' %}?prefix={{ prefix.new_subnet }}{% if prefix.vrf %}&vrf={{ prefix.vrf.pk }}{% endif %}{% if prefix.site %}&site={{ prefix.site.pk }}{% endif %}" class="btn btn-success">
                 <i class="glyphicon glyphicon-plus" aria-hidden="true"></i> Add Child Prefix

--- a/netbox/templates/ipam/prefix_ipaddresses.html
+++ b/netbox/templates/ipam/prefix_ipaddresses.html
@@ -7,7 +7,7 @@
 {% include 'ipam/inc/prefix_header.html' with active_tab='ip-addresses' %}
 <div class="row">
 	<div class="col-md-12">
-        {% include 'utilities/obj_table.html' with table=ip_table table_template='panel_table.html' heading='IP Addresses' bulk_edit_url='ipam:ipaddress_bulk_edit' bulk_delete_url='ipam:ipaddress_bulk_delete' %}
+        {% include 'utilities/obj_table.html' with table=ip_table table_template='panel_table.html' heading='IP Addresses' icon='map-signs' bulk_edit_url='ipam:ipaddress_bulk_edit' bulk_delete_url='ipam:ipaddress_bulk_delete' %}
     </div>
 </div>
 {% endblock %}

--- a/netbox/templates/ipam/vlan.html
+++ b/netbox/templates/ipam/vlan.html
@@ -44,6 +44,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-exchange"></i> 
                 <strong>VLAN</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -83,6 +84,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-cubes"></i> 
                 <strong>Prefixes</strong>
             </div>
             {% if prefixes %}

--- a/netbox/templates/ipam/vrf.html
+++ b/netbox/templates/ipam/vrf.html
@@ -23,6 +23,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-exchange"></i> 
                 <strong>VRF</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -54,6 +55,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-cubes"></i> 
                 <strong>Prefixes</strong>
             </div>
             {% if prefixes %}

--- a/netbox/templates/ipam/vrf_list.html
+++ b/netbox/templates/ipam/vrf_list.html
@@ -26,6 +26,7 @@
 	<div class="col-md-3">
 		<div class="panel panel-default">
 			<div class="panel-heading">
+				<span class="glyphicon glyphicon-search" aria-hidden="true"></span> 
 				<strong>Search</strong>
 			</div>
 			<div class="panel-body">

--- a/netbox/templates/login.html
+++ b/netbox/templates/login.html
@@ -15,6 +15,7 @@
         <form action="{% url 'login' %}" method="post" class="form form-horizontal">
             <div class="panel panel-default">
                 <div class="panel-heading">
+                    <i class="glyphicon glyphicon-log-in" aria-hidden="true"></i> 
                     <strong>Log In</strong>
                 </div>
                 <div class="panel-body">

--- a/netbox/templates/panel_table.html
+++ b/netbox/templates/panel_table.html
@@ -8,6 +8,7 @@
 <div class="panel panel-{{ panel_class|default:'default' }}">
     {% if heading %}
         <div class="panel-heading">
+            <i class="fa fa-fw fa-{{ icon }}"></i> 
             <strong>{{ heading }}</strong>
         </div>
     {% endif %}

--- a/netbox/templates/secrets/secret.html
+++ b/netbox/templates/secrets/secret.html
@@ -33,6 +33,7 @@
 	<div class="col-md-6">
         <div class="panel panel-default">
             <div class="panel-heading">
+            	<i class="fa fa-fw fa-user-secret"></i> 
                 <strong>Secret Attributes</strong>
             </div>
             <table class="table table-hover panel-body">
@@ -71,6 +72,7 @@
         {% if secret|decryptable_by:request.user %}
             <div class="panel panel-default">
                 <div class="panel-heading">
+                    <i class="fa fa-fw fa-lock"></i> 
                     <strong>Secret Data</strong>
                 </div>
                 <div class="panel-body">

--- a/netbox/templates/secrets/secret_edit.html
+++ b/netbox/templates/secrets/secret_edit.html
@@ -28,7 +28,9 @@
     <div class="row">
         <div class="col-md-6">
             <div class="panel panel-default">
-                <div class="panel-heading"><strong>Secret Attributes</strong></div>
+                <div class="panel-heading">
+                	<i class="fa fa-fw fa-user-secret"></i> 
+                	<strong>Secret Attributes</strong></div>
                 <div class="panel-body">
                     <div class="form-group">
                         <label class="col-md-3 control-label required">Device</label>
@@ -44,7 +46,9 @@
         </div>
         <div class="col-md-6">
             <div class="panel panel-default">
-                <div class="panel-heading"><strong>Secret Data</strong></div>
+                <div class="panel-heading">
+                	<i class="fa fa-fw fa-lock"></i> 
+                	<strong>Secret Data</strong></div>
                 <div class="panel-body">
                     {% if secret.pk %}
                         <div class="form-group">

--- a/netbox/templates/users/change_password.html
+++ b/netbox/templates/users/change_password.html
@@ -25,7 +25,9 @@
                 </div>
             {% endif %}
             <div class="panel panel-default">
-                <div class="panel-heading"><strong>Password</strong></div>
+                <div class="panel-heading">
+                	<i class="fa fa-fw fa-lock"></i> 
+                	<strong>Password</strong></div>
                 <div class="panel-body">
                     {% render_field form.old_password %}
                     {% render_field form.new_password1 %}

--- a/netbox/templates/utilities/bulk_edit_form.html
+++ b/netbox/templates/utilities/bulk_edit_form.html
@@ -14,7 +14,7 @@
     <div class="row">
         <div class="col-md-7">
             <div class="panel panel-default">
-                <div class="panel-heading"><strong>{% block selected_objects_title %}Selected For Editing{% endblock %}</strong></div>
+                <div class="panel-heading"><strong>{% block selected_objects_title %}<span class="glyphicon glyphicon-pencil" aria-hidden="true"></span> Selected For Editing{% endblock %}</strong></div>
                 <table class="panel-body table table-hover">
                     {% block select_objects_table %}{% endblock %}
                 </table>
@@ -30,7 +30,7 @@
                 </div>
             {% endif %}
             <div class="panel panel-default">
-                <div class="panel-heading"><strong>{% block form_title %}Attributes{% endblock %}</strong></div>
+                <div class="panel-heading"><strong>{% block form_title %}<i class="fa fa-fw fa-list-ul"></i> Attributes{% endblock %}</strong></div>
                 <div class="panel-body">
                     {% render_form form %}
                 </div>


### PR DESCRIPTION
Adds icons to panel headers in info, inventory and LLDP views

@jeremystretch I'll likely chat with you in IRC about adding icons per item in some of these panels (device site, rack, position)... It might be overkill
