### PR TITLE
Updated IPAddressInterfaceSerializer to subclass WritableNestedSerial…

### DIFF
--- a/netbox/ipam/api/serializers.py
+++ b/netbox/ipam/api/serializers.py
@@ -234,10 +234,10 @@ class AvailablePrefixSerializer(serializers.Serializer):
 # IP addresses
 #
 
-class IPAddressInterfaceSerializer(serializers.ModelSerializer):
+class IPAddressInterfaceSerializer(WritableNestedSerializer):
     url = serializers.SerializerMethodField()  # We're imitating a HyperlinkedIdentityField here
-    device = NestedDeviceSerializer()
-    virtual_machine = NestedVirtualMachineSerializer()
+    device = NestedDeviceSerializer(read_only=True)
+    virtual_machine = NestedVirtualMachineSerializer(read_only=True)
 
     class Meta(InterfaceSerializer.Meta):
         model = Interface


### PR DESCRIPTION
…izer

Also added readonly args to device and virtual_machine attrs to prevent unnecessary validation

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:

#2299 

<!--
    Please include a summary of the proposed changes below.
-->

Per @jeremystretch recommendation, I changed IPAddressInterfaceSerializer to subclass the more modern WritableNestedSerializer.  Considering WritableNestedSerializer takes only a PK for write ops, and because nested attrs for device and virtual_machine were still throwing validation errors after changing the parent class, I added `read_only=True` args to both.  This fixed the validation and I confirmed that I could alternately PATCH an address with interface values of NULL or a PK successfully.