### PR TITLE
Display "Access VLAN" on hover in interfaces list

### DIFF
--- a/netbox/templates/dcim/inc/interface.html
+++ b/netbox/templates/dcim/inc/interface.html
@@ -9,7 +9,8 @@
 
     {# Icon and name #}
     <td>
-        <span title="{{ iface.get_form_factor_display }}">
+        <span title="{{ iface.get_form_factor_display }}{% if iface.untagged_vlan is not None %}
+ 13 Access VLAN: {{ iface.untagged_vlan }}{% endif %}">
             <i class="fa fa-fw fa-{% if iface.mgmt_only %}wrench{% elif iface.is_lag %}align-justify{% elif iface.is_virtual %}circle{% elif iface.is_wireless %}wifi{% else %}exchange{% endif %}"></i>
             <a href="{{ iface.get_absolute_url }}">{{ iface }}</a>
         </span>


### PR DESCRIPTION
### Fixes:

This pull request fixes #2430.

Displaying VLANs in a device's interface list is very useful for us. That way we can see at once what Access VLAN a interfaces is connected to. Originally I also wanted to display Tagged VLANs in the hover, but I couldn't find out how to do it. Thus this patch only displays the Access VLANs.

We'd be very happy if you'd include this feature.

Thanks a lot for netbox!