### PR TITLE
Add Utilization to PrefixTable

### DIFF
--- a/netbox/ipam/models.py
+++ b/netbox/ipam/models.py
@@ -300,7 +300,38 @@ class Prefix(CreatedUpdatedModel, CustomFieldModel):
 
     def get_status_class(self):
         return STATUS_CHOICE_CLASSES[self.status]
+        
+    def get_utilization(self):
+        """
+        Determine the utilization rate of the aggregate prefix and return it as a percentage.
+        """
+        if self.vrf:
+            # If the prefix is in a VRF, show child prefixes only within that VRF.
+            child_prefixes = Prefix.objects.filter(vrf=self.vrf)
+        else:
+            # If the prefix is in the global table, show child prefixes from all VRFs.
+            child_prefixes = Prefix.objects.all()
+        child_prefixes = child_prefixes.filter(prefix__net_contained=str(self.prefix))\
+            .select_related('site', 'role').annotate_depth(limit=0)
+        child_ips = IPAddress.objects.filter(vrf=self.vrf, address__net_contained_or_equal=str(self.prefix))
 
+        # Remove overlapping prefixes from list of children
+        if child_prefixes:
+            networks = cidr_merge([c.prefix for c in child_prefixes])
+            children_size = float(0)
+            for p in networks:
+                children_size += p.size
+            return int(children_size / self.prefix.size * 100)
+        elif child_ips:
+            # code to calculate IP Utilization
+            ipaddress_count = child_ips.count()
+
+            if self.prefix.version == 4 and self.prefix.prefixlen < 31:
+                return int(((float(ipaddress_count) + 2 )/self.prefix.size) * 100)
+            else:
+                return int((float(ipaddress_count) / self.prefix.size ) * 100)
+        else:
+                return 0
 
 class IPAddressManager(models.Manager):
 

--- a/netbox/ipam/models.py
+++ b/netbox/ipam/models.py
@@ -300,7 +300,7 @@ class Prefix(CreatedUpdatedModel, CustomFieldModel):
 
     def get_status_class(self):
         return STATUS_CHOICE_CLASSES[self.status]
-        
+
     def get_utilization(self):
         """
         Determine the utilization rate of the aggregate prefix and return it as a percentage.
@@ -327,11 +327,12 @@ class Prefix(CreatedUpdatedModel, CustomFieldModel):
             ipaddress_count = child_ips.count()
 
             if self.prefix.version == 4 and self.prefix.prefixlen < 31:
-                return int(((float(ipaddress_count) + 2 )/self.prefix.size) * 100)
+                return int(((float(ipaddress_count) + 2) / self.prefix.size) * 100)
             else:
-                return int((float(ipaddress_count) / self.prefix.size ) * 100)
+                return int((float(ipaddress_count) / self.prefix.size) * 100)
         else:
-                return 0
+            return 0
+
 
 class IPAddressManager(models.Manager):
 

--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -164,10 +164,11 @@ class PrefixTable(BaseTable):
     site = tables.LinkColumn('dcim:site', args=[Accessor('site.slug')], verbose_name='Site')
     role = tables.Column(verbose_name='Role')
     description = tables.Column(orderable=False, verbose_name='Description')
+    utilization = tables.TemplateColumn(UTILIZATION_GRAPH, orderable=False, verbose_name='Utilization')
 
     class Meta(BaseTable.Meta):
         model = Prefix
-        fields = ('pk', 'prefix', 'status', 'vrf', 'tenant', 'site', 'role', 'description')
+        fields = ('pk', 'prefix', 'status', 'utilization', 'vrf', 'tenant', 'site', 'role', 'description')
         row_attrs = {
             'class': lambda record: 'success' if not record.pk else '',
         }


### PR DESCRIPTION
From https://github.com/digitalocean/netbox/issues/40

This patch calculates prefix utilization based on the following rules and displays it in the PrefixTable:
1.  If the prefix has any child prefixes in the same VRF,  use sum of child prefix size.  This is the same behavior as aggregates
2.  If the prefix has no child prefixes and does have IPs,  and is not a /32,  use sum of IPs +2 over prefix size.
3.  If the prefix has no child prefixes and does have IPs,  and is a /32,  use sum of IPs over prefix size.
4.  If the prefix has no child prefixes and no IPs,  return 0.
