### PR TITLE
Enforce Global Unique on Prefixes

### DIFF
--- a/netbox/ipam/models.py
+++ b/netbox/ipam/models.py
@@ -422,19 +422,13 @@ class IPAddress(CreatedUpdatedModel, CustomFieldModel):
         return reverse('ipam:ipaddress', args=[self.pk])
 
     def clean(self):
-        if ((not self.vrf and settings.ENFORCE_GLOBAL_UNIQUE) or (self.vrf and self.vrf.enforce_unique)):
-            dupes = IPAddress.objects.duplicates(self)
-            if dupes:
-                raise ValidationError({
-                    'address': "Duplicate IP address found in global table: {}".format(dupes.first())
-                })
 
         # Enforce unique IP space if applicable
         if ((not self.vrf and settings.ENFORCE_GLOBAL_UNIQUE) or (self.vrf and self.vrf.enforce_unique)):
             dupes = IPAddress.objects.duplicates(self)
             if dupes:
                 raise ValidationError({
-                    'address': "Duplicate IP address found in {}: {}".format(
+                    'address': "Duplicate IP Address found in {}: {}".format(
                         "VRF {}".format(self.vrf) if self.vrf else "global table",
                         dupes.first(),
                     )

--- a/netbox/ipam/tests/test_models.py
+++ b/netbox/ipam/tests/test_models.py
@@ -1,0 +1,72 @@
+import netaddr
+
+from django.test import TestCase, override_settings
+
+from ipam.models import IPAddress, Prefix, VRF
+from django.core.exceptions import ValidationError
+
+
+class TestPrefix(TestCase):
+
+    fixtures = [
+        'dcim',
+        'ipam'
+    ]
+
+    def test_create(self):
+        prefix = Prefix.objects.create(
+            prefix=netaddr.IPNetwork('10.1.1.0/24'),
+            status=1
+        )
+        self.assertIsNone(prefix.clean())
+
+    @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
+    def test_duplicate_global(self):
+        prefix = Prefix.objects.create(
+            prefix=netaddr.IPNetwork('10.1.1.0/24'),
+            status=1
+        )
+        self.assertRaises(ValidationError, prefix.clean)
+
+    @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
+    def test_duplicate_vrf(self):
+        pfx_kwargs = {
+            "prefix": netaddr.IPNetwork('10.1.1.0/24'),
+            "status": 1,
+            "vrf": VRF.objects.create(name='Test', rd='1:1'),
+        }
+        Prefix.objects.create(**pfx_kwargs)
+        dup_prefix = Prefix.objects.create(**pfx_kwargs)
+        self.assertRaises(ValidationError, dup_prefix.clean)
+
+
+class TestIPAddress(TestCase):
+
+    fixtures = [
+        'dcim',
+        'ipam'
+    ]
+
+    def test_create(self):
+        address = IPAddress.objects.create(
+            address=netaddr.IPNetwork('10.0.254.1/24'),
+        )
+        self.assertIsNone(address.clean())
+
+    @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
+    def test_duplicate_global(self):
+        address = IPAddress.objects.create(
+            address=netaddr.IPNetwork('10.0.254.1/24'),
+        )
+        self.assertRaises(ValidationError, address.clean)
+
+    @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
+    def test_duplicate_vrf(self):
+        pfx_kwargs = {
+            "address": netaddr.IPNetwork('10.0.254.1/24'),
+            "status": 1,
+            "vrf": VRF.objects.create(name='Test', rd='1:1'),
+        }
+        IPAddress.objects.create(**pfx_kwargs)
+        dup_address = IPAddress.objects.create(**pfx_kwargs)
+        self.assertRaises(ValidationError, dup_address.clean)


### PR DESCRIPTION
Should fix #802 - the language in the docs made it seem like `ENFORCE_GLOBAL_UNIQUE` should work on prefixes as well as IPAddress objects in the GRT, but I didn't find the logic for Prefixes. Refactored each model's `clean()` method a little. Also added some tests for the behavior in both models.