### PR TITLE
rburkholder - patch - tenant serialiser - add description field to output

### DIFF
--- a/netbox/tenancy/api/serializers.py
+++ b/netbox/tenancy/api/serializers.py
@@ -30,7 +30,7 @@ class TenantSerializer(CustomFieldSerializer, serializers.ModelSerializer):
 
     class Meta:
         model = Tenant
-        fields = ['id', 'name', 'slug', 'group', 'comments', 'custom_fields']
+        fields = ['id', 'name', 'slug', 'group', 'description', 'comments', 'custom_fields']
 
 
 class TenantNestedSerializer(TenantSerializer):


### PR DESCRIPTION
This might be just an oversight.  Other data models do include the description in their serialisers.  The API produces the description field with this change.