### PR TITLE
Allow import/export of interfaces, provide interface list page with filters, and inline descriptions

### DIFF
--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -49,11 +49,11 @@ IFACE_ORDERING_CHOICES = [
 ]
 
 # Interface enabled as choice
-IFACE_DISABLED = 0
-IFACE_ENABLED = 1
+IFACE_DISABLED = False
+IFACE_ENABLED = True
 IFACE_ENABLED_CHOICES = [
-    [IFACE_ENABLED,'Enabled'],
-    [IFACE_DISABLED,'Disabled']
+    [IFACE_DISABLED, 'Disabled'],
+    [IFACE_ENABLED, 'Enabled'],
 ]
 
 # Interface form factors

--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -48,6 +48,9 @@ IFACE_ORDERING_CHOICES = [
     [IFACE_ORDERING_NAME, 'Name (alphabetically)']
 ]
 
+# Interface enabled as choice
+IFACE_DISABLED = 0
+IFACE_ENABLED = 1
 IFACE_ENABLED_CHOICES = [
     [IFACE_ENABLED,'Enabled'],
     [IFACE_DISABLED,'Disabled']

--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -48,6 +48,11 @@ IFACE_ORDERING_CHOICES = [
     [IFACE_ORDERING_NAME, 'Name (alphabetically)']
 ]
 
+IFACE_ENABLED_CHOICES = [
+    [IFACE_ENABLED,'Enabled'],
+    [IFACE_DISABLED,'Disabled']
+]
+
 # Interface form factors
 # Virtual
 IFACE_FF_VIRTUAL = 0

--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -56,6 +56,11 @@ IFACE_ENABLED_CHOICES = [
     [IFACE_ENABLED, 'Enabled'],
 ]
 
+IFACE_STATUS_CLASSES = {
+    0: 'disabled',
+    1: 'enabled',
+}
+
 # Interface form factors
 # Virtual
 IFACE_FF_VIRTUAL = 0

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -586,9 +586,9 @@ class InterfaceListFilter(django_filters.FilterSet):
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
-        name='site__slug',
+        name='site',
         queryset=Device.objects.select_related('site'),
-        to_field_name='slug',
+        to_field_name='site',
         label='Site name (slug)',
     )
     #role_id = django_filters.ModelMultipleChoiceFilter(

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -623,14 +623,16 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_site(self, queryset, name, value):
         try:
             site = Device.objects.select_related('device_id','site').get(**{name: value})
-            return queryset
+            ordering = device.site.interface_ordering
+            return queryset.filter(device=device_id).order_naturally(ordering)
         except Device.DoesNotExist:
             return queryset.none()
     
     def filter_role(self, queryset, name, value):
         try:
             site = Device.objects.select_related('device_id','device_role').get(**{name: value})
-            return queryset
+            ordering = device.device_role.interface_ordering
+            return queryset.filter(device=device_id).order_naturally(ordering)
         except Device.DoesNotExist:
             return queryset.none()
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -617,7 +617,7 @@ class InterfaceListFilter(django_filters.FilterSet):
         try:
             device = Device.objects.select_related('site').get(**{name: value})
             ordering = device.site.interface_ordering
-            return queryset.filter(device=device).order_naturally(ordering)
+            return queryset.filter(site=site).order_naturally(ordering)
         except Device.DoesNotExist:
             return queryset.none()
     

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -659,7 +659,7 @@ class InterfaceListFilter(django_filters.FilterSet):
         if not value.strip():
             return queryset
         return queryset.filter(
-            Q(device__icontains=value.strip()) |
+            Q(device__name__icontains=value.strip()) |
             Q(mac_address__icontains=value)
         ).distinct()
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -590,16 +590,16 @@ class InterfaceListFilter(django_filters.FilterSet):
         method='filter_role',
         label='Role (slug)',
     )
-    rack_group_id = django_filters.ModelMultipleChoiceFilter(
-        name='rack__group',
-        method='filter_rack_group',
-        label='Rack group (ID)',
-    )
-    #rack_id = NullableModelMultipleChoiceFilter(
-    #    name='rack',
-    #    method='filter_rack',
-    #    label='Rack (ID)',
+    #rack_group_id = django_filters.ModelMultipleChoiceFilter(
+    #    name='rack__group',
+    #    method='filter_rack_group',
+    #    label='Rack group (ID)',
     #)
+    rack_id = NullableModelMultipleChoiceFilter(
+        name='rack',
+        method='filter_rack',
+        label='Rack (ID)',
+    )
     type = django_filters.CharFilter(
         method='filter_type',
         label='Interface type',

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -586,14 +586,19 @@ class InterfaceListFilter(django_filters.FilterSet):
         method='filter_site',
         label='Site (slug)',
     )
-    #role_id = django_filters.ModelMultipleChoiceFilter(
-    #    method='_filter_role',
-    #    name='device_role',
-    #    label='Role (ID)',
-    #)
     role = django_filters.CharFilter(
         method='filter_role',
         label='Role (slug)',
+    )
+    rack_group_id = django_filters.ModelMultipleChoiceFilter(
+        name='rack__group',
+        method='filter_rack_group',
+        label='Rack group (ID)',
+    )
+    rack_id = NullableModelMultipleChoiceFilter(
+        name='rack',
+        method='filter_rack',
+        label='Rack (ID)',
     )
     type = django_filters.CharFilter(
         method='filter_type',
@@ -617,6 +622,16 @@ class InterfaceListFilter(django_filters.FilterSet):
         if not value.strip():
             return queryset
         return queryset.filter(device__device_role__slug=value)
+
+    def filter_rack(self, queryset, name, value):
+        if not value.strip():
+            return queryset
+        return queryset.filter(device__rack=value)
+
+    def filter_rack_group(self, queryset, name, value):
+        if not value.strip():
+            return queryset
+        return queryset.filter(device__rack__group=value)
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -616,7 +616,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_role(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(device__device_role__name__slug=value)
+        return queryset.filter(device__device_role__slug=value)
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -631,7 +631,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_rack_group(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(device__rack__group=value)
+        return queryset.filter(device__rack__group__name=value)
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -616,7 +616,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_role(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(device_role__slug=value)
+        return queryset.filter(device__device_role__slug=value)
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -583,12 +583,12 @@ class InterfaceListFilter(django_filters.FilterSet):
             label='Search',
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Device.objects.all(),
+        queryset=Device.objects.get('device_id__site'),
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
         name='site',
-        queryset=Device.objects.all(),
+        queryset=Device.objects.get('device_id__site'),
         to_field_name='site',
         label='Site name (slug)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -621,7 +621,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_site(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(device_id__device__site__slug=value)
+        return queryset.filter(device__site__slug=value)
     
     def filter_role(self, queryset, name, value):
         try:

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -660,7 +660,8 @@ class InterfaceListFilter(django_filters.FilterSet):
             return queryset
         return queryset.filter(
             Q(device__name__icontains=value.strip()) |
-            Q(mac_address__icontains=value)
+            Q(description__icontains=value.strip()) |
+            Q(mac_address__icontains=value.strip())
         ).distinct()
 
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -590,11 +590,11 @@ class InterfaceListFilter(django_filters.FilterSet):
         method='filter_role',
         label='Role (slug)',
     )
-    rack_group_id = django_filters.ModelMultipleChoiceFilter(
-        name='rack__group',
-        method='filter_rack_group',
-        label='Rack group (ID)',
-    )
+    #rack_group_id = django_filters.ModelMultipleChoiceFilter(
+    #    name='rack__group',
+    #    method='filter_rack_group',
+    #    label='Rack group (ID)',
+    #)
     rack_id = NullableModelMultipleChoiceFilter(
         name='rack',
         method='filter_rack',

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -587,8 +587,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     )
     site = django_filters.ModelMultipleChoiceFilter(
         name='site',
-        queryset=Device.objects.select_related('site'),
-        to_field_name='site',
+        method='_filter_site',
         label='Site name (slug)',
     )
     #role_id = django_filters.ModelMultipleChoiceFilter(
@@ -617,7 +616,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_site(self, queryset, name, value):
         try:
             device = Device.objects.select_related('site').get(**{name: value})
-            ordering = device.device_type.interface_ordering
+            ordering = device.site.interface_ordering
             return queryset.filter(device=device).order_naturally(ordering)
         except Device.DoesNotExist:
             return queryset.none()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -590,11 +590,11 @@ class InterfaceListFilter(django_filters.FilterSet):
         method='filter_role',
         label='Role (slug)',
     )
-    #rack_group_id = django_filters.ModelMultipleChoiceFilter(
-    #    name='rack__group',
-    #    method='_filter_rack_group',
-    #    label='Rack group (ID)',
-    #)
+    rack_group_id = NullableModelMultipleChoiceFilter(
+        name='device__rack__group',
+        queryset=RackGroup.objects.all(),
+        label='Rack Group(ID)',
+    )
     rack_id = NullableModelMultipleChoiceFilter(
         name='device__rack',
         queryset=Rack.objects.all(),

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -592,12 +592,11 @@ class InterfaceListFilter(django_filters.FilterSet):
     )
     #rack_group_id = django_filters.ModelMultipleChoiceFilter(
     #    name='rack__group',
-    #    method='filter_rack_group',
+    #    method='_filter_rack_group',
     #    label='Rack group (ID)',
     #)
     rack_id = NullableModelMultipleChoiceFilter(
-        name='device__rack',
-        method='filter_rack',
+        method='_filter_rack',
         label='Rack (ID)',
     )
     type = django_filters.CharFilter(

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -659,7 +659,7 @@ class InterfaceListFilter(django_filters.FilterSet):
         if not value.strip():
             return queryset
         return queryset.filter(
-            Q(mac_address__icontains=value) |
+            Q(mac_address__icontains=value)
         ).distinct()
 
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -622,14 +622,14 @@ class InterfaceListFilter(django_filters.FilterSet):
 
     def filter_site(self, queryset, name, value):
         try:
-            site = Site.objects.select_related('device_id').get(**{name: value})
+            site = Device.objects.select_related('device_id','site').get(**{name: value})
             return queryset
         except Device.DoesNotExist:
             return queryset.none()
     
     def filter_role(self, queryset, name, value):
         try:
-            site = DeviceRole.objects.select_related('device_id').get(**{name: value})
+            site = Device.objects.select_related('device_id','device_role').get(**{name: value})
             return queryset
         except Device.DoesNotExist:
             return queryset.none()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -590,16 +590,16 @@ class InterfaceListFilter(django_filters.FilterSet):
         method='filter_role',
         label='Role (slug)',
     )
-    #rack_group_id = django_filters.ModelMultipleChoiceFilter(
-    #    name='rack__group',
-    #    method='filter_rack_group',
-    #    label='Rack group (ID)',
-    #)
-    rack_id = NullableModelMultipleChoiceFilter(
-        name='rack',
-        method='filter_rack',
-        label='Rack (ID)',
+    rack_group_id = django_filters.ModelMultipleChoiceFilter(
+        name='rack__group',
+        method='filter_rack_group',
+        label='Rack group (ID)',
     )
+    #rack_id = NullableModelMultipleChoiceFilter(
+    #    name='rack',
+    #    method='filter_rack',
+    #    label='Rack (ID)',
+    #)
     type = django_filters.CharFilter(
         method='filter_type',
         label='Interface type',

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -596,7 +596,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     #    label='Rack group (ID)',
     #)
     rack_id = NullableModelMultipleChoiceFilter(
-        name='rack',
+        name='device__rack',
         method='filter_rack',
         label='Rack (ID)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -596,7 +596,8 @@ class InterfaceListFilter(django_filters.FilterSet):
     #    label='Rack group (ID)',
     #)
     rack_id = NullableModelMultipleChoiceFilter(
-        method='_filter_rack',
+        name='device__rack',
+        queryset=Rack.objects.all(),
         label='Rack (ID)',
     )
     type = django_filters.CharFilter(

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -623,16 +623,6 @@ class InterfaceListFilter(django_filters.FilterSet):
             return queryset
         return queryset.filter(device__device_role__slug=value)
 
-    def filter_rack(self, queryset, name, value):
-        if not value.strip():
-            return queryset
-        return queryset.filter(device__rack=value)
-
-    def filter_rack_group(self, queryset, name, value):
-        if not value.strip():
-            return queryset
-        return queryset.filter(device__rack__group__name=value)
-
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()
         return {

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -617,7 +617,7 @@ class InterfaceListFilter(django_filters.FilterSet):
 
     def filter_site(self, queryset, name, value):
         #try:
-        device = Device.objects.filter(name=value).distinct()
+        device = Device.objects.filter(**{name: value}).distinct()
         return queryset
         #except Device.DoesNotExist:
         #    return queryset.none()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -614,6 +614,10 @@ class InterfaceListFilter(django_filters.FilterSet):
         method='_mac_address',
         label='MAC address',
     )
+    description = django_filters.CharFilter(
+        method='filter_type',
+        label='Description',
+    )
 
     class Meta:
         model = Interface
@@ -650,10 +654,8 @@ class InterfaceListFilter(django_filters.FilterSet):
             return queryset
         return queryset.filter(
             Q(name__icontains=value) |
-            Q(serial__icontains=value.strip()) |
-            Q(inventory_items__serial__icontains=value.strip()) |
-            Q(asset_tag=value.strip()) |
-            Q(comments__icontains=value)
+            Q(device__icontains=value.strip()) |
+            Q(description__icontains=value)
         ).distinct()
 
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -582,12 +582,12 @@ class InterfaceListFilter(django_filters.FilterSet):
             label='Search',
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Site.objects.select_related('device_id__site','site_id'),
+        queryset=Device.objects.select_related('site'),
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
         name='site__slug',
-        queryset=Site.objects.select_related('device_id__site','site_id'),
+        queryset=Device.objects.select_related('site'),
         to_field_name='slug',
         label='Site name (slug)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -591,7 +591,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     #    name='device_role',
     #    label='Role (ID)',
     #)
-    role = django_filters.ModelMultipleChoiceFilter(
+    role = django_filters.CharFilter(
         method='filter_role',
         label='Role (slug)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -614,9 +614,9 @@ class InterfaceListFilter(django_filters.FilterSet):
         return queryset.filter(device__site__slug=value)
     
     def filter_role(self, queryset, name, value):
-       if not value.strip():
+        if not value.strip():
             return queryset
-    return queryset.filter(device_role__slug=value)
+        return queryset.filter(device_role__slug=value)
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -583,12 +583,12 @@ class InterfaceListFilter(django_filters.FilterSet):
             label='Search',
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Site.objects.all(),
+        queryset=Site.objects.select.related('site_id','device_id__site'),
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
         name='site__slug',
-        queryset=Site.objects.all(),
+        queryset=Site.objects.select_related('site_id','device_id__site'),
         to_field_name='slug',
         label='Site name (slug)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -582,12 +582,12 @@ class InterfaceListFilter(django_filters.FilterSet):
             label='Search',
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Site.objects.select_related('device_id','site'),
+        queryset=Site.objects.select_related('device_id__site','site_id'),
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
         name='site__slug',
-        queryset=Site.objects.select_related('device_id','site'),
+        queryset=Site.objects.select_related('device_id__site','site_id'),
         to_field_name='slug',
         label='Site name (slug)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -583,12 +583,12 @@ class InterfaceListFilter(django_filters.FilterSet):
             label='Search',
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Device.objects.select_related('site').all(),
+        queryset=Device.objects.all(),
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
         name='site',
-        queryset=Device.objects.select_related('site').all(),
+        queryset=Device.objects.all(),
         to_field_name='site',
         label='Site name (slug)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -592,7 +592,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     #    label='Role (ID)',
     #)
     role = django_filters.ModelMultipleChoiceFilter(
-        method='_filter_role',
+        method='filter_role',
         label='Role (slug)',
     )
     type = django_filters.CharFilter(

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -617,7 +617,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_site(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(interface__device__device__site__slug=value)
+        return queryset.filter(interfaces__device_id__device__site__slug=value)
     
     def filter_role(self, queryset, name, value):
         try:

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -582,11 +582,11 @@ class InterfaceListFilter(django_filters.FilterSet):
             method='search',
             label='Search',
     )
-    site_id = django_filters.ModelMultipleChoiceFilter(
-        name='site',
-        method='_filter_site',
-        label='Site (ID)',
-    )
+    #site_id = django_filters.ModelMultipleChoiceFilter(
+    #    name='site',
+    #    method='_filter_site',
+    #    label='Site (ID)',
+    #)
     site = django_filters.ModelMultipleChoiceFilter(
         name='site',
         method='_filter_site',

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -593,18 +593,22 @@ class InterfaceListFilter(django_filters.FilterSet):
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
         method='_filter_site',
+        name='site',
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
         method='_filter_site',
+        name='site',
         label='Site name (slug)',
     )
     role_id = django_filters.ModelMultipleChoiceFilter(
         method='_filter_role',
+        name='device_role',
         label='Role (ID)',
     )
     role = django_filters.ModelMultipleChoiceFilter(
         method='_filter_role',
+        name='device_role',
         label='Role (slug)',
     )
     type = django_filters.CharFilter(

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -582,15 +582,6 @@ class InterfaceListFilter(django_filters.FilterSet):
             method='search',
             label='Search',
     )
-    device = django_filters.CharFilter(
-        method='filter_device',
-        label='Device',
-    )
-    #site_id = django_filters.ModelMultipleChoiceFilter(
-    #    name='site',
-    #    method='_filter_site',
-    #    label='Site (ID)',
-    #)
     site = django_filters.CharFilter(
         method='filter_site',
         label='Site (slug)',
@@ -629,11 +620,6 @@ class InterfaceListFilter(django_filters.FilterSet):
             return queryset
         except Device.DoesNotExist:
             return queryset.none()
-
-    def filter_device(self, queryset, name, value):
-        if not value.strip():
-            return queryset
-        return queryset.filter(device__name__icontains=value)
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -591,16 +591,16 @@ class InterfaceListFilter(django_filters.FilterSet):
             method='search',
             label='Search',
     )
-    #site_id = django_filters.ModelMultipleChoiceFilter(
-    #    method='_filter_site',
-    #    name='site',
-    #    label='Site (ID)',
-    #)
-    #site = django_filters.ModelMultipleChoiceFilter(
-    #    method='_filter_site',
-    #    name='site',
-    #    label='Site name (slug)',
-    #)
+    site_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=Site.objects.all(),
+        label='Site (ID)',
+    )
+    site = django_filters.ModelMultipleChoiceFilter(
+        name='site__slug',
+        queryset=Site.objects.all(),
+        to_field_name='slug',
+        label='Site name (slug)',
+    )
     #role_id = django_filters.ModelMultipleChoiceFilter(
     #    method='_filter_role',
     #    name='device_role',

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -616,7 +616,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_role(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(device__device_role__slug=value)
+        return queryset.filter(device__device_role=value)
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -519,7 +519,8 @@ class PowerOutletFilter(DeviceComponentFilterSet):
 
 class InterfaceFilter(django_filters.FilterSet):
     """
-    
+    Not using DeviceComponentFilterSet for Interfaces because we need to glean the ordering logic from the parent
+    Device's DeviceType.
     """
     device = django_filters.CharFilter(
         method='filter_device',
@@ -580,6 +581,16 @@ class InterfaceListFilter(django_filters.FilterSet):
     q = django_filters.CharFilter(
             method='search',
             label='Search',
+    )
+    site_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=Site.objects.all(),
+        label='Site (ID)',
+    )
+    site = django_filters.ModelMultipleChoiceFilter(
+        name='site__slug',
+        queryset=Site.objects.all(),
+        to_field_name='slug',
+        label='Site name (slug)',
     )
     #site_id = django_filters.ModelMultipleChoiceFilter(
     #    queryset=Device.objects.select_related('site'),

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -589,7 +589,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     site = django_filters.ModelMultipleChoiceFilter(
         name='site__slug',
         queryset=Device.objects.select_related('site').all(),
-        to_field_name='slug',
+        to_field_name='site',
         label='Site name (slug)',
     )
     #site_id = django_filters.ModelMultipleChoiceFilter(

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -616,7 +616,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_role(self, queryset, name, value):
        if not value.strip():
             return queryset
-        return queryset.filter(device_role__slug=value)
+    return queryset.filter(device_role__slug=value)
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -611,14 +611,20 @@ class InterfaceListFilter(django_filters.FilterSet):
         to_field_name='slug',
         label='Site name (slug)',
     )
+    role_id = django_filters.ModelMultipleChoiceFilter(
+        name='device_role_id',
+        queryset=DeviceRole.objects.all(),
+        label='Role (ID)',
+    )
+    role = django_filters.ModelMultipleChoiceFilter(
+        name='device_role__slug',
+        queryset=DeviceRole.objects.all(),
+        to_field_name='slug',
+        label='Role (slug)',
+    )
     type = django_filters.CharFilter(
         method='filter_type',
         label='Interface type',
-    )
-    lag_id = django_filters.ModelMultipleChoiceFilter(
-        name='lag',
-        queryset=Interface.objects.all(),
-        label='LAG interface (ID)',
     )
     mac_address = django_filters.CharFilter(
         method='_mac_address',

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -582,6 +582,10 @@ class InterfaceListFilter(django_filters.FilterSet):
             method='search',
             label='Search',
     )
+    device = django_filters.CharFilter(
+        method='filter_device',
+        label='Device',
+    )
     #site_id = django_filters.ModelMultipleChoiceFilter(
     #    name='site',
     #    method='_filter_site',
@@ -617,7 +621,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_site(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(interfaces__device_id__device__site__slug=value)
+        return queryset.filter(device_id__device__site__slug=value)
     
     def filter_role(self, queryset, name, value):
         try:
@@ -625,6 +629,12 @@ class InterfaceListFilter(django_filters.FilterSet):
             return queryset
         except Device.DoesNotExist:
             return queryset.none()
+
+     def filter_device(self, queryset, name, value):
+        if not value.strip():
+            return queryset
+        return queryset.filter(device__name__icontains=value)
+        )
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -583,7 +583,7 @@ class InterfaceListFilter(django_filters.FilterSet):
             label='Search',
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
-        name='site'
+        name='site',
         method='_filter_site',
         label='Site (ID)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -634,7 +634,6 @@ class InterfaceListFilter(django_filters.FilterSet):
         if not value.strip():
             return queryset
         return queryset.filter(device__name__icontains=value)
-        )
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -583,12 +583,12 @@ class InterfaceListFilter(django_filters.FilterSet):
             label='Search',
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Device.objects.get('device_id__site'),
+        queryset=Device.objects.get(**{device_id__site: value}),
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
         name='site',
-        queryset=Device.objects.get('device_id__site'),
+        queryset=Device.objects.get(**{device_id__site: value}),
         to_field_name='site',
         label='Site name (slug)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -582,6 +582,11 @@ class InterfaceListFilter(django_filters.FilterSet):
             method='search',
             label='Search',
     )
+    device = django_filters.CharFilter(
+        method='filter_device',
+        name='name',
+        label='Device',
+    )
     site = django_filters.CharFilter(
         method='filter_site',
         label='Site (slug)',
@@ -612,6 +617,14 @@ class InterfaceListFilter(django_filters.FilterSet):
     class Meta:
         model = Interface
         fields = ['form_factor', 'enabled', 'mtu']
+
+    def filter_device(self, queryset, name, value):
+        try:
+            device = Device.objects.select_related('device_type').get(**{name: value})
+            ordering = device.device_type.interface_ordering
+            return queryset.filter(device=device).order_naturally(ordering)
+        except Device.DoesNotExist:
+            return queryset.none()
 
     def filter_site(self, queryset, name, value):
         if not value.strip():

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -624,14 +624,10 @@ class InterfaceListFilter(django_filters.FilterSet):
         method='_mac_address',
         label='MAC address',
     )
-    description = django_filters.CharFilter(
-        method='filter_type',
-        label='Description',
-    )
 
     class Meta:
         model = Interface
-        fields = ['name', 'form_factor', 'enabled', 'mtu', 'mgmt_only']
+        fields = ['form_factor', 'enabled', 'mtu']
 
     def filter_device(self, queryset, name, value):
         try:
@@ -665,6 +661,7 @@ class InterfaceListFilter(django_filters.FilterSet):
         return queryset.filter(
             Q(device__icontains=value.strip()) |
             Q(name__icontains=value.strip()) |
+            Q(mac_address__icontains=value.strip()) |
             Q(description__icontains=value.strip())
         ).distinct()
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -591,26 +591,26 @@ class InterfaceListFilter(django_filters.FilterSet):
             method='search',
             label='Search',
     )
-    site_id = django_filters.ModelMultipleChoiceFilter(
-        method='_filter_site',
-        name='site',
-        label='Site (ID)',
-    )
-    site = django_filters.ModelMultipleChoiceFilter(
-        method='_filter_site',
-        name='site',
-        label='Site name (slug)',
-    )
-    role_id = django_filters.ModelMultipleChoiceFilter(
-        method='_filter_role',
-        name='device_role',
-        label='Role (ID)',
-    )
-    role = django_filters.ModelMultipleChoiceFilter(
-        method='_filter_role',
-        name='device_role',
-        label='Role (slug)',
-    )
+    #site_id = django_filters.ModelMultipleChoiceFilter(
+    #    method='_filter_site',
+    #    name='site',
+    #    label='Site (ID)',
+    #)
+    #site = django_filters.ModelMultipleChoiceFilter(
+    #    method='_filter_site',
+    #    name='site',
+    #    label='Site name (slug)',
+    #)
+    #role_id = django_filters.ModelMultipleChoiceFilter(
+    #    method='_filter_role',
+    #    name='device_role',
+    #    label='Role (ID)',
+    #)
+    #role = django_filters.ModelMultipleChoiceFilter(
+    #    method='_filter_role',
+    #    name='device_role',
+    #    label='Role (slug)',
+    #)
     type = django_filters.CharFilter(
         method='filter_type',
         label='Interface type',

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -630,7 +630,7 @@ class InterfaceListFilter(django_filters.FilterSet):
         except Device.DoesNotExist:
             return queryset.none()
 
-     def filter_device(self, queryset, name, value):
+    def filter_device(self, queryset, name, value):
         if not value.strip():
             return queryset
         return queryset.filter(device__name__icontains=value)

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -581,15 +581,15 @@ class InterfaceListFilter(django_filters.FilterSet):
             method='search',
             label='Search',
     )
-    site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Device.objects.select_related('site'),
-        label='Site (ID)',
-    )
-    site = django_filters.ModelMultipleChoiceFilter(
-        name='site',
-        method='_filter_site',
-        label='Site name (slug)',
-    )
+    #site_id = django_filters.ModelMultipleChoiceFilter(
+    #    queryset=Device.objects.select_related('site'),
+    #    label='Site (ID)',
+    #)
+    #site = django_filters.ModelMultipleChoiceFilter(
+    #    name='site',
+    #    method='_filter_site',
+    #    label='Site name (slug)',
+    #)
     #role_id = django_filters.ModelMultipleChoiceFilter(
     #    method='_filter_role',
     #    name='device_role',

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -583,12 +583,12 @@ class InterfaceListFilter(django_filters.FilterSet):
             label='Search',
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Site.objects.select_related('site_id','device_id__site').all(),
+        queryset=Device.objects.select_related('site_id','device_id__site').all(),
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
         name='site__slug',
-        queryset=Site.objects.select_related('site_id','device_id__site').all(),
+        queryset=Device.objects.select_related('site_id','device_id__site').all(),
         to_field_name='slug',
         label='Site name (slug)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -583,12 +583,12 @@ class InterfaceListFilter(django_filters.FilterSet):
             label='Search',
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Device.objects.select_related('site','device_id__site').all(),
+        queryset=Device.objects.select_related('site').all(),
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
         name='site__slug',
-        queryset=Device.objects.select_related('site','device_id__site').all(),
+        queryset=Device.objects.select_related('site').all(),
         to_field_name='slug',
         label='Site name (slug)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -583,7 +583,7 @@ class InterfaceListFilter(django_filters.FilterSet):
             label='Search',
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Site.objects.select.related('site_id','device_id__site').all(),
+        queryset=Site.objects.select_related('site_id','device_id__site').all(),
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -616,11 +616,11 @@ class InterfaceListFilter(django_filters.FilterSet):
         fields = ['form_factor', 'enabled', 'mtu']
 
     def filter_site(self, queryset, name, value):
-        try:
-            device = Device.objects.filter(name=value).distinct()
-            return queryset
-        except Device.DoesNotExist:
-            return queryset.none()
+        #try:
+        device = Device.objects.filter(name=value).distinct()
+        return queryset
+        #except Device.DoesNotExist:
+        #    return queryset.none()
     
     def filter_role(self, queryset, name, value):
         try:

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -659,9 +659,7 @@ class InterfaceListFilter(django_filters.FilterSet):
         if not value.strip():
             return queryset
         return queryset.filter(
-            Q(device__icontains=value.strip()) |
-            Q(name__icontains=value.strip()) |
-            Q(mac_address__icontains=value)
+            Q(mac_address__icontains=value) |
         ).distinct()
 
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -587,7 +587,7 @@ class InterfaceListFilter(django_filters.FilterSet):
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
-        name='site__slug',
+        name='site',
         queryset=Device.objects.select_related('site').all(),
         to_field_name='site',
         label='Site name (slug)',

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -535,16 +535,6 @@ class InterfaceFilter(django_filters.FilterSet):
         method='filter_type',
         label='Interface type',
     )
-    site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Site.objects.all(),
-        label='Site (ID)',
-    )
-    site = django_filters.ModelMultipleChoiceFilter(
-        name='site__slug',
-        queryset=Site.objects.all(),
-        to_field_name='slug',
-        label='Site name (slug)',
-    )
     lag_id = django_filters.ModelMultipleChoiceFilter(
         name='lag',
         queryset=Interface.objects.all(),
@@ -592,12 +582,12 @@ class InterfaceListFilter(django_filters.FilterSet):
             label='Search',
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Site.objects.all(),
+        queryset=Site.objects.select_related('device_id','site'),
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
         name='site__slug',
-        queryset=Site.objects.all(),
+        queryset=Site.objects.select_related('device_id','site'),
         to_field_name='slug',
         label='Site name (slug)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -616,7 +616,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_role(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(device__device_role__name=value)
+        return queryset.filter(device__device_role__name__slug=value)
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -583,12 +583,12 @@ class InterfaceListFilter(django_filters.FilterSet):
             label='Search',
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Site.objects.select.related('site_id','device_id__site'),
+        queryset=Site.objects.select.related('site_id','device_id__site').all(),
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
         name='site__slug',
-        queryset=Site.objects.select_related('site_id','device_id__site'),
+        queryset=Site.objects.select_related('site_id','device_id__site').all(),
         to_field_name='slug',
         label='Site name (slug)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -617,7 +617,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_site(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(device_id__device__site__slug=value)
+        return queryset.filter(device__device__site__slug=value)
     
     def filter_role(self, queryset, name, value):
         try:

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -582,15 +582,16 @@ class InterfaceListFilter(django_filters.FilterSet):
             method='search',
             label='Search',
     )
-    #site_id = django_filters.ModelMultipleChoiceFilter(
-    #    queryset=Device.objects.select_related('site'),
-    #    label='Site (ID)',
-    #)
-    #site = django_filters.ModelMultipleChoiceFilter(
-    #    name='site',
-    #    method='_filter_site',
-    #    label='Site name (slug)',
-    #)
+    site_id = django_filters.ModelMultipleChoiceFilter(
+        name='site'
+        method='_filter_site',
+        label='Site (ID)',
+    )
+    site = django_filters.ModelMultipleChoiceFilter(
+        name='site',
+        method='_filter_site',
+        label='Site name (slug)',
+    )
     #role_id = django_filters.ModelMultipleChoiceFilter(
     #    method='_filter_role',
     #    name='device_role',
@@ -616,17 +617,15 @@ class InterfaceListFilter(django_filters.FilterSet):
 
     def filter_site(self, queryset, name, value):
         try:
-            device = Device.objects.select_related('site').get(**{name: value})
-            ordering = device.site.interface_ordering
-            return queryset.filter(site=site).order_naturally(ordering)
+            device = Device.objects.filter(name=value).distinct()
+            return queryset
         except Device.DoesNotExist:
             return queryset.none()
     
     def filter_role(self, queryset, name, value):
         try:
-            device = Device.objects.select_related('device_role').get(**{name: value})
-            ordering = device.device_type.interface_ordering
-            return queryset.filter(device=device).order_naturally(ordering)
+            device = Device.objects.filter(name=value).distinct()
+            return queryset
         except Device.DoesNotExist:
             return queryset.none()
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -622,14 +622,14 @@ class InterfaceListFilter(django_filters.FilterSet):
 
     def filter_site(self, queryset, name, value):
         try:
-            site = Site.objects.select_related('device_id__site').get(**{name: value})
+            site = Site.objects.select_related('device_id').get(**{name: value})
             return queryset
         except Device.DoesNotExist:
             return queryset.none()
     
     def filter_role(self, queryset, name, value):
         try:
-            site = DeviceRole.objects.select_related('device_id__device_role').get(**{name: value})
+            site = DeviceRole.objects.select_related('device_id').get(**{name: value})
             return queryset
         except Device.DoesNotExist:
             return queryset.none()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -655,7 +655,7 @@ class InterfaceListFilter(django_filters.FilterSet):
         if not value:
             return queryset
         try:
-            return queryset.filter(interfaces__mac_address=value).distinct()
+            return queryset.filter(mac_address=value)
         except AddrFormatError:
             return queryset.none()
 
@@ -663,7 +663,7 @@ class InterfaceListFilter(django_filters.FilterSet):
         if not value.strip():
             return queryset
         return queryset.filter(
-            Q(device__icontains=value) |
+            Q(device_id__icontains=value) |
             Q(description__icontains=value)
         ).distinct()
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -663,7 +663,6 @@ class InterfaceListFilter(django_filters.FilterSet):
         if not value.strip():
             return queryset
         return queryset.filter(
-            Q(name__icontains=value) |
             Q(device__icontains=value) |
             Q(description__icontains=value)
         ).distinct()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -662,7 +662,7 @@ class InterfaceListFilter(django_filters.FilterSet):
             Q(device__icontains=value.strip()) |
             Q(name__icontains=value.strip()) |
             Q(mac_address__icontains=value.strip()) |
-            Q(description__icontains=value.strip())
+            Q(description__icontains=value)
         ).distinct()
 
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -659,6 +659,7 @@ class InterfaceListFilter(django_filters.FilterSet):
         if not value.strip():
             return queryset
         return queryset.filter(
+            Q(device__icontains=value.strip()) |
             Q(mac_address__icontains=value)
         ).distinct()
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -591,16 +591,6 @@ class InterfaceListFilter(django_filters.FilterSet):
             method='search',
             label='Search',
     )
-    device_id = django_filters.NumberFilter(
-        method='filter_device',
-        name='pk',
-        label='Device (ID)',
-    )
-    device = django_filters.CharFilter(
-        method='filter_device',
-        name='name',
-        label='Device',
-    )
     site_id = django_filters.ModelMultipleChoiceFilter(
         queryset=Site.objects.all(),
         label='Site (ID)',
@@ -634,14 +624,6 @@ class InterfaceListFilter(django_filters.FilterSet):
     class Meta:
         model = Interface
         fields = ['form_factor', 'enabled', 'mtu']
-
-    def filter_device(self, queryset, name, value):
-        try:
-            device = Device.objects.select_related('device_type').get(**{name: value})
-            ordering = device.device_type.interface_ordering
-            return queryset.filter(device=device).order_naturally(ordering)
-        except Device.DoesNotExist:
-            return queryset.none()
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -661,8 +661,7 @@ class InterfaceListFilter(django_filters.FilterSet):
         return queryset.filter(
             Q(device__icontains=value.strip()) |
             Q(name__icontains=value.strip()) |
-            Q(mac_address__icontains=value.strip()) |
-            Q(description__icontains=value)
+            Q(mac_address__icontains=value)
         ).distinct()
 
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -617,7 +617,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_site(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(device__device__site__slug=value)
+        return queryset.filter(interface__device__device__site__slug=value)
     
     def filter_role(self, queryset, name, value):
         try:

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -587,10 +587,9 @@ class InterfaceListFilter(django_filters.FilterSet):
     #    method='_filter_site',
     #    label='Site (ID)',
     #)
-    site = django_filters.ModelMultipleChoiceFilter(
-        name='site',
-        method='_filter_site',
-        label='Site name (slug)',
+    site = django_filters.CharFilter(
+        method='filter_site',
+        label='Site (slug)',
     )
     #role_id = django_filters.ModelMultipleChoiceFilter(
     #    method='_filter_role',

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -582,16 +582,6 @@ class InterfaceListFilter(django_filters.FilterSet):
             method='search',
             label='Search',
     )
-    site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Device.objects.get(**{device_id__site: value}),
-        label='Site (ID)',
-    )
-    site = django_filters.ModelMultipleChoiceFilter(
-        name='site',
-        queryset=Device.objects.get(**{device_id__site: value}),
-        to_field_name='site',
-        label='Site name (slug)',
-    )
     #site_id = django_filters.ModelMultipleChoiceFilter(
     #    queryset=Device.objects.select_related('site'),
     #    label='Site (ID)',

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -591,11 +591,10 @@ class InterfaceListFilter(django_filters.FilterSet):
     #    name='device_role',
     #    label='Role (ID)',
     #)
-    #role = django_filters.ModelMultipleChoiceFilter(
-    #    method='_filter_role',
-    #    name='device_role',
-    #    label='Role (slug)',
-    #)
+    role = django_filters.ModelMultipleChoiceFilter(
+        method='_filter_role',
+        label='Role (slug)',
+    )
     type = django_filters.CharFilter(
         method='filter_type',
         label='Interface type',
@@ -615,11 +614,9 @@ class InterfaceListFilter(django_filters.FilterSet):
         return queryset.filter(device__site__slug=value)
     
     def filter_role(self, queryset, name, value):
-        try:
-            device = Device.objects.filter(name=value).distinct()
+       if not value.strip():
             return queryset
-        except Device.DoesNotExist:
-            return queryset.none()
+        return queryset.filter(device_role__slug=value)
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -663,9 +663,9 @@ class InterfaceListFilter(django_filters.FilterSet):
         if not value.strip():
             return queryset
         return queryset.filter(
-            Q(device_id__icontains=value)
-            # |
-            #Q(description__icontains=value)
+            Q(device__icontains=value.strip()) |
+            Q(name__icontains=value.strip()) |
+            Q(description__icontains=value.strip())
         ).distinct()
 
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -622,17 +622,17 @@ class InterfaceListFilter(django_filters.FilterSet):
 
     def filter_site(self, queryset, name, value):
         try:
-            site = Device.objects.select_related('device_id','site').get(**{name: value})
-            ordering = device.site.interface_ordering
-            return queryset.filter(device=device_id).order_naturally(ordering)
+           device = Device.objects.select_related('site').get(**{name: value})
+            ordering = device.device_type.interface_ordering
+            return queryset.filter(device=device).order_naturally(ordering)
         except Device.DoesNotExist:
             return queryset.none()
     
     def filter_role(self, queryset, name, value):
         try:
-            site = Device.objects.select_related('device_id','device_role').get(**{name: value})
-            ordering = device.device_role.interface_ordering
-            return queryset.filter(device=device_id).order_naturally(ordering)
+            device = Device.objects.select_related('device_role').get(**{name: value})
+            ordering = device.device_type.interface_ordering
+            return queryset.filter(device=device).order_naturally(ordering)
         except Device.DoesNotExist:
             return queryset.none()
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -583,12 +583,12 @@ class InterfaceListFilter(django_filters.FilterSet):
             label='Search',
     )
     site_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=Device.objects.select_related('site_id','device_id__site').all(),
+        queryset=Device.objects.select_related('site','device_id__site').all(),
         label='Site (ID)',
     )
     site = django_filters.ModelMultipleChoiceFilter(
         name='site__slug',
-        queryset=Device.objects.select_related('site_id','device_id__site').all(),
+        queryset=Device.objects.select_related('site','device_id__site').all(),
         to_field_name='slug',
         label='Site name (slug)',
     )

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -616,11 +616,9 @@ class InterfaceListFilter(django_filters.FilterSet):
         fields = ['form_factor', 'enabled', 'mtu']
 
     def filter_site(self, queryset, name, value):
-        #try:
-        device = Device.objects.filter(**{name: value}).distinct()
-        return queryset
-        #except Device.DoesNotExist:
-        #    return queryset.none()
+        if not value.strip():
+            return queryset
+        return queryset.filter(device_id__device__site__slug=value)
     
     def filter_role(self, queryset, name, value):
         try:

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -655,7 +655,7 @@ class InterfaceListFilter(django_filters.FilterSet):
         if not value:
             return queryset
         try:
-            return queryset.filter(mac_address=value)
+            return queryset.filter(mac_address__icontains=value)
         except AddrFormatError:
             return queryset.none()
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -653,6 +653,7 @@ class InterfaceListFilter(django_filters.FilterSet):
             return queryset
         return queryset.filter(
             Q(device__name__icontains=value.strip()) |
+            Q(name__icontains=value.strip()) |
             Q(description__icontains=value.strip()) |
             Q(mac_address__icontains=value.strip())
         ).distinct()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -616,7 +616,7 @@ class InterfaceListFilter(django_filters.FilterSet):
     def filter_role(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(device__device_role=value)
+        return queryset.filter(device__device_role__name=value)
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -622,7 +622,7 @@ class InterfaceListFilter(django_filters.FilterSet):
 
     def filter_site(self, queryset, name, value):
         try:
-           device = Device.objects.select_related('site').get(**{name: value})
+            device = Device.objects.select_related('site').get(**{name: value})
             ordering = device.device_type.interface_ordering
             return queryset.filter(device=device).order_naturally(ordering)
         except Device.DoesNotExist:

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -664,7 +664,7 @@ class InterfaceListFilter(django_filters.FilterSet):
             return queryset
         return queryset.filter(
             Q(name__icontains=value) |
-            Q(device__icontains=value.strip()) |
+            Q(device__icontains=value) |
             Q(description__icontains=value)
         ).distinct()
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -663,8 +663,9 @@ class InterfaceListFilter(django_filters.FilterSet):
         if not value.strip():
             return queryset
         return queryset.filter(
-            Q(device_id__icontains=value) |
-            Q(description__icontains=value)
+            Q(device_id__icontains=value)
+            # |
+            #Q(description__icontains=value)
         ).distinct()
 
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -601,6 +601,16 @@ class InterfaceListFilter(django_filters.FilterSet):
         name='name',
         label='Device',
     )
+    site_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=Site.objects.all(),
+        label='Site (ID)',
+    )
+    site = django_filters.ModelMultipleChoiceFilter(
+        name='site__slug',
+        queryset=Site.objects.all(),
+        to_field_name='slug',
+        label='Site name (slug)',
+    )
     type = django_filters.CharFilter(
         method='filter_type',
         label='Interface type',

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1607,7 +1607,7 @@ class InterfaceCSVForm(forms.ModelForm):
                 device=device_id, form_factor=IFACE_FF_LAG).get(
                 lag=lag_name.id
             )
-        if lag is not None:
+        if not lag_name:
             return None
         return lag
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1623,7 +1623,8 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     rack_group_id = FilterChoiceField(
         required=False,
         queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
-        label='Rack group'
+        label='Rack group',
+        empty_label='None'
     )
     rack_id = FilterChoiceField(
         required=False,

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1621,13 +1621,15 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
     rack_group_id = FilterChoiceField(
+        required=False,
         queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
-        label='Rack group',
+        label='Rack group'
     )
     rack_id = FilterChoiceField(
+        required=False,
         queryset=Rack.objects.annotate(filter_count=Count('devices')),
         label='Rack',
-        null_option=(0, 'None'),
+        null_option=(0, 'None')
     )
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1598,9 +1598,9 @@ class InterfaceCSVForm(forms.ModelForm):
 
     def clean_lag(self):
         device = None
-        if self.fields['device'] is not None:
+        if self.cleaned_data['device'] is not None:
             lag = Interface.objects.filter(
-                device=self.fields['device'], form_factor=IFACE_FF_LAG).get(
+                device=self.cleaned_data['device'], form_factor=IFACE_FF_LAG).get(
                 lag=self.cleaned_data['lag'], name=lag
             )
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1549,7 +1549,7 @@ class InterfaceCSVForm(forms.ModelForm):
         required=False,
         help_text='MAC address of interface'
     )
-    form_factor = forms.CharField(
+    form_factor = forms.IntegerField(
         required=False,
         help_text='Interface Form Factor'
     )
@@ -1557,11 +1557,11 @@ class InterfaceCSVForm(forms.ModelForm):
         required=False,
         help_text='Description for interface'
     )
-    enabled = forms.NullBooleanField(
+    enabled = forms.BooleanField(
         required=False,
         help_text='Enabled/Disabled'
     )
-    mtu = forms.CharField(
+    mtu = forms.IntegerField(
         required=False,
         help_text='MTU'
     )
@@ -1569,15 +1569,15 @@ class InterfaceCSVForm(forms.ModelForm):
         required=False,
         help_text='Management Only'
     )
-    is_virtual = forms.NullBooleanField(
+    is_virtual = forms.BooleanField(
         required=False,
         help_text='Is Virtual?'
     )
-    is_wireless = forms.NullBooleanField(
+    is_wireless = forms.BooleanField(
         required=False,
         help_text='Is Wireless?'
     )
-    is_lag = forms.NullBooleanField(
+    is_lag = forms.BooleanField(
         required=False,
         help_text='Is Lag?'
     )

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1621,11 +1621,11 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
-    #role = FilterChoiceField(
-    #    required=False,
-    #    queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
-    #    to_field_name='slug'
-    #)
+    role = FilterChoiceField(
+        required=False,
+        queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
+        to_field_name='slug'
+    )
 
 
 #

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1622,7 +1622,7 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
     site = FilterChoiceField(
         queryset=Site.objects.annotate(filter_count=Count('devices')),
-        to_field_name='slug',
+        to_field_name='slug'
     )
     #device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
     device = forms.CharField(required=False, label='Device name')

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1623,14 +1623,12 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     rack_group_id = forms.ModelChoiceField(
         required=False,
         queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
-        label='Rack group',
-        null_option=(0, 'None')
+        label='Rack group'
     )
     rack_id = forms.ModelChoiceField(
         required=False,
         queryset=Rack.objects.annotate(filter_count=Count('devices')),
-        label='Rack',
-        null_option=(0, 'None')
+        label='Rack'
     )
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1573,7 +1573,7 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
-    device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
+    #device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
     #enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     #role = FilterChoiceField(
     #    queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1543,7 +1543,7 @@ class InterfaceCSVForm(forms.ModelForm):
     )
     lag = FlexibleModelChoiceField(
         queryset=Interface.objects.filter(form_factor=IFACE_FF_LAG),
-        to_field_name='lag',
+        to_field_name='name',
         required=False,
         help_text='Lag Name or ID of interface',
         error_messages={'invalid_choice': 'Lag not found.'}
@@ -1600,11 +1600,11 @@ class InterfaceCSVForm(forms.ModelForm):
 
 
     def clean_lag(self):
-        device = None
-        lag_name = self.data.get('lag')
-        if self.data['device'] is not None and lag_name is not None:
+        device_id = self.cleaned_data.get('device')
+        lag_name = self.cleaned_data.get('lag')
+        if device_id is not None and lag_name is not None:
             lag = Interface.objects.filter(
-                device=self.data.get('device'), form_factor=IFACE_FF_LAG).get(
+                device=device_id, form_factor=IFACE_FF_LAG).get(
                 lag=lag_name.id
             )
         if not lag:

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1543,7 +1543,7 @@ class InterfaceCSVForm(forms.ModelForm):
     )
     lag = FlexibleModelChoiceField(
         required=False,
-        queryset = Interface.objects.order_naturally().filter(form_factor=IFACE_FF_LAG)
+        queryset = Interface.objects.order_naturally().filter(form_factor=IFACE_FF_LAG),
         help_text='Lag Name',
         error_messages={'invalid_choice': 'Lag not found.'}
     )

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1597,18 +1597,13 @@ class InterfaceCSVForm(forms.ModelForm):
 
 
     def clean_lag(self):
-        try:
-            if device is not None:
-                interface_ordering = device.device_type.interface_ordering
-                lag = Interface.objects.order_naturally(method=interface_ordering).filter(
-                    device=device, form_factor=IFACE_FF_LAG).get(
-                    lag=self.cleaned_data['lag'], name=lag
-                )
-                self.fields['lag'].queryset = Interface.objects.order_naturally(method=interface_ordering).filter(
-                    device=device, form_factor=IFACE_FF_LAG
-                )
-        except:
-            return None
+        if device is not None:
+            interface_ordering = device.device_type.interface_ordering
+            lag = Interface.objects.order_naturally(method=interface_ordering).filter(
+                device=device, form_factor=IFACE_FF_LAG).get(
+                lag=self.cleaned_data['lag'], name=lag
+            )
+
 
         if not lag:
             return None

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1574,12 +1574,12 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
     device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
-    enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
+    #enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     #role = FilterChoiceField(
     #    queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
     #    to_field_name='slug',
     #)
-    mac_address = forms.CharField(required=False, label='MAC address')
+    #mac_address = forms.CharField(required=False, label='MAC address')
 
 
 #

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1543,7 +1543,7 @@ class InterfaceCSVForm(forms.ModelForm):
     )
     lag = FlexibleModelChoiceField(
         queryset=Interface.objects.filter(form_factor=IFACE_FF_LAG),
-        to_field_name='name',
+        to_field_name='lag',
         required=False,
         help_text='Lag Name or ID of interface',
         error_messages={'invalid_choice': 'Lag not found.'}

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1696,6 +1696,41 @@ class InterfaceConnectionCSVForm(forms.ModelForm):
         return interface
 
 
+class InterfaceCSVForm(forms.ModelForm):
+    device = FlexibleModelChoiceField(
+        queryset=Device.objects.all(),
+        to_field_name='name',
+        help_text='Name or ID of device',
+        error_messages={'invalid_choice': 'Device not found.'}
+    )
+    name = forms.CharField(
+        help_text='Name of interface'
+    )
+    mac_address = forms.CharField(
+        required=False,
+        help_text='MAC address of interface'
+    )
+    description = forms.CharField(
+        required=False,
+        help_text='Description for interface'
+    )
+    
+    class Meta:
+        model = Interface
+        fields = [
+            'device', 'name', 'mac_address', 'description'
+        ]
+
+
+    def clean_interface(self):
+
+        interface_name = self.cleaned_data.get('interface_name')
+        if not interface:
+            return None
+        
+        return interface
+
+
 class InterfaceConnectionDeletionForm(ConfirmationForm):
     # Used for HTTP redirect upon successful deletion
     device = forms.ModelChoiceField(queryset=Device.objects.all(), widget=forms.HiddenInput(), required=False)

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1543,7 +1543,7 @@ class InterfaceCSVForm(forms.ModelForm):
     )
     lag = FlexibleModelChoiceField(
         required=False,
-        queryset = Interface.objects.order_naturally().filter(device=device,form_factor=IFACE_FF_LAG),
+        queryset = Interface.objects.order_naturally().filter(form_factor=IFACE_FF_LAG),
         help_text='Lag Name',
         error_messages={'invalid_choice': 'Lag not found.'}
     )
@@ -1559,7 +1559,7 @@ class InterfaceCSVForm(forms.ModelForm):
         required=False,
         help_text='Description for interface'
     )
-    enabled = forms.CharField(
+    enabled = forms.BooleanField(
         required=False,
         help_text='Enabled/Disabled'
     )
@@ -1571,15 +1571,15 @@ class InterfaceCSVForm(forms.ModelForm):
         required=False,
         help_text='Management Only'
     )
-    is_virtual = forms.CharField(
+    is_virtual = forms.BooleanField(
         required=False,
         help_text='Is Virtual?'
     )
-    is_wireless = forms.CharField(
+    is_wireless = forms.BooleanField(
         required=False,
         help_text='Is Wireless?'
     )
-    is_lag = forms.CharField(
+    is_lag = forms.BooleanField(
         required=False,
         help_text='Is Lag?'
     )

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1605,7 +1605,7 @@ class InterfaceCSVForm(forms.ModelForm):
         if device_id is not None and lag_name is not None:
             lag = Interface.objects.filter(
                 device=device_id, form_factor=IFACE_FF_LAG).get(
-                lag=lag_name.id
+                lag=lag_name
             )
         if not lag_name:
             return None

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1623,8 +1623,9 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     device = forms.CharField(required=False, label='Device name')
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(
+        required=False,
         queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
-        to_field_name='slug',
+        to_field_name='slug'
     )
     mac_address = forms.CharField(required=False, label='MAC address')
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1620,7 +1620,7 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
-    rack_group_id = forms.FilterChoiceFieldField(
+    rack_group_id = FilterChoiceFieldField(
         required=False,
         queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
         label='Rack group',

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1602,10 +1602,10 @@ class InterfaceCSVForm(forms.ModelForm):
     def clean_lag(self):
         device = None
         lag_name = self.data.get('lag')
-        if self.data['device'] is not None:
+        if self.data['device'] is not None and lag_name is not None:
             lag = Interface.objects.filter(
                 device=self.data.get('device'), form_factor=IFACE_FF_LAG).get(
-                lag=lag_name
+                lag=lag_name.id
             )
         if not lag:
             return None

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1620,17 +1620,17 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
-    #rack_group_id = forms.FilterChoiceFieldField(
-    #    required=False,
-    #    queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
-    #    label='Rack group'
-    #)
+    rack_group_id = forms.FilterChoiceFieldField(
+        required=False,
+        queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
+        label='Rack group',
+        null_option=(None, 'None')
+    )
     rack_id = FilterChoiceField(
         required=False,
         queryset=Rack.objects.annotate(filter_count=Count('devices')),
         label='Rack',
-        null_option=(None, 'None'),
-        empty_label='--------'
+        null_option=(None, 'None')
     )
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1625,7 +1625,7 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     #    queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
     #    label='Rack group'
     #)
-    rack_id = forms.FilterChoiceField(
+    rack_id = FilterChoiceField(
         required=False,
         queryset=Rack.objects.annotate(filter_count=Count('devices')),
         label='Rack',

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1574,11 +1574,11 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
     device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
-    #enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
-    role = FilterChoiceField(
-        queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
-        to_field_name='slug',
-    )
+    enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
+    #role = FilterChoiceField(
+    #    queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
+    #    to_field_name='slug',
+    #)
     mac_address = forms.CharField(required=False, label='MAC address')
 
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1605,7 +1605,7 @@ class InterfaceCSVForm(forms.ModelForm):
         if device_id is not None and lag_name is not None:
             lag = Interface.objects.filter(
                 device=device_id, form_factor=IFACE_FF_LAG).get(
-                lag=lag_name
+                name=lag_name
             )
         if not lag_name:
             return None

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1544,6 +1544,7 @@ class InterfaceCSVForm(forms.ModelForm):
     lag = FlexibleModelChoiceField(
         queryset=Interface.objects.filter(form_factor=IFACE_FF_LAG),
         to_field_name='name',
+        required=False,
         help_text='Lag Name or ID of interface',
         error_messages={'invalid_choice': 'Lag not found.'}
     )

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1629,7 +1629,8 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
         required=False,
         queryset=Rack.objects.annotate(filter_count=Count('devices')),
         label='Rack',
-        null_option=(None, 'None')
+        null_option=(None, 'None'),
+        empty_label='--------'
     )
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1597,10 +1597,10 @@ class InterfaceCSVForm(forms.ModelForm):
 
 
     def clean_lag(self):
-        if device is not None:
-            interface_ordering = device.device_type.interface_ordering
+        if self.device is not None:
+            interface_ordering = self.device.device_type.interface_ordering
             lag = Interface.objects.order_naturally(method=interface_ordering).filter(
-                device=device, form_factor=IFACE_FF_LAG).get(
+                device=self.device, form_factor=IFACE_FF_LAG).get(
                 lag=self.cleaned_data['lag'], name=lag
             )
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1620,15 +1620,14 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     model = Interface
     q = forms.CharField(required=False, label='Search')
-    site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
-    #site = FilterChoiceField(
-    #    queryset=Site.objects.annotate(filter_count=Count('devices')),
-    #    to_field_name='slug'
-    #)
+    site = FilterChoiceField(
+        queryset=Site.objects.annotate(filter_count=Count('member_interfaces')),
+        to_field_name='slug'
+    )
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(
         required=False,
-        queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
+        queryset=DeviceRole.objects.annotate(filter_count=Count('member_interfaces')),
         to_field_name='slug'
     )
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1620,13 +1620,13 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
-    rack_group_id = FilterChoiceField(
+    rack_group_id = ModelChoiceField(
         required=False,
         queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
         label='Rack group',
         null_option=(0, 'None')
     )
-    rack_id = FilterChoiceField(
+    rack_id = ModelChoiceField(
         required=False,
         queryset=Rack.objects.annotate(filter_count=Count('devices')),
         label='Rack',

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1574,7 +1574,7 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
     device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
-    enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
+    #enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(
         queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
         to_field_name='slug',

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1541,9 +1541,11 @@ class InterfaceCSVForm(forms.ModelForm):
     name = forms.CharField(
         help_text='Name of interface'
     )
-    lag = forms.CharField(
+    lag = FlexibleModelChoiceField(
         required=False,
-        help_text='Lag Name'
+        queryset = Interface.objects.order_naturally().filter(form_factor=IFACE_FF_LAG)
+        help_text='Lag Name',
+        error_messages={'invalid_choice': 'Lag not found.'}
     )
     mac_address = forms.CharField(
         required=False,

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -21,7 +21,7 @@ from .formfields import MACAddressFormField
 from .models import (
     DeviceBay, DeviceBayTemplate, CONNECTION_STATUS_CHOICES, CONNECTION_STATUS_CONNECTED, ConsolePort,
     ConsolePortTemplate, ConsoleServerPort, ConsoleServerPortTemplate, Device, DeviceRole, DeviceType, Interface,
-    IFACE_FF_CHOICES, IFACE_FF_LAG, IFACE_ORDERING_CHOICES, InterfaceConnection, InterfaceTemplate, Manufacturer,
+    IFACE_FF_CHOICES, IFACE_FF_LAG, IFACE_ENABLED_CHOICES, IFACE_ORDERING_CHOICES, InterfaceConnection, InterfaceTemplate, Manufacturer,
     InventoryItem, Platform, PowerOutlet, PowerOutletTemplate, PowerPort, PowerPortTemplate, RACK_FACE_CHOICES,
     RACK_TYPE_CHOICES, RACK_WIDTH_CHOICES, Rack, RackGroup, RackReservation, RackRole, RACK_WIDTH_19IN, RACK_WIDTH_23IN,
     Region, Site, STATUS_CHOICES, SUBDEVICE_ROLE_CHILD, SUBDEVICE_ROLE_PARENT,

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1571,6 +1571,17 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
     device = forms.CharField(required=False, label='Device name')
 
 
+class InterfaceListFilterForm(BootstrapMixin, forms.Form):
+    site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
+    device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
+    enabled = form.ModelChoiceField(choices=((INTERFACE_ENABLED,'Enabled'),(INTERFACE_DISABLED,'Disabled')),required=False)
+    role = FilterChoiceField(
+        queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
+        to_field_name='slug',
+    )
+    mac_address = forms.CharField(required=False, label='MAC address')
+
+
 #
 # Interface connections
 #

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1624,13 +1624,13 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
         required=False,
         queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
         label='Rack group',
-        null_option=(None, 'None')
+        null_option=(0, 'None')
     )
     rack_id = FilterChoiceField(
         required=False,
         queryset=Rack.objects.annotate(filter_count=Count('devices')),
         label='Rack',
-        null_option=(None, 'None')
+        null_option=(0, 'None')
     )
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1598,10 +1598,10 @@ class InterfaceCSVForm(forms.ModelForm):
 
     def clean_lag(self):
         device = None
-        if self.device is not None:
-            interface_ordering = self.device.device_type.interface_ordering
+        if self.fields['device'] is not None:
+            interface_ordering = self.fields['device'].device_type.interface_ordering
             lag = Interface.objects.order_naturally(method=interface_ordering).filter(
-                device=self.device, form_factor=IFACE_FF_LAG).get(
+                device=self.fields['device'], form_factor=IFACE_FF_LAG).get(
                 lag=self.cleaned_data['lag'], name=lag
             )
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1541,20 +1541,46 @@ class InterfaceCSVForm(forms.ModelForm):
     name = forms.CharField(
         help_text='Name of interface'
     )
+    lag = forms.CharField(
+        required=False,
+        help_text='Lag Name'
+    )
     mac_address = forms.CharField(
         required=False,
         help_text='MAC address of interface'
+    )
+    form_factor = forms.CharField(
+        required=False,
+        help_text='Interface Form Factor'
     )
     description = forms.CharField(
         required=False,
         help_text='Description for interface'
     )
+    enabled = forms.CharField(
+        required=False,
+        help_text='Enabled/Disabled'
+    )
+    mtu = forms.CharField(
+        required=False,
+        help_text='MTU'
+    )
+    mgmt_only = forms.CharField(
+        required=False,
+        help_text='Management Only'
+    )
+    is_virtual = forms.CharField(
+        required=False,
+        help_text='Is Virtual?'
+    )
+    is_wireless = forms.CharField(
+        required=False,
+        help_text='Is Wireless?'
+    )
     
     class Meta:
         model = Interface
-        fields = [
-            'device', 'name', 'mac_address', 'description'
-        ]
+        fields = ('device', 'lag','name','mac_address','form_factor','enabled','description','mtu','mgmt_only','is_virtual','is_wireless')
 
 
     def clean_interface(self):

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1543,7 +1543,7 @@ class InterfaceCSVForm(forms.ModelForm):
     )
     lag = FlexibleModelChoiceField(
         required=False,
-        queryset = Interface.objects.order_naturally(method=interface_ordering).filter(device=device,form_factor=IFACE_FF_LAG),
+        queryset = Interface.objects.order_naturally().filter(device=device,form_factor=IFACE_FF_LAG),
         help_text='Lag Name',
         error_messages={'invalid_choice': 'Lag not found.'}
     )

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1607,7 +1607,7 @@ class InterfaceCSVForm(forms.ModelForm):
                 device=device_id, form_factor=IFACE_FF_LAG).get(
                 lag=lag_name.id
             )
-        if not self.data('lag'):
+        if lag is not None:
             return None
         return lag
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1621,7 +1621,7 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     model = Interface
     q = forms.CharField(required=False, label='Search')
     site = FilterChoiceField(
-        queryset=Site.objects.annotate(filter_count=Count('devices')),
+        queryset=Site.objects.annotate(filter_count=Count('interfaces')),
         to_field_name='slug',
     )
     #device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1607,7 +1607,7 @@ class InterfaceCSVForm(forms.ModelForm):
                 device=device_id, form_factor=IFACE_FF_LAG).get(
                 lag=lag_name.id
             )
-        if not self.lag:
+        if not self.data('lag'):
             return None
         return lag
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1620,6 +1620,15 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
+    rack_group_id = FilterChoiceField(
+        queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
+        label='Rack group',
+    )
+    rack_id = FilterChoiceField(
+        queryset=Rack.objects.annotate(filter_count=Count('devices')),
+        label='Rack',
+        null_option=(0, 'None'),
+    )
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(
         required=False,

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1618,16 +1618,15 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 
 
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
-    model = Interface
     q = forms.CharField(required=False, label='Search')
     site = FilterChoiceField(
-        queryset=Site.objects.annotate(filter_count=Count('member_interfaces')),
+        queryset=Site.objects.annotate(filter_count=Count('devices')),
         to_field_name='slug'
     )
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(
         required=False,
-        queryset=DeviceRole.objects.annotate(filter_count=Count('member_interfaces')),
+        queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
         to_field_name='slug'
     )
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1574,12 +1574,12 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
     #device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
-    #enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
-    #role = FilterChoiceField(
-    #    queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
-    #    to_field_name='slug',
-    #)
-    #mac_address = forms.CharField(required=False, label='MAC address')
+    enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
+    role = FilterChoiceField(
+        queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
+        to_field_name='slug',
+    )
+    mac_address = forms.CharField(required=False, label='MAC address')
 
 
 #

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1624,7 +1624,7 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
         required=False,
         queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
         label='Rack group',
-        empty_label='None'
+        null_option=(0, 'None')
     )
     rack_id = FilterChoiceField(
         required=False,

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1601,7 +1601,7 @@ class InterfaceCSVForm(forms.ModelForm):
         if self.cleaned_data['device'] is not None:
             lag = Interface.objects.filter(
                 device=self.cleaned_data['device'], form_factor=IFACE_FF_LAG).get(
-                lag=self.cleaned_data['lag'], name=lag
+                self.cleaned_data['lag']
             )
 
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1620,7 +1620,6 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
-    device = forms.CharField(required=False, label='Device name')
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     #role = FilterChoiceField(
     #    required=False,

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1621,7 +1621,7 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     model = Interface
     q = forms.CharField(required=False, label='Search')
     site = FilterChoiceField(
-        queryset=Site.objects.annotate(filter_count=Count('interfaces')),
+        queryset=Site.objects.annotate(filter_count=Count('devices')),
         to_field_name='slug',
     )
     #device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1541,9 +1541,11 @@ class InterfaceCSVForm(forms.ModelForm):
     name = forms.CharField(
         help_text='Name of interface'
     )
-    lag = forms.CharField(
-        required=False,
-        help_text='Lag Name'
+    lag = FlexibleModelChoiceField(
+        queryset=Interface.objects.filter(form_factor=IFACE_FF_LAG),
+        to_field_name='name',
+        help_text='Lag Name or ID of interface',
+        error_messages={'invalid_choice': 'Lag not found.'}
     )
     mac_address = forms.CharField(
         required=False,
@@ -1598,13 +1600,12 @@ class InterfaceCSVForm(forms.ModelForm):
 
     def clean_lag(self):
         device = None
-        if self.cleaned_data['device'] is not None:
+        lag_name = self.data.get('lag')
+        if self.data['device'] is not None:
             lag = Interface.objects.filter(
-                device=self.cleaned_data['device'], form_factor=IFACE_FF_LAG).get(
-                lag=self.cleaned_data['lag']
+                device=self.data.get('device'), form_factor=IFACE_FF_LAG).get(
+                lag=lag_name
             )
-
-
         if not lag:
             return None
         return lag

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1623,7 +1623,7 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     rack_group_id = FilterChoiceField(
         required=False,
         queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
-        label='Rack group',
+        label='Rack Group',
         null_option=(0, 'None')
     )
     rack_id = FilterChoiceField(
@@ -1636,8 +1636,10 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     role = FilterChoiceField(
         required=False,
         queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
-        to_field_name='slug'
+        to_field_name='slug',
+        label='Device Role'
     )
+    device = forms.CharField(required=False, label='Device Name')
 
 
 #

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1531,6 +1531,46 @@ class InterfaceBulkDisconnectForm(ConfirmationForm):
     pk = forms.ModelMultipleChoiceField(queryset=Interface.objects.all(), widget=forms.MultipleHiddenInput)
 
 
+class InterfaceCSVForm(forms.ModelForm):
+    device = FlexibleModelChoiceField(
+        queryset=Device.objects.all(),
+        to_field_name='name',
+        help_text='Name or ID of device',
+        error_messages={'invalid_choice': 'Device not found.'}
+    )
+    name = forms.CharField(
+        help_text='Name of interface'
+    )
+    mac_address = forms.CharField(
+        required=False,
+        help_text='MAC address of interface'
+    )
+    description = forms.CharField(
+        required=False,
+        help_text='Description for interface'
+    )
+    
+    class Meta:
+        model = Interface
+        fields = [
+            'device', 'name', 'mac_address', 'description'
+        ]
+
+
+    def clean_interface(self):
+
+        interface_name = self.cleaned_data.get('interface_name')
+        if not interface:
+            return None
+        
+        return interface
+
+
+class InterfaceFilterForm(BootstrapMixin, forms.Form):
+    site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
+    device = forms.CharField(required=False, label='Device name')
+
+
 #
 # Interface connections
 #
@@ -1693,41 +1733,6 @@ class InterfaceConnectionCSVForm(forms.ModelForm):
                 self.cleaned_data['device_b'], interface_name
             ))
 
-        return interface
-
-
-class InterfaceCSVForm(forms.ModelForm):
-    device = FlexibleModelChoiceField(
-        queryset=Device.objects.all(),
-        to_field_name='name',
-        help_text='Name or ID of device',
-        error_messages={'invalid_choice': 'Device not found.'}
-    )
-    name = forms.CharField(
-        help_text='Name of interface'
-    )
-    mac_address = forms.CharField(
-        required=False,
-        help_text='MAC address of interface'
-    )
-    description = forms.CharField(
-        required=False,
-        help_text='Description for interface'
-    )
-    
-    class Meta:
-        model = Interface
-        fields = [
-            'device', 'name', 'mac_address', 'description'
-        ]
-
-
-    def clean_interface(self):
-
-        interface_name = self.cleaned_data.get('interface_name')
-        if not interface:
-            return None
-        
         return interface
 
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1620,7 +1620,7 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
-    rack_group_id = FilterChoiceFieldField(
+    rack_group_id = FilterChoiceField(
         required=False,
         queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
         label='Rack group',

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1601,7 +1601,7 @@ class InterfaceCSVForm(forms.ModelForm):
         if self.cleaned_data['device'] is not None:
             lag = Interface.objects.filter(
                 device=self.cleaned_data['device'], form_factor=IFACE_FF_LAG).get(
-                self.cleaned_data['lag']
+                lag=self.cleaned_data['lag']
             )
 
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1599,8 +1599,7 @@ class InterfaceCSVForm(forms.ModelForm):
     def clean_lag(self):
         device = None
         if self.fields['device'] is not None:
-            interface_ordering = device.device_type.interface_ordering
-            lag = Interface.objects.order_naturally(method=interface_ordering).filter(
+            lag = Interface.objects.filter(
                 device=self.fields['device'], form_factor=IFACE_FF_LAG).get(
                 lag=self.cleaned_data['lag'], name=lag
             )

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1620,12 +1620,12 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
-    rack_group_id = forms.ModelChoiceField(
+    rack_group_id = forms.FilterChoiceFieldField(
         required=False,
         queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
         label='Rack group'
     )
-    rack_id = forms.ModelChoiceField(
+    rack_id = forms.FilterChoiceField(
         required=False,
         queryset=Rack.objects.annotate(filter_count=Count('devices')),
         label='Rack'

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1620,19 +1620,17 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     model = Interface
     q = forms.CharField(required=False, label='Search')
-    site = FilterChoiceField(
-        queryset=Site.objects.annotate(filter_count=Count('devices')),
-        to_field_name='slug'
-    )
-    #device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
-    device = forms.CharField(required=False, label='Device name')
+    site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
+    #site = FilterChoiceField(
+    #    queryset=Site.objects.annotate(filter_count=Count('devices')),
+    #    to_field_name='slug'
+    #)
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(
         required=False,
         queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
         to_field_name='slug'
     )
-    mac_address = forms.CharField(required=False, label='MAC address')
 
 
 #

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1620,13 +1620,13 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
-    rack_group_id = ModelChoiceField(
+    rack_group_id = forms.ModelChoiceField(
         required=False,
         queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
         label='Rack group',
         null_option=(0, 'None')
     )
-    rack_id = ModelChoiceField(
+    rack_id = forms.ModelChoiceField(
         required=False,
         queryset=Rack.objects.annotate(filter_count=Count('devices')),
         label='Rack',

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1620,15 +1620,16 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
-    rack_group_id = forms.FilterChoiceFieldField(
-        required=False,
-        queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
-        label='Rack group'
-    )
+    #rack_group_id = forms.FilterChoiceFieldField(
+    #    required=False,
+    #    queryset=RackGroup.objects.select_related('site').annotate(filter_count=Count('racks__devices')),
+    #    label='Rack group'
+    #)
     rack_id = forms.FilterChoiceField(
         required=False,
         queryset=Rack.objects.annotate(filter_count=Count('devices')),
-        label='Rack'
+        label='Rack',
+        null_option=(, 'None')
     )
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1543,7 +1543,7 @@ class InterfaceCSVForm(forms.ModelForm):
     )
     lag = FlexibleModelChoiceField(
         required=False,
-        queryset = Interface.objects.order_naturally().filter(form_factor=IFACE_FF_LAG),
+        queryset = Interface.objects.order_naturally(method=interface_ordering).filter(device=device,form_factor=IFACE_FF_LAG),
         help_text='Lag Name',
         error_messages={'invalid_choice': 'Lag not found.'}
     )
@@ -1579,10 +1579,14 @@ class InterfaceCSVForm(forms.ModelForm):
         required=False,
         help_text='Is Wireless?'
     )
+    is_lag = forms.CharField(
+        required=False,
+        help_text='Is Lag?'
+    )
     
     class Meta:
         model = Interface
-        fields = ('device', 'lag','name','mac_address','form_factor','enabled','description','mtu','mgmt_only','is_virtual','is_wireless')
+        fields = ('device', 'lag','name','mac_address','form_factor','enabled','description','mtu','mgmt_only','is_virtual','is_wireless','is_lag')
 
 
     def clean_interface(self):

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1619,16 +1619,13 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
-    site = FilterChoiceField(
-        queryset=Site.objects.annotate(filter_count=Count('devices')),
-        to_field_name='slug'
-    )
+    site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
-    role = FilterChoiceField(
-        required=False,
-        queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
-        to_field_name='slug'
-    )
+    #role = FilterChoiceField(
+    #    required=False,
+    #    queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
+    #    to_field_name='slug'
+    #)
 
 
 #

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1574,7 +1574,7 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
     device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
-    enabled = form.ModelChoiceField(choices=((INTERFACE_ENABLED,'Enabled'),(INTERFACE_DISABLED,'Disabled')),required=False)
+    enabled = forms.ModelChoiceField(choices=((INTERFACE_ENABLED,'Enabled'),(INTERFACE_DISABLED,'Disabled')),required=False)
     role = FilterChoiceField(
         queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
         to_field_name='slug',

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1574,7 +1574,7 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
     device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
-    enabled = forms.ModelChoiceField(choices=IFACE_ENABLED_CHOICES,required=False)
+    enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(
         queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
         to_field_name='slug',

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1597,6 +1597,7 @@ class InterfaceCSVForm(forms.ModelForm):
 
 
     def clean_lag(self):
+        device = None
         if self.device is not None:
             interface_ordering = self.device.device_type.interface_ordering
             lag = Interface.objects.order_naturally(method=interface_ordering).filter(

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1607,7 +1607,7 @@ class InterfaceCSVForm(forms.ModelForm):
                 device=device_id, form_factor=IFACE_FF_LAG).get(
                 lag=lag_name.id
             )
-        if not lag:
+        if not self.lag:
             return None
         return lag
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1599,7 +1599,7 @@ class InterfaceCSVForm(forms.ModelForm):
     def clean_lag(self):
         device = None
         if self.fields['device'] is not None:
-            interface_ordering = self.fields['device'].device_type.interface_ordering
+            interface_ordering = device.device_type.interface_ordering
             lag = Interface.objects.order_naturally(method=interface_ordering).filter(
                 device=self.fields['device'], form_factor=IFACE_FF_LAG).get(
                 lag=self.cleaned_data['lag'], name=lag

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1620,6 +1620,7 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     q = forms.CharField(required=False, label='Search')
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
+    device = forms.CharField(required=False, label='Device name')
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     #role = FilterChoiceField(
     #    required=False,

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1574,6 +1574,7 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
     #device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
+    device = forms.CharField(required=False, label='Device name')
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(
         queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1574,7 +1574,7 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
     site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
     device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
-    enabled = forms.ModelChoiceField(choices=((INTERFACE_ENABLED,'Enabled'),(INTERFACE_DISABLED,'Disabled')),required=False)
+    enabled = forms.ModelChoiceField(choices=IFACE_ENABLED_CHOICES,required=False)
     role = FilterChoiceField(
         queryset=DeviceRole.objects.annotate(filter_count=Count('devices')),
         to_field_name='slug',

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1629,7 +1629,7 @@ class InterfaceListFilterForm(BootstrapMixin, forms.Form):
         required=False,
         queryset=Rack.objects.annotate(filter_count=Count('devices')),
         label='Rack',
-        null_option=(, 'None')
+        null_option=(None, 'None')
     )
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)
     role = FilterChoiceField(

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1618,7 +1618,12 @@ class InterfaceFilterForm(BootstrapMixin, forms.Form):
 
 
 class InterfaceListFilterForm(BootstrapMixin, forms.Form):
-    site = forms.ModelChoiceField(required=False, queryset=Site.objects.all(), to_field_name='slug')
+    model = Interface
+    q = forms.CharField(required=False, label='Search')
+    site = FilterChoiceField(
+        queryset=Site.objects.annotate(filter_count=Count('devices')),
+        to_field_name='slug',
+    )
     #device = forms.ModelChoiceField(required=False, queryset=Device.objects.all(), to_field_name='slug')
     device = forms.CharField(required=False, label='Device name')
     enabled = forms.ChoiceField(choices=add_blank_choice(IFACE_ENABLED_CHOICES), required=False)

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -1233,6 +1233,17 @@ class Interface(models.Model):
             pass
         return None
 
+    # Used for  export
+    def to_csv(self):
+        return csv_format([
+            self.device.identifier,
+            self.lag,
+            self.name,
+            self.mac,
+            self.form_factor,
+            self.description,
+        ])
+
 
 class InterfaceConnection(models.Model):
     """

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -1208,9 +1208,6 @@ class Interface(models.Model):
             pass
         return bool(self.connection)
 
-    def get_status_class(self):
-        return IFACE_ENABLED_CHOICES[self.enabled]
-
     @property
     def connection(self):
         try:
@@ -1236,6 +1233,9 @@ class Interface(models.Model):
         except ObjectDoesNotExist:
             pass
         return None
+
+    def get_status_class(self):
+        return IFACE_ENABLED_CHOICES[self.enabled]
 
     # Used for  export
     def to_csv(self):

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -1239,7 +1239,7 @@ class Interface(models.Model):
             self.device.identifier,
             self.lag,
             self.name,
-            self.mac,
+            self.mac_address,
             self.form_factor,
             self.description,
         ])

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -1146,7 +1146,7 @@ class Interface(models.Model):
         help_text="This interface is used only for out-of-band management"
     )
     description = models.CharField(max_length=100, blank=True)
-
+    custom_field_values = GenericRelation(CustomFieldValue, content_type_field='obj_type', object_id_field='obj_id')
     objects = InterfaceQuerySet.as_manager()
     
     csv_headers = ['device','lag','name','mac_address','form_factor','enabled','description','mtu','mgmt_only','is_virtual','is_wireless','is_connected','is_lag']

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -1121,7 +1121,7 @@ class PowerOutlet(models.Model):
 #
 
 @python_2_unicode_compatible
-class Interface(CreatedUpdatedModel, CustomFieldModel):
+class Interface(models.Model):
     """
     A physical data interface within a Device. An Interface can connect to exactly one other Interface via the creation
     of an InterfaceConnection.
@@ -1146,7 +1146,6 @@ class Interface(CreatedUpdatedModel, CustomFieldModel):
         help_text="This interface is used only for out-of-band management"
     )
     description = models.CharField(max_length=100, blank=True)
-    custom_field_values = GenericRelation(CustomFieldValue, content_type_field='obj_type', object_id_field='obj_id')
     objects = InterfaceQuerySet.as_manager()
     
     csv_headers = ['device','lag','name','mac_address','form_factor','enabled','description','mtu','mgmt_only','is_virtual','is_wireless','is_connected','is_lag']

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -1235,7 +1235,7 @@ class Interface(models.Model):
         return None
 
     def get_status_class(self):
-        return IFACE_ENABLED_CHOICES[self.enabled]
+        return IFACE_STATUS_CLASSES[self.enabled]
 
     # Used for  export
     def to_csv(self):

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -1148,7 +1148,9 @@ class Interface(models.Model):
     description = models.CharField(max_length=100, blank=True)
 
     objects = InterfaceQuerySet.as_manager()
-
+    
+    csv_headers = ['device','lag','name','mac_address','form_factor','enabled','description','mtu','mgmt_only','is_virtual','is_wireless','is_connected','is_lag']
+    
     class Meta:
         ordering = ['device', 'name']
         unique_together = ['device', 'name']

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -1121,7 +1121,7 @@ class PowerOutlet(models.Model):
 #
 
 @python_2_unicode_compatible
-class Interface(models.Model):
+class Interface(CreatedUpdatedModel, CustomFieldModel):
     """
     A physical data interface within a Device. An Interface can connect to exactly one other Interface via the creation
     of an InterfaceConnection.
@@ -1208,6 +1208,9 @@ class Interface(models.Model):
         except ObjectDoesNotExist:
             pass
         return bool(self.connection)
+
+    def get_status_class(self):
+        return IFACE_ENABLED_CHOICES[self.enabled]
 
     @property
     def connection(self):

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -1241,7 +1241,14 @@ class Interface(models.Model):
             self.name,
             self.mac_address,
             self.form_factor,
+            self.enabled,
             self.description,
+            self.mtu,
+            self.mgmt_only,
+            self.is_virtual,
+            self.is_wireless,
+            self.is_connected,
+            self.is_lag,
         ])
 
 

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -41,7 +41,7 @@ DEVICE_LINK = """
 
 INTERFACE_LINK = """
 <a href="{% url 'dcim:interface' pk=record.pk %}">
-    {{ record.name|default:'<span class="label label-info">--</span>' }}
+    {{ record.name|default:'<span class="label label-info"></span>' }}
 </a>
 """
 
@@ -551,8 +551,8 @@ class InterfaceImportTable(BaseTable):
 class InterfaceListTable(BaseTable):
     device = tables.LinkColumn('dcim:device', accessor=Accessor('interface.device'),
                                  args=[Accessor('interface.device.pk')], verbose_name='Device')
-    #name = tables.TemplateColumn(template_code=INTERFACE_LINK, verbose_name='Interface')
-    name = tables.Column(verbose_name='Interface')
+    name = tables.TemplateColumn(template_code=INTERFACE_LINK, verbose_name='Interface')
+    #name = tables.Column(verbose_name='Interface')
     #enabled = tables.TemplateColumn(template_code=INTERFACE_ENABLED, verbose_name='Enabled')
     form_factor = tables.Column(verbose_name='Form Factor')
     mac_address = tables.Column(verbose_name='MAC Address')

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -538,14 +538,19 @@ class InterfaceConnectionTable(BaseTable):
 class InterfaceImportTable(BaseTable):
     device = tables.LinkColumn('dcim:device', accessor=Accessor('interface.device'),
                                  args=[Accessor('interface.device.pk')], verbose_name='Device')
+    lag = tables.Column(verbose_name='Lag')
     name = tables.Column(verbose_name='Interface')
-    form_factor = tables.Column(verbose_name='Form Factor')
     mac_address = tables.Column(verbose_name='MAC Address')
+    form_factor = tables.Column(verbose_name='Form Factor')
+    enabled = tables.Column(verbose_name='Enabled')
     description = tables.Column(verbose_name='Description')
-
+    mtu = tables.Column(verbose_name='MTU')
+    mgmt_only = tables.Column(verbose_name='MGMT Only')
+    is_virtual = tables.Column(verbose_name='Virtual')
+    is_wireless = tables.Column(verbose_name='Wireless')
     class Meta(BaseTable.Meta):
         model = Interface
-        fields = ('device', 'name', 'form_factor','mac_address', 'description')
+        fields = ('device', 'lag','name','mac_address','form_factor','enabled','description','mtu','mgmt_only','is_virtual','is_wireless')
 
 
 class InterfaceListTable(BaseTable):

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -104,7 +104,7 @@ DEVICE_STATUS = """
 """
 
 INTERFACE_ENABLED = """
-<span class="label label-{{ record.get_status_class }}">{{ record.is_enabled }}</span>
+<span class="label label-{{ record.get_status_class }}">{{ record.enabled }}</span>
 """
 
 DEVICE_PRIMARY_IP = """

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -549,7 +549,6 @@ class InterfaceImportTable(BaseTable):
 
 
 class InterfaceListTable(BaseTable):
-    pk = ToggleColumn()
     device = tables.LinkColumn('dcim:device', accessor=Accessor('interface.device'),
                                  args=[Accessor('interface.device.pk')], verbose_name='Device')
     name = tables.TemplateColumn(template_code=INTERFACE_LINK, verbose_name='Interface')

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -539,13 +539,15 @@ class InterfaceImportTable(BaseTable):
 
 
 class InterfaceListTable(BaseTable):
+    pk = ToggleColumn()
     device = tables.LinkColumn('dcim:device', accessor=Accessor('interface.device'),
                                  args=[Accessor('interface.device.pk')], verbose_name='Device')
-    name = tables.Column(verbose_name='Interface')
+    name = tables.TemplateColumn(template_code=INTERFACE_LINK, verbose_name='Interface')
+    enabled = tables.TemplateColumn(template_code=INTERFACE_ENABLED, verbose_name='Enabled')
     form_factor = tables.Column(verbose_name='Form Factor')
     mac_address = tables.Column(verbose_name='MAC Address')
-    description = tables.Column(verbose_name='Description')
+    description = tables.TemplateColumn(template_code=INTERFACE_LINK, verbose_name='Description')
 
     class Meta(BaseTable.Meta):
         model = Interface
-        fields = ('device', 'name', 'form_factor','mac_address', 'description')
+        fields = ('pk','device', 'name', 'form_factor','mac_address', 'description')

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -538,7 +538,9 @@ class InterfaceConnectionTable(BaseTable):
 class InterfaceImportTable(BaseTable):
     device = tables.LinkColumn('dcim:device', accessor=Accessor('interface.device'),
                                  args=[Accessor('interface.device.pk')], verbose_name='Device')
-    lag = tables.Column(verbose_name='Lag ID')
+    lag = tables.LinkColumn('dcim:interface', accessor=Accessor('self.name'),
+                                 args=[Accessor('self.pk')], verbose_name='Lag ID')
+    #lag = tables.Column(verbose_name='Lag ID')
     name = tables.Column(verbose_name='Interface')
     mac_address = tables.Column(verbose_name='MAC Address')
     form_factor = tables.Column(verbose_name='Form Factor')

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -553,11 +553,11 @@ class InterfaceListTable(BaseTable):
     device = tables.LinkColumn('dcim:device', accessor=Accessor('interface.device'),
                                  args=[Accessor('interface.device.pk')], verbose_name='Device')
     name = tables.TemplateColumn(template_code=INTERFACE_LINK, verbose_name='Interface')
-    enabled = tables.TemplateColumn(template_code=INTERFACE_ENABLED, verbose_name='Enabled')
+    #enabled = tables.TemplateColumn(template_code=INTERFACE_ENABLED, verbose_name='Enabled')
     form_factor = tables.Column(verbose_name='Form Factor')
     mac_address = tables.Column(verbose_name='MAC Address')
     description = tables.Column(verbose_name='Description')
 
     class Meta(BaseTable.Meta):
         model = Interface
-        fields = ('pk','device', 'name', 'enabled', 'form_factor','mac_address', 'description')
+        fields = ('pk','device','name','form_factor','mac_address','description')

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -104,7 +104,7 @@ DEVICE_STATUS = """
 """
 
 INTERFACE_ENABLED = """
-<span class="label label-{{ record.get_status_class }}">{{ record.get_status_display }}</span>
+<span class="label label-{{ record.get_status_class }}">{{ record.enabled }}</span>
 """
 
 DEVICE_PRIMARY_IP = """
@@ -540,7 +540,6 @@ class InterfaceImportTable(BaseTable):
                                  args=[Accessor('interface.device.pk')], verbose_name='Device')
     lag = tables.LinkColumn('dcim:interface', accessor=Accessor('self.name'),
                                  args=[Accessor('self.pk')], verbose_name='Lag ID')
-    #lag = tables.Column(verbose_name='Lag ID')
     name = tables.Column(verbose_name='Interface')
     mac_address = tables.Column(verbose_name='MAC Address')
     form_factor = tables.Column(verbose_name='Form Factor')

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -549,15 +549,15 @@ class InterfaceImportTable(BaseTable):
 
 
 class InterfaceListTable(BaseTable):
-    device = tables.LinkColumn('dcim:device', accessor=Accessor('interface.device'),
-                                 args=[Accessor('interface.device.identifier')], verbose_name='Device')
+    device = tables.LinkColumn('dcim:device', accessor=Accessor('device'),
+                                 args=[Accessor('device.pk')], verbose_name='Device')
     name = tables.TemplateColumn(template_code=INTERFACE_LINK, verbose_name='Interface')
     #name = tables.Column(verbose_name='Interface')
-    #enabled = tables.TemplateColumn(template_code=INTERFACE_ENABLED, verbose_name='Enabled')
+    enabled = tables.TemplateColumn(template_code=INTERFACE_ENABLED, verbose_name='Enabled')
     form_factor = tables.Column(verbose_name='Form Factor')
     mac_address = tables.Column(verbose_name='MAC Address')
     description = tables.Column(verbose_name='Description')
 
     class Meta(BaseTable.Meta):
         model = Interface
-        fields = ('device','name','form_factor','mac_address','description')
+        fields = ('device','name','enabled','form_factor','mac_address','description')

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -550,7 +550,7 @@ class InterfaceImportTable(BaseTable):
 
 class InterfaceListTable(BaseTable):
     device = tables.LinkColumn('dcim:device', accessor=Accessor('interface.device'),
-                                 args=[Accessor('interface.device.pk')], verbose_name='Device')
+                                 args=[Accessor('interface.device.identifier')], verbose_name='Device')
     name = tables.TemplateColumn(template_code=INTERFACE_LINK, verbose_name='Interface')
     #name = tables.Column(verbose_name='Interface')
     #enabled = tables.TemplateColumn(template_code=INTERFACE_ENABLED, verbose_name='Enabled')

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -40,7 +40,7 @@ DEVICE_LINK = """
 """
 
 INTERFACE_LINK = """
-<a href="{% url 'dcim:device' pk=record.device %}">
+<a href="{% url 'dcim:device' pk=record.device.pk %}">
     {{ record.name|default:'<span class="label label-info"> - </span>' }}
 </a>
 """

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -556,8 +556,8 @@ class InterfaceListTable(BaseTable):
     enabled = tables.TemplateColumn(template_code=INTERFACE_ENABLED, verbose_name='Enabled')
     form_factor = tables.Column(verbose_name='Form Factor')
     mac_address = tables.Column(verbose_name='MAC Address')
-    description = tables.TemplateColumn(template_code=INTERFACE_LINK, verbose_name='Description')
+    description = tables.Column(verbose_name='Description')
 
     class Meta(BaseTable.Meta):
         model = Interface
-        fields = ('pk','device', 'name', 'form_factor','mac_address', 'description')
+        fields = ('pk','device', 'name', 'enabled', 'form_factor','mac_address', 'description')

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -40,8 +40,8 @@ DEVICE_LINK = """
 """
 
 INTERFACE_LINK = """
-<a href="{% url 'dcim:interface' pk=record.pk %}">
-    {{ record.name|default:'<span class="label label-info"></span>' }}
+<a href="{% url 'dcim:device' pk=record.device %}">
+    {{ record.name|default:'<span class="label label-info"> - </span>' }}
 </a>
 """
 

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -39,6 +39,12 @@ DEVICE_LINK = """
 </a>
 """
 
+INTERFACE_LINK = """
+<a href="{% url 'dcim:interface' pk=record.pk %}">
+    {{ record.name|default:'<span class="label label-info">--</span>' }}
+</a>
+"""
+
 REGION_ACTIONS = """
 {% if perms.dcim.change_region %}
     <a href="{% url 'dcim:region_edit' pk=record.pk %}" class="btn btn-xs btn-warning"><i class="glyphicon glyphicon-pencil" aria-hidden="true"></i></a>
@@ -95,6 +101,10 @@ DEVICE_ROLE = """
 
 DEVICE_STATUS = """
 <span class="label label-{{ record.get_status_class }}">{{ record.get_status_display }}</span>
+"""
+
+INTERFACE_ENABLED = """
+<span class="label label-{{ record.get_status_class }}">{{ record.is_enabled }}</span>
 """
 
 DEVICE_PRIMARY_IP = """

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -536,3 +536,16 @@ class InterfaceImportTable(BaseTable):
     class Meta(BaseTable.Meta):
         model = Interface
         fields = ('device', 'name', 'form_factor','mac_address', 'description')
+
+
+class InterfaceListTable(BaseTable):
+    device = tables.LinkColumn('dcim:device', accessor=Accessor('interface.device'),
+                                 args=[Accessor('interface.device.pk')], verbose_name='Device')
+    name = tables.Column(verbose_name='Interface')
+    form_factor = tables.Column(verbose_name='Form Factor')
+    mac_address = tables.Column(verbose_name='MAC Address')
+    description = tables.Column(verbose_name='Description')
+
+    class Meta(BaseTable.Meta):
+        model = Interface
+        fields = ('device', 'name', 'form_factor','mac_address', 'description')

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -551,7 +551,8 @@ class InterfaceImportTable(BaseTable):
 class InterfaceListTable(BaseTable):
     device = tables.LinkColumn('dcim:device', accessor=Accessor('interface.device'),
                                  args=[Accessor('interface.device.pk')], verbose_name='Device')
-    name = tables.TemplateColumn(template_code=INTERFACE_LINK, verbose_name='Interface')
+    #name = tables.TemplateColumn(template_code=INTERFACE_LINK, verbose_name='Interface')
+    name = tables.Column(verbose_name='Interface')
     #enabled = tables.TemplateColumn(template_code=INTERFACE_ENABLED, verbose_name='Enabled')
     form_factor = tables.Column(verbose_name='Form Factor')
     mac_address = tables.Column(verbose_name='MAC Address')
@@ -559,4 +560,4 @@ class InterfaceListTable(BaseTable):
 
     class Meta(BaseTable.Meta):
         model = Interface
-        fields = ('pk','device','name','form_factor','mac_address','description')
+        fields = ('device','name','form_factor','mac_address','description')

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -559,7 +559,6 @@ class InterfaceListTable(BaseTable):
     device = tables.LinkColumn('dcim:device', accessor=Accessor('device'),
                                  args=[Accessor('device.pk')], verbose_name='Device')
     name = tables.TemplateColumn(template_code=INTERFACE_LINK, verbose_name='Interface')
-    #name = tables.Column(verbose_name='Interface')
     enabled = tables.TemplateColumn(template_code=INTERFACE_ENABLED, verbose_name='Enabled')
     form_factor = tables.Column(verbose_name='Form Factor')
     mac_address = tables.Column(verbose_name='MAC Address')

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -538,7 +538,7 @@ class InterfaceConnectionTable(BaseTable):
 class InterfaceImportTable(BaseTable):
     device = tables.LinkColumn('dcim:device', accessor=Accessor('interface.device'),
                                  args=[Accessor('interface.device.pk')], verbose_name='Device')
-    lag = tables.Column(verbose_name='Lag')
+    lag = tables.Column(verbose_name='Lag ID')
     name = tables.Column(verbose_name='Interface')
     mac_address = tables.Column(verbose_name='MAC Address')
     form_factor = tables.Column(verbose_name='Form Factor')
@@ -546,11 +546,12 @@ class InterfaceImportTable(BaseTable):
     description = tables.Column(verbose_name='Description')
     mtu = tables.Column(verbose_name='MTU')
     mgmt_only = tables.Column(verbose_name='MGMT Only')
-    is_virtual = tables.Column(verbose_name='Virtual')
-    is_wireless = tables.Column(verbose_name='Wireless')
+    is_virtual = tables.Column(verbose_name='Is Virtual?')
+    is_wireless = tables.Column(verbose_name='Is Wireless?')
+    is_lag = tables.Column(verbose_name='Is Lag?')
     class Meta(BaseTable.Meta):
         model = Interface
-        fields = ('device', 'lag','name','mac_address','form_factor','enabled','description','mtu','mgmt_only','is_virtual','is_wireless')
+        fields = ('device', 'lag','name','mac_address','form_factor','enabled','description','mtu','mgmt_only','is_virtual','is_wireless','is_lag')
 
 
 class InterfaceListTable(BaseTable):

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -523,3 +523,16 @@ class InterfaceConnectionTable(BaseTable):
     class Meta(BaseTable.Meta):
         model = Interface
         fields = ('device_a', 'interface_a', 'device_b', 'interface_b')
+
+
+class InterfaceImportTable(BaseTable):
+    device = tables.LinkColumn('dcim:device', accessor=Accessor('interface.device'),
+                                 args=[Accessor('interface.device.pk')], verbose_name='Device')
+    name = tables.Column(verbose_name='Interface')
+    form_factor = tables.Column(verbose_name='Form Factor')
+    mac_address = tables.Column(verbose_name='MAC Address')
+    description = tables.Column(verbose_name='Description')
+
+    class Meta(BaseTable.Meta):
+        model = Interface
+        fields = ('device', 'name', 'form_factor','mac_address', 'description')

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -104,7 +104,7 @@ DEVICE_STATUS = """
 """
 
 INTERFACE_ENABLED = """
-<span class="label label-{{ record.get_status_class }}">{{ record.enabled }}</span>
+<span class="label label-{{ record.get_status_class }}">{{ record.get_status_display }}</span>
 """
 
 DEVICE_PRIMARY_IP = """

--- a/netbox/dcim/urls.py
+++ b/netbox/dcim/urls.py
@@ -177,7 +177,8 @@ urlpatterns = [
     url(r'^interface-connections/(?P<pk>\d+)/delete/$', views.interfaceconnection_delete, name='interfaceconnection_delete'),
     url(r'^interfaces/(?P<pk>\d+)/edit/$', views.InterfaceEditView.as_view(), name='interface_edit'),
     url(r'^interfaces/(?P<pk>\d+)/delete/$', views.InterfaceDeleteView.as_view(), name='interface_delete'),
-    url(r'^interfaces/import/$', views.InterfacesBulkImportView.as_view(), name='interfaces_import'),
+    url(r'^interfaces/$', views.InterfaceListView.as_view(), name='interface_list'),
+    url(r'^interfaces/import/$', views.InterfacesBulkImportView.as_view(), name='interface_import'),
 
     # Device bays
     url(r'^devices/device-bays/add/$', views.DeviceBulkAddDeviceBayView.as_view(), name='device_bulk_add_devicebay'),

--- a/netbox/dcim/urls.py
+++ b/netbox/dcim/urls.py
@@ -177,6 +177,7 @@ urlpatterns = [
     url(r'^interface-connections/(?P<pk>\d+)/delete/$', views.interfaceconnection_delete, name='interfaceconnection_delete'),
     url(r'^interfaces/(?P<pk>\d+)/edit/$', views.InterfaceEditView.as_view(), name='interface_edit'),
     url(r'^interfaces/(?P<pk>\d+)/delete/$', views.InterfaceDeleteView.as_view(), name='interface_delete'),
+    url(r'^interfaces/import/$', views.InterfacesBulkImportView.as_view(), name='interfaces_import'),
 
     # Device bays
     url(r'^devices/device-bays/add/$', views.DeviceBulkAddDeviceBayView.as_view(), name='device_bulk_add_devicebay'),

--- a/netbox/dcim/urls.py
+++ b/netbox/dcim/urls.py
@@ -178,7 +178,7 @@ urlpatterns = [
     url(r'^interfaces/(?P<pk>\d+)/edit/$', views.InterfaceEditView.as_view(), name='interface_edit'),
     url(r'^interfaces/(?P<pk>\d+)/delete/$', views.InterfaceDeleteView.as_view(), name='interface_delete'),
     url(r'^interfaces/$', views.InterfaceListView.as_view(), name='interface_list'),
-    url(r'^interfaces/import/$', views.InterfacesBulkImportView.as_view(), name='interface_import'),
+    url(r'^interfaces/import/$', views.InterfaceBulkImportView.as_view(), name='interface_import'),
 
     # Device bays
     url(r'^devices/device-bays/add/$', views.DeviceBulkAddDeviceBayView.as_view(), name='device_bulk_add_devicebay'),

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1548,6 +1548,22 @@ class InterfaceBulkDeleteView(PermissionRequiredMixin, BulkDeleteView):
     table = tables.InterfaceTable
 
 
+class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
+    permission_required = 'dcim.change_interface'
+    model_form = forms.InterfaceCSVForm
+    table = tables.InterfaceImportTable
+    default_return_url = 'dcim:interface_list'
+
+
+class InterfaceListView(ObjectListView):
+    queryset = InterfaceConnection.objects.select_related('device')\
+        .order_by('device', 'interface')
+    filter = filters.InterfaceFilter
+    filter_form = forms.InterfaceFilterForm
+    table = tables.InterfaceTable
+    template_name = 'dcim/interface_list.html'
+
+
 #
 # Device bays
 #
@@ -1836,13 +1852,6 @@ class InterfaceConnectionsBulkImportView(PermissionRequiredMixin, BulkImportView
     model_form = forms.InterfaceConnectionCSVForm
     table = tables.InterfaceConnectionTable
     default_return_url = 'dcim:interface_connections_list'
-
-
-class InterfacesBulkImportView(PermissionRequiredMixin, BulkImportView):
-    permission_required = 'dcim.change_interface'
-    model_form = forms.InterfaceCSVForm
-    table = tables.InterfaceImportTable
-    default_return_url = 'dcim:device_list'
 
 
 #

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1838,6 +1838,13 @@ class InterfaceConnectionsBulkImportView(PermissionRequiredMixin, BulkImportView
     default_return_url = 'dcim:interface_connections_list'
 
 
+class InterfacesBulkImportView(PermissionRequiredMixin, BulkImportView):
+    permission_required = 'dcim.change_interface'
+    model_form = forms.InterfaceCSVForm
+    table = tables.InterfaceImportTable
+    default_return_url = 'dcim:device_list'
+
+
 #
 # Connections
 #

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1557,7 +1557,7 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 class InterfaceListView(ObjectListView):
     queryset = Interface.objects.all()
-    #filter = filters.InterfaceFilter
+    filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm
     table = tables.InterfaceListTable
     template_name = 'dcim/interface_list.html'

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1557,8 +1557,8 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 class InterfaceListView(ObjectListView):
     queryset = Interface.objects.all()
-    filter = filters.DeviceFilter
-    filter_form = forms.InterfaceListFilterForm
+    filter = filters.InterfaceFilter
+    filter_form = forms.DeviceFilterForm
     table = tables.InterfaceListTable
     template_name = 'dcim/interface_list.html'
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1556,7 +1556,8 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 
 class InterfaceListView(ObjectListView):
-    queryset = Interface.objects.all()
+    #queryset = Interface.objects.all()
+    queryset = Interface.objects.select_related('device__name')
     filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm
     table = tables.InterfaceListTable

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1557,7 +1557,7 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 class InterfaceListView(ObjectListView):
     queryset = Interface.objects.all()
-    filter = filters.InterfaceFilter
+    filter = filters.InterfaceListFilter
     filter_form = forms.InterfaceListFilterForm
     table = tables.InterfaceListTable
     template_name = 'dcim/interface_list.html'

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1556,8 +1556,8 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 
 class InterfaceListView(ObjectListView):
-    queryset = Interface.objects.select_related('device', 'name', 'description')\
-        .order_by('device', 'name', 'description')
+    queryset = Interface.objects.select_related('device', 'interface__device')\
+        .order_by('device__name', 'interface__name', 'interface__description')
     filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm
     table = tables.InterfaceTable

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1556,8 +1556,8 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 
 class InterfaceListView(ObjectListView):
-    queryset = Interface.objects.select_related('device')\
-        .order_by('device', 'interface')
+    queryset = Interface.objects.select_related('device', 'name', 'description')\
+        .order_by('device', 'name', 'description')
     filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm
     table = tables.InterfaceTable

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1558,7 +1558,7 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 class InterfaceListView(ObjectListView):
     queryset = Interface.objects.all()
     filter = filters.InterfaceFilter
-    filter_form = forms.DeviceFilterForm
+    filter_form = forms.InterfaceConnectionFilterForm
     table = tables.InterfaceListTable
     template_name = 'dcim/interface_list.html'
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1556,7 +1556,7 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 
 class InterfaceListView(ObjectListView):
-    queryset = Interface.objects.select_related('device').filter(interface__isnull=False)\\
+    queryset = Interface.objects.select_related('device').filter(interface__isnull=False)\
         .order_by('interface__device__name', 'interface__name')
     filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1556,7 +1556,7 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 
 class InterfaceListView(ObjectListView):
-    queryset = Interface.objects.select_related('device', 'interface__device')\
+    queryset = Interface.objects.select_related('device')\
         .order_by('device', 'interface__name', 'interface__description')
     filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1557,7 +1557,7 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 class InterfaceListView(ObjectListView):
     queryset = Interface.objects.all()
-    filter = filters.InterfaceFilter
+    #filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm
     table = tables.InterfaceListTable
     template_name = 'dcim/interface_list.html'

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1556,8 +1556,7 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 
 class InterfaceListView(ObjectListView):
-    queryset = Interface.objects.select_related('device').filter(interface__isnull=False)\
-        .order_by('interface__device__name', 'interface__name')
+    queryset = Interface.objects.all()
     filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm
     table = tables.InterfaceListTable

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1556,8 +1556,7 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 
 class InterfaceListView(ObjectListView):
-    #queryset = Interface.objects.all()
-    queryset = Interface.objects.select_related('device__name')
+    queryset = Interface.objects.all().filter(device=device)
     filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm
     table = tables.InterfaceListTable

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1557,7 +1557,7 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 class InterfaceListView(ObjectListView):
     queryset = Interface.objects.all()
-    filter = filters.InterfaceFilter
+    filter = filters.DeviceFilter
     filter_form = forms.InterfaceListFilterForm
     table = tables.InterfaceListTable
     template_name = 'dcim/interface_list.html'

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1557,10 +1557,10 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 class InterfaceListView(ObjectListView):
     queryset = Interface.objects.select_related('device', 'interface__device')\
-        .order_by('device__name', 'interface__name', 'interface__description')
+        .order_by('device', 'interface__name', 'interface__description')
     filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm
-    table = tables.InterfaceTable
+    table = tables.InterfaceListTable
     template_name = 'dcim/interface_list.html'
 
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1556,8 +1556,8 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 
 class InterfaceListView(ObjectListView):
-    #queryset = Interface.objects.select_related('device')\
-    #    .order_by('device', 'interface__name', 'interface__description')
+    queryset = Interface.objects.select_related('device').filter(interface__isnull=False)\\
+        .order_by('interface__device__name', 'interface__name')
     filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm
     table = tables.InterfaceListTable

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1558,7 +1558,7 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 class InterfaceListView(ObjectListView):
     queryset = Interface.objects.all()
     filter = filters.InterfaceFilter
-    filter_form = forms.InterfaceConnectionFilterForm
+    filter_form = forms.InterfaceFilterForm
     table = tables.InterfaceListTable
     template_name = 'dcim/interface_list.html'
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1556,7 +1556,7 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 
 class InterfaceListView(ObjectListView):
-    queryset = Interface.objects.all().filter(device=device)
+    queryset = Interface.objects.all()
     filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm
     table = tables.InterfaceListTable

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1556,7 +1556,7 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 
 class InterfaceListView(ObjectListView):
-    queryset = InterfaceConnection.objects.select_related('device')\
+    queryset = Interface.objects.select_related('device')\
         .order_by('device', 'interface')
     filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1556,8 +1556,8 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 
 
 class InterfaceListView(ObjectListView):
-    queryset = Interface.objects.select_related('device')\
-        .order_by('device', 'interface__name', 'interface__description')
+    #queryset = Interface.objects.select_related('device')\
+    #    .order_by('device', 'interface__name', 'interface__description')
     filter = filters.InterfaceFilter
     filter_form = forms.InterfaceFilterForm
     table = tables.InterfaceListTable

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1558,7 +1558,7 @@ class InterfaceBulkImportView(PermissionRequiredMixin, BulkImportView):
 class InterfaceListView(ObjectListView):
     queryset = Interface.objects.all()
     filter = filters.InterfaceFilter
-    filter_form = forms.InterfaceFilterForm
+    filter_form = forms.InterfaceListFilterForm
     table = tables.InterfaceListTable
     template_name = 'dcim/interface_list.html'
 

--- a/netbox/extras/constants.py
+++ b/netbox/extras/constants.py
@@ -37,10 +37,10 @@ GRAPH_TYPE_CHOICES = (
 
 # Models which support export templates
 EXPORTTEMPLATE_MODELS = [
-    'site', 'rack', 'device', 'consoleport', 'powerport', 'interfaceconnection',                # DCIM
-    'aggregate', 'prefix', 'ipaddress', 'vlan',                                                 # IPAM
-    'provider', 'circuit',                                                                      # Circuits
-    'tenant',                                                                                   # Tenants
+    'site', 'rack', 'device', 'consoleport', 'powerport', 'interfaceconnection',    # DCIM
+    'aggregate', 'prefix', 'ipaddress', 'vlan',                                     # IPAM
+    'provider', 'circuit',                                                          # Circuits
+    'tenant',                                                                       # Tenants
 ]
 
 # User action types

--- a/netbox/extras/constants.py
+++ b/netbox/extras/constants.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 # Models which support custom fields
 CUSTOMFIELD_MODELS = (
-    'site', 'rack', 'devicetype', 'device',                 # DCIM
+    'site', 'rack', 'devicetype', 'device', 'interface',    # DCIM
     'aggregate', 'prefix', 'ipaddress', 'vlan', 'vrf',      # IPAM
     'provider', 'circuit',                                  # Circuits
     'tenant',                                               # Tenants
@@ -37,10 +37,10 @@ GRAPH_TYPE_CHOICES = (
 
 # Models which support export templates
 EXPORTTEMPLATE_MODELS = [
-    'site', 'rack', 'device', 'consoleport', 'powerport', 'interfaceconnection',    # DCIM
-    'aggregate', 'prefix', 'ipaddress', 'vlan',                                     # IPAM
-    'provider', 'circuit',                                                          # Circuits
-    'tenant',                                                                       # Tenants
+    'site', 'rack', 'device', 'consoleport', 'powerport', 'interfaceconnection', 'interface',   # DCIM
+    'aggregate', 'prefix', 'ipaddress', 'vlan',                                                 # IPAM
+    'provider', 'circuit',                                                                      # Circuits
+    'tenant',                                                                                   # Tenants
 ]
 
 # User action types

--- a/netbox/extras/constants.py
+++ b/netbox/extras/constants.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 
 # Models which support custom fields
 CUSTOMFIELD_MODELS = (
-    'site', 'rack', 'devicetype', 'device', 'interface',    # DCIM
+    'site', 'rack', 'devicetype', 'device',                 # DCIM
     'aggregate', 'prefix', 'ipaddress', 'vlan', 'vrf',      # IPAM
     'provider', 'circuit',                                  # Circuits
     'tenant',                                               # Tenants
@@ -37,7 +37,7 @@ GRAPH_TYPE_CHOICES = (
 
 # Models which support export templates
 EXPORTTEMPLATE_MODELS = [
-    'site', 'rack', 'device', 'consoleport', 'powerport', 'interfaceconnection', 'interface',   # DCIM
+    'site', 'rack', 'device', 'consoleport', 'powerport', 'interfaceconnection',                # DCIM
     'aggregate', 'prefix', 'ipaddress', 'vlan',                                                 # IPAM
     'provider', 'circuit',                                                                      # Circuits
     'tenant',                                                                                   # Tenants

--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -385,3 +385,17 @@ td .progress {
 textarea {
     font-family: Consolas, Lucida Console, monospace;
 }
+.label-enabled {
+  background-color: #6fd86f;
+}
+.label-enabled[href]:hover,
+.label-enabled[href]:focus {
+  background-color: #3ccd3c;
+}
+.label-disabled {
+  background-color: #d86f6f;
+}
+.label-disabled[href]:hover,
+.label-disabled[href]:focus {
+  background-color: #cd3c3c;
+}

--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -400,5 +400,8 @@ textarea {
   background-color: #cd3c3c;
 }
 i.fa-comment-o {
-  visibility:hidden;
+  display:inline;
+}
+.iface-description {
+  display:none;
 }

--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -399,3 +399,6 @@ textarea {
 .label-disabled[href]:focus {
   background-color: #cd3c3c;
 }
+i.fa-comment-o {
+  visibility:hidden;
+}

--- a/netbox/templates/_base.html
+++ b/netbox/templates/_base.html
@@ -85,6 +85,9 @@
                                 <li><a href="{% url 'dcim:device_add' %}"><i class="fa fa-plus" aria-hidden="true"></i> Add a Device</a></li>
                                 <li><a href="{% url 'dcim:device_import' %}"><i class="fa fa-download" aria-hidden="true"></i> Import Devices</a></li>
                             {% endif %}
+                            {% if perms.dcim.add_interface %}
+                                <li><a href="{% url 'dcim:interfaces_import' %}"><i class="fa fa-download" aria-hidden="true"></i> Import Interfaces</a></li>
+                            {% endif %}
                             {% if perms.ipam.add_device or perms.ipam.add_devicetype %}
                                 <li class="divider"></li>
                             {% endif %}

--- a/netbox/templates/_base.html
+++ b/netbox/templates/_base.html
@@ -85,6 +85,7 @@
                                 <li><a href="{% url 'dcim:device_add' %}"><i class="fa fa-plus" aria-hidden="true"></i> Add a Device</a></li>
                                 <li><a href="{% url 'dcim:device_import' %}"><i class="fa fa-download" aria-hidden="true"></i> Import Devices</a></li>
                             {% endif %}
+                            <li><a href="{% url 'dcim:interface_list' %}"><i class="fa fa-search" aria-hidden="true"></i> Interfaces</a></li>
                             {% if perms.dcim.add_interface %}
                                 <li><a href="{% url 'dcim:interface_import' %}"><i class="fa fa-download" aria-hidden="true"></i> Import Interfaces</a></li>
                             {% endif %}

--- a/netbox/templates/_base.html
+++ b/netbox/templates/_base.html
@@ -86,7 +86,7 @@
                                 <li><a href="{% url 'dcim:device_import' %}"><i class="fa fa-download" aria-hidden="true"></i> Import Devices</a></li>
                             {% endif %}
                             {% if perms.dcim.add_interface %}
-                                <li><a href="{% url 'dcim:interfaces_import' %}"><i class="fa fa-download" aria-hidden="true"></i> Import Interfaces</a></li>
+                                <li><a href="{% url 'dcim:interface_import' %}"><i class="fa fa-download" aria-hidden="true"></i> Import Interfaces</a></li>
                             {% endif %}
                             {% if perms.ipam.add_device or perms.ipam.add_devicetype %}
                                 <li class="divider"></li>

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -389,7 +389,7 @@
                             <span class="glyphicon glyphicon-check" aria-hidden="true"></span> Show IPs
                         </button>
                         <button class="btn btn-default btn-xs toggle-description">
-                            <span class="glyphicon glyphicon-check" aria-hidden="true"></span> Show Descriptions
+                            <span class="glyphicon glyphicon-uncheck" aria-hidden="true"></span> Show Descriptions
                         </button>
                         {% if perms.dcim.change_interface and interfaces|length > 1 %}
                             <button class="btn btn-default btn-xs toggle">
@@ -640,7 +640,7 @@ $('button.toggle-description').click(function() {
         $('span.iface-description').show();
         $('i.fa-comment-o').hide();
     }
-    //$(this).attr('selected', !selected);
+    $(this).attr('selected', !selected);
     $(this).children('span').toggleClass('glyphicon-check glyphicon-unchecked');
     return false;
 });

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -388,6 +388,9 @@
                         <button class="btn btn-default btn-xs toggle-ips" selected="selected">
                             <span class="glyphicon glyphicon-check" aria-hidden="true"></span> Show IPs
                         </button>
+                        <button class="btn btn-default btn-xs toggle-description" selected="selected">
+                            <span class="glyphicon glyphicon-check" aria-hidden="true"></span> Show Description
+                        </button>
                         {% if perms.dcim.change_interface and interfaces|length > 1 %}
                             <button class="btn btn-default btn-xs toggle">
                                 <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span> Select all
@@ -622,6 +625,18 @@ $('button.toggle-ips').click(function() {
         $('#interfaces_table tr.ipaddress').hide();
     } else {
         $('#interfaces_table tr.ipaddress').show();
+    }
+    $(this).attr('selected', !selected);
+    $(this).children('span').toggleClass('glyphicon-check glyphicon-unchecked');
+    return false;
+});
+// Toggle the display of Descriptions under interfaces
+$('button.toggle-description').click(function() {
+    var selected = $(this).attr('selected');
+    if (selected) {
+        $('#interfaces_table tr.description').hide();
+    } else {
+        $('#interfaces_table tr.description').show();
     }
     $(this).attr('selected', !selected);
     $(this).children('span').toggleClass('glyphicon-check glyphicon-unchecked');

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -389,7 +389,7 @@
                             <span class="glyphicon glyphicon-check" aria-hidden="true"></span> Show IPs
                         </button>
                         <button class="btn btn-default btn-xs toggle-description">
-                            <span class="glyphicon glyphicon-uncheck" aria-hidden="true"></span> Show Descriptions
+                            <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span> Show Descriptions
                         </button>
                         {% if perms.dcim.change_interface and interfaces|length > 1 %}
                             <button class="btn btn-default btn-xs toggle">

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -635,8 +635,10 @@ $('button.toggle-description').click(function() {
     var selected = $(this).attr('selected');
     if (selected) {
         $('span.iface-description').hide();
+        $('i.fa-comment-o').show();
     } else {
         $('span.iface-description').show();
+        $('i.fa-comment-o').hide();
     }
     $(this).attr('selected', !selected);
     $(this).children('span').toggleClass('glyphicon-check glyphicon-unchecked');

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -381,7 +381,6 @@
                     Import Interfaces
                 </a>
                 {% endif %}
-                {% include 'inc/export_button.html' with obj_type='interfaces' %}
                 <div class="panel-heading">
                     <strong>Interfaces</strong>
                     <div class="pull-right">

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -374,6 +374,14 @@
                 <input type="hidden" name="device" value="{{ device.pk }}" />
             {% endif %}
             <div class="panel panel-default">
+                <div class="pull-right">
+                {% if perms.dcim.add_interface %}
+                <a href="{% url 'dcim:interfaces_import' %}" class="btn btn-info">
+                <span class="fa fa-download" aria-hidden="true"></span>
+                    Import Interfaces
+                </a>
+                {% endif %}
+                {% include 'inc/export_button.html' with obj_type='interfaces' %}
                 <div class="panel-heading">
                     <strong>Interfaces</strong>
                     <div class="pull-right">

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -380,6 +380,10 @@
                 <span class="fa fa-download" aria-hidden="true"></span>
                     Import Interfaces
                 </a>
+                 <a href="{% url 'dcim:interface_list' %}?device={{ device.name }}&export" class="btn btn-success">
+                    <span class="fa fa-upload" aria-hidden="true"></span>
+                    Export Interfaces
+                </a>
                 {% endif %}
                 <div class="panel-heading">
                     <strong>Interfaces</strong>

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -634,9 +634,9 @@ $('button.toggle-ips').click(function() {
 $('button.toggle-description').click(function() {
     var selected = $(this).attr('selected');
     if (selected) {
-        $('#interfaces_table tr.description').hide();
+        $('#interfaces_table iface.description').hide();
     } else {
-        $('#interfaces_table tr.description').show();
+        $('#interfaces_table iface.description').show();
     }
     $(this).attr('selected', !selected);
     $(this).children('span').toggleClass('glyphicon-check glyphicon-unchecked');

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -376,7 +376,7 @@
             <div class="panel panel-default">
                 <div class="pull-right">
                 {% if perms.dcim.add_interface %}
-                <a href="{% url 'dcim:interfaces_import' %}" class="btn btn-info">
+                <a href="{% url 'dcim:interface_import' %}" class="btn btn-info">
                 <span class="fa fa-download" aria-hidden="true"></span>
                     Import Interfaces
                 </a>

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -640,7 +640,7 @@ $('button.toggle-description').click(function() {
         $('span.iface-description').show();
         $('i.fa-comment-o').hide();
     }
-    $(this).attr('selected', !selected);
+    //$(this).attr('selected', !selected);
     $(this).children('span').toggleClass('glyphicon-check glyphicon-unchecked');
     return false;
 });

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -634,9 +634,9 @@ $('button.toggle-ips').click(function() {
 $('button.toggle-description').click(function() {
     var selected = $(this).attr('selected');
     if (selected) {
-        $('#interfaces_table iface.description').hide();
+        $('span.iface-description').hide();
     } else {
-        $('#interfaces_table iface.description').show();
+        $('span.iface-description').show();
     }
     $(this).attr('selected', !selected);
     $(this).children('span').toggleClass('glyphicon-check glyphicon-unchecked');

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -388,8 +388,8 @@
                         <button class="btn btn-default btn-xs toggle-ips" selected="selected">
                             <span class="glyphicon glyphicon-check" aria-hidden="true"></span> Show IPs
                         </button>
-                        <button class="btn btn-default btn-xs toggle-description" selected="selected">
-                            <span class="glyphicon glyphicon-check" aria-hidden="true"></span> Show Description
+                        <button class="btn btn-default btn-xs toggle-description">
+                            <span class="glyphicon glyphicon-check" aria-hidden="true"></span> Show Descriptions
                         </button>
                         {% if perms.dcim.change_interface and interfaces|length > 1 %}
                             <button class="btn btn-default btn-xs toggle">

--- a/netbox/templates/dcim/inc/interface.html
+++ b/netbox/templates/dcim/inc/interface.html
@@ -15,7 +15,7 @@
         {% endif %}
         <td>
         {% if iface.description %}
-            <span title="{{ iface.description }}">{{ iface.description }}</span>
+            <span title="iface.description">{{ iface.description }}</span>
         {% endif %}
     </td>
     </td>

--- a/netbox/templates/dcim/inc/interface.html
+++ b/netbox/templates/dcim/inc/interface.html
@@ -11,7 +11,7 @@
             <span class="label label-primary">{{ iface.lag.name }}</span>
         {% endif %}
         {% if iface.description %}
-            <i class="fa fa-fw fa-comment-o" hidden="true" title="{{ iface.description }}"></i>
+            <i class="fa fa-fw fa-comment-o" aria-hidden="true" title="{{ iface.description }}"></i>
         {% endif %}
         <td>
         {% if iface.description %}

--- a/netbox/templates/dcim/inc/interface.html
+++ b/netbox/templates/dcim/inc/interface.html
@@ -11,7 +11,7 @@
             <span class="label label-primary">{{ iface.lag.name }}</span>
         {% endif %}
         {% if iface.description %}
-            <i class="fa fa-fw fa-comment-o" title="{{ iface.description }}"></i>
+            <i class="fa fa-fw fa-comment-o" aria-hidden="true" title="{{ iface.description }}"></i>
         {% endif %}
         <td>
         {% if iface.description %}

--- a/netbox/templates/dcim/inc/interface.html
+++ b/netbox/templates/dcim/inc/interface.html
@@ -15,7 +15,7 @@
         {% endif %}
         <td>
         {% if iface.description %}
-            <span class="label label-primary iface-description" title="{{ iface.description }}">{{ iface.description }}</span>
+            <span class="text-muted iface-description" title="{{ iface.description }}">{{ iface.description }}</span>
         {% endif %}
     </td>
     </td>

--- a/netbox/templates/dcim/inc/interface.html
+++ b/netbox/templates/dcim/inc/interface.html
@@ -13,6 +13,11 @@
         {% if iface.description %}
             <i class="fa fa-fw fa-comment-o" title="{{ iface.description }}"></i>
         {% endif %}
+        <td>
+        {% if iface.description %}
+            <span title="{{ iface.description }}">{{ iface.description }}</span>
+        {% endif %}
+    </td>
     </td>
     <td>{{ iface.mtu|default:"" }}</td>
     <td>{{ iface.mac_address|default:"" }}</td>

--- a/netbox/templates/dcim/inc/interface.html
+++ b/netbox/templates/dcim/inc/interface.html
@@ -11,7 +11,7 @@
             <span class="label label-primary">{{ iface.lag.name }}</span>
         {% endif %}
         {% if iface.description %}
-            <i class="fa fa-fw fa-comment-o" aria-hidden="true" title="{{ iface.description }}"></i>
+            <i class="fa fa-fw fa-comment-o" hidden="true" title="{{ iface.description }}"></i>
         {% endif %}
         <td>
         {% if iface.description %}

--- a/netbox/templates/dcim/inc/interface.html
+++ b/netbox/templates/dcim/inc/interface.html
@@ -15,7 +15,7 @@
         {% endif %}
         <td>
         {% if iface.description %}
-            <span title="iface.description">{{ iface.description }}</span>
+            <span class="label label-primary iface-description" title="{{ iface.description }}">{{ iface.description }}</span>
         {% endif %}
     </td>
     </td>

--- a/netbox/templates/dcim/interface_list.html
+++ b/netbox/templates/dcim/interface_list.html
@@ -10,7 +10,6 @@
             Import Interfaces
         </a>
     {% endif %}
-    {% include 'inc/export_button.html' with obj_type='interfaces' %}
 </div>
 <h1>Interfaces</h1>
 <div class="row">

--- a/netbox/templates/dcim/interface_list.html
+++ b/netbox/templates/dcim/interface_list.html
@@ -10,6 +10,7 @@
             Import Interfaces
         </a>
     {% endif %}
+    {% include 'inc/export_button.html' with obj_type='interfaces' %}
 </div>
 <h1>Interfaces</h1>
 <div class="row">

--- a/netbox/templates/dcim/interface_list.html
+++ b/netbox/templates/dcim/interface_list.html
@@ -1,0 +1,24 @@
+{% extends '_base.html' %}
+
+{% block title %}Interfaces{% endblock %}
+
+{% block content %}
+<div class="pull-right">
+    {% if perms.dcim.add_interfaces %}
+        <a href="{% url 'dcim:interface_import' %}" class="btn btn-info">
+            <span class="fa fa-download" aria-hidden="true"></span>
+            Import Interfaces
+        </a>
+    {% endif %}
+    {% include 'inc/export_button.html' with obj_type='interface' %}
+</div>
+<h1>Interface Connections</h1>
+<div class="row">
+	<div class="col-md-9">
+        {% include 'responsive_table.html' %}
+    </div>
+    <div class="col-md-3">
+		{% include 'inc/search_panel.html' %}
+    </div>
+</div>
+{% endblock %}

--- a/netbox/templates/dcim/interface_list.html
+++ b/netbox/templates/dcim/interface_list.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="pull-right">
-    {% if perms.dcim.add_interfaces %}
+    {% if perms.dcim.add_interface %}
         <a href="{% url 'dcim:interface_import' %}" class="btn btn-info">
             <span class="fa fa-download" aria-hidden="true"></span>
             Import Interfaces

--- a/netbox/templates/dcim/interface_list.html
+++ b/netbox/templates/dcim/interface_list.html
@@ -12,7 +12,7 @@
     {% endif %}
     {% include 'inc/export_button.html' with obj_type='interface' %}
 </div>
-<h1>Interface Connections</h1>
+<h1>Interfaces</h1>
 <div class="row">
 	<div class="col-md-9">
         {% include 'responsive_table.html' %}

--- a/netbox/templates/dcim/interface_list.html
+++ b/netbox/templates/dcim/interface_list.html
@@ -10,7 +10,7 @@
             Import Interfaces
         </a>
     {% endif %}
-    {% include 'inc/export_button.html' with obj_type='interface' %}
+    {% include 'inc/export_button.html' with obj_type='interfaces' %}
 </div>
 <h1>Interfaces</h1>
 <div class="row">


### PR DESCRIPTION
### Fixes: #1347 Bulk CSV import for more object types

If you would prefer I can open a feature request/requests specifically for these changes under my name and resubmit.  Apologize for all of the tiny commits...netbox dev running on non-local vm and I'm a Django novice.

Proposed changes:
1. Add Import Interfaces CSV form
2. Add Interfaces List form to allow search and filtering for export
3. Add Import and Export Interfaces buttons to Device view with direct link to Interface List form export(for specific device).
4. Toggle inline descriptions vs. hover comment bubble (Default off using css visibility:none)

Also apologize for the laziness and trying to sneak in 4 ;)