### PR TITLE
docs: web-server link to new ssl tutorials for 16.04

### DIFF
--- a/docs/installation/web-server.md
+++ b/docs/installation/web-server.md
@@ -51,7 +51,7 @@ Restart the nginx service to use the new configuration.
 # service nginx restart
 ```
 
-To enable SSL, consider this guide on [securing nginx with Let's Encrypt](https://www.digitalocean.com/community/tutorials/how-to-secure-nginx-with-let-s-encrypt-on-ubuntu-14-04).
+To enable SSL, consider this guide on [securing nginx with Let's Encrypt](https://www.digitalocean.com/community/tutorials/how-to-secure-nginx-with-let-s-encrypt-on-ubuntu-16-04).
 
 ## Option B: Apache
 
@@ -96,7 +96,7 @@ Save the contents of the above example in `/etc/apache2/sites-available/netbox.c
 # service apache2 restart
 ```
 
-To enable SSL, consider this guide on [securing Apache with Let's Encrypt](https://www.digitalocean.com/community/tutorials/how-to-secure-apache-with-let-s-encrypt-on-ubuntu-14-04).
+To enable SSL, consider this guide on [securing Apache with Let's Encrypt](https://www.digitalocean.com/community/tutorials/how-to-secure-apache-with-let-s-encrypt-on-ubuntu-16-04).
 
 # gunicorn Installation
 


### PR DESCRIPTION
Noticed that the docs says this is tested/only for Ubuntu 16.04 but SSL tutorials are linking to 14.04 versions. Not sure are they any difference or will there be in future, but I updated links to new, as they appeared in meanwhile. 