### PR TITLE
Release v2.3.1

### DIFF
--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -21,6 +21,12 @@ Copy the 'configuration.py' you created when first installing to the new version
 # cp /opt/netbox-X.Y.Z/netbox/netbox/configuration.py /opt/netbox/netbox/netbox/configuration.py
 ```
 
+Be sure to replicate your uploaded media as well. (The exact action necessary will depend on where you choose to store your media, but in general moving or copying the media directory will suffice.)
+
+```no-highlight
+# cp -pr /opt/netbox-X.Y.Z/netbox/media/ /opt/netbox/netbox/
+```
+
 If you followed the original installation guide to set up gunicorn, be sure to copy its configuration as well:
 
 ```no-highlight

--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -734,14 +734,30 @@ class WritableInterfaceSerializer(ValidatedModelSerializer):
         # Validate that all untagged VLANs either belong to the same site as the Interface's parent Deivce or
         # VirtualMachine, or are global.
         parent = self.instance.parent if self.instance else data.get('device') or data.get('virtual_machine')
-        for vlan in data.get('tagged_vlans', []):
+        tagged_vlans = data.pop('tagged_vlans', [])
+        for vlan in tagged_vlans:
             if vlan.site not in [parent, None]:
                 raise serializers.ValidationError(
                     "Tagged VLAN {} must belong to the same site as the interface's parent device/VM, or it must be "
                     "global".format(vlan)
                 )
 
-        return super(WritableInterfaceSerializer, self).validate(data)
+        validated_data = super(WritableInterfaceSerializer, self).validate(data)
+        if tagged_vlans:
+            validated_data['tagged_vlans'] = tagged_vlans
+        return validated_data
+
+    def create(self, validated_data):
+        """
+        Becasue tagged_vlans is a M2M relationship, we have to create the interface first
+        """
+        tagged_vlans = validated_data.pop('tagged_vlans', None)
+        interface = Interface.objects.create(**validated_data)
+        interface.save()
+        if tagged_vlans:
+            interface.tagged_vlans = tagged_vlans
+            interface.save()
+        return interface
 
 
 #

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1728,10 +1728,10 @@ class InterfaceForm(BootstrapMixin, forms.ModelForm, ChainedFieldsMixin):
             self.fields['site'].initial = None
 
         # Limit the initial vlan choices
-        if self.is_bound:
+        if self.is_bound and self.data.get('vlan_group') and self.data.get('site'):
             filter_dict = {
-                'group_id': self.data.get('vlan_group') or None,
-                'site_id': self.data.get('site') or None,
+                'group_id': self.data.get('vlan_group'),
+                'site_id': self.data.get('site'),
             }
         elif self.initial.get('untagged_vlan'):
             filter_dict = {
@@ -1854,10 +1854,10 @@ class InterfaceCreateForm(ComponentForm, ChainedFieldsMixin):
             self.fields['site'].initial = None
 
         # Limit the initial vlan choices
-        if self.is_bound:
+        if self.is_bound and self.data.get('vlan_group') and self.data.get('site'):
             filter_dict = {
-                'group_id': self.data.get('vlan_group') or None,
-                'site_id': self.data.get('site') or None,
+                'group_id': self.data.get('vlan_group'),
+                'site_id': self.data.get('site'),
             }
         elif self.initial.get('untagged_vlan'):
             filter_dict = {
@@ -1968,10 +1968,10 @@ class InterfaceBulkEditForm(BootstrapMixin, BulkEditForm, ChainedFieldsMixin):
             self.fields['site'].queryset = Site.objects.none()
             self.fields['site'].initial = None
 
-        if self.is_bound:
+        if self.is_bound and self.data.get('vlan_group') and self.data.get('site'):
             filter_dict = {
-                'group_id': self.data.get('vlan_group') or None,
-                'site_id': self.data.get('site') or None,
+                'group_id': self.data.get('vlan_group'),
+                'site_id': self.data.get('site'),
             }
         else:
             filter_dict = {

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1883,7 +1883,6 @@ class InterfaceCreateForm(ComponentForm, ChainedFieldsMixin):
 
 class InterfaceBulkEditForm(BootstrapMixin, BulkEditForm, ChainedFieldsMixin):
     pk = forms.ModelMultipleChoiceField(queryset=Interface.objects.all(), widget=forms.MultipleHiddenInput)
-    device = forms.ModelChoiceField(queryset=Device.objects.all(), widget=forms.HiddenInput)
     form_factor = forms.ChoiceField(choices=add_blank_choice(IFACE_FF_CHOICES), required=False)
     enabled = forms.NullBooleanField(required=False, widget=BulkEditNullBooleanSelect)
     lag = forms.ModelChoiceField(queryset=Interface.objects.all(), required=False, label='Parent LAG')
@@ -1943,17 +1942,7 @@ class InterfaceBulkEditForm(BootstrapMixin, BulkEditForm, ChainedFieldsMixin):
         super(InterfaceBulkEditForm, self).__init__(*args, **kwargs)
 
         # Limit LAG choices to interfaces which belong to the parent device (or VC master)
-        device = None
-        if self.initial.get('device'):
-            try:
-                device = Device.objects.get(pk=self.initial.get('device'))
-            except Device.DoesNotExist:
-                pass
-        else:
-            try:
-                device = Device.objects.get(pk=self.data.get('device'))
-            except Device.DoesNotExist:
-                pass
+        device = self.parent_obj
         if device is not None:
             interface_ordering = device.device_type.interface_ordering
             self.fields['lag'].queryset = Interface.objects.order_naturally(method=interface_ordering).filter(

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1679,6 +1679,7 @@ class InterfaceForm(BootstrapMixin, forms.ModelForm, ChainedFieldsMixin):
         label='Untagged VLAN',
         widget=APISelect(
             api_url='/api/ipam/vlans/?site_id={{site}}&group_id={{vlan_group}}',
+            display_field='display_name'
         )
     )
     tagged_vlans = ChainedModelMultipleChoiceField(
@@ -1691,6 +1692,7 @@ class InterfaceForm(BootstrapMixin, forms.ModelForm, ChainedFieldsMixin):
         label='Tagged VLANs',
         widget=APISelectMultiple(
             api_url='/api/ipam/vlans/?site_id={{site}}&group_id={{vlan_group}}',
+            display_field='display_name'
         )
     )
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -2291,11 +2291,12 @@ class BaseVCMemberFormSet(forms.BaseModelFormSet):
         # Check for duplicate VC position values
         vc_position_list = []
         for form in self.forms:
-            vc_position = form.cleaned_data['vc_position']
-            if vc_position in vc_position_list:
-                error_msg = 'A virtual chassis member already exists in position {}.'.format(vc_position)
-                form.add_error('vc_position', error_msg)
-            vc_position_list.append(vc_position)
+            vc_position = form.cleaned_data.get('vc_position')
+            if vc_position:
+                if vc_position in vc_position_list:
+                    error_msg = 'A virtual chassis member already exists in position {}.'.format(vc_position)
+                    form.add_error('vc_position', error_msg)
+                vc_position_list.append(vc_position)
 
 
 class DeviceVCMembershipForm(forms.ModelForm):

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -2069,7 +2069,7 @@ class InterfaceConnectionForm(BootstrapMixin, ChainedFieldsMixin, forms.ModelFor
         super(InterfaceConnectionForm, self).__init__(*args, **kwargs)
 
         # Initialize interface A choices
-        device_a_interfaces = Interface.objects.connectable().order_naturally().filter(device=device_a).select_related(
+        device_a_interfaces = device_a.vc_interfaces.connectable().order_naturally().select_related(
             'circuit_termination', 'connected_as_a', 'connected_as_b'
         )
         self.fields['interface_a'].choices = [
@@ -2078,9 +2078,11 @@ class InterfaceConnectionForm(BootstrapMixin, ChainedFieldsMixin, forms.ModelFor
 
         # Mark connected interfaces as disabled
         if self.data.get('device_b'):
-            self.fields['interface_b'].choices = [
-                (iface.id, {'label': iface.name, 'disabled': iface.is_connected}) for iface in self.fields['interface_b'].queryset
-            ]
+            self.fields['interface_b'].choices = []
+            for iface in self.fields['interface_b'].queryset:
+                self.fields['interface_b'].choices.append(
+                    (iface.id, {'label': iface.name, 'disabled': iface.is_connected})
+                )
 
 
 class InterfaceConnectionCSVForm(forms.ModelForm):

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.paginator import EmptyPage, PageNotAnInteger
 from django.db import transaction
 from django.db.models import Count, Q
-from django.forms import ModelChoiceField, ModelForm, modelformset_factory
+from django.forms import modelformset_factory
 from django.http import HttpResponseRedirect
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -2082,13 +2082,12 @@ class VirtualChassisCreateView(PermissionRequiredMixin, View):
         # Get the list of devices being added to a VirtualChassis
         pk_form = forms.DeviceSelectionForm(request.POST)
         pk_form.full_clean()
+        if not pk_form.cleaned_data.get('pk'):
+            messages.warning(request, "No devices were selected.")
+            return redirect('dcim:device_list')
         device_queryset = Device.objects.filter(
             pk__in=pk_form.cleaned_data.get('pk')
         ).select_related('rack').order_by('vc_position')
-
-        if not device_queryset:
-            messages.warning(request, "No devices were selected.")
-            return redirect('dcim:device_list')
 
         VCMemberFormSet = modelformset_factory(
             model=Device,

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -22,7 +22,7 @@ if sys.version_info[0] < 3:
         DeprecationWarning
     )
 
-VERSION = '2.3.0'
+VERSION = '2.3.1-dev'
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -22,7 +22,7 @@ if sys.version_info[0] < 3:
         DeprecationWarning
     )
 
-VERSION = '2.3.1-dev'
+VERSION = '2.3.1'
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/netbox/templates/dcim/inc/consoleport.html
+++ b/netbox/templates/dcim/inc/consoleport.html
@@ -44,7 +44,7 @@
                     <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                 </button>
             {% else %}
-                <a href="{% url 'dcim:consoleport_delete' pk=cp.pk %}" title="Delete port" class="btn btn-danger btn-xs">
+                <a href="{% url 'dcim:consoleport_delete' pk=cp.pk %}?return_url={{ device.get_absolute_url }}" title="Delete port" class="btn btn-danger btn-xs">
                     <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                 </a>
             {% endif %}

--- a/netbox/templates/dcim/inc/consoleserverport.html
+++ b/netbox/templates/dcim/inc/consoleserverport.html
@@ -49,7 +49,7 @@
                     <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                 </button>
             {% else %}
-                <a href="{% url 'dcim:consoleserverport_delete' pk=csp.pk %}" title="Delete port" class="btn btn-danger btn-xs">
+                <a href="{% url 'dcim:consoleserverport_delete' pk=csp.pk %}?return_url={{ device.get_absolute_url }}" title="Delete port" class="btn btn-danger btn-xs">
                     <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                 </a>
             {% endif %}

--- a/netbox/templates/dcim/inc/devicebay.html
+++ b/netbox/templates/dcim/inc/devicebay.html
@@ -40,7 +40,7 @@
                     <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                 </button>
             {% else %}
-                <a href="{% url 'dcim:devicebay_delete' pk=devicebay.pk %}" class="btn btn-danger btn-xs">
+                <a href="{% url 'dcim:devicebay_delete' pk=devicebay.pk %}?return_url={{ device.get_absolute_url }}" class="btn btn-danger btn-xs">
                     <i class="glyphicon glyphicon-trash" aria-hidden="true" title="Delete device bay"></i>
                 </a>
             {% endif %}

--- a/netbox/templates/dcim/inc/interface.html
+++ b/netbox/templates/dcim/inc/interface.html
@@ -124,7 +124,7 @@
                     <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                 </button>
             {% else %}
-                <a href="{% if iface.device_id %}{% url 'dcim:interface_delete' pk=iface.pk %}{% else %}{% url 'virtualization:interface_delete' pk=iface.pk %}{% endif %}" class="btn btn-danger btn-xs" title="Delete interface">
+                <a href="{% if iface.device_id %}{% url 'dcim:interface_delete' pk=iface.pk %}{% else %}{% url 'virtualization:interface_delete' pk=iface.pk %}{% endif %}?return_url={{ device.get_absolute_url }}" class="btn btn-danger btn-xs" title="Delete interface">
                     <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                 </a>
             {% endif %}

--- a/netbox/templates/dcim/inc/inventoryitem.html
+++ b/netbox/templates/dcim/inc/inventoryitem.html
@@ -11,7 +11,7 @@
             <a href="{% url 'dcim:inventoryitem_edit' pk=item.pk %}" class="btn btn-xs btn-warning"><span class="glyphicon glyphicon-pencil" aria-hidden="true"></span></a>
         {% endif %}
         {% if perms.dcim.delete_inventoryitem %}
-            <a href="{% url 'dcim:inventoryitem_delete' pk=item.pk %}" class="btn btn-xs btn-danger"><span class="glyphicon glyphicon-trash" aria-hidden="true"></span></a>
+            <a href="{% url 'dcim:inventoryitem_delete' pk=item.pk %}?return_url={% url 'dcim:device_inventory' pk=device.pk %}" class="btn btn-xs btn-danger"><span class="glyphicon glyphicon-trash" aria-hidden="true"></span></a>
         {% endif %}
     </td>
 </tr>

--- a/netbox/templates/dcim/inc/poweroutlet.html
+++ b/netbox/templates/dcim/inc/poweroutlet.html
@@ -49,7 +49,7 @@
                     <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                 </button>
             {% else %}
-                <a href="{% url 'dcim:poweroutlet_delete' pk=po.pk %}" title="Delete outlet" class="btn btn-danger btn-xs">
+                <a href="{% url 'dcim:poweroutlet_delete' pk=po.pk %}?return_url={{ device.get_absolute_url }}" title="Delete outlet" class="btn btn-danger btn-xs">
                     <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                 </a>
             {% endif %}

--- a/netbox/templates/dcim/inc/powerport.html
+++ b/netbox/templates/dcim/inc/powerport.html
@@ -44,7 +44,7 @@
                     <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                 </button>
             {% else %}
-                <a href="{% url 'dcim:powerport_delete' pk=pp.pk %}" title="Delete port" class="btn btn-danger btn-xs">
+                <a href="{% url 'dcim:powerport_delete' pk=pp.pk %}?return_url={{ device.get_absolute_url }}" title="Delete port" class="btn btn-danger btn-xs">
                     <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                 </a>
             {% endif %}

--- a/netbox/utilities/api.py
+++ b/netbox/utilities/api.py
@@ -55,7 +55,7 @@ class ValidatedModelSerializer(ModelSerializer):
             model = self.Meta.model
             # Ignore ManyToManyFields for new instances (a PK is needed for validation)
             for field in model._meta.get_fields():
-                if isinstance(field, ManyToManyField):
+                if isinstance(field, ManyToManyField) and field.name in attrs:
                     attrs.pop(field.name)
             instance = self.Meta.model(**attrs)
         else:

--- a/netbox/utilities/api.py
+++ b/netbox/utilities/api.py
@@ -5,6 +5,7 @@ import pytz
 
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import ManyToManyField
 from django.http import Http404
 from rest_framework import mixins
 from rest_framework.exceptions import APIException
@@ -51,6 +52,11 @@ class ValidatedModelSerializer(ModelSerializer):
 
         # Run clean() on an instance of the model
         if self.instance is None:
+            model = self.Meta.model
+            # Ignore ManyToManyFields for new instances (a PK is needed for validation)
+            for field in model._meta.get_fields():
+                if isinstance(field, ManyToManyField):
+                    attrs.pop(field.name)
             instance = self.Meta.model(**attrs)
         else:
             instance = self.instance

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -539,9 +539,11 @@ class ComponentForm(BootstrapMixin, forms.Form):
 
 class BulkEditForm(forms.Form):
 
-    def __init__(self, model, *args, **kwargs):
+    def __init__(self, model, parent_obj=None, *args, **kwargs):
         super(BulkEditForm, self).__init__(*args, **kwargs)
         self.model = model
+        self.parent_obj = parent_obj
+
         # Copy any nullable fields defined in Meta
         if hasattr(self.Meta, 'nullable_fields'):
             self.nullable_fields = [field for field in self.Meta.nullable_fields]

--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -507,7 +507,7 @@ class BulkEditView(View):
             pk_list = [int(pk) for pk in request.POST.getlist('pk')]
 
         if '_apply' in request.POST:
-            form = self.form(self.cls, request.POST)
+            form = self.form(self.cls, parent_obj, request.POST)
             if form.is_valid():
 
                 custom_fields = form.custom_fields if hasattr(form, 'custom_fields') else []
@@ -565,7 +565,7 @@ class BulkEditView(View):
         else:
             initial_data = request.POST.copy()
             initial_data['pk'] = pk_list
-            form = self.form(self.cls, initial=initial_data)
+            form = self.form(self.cls, parent_obj, initial=initial_data)
 
         # Retrieve objects being edited
         queryset = self.queryset or self.cls.objects.all()

--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -35,6 +35,7 @@ class CustomFieldQueryset:
 
     def __init__(self, queryset, custom_fields):
         self.queryset = queryset
+        self.model = queryset.model
         self.custom_fields = custom_fields
 
     def __iter__(self):

--- a/netbox/virtualization/api/views.py
+++ b/netbox/virtualization/api/views.py
@@ -25,11 +25,13 @@ class VirtualizationFieldChoicesViewSet(FieldChoicesViewSet):
 class ClusterTypeViewSet(ModelViewSet):
     queryset = ClusterType.objects.all()
     serializer_class = serializers.ClusterTypeSerializer
+    filter_class = filters.ClusterTypeFilter
 
 
 class ClusterGroupViewSet(ModelViewSet):
     queryset = ClusterGroup.objects.all()
     serializer_class = serializers.ClusterGroupSerializer
+    filter_class = filters.ClusterGroupFilter
 
 
 class ClusterViewSet(CustomFieldModelViewSet):

--- a/netbox/virtualization/filters.py
+++ b/netbox/virtualization/filters.py
@@ -13,6 +13,20 @@ from .constants import VM_STATUS_CHOICES
 from .models import Cluster, ClusterGroup, ClusterType, VirtualMachine
 
 
+class ClusterTypeFilter(django_filters.FilterSet):
+
+    class Meta:
+        model = ClusterType
+        fields = ['name', 'slug']
+
+
+class ClusterGroupFilter(django_filters.FilterSet):
+
+    class Meta:
+        model = ClusterGroup
+        fields = ['name', 'slug']
+
+
 class ClusterFilter(CustomFieldFilterSet):
     id__in = NumericInFilter(name='id', lookup_expr='in')
     q = django_filters.CharFilter(

--- a/netbox/virtualization/forms.py
+++ b/netbox/virtualization/forms.py
@@ -442,7 +442,6 @@ class InterfaceCreateForm(ComponentForm):
 
 class InterfaceBulkEditForm(BootstrapMixin, BulkEditForm):
     pk = forms.ModelMultipleChoiceField(queryset=Interface.objects.all(), widget=forms.MultipleHiddenInput)
-    virtual_machine = forms.ModelChoiceField(queryset=VirtualMachine.objects.all(), widget=forms.HiddenInput)
     enabled = forms.NullBooleanField(required=False, widget=BulkEditNullBooleanSelect)
     mtu = forms.IntegerField(required=False, min_value=1, max_value=32767, label='MTU')
     description = forms.CharField(max_length=100, required=False)


### PR DESCRIPTION
## Enhancements

* [#1910](https://github.com/digitalocean/netbox/issues/1910) - Added filters for cluster group and cluster type

## Bug Fixes

* [#1915](https://github.com/digitalocean/netbox/issues/1915) - Redirect to device view after deleting a component
* [#1919](https://github.com/digitalocean/netbox/issues/1919) - Prevent exception when attempting to create a virtual machine without selecting devices
* [#1921](https://github.com/digitalocean/netbox/issues/1921) - Ignore ManyToManyFields when validating a new object created via the API
* [#1924](https://github.com/digitalocean/netbox/issues/1924) - Include VID in VLAN lists when editing an interface
* [#1926](https://github.com/digitalocean/netbox/issues/1926) - Prevent reassignment of parent device when bulk editing VC member interfaces
* [#1927](https://github.com/digitalocean/netbox/issues/1927) - Include all VC member interfaces on A side when creating a new interface connection
* [#1928](https://github.com/digitalocean/netbox/issues/1928) - Fixed form validation when modifying VLANs assigned to an interface
* [#1934](https://github.com/digitalocean/netbox/issues/1934) - Fixed exception when rendering export template on an object type with custom fields assigned
* [#1935](https://github.com/digitalocean/netbox/issues/1935) - Correct API validation of VLANs assigned to interfaces
* [#1936](https://github.com/digitalocean/netbox/issues/1936) - Trigger validation error when attempting to create a virtual chassis without specifying member positions