### PR TITLE
Add missing library

### DIFF
--- a/docs/installation/3-http-daemon.md
+++ b/docs/installation/3-http-daemon.md
@@ -56,7 +56,7 @@ To enable SSL, consider this guide on [securing nginx with Let's Encrypt](https:
 ## Option B: Apache
 
 ```no-highlight
-# apt-get install -y apache2
+# apt-get install -y apache2 libapache2-mod-wsgi-py3
 ```
 
 Once Apache is installed, proceed with the following configuration (Be sure to modify the `ServerName` appropriately):


### PR DESCRIPTION
WSGIPassAuthorization fails if libapache2-mod-wsgi-py3 is missing

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:

<!--
    Please include a summary of the proposed changes below.
-->
