### PR TITLE
Fixes #2125 - Show child status in device bay list

### DIFF
--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -387,6 +387,7 @@
                                 <th class="pk"><input type="checkbox" class="toggle" title="Toggle all" /></th>
                             {% endif %}
                             <th>Name</th>
+                            <th>Status</th>
                             <th colspan="2">Installed Device</th>
                             <th></th>
                         </tr>

--- a/netbox/templates/dcim/inc/devicebay.html
+++ b/netbox/templates/dcim/inc/devicebay.html
@@ -9,12 +9,16 @@
     </td>
     {% if devicebay.installed_device %}
         <td>
+            <span class="label label-{{ devicebay.installed_device.get_status_class }}">{{ devicebay.installed_device.get_status_display }}</span>
+        </td>
+        <td>
             <a href="{% url 'dcim:device' pk=devicebay.installed_device.pk %}">{{ devicebay.installed_device }}</a>
         </td>
         <td>
             <span>{{ devicebay.installed_device.device_type.full_name }}</span>
         </td>
     {% else %}
+        <td></td>
         <td colspan="2">
             <span class="text-muted">Vacant</span>
         </td>


### PR DESCRIPTION
Exposes devicebay.installed_device.status in the parent device detail view.

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
#2125 
<!--
    Please include a summary of the proposed changes below.
-->
Adds `Status` column to Device Bay table in parent's detail view.

![image](https://user-images.githubusercontent.com/2475277/42546236-232bd9a0-8482-11e8-948e-660618c90813.png)
