### PR TITLE
resolved utilities views import for ComponentCreateView, fixes #1727

### DIFF
--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -216,7 +216,7 @@ class RackUnitSerializer(serializers.Serializer):
 
 class RackReservationSerializer(serializers.ModelSerializer):
     rack = NestedRackSerializer()
-    user= NestedUserSerializer()
+    user = NestedUserSerializer()
     tenant = NestedTenantSerializer()
 
     class Meta:

--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -25,6 +25,7 @@ from utilities.forms import BootstrapMixin, CSVDataField
 from .error_handlers import handle_protectederror
 from .forms import ConfirmationForm
 from .paginator import EnhancedPaginator
+from .constants import *
 
 
 class CustomFieldQueryset:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1727 

<!--
    Please include a summary of the proposed changes below.
-->
The utilities views.py was missing an import from constants which is needed to pull in a list of Many2Many field types for the ComponentCreateView.