### PR TITLE
Fix for #1778.

### DIFF
--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -308,8 +308,14 @@ class BulkCreateView(View):
 
     def get(self, request):
 
+        # Set initial values for visible form fields from query args
+        initial = {}
+        for field in getattr(self.model_form._meta, 'fields', []):
+            if request.GET.get(field):
+                initial[field] = request.GET[field]
+
         form = self.form()
-        model_form = self.model_form()
+        model_form = self.model_form(initial=initial)
 
         return render(request, self.template_name, {
             'obj_type': self.model_form._meta.model._meta.verbose_name,


### PR DESCRIPTION
This will set initial values for visible bulk-add form fields from query args.

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
#1778 
<!--
    Please include a summary of the proposed changes below.
-->
This is a simple fix to allow bulk-addition of addresses to receive initial values set in the single-address-addition form, which are already passed as query args in the URL.

The approach I took is just to loop through the form's visible Meta fields, and build a dict of initial form field values from query args that match field names. (initial vals described here):

https://docs.djangoproject.com/en/dev/topics/forms/modelforms/#providing-initial-values

Query args that don't match field names are ignored since we loop on meta fields, not the query args, and Django quietly ignores invalid initial values.

There are alternate approaches to comparing the fields but they seemed like micro optimizations and slightly less easy to read:

```python
        fields = getattr(self.model_form._meta, 'fields', [])
        for field in set(fields).intersection(request.GET.keys()):
            if request.GET[field]:
                initial[field] = request.GET[field]
```