### PR TITLE
Docker should allow multiple ALLOWED_HOSTS

### DIFF
--- a/netbox/netbox/configuration.docker.py
+++ b/netbox/netbox/configuration.docker.py
@@ -9,7 +9,7 @@ import os
 # access to the server via any other hostnames. The first FQDN in the list will be treated as the preferred name.
 #
 # Example: ALLOWED_HOSTS = ['netbox.example.com', 'netbox.internal.local']
-ALLOWED_HOSTS = [os.environ.get('ALLOWED_HOSTS', '')]
+ALLOWED_HOSTS = os.environ.get('ALLOWED_HOSTS', '').split(' ')
 
 # PostgreSQL database configuration.
 DATABASE = {


### PR DESCRIPTION
When I was trying to install netbox under docker, I was failing to get it to work because the docker config didn't support multiple entries in ALLOWED_HOSTS.

This PR makes it space delimited.
