### PR TITLE
Closes #2168: Add Extreme SummitStack interface form factors

### DIFF
--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -95,7 +95,8 @@ IFACE_FF_FLEXSTACK_PLUS = 5150
 IFACE_FF_JUNIPER_VCP = 5200
 IFACE_FF_EXTREME_SS = 5300
 IFACE_FF_EXTREME_SS128 = 5310
-IFACE_FF_EXTREME_SS512 = 5320
+IFACE_FF_EXTREME_SS256 = 5320
+IFACE_FF_EXTREME_SS512 = 5330
 
 # Other
 IFACE_FF_OTHER = 32767
@@ -173,8 +174,9 @@ IFACE_FF_CHOICES = [
             [IFACE_FF_FLEXSTACK_PLUS, 'Cisco FlexStack Plus'],
             [IFACE_FF_JUNIPER_VCP, 'Juniper VCP'],
             [IFACE_FF_EXTREME_SS, 'Extreme SummitStack'],
-            [IFACE_FF_EXTREME_SS128, 'Extreme SummitStack128'],
-            [IFACE_FF_EXTREME_SS512, 'Extreme SummitStack512'],
+            [IFACE_FF_EXTREME_SS128, 'Extreme SummitStack-128'],
+            [IFACE_FF_EXTREME_SS128, 'Extreme SummitStack-256'],
+            [IFACE_FF_EXTREME_SS512, 'Extreme SummitStack-512'],
         ]
     ],
     [

--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -93,6 +93,10 @@ IFACE_FF_STACKWISE_PLUS = 5050
 IFACE_FF_FLEXSTACK = 5100
 IFACE_FF_FLEXSTACK_PLUS = 5150
 IFACE_FF_JUNIPER_VCP = 5200
+IFACE_FF_EXTREME_SS = 5300
+IFACE_FF_EXTREME_SS128 = 5310
+IFACE_FF_EXTREME_SS512 = 5320
+
 # Other
 IFACE_FF_OTHER = 32767
 
@@ -168,6 +172,9 @@ IFACE_FF_CHOICES = [
             [IFACE_FF_FLEXSTACK, 'Cisco FlexStack'],
             [IFACE_FF_FLEXSTACK_PLUS, 'Cisco FlexStack Plus'],
             [IFACE_FF_JUNIPER_VCP, 'Juniper VCP'],
+            [IFACE_FF_EXTREME_SS, 'Extreme SummitStack'],
+            [IFACE_FF_EXTREME_SS128, 'Extreme SummitStack128'],
+            [IFACE_FF_EXTREME_SS512, 'Extreme SummitStack512'],
         ]
     ],
     [


### PR DESCRIPTION
Adding support for Extreme Networks SummitStack port types.

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes: #2168

Adds support for Extreme Networks SummitStack port types.
