### PR TITLE
Removed superfluous "is" in error message

### DIFF
--- a/netbox/ipam/models.py
+++ b/netbox/ipam/models.py
@@ -139,7 +139,7 @@ class Aggregate(CreatedUpdatedModel, CustomFieldModel):
             if self.pk:
                 covered_aggregates = covered_aggregates.exclude(pk=self.pk)
             if covered_aggregates:
-                raise ValidationError("{} is overlaps with an existing aggregate ({})"
+                raise ValidationError("{} overlaps with an existing aggregate ({})"
                                       .format(self.prefix, covered_aggregates[0]))
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
As described in title, I removed a superfluous "is" in error message for overlapping aggregates.
