### PR TITLE
Fixes #1651: Remove explicit reference to the `name` field

### DIFF
--- a/netbox/templates/dcim/inc/consoleserverport.html
+++ b/netbox/templates/dcim/inc/consoleserverport.html
@@ -5,7 +5,7 @@
         </td>
     {% endif %}
     <td>
-        <i class="fa fa-fw fa-keyboard-o"></i> {{ csp.name }}
+        <i class="fa fa-fw fa-keyboard-o"></i> {{ csp }}
     </td>
     <td></td>
     {% if csp.connected_console %}


### PR DESCRIPTION
### Fixes:
#1651 
<!--
    Please include a summary of the proposed changes below.
-->
Remove the explicit usage of the `name` field, and let the __str__ method of the ConsoleServerPort class handle the display
