### PR TITLE
implements #2166 - asset tag partial string search

### DIFF
--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -509,7 +509,7 @@ class DeviceFilter(CustomFieldFilterSet, django_filters.FilterSet):
             Q(name__icontains=value) |
             Q(serial__icontains=value.strip()) |
             Q(inventory_items__serial__icontains=value.strip()) |
-            Q(asset_tag=value.strip()) |
+            Q(asset_tag__icontains=value.strip()) |
             Q(comments__icontains=value)
         ).distinct()
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #2166 

<!--
    Please include a summary of the proposed changes below.
-->

Awaiting conversation in #2166, I have implemented the icontains filter for the `asset_tag` field on the DeviceFilter.
