### PR TITLE
gitignore .venv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /netbox/netbox/configuration.py
 /netbox/static
 .idea
+/.venv
 /*.sh
 !upgrade.sh
 fabfile.py


### PR DESCRIPTION
often, a .venv is added at a package root containing the virtualenv. so
exclude this for git