### PR TITLE
#1983: Be able to use regex in interface bulk renaming

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -35,6 +35,7 @@ from .models import (
     InventoryItem, Platform, PowerOutlet, PowerOutletTemplate, PowerPort, PowerPortTemplate, Rack, RackGroup,
     RackReservation, RackRole, Region, Site, VirtualChassis,
 )
+from re import sub
 
 
 class BulkRenameView(View):
@@ -59,7 +60,7 @@ class BulkRenameView(View):
 
             if form.is_valid():
                 for obj in selected_objects:
-                    obj.new_name = obj.name.replace(form.cleaned_data['find'], form.cleaned_data['replace'])
+                    obj.new_name = sub(form.cleaned_data['find'], form.cleaned_data['replace'], obj.name)
 
                 if '_apply' in request.POST:
                     for obj in selected_objects:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->

### Fixes: #1983

<!--
    Please include a summary of the proposed changes below.
-->

It's a just a minor modification of BulkRenamingView class to be able to use regex in interface bulk renaming.