### PR TITLE
[security] generate_secret_key should use a csprng

### DIFF
--- a/netbox/generate_secret_key.py
+++ b/netbox/generate_secret_key.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # This script will generate a random 50-character string suitable for use as a SECRET_KEY.
 import os
-import random
+import base64
 
-charset = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*(-_=+)'
-random.seed = (os.urandom(2048))
-print(''.join(random.choice(charset) for c in range(50)))
+print(base64.urlsafe_b64encode(os.urandom(64))[:50])


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1092

<!--
    Please include a summary of the proposed changes below.
-->
Original implementation used a very large seed (2048 bytes) but then performed
encoding using the insecure Mersenne Twister pseudo random number generator.
`random.seed` would actually take a `hash` of the input resulting in a much
smaller keyspace (64bits) and then biases in the insecure random number
generator could result in more predictable keys than intended.

The new implementation uses the system's cryptographically secure pseudo
random number generator (`os.urandom`) with `512` bits and then does a
straight encoding of that using base64, resulting in ~312 bits entropy.