### PR TITLE
Fix for bulk interface edit form 802.1Q settings

### DIFF
--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1934,6 +1934,11 @@ class InterfaceBulkEditForm(BootstrapMixin, BulkEditForm, ChainedFieldsMixin):
                 device = Device.objects.get(pk=self.initial.get('device'))
             except Device.DoesNotExist:
                 pass
+        else:
+            try:
+                device = Device.objects.get(pk=self.data.get('device'))
+            except Device.DoesNotExist:
+                pass
         if device is not None:
             interface_ordering = device.device_type.interface_ordering
             self.fields['lag'].queryset = Interface.objects.order_naturally(method=interface_ordering).filter(
@@ -1950,10 +1955,16 @@ class InterfaceBulkEditForm(BootstrapMixin, BulkEditForm, ChainedFieldsMixin):
             self.fields['site'].queryset = Site.objects.none()
             self.fields['site'].initial = None
 
-        filter_dict = {
-            'group_id': None,
-            'site_id': None,
-        }
+        if self.is_bound:
+            filter_dict = {
+                'group_id': self.data.get('vlan_group') or None,
+                'site_id': self.data.get('site') or None,
+            }
+        else:
+            filter_dict = {
+                'group_id': None,
+                'site_id': None,
+            }
 
         self.fields['untagged_vlan'].queryset = VLAN.objects.filter(**filter_dict)
         self.fields['tagged_vlans'].queryset = VLAN.objects.filter(**filter_dict)

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -2336,3 +2336,4 @@ class DeviceVCMembershipForm(forms.ModelForm):
             raise forms.ValidationError("A virtual chassis member already exists in this position.")
 
         return vc_position
+    

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -2336,4 +2336,3 @@ class DeviceVCMembershipForm(forms.ModelForm):
             raise forms.ValidationError("A virtual chassis member already exists in this position.")
 
         return vc_position
-    


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1881 

<!--
    Please include a summary of the proposed changes below.
-->
Fixed the form init to account for bound data to get the device context for building the proper querysets for the 802.1q fields.
