### PR TITLE
Fixing typo in permission check for ClusterView.

### DIFF
--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -115,7 +115,7 @@ class ClusterView(View):
             'site', 'rack', 'tenant', 'device_type__manufacturer'
         )
         device_table = DeviceTable(list(devices), orderable=False)
-        if request.user.has_perm('virtualization:change_cluster'):
+        if request.user.has_perm('virtualization.change_cluster'):
             device_table.columns.show('pk')
 
         return render(request, 'virtualization/cluster.html', {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #2098 

<!--
    Please include a summary of the proposed changes below.
-->
As explained in great detail in the issue, there is a typo in the permissions check for ClusterView. Replacing the colon with a period fixes this issue.