### PR TITLE
Added note for Apache installs using Debian

### DIFF
--- a/docs/installation/web-server.md
+++ b/docs/installation/web-server.md
@@ -96,6 +96,8 @@ Save the contents of the above example in `/etc/apache2/sites-available/netbox.c
 # service apache2 restart
 ```
 
+Note: Installations on Debian will require an additional package, libapache2-mod-wsgi-py3. Without it the restart command above will fail and checking the Apache status will show it is because of the WSGIPassAuthorization command.
+
 To enable SSL, consider this guide on [securing Apache with Let's Encrypt](https://www.digitalocean.com/community/tutorials/how-to-secure-apache-with-let-s-encrypt-on-ubuntu-16-04).
 
 # gunicorn Installation


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

### Fixes:
Corrects missing requirement for Debian using Apache
<!--
    Please include a summary of the proposed changes below.
-->
Install on Debian using Apache fails as described in issue  #1688 and requires installing libapache2-mod-wsgi-py3 to continue using  #WSGIPassAuthorization
