### PR TITLE
Python3 fixes for CentOS/RHEL

### DIFF
--- a/docs/installation/netbox.md
+++ b/docs/installation/netbox.md
@@ -20,7 +20,8 @@ Python 3:
 
 ```no-highlight
 # yum install -y epel-release
-# yum install -y gcc python3 python3-devel python3-pip libxml2-devel libxslt-devel libffi-devel graphviz openssl-devel
+# yum install -y gcc python34 python34-devel python34-setuptools libxml2-devel libxslt-devel libffi-devel graphviz openssl-devel
+# easy_install-3.4 pip
 ```
 
 Python 2:


### PR DESCRIPTION
1) python3 should be python34
2) python34-pip does does exist, you must install python34-setuptools and then: easy_install-3.4 pip

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:

<!--
    Please include a summary of the proposed changes below.
-->
