### PR TITLE
Fix misleading build matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ Questions? Comments? Please subscribe to [the netbox-discuss mailing list](https
 
 ### Build Status
 
-|             | python 2.7 |
+NetBox is built against both Python 2.7 and 3.5.  Python 3.5 is recommended.
+
+|             | status |
 |-------------|------------|
 | **master** | [![Build Status](https://travis-ci.org/digitalocean/netbox.svg?branch=master)](https://travis-ci.org/digitalocean/netbox) |
 | **develop** | [![Build Status](https://travis-ci.org/digitalocean/netbox.svg?branch=develop)](https://travis-ci.org/digitalocean/netbox) |


### PR DESCRIPTION
At one point, I had intended to have a matrix of build badges for each different branch and Python version combination.  It seems this is not possible with Travis.

This change replaces "python 2.7" with "status" and clarifies that both Python 2.7 and 3.5 are tested, but Python 3.5 is recommended.