### PR TITLE
Fixes #2294 - 500 From API when PUT with Empty Tags

### DIFF
--- a/netbox/utilities/utils.py
+++ b/netbox/utilities/utils.py
@@ -101,7 +101,7 @@ def serialize_object(obj, extra=None):
         }
 
     # Include any tags
-    if hasattr(obj, 'tags'):
+    if hasattr(obj, 'tags') and obj.tags:
         data['tags'] = [tag.name for tag in obj.tags.all()]
 
     # Append any extra data


### PR DESCRIPTION
Checks that obj.tags isn't empty before trying to call .all()

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:
#2294 
<!--
    Please include a summary of the proposed changes below.
-->