### PR TITLE
Fixed #1612 missing field 'serial' in function to_csv()

### DIFF
--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -296,6 +296,7 @@ class Rack(CreatedUpdatedModel, CustomFieldModel):
             self.tenant.name if self.tenant else None,
             self.role.name if self.role else None,
             self.get_type_display() if self.type else None,
+            self.serial,
             self.width,
             self.u_height,
             self.desc_units,


### PR DESCRIPTION
### Fixes:#1612

missing  'serial' field in function to_csv()
