### PR TITLE
Pass the actual Host header as X-Forwarded-Host in nginx config, use device.display_name property in rack elevation template

### DIFF
--- a/docs/installation/web-server.md
+++ b/docs/installation/web-server.md
@@ -29,7 +29,7 @@ server {
 
     location / {
         proxy_pass http://127.0.0.1:8001;
-        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
         add_header P3P 'CP="ALL DSP COR PSAa PSDa OUR NOR ONL UNI COM NAV"';

--- a/netbox/templates/dcim/inc/rack_elevation.html
+++ b/netbox/templates/dcim/inc/rack_elevation.html
@@ -27,7 +27,7 @@
                     {% ifequal u.device.face face_id %}
                         <a href="{% url 'dcim:device' pk=u.device.pk %}" data-toggle="popover" data-trigger="hover" data-container="body" data-html="true"
                            data-content="{{ u.device.device_role }}<br />{{ u.device.device_type.full_name }} ({{ u.device.device_type.u_height }}U){% if u.device.asset_tag %}<br />{{ u.device.asset_tag }}{% endif %}">
-                            {{ u.device.name|default:u.device.device_role }}
+                            {{ u.device.display_name }}
                             {% if u.device.devicebay_count %}
                                 ({{ u.device.get_children.count }}/{{ u.device.devicebay_count }})
                             {% endif %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
1. Nginx config in docs
The sample nginx config in the installation documents passes the $server_name value in the X-Forwarded-Host header instead of the actual Host header value in the request. A response containing an absolute URL can have a different domain name than was in the original request, which might not match an SSL certificate, preventing further requests. 
If value of the Host header is used to generate the absolute URLs (also as mentioned in https://github.com/digitalocean/netbox/issues/1184 ) then originally requested domain name will continue in the responses and continue working with SSL certificates. The $host variable in the nginx configuration http://nginx.org/en/docs/http/ngx_http_core_module.html#var_host can fall back to $server_name in case Host isn't set, so this should still work as before in some cases.

2. Device names in rack elevations
In rack elevations, the device name will show, or in case of unnamed devices it will show the device type. In case an unnamed device is a member of a virtual chassis though, it should show the name of the master member. This logic is part of the device.display_name property in the model, but before this change the rack elevation template doesn't use that property and does a similar logic except for the virtual chassis handling.