### PR TITLE
Fix #2284: Record object deletions before the request finishes

### DIFF
--- a/netbox/extras/webhooks.py
+++ b/netbox/extras/webhooks.py
@@ -1,11 +1,13 @@
 import datetime
 
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 
 from extras.models import Webhook
 from extras.constants import OBJECTCHANGE_ACTION_CREATE, OBJECTCHANGE_ACTION_DELETE, OBJECTCHANGE_ACTION_UPDATE
 from utilities.api import get_serializer_for_model
+from .constants import WEBHOOK_MODELS
 
 
 def enqueue_webhooks(instance, action):
@@ -13,6 +15,9 @@ def enqueue_webhooks(instance, action):
     Find Webhook(s) assigned to this instance + action and enqueue them
     to be processed
     """
+    if not settings.WEBHOOKS_ENABLED or instance._meta.model_name not in WEBHOOK_MODELS:
+        return
+
     type_create = action == OBJECTCHANGE_ACTION_CREATE
     type_update = action == OBJECTCHANGE_ACTION_UPDATE
     type_delete = action == OBJECTCHANGE_ACTION_DELETE


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #2284

Handle `pre_delete` immediately, but wait until the request has finished to handle `post_save`.