### PR TITLE
Fixes 2344 - VM not in a Site throws an AttributeError when assigning…

### DIFF
--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1817,12 +1817,13 @@ class InterfaceAssignVLANsForm(BootstrapMixin, forms.ModelForm):
                 vlan_choices.append((parent.site.name, [(vlan.pk, vlan) for vlan in site_vlans]))
 
             # Add grouped site VLANs
-            for group in VLANGroup.objects.filter(site=parent.site):
-                site_group_vlans = VLAN.objects.filter(group=group).exclude(pk__in=assigned_vlans)
-                vlan_choices.append((
-                    '{} / {}'.format(group.site.name, group.name),
-                    [(vlan.pk, vlan) for vlan in site_group_vlans]
-                ))
+            if parent.site:
+                for group in VLANGroup.objects.filter(site=parent.site):
+                    site_group_vlans = VLAN.objects.filter(group=group).exclude(pk__in=assigned_vlans)
+                    vlan_choices.append((
+                        '{} / {}'.format(group.site.name, group.name),
+                        [(vlan.pk, vlan) for vlan in site_group_vlans]
+                    ))
 
         self.fields['vlans'].choices = vlan_choices
 


### PR DESCRIPTION
### Fixes: #2344

Adds a check for parent.site before attempting to generate Site Group Vlans for the parent site.
