### PR TITLE
Revert "Changes to Dockerfile to make the build faster"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,24 @@
-FROM python:2.7-wheezy
+FROM ubuntu:14.04
 
-WORKDIR /opt/netbox
-
-ADD . /opt/netbox
-#RUN git clone --depth 1 https://github.com/digitalocean/netbox.git -b master . \
-RUN	pip install -r requirements.txt
+RUN apt-get update && apt-get install -y \
+	python2.7 \
+	python-dev \
+	git \
+	python-pip \
+	libxml2-dev \
+	libxslt1-dev \
+	libffi-dev \
+	graphviz \
+	libpq-dev \
+	build-essential \
+	gunicorn \
+	--no-install-recommends \
+	&& rm -rf /var/lib/apt/lists/* \
+	&& mkdir -p /opt/netbox \
+	&& cd /opt/netbox \
+	&& git clone --depth 1 https://github.com/digitalocean/netbox.git -b master . \
+	&& pip install -r requirements.txt \
+	&& apt-get purge -y --auto-remove git build-essential
 
 ADD docker/docker-entrypoint.sh /docker-entrypoint.sh
 ADD netbox/netbox/configuration.docker.py /opt/netbox/netbox/netbox/configuration.py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-gunicorn==17.5
 cryptography==1.4
 Django==1.10
 django-debug-toolbar==1.4


### PR DESCRIPTION
Reverts digitalocean/netbox#478

We don't want to add gunicorn to `requirements.txt` because it's not a strict requirement for NetBox. A user could opt to use uWSGI instead, for instance.
