### PR TITLE
change rack elevation template to use device.display_name property

### DIFF
--- a/netbox/templates/dcim/inc/rack_elevation.html
+++ b/netbox/templates/dcim/inc/rack_elevation.html
@@ -27,13 +27,13 @@
                     {% ifequal u.device.face face_id %}
                         <a href="{% url 'dcim:device' pk=u.device.pk %}" data-toggle="popover" data-trigger="hover" data-container="body" data-html="true"
                            data-content="{{ u.device.device_role }}<br />{{ u.device.device_type.full_name }} ({{ u.device.device_type.u_height }}U){% if u.device.asset_tag %}<br />{{ u.device.asset_tag }}{% endif %}">
-                            {{ u.device.name|default:u.device.device_role }}
+                            {{ u.device.display_name }}
                             {% if u.device.devicebay_count %}
                                 ({{ u.device.get_children.count }}/{{ u.device.devicebay_count }})
                             {% endif %}
                         </a>
                     {% else %}
-                        <span>{{ u.device.name|default:u.device.device_role }}</span>
+                        <span>{{ u.device.display_name }}</span>
                     {% endifequal %}
                 </li>
             {% else %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:

The display_name property works better for virtual chassis members. For standalone unnamed devices though, it will show the device type name instead of the device role name. I'm not sure one of those is definitely better than the other. I hope this makes sense though!
