### PR TITLE
Fix for Docker ldap

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,10 @@ WORKDIR /opt/netbox
 ARG BRANCH=master
 ARG URL=https://github.com/digitalocean/netbox.git
 RUN git clone --depth 1 $URL -b $BRANCH .  && \
-	pip install gunicorn==17.5 && pip install -r requirements.txt
+    apt-get update -qq && apt-get install -y libldap2-dev libsasl2-dev libssl-dev && \
+	pip install gunicorn==17.5 && \
+	pip install django-auth-ldap && \
+    pip install -r requirements.txt
 
 ADD docker/docker-entrypoint.sh /docker-entrypoint.sh
 ADD netbox/netbox/configuration.docker.py /opt/netbox/netbox/netbox/configuration.py

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -71,7 +71,7 @@ if LDAP_CONFIGURED:
         logger.setLevel(logging.DEBUG)
     except ImportError:
         raise ImproperlyConfigured("LDAP authentication has been configured, but django-auth-ldap is not installed. "
-                                   "You can remove netbox/ldap.py to disable LDAP.")
+                                   "You can remove netbox/ldap_config.py to disable LDAP.")
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 


### PR DESCRIPTION
This is a fix for issue #542.

This loads the LDAP libraries into the Dockerfile.  In order to use them you will still need to create ldap_config.py with the proper values, then you can include it in docker-compose.yml.

Example:

```
    volumes:
    - netbox-static-files:/opt/netbox/netbox/static
    - ./netbox/netbox/ldap_config.py:/opt/netbox/netbox/netbox/ldap_config.py
```
