### PR TITLE
Improve prefixes description visibility

### DIFF
--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -48,13 +48,23 @@ PREFIX_LINK = """
 {% else %}
     <span style="padding-left: {{ record.depth }}9px">
 {% endif %}
-    <a href="{% if record.pk %}{% url 'ipam:prefix' pk=record.pk %}{% else %}{% url 'ipam:prefix_add' %}?prefix={{ record }}{% if parent.vrf %}&vrf={{ parent.vrf.pk }}{% endif %}{% if parent.site %}&site={{ parent.site.pk }}{% endif %}{% endif %}">{{ record.prefix }}</a>
+    <a href="{% if record.pk %}{% url 'ipam:prefix' pk=record.pk %}{% else %}{% url 'ipam:prefix_add' %}?prefix={{ record }}{% if parent.vrf %}&vrf={{ parent.vrf.pk }}{% endif %}{% if parent.site %}&site={{ parent.site.pk }}{% endif %}{% endif %}">
+{% if record.description %}
+{{ record.prefix }}</a> - {{ record.description }}
+{% else %}
+{{ record.prefix }}</a>
+{% endif %}
 </span>
 """
 
 PREFIX_LINK_BRIEF = """
 <span style="padding-left: {{ record.depth }}0px">
-    <a href="{% if record.pk %}{% url 'ipam:prefix' pk=record.pk %}{% else %}{% url 'ipam:prefix_add' %}?prefix={{ record }}{% if parent.vrf %}&vrf={{ parent.vrf.pk }}{% endif %}{% if parent.site %}&site={{ parent.site.pk }}{% endif %}{% endif %}">{{ record.prefix }}</a>
+    <a href="{% if record.pk %}{% url 'ipam:prefix' pk=record.pk %}{% else %}{% url 'ipam:prefix_add' %}?prefix={{ record }}{% if parent.vrf %}&vrf={{ parent.vrf.pk }}{% endif %}{% if parent.site %}&site={{ parent.site.pk }}{% endif %}{% endif %}">
+{% if record.description %}
+{{ record.prefix }}</a> - {{ record.description }}
+{% else %}
+{{ record.prefix }}</a>
+{% endif %}
 </span>
 """
 
@@ -247,7 +257,7 @@ class PrefixTable(BaseTable):
 
     class Meta(BaseTable.Meta):
         model = Prefix
-        fields = ('pk', 'prefix', 'status', 'vrf', 'tenant', 'site', 'vlan', 'role', 'description')
+        fields = ('pk', 'prefix', 'status', 'vrf', 'tenant', 'site', 'vlan', 'role')
         row_attrs = {
             'class': lambda record: 'success' if not record.pk else '',
         }

--- a/netbox/templates/ipam/inc/prefix_header.html
+++ b/netbox/templates/ipam/inc/prefix_header.html
@@ -41,7 +41,11 @@
 		</a>
     {% endif %}
 </div>
+{% if prefix.description %}
+<h1>{{ prefix }} - {{ prefix.description }}</h1>
+{% else %}
 <h1>{{ prefix }}</h1>
+{% endif %}
 {% include 'inc/created_updated.html' with obj=prefix %}
 <ul class="nav nav-tabs" style="margin-bottom: 20px">
     <li role="presentation"{% if active_tab == 'prefix' %} class="active"{% endif %}><a href="{% url 'ipam:prefix' pk=prefix.pk %}">Prefix</a></li>

--- a/netbox/templates/ipam/prefix_edit.html
+++ b/netbox/templates/ipam/prefix_edit.html
@@ -6,12 +6,12 @@
         <div class="panel-heading"><strong>Prefix</strong></div>
         <div class="panel-body">
             {% render_field form.prefix %}
+            {% render_field form.description %}
             {% render_field form.status %}
             {% render_field form.vrf %}
             {% render_field form.site %}
             {% render_field form.vlan %}
             {% render_field form.role %}
-            {% render_field form.description %}
             {% render_field form.is_pool %}
         </div>
     </div>


### PR DESCRIPTION
CIDR notation is not that human readable so when you have a lot of prefixes and children prefixes, descriptions are really helpful to understand your network infrastructure.

Current displays kind of hide descriptions instead of highlighting it. This patch tries to fix that.

Signed-off-by: Sylvain Rabot <s.rabot@lectra.com>

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:

<!--
    Please include a summary of the proposed changes below.
-->
