### PR TITLE
Move the create/update/cancel buttons to the right-hand side and make them float

### DIFF
--- a/netbox/circuits/views.py
+++ b/netbox/circuits/views.py
@@ -5,7 +5,7 @@ from django.contrib.auth.decorators import permission_required
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.db import transaction
 from django.db.models import Count
-from django.shortcuts import get_object_or_404, redirect, render
+from django.shortcuts import get_object_or_404, redirect, render, reverse
 from django.views.generic import View
 
 from extras.models import Graph, GRAPH_TYPE_PROVIDER
@@ -261,6 +261,7 @@ class CircuitTerminationCreateView(PermissionRequiredMixin, ObjectEditView):
     model = CircuitTermination
     model_form = forms.CircuitTerminationForm
     template_name = 'circuits/circuittermination_edit.html'
+    enable_add_another = False
 
     def alter_obj(self, obj, request, url_args, url_kwargs):
         if 'circuit' in url_kwargs:

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -452,6 +452,9 @@ class RackReservationCreateView(PermissionRequiredMixin, ObjectEditView):
     def get_return_url(self, request, obj):
         return obj.rack.get_absolute_url()
 
+    def get_add_url(self, obj):
+        return reverse('dcim:rack_add_reservation', kwargs={'rack': obj.rack.pk})
+
 
 class RackReservationEditView(RackReservationCreateView):
     permission_required = 'dcim.change_rackreservation'

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -195,6 +195,7 @@ class ImageAttachmentEditView(PermissionRequiredMixin, ObjectEditView):
     permission_required = 'extras.change_imageattachment'
     model = ImageAttachment
     model_form = ImageAttachmentForm
+    enable_add_another = False
 
     def alter_obj(self, imageattachment, request, args, kwargs):
         if not imageattachment.pk:

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -983,6 +983,7 @@ class ServiceCreateView(PermissionRequiredMixin, ObjectEditView):
     model = Service
     model_form = forms.ServiceForm
     template_name = 'ipam/service_edit.html'
+    enable_add_another = False
 
     def alter_obj(self, obj, request, url_args, url_kwargs):
         if 'device' in url_kwargs:

--- a/netbox/secrets/views.py
+++ b/netbox/secrets/views.py
@@ -132,7 +132,7 @@ def secret_add(request, pk):
         form = forms.SecretForm(instance=secret)
 
     return render(request, 'secrets/secret_edit.html', {
-        'secret': secret,
+        'obj': secret,
         'form': form,
         'return_url': device.get_absolute_url(),
     })
@@ -185,7 +185,7 @@ def secret_edit(request, pk):
         form = forms.SecretForm(instance=secret)
 
     return render(request, 'secrets/secret_edit.html', {
-        'secret': secret,
+        'obj': secret,
         'form': form,
         'return_url': reverse('secrets:secret', kwargs={'pk': secret.pk}),
     })

--- a/netbox/templates/circuits/circuittermination_edit.html
+++ b/netbox/templates/circuits/circuittermination_edit.html
@@ -1,91 +1,64 @@
-{% extends '_base.html' %}
+{% extends 'utilities/obj_edit.html' %}
 {% load staticfiles %}
 {% load form_helpers %}
 
-{% block content %}
-    <form action="." method="post" class="form form-horizontal">
-        {% csrf_token %}
-        {% for field in form.hidden_fields %}
-            {{ field }}
-        {% endfor %}
-        <div class="row">
-            <div class="col-md-6 col-md-offset-3">
-                <h3>{% block title %}Circuit {{ obj.circuit }} - {{ form.term_side.value }} Side{% endblock %}</h3>
-                {% if form.non_field_errors %}
-                    <div class="panel panel-danger">
-                        <div class="panel-heading"><strong>Errors</strong></div>
-                        <div class="panel-body">
-                            {{ form.non_field_errors }}
-                        </div>
-                    </div>
-                {% endif %}
-                <div class="panel panel-default">
-                    <div class="panel-heading"><strong>Location</strong></div>
-                    <div class="panel-body">
-                        <div class="form-group">
-                            <label class="col-md-3 control-label">Provider</label>
-                            <div class="col-md-9">
-                                <p class="form-control-static">{{ obj.circuit.provider }}</p>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="col-md-3 control-label">Circuit</label>
-                            <div class="col-md-9">
-                                <p class="form-control-static">{{ obj.circuit.cid }}</p>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="col-md-3 control-label">Termination</label>
-                            <div class="col-md-9">
-                                <p class="form-control-static">{{ form.term_side.value }}</p>
-                            </div>
-                        </div>
-                        {% render_field form.site %}
-                        {% render_field form.rack %}
-                        {% render_field form.device %}
-                        {% render_field form.interface %}
-                    </div>
-                </div>
-                <div class="panel panel-default">
-                    <div class="panel-heading"><strong>Termination Details</strong></div>
-                    <div class="panel-body">
-                        <div class="form-group">
-                            <label class="col-md-3 control-label required" for="id_port_speed">{{ form.port_speed.label }}</label>
-                            <div class="col-md-9">
-                                <div class="input-group">
-                                    {{ form.port_speed }}
-                                    {% include 'circuits/inc/speed_widget.html' with target_field='port_speed' %}
-                                </div>
-                                <span class="help-block">{{ form.port_speed.help_text }}</span>
-                            </div>
-                        </div>
-                        <div class="form-group">
-                            <label class="col-md-3 control-label" for="id_upstream_speed">{{ form.upstream_speed.label }}</label>
-                            <div class="col-md-9">
-                                <div class="input-group">
-                                    {{ form.upstream_speed }}
-                                    {% include 'circuits/inc/speed_widget.html' with target_field='upstream_speed' %}
-                                </div>
-                                <span class="help-block">{{ form.upstream_speed.help_text }}</span>
-                            </div>
-                        </div>
-                        {% render_field form.xconnect_id %}
-                        {% render_field form.pp_info %}
-                    </div>
+{% block title %}Circuit {{ obj.circuit }} - {{ form.term_side.value }} Side{% endblock %}
+
+{% block form %}
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>Location</strong></div>
+        <div class="panel-body">
+            <div class="form-group">
+                <label class="col-md-3 control-label">Provider</label>
+                <div class="col-md-9">
+                    <p class="form-control-static">{{ obj.circuit.provider }}</p>
                 </div>
             </div>
-        </div>
-        <div class="row">
-            <div class="col-md-6 col-md-offset-3 text-right">
-                {% if obj.pk %}
-                    <button type="submit" name="_update" class="btn btn-primary">Update</button>
-                {% else %}
-                    <button type="submit" name="_create" class="btn btn-primary">Create</button>
-                {% endif %}
-                <a href="{{ return_url }}" class="btn btn-default">Cancel</a>
+            <div class="form-group">
+                <label class="col-md-3 control-label">Circuit</label>
+                <div class="col-md-9">
+                    <p class="form-control-static">{{ obj.circuit.cid }}</p>
+                </div>
             </div>
+            <div class="form-group">
+                <label class="col-md-3 control-label">Termination</label>
+                <div class="col-md-9">
+                    <p class="form-control-static">{{ form.term_side.value }}</p>
+                </div>
+            </div>
+            {% render_field form.site %}
+            {% render_field form.rack %}
+            {% render_field form.device %}
+            {% render_field form.interface %}
         </div>
-    </form>
+    </div>
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>Termination Details</strong></div>
+        <div class="panel-body">
+            <div class="form-group">
+                <label class="col-md-3 control-label required" for="id_port_speed">{{ form.port_speed.label }}</label>
+                <div class="col-md-9">
+                    <div class="input-group">
+                        {{ form.port_speed }}
+                        {% include 'circuits/inc/speed_widget.html' with target_field='port_speed' %}
+                    </div>
+                    <span class="help-block">{{ form.port_speed.help_text }}</span>
+                </div>
+            </div>
+            <div class="form-group">
+                <label class="col-md-3 control-label" for="id_upstream_speed">{{ form.upstream_speed.label }}</label>
+                <div class="col-md-9">
+                    <div class="input-group">
+                        {{ form.upstream_speed }}
+                        {% include 'circuits/inc/speed_widget.html' with target_field='upstream_speed' %}
+                    </div>
+                    <span class="help-block">{{ form.upstream_speed.help_text }}</span>
+                </div>
+            </div>
+            {% render_field form.xconnect_id %}
+            {% render_field form.pp_info %}
+        </div>
+    </div>
 {% endblock %}
 
 {% block javascript %}

--- a/netbox/templates/dcim/interface_edit.html
+++ b/netbox/templates/dcim/interface_edit.html
@@ -35,17 +35,6 @@
     {% endif %}
 {% endblock %}
 
-{% block buttons %}
-    {% if obj.pk %}
-        <button type="submit" name="_update" class="btn btn-primary">Update</button>
-        <button type="submit" formaction="?return_url={% url 'dcim:interface_edit' pk=obj.pk %}" class="btn btn-primary">Update and Continue Editing</button>
-    {% else %}
-        <button type="submit" name="_create" class="btn btn-primary">Create</button>
-        <button type="submit" name="_addanother" class="btn btn-primary">Create and Add Another</button>
-    {% endif %}
-    <a href="{{ return_url }}" class="btn btn-default">Cancel</a>
-{% endblock %}
-
 {% block javascript %}
     <script type="text/javascript">
         $(document).ready(function() {

--- a/netbox/templates/secrets/secret_edit.html
+++ b/netbox/templates/secrets/secret_edit.html
@@ -1,94 +1,64 @@
-{% extends '_base.html' %}
+{% extends 'utilities/obj_edit.html' %}
 {% load static from staticfiles %}
 {% load form_helpers %}
 
-{% block content %}
-<form action="." method="post" class="form form-horizontal">
-    {% csrf_token %}
-    {{ form.private_key }}
-    <div class="row">
-        <div class="col-md-6 col-md-offset-3">
-            <h3>{% block title %}{% if secret.pk %}Editing {{ secret }}{% else %}Add a Secret{% endif %}{% endblock %}</h3>
-            {% if form.non_field_errors %}
-                <div class="panel panel-danger">
-                    <div class="panel-heading"><strong>Errors</strong></div>
-                    <div class="panel-body">
-                        {{ form.non_field_errors }}
-                    </div>
-                </div>
-            {% endif %}
-            <div class="panel panel-default">
-                <div class="panel-heading"><strong>Secret Attributes</strong></div>
-                <div class="panel-body">
-                    <div class="form-group">
-                        <label class="col-md-3 control-label required">Device</label>
-                        <div class="col-md-9">
-                            <p class="form-control-static">{{ secret.device }}</p>
-                        </div>
-                    </div>
-                    {% render_field form.role %}
-                    {% render_field form.name %}
-                    {% render_field form.userkeys %}
-                </div>
-            </div>
-            <div class="panel panel-default">
-                <div class="panel-heading"><strong>Secret Data</strong></div>
-                <div class="panel-body">
-                    {% if secret.pk %}
-                        <div class="form-group">
-                            <label class="col-md-3 control-label required">Current Plaintext</label>
-                            <div class="col-md-7">
-                                <p class="form-control-static" id="secret_{{ secret.pk }}">********</p>
-                            </div>
-                            <div class="col-md-2 text-right">
-                                <button class="btn btn-xs btn-success unlock-secret" secret-id="{{ secret.pk }}">
-                                    <i class="fa fa-lock"></i> Unlock
-                                </button>
-                                <button class="btn btn-xs btn-danger lock-secret collapse" secret-id="{{ secret.pk }}">
-                                    <i class="fa fa-unlock-alt"></i> Lock
-                                </button>
-                            </div>
-                        </div>
-                    {% endif %}
-                    {% render_field form.plaintext %}
-                    {% render_field form.plaintext2 %}
-                </div>
-            </div>
-            {% if form.custom_fields %}
-                <div class="panel panel-default">
-                    <div class="panel-heading"><strong>Custom Fields</strong></div>
-                    <div class="panel-body">
-                        {% render_custom_fields form %}
-                    </div>
-                </div>
-            {% endif %}
-            <div class="panel panel-default">
-                <div class="panel-heading"><strong>Tags</strong></div>
-                <div class="panel-body">
-                    {% render_field form.tags %}
-                </div>
-            </div>
-        </div>
-    </div>
-    <div class="row">
-        <div class="form-group">
-            <div class="col-md-12 text-center">
-                {% if secret.pk %}
-                    <button type="submit" name="_update" class="btn btn-primary">Update</button>
-                    <a href="{% url 'secrets:secret' pk=secret.pk %}" class="btn btn-default">Cancel</a>
-                {% else %}
-                    <button type="submit" name="_create" class="btn btn-primary">Create</button>
-                    <button type="submit" name="_addanother" class="btn btn-primary">Create and Add Another</button>
-                    <a href="{{ return_url }}" class="btn btn-default">Cancel</a>
-                {% endif %}
-		    </div>
-        </div>
-    </div>
-</form>
+{% block title %}{% if obj.pk %}Editing {{ secret }}{% else %}Add a Secret{% endif %}{% endblock %}
 
-{% include 'secrets/inc/private_key_modal.html' %}
+{% block form %}
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>Secret Attributes</strong></div>
+        <div class="panel-body">
+            <div class="form-group">
+                <label class="col-md-3 control-label required">Device</label>
+                <div class="col-md-9">
+                    <p class="form-control-static">{{ obj.device }}</p>
+                </div>
+            </div>
+            {% render_field form.role %}
+            {% render_field form.name %}
+            {% render_field form.userkeys %}
+        </div>
+    </div>
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>Secret Data</strong></div>
+        <div class="panel-body">
+            {% if obj.pk %}
+                <div class="form-group">
+                    <label class="col-md-3 control-label required">Current Plaintext</label>
+                    <div class="col-md-7">
+                        <p class="form-control-static" id="secret_{{ obj.pk }}">********</p>
+                    </div>
+                    <div class="col-md-2 text-right">
+                        <button class="btn btn-xs btn-success unlock-secret" secret-id="{{ obj.pk }}">
+                            <i class="fa fa-lock"></i> Unlock
+                        </button>
+                        <button class="btn btn-xs btn-danger lock-secret collapse" secret-id="{{ obj.pk }}">
+                            <i class="fa fa-unlock-alt"></i> Lock
+                        </button>
+                    </div>
+                </div>
+            {% endif %}
+            {% render_field form.plaintext %}
+            {% render_field form.plaintext2 %}
+        </div>
+    </div>
+    {% if form.custom_fields %}
+        <div class="panel panel-default">
+            <div class="panel-heading"><strong>Custom Fields</strong></div>
+            <div class="panel-body">
+                {% render_custom_fields form %}
+            </div>
+        </div>
+    {% endif %}
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>Tags</strong></div>
+        <div class="panel-body">
+            {% render_field form.tags %}
+        </div>
+    </div>
 {% endblock %}
 
 {% block javascript %}
+{% include 'secrets/inc/private_key_modal.html' %}
 <script src="{% static 'js/secrets.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock %}

--- a/netbox/templates/tenancy/tenant_edit.html
+++ b/netbox/templates/tenancy/tenant_edit.html
@@ -1,5 +1,4 @@
 {% extends 'utilities/obj_edit.html' %}
-{% load static from staticfiles %}
 {% load form_helpers %}
 
 {% block form %}

--- a/netbox/templates/utilities/obj_edit.html
+++ b/netbox/templates/utilities/obj_edit.html
@@ -10,6 +10,10 @@
         <div class="row">
             <div class="col-md-6 col-md-offset-3">
                 <h3>{% block title %}{% if obj.pk %}Editing {{ obj_type }} {{ obj }}{% else %}Add a new {{ obj_type }}{% endif %}{% endblock %}</h3>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-6 col-md-offset-3">
                 {% block tabs %}{% endblock %}
                 {% if form.non_field_errors %}
                     <div class="panel panel-danger">
@@ -28,18 +32,18 @@
                     </div>
                 {% endblock %}
             </div>
-        </div>
-        <div class="row">
-            <div class="col-md-6 col-md-offset-3 text-right">
-                {% block buttons %}
-                    {% if obj.pk %}
-                        <button type="submit" name="_update" class="btn btn-primary">Update</button>
-                    {% else %}
-                        <button type="submit" name="_create" class="btn btn-primary">Create</button>
-                        <button type="submit" name="_addanother" class="btn btn-primary">Create and Add Another</button>
-                    {% endif %}
-                    <a href="{{ return_url }}" class="btn btn-default">Cancel</a>
-                {% endblock %}
+            <div class="col-md-3">
+                <div style="position: fixed">
+                    {% block buttons %}
+                        {% if obj.pk %}
+                            <p><button type="submit" name="_save" class="btn btn-success"><i class="fa fa-save"></i> Save</button></p>
+                        {% else %}
+                            <p><button type="submit" name="_create" class="btn btn-success"><i class="fa fa-plus"></i> Create</button></p>
+                            <p><button type="submit" name="_addanother" class="btn btn-primary"><i class="fa fa-plus"></i> Create and Add Another</button></p>
+                        {% endif %}
+                        <p><a href="{{ return_url }}" class="btn btn-default"><i class="fa fa-ban"></i> Cancel</a></p>
+                    {% endblock %}
+                </div>
             </div>
         </div>
     </form>

--- a/netbox/templates/utilities/obj_edit.html
+++ b/netbox/templates/utilities/obj_edit.html
@@ -35,13 +35,25 @@
             <div class="col-md-3">
                 <div style="position: fixed">
                     {% block buttons %}
-                        {% if obj.pk %}
-                            <p><button type="submit" name="_save" class="btn btn-success"><i class="fa fa-save"></i> Save</button></p>
-                        {% else %}
-                            <p><button type="submit" name="_create" class="btn btn-success"><i class="fa fa-plus"></i> Create</button></p>
-                            <p><button type="submit" name="_addanother" class="btn btn-primary"><i class="fa fa-plus"></i> Create and Add Another</button></p>
-                        {% endif %}
-                        <p><a href="{{ return_url }}" class="btn btn-default"><i class="fa fa-ban"></i> Cancel</a></p>
+                        <div class="btn-group">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="fa fa-save"></i> Save
+                            </button>
+                            <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                                <span class="caret"></span>
+                            </button>
+                            <ul class="dropdown-menu">
+                                <li>
+                                    <button type="submit" name="_continue" class="btn btn-link">Save and Continue Editing</button>
+                                    {% if enable_add_another %}
+                                        <button type="submit" name="_addanother" class="btn btn-link">Save and Add Another</button>
+                                    {% endif %}
+                                </li>
+                            </ul>
+                        </div>
+                        <div style="margin-top: 12px">
+                            <a href="{{ return_url }}" class="btn btn-default"><i class="fa fa-ban"></i> Cancel</a>
+                        </div>
                     {% endblock %}
                 </div>
             </div>

--- a/netbox/templates/virtualization/interface_edit.html
+++ b/netbox/templates/virtualization/interface_edit.html
@@ -26,17 +26,6 @@
     {% endif %}
 {% endblock %}
 
-{% block buttons %}
-    {% if obj.pk %}
-        <button type="submit" name="_update" class="btn btn-primary">Update</button>
-        <button type="submit" formaction="?return_url={% url 'virtualization:interface_edit' pk=obj.pk %}" class="btn btn-primary">Update and Continue Editing</button>
-    {% else %}
-        <button type="submit" name="_create" class="btn btn-primary">Create</button>
-        <button type="submit" name="_addanother" class="btn btn-primary">Create and Add Another</button>
-    {% endif %}
-    <a href="{{ return_url }}" class="btn btn-default">Cancel</a>
-{% endblock %}
-
 {% block javascript %}
     <script type="text/javascript">
         $(document).ready(function() {


### PR DESCRIPTION
### Fixes: #2237

This approach moves the create/update/cancel buttons when editing an object to the top right corner and keeps them fixed as the page scrolls. This ensures the buttons are always immediately accessible regardless of where the user is focused in the form.