### PR TITLE
Preserve fileextension, regardless of upper or lower case on imageupload

### DIFF
--- a/netbox/extras/models.py
+++ b/netbox/extras/models.py
@@ -387,7 +387,7 @@ def image_upload(instance, filename):
     path = 'image-attachments/'
 
     # Rename the file to the provided name, if any. Attempt to preserve the file extension.
-    extension = filename.rsplit('.')[-1]
+    extension = filename.rsplit('.')[-1].lower()
     if instance.name and extension in ['bmp', 'gif', 'jpeg', 'jpg', 'png']:
         filename = '.'.join([instance.name, extension])
     elif instance.name:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1301 

<!--
    Please include a summary of the proposed changes below.
-->
Fileextension on imageuploads will be kept, regardless of the case