### PR TITLE
Fixed #1928 form bound check for site and vlan group

### DIFF
--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1728,10 +1728,10 @@ class InterfaceForm(BootstrapMixin, forms.ModelForm, ChainedFieldsMixin):
             self.fields['site'].initial = None
 
         # Limit the initial vlan choices
-        if self.is_bound:
+        if self.is_bound and self.data.get('vlan_group') and self.data.get('site'):
             filter_dict = {
-                'group_id': self.data.get('vlan_group') or None,
-                'site_id': self.data.get('site') or None,
+                'group_id': self.data.get('vlan_group'),
+                'site_id': self.data.get('site'),
             }
         elif self.initial.get('untagged_vlan'):
             filter_dict = {
@@ -1854,10 +1854,10 @@ class InterfaceCreateForm(ComponentForm, ChainedFieldsMixin):
             self.fields['site'].initial = None
 
         # Limit the initial vlan choices
-        if self.is_bound:
+        if self.is_bound and self.data.get('vlan_group') and self.data.get('site'):
             filter_dict = {
-                'group_id': self.data.get('vlan_group') or None,
-                'site_id': self.data.get('site') or None,
+                'group_id': self.data.get('vlan_group'),
+                'site_id': self.data.get('site'),
             }
         elif self.initial.get('untagged_vlan'):
             filter_dict = {
@@ -1968,10 +1968,10 @@ class InterfaceBulkEditForm(BootstrapMixin, BulkEditForm, ChainedFieldsMixin):
             self.fields['site'].queryset = Site.objects.none()
             self.fields['site'].initial = None
 
-        if self.is_bound:
+        if self.is_bound and self.data.get('vlan_group') and self.data.get('site'):
             filter_dict = {
-                'group_id': self.data.get('vlan_group') or None,
-                'site_id': self.data.get('site') or None,
+                'group_id': self.data.get('vlan_group'),
+                'site_id': self.data.get('site'),
             }
         else:
             filter_dict = {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1928 

Fixed a bug in the way the form checked the bound state to assign the site and vlan_group filters. This caused a problem when submitting the form with no changes after creating an interface.
