### PR TITLE
FIX: filtering devices fails because mac address filter is a required

### DIFF
--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -612,7 +612,7 @@ class DeviceFilterForm(BootstrapMixin, CustomFieldFilterForm):
     platform = FilterChoiceField(queryset=Platform.objects.annotate(filter_count=Count('devices')),
                                  to_field_name='slug', null_option=(0, 'None'))
     status = forms.NullBooleanField(required=False, widget=forms.Select(choices=FORM_STATUS_CHOICES))
-    mac_address = forms.CharField(label='MAC address')
+    mac_address = forms.CharField(label='MAC address', required=False)
 
 
 #


### PR DESCRIPTION
Branch: develop

Browser: Chrome

Steps to reproduce:

List all Devices to view the Filter Device form. 
Hit Submit, it says the MAC address field must be filled out.Noticed the MAC address field has the "required" attribute attached to it.

This simple patch resolves the issue for  me. 
