### PR TITLE
Adopt django-taggit-serializer for representation of assigned tags in the API

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -7,6 +7,7 @@ django-filter==1.1.0
 django-mptt
 django-tables2
 django-taggit
+django-taggit-serializer
 django-timezone-field
 # https://github.com/encode/django-rest-framework/issues/6053
 djangorestframework==3.8.1

--- a/netbox/circuits/api/serializers.py
+++ b/netbox/circuits/api/serializers.py
@@ -1,22 +1,22 @@
 from __future__ import unicode_literals
 
 from rest_framework import serializers
-from taggit.models import Tag
+from taggit_serializer.serializers import TaggitSerializer, TagListSerializerField
 
 from circuits.constants import CIRCUIT_STATUS_CHOICES
 from circuits.models import Provider, Circuit, CircuitTermination, CircuitType
 from dcim.api.serializers import NestedSiteSerializer, InterfaceSerializer
 from extras.api.customfields import CustomFieldModelSerializer
 from tenancy.api.serializers import NestedTenantSerializer
-from utilities.api import ChoiceField, TagField, ValidatedModelSerializer, WritableNestedSerializer
+from utilities.api import ChoiceField, ValidatedModelSerializer, WritableNestedSerializer
 
 
 #
 # Providers
 #
 
-class ProviderSerializer(CustomFieldModelSerializer):
-    tags = TagField(queryset=Tag.objects.all(), required=False, many=True)
+class ProviderSerializer(TaggitSerializer, CustomFieldModelSerializer):
+    tags = TagListSerializerField(required=False)
 
     class Meta:
         model = Provider
@@ -57,12 +57,12 @@ class NestedCircuitTypeSerializer(WritableNestedSerializer):
 # Circuits
 #
 
-class CircuitSerializer(CustomFieldModelSerializer):
+class CircuitSerializer(TaggitSerializer, CustomFieldModelSerializer):
     provider = NestedProviderSerializer()
     status = ChoiceField(choices=CIRCUIT_STATUS_CHOICES, required=False)
     type = NestedCircuitTypeSerializer()
     tenant = NestedTenantSerializer(required=False, allow_null=True)
-    tags = TagField(queryset=Tag.objects.all(), required=False, many=True)
+    tags = TagListSerializerField(required=False)
 
     class Meta:
         model = Circuit

--- a/netbox/ipam/api/serializers.py
+++ b/netbox/ipam/api/serializers.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 from rest_framework import serializers
 from rest_framework.reverse import reverse
 from rest_framework.validators import UniqueTogetherValidator
-from taggit.models import Tag
+from taggit_serializer.serializers import TaggitSerializer, TagListSerializerField
 
 from dcim.api.serializers import NestedDeviceSerializer, InterfaceSerializer, NestedSiteSerializer
 from dcim.models import Interface
@@ -16,7 +16,7 @@ from ipam.constants import (
 from ipam.models import Aggregate, IPAddress, Prefix, RIR, Role, Service, VLAN, VLANGroup, VRF
 from tenancy.api.serializers import NestedTenantSerializer
 from utilities.api import (
-    ChoiceField, SerializedPKRelatedField, TagField, ValidatedModelSerializer, WritableNestedSerializer,
+    ChoiceField, SerializedPKRelatedField, ValidatedModelSerializer, WritableNestedSerializer,
 )
 from virtualization.api.serializers import NestedVirtualMachineSerializer
 
@@ -25,9 +25,9 @@ from virtualization.api.serializers import NestedVirtualMachineSerializer
 # VRFs
 #
 
-class VRFSerializer(CustomFieldModelSerializer):
+class VRFSerializer(TaggitSerializer, CustomFieldModelSerializer):
     tenant = NestedTenantSerializer(required=False, allow_null=True)
-    tags = TagField(queryset=Tag.objects.all(), required=False, many=True)
+    tags = TagListSerializerField(required=False)
 
     class Meta:
         model = VRF
@@ -87,9 +87,9 @@ class NestedRIRSerializer(WritableNestedSerializer):
 # Aggregates
 #
 
-class AggregateSerializer(CustomFieldModelSerializer):
+class AggregateSerializer(TaggitSerializer, CustomFieldModelSerializer):
     rir = NestedRIRSerializer()
-    tags = TagField(queryset=Tag.objects.all(), required=False, many=True)
+    tags = TagListSerializerField(required=False)
 
     class Meta:
         model = Aggregate
@@ -147,13 +147,13 @@ class NestedVLANGroupSerializer(WritableNestedSerializer):
 # VLANs
 #
 
-class VLANSerializer(CustomFieldModelSerializer):
+class VLANSerializer(TaggitSerializer, CustomFieldModelSerializer):
     site = NestedSiteSerializer(required=False, allow_null=True)
     group = NestedVLANGroupSerializer(required=False, allow_null=True)
     tenant = NestedTenantSerializer(required=False, allow_null=True)
     status = ChoiceField(choices=VLAN_STATUS_CHOICES, required=False)
     role = NestedRoleSerializer(required=False, allow_null=True)
-    tags = TagField(queryset=Tag.objects.all(), required=False, many=True)
+    tags = TagListSerializerField(required=False)
 
     class Meta:
         model = VLAN
@@ -190,14 +190,14 @@ class NestedVLANSerializer(WritableNestedSerializer):
 # Prefixes
 #
 
-class PrefixSerializer(CustomFieldModelSerializer):
+class PrefixSerializer(TaggitSerializer, CustomFieldModelSerializer):
     site = NestedSiteSerializer(required=False, allow_null=True)
     vrf = NestedVRFSerializer(required=False, allow_null=True)
     tenant = NestedTenantSerializer(required=False, allow_null=True)
     vlan = NestedVLANSerializer(required=False, allow_null=True)
     status = ChoiceField(choices=PREFIX_STATUS_CHOICES, required=False)
     role = NestedRoleSerializer(required=False, allow_null=True)
-    tags = TagField(queryset=Tag.objects.all(), required=False, many=True)
+    tags = TagListSerializerField(required=False)
 
     class Meta:
         model = Prefix
@@ -254,13 +254,13 @@ class IPAddressInterfaceSerializer(serializers.ModelSerializer):
         return reverse(url_name, kwargs={'pk': obj.pk}, request=self.context['request'])
 
 
-class IPAddressSerializer(CustomFieldModelSerializer):
+class IPAddressSerializer(TaggitSerializer, CustomFieldModelSerializer):
     vrf = NestedVRFSerializer(required=False, allow_null=True)
     tenant = NestedTenantSerializer(required=False, allow_null=True)
     status = ChoiceField(choices=IPADDRESS_STATUS_CHOICES, required=False)
     role = ChoiceField(choices=IPADDRESS_ROLE_CHOICES, required=False)
     interface = IPAddressInterfaceSerializer(required=False, allow_null=True)
-    tags = TagField(queryset=Tag.objects.all(), required=False, many=True)
+    tags = TagListSerializerField(required=False)
 
     class Meta:
         model = IPAddress

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -144,6 +144,7 @@ INSTALLED_APPS = [
     'mptt',
     'rest_framework',
     'taggit',
+    'taggit_serializer',
     'timezone_field',
     'circuits',
     'dcim',

--- a/netbox/secrets/api/serializers.py
+++ b/netbox/secrets/api/serializers.py
@@ -2,12 +2,12 @@ from __future__ import unicode_literals
 
 from rest_framework import serializers
 from rest_framework.validators import UniqueTogetherValidator
-from taggit.models import Tag
+from taggit_serializer.serializers import TaggitSerializer, TagListSerializerField
 
 from dcim.api.serializers import NestedDeviceSerializer
 from extras.api.customfields import CustomFieldModelSerializer
 from secrets.models import Secret, SecretRole
-from utilities.api import TagField, ValidatedModelSerializer, WritableNestedSerializer
+from utilities.api import ValidatedModelSerializer, WritableNestedSerializer
 
 
 #
@@ -33,11 +33,11 @@ class NestedSecretRoleSerializer(WritableNestedSerializer):
 # Secrets
 #
 
-class SecretSerializer(CustomFieldModelSerializer):
+class SecretSerializer(TaggitSerializer, CustomFieldModelSerializer):
     device = NestedDeviceSerializer()
     role = NestedSecretRoleSerializer()
     plaintext = serializers.CharField()
-    tags = TagField(queryset=Tag.objects.all(), required=False, many=True)
+    tags = TagListSerializerField(required=False)
 
     class Meta:
         model = Secret

--- a/netbox/tenancy/api/serializers.py
+++ b/netbox/tenancy/api/serializers.py
@@ -1,11 +1,11 @@
 from __future__ import unicode_literals
 
 from rest_framework import serializers
-from taggit.models import Tag
+from taggit_serializer.serializers import TaggitSerializer, TagListSerializerField
 
 from extras.api.customfields import CustomFieldModelSerializer
 from tenancy.models import Tenant, TenantGroup
-from utilities.api import TagField, ValidatedModelSerializer, WritableNestedSerializer
+from utilities.api import ValidatedModelSerializer, WritableNestedSerializer
 
 
 #
@@ -31,9 +31,9 @@ class NestedTenantGroupSerializer(WritableNestedSerializer):
 # Tenants
 #
 
-class TenantSerializer(CustomFieldModelSerializer):
+class TenantSerializer(TaggitSerializer, CustomFieldModelSerializer):
     group = NestedTenantGroupSerializer(required=False)
-    tags = TagField(queryset=Tag.objects.all(), required=False, many=True)
+    tags = TagListSerializerField(required=False)
 
     class Meta:
         model = Tenant

--- a/netbox/utilities/utils.py
+++ b/netbox/utilities/utils.py
@@ -101,8 +101,8 @@ def serialize_object(obj, extra=None):
         }
 
     # Include any tags
-    if hasattr(obj, 'tags'):
-        data['tags'] = [tag.name for tag in obj.tags.all()]
+    # if hasattr(obj, 'tags'):
+    #     data['tags'] = [tag.name for tag in obj.tags.all()]
 
     # Append any extra data
     if extra is not None:

--- a/netbox/virtualization/api/serializers.py
+++ b/netbox/virtualization/api/serializers.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from rest_framework import serializers
-from taggit.models import Tag
+from taggit_serializer.serializers import TaggitSerializer, TagListSerializerField
 
 from dcim.api.serializers import NestedDeviceRoleSerializer, NestedPlatformSerializer, NestedSiteSerializer
 from dcim.constants import IFACE_MODE_CHOICES
@@ -9,7 +9,7 @@ from dcim.models import Interface
 from extras.api.customfields import CustomFieldModelSerializer
 from ipam.models import IPAddress, VLAN
 from tenancy.api.serializers import NestedTenantSerializer
-from utilities.api import ChoiceField, TagField, ValidatedModelSerializer, WritableNestedSerializer
+from utilities.api import ChoiceField, ValidatedModelSerializer, WritableNestedSerializer
 from virtualization.constants import VM_STATUS_CHOICES
 from virtualization.models import Cluster, ClusterGroup, ClusterType, VirtualMachine
 
@@ -56,11 +56,11 @@ class NestedClusterGroupSerializer(WritableNestedSerializer):
 # Clusters
 #
 
-class ClusterSerializer(CustomFieldModelSerializer):
+class ClusterSerializer(TaggitSerializer, CustomFieldModelSerializer):
     type = NestedClusterTypeSerializer()
     group = NestedClusterGroupSerializer(required=False, allow_null=True)
     site = NestedSiteSerializer(required=False, allow_null=True)
-    tags = TagField(queryset=Tag.objects.all(), required=False, many=True)
+    tags = TagListSerializerField(required=False)
 
     class Meta:
         model = Cluster
@@ -90,7 +90,7 @@ class VirtualMachineIPAddressSerializer(serializers.ModelSerializer):
         fields = ['id', 'url', 'family', 'address']
 
 
-class VirtualMachineSerializer(CustomFieldModelSerializer):
+class VirtualMachineSerializer(TaggitSerializer, CustomFieldModelSerializer):
     status = ChoiceField(choices=VM_STATUS_CHOICES, required=False)
     cluster = NestedClusterSerializer(required=False, allow_null=True)
     role = NestedDeviceRoleSerializer(required=False, allow_null=True)
@@ -99,7 +99,7 @@ class VirtualMachineSerializer(CustomFieldModelSerializer):
     primary_ip = VirtualMachineIPAddressSerializer(read_only=True)
     primary_ip4 = VirtualMachineIPAddressSerializer(required=False, allow_null=True)
     primary_ip6 = VirtualMachineIPAddressSerializer(required=False, allow_null=True)
-    tags = TagField(queryset=Tag.objects.all(), required=False, many=True)
+    tags = TagListSerializerField(required=False)
 
     class Meta:
         model = VirtualMachine

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ django-filter==1.1.0
 django-mptt==0.9.1
 django-tables2==1.21.2
 django-taggit==0.22.2
+django-taggit-serializer==0.1.7
 django-timezone-field==2.1
 djangorestframework==3.8.1
 drf-yasg[validation]==1.9.1


### PR DESCRIPTION
### Fixes: #2296

There are several issues with the way we handle tags in the API. These are difficult to resolve, since the tags manager isn't quite the same as a traditional ManyToManyField, specifically in that it reads and writes a list of strings. We should employ [django-taggit-serializer](https://github.com/glemmaPaul/django-taggit-serializer), which appears to have worked out these issues. The project is a bit stale, but I don't see much changing in the near future, and we can always clone it internally if needed.
