### PR TITLE
Release v1.7.2-r1

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -12,7 +12,7 @@ except ImportError:
                                "the documentation.")
 
 
-VERSION = '1.7.2'
+VERSION = '1.7.3-dev'
 
 # Import local configuration
 for setting in ['ALLOWED_HOSTS', 'DATABASE', 'SECRET_KEY']:

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -12,7 +12,7 @@ except ImportError:
                                "the documentation.")
 
 
-VERSION = '1.7.3-dev'
+VERSION = '1.7.2-r1'
 
 # Import local configuration
 for setting in ['ALLOWED_HOSTS', 'DATABASE', 'SECRET_KEY']:

--- a/netbox/templates/dcim/inc/_rack_elevation.html
+++ b/netbox/templates/dcim/inc/_rack_elevation.html
@@ -21,7 +21,7 @@
     <ul class="rack rack_near_face">
         {% for u in primary_face %}
             {% if u.device %}
-                <li class="occupied h{{ u.device.device_type.u_height }}u{% ifequal u.device.face face_id %} {{ u.device.device_role.color }}{% endifequal %}">
+                <li class="occupied h{{ u.device.device_type.u_height }}u"{% ifequal u.device.face face_id %} style="background-color: #{{ u.device.device_role.color }}"{% endifequal %}>
                     {% ifequal u.device.face face_id %}
                         <a href="{% url 'dcim:device' pk=u.device.pk %}" data-toggle="popover" data-trigger="hover" data-container="body" data-html="true"
                            data-content="{{ u.device.device_role }}<br />{{ u.device.device_type }} ({{ u.device.device_type.u_height }}U)">


### PR DESCRIPTION
## Improvements

* [#663](https://github.com/digitalocean/netbox/issues/663) - Added MAC address search field to device list
* [#672](https://github.com/digitalocean/netbox/issues/672) - Increased the selection of available colors for rack and device roles
* [#695](https://github.com/digitalocean/netbox/issues/695) - Added is_private field to RIR

## Bug Fixes

* [#677](https://github.com/digitalocean/netbox/issues/677) - Fix setuptools installation error on Debian 8.6
* [#696](https://github.com/digitalocean/netbox/issues/696) - Corrected link to VRF in prefix and IP address breadcrumbs
* [#702](https://github.com/digitalocean/netbox/issues/702) - Improved Unicode support for custom fields
* [#712](https://github.com/digitalocean/netbox/issues/712) - Corrected export of tenants which are not assigned to a group
* [#713](https://github.com/digitalocean/netbox/issues/713) - Include a label for the comments field when editing circuits, providers, or racks in bulk
* [#718](https://github.com/digitalocean/netbox/issues/718) - Restore is_primary field on IP assignment form
* [#723](https://github.com/digitalocean/netbox/issues/723) - API documentation is now accessible when using BASE_PATH
* [#727](https://github.com/digitalocean/netbox/issues/727) - Corrected invalid rack elevation display in v1.7.2
