### PR TITLE
Implements #1586, add additional variants for ExpandableNameFields

### DIFF
--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -39,7 +39,7 @@ COLOR_CHOICES = (
     ('111111', 'Black'),
 )
 NUMERIC_EXPANSION_PATTERN = '\[((?:\d+[?:,-])+\d+)\]'
-ALPHABETIC_EXPANSION_PATTERN = '\[((?:[a-z]+[?:,-])+[a-z]+)\]'
+ALPHANUMERIC_EXPANSION_PATTERN = '\[((?:\w+[?:,-])+\w+)\]'
 IP4_EXPANSION_PATTERN = '\[((?:[0-9]{1,3}[?:,-])+[0-9]{1,3})\]'
 IP6_EXPANSION_PATTERN = '\[((?:[0-9a-f]{1,4}[?:,-])+[0-9a-f]{1,4})\]'
 
@@ -78,9 +78,9 @@ def expand_numeric_pattern(string):
             yield "{}{}{}".format(lead, i, remnant)
 
 
-def parse_alphabetic_range(string):
+def parse_alphanumeric_range(string):
     """
-    Expand an alphabetic range (continuous or not) into a list.
+    Expand an alphanumeric range (continuous or not) into a list.
     'a-d,f' => ['a', 'b', 'c', 'd', 'f']
     """
     values = []
@@ -95,15 +95,15 @@ def parse_alphabetic_range(string):
     return values
 
 
-def expand_alphabetic_pattern(string):
+def expand_alphanumeric_pattern(string):
     """
     Expand an alphabetic pattern into a list of strings.
     """
-    lead, pattern, remnant = re.split(ALPHABETIC_EXPANSION_PATTERN, string, maxsplit=1)
-    parsed_range = parse_alphabetic_range(pattern)
+    lead, pattern, remnant = re.split(ALPHANUMERIC_EXPANSION_PATTERN, string, maxsplit=1)
+    parsed_range = parse_alphanumeric_range(pattern)
     for i in parsed_range:
-        if re.search(ALPHABETIC_EXPANSION_PATTERN, remnant):
-            for string in expand_alphabetic_pattern(remnant):
+        if re.search(ALPHANUMERIC_EXPANSION_PATTERN, remnant):
+            for string in expand_alphanumeric_pattern(remnant):
                 yield "{}{}{}".format(lead, i, string)
         else:
             yield "{}{}{}".format(lead, i, remnant)
@@ -339,12 +339,9 @@ class ExpandableNameField(forms.CharField):
                              'Example: <code>ge-0/0/[0-23,25,30]</code>'
 
     def to_python(self, value):
-        values = []
-        if re.search(NUMERIC_EXPANSION_PATTERN, value):
-            values += expand_numeric_pattern(value)
-        if re.search(ALPHABETIC_EXPANSION_PATTERN, value):
-            values += expand_alphabetic_pattern(value)
-        return values
+        if re.search(ALPHANUMERIC_EXPANSION_PATTERN, value):
+            return list(expand_alphanumeric_pattern(value))
+        return [value]
 
 
 class ExpandableIPAddressField(forms.CharField):

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -89,9 +89,10 @@ def parse_alphanumeric_range(string):
         try:
             begin, end = dash_range.split('-')
             # Skip if incompatible types or mixed case, just like any other bad pattern
-            if (str.isalpha(begin) and str.isdigit(end)) or (str.isdigit(begin) and str.isalpha(end)):
+            vals = begin + end
+            if not (vals.isdigit() or vals.isalpha()):
                 continue
-            if not (str.isupper(begin + end) or str.islower(begin + end)):
+            if vals.isalpha() and not (vals.isupper() or vals.islower()):
                 continue
         except ValueError:
             begin, end = dash_range, dash_range

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -39,7 +39,7 @@ COLOR_CHOICES = (
     ('111111', 'Black'),
 )
 NUMERIC_EXPANSION_PATTERN = '\[((?:\d+[?:,-])+\d+)\]'
-ALPHANUMERIC_EXPANSION_PATTERN = '\[((?:\w+[?:,-])+\w+)\]'
+ALPHANUMERIC_EXPANSION_PATTERN = '\[((?:[a-zA-Z0-9]+[?:,-])+[a-zA-Z0-9]+)\]'
 IP4_EXPANSION_PATTERN = '\[((?:[0-9]{1,3}[?:,-])+[0-9]{1,3})\]'
 IP6_EXPANSION_PATTERN = '\[((?:[0-9a-f]{1,4}[?:,-])+[0-9a-f]{1,4})\]'
 
@@ -87,6 +87,8 @@ def parse_alphanumeric_range(string):
     for dash_range in string.split(','):
         try:
             begin, end = dash_range.split('-')
+            if (str.isalpha(begin) and str.isdigit(end)) or (str.isdigit(begin) and str.isalpha(end)):
+                continue  # Skip if it's invalid, just like any other bad pattern
         except ValueError:
             begin, end = dash_range, dash_range
         nums = list(range(ord(begin), ord(end)+1))

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -341,7 +341,7 @@ class ExpandableNameField(forms.CharField):
         super(ExpandableNameField, self).__init__(*args, **kwargs)
         if not self.help_text:
             self.help_text = 'Alphanumeric ranges are supported for bulk creation.<br />' \
-                             'Mixed cases and types in ranges are not supported.<br />' \
+                             'Mixed cases and types within a single range are not supported.<br />' \
                              'Examples:<ul><li><code>ge-0/0/[0-23,25,30]</code></li>' \
                              '<li><code>e[0-3][a-d,f]</code></li>' \
                              '<li><code>e[0-3,a-d,f]</code></li></ul>'

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -340,8 +340,11 @@ class ExpandableNameField(forms.CharField):
     def __init__(self, *args, **kwargs):
         super(ExpandableNameField, self).__init__(*args, **kwargs)
         if not self.help_text:
-            self.help_text = 'Numeric ranges are supported for bulk creation.<br />'\
-                             'Example: <code>ge-0/0/[0-23,25,30]</code>'
+            self.help_text = 'Alphanumeric ranges are supported for bulk creation.<br />' \
+                             'Mixed cases and types in ranges are not supported.<br />' \
+                             'Examples:<ul><li><code>ge-0/0/[0-23,25,30]</code></li>' \
+                             '<li><code>e[0-3][a-d,f]</code></li>' \
+                             '<li><code>e[0-3,a-d,f]</code></li></ul>'
 
     def to_python(self, value):
         if re.search(ALPHANUMERIC_EXPANSION_PATTERN, value):

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -87,8 +87,11 @@ def parse_alphanumeric_range(string):
     for dash_range in string.split(','):
         try:
             begin, end = dash_range.split('-')
+            # Skip if incompatible types or mixed case, just like any other bad pattern
             if (str.isalpha(begin) and str.isdigit(end)) or (str.isdigit(begin) and str.isalpha(end)):
-                continue  # Skip if it's invalid, just like any other bad pattern
+                continue
+            if not (str.isupper(begin + end) or str.islower(begin + end)):
+                continue
         except ValueError:
             begin, end = dash_range, dash_range
         nums = list(range(ord(begin), ord(end)+1))

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -88,17 +88,18 @@ def parse_alphanumeric_range(string):
     for dash_range in string.split(','):
         try:
             begin, end = dash_range.split('-')
-            # Skip if incompatible types or mixed case, just like any other bad pattern
             vals = begin + end
-            if not (vals.isdigit() or vals.isalpha()):
-                continue
-            if vals.isalpha() and not (vals.isupper() or vals.islower()):
-                continue
+            # Break out of loop if there's an invalid pattern to return an error
+            if (not (vals.isdigit() or vals.isalpha())) or (vals.isalpha() and not (vals.isupper() or vals.islower())):
+                return []
         except ValueError:
             begin, end = dash_range, dash_range
-        nums = list(range(ord(begin), ord(end) + 1))
-        for n in nums:
-            values.append(chr(n))
+        if begin.isdigit() and end.isdigit():
+            for n in list(range(int(begin), int(end) + 1)):
+                values.append(n)
+        else:
+            for n in list(range(ord(begin), ord(end) + 1)):
+                values.append(chr(n))
     return values
 
 

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -96,7 +96,7 @@ def parse_alphanumeric_range(string):
                 continue
         except ValueError:
             begin, end = dash_range, dash_range
-        nums = list(range(ord(begin), ord(end)+1))
+        nums = list(range(ord(begin), ord(end) + 1))
         for n in nums:
             values.append(chr(n))
     return values

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -81,7 +81,8 @@ def expand_numeric_pattern(string):
 def parse_alphanumeric_range(string):
     """
     Expand an alphanumeric range (continuous or not) into a list.
-    'a-d,f' => ['a', 'b', 'c', 'd', 'f']
+    'a-d,f' => [a, b, c, d, f]
+    '0-3,a-d' => [0, 1, 2, 3, a, b, c, d]
     """
     values = []
     for dash_range in string.split(','):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
#1586: When creating Interfaces, allow more wildcard variants
<!--
    Please include a summary of the proposed changes below.
-->
Adds the availability for using alphanumeric characters instead of just numeric characters for ExpandableNameFields. This adds to the available characters available for use in expansions from just `[0-9]` to `[a-zA-Z0-9]` (or the regex equivalent of `\w` without `_`).

Mixing of types (numeric or alphabetic) or cases (uppercase or lowercase) within the same range is not allowed and is prevented.

Examples of what's allowed:
```nohighlight
[0-2,a-c,A-C] => 0, 1, 2, a, b, c, A, B, C
[0-2][a-b] => 0a, 0b, 1a, 1b, 2a, 2b
```

Examples of what's **not** allowed and is prevented:
```nohighlight
[0-a]
[A-z]
```