### PR TITLE
add an api call for listing all connections

### DIFF
--- a/netbox/dcim/api/urls.py
+++ b/netbox/dcim/api/urls.py
@@ -61,7 +61,8 @@ urlpatterns = [
     url(r'^interfaces/(?P<pk>\d+)/$', InterfaceDetailView.as_view(), name='interface_detail'),
     url(r'^interfaces/(?P<pk>\d+)/graphs/$', GraphListView.as_view(), {'type': GRAPH_TYPE_INTERFACE},
         name='interface_graphs'),
-    url(r'^interface-connections/(?P<pk>\d+)/$', InterfaceConnectionView.as_view(), name='interfaceconnection'),
+    url(r'^interface-connections/$', InterfaceConnectionListView.as_view(), name='interfaceconnection_list'),
+    url(r'^interface-connections/(?P<pk>\d+)/$', InterfaceConnectionView.as_view(), name='interfaceconnection_detail'),
 
     # Miscellaneous
     url(r'^related-connections/$', RelatedConnectionsView.as_view(), name='related_connections'),

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -326,6 +326,14 @@ class InterfaceConnectionView(generics.RetrieveUpdateDestroyAPIView):
     queryset = InterfaceConnection.objects.all()
 
 
+class InterfaceConnectionListView(generics.ListAPIView):
+    """
+    Retrieve a list of all interface connections
+    """
+    serializer_class = serializers.InterfaceConnectionSerializer
+    queryset = InterfaceConnection.objects.all()
+
+
 #
 # Device bays
 #


### PR DESCRIPTION
Add a first pass at listing all interface connections, there really needs to be a /devices/{pk}/interface-connections/ endpoint as well.

fixes #258 
