### PR TITLE
Fix alias value

### DIFF
--- a/docs/installation/web-server.md
+++ b/docs/installation/web-server.md
@@ -24,7 +24,7 @@ server {
     client_max_body_size 25m;
 
     location /static/ {
-        alias /opt/netbox/netbox/static/;
+        alias /opt/netbox/netbox/project-static/;
     }
 
     location / {


### PR DESCRIPTION
At least for v2.3-beta2, the alias location should be `project-static`
and not `static`.

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: Documentation for web server installation. 

<!--
    Please include a summary of the proposed changes below.
-->
