### PR TITLE
Fixed csv reader to handle special characters

### DIFF
--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -142,10 +142,15 @@ class CSVDataField(forms.CharField):
         if not self.help_text:
             self.help_text = 'Enter one line per record in CSV format.'
 
+    def utf_8_encoder(self, unicode_csv_data):
+        # convert csv,reader to utf-8e
+        for line in unicode_csv_data:
+            yield line.encode('utf-8')
+
     def to_python(self, value):
         # Return a list of dictionaries, each representing an individual record
         records = []
-        reader = csv.reader(value.splitlines())
+        reader = csv.reader(self.utf_8_encoder(value.splitlines()))
         for i, row in enumerate(reader, start=1):
             if row:
                 if len(row) < len(self.columns):


### PR DESCRIPTION
Added a wrapper for csv reader used in imports so it can support reading unicode CSV data. This make it possible for all csv imports in netbox to support special characters like æøå.
