### PR TITLE
gitignore static folder, concretize configuration.py location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
-configuration.py
+/netbox/netbox/configuration.py
+/netbox/static
 .idea
 /*.sh
 !upgrade.sh


### PR DESCRIPTION
this adds the netbox/static folder to the gitignore file, and further
specifies the path from where we'd like to ignore net netbox configuration.py.
