### PR TITLE
added X-Forwarded-Proto header to apache config

### DIFF
--- a/docs/installation/web-server.md
+++ b/docs/installation/web-server.md
@@ -82,6 +82,7 @@ Once Apache is installed, proceed with the following configuration (Be sure to m
         ProxyPass !
     </Location>
 
+    RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
     ProxyPass / http://127.0.0.1:8001/
     ProxyPassReverse / http://127.0.0.1:8001/
 </VirtualHost>
@@ -92,6 +93,7 @@ Save the contents of the above example in `/etc/apache2/sites-available/netbox.c
 ```no-highlight
 # a2enmod proxy
 # a2enmod proxy_http
+# a2enmod headers
 # a2ensite netbox
 # service apache2 restart
 ```


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #1984

Added the `X-Forwarded-Proto` header to the example apache config in the docs
