### PR TITLE
Added missing package for CentOS and Fedora

### DIFF
--- a/docs/installation/netbox.md
+++ b/docs/installation/netbox.md
@@ -20,7 +20,7 @@ Python 3:
 
 ```no-highlight
 # yum install -y epel-release
-# yum install -y gcc python34 python34-devel python34-setuptools libxml2-devel libxslt-devel libffi-devel graphviz openssl-devel
+# yum install -y gcc python34 python34-devel python34-setuptools libxml2-devel libxslt-devel libffi-devel graphviz openssl-devel redhat-rpm-config
 # easy_install-3.4 pip
 # ln -s -f python3.4 /usr/bin/python
 ```
@@ -29,7 +29,7 @@ Python 2:
 
 ```no-highlight
 # yum install -y epel-release
-# yum install -y gcc python2 python-devel python-pip libxml2-devel libxslt-devel libffi-devel graphviz openssl-devel
+# yum install -y gcc python2 python-devel python-pip libxml2-devel libxslt-devel libffi-devel graphviz openssl-devel redhat-rpm-config
 ```
 
 You may opt to install NetBox either from a numbered release or by cloning the master branch of its repository on GitHub.


### PR DESCRIPTION
Without the added package, installation fails during `pip install -r requirements.txt` on the pycrypto package for me in CentOS 6 and 7 and Fedora.

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
* Documentation

<!--
    Please include a summary of the proposed changes below.
-->
Adds the package `redhat-rpm-config` to the `yum` commands for CentOS.