### PR TITLE
Changes to Dockerfile to make the build faster

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,10 @@
-FROM ubuntu:14.04
+FROM python:2.7-wheezy
 
-RUN apt-get update && apt-get install -y \
-	python2.7 \
-	python-dev \
-	git \
-	python-pip \
-	libxml2-dev \
-	libxslt1-dev \
-	libffi-dev \
-	graphviz \
-	libpq-dev \
-	build-essential \
-	gunicorn \
-	--no-install-recommends \
-	&& rm -rf /var/lib/apt/lists/* \
-	&& mkdir -p /opt/netbox \
-	&& cd /opt/netbox \
-	&& git clone --depth 1 https://github.com/digitalocean/netbox.git -b master . \
-	&& pip install -r requirements.txt \
-	&& apt-get purge -y --auto-remove git build-essential
+WORKDIR /opt/netbox
+
+ADD . /opt/netbox
+#RUN git clone --depth 1 https://github.com/digitalocean/netbox.git -b master . \
+RUN	pip install -r requirements.txt
 
 ADD docker/docker-entrypoint.sh /docker-entrypoint.sh
 ADD netbox/netbox/configuration.docker.py /opt/netbox/netbox/netbox/configuration.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+gunicorn==17.5
 cryptography==1.4
 Django==1.10
 django-debug-toolbar==1.4


### PR DESCRIPTION
To download a new version with docker, I've been running

```
git pull
docker-compose build --no-cache
```

This is slow, but no-cache is needed so that "git clone" pulls the
latest copy.

Most of the slowness comes from pulling down apt files each time a
rebuild needs to be done.  If we move that into a docker image then only
the local changes need to be rebuilt.

Further refinements could be done.  If the python dependencies that are
brought in from requirements.txt could be moved to an image then nothing
would change between updates as long as dependant versions hadn't
changed.  This would probably be more trouble than it's worth, unless
you're recreating netbox containers 10-20 times a day.

This rebases #436 and supercedes #477 
