### PR TITLE
Added mac_address to IPAddressInterfaceSerializer

### DIFF
--- a/netbox/ipam/api/serializers.py
+++ b/netbox/ipam/api/serializers.py
@@ -275,7 +275,7 @@ class IPAddressInterfaceSerializer(serializers.ModelSerializer):
     class Meta(InterfaceSerializer.Meta):
         model = Interface
         fields = [
-            'id', 'url', 'device', 'virtual_machine', 'name',
+            'id', 'url', 'device', 'virtual_machine', 'name', 'mac_address',
         ]
 
     def get_url(self, obj):


### PR DESCRIPTION
### Fixes:

We use Netbox to fill our dhcp server. With the mac_address in the IPAddressSerializer we only have to do one call to get all the information.