### PR TITLE
Added ldap_config.py and gunicorn_config.py to .gitignore file.  File…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 !upgrade.sh
 fabfile.py
 *.swp
+/netbox/netbox/ldap_config.py
+gunicorn_config.py


### PR DESCRIPTION
… locations are consistent with the installation guide.

If found that when upgrading from v1.8.0 to v1.8.1 via git, there were issues with merging.  Adding these 2 files to .gitignore should resolve this.  