### PR TITLE
travis: Automate docker builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
+sudo: required
+
+services:
+  - docker
+
+env:
+  - DOCKER_TAG=$TRAVIS_TAG
+
 language: python
 python:
   - "2.7"
@@ -6,3 +14,7 @@ install:
   - pip install pep8
 script:
   - ./scripts/cibuild.sh
+after_success:
+  - if [ ! -z "$TRAVIS_TAG" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    ./scripts/docker-build.sh;
+    fi

--- a/scripts/docker-build.sh
+++ b/scripts/docker-build.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
+if [ $? -ne 0 ]; then
+  echo "docker login failed."
+  exit 1
+fi
+
+docker build -t "$DOCKER_REPOSITORY/$DOCKER_IMAGE_NAME:$DOCKER_TAG" .
+if [ $? -ne 0 ]; then
+  echo "docker build failed."
+  exit 1
+fi
+
+docker push "$DOCKER_REPOSITORY/$DOCKER_IMAGE_NAME:$DOCKER_TAG"
+if [ $? -ne 0 ]; then
+  echo "docker push failed."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
This adds automation for docker builds when a new tag is pushed up. Once a new tag is pushed up, docker build gets run with that tag used as the docker tag that then gets pushed up to [docker hub](https://hub.docker.com/r/digitalocean/netbox/).

This depends on 4 new environment variable to be set up in the [settings](https://travis-ci.org/digitalocean/netbox/settings):
- `DOCKER_REPOSITORY` - `digitalocean`
- `DOCKER_IMAGE_NAME` - `netbox`
- `DOCKER_USERNAME` - we have a user set up for this (stored as a secure environment variable)
- `DOCKER_PASSWORD` - password for the aforementioned user (stored as a secure environment variable)

cc @zachmoody @mdlayher 
