### PR TITLE
Fix type mismatches in API view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ v2.4.5 (FUTURE)
 
 ## Bug Fixes
 
+* [#2400](https://github.com/digitalocean/netbox/issues/2400) - API variable type mismatch at creating/modifying an entry
 * [#2406](https://github.com/digitalocean/netbox/issues/2406) - Remove hard-coded limit of 1000 objects from API-populated form fields
 
 ---

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -279,6 +279,7 @@ SWAGGER_SETTINGS = {
         'utilities.custom_inspectors.NullableBooleanFieldInspector',
         'utilities.custom_inspectors.CustomChoiceFieldInspector',
         'utilities.custom_inspectors.TagListFieldInspector',
+        'utilities.custom_inspectors.SerializedPKRelatedFieldInspector',
         'drf_yasg.inspectors.CamelCaseJSONFilter',
         'drf_yasg.inspectors.ReferencingSerializerInspector',
         'drf_yasg.inspectors.RelatedFieldInspector',

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -275,6 +275,7 @@ RQ_QUEUES = {
 
 # drf_yasg settings for Swagger
 SWAGGER_SETTINGS = {
+    'DEFAULT_AUTO_SCHEMA_CLASS': 'utilities.custom_inspectors.NetBoxSwaggerAutoSchema',
     'DEFAULT_FIELD_INSPECTORS': [
         'utilities.custom_inspectors.NullableBooleanFieldInspector',
         'utilities.custom_inspectors.CustomChoiceFieldInspector',

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -278,6 +278,7 @@ SWAGGER_SETTINGS = {
     'DEFAULT_FIELD_INSPECTORS': [
         'utilities.custom_inspectors.NullableBooleanFieldInspector',
         'utilities.custom_inspectors.CustomChoiceFieldInspector',
+        'utilities.custom_inspectors.TagListFieldInspector',
         'drf_yasg.inspectors.CamelCaseJSONFilter',
         'drf_yasg.inspectors.ReferencingSerializerInspector',
         'drf_yasg.inspectors.RelatedFieldInspector',

--- a/netbox/utilities/custom_inspectors.py
+++ b/netbox/utilities/custom_inspectors.py
@@ -1,9 +1,23 @@
 from drf_yasg import openapi
 from drf_yasg.inspectors import FieldInspector, NotHandled, PaginatorInspector, FilterInspector
 from rest_framework.fields import ChoiceField
+from taggit_serializer.serializers import TagListSerializerField
 
 from extras.api.customfields import CustomFieldsSerializer
 from utilities.api import ChoiceField
+
+
+class TagListFieldInspector(FieldInspector):
+    def field_to_swagger_object(self, field, swagger_object_type, use_references, **kwargs):
+        SwaggerType, ChildSwaggerType = self._get_partial_types(field, swagger_object_type, use_references, **kwargs)
+        if isinstance(field, TagListSerializerField):
+            child_schema = self.probe_field_inspectors(field.child, ChildSwaggerType, use_references)
+            return SwaggerType(
+                type=openapi.TYPE_ARRAY,
+                items=child_schema,
+            )
+
+        return NotHandled
 
 
 class CustomChoiceFieldInspector(FieldInspector):

--- a/netbox/utilities/custom_inspectors.py
+++ b/netbox/utilities/custom_inspectors.py
@@ -4,7 +4,16 @@ from rest_framework.fields import ChoiceField
 from taggit_serializer.serializers import TagListSerializerField
 
 from extras.api.customfields import CustomFieldsSerializer
-from utilities.api import ChoiceField
+from utilities.api import ChoiceField, SerializedPKRelatedField
+
+
+class SerializedPKRelatedFieldInspector(FieldInspector):
+    def field_to_swagger_object(self, field, swagger_object_type, use_references, **kwargs):
+        SwaggerType, ChildSwaggerType = self._get_partial_types(field, swagger_object_type, use_references, **kwargs)
+        if isinstance(field, SerializedPKRelatedField):
+            return self.probe_field_inspectors(field.serializer(), ChildSwaggerType, use_references)
+
+        return NotHandled
 
 
 class TagListFieldInspector(FieldInspector):


### PR DESCRIPTION
This is a fix for issue #2400 but includes some other API view issue fixes by introducing a sub class of `SwaggerAutoSchema` and some `FieldInspector`s.

I've searched a way not to replace `SwaggerAutoSchema` but as I wrote in a commit message, I could not find others which can distinguish a request from a response except overriding `SwaggerAutoSchema.get_request_serializer(self)`.

Please feel free to comment.