### PR TITLE
Add tags to prefetch_related to reduce query load

### DIFF
--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -228,7 +228,7 @@ class DeviceViewSet(CustomFieldModelViewSet):
         'device_type__manufacturer', 'device_role', 'tenant', 'platform', 'site', 'rack', 'parent_bay',
         'virtual_chassis__master',
     ).prefetch_related(
-        'primary_ip4__nat_outside', 'primary_ip6__nat_outside',
+        'primary_ip4__nat_outside', 'primary_ip6__nat_outside', 'tags'
     )
     filter_class = filters.DeviceFilter
 


### PR DESCRIPTION
### Fixes: #2438

Device listing took a very long time for a large number of devices.
This patch reduces the number of SQL queries.