### PR TITLE
Add Ansible alternative installation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,4 @@ and run `upgrade.sh`.
 
 * [Docker container](https://github.com/ninech/netbox-docker) (via [@cimnine](https://github.com/cimnine))
 * [Vagrant deployment](https://github.com/ryanmerolle/netbox-vagrant) (via [@ryanmerolle](https://github.com/ryanmerolle))
+* [Ansible deployment](https://github.com/lae/ansible-role-netbox) (via [@lae](https://github.com/lae))


### PR DESCRIPTION
Just noticed the alternative installation section so I thought I'd include this.