### PR TITLE
Fixes #2157: Natural ordering breaks when sorting objects by name

### DIFF
--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -77,9 +77,7 @@ class Region(MPTTModel):
 #
 
 class SiteManager(NaturalOrderByManager):
-
-    def get_queryset(self):
-        return self.natural_order_by('name')
+    natural_order_field = 'name'
 
 
 @python_2_unicode_compatible
@@ -308,9 +306,7 @@ class RackRole(models.Model):
 
 
 class RackManager(NaturalOrderByManager):
-
-    def get_queryset(self):
-        return self.natural_order_by('site__name', 'name')
+    natural_order_field = 'name'
 
 
 @python_2_unicode_compatible
@@ -1098,9 +1094,7 @@ class Platform(models.Model):
 
 
 class DeviceManager(NaturalOrderByManager):
-
-    def get_queryset(self):
-        return self.natural_order_by('name')
+    natural_order_field = 'name'
 
 
 @python_2_unicode_compatible

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -175,7 +175,7 @@ class RegionTable(BaseTable):
 
 class SiteTable(BaseTable):
     pk = ToggleColumn()
-    name = tables.LinkColumn()
+    name = tables.LinkColumn(order_by=('_nat1', '_nat2', '_nat3'))
     status = tables.TemplateColumn(template_code=STATUS_LABEL, verbose_name='Status')
     region = tables.TemplateColumn(template_code=SITE_REGION_LINK)
     tenant = tables.TemplateColumn(template_code=COL_TENANT)
@@ -236,7 +236,7 @@ class RackRoleTable(BaseTable):
 
 class RackTable(BaseTable):
     pk = ToggleColumn()
-    name = tables.LinkColumn()
+    name = tables.LinkColumn(order_by=('_nat1', '_nat2', '_nat3'))
     site = tables.LinkColumn('dcim:site', args=[Accessor('site.slug')])
     group = tables.Column(accessor=Accessor('group.name'), verbose_name='Group')
     tenant = tables.TemplateColumn(template_code=COL_TENANT)
@@ -469,7 +469,10 @@ class PlatformTable(BaseTable):
 
 class DeviceTable(BaseTable):
     pk = ToggleColumn()
-    name = tables.TemplateColumn(template_code=DEVICE_LINK)
+    name = tables.TemplateColumn(
+        order_by=('_nat1', '_nat2', '_nat3'),
+        template_code=DEVICE_LINK
+    )
     status = tables.TemplateColumn(template_code=STATUS_LABEL, verbose_name='Status')
     tenant = tables.TemplateColumn(template_code=COL_TENANT)
     site = tables.LinkColumn('dcim:site', args=[Accessor('site.slug')])


### PR DESCRIPTION
### Fixes: #2157

Reworked NaturalOrderByManager to intelligently replace references of the designated natural ordering field with its three subfields.
