### PR TITLE
Use relative paths

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -195,13 +195,13 @@ USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
 STATIC_ROOT = BASE_DIR + '/static/'
-STATIC_URL = '/{}static/'.format(BASE_PATH)
+STATIC_URL = '{}static/'.format(BASE_PATH)
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, "project-static"),
 )
 
 # Media
-MEDIA_URL = '/{}media/'.format(BASE_PATH)
+MEDIA_URL = '{}media/'.format(BASE_PATH)
 
 # Disable default limit of 1000 fields per request. Needed for bulk deletion of objects. (Added in Django 1.10.)
 DATA_UPLOAD_MAX_NUMBER_FIELDS = None
@@ -212,7 +212,7 @@ MESSAGE_TAGS = {
 }
 
 # Authentication URLs
-LOGIN_URL = '/{}login/'.format(BASE_PATH)
+LOGIN_URL = '{}login/'.format(BASE_PATH)
 
 # Secrets
 SECRETS_MIN_PUBKEY_SIZE = 2048

--- a/netbox/templates/_base.html
+++ b/netbox/templates/_base.html
@@ -67,7 +67,7 @@
 <script src="{% static 'bootstrap-3.3.7-dist/js/bootstrap.min.js' %}"></script>
 <script src="{% static 'js/forms.js' %}?v{{ settings.VERSION }}"></script>
 <script type="text/javascript">
-    var netbox_api_path = "/{{ settings.BASE_PATH }}api/";
+    var netbox_api_path = "{{ settings.BASE_PATH }}api/";
     var loading = $(".loading");
     $(document).ajaxStart(function() {
         loading.show();

--- a/netbox/templates/rest_framework/api.html
+++ b/netbox/templates/rest_framework/api.html
@@ -1,5 +1,5 @@
 {% extends 'rest_framework/base.html' %}
 
 {% block branding %}
-    <a class="navbar-brand" href="/{{ settings.BASE_PATH }}">NetBox</a>
+    <a class="navbar-brand" href="{{ settings.BASE_PATH }}">NetBox</a>
 {% endblock %}

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -188,7 +188,7 @@ class APISelect(SelectWithDisabled):
         super(APISelect, self).__init__(*args, **kwargs)
 
         self.attrs['class'] = 'api-select'
-        self.attrs['api-url'] = '/{}{}'.format(settings.BASE_PATH, api_url.lstrip('/'))  # Inject BASE_PATH
+        self.attrs['api-url'] = '{}{}'.format(settings.BASE_PATH, api_url.lstrip('/'))  # Inject BASE_PATH
         if display_field:
             self.attrs['display-field'] = display_field
         if disabled_indicator:


### PR DESCRIPTION
Relative paths are helpful when running netbox behind a load balancer
where the client's path may not match what the server receives.

BASE_PATH can still be used to mimic the current behavior by setting:
BASE_PATH = '/'

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:

Situation where the client is loading ex. /netbox but the netbox app is not aware it is behind a LB, and instead is serving from /. The LB in this case is responsible for path stripping the /netbox to /, but due to how netbox serves the requests it will link all of the static content using / which is not valid.

<!--
    Please include a summary of the proposed changes below.
-->
