### PR TITLE
docs: typo fix in devices

### DIFF
--- a/docs/core-functionality/devices.md
+++ b/docs/core-functionality/devices.md
@@ -99,7 +99,7 @@ Device bays represent the ability of a device to house child devices. For exampl
 
 # Platforms
 
-A platform defines the type of software running on a device or virtual machine. This can be helpful when it is necessary to distinguish between, for instance, different feature sets. Note that two devices of same type may be assigned different platforms: for example, one Juniper MX240 running Junos 14 and another running Junos 15.
+A platform defines the type of software running on a device or virtual machine. This can be helpful when it is necessary to distinguish between, for instance, different feature sets. Note that two devices of the same type may be assigned different platforms: for example, one Juniper MX240 running Junos 14 and another running Junos 15.
 
 The platform model is also used to indicate which [NAPALM](https://napalm-automation.net/) driver NetBox should use when connecting to a remote device. The name of the driver along with optional parameters are stored with the platform. See the [API documentation](api/napalm-integration.md) for more information on NAPALM integration.
 


### PR DESCRIPTION
This PR fixes a typo in `devices.md`. An article was missing.

I am aware that this PR violates the workflow, but I’m unsure whether I should file an issue for typos like this first. Any input on this?

Cheers