### PR TITLE
Restrict view to specific Tenant according to LDAP Group belonging

### DIFF
--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -233,7 +233,7 @@ class WritableRackReservationSerializer(ValidatedModelSerializer):
 
     class Meta:
         model = RackReservation
-        fields = ['id', 'rack', 'units', 'user', 'description']
+        fields = ['id', 'rack', 'units', 'user', 'tenant', 'description']
 
 
 #

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -157,6 +157,7 @@ class RegionBulkDeleteView(PermissionRequiredMixin, BulkDeleteView):
     permission_required = 'dcim.delete_region'
     cls = Region
     queryset = Region.objects.annotate(site_count=Count('sites'))
+    filter = filters.RegionFilter
     table = tables.RegionTable
     default_return_url = 'dcim:region_list'
 
@@ -491,6 +492,7 @@ class RackReservationBulkEditView(PermissionRequiredMixin, BulkEditView):
 class RackReservationBulkDeleteView(PermissionRequiredMixin, BulkDeleteView):
     permission_required = 'dcim.delete_rackreservation'
     cls = RackReservation
+    filter = filters.RackReservationFilter
     table = tables.RackReservationTable
     default_return_url = 'dcim:rackreservation_list'
 

--- a/netbox/ipam/fields.py
+++ b/netbox/ipam/fields.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django.core.exceptions import ValidationError
 from django.db import models
-from netaddr import IPNetwork
+from netaddr import AddrFormatError, IPNetwork
 
 from .formfields import IPFormField
 from . import lookups
@@ -26,7 +26,9 @@ class BaseIPField(models.Field):
             return value
         try:
             return IPNetwork(value)
-        except ValueError as e:
+        except AddrFormatError as e:
+            raise ValidationError("Invalid IP address format: {}".format(value))
+        except (TypeError, ValueError) as e:
             raise ValidationError(e)
 
     def get_prep_value(self, value):

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -22,7 +22,7 @@ if sys.version_info[0] < 3:
         DeprecationWarning
     )
 
-VERSION = '2.3.3'
+VERSION = '2.3.4-dev'
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/netbox/templates/dcim/inc/interface.html
+++ b/netbox/templates/dcim/inc/interface.html
@@ -105,7 +105,7 @@
                     <button class="btn btn-warning btn-xs interface-toggle connected" disabled="disabled" title="Circuits cannot be marked as planned or connected">
                         <i class="glyphicon glyphicon-ban-circle" aria-hidden="true"></i>
                     </button>
-                    <a href="{% url 'circuits:circuittermination_edit' pk=iface.circuit_termination.pk %}&return_url={{ device.get_absolute_url }}" class="btn btn-danger btn-xs" title="Edit circuit termination">
+                    <a href="{% url 'circuits:circuittermination_edit' pk=iface.circuit_termination.pk %}?return_url={{ device.get_absolute_url }}" class="btn btn-danger btn-xs" title="Edit circuit termination">
                         <i class="glyphicon glyphicon-resize-full" aria-hidden="true"></i>
                     </a>
                 {% else %}

--- a/netbox/templates/dcim/rackrole_list.html
+++ b/netbox/templates/dcim/rackrole_list.html
@@ -1,22 +1,17 @@
 {% extends '_base.html' %}
-{% load helpers %}
+{% load buttons %}
 
 {% block content %}
 <div class="pull-right">
     {% if perms.dcim.add_rackrole %}
-        <a href="{% url 'dcim:rackrole_add' %}" class="btn btn-primary">
-            <span class="fa fa-plus" aria-hidden="true"></span>
-            Add a rack role
-        </a>
-        <a href="{% url 'dcim:rackrole_import' %}" class="btn btn-info">
-            <span class="fa fa-download" aria-hidden="true"></span>
-            Import rack roles
-        </a>
+        {% add_button 'dcim:rackrole_add' %}
+        {% import_button 'dcim:rackrole_import' %}
     {% endif %}
+    {% export_button content_type %}
 </div>
 <h1>{% block title %}Rack Roles{% endblock %}</h1>
 <div class="row">
-	<div class="col-md-12">
+    <div class="col-md-12">
         {% include 'utilities/obj_table.html' with bulk_delete_url='dcim:rackrole_bulk_delete' %}
     </div>
 </div>

--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -626,8 +626,11 @@ class BulkDeleteView(View):
             return_url = reverse(self.default_return_url)
 
         # Are we deleting *all* objects in the queryset or just a selected subset?
-        if request.POST.get('_all') and self.filter is not None:
-            pk_list = [obj.pk for obj in self.filter(request.GET, self.cls.objects.only('pk')).qs]
+        if request.POST.get('_all'):
+            if self.filter is not None:
+                pk_list = [obj.pk for obj in self.filter(request.GET, self.cls.objects.only('pk')).qs]
+            else:
+                pk_list = self.cls.objects.values_list('pk', flat=True)
         else:
             pk_list = [int(pk) for pk in request.POST.getlist('pk')]
 

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -115,7 +115,7 @@ class ClusterView(View):
             'site', 'rack', 'tenant', 'device_type__manufacturer'
         )
         device_table = DeviceTable(list(devices), orderable=False)
-        if request.user.has_perm('virtualization:change_cluster'):
+        if request.user.has_perm('virtualization.change_cluster'):
             device_table.columns.show('pk')
 
         return render(request, 'virtualization/cluster.html', {

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -160,6 +160,7 @@ class ClusterBulkDeleteView(PermissionRequiredMixin, BulkDeleteView):
     permission_required = 'virtualization.delete_cluster'
     cls = Cluster
     queryset = Cluster.objects.all()
+    filter = filters.ClusterFilter
     table = tables.ClusterTable
     default_return_url = 'virtualization:cluster_list'
 


### PR DESCRIPTION
Hello,

I don't know if it is already implemented, but it would be great to restrict user view to only specific Tenants based on the user LDAP Group.

This is something we need because we are hosting customers info in our Netbox, and we would like to give them a read/write access, but only on their tenants...

Regards,

Thomas

