### PR TITLE
Force Unix line endings on shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
### Fixes:  #952 

By setting .gitattributes, we force LF rather than CRLF line endings on
shell scripts on Windows. Other files are left as is.

This makes the quickstart docker instructions work on Windows (using
Docker for Windows).