### PR TITLE
fix for Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,10 @@ FROM python:2.7-wheezy
 
 WORKDIR /opt/netbox
 
-ADD . /opt/netbox
-RUN git clone --depth 1 https://github.com/digitalocean/netbox.git -b master . \
-RUN	pip install gunicorn==17.5 && pip install -r requirements.txt
+ARG BRANCH=master
+ARG URL=https://github.com/digitalocean/netbox.git
+RUN git clone --depth 1 $URL -b $BRANCH .  && \
+	pip install gunicorn==17.5 && pip install -r requirements.txt
 
 ADD docker/docker-entrypoint.sh /docker-entrypoint.sh
 ADD netbox/netbox/configuration.docker.py /opt/netbox/netbox/netbox/configuration.py


### PR DESCRIPTION
I had left a couple of statements in that I used while testing the new file. 
Together they broke in a way I couldn't really test until the code was
merged into the develop branch.

I believe I've fixed it so that the "master" branch and "develop"
branch can use the same Dockerfile options.  You override which branch
it pulls by setting a build-args variable, either via docker-compose or
in the docker build options.
