### PR TITLE
allow comma-separated ALLOWED_HOSTS env

### DIFF
--- a/netbox/netbox/configuration.docker.py
+++ b/netbox/netbox/configuration.docker.py
@@ -9,7 +9,7 @@ import os
 # access to the server via any other hostnames. The first FQDN in the list will be treated as the preferred name.
 #
 # Example: ALLOWED_HOSTS = ['netbox.example.com', 'netbox.internal.local']
-ALLOWED_HOSTS = [os.environ.get('ALLOWED_HOSTS', '')]
+ALLOWED_HOSTS = [host.strip() for host in os.environ.get('ALLOWED_HOSTS', '').split(',')]
 
 # PostgreSQL database configuration.
 DATABASE = {


### PR DESCRIPTION
when we have a comma-separated ALLOWED_HOSTS environment variable, split them,
strip the whitespaces and put them into an array
