### PR TITLE
Fix interface ordering of Loopback1.1 interfaces 

### DIFF
--- a/netbox/dcim/querysets.py
+++ b/netbox/dcim/querysets.py
@@ -44,7 +44,7 @@ class InterfaceQuerySet(QuerySet):
 
         TYPE_RE = r"SUBSTRING({} FROM '^([^0-9]+)')"
         ID_RE = r"CAST(SUBSTRING({} FROM '^(?:[^0-9]+)(\d{{1,9}})$') AS integer)"
-        SLOT_RE = r"CAST(SUBSTRING({} FROM '^(?:[^0-9]+)?(\d{{1,9}})\/') AS integer)"
+        SLOT_RE = r"CAST(SUBSTRING({} FROM '^(?:[^0-9]+)?(\d{{1,9}})\/?') AS integer)"
         SUBSLOT_RE = r"COALESCE(CAST(SUBSTRING({} FROM '^(?:[^0-9]+)?(?:\d{{1,9}}\/)(\d{{1,9}})') AS integer), 0)"
         POSITION_RE = r"COALESCE(CAST(SUBSTRING({} FROM '^(?:[^0-9]+)?(?:\d{{1,9}}\/){{2}}(\d{{1,9}})') AS integer), 0)"
         SUBPOSITION_RE = r"COALESCE(CAST(SUBSTRING({} FROM '^(?:[^0-9]+)?(?:\d{{1,9}}\/){{3}}(\d{{1,9}})') AS integer), 0)"

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -216,10 +216,9 @@ class InterfaceTestCase(TestCase):
             device=device1,
             name='Loopback1'
         )
-
         self.assertEqual(
             list(Interface.objects.all().order_naturally()),
-            [interface1, interface5, interface4, interface3, interface2, interface6]
+            [interface6, interface1, interface5, interface4, interface3, interface2]
         )
 
     def test_interface_order_natural_subinterfaces(self):
@@ -256,7 +255,15 @@ class InterfaceTestCase(TestCase):
             device=device1,
             name='GigabitEthernet0'
         )
+        interface7 = Interface.objects.create(
+            device=device1,
+            name='Loopback1'
+        )
+        interface8 = Interface.objects.create(
+            device=device1,
+            name='Loopback1.1'
+        )
         self.assertEqual(
             list(Interface.objects.all().order_naturally()),
-            [interface4, interface3, interface5, interface2, interface1, interface6]
+            [interface6, interface4, interface3, interface5, interface2, interface1, interface7, interface8]
         )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
Ordering of subinterfaces LoopBack1.1 (or for Juniper ae0, ae1, ae0.1).

<!--
    Please include a summary of the proposed changes below.
-->
