### PR TITLE
compare strings using "==" not "is", fix crash bug

### DIFF
--- a/netbox/extras/models.py
+++ b/netbox/extras/models.py
@@ -127,7 +127,7 @@ class CustomField(models.Model):
         """
         Convert a string into the object it represents depending on the type of field
         """
-        if serialized_value is '':
+        if serialized_value == '':
             return None
         if self.type == CF_TYPE_INTEGER:
             return int(serialized_value)


### PR DESCRIPTION
fixes #1980 

To my knowledge strings should be compared using `==` not `is`, but I can't find a proper source on that. At least this explains the weird behavior described in the fixed bug.