### PR TITLE
Remove ConfirmationForm superclass from BulkDeleteForm

### DIFF
--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -21,7 +21,7 @@ from django.utils.safestring import mark_safe
 from django.views.generic import View
 
 from extras.models import CustomField, CustomFieldValue, ExportTemplate, UserAction
-from utilities.forms import BootstrapMixin, CSVDataField
+from utilities.forms import BootstrapMixin, CSVDataField, ReturnURLForm
 from .error_handlers import handle_protectederror
 from .forms import ConfirmationForm
 from .paginator import EnhancedPaginator
@@ -697,7 +697,7 @@ class BulkDeleteView(View):
         Provide a standard bulk delete form if none has been specified for the view
         """
 
-        class BulkDeleteForm(ConfirmationForm):
+        class BulkDeleteForm(BootstrapMixin, ReturnURLForm):
             pk = ModelMultipleChoiceField(queryset=self.cls.objects.all(), widget=MultipleHiddenInput)
 
         if self.form:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
#1603: Checkboxes on UI at "/ipam/vrfs/X" Not Linked to Any Action
<!--
    Please include a summary of the proposed changes below.
-->
This fixes the above issue by disconnecting BulkDeleteForm from ConfirmationForm.