### PR TITLE
Fixes #2143 - PUTs to Site Endpoint Requires Value for time_zone

### DIFF
--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -80,7 +80,7 @@ class NestedSiteSerializer(serializers.ModelSerializer):
 
 
 class WritableSiteSerializer(CustomFieldModelSerializer):
-    time_zone = TimeZoneField(required=False)
+    time_zone = TimeZoneField(required=False, allow_null=True)
 
     class Meta:
         model = Site


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
#2143 
<!--
    Please include a summary of the proposed changes below.
-->
Allow null values for `time_zone` field in the writeable serializer for the sites endpoint.
