### PR TITLE
Fixes #1400: Device interface shows twice on IP Addresses page

### DIFF
--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -80,7 +80,6 @@ IPADDRESS_LINK = """
 IPADDRESS_DEVICE = """
 {% if record.interface %}
     <a href="{{ record.interface.device.get_absolute_url }}">{{ record.interface.device }}</a>
-    ({{ record.interface.name }})
 {% else %}
     &mdash;
 {% endif %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
Fixes #1400: Device interface shows twice on IP Addresses page
<!--
    Please include a summary of the proposed changes below.
-->
