### PR TITLE
Release v2.2.8

### DIFF
--- a/docs/installation/ldap.md
+++ b/docs/installation/ldap.md
@@ -24,7 +24,7 @@ sudo pip install django-auth-ldap
 
 # Configuration
 
-Create a file in the same directory as `configuration.py` (typically `netbox/netbox/`) named `ldap_config.py`. Define all of the parameters required below in `ldap_config.py`.
+Create a file in the same directory as `configuration.py` (typically `netbox/netbox/`) named `ldap_config.py`. Define all of the parameters required below in `ldap_config.py`. Complete documentation of all `django-auth-ldap` configuration options is included in the project's [official documentation](http://django-auth-ldap.readthedocs.io/).
 
 ## General Server Configuration
 
@@ -52,6 +52,8 @@ AUTH_LDAP_BIND_PASSWORD = "demo"
 LDAP_IGNORE_CERT_ERRORS = True
 ```
 
+STARTTLS can be configured by setting `AUTH_LDAP_START_TLS = True` and using the `ldap://` URI scheme.
+
 ## User Authentication
 
 !!! info
@@ -78,7 +80,7 @@ AUTH_LDAP_USER_ATTR_MAP = {
 ```
 
 # User Groups for Permissions
-!!! Info
+!!! info
     When using Microsoft Active Directory, Support for nested Groups can be activated by using `GroupOfNamesType()` instead of `NestedGroupOfNamesType()` for `AUTH_LDAP_GROUP_TYPE`.
 
 ```python

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -455,7 +455,7 @@ class DeviceFilter(CustomFieldFilterSet, django_filters.FilterSet):
 
     class Meta:
         model = Device
-        fields = ['serial']
+        fields = ['serial', 'position']
 
     def search(self, queryset, name, value):
         if not value.strip():

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -163,7 +163,7 @@ class RackFilter(CustomFieldFilterSet, django_filters.FilterSet):
 
     class Meta:
         model = Rack
-        fields = ['serial', 'type', 'width', 'u_height', 'desc_units']
+        fields = ['name', 'serial', 'type', 'width', 'u_height', 'desc_units']
 
     def search(self, queryset, name, value):
         if not value.strip():

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -330,7 +330,7 @@ class DeviceRoleFilter(django_filters.FilterSet):
 
     class Meta:
         model = DeviceRole
-        fields = ['name', 'slug', 'color']
+        fields = ['name', 'slug', 'color', 'vm_role']
 
 
 class PlatformFilter(django_filters.FilterSet):

--- a/netbox/ipam/urls.py
+++ b/netbox/ipam/urls.py
@@ -51,6 +51,7 @@ urlpatterns = [
     url(r'^prefixes/(?P<pk>\d+)/$', views.PrefixView.as_view(), name='prefix'),
     url(r'^prefixes/(?P<pk>\d+)/edit/$', views.PrefixEditView.as_view(), name='prefix_edit'),
     url(r'^prefixes/(?P<pk>\d+)/delete/$', views.PrefixDeleteView.as_view(), name='prefix_delete'),
+    url(r'^prefixes/(?P<pk>\d+)/prefixes/$', views.PrefixPrefixesView.as_view(), name='prefix_prefixes'),
     url(r'^prefixes/(?P<pk>\d+)/ip-addresses/$', views.PrefixIPAddressesView.as_view(), name='prefix_ipaddresses'),
 
     # IP addresses

--- a/netbox/netbox/api.py
+++ b/netbox/netbox/api.py
@@ -20,6 +20,9 @@ class FormlessBrowsableAPIRenderer(BrowsableAPIRenderer):
     def show_form_for_method(self, *args, **kwargs):
         return False
 
+    def get_filter_form(self, data, view, request):
+        return None
+
 
 #
 # Authentication

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -13,7 +13,7 @@ except ImportError:
     )
 
 
-VERSION = '2.2.7'
+VERSION = '2.2.8-dev'
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -13,7 +13,7 @@ except ImportError:
     )
 
 
-VERSION = '2.2.8-dev'
+VERSION = '2.2.8'
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -535,7 +535,7 @@
                 <div class="panel-heading">
                     <strong>Power Outlets</strong>
                     <div class="pull-right">
-                        {% if perms.dcim.change_poweroutlet and cs_ports|length > 1 %}
+                        {% if perms.dcim.change_poweroutlet and power_outlets|length > 1 %}
                             <button class="btn btn-default btn-xs toggle">
                                 <span class="glyphicon glyphicon-unchecked" aria-hidden="true"></span> Select all
                             </button>

--- a/netbox/templates/dcim/devicetype_list.html
+++ b/netbox/templates/dcim/devicetype_list.html
@@ -13,7 +13,7 @@
             Import device types
         </a>
     {% endif %}
-    {% include 'inc/export_button.html' with obj_type='devicetypes' %}
+    {% include 'inc/export_button.html' with obj_type='device types' %}
 </div>
 <h1>{% block title %}Device Types{% endblock %}</h1>
 <div class="row">

--- a/netbox/templates/dcim/rackgroup_list.html
+++ b/netbox/templates/dcim/rackgroup_list.html
@@ -13,7 +13,7 @@
             Import rack groups
         </a>
     {% endif %}
-    {% include 'inc/export_button.html' with obj_type='rackgroups' %}
+    {% include 'inc/export_button.html' with obj_type='rack groups' %}
 </div>
 <h1>{% block title %}Rack Groups{% endblock %}</h1>
 <div class="row">

--- a/netbox/templates/ipam/inc/prefix_header.html
+++ b/netbox/templates/ipam/inc/prefix_header.html
@@ -22,8 +22,13 @@
     </div>
 </div>
 <div class="pull-right">
-    {% if perms.ipam.add_ipaddress %}
-		<a href="{% url 'ipam:ipaddress_add' %}?address={{ prefix.get_first_available_ip }}&vrf={{ prefix.vrf.pk }}&tenant_group={{ prefix.tenant.group.pk }}&tenant={{ prefix.tenant.pk }}" class="btn btn-success">
+    {% if perms.ipam.add_prefix and active_tab == 'prefixes' and first_available_prefix %}
+        <a href="{% url 'ipam:prefix_add' %}?prefix={{ first_available_prefix }}&vrf={{ prefix.vrf.pk }}&site={{ prefix.site.pk }}&tenant_group={{ prefix.tenant.group.pk }}&tenant={{ prefix.tenant.pk }}" class="btn btn-success">
+            <i class="fa fa-plus" aria-hidden="true"></i> Add Child Prefix
+        </a>
+    {% endif %}
+    {% if perms.ipam.add_ipaddress and active_tab == 'ip-addresses' and first_available_ip %}
+		<a href="{% url 'ipam:ipaddress_add' %}?address={{ first_available_ip }}&vrf={{ prefix.vrf.pk }}&tenant_group={{ prefix.tenant.group.pk }}&tenant={{ prefix.tenant.pk }}" class="btn btn-success">
 			<span class="fa fa-plus" aria-hidden="true"></span>
 			Add an IP Address
 		</a>
@@ -45,5 +50,6 @@
 {% include 'inc/created_updated.html' with obj=prefix %}
 <ul class="nav nav-tabs" style="margin-bottom: 20px">
     <li role="presentation"{% if active_tab == 'prefix' %} class="active"{% endif %}><a href="{% url 'ipam:prefix' pk=prefix.pk %}">Prefix</a></li>
+    <li role="presentation"{% if active_tab == 'prefixes' %} class="active"{% endif %}><a href="{% url 'ipam:prefix_prefixes' pk=prefix.pk %}">Child Prefixes <span class="badge">{{ prefix.get_child_prefixes.count }}</span></a></li>
     <li role="presentation"{% if active_tab == 'ip-addresses' %} class="active"{% endif %}><a href="{% url 'ipam:prefix_ipaddresses' pk=prefix.pk %}">IP Addresses <span class="badge">{{ prefix.get_child_ips.count }}</span></a></li>
 </ul>

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -139,15 +139,4 @@
         {% include 'panel_table.html' with table=parent_prefix_table heading='Parent Prefixes' %}
 	</div>
 </div>
-<div class="row">
-	<div class="col-md-12">
-        {% if child_prefix_table.rows %}
-            {% include 'utilities/obj_table.html' with table=child_prefix_table table_template='panel_table.html' heading='Child Prefixes' parent=prefix bulk_edit_url='ipam:prefix_bulk_edit' bulk_delete_url='ipam:prefix_bulk_delete' %}
-        {% elif prefix.new_subnet %}
-            <a href="{% url 'ipam:prefix_add' %}?prefix={{ prefix.new_subnet }}{% if prefix.vrf %}&vrf={{ prefix.vrf.pk }}{% endif %}{% if prefix.site %}&site={{ prefix.site.pk }}{% endif %}" class="btn btn-success">
-                <i class="fa fa-plus" aria-hidden="true"></i> Add Child Prefix
-            </a>
-        {% endif %}
-    </div>
-</div>
 {% endblock %}

--- a/netbox/templates/ipam/prefix_ipaddresses.html
+++ b/netbox/templates/ipam/prefix_ipaddresses.html
@@ -3,10 +3,10 @@
 {% block title %}{{ prefix }} - IP Addresses{% endblock %}
 
 {% block content %}
-{% include 'ipam/inc/prefix_header.html' with active_tab='ip-addresses' %}
-<div class="row">
-	<div class="col-md-12">
-        {% include 'utilities/obj_table.html' with table=ip_table table_template='panel_table.html' heading='IP Addresses' bulk_edit_url='ipam:ipaddress_bulk_edit' bulk_delete_url='ipam:ipaddress_bulk_delete' %}
+    {% include 'ipam/inc/prefix_header.html' with active_tab='ip-addresses' %}
+    <div class="row">
+        <div class="col-md-12">
+            {% include 'utilities/obj_table.html' with table=ip_table table_template='panel_table.html' heading='IP Addresses' bulk_edit_url='ipam:ipaddress_bulk_edit' bulk_delete_url='ipam:ipaddress_bulk_delete' %}
+        </div>
     </div>
-</div>
 {% endblock %}

--- a/netbox/templates/ipam/prefix_prefixes.html
+++ b/netbox/templates/ipam/prefix_prefixes.html
@@ -1,0 +1,12 @@
+{% extends '_base.html' %}
+
+{% block title %}{{ prefix }} - Prefixes{% endblock %}
+
+{% block content %}
+    {% include 'ipam/inc/prefix_header.html' with active_tab='prefixes' %}
+    <div class="row">
+        <div class="col-md-12">
+            {% include 'utilities/obj_table.html' with table=prefix_table table_template='panel_table.html' heading='Child Prefixes' bulk_edit_url='ipam:prefix_bulk_edit' bulk_delete_url='ipam:prefix_bulk_delete' %}
+        </div>
+    </div>
+{% endblock %}

--- a/netbox/templates/search.html
+++ b/netbox/templates/search.html
@@ -13,12 +13,14 @@
                     {% for obj_type in results %}
                         <h3 id="{{ obj_type.name|lower }}">{{ obj_type.name|bettertitle }}</h3>
                         {% include 'panel_table.html' with table=obj_type.table hide_paginator=True %}
-                        {% if obj_type.table.page.has_next %}
-                            <a href="{{ obj_type.url }}" class="btn btn-primary pull-right">
-                                <span class="fa fa-arrow-right" aria-hidden="true"></span>
+                        <a href="{{ obj_type.url }}" class="btn btn-primary pull-right">
+                            <span class="fa fa-arrow-right" aria-hidden="true"></span>
+                            {% if obj_type.table.page.has_next %}
                                 See all {{ obj_type.table.page.paginator.count }} results
-                            </a>
-                        {% endif %}
+                            {% else %}
+                                Refine search
+                            {% endif %}
+                        </a>
                     <div class="clearfix"></div>
                     {% endfor %}
                 </div>

--- a/netbox/utilities/middleware.py
+++ b/netbox/utilities/middleware.py
@@ -4,7 +4,7 @@ import sys
 
 from django.conf import settings
 from django.db import ProgrammingError
-from django.http import HttpResponseRedirect
+from django.http import Http404, HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
 
@@ -59,6 +59,10 @@ class ExceptionHandlingMiddleware(object):
 
         # Don't catch exceptions when in debug mode
         if settings.DEBUG:
+            return
+
+        # Ignore Http404s (defer to Django's built-in 404 handling)
+        if isinstance(exception, Http404):
             return
 
         # Determine the type of exception

--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -308,8 +308,14 @@ class BulkCreateView(View):
 
     def get(self, request):
 
+        # Set initial values for visible form fields from query args
+        initial = {}
+        for field in getattr(self.model_form._meta, 'fields', []):
+            if request.GET.get(field):
+                initial[field] = request.GET[field]
+
         form = self.form()
-        model_form = self.model_form()
+        model_form = self.model_form(initial=initial)
 
         return render(request, self.template_name, {
             'obj_type': self.model_form._meta.model._meta.verbose_name,

--- a/netbox/virtualization/filters.py
+++ b/netbox/virtualization/filters.py
@@ -84,6 +84,17 @@ class VirtualMachineFilter(CustomFieldFilterSet):
         to_field_name='slug',
         label='Cluster group (slug)',
     )
+    cluster_type_id = django_filters.ModelMultipleChoiceFilter(
+        name='cluster__type',
+        queryset=ClusterType.objects.all(),
+        label='Cluster type (ID)',
+    )
+    cluster_type = django_filters.ModelMultipleChoiceFilter(
+        name='cluster__type__slug',
+        queryset=ClusterType.objects.all(),
+        to_field_name='slug',
+        label='Cluster type (slug)',
+    )
     cluster_id = django_filters.ModelMultipleChoiceFilter(
         queryset=Cluster.objects.all(),
         label='Cluster (ID)',

--- a/netbox/virtualization/forms.py
+++ b/netbox/virtualization/forms.py
@@ -340,6 +340,11 @@ class VirtualMachineFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         null_option=(0, 'None')
     )
+    cluster_type = FilterChoiceField(
+        queryset=ClusterType.objects.all(),
+        to_field_name='slug',
+        null_option=(0, 'None')
+    )
     cluster_id = FilterChoiceField(
         queryset=Cluster.objects.annotate(filter_count=Count('virtual_machines')),
         label='Cluster'

--- a/netbox/virtualization/models.py
+++ b/netbox/virtualization/models.py
@@ -139,6 +139,7 @@ class Cluster(CreatedUpdatedModel, CustomFieldModel):
             self.name,
             self.type.name,
             self.group.name if self.group else None,
+            self.site.name if self.site else None,
             self.comments,
         ])
 


### PR DESCRIPTION
## Enhancements

* [#1771](https://github.com/digitalocean/netbox/issues/1771) - Added name filter for racks
* [#1772](https://github.com/digitalocean/netbox/issues/1772) - Added position filter for devices
* [#1773](https://github.com/digitalocean/netbox/issues/1773) - Moved child prefixes table to its own view
* [#1774](https://github.com/digitalocean/netbox/issues/1774) - Include a button to refine search results for all object types under global search
* [#1784](https://github.com/digitalocean/netbox/issues/1784) - Added `cluster_type` filters for virtual machines

## Bug Fixes

* [#1766](https://github.com/digitalocean/netbox/issues/1766) - Fixed display of "select all" button on device power outlets list
* [#1767](https://github.com/digitalocean/netbox/issues/1767) - Use proper template for 404 responses
* [#1778](https://github.com/digitalocean/netbox/issues/1778) - Preserve initial VRF assignment when adding IP addresses in bulk from a prefix
* [#1783](https://github.com/digitalocean/netbox/issues/1783) - Added `vm_role` filter for device roles
* [#1785](https://github.com/digitalocean/netbox/issues/1785) - Omit filter forms from browsable API
* [#1787](https://github.com/digitalocean/netbox/issues/1787) - Added missing site field to virtualization cluster CSV export