### PR TITLE
Pointing Dockerfile to 'v2-beta' branch instead of a particular tag

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM python:2.7-wheezy
 
 WORKDIR /opt/netbox
 
-ARG BRANCH=v2.0-beta1
+ARG BRANCH=v2-beta
 ARG URL=https://github.com/digitalocean/netbox.git
 RUN git clone --depth 1 $URL -b $BRANCH .  && \
     apt-get update -qq && apt-get install -y libldap2-dev libsasl2-dev libssl-dev graphviz && \


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: https://github.com/digitalocean/netbox/issues/1063

<!--
    Please include a summary of the proposed changes below.
-->

Was trying to deploy v2 Beta 2 using Docker but was getting the wrong version.

A follow up to https://github.com/digitalocean/netbox/pull/986 even though this will no longer be relevant once https://github.com/digitalocean/netbox/issues/1008 is done.