### PR TITLE
Release v1.5.2

### DIFF
--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -1032,6 +1032,13 @@ class Interface(models.Model):
     def __unicode__(self):
         return self.name
 
+    def clean(self):
+
+        if self.form_factor == IFACE_FF_VIRTUAL and self.is_connected:
+            raise ValidationError({'form_factor': "Virtual interfaces cannot be connected to another interface or "
+                                                  "circuit. Disconnect the interface or choose a physical form "
+                                                  "factor."})
+
     @property
     def is_physical(self):
         return self.form_factor != IFACE_FF_VIRTUAL

--- a/netbox/extras/models.py
+++ b/netbox/extras/models.py
@@ -18,9 +18,10 @@ GRAPH_TYPE_CHOICES = (
 )
 
 EXPORTTEMPLATE_MODELS = [
-    'site', 'rack', 'device', 'consoleport', 'powerport', 'interfaceconnection',
-    'aggregate', 'prefix', 'ipaddress', 'vlan',
-    'provider', 'circuit'
+    'site', 'rack', 'device', 'consoleport', 'powerport', 'interfaceconnection',    # DCIM
+    'aggregate', 'prefix', 'ipaddress', 'vlan',                                     # IPAM
+    'provider', 'circuit',                                                          # Circuits
+    'tenant',                                                                       # Tenants
 ]
 
 ACTION_CREATE = 1

--- a/netbox/ipam/models.py
+++ b/netbox/ipam/models.py
@@ -302,10 +302,12 @@ class IPAddressManager(models.Manager):
         """
         By default, PostgreSQL will order INETs with shorter (larger) prefix lengths ahead of those with longer
         (smaller) masks. This makes no sense when ordering IPs, which should be ordered solely by family and host
-        address. Here, we alter the default ordering to use HOST(address) instead of the raw address value.
+        address. We can use HOST() to extract just the host portion of the address (ignoring its mask), but we must
+        then re-cast this value to INET() so that records will be ordered properly. We are essentially re-casting each
+        IP address as a /32 or /128.
         """
         qs = super(IPAddressManager, self).get_queryset()
-        return qs.annotate(host=RawSQL('HOST(ipam_ipaddress.address)', [])).order_by('family', 'host')
+        return qs.annotate(host=RawSQL('INET(HOST(ipam_ipaddress.address))', [])).order_by('family', 'host')
 
 
 class IPAddress(CreatedUpdatedModel):

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -12,7 +12,7 @@ except ImportError:
                                "the documentation.")
 
 
-VERSION = '1.5.2-dev'
+VERSION = '1.5.2'
 
 # Import local configuration
 for setting in ['ALLOWED_HOSTS', 'DATABASE', 'SECRET_KEY']:

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -12,7 +12,7 @@ except ImportError:
                                "the documentation.")
 
 
-VERSION = '1.5.1'
+VERSION = '1.5.2-dev'
 
 # Import local configuration
 for setting in ['ALLOWED_HOSTS', 'DATABASE', 'SECRET_KEY']:

--- a/netbox/project-static/js/livesearch.js
+++ b/netbox/project-static/js/livesearch.js
@@ -8,9 +8,15 @@ $(document).ready(function() {
     }
 
     // Update livesearch text when real field changes
-    search_field.val(real_field.children('option:selected').text());
-    real_field.change(function() {
+    if (real_field.val()) {
         search_field.val(real_field.children('option:selected').text());
+    }
+    real_field.change(function() {
+        if (real_field.val()) {
+            search_field.val(real_field.children('option:selected').text());
+        } else {
+            search_field.val('');
+        }
     });
 
     search_field.autocomplete({

--- a/netbox/templates/circuits/circuit_list.html
+++ b/netbox/templates/circuits/circuit_list.html
@@ -10,6 +10,10 @@
 			<span class="fa fa-plus" aria-hidden="true"></span>
 			Add a circuit
 		</a>
+        <a href="{% url 'circuits:circuit_import' %}" class="btn btn-info">
+            <span class="fa fa-download" aria-hidden="true"></span>
+            Import circuits
+        </a>
     {% endif %}
     {% include 'inc/export_button.html' with obj_type='circuits' %}
 </div>

--- a/netbox/templates/circuits/provider_list.html
+++ b/netbox/templates/circuits/provider_list.html
@@ -9,6 +9,10 @@
 			<span class="fa fa-plus" aria-hidden="true"></span>
 			Add a provider
 		</a>
+        <a href="{% url 'circuits:provider_import' %}" class="btn btn-info">
+            <span class="fa fa-download" aria-hidden="true"></span>
+            Import providers
+        </a>
     {% endif %}
     {% include 'inc/export_button.html' with obj_type='providers' %}
 </div>

--- a/netbox/templates/dcim/inc/_interface.html
+++ b/netbox/templates/dcim/inc/_interface.html
@@ -56,6 +56,10 @@
                     <a href="{% url 'dcim:interfaceconnection_delete' pk=iface.connection.pk %}?device={{ device.pk }}" class="btn btn-danger btn-xs" title="Delete connection">
                         <i class="glyphicon glyphicon-remove" aria-hidden="true"></i>
                     </a>
+                {% elif iface.circuit and perms.circuits.change_circuit %}
+                    <a href="{% url 'circuits:circuit_edit' pk=iface.circuit.pk %}" class="btn btn-danger btn-xs" title="Edit circuit">
+                        <i class="glyphicon glyphicon-remove" aria-hidden="true"></i>
+                    </a>
                 {% else %}
                     <a href="{% url 'dcim:interfaceconnection_add' pk=device.pk %}?interface={{ iface.pk }}" class="btn btn-success btn-xs" title="Connect">
                         <i class="glyphicon glyphicon-plus" aria-hidden="true"></i>

--- a/netbox/templates/ipam/aggregate_list.html
+++ b/netbox/templates/ipam/aggregate_list.html
@@ -11,6 +11,10 @@
 			<span class="fa fa-plus" aria-hidden="true"></span>
 			Add an aggregate
 		</a>
+        <a href="{% url 'ipam:aggregate_import' %}" class="btn btn-info">
+            <span class="fa fa-download" aria-hidden="true"></span>
+            Import aggregates
+        </a>
     {% endif %}
     {% include 'inc/export_button.html' with obj_type='aggregates' %}
 </div>

--- a/netbox/templates/tenancy/tenant_list.html
+++ b/netbox/templates/tenancy/tenant_list.html
@@ -10,6 +10,10 @@
 			<span class="fa fa-plus" aria-hidden="true"></span>
 			Add a tenant
 		</a>
+        <a href="{% url 'tenancy:tenant_import' %}" class="btn btn-info">
+            <span class="fa fa-download" aria-hidden="true"></span>
+            Import tenants
+        </a>
     {% endif %}
     {% include 'inc/export_button.html' with obj_type='tenants' %}
 </div>

--- a/netbox/tenancy/views.py
+++ b/netbox/tenancy/views.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.mixins import PermissionRequiredMixin
-from django.db.models import Count
+from django.db.models import Count, Q
 from django.shortcuts import get_object_or_404, render
 
 from circuits.models import Circuit
@@ -59,8 +59,14 @@ def tenant(request, slug):
         'rack_count': Rack.objects.filter(tenant=tenant).count(),
         'device_count': Device.objects.filter(tenant=tenant).count(),
         'vrf_count': VRF.objects.filter(tenant=tenant).count(),
-        'prefix_count': Prefix.objects.filter(tenant=tenant).count(),
-        'ipaddress_count': IPAddress.objects.filter(tenant=tenant).count(),
+        'prefix_count': Prefix.objects.filter(
+            Q(tenant=tenant) |
+            Q(tenant__isnull=True, vrf__tenant=tenant)
+        ).count(),
+        'ipaddress_count': IPAddress.objects.filter(
+            Q(tenant=tenant) |
+            Q(tenant__isnull=True, vrf__tenant=tenant)
+        ).count(),
         'vlan_count': VLAN.objects.filter(tenant=tenant).count(),
         'circuit_count': Circuit.objects.filter(tenant=tenant).count(),
     }


### PR DESCRIPTION
## Bug Fixes
- [#460](https://github.com/digitalocean/netbox/issues/460) - Corrected ordering of IP addresses with differing prefix lengths
- [#463](https://github.com/digitalocean/netbox/issues/463) - Prevent prepopulation of livesearch field with '---------'
- [#467](https://github.com/digitalocean/netbox/issues/467) - Include prefixes and IPs which inherit tenancy from their VRF in tenant stats
- [#468](https://github.com/digitalocean/netbox/issues/468) - Don't allow connected interfaces to be changed to the "virtual" form factor
- [#469](https://github.com/digitalocean/netbox/issues/469) - Added missing import buttons to list views
- [#472](https://github.com/digitalocean/netbox/issues/472) - Hide the connection button for interfaces which have a circuit terminated to them
