### PR TITLE
#2279: Update API/Code/Help to open in new tab

### DIFF
--- a/netbox/templates/_base.html
+++ b/netbox/templates/_base.html
@@ -54,9 +54,9 @@
                 <div class="col-xs-4 text-right">
                     <p class="text-muted">
                         <i class="fa fa-fw fa-book text-primary"></i> <a href="http://netbox.readthedocs.io/" target="_blank">Docs</a> &middot;
-                        <i class="fa fa-fw fa-cloud text-primary"></i> <a href="{% url 'api_docs' %}">API</a> &middot;
-                        <i class="fa fa-fw fa-code text-primary"></i> <a href="https://github.com/digitalocean/netbox">Code</a> &middot;
-                        <i class="fa fa-fw fa-support text-primary"></i> <a href="https://github.com/digitalocean/netbox/wiki">Help</a>
+                        <i class="fa fa-fw fa-cloud text-primary"></i> <a href="{% url 'api_docs' %}" target="_blank">API</a> &middot;
+                        <i class="fa fa-fw fa-code text-primary"></i> <a href="https://github.com/digitalocean/netbox" target="_blank">Code</a> &middot;
+                        <i class="fa fa-fw fa-support text-primary"></i> <a href="https://github.com/digitalocean/netbox/wiki" target="_blank">Help</a>
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
### Fixes:
Make the API, Code, and Help links in the page footer open in a new windows/tab by default.
https://github.com/digitalocean/netbox/issues/2279