### PR TITLE
Make netbox pages more print-friendly

### DIFF
--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -451,4 +451,10 @@ textarea {
     .sub-header {
         display: none;
     }
+    #panel-search {
+        display: none;
+    }
+    #panel-tags {
+        display: none;
+    }
 }

--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -445,3 +445,10 @@ td .progress {
 textarea {
     font-family: Consolas, Lucida Console, monospace;
 }
+
+/* Hide some elements for printing */
+@media print {
+    .sub-header {
+        display: none;
+    }
+}

--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -462,6 +462,9 @@ textarea {
     .sub-header {
         display: none;
     }
+    #related {
+        display: none;
+    }
     #panel-search {
         display: none;
     }

--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -8,8 +8,10 @@ html {
 html, body {
     height: 100%;
 }
-body {
-    padding-top: 70px;
+@media screen {
+    body {
+        padding-top: 70px;
+    }
 }
 .container {
     width: auto;
@@ -448,6 +450,15 @@ textarea {
 
 /* Hide some elements for printing */
 @media print {
+    .footer {
+        display: none;
+    }
+    .btn {
+        display: none;
+    }
+    .nav-tabs, .nav-pills {
+        display: none;
+    }
     .sub-header {
         display: none;
     }
@@ -456,5 +467,8 @@ textarea {
     }
     #panel-tags {
         display: none;
+    }
+    a[href]:after {
+        content: none;
     }
 }

--- a/netbox/templates/circuits/circuit.html
+++ b/netbox/templates/circuits/circuit.html
@@ -4,7 +4,7 @@
 {% block title %}{{ circuit }}{% endblock %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 <li><a href="{% url 'circuits:circuit_list' %}">Circuits</a></li>

--- a/netbox/templates/circuits/provider.html
+++ b/netbox/templates/circuits/provider.html
@@ -5,7 +5,7 @@
 {% block title %}{{ provider }}{% endblock %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 <li><a href="{% url 'circuits:provider_list' %}">Providers</a></li>

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -415,7 +415,7 @@
                     </div>
                 {% endif %}
             </div>
-            <div class="panel panel-default">
+            <div class="panel panel-default" id="related">
                 <div class="panel-heading">
                     <strong>Related Devices</strong>
                 </div>

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -5,7 +5,7 @@
 {% block title %}{{ device }}{% endblock %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
         <ol class="breadcrumb">
             <li><a href="{% url 'dcim:site' slug=device.site.slug %}">{{ device.site }}</a></li>

--- a/netbox/templates/dcim/devicetype.html
+++ b/netbox/templates/dcim/devicetype.html
@@ -4,7 +4,7 @@
 {% block title %}{{ devicetype.manufacturer }} {{ devicetype.model }}{% endblock %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-md-12">
             <ol class="breadcrumb">
                 <li><a href="{% url 'dcim:devicetype_list' %}">Device Types</a></li>

--- a/netbox/templates/dcim/interface.html
+++ b/netbox/templates/dcim/interface.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-md-12">
             <ol class="breadcrumb">
                 {% if interface.device %}

--- a/netbox/templates/dcim/rack.html
+++ b/netbox/templates/dcim/rack.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 <li><a href="{% url 'dcim:rack_list' %}">Racks</a></li>

--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -4,7 +4,7 @@
 {% load helpers %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 <li><a href="{% url 'dcim:site_list' %}">Sites</a></li>

--- a/netbox/templates/extras/configcontext.html
+++ b/netbox/templates/extras/configcontext.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 <li><a href="{% url 'extras:configcontext_list' %}">Config Contexts</a></li>

--- a/netbox/templates/extras/objectchange.html
+++ b/netbox/templates/extras/objectchange.html
@@ -97,7 +97,7 @@
     </div>
     <div class="row">
         <div class="col-md-12">
-            {% include 'panel_table.html' with table=related_changes_table heading='Related Changes' %}
+            {% include 'panel_table.html' with table=related_changes_table heading='Related Changes' panel_id='related' %}
             {% if related_changes_count > related_changes_table.rows|length %}
                 <div class="pull-right">
                     <a href="{% url 'extras:objectchange_list' %}?request_id={{ objectchange.request_id }}" class="btn btn-primary">See all {{ related_changes_count|add:"1" }} changes</a>

--- a/netbox/templates/extras/objectchange.html
+++ b/netbox/templates/extras/objectchange.html
@@ -4,7 +4,7 @@
 {% block title %}{{ objectchange }}{% endblock %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 <li><a href="{% url 'extras:objectchange_list' %}">Changelog</a></li>

--- a/netbox/templates/extras/report.html
+++ b/netbox/templates/extras/report.html
@@ -4,7 +4,7 @@
 {% block title %}{{ report.name }}{% endblock %}
 
 {% block content %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-md-12">
             <ol class="breadcrumb">
                 <li><a href="{% url 'extras:report_list' %}">Reports</a></li>

--- a/netbox/templates/inc/search_panel.html
+++ b/netbox/templates/inc/search_panel.html
@@ -1,6 +1,6 @@
 {% load form_helpers %}
 
-<div class="panel panel-default">
+<div class="panel panel-default" id="panel-search">
     <div class="panel-heading">
         <span class="fa fa-search" aria-hidden="true"></span>
         <strong>Search</strong>

--- a/netbox/templates/inc/tags_panel.html
+++ b/netbox/templates/inc/tags_panel.html
@@ -1,6 +1,6 @@
 {% load helpers %}
 
-<div class="panel panel-default">
+<div class="panel panel-default" id="panel-tags">
     <div class="panel-heading">
         <span class="fa fa-tags" aria-hidden="true"></span>
         <strong>Tags</strong>

--- a/netbox/templates/ipam/aggregate.html
+++ b/netbox/templates/ipam/aggregate.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 <li><a href="{% url 'ipam:aggregate_list' %}">Aggregates</a></li>

--- a/netbox/templates/ipam/ipaddress.html
+++ b/netbox/templates/ipam/ipaddress.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 <li><a href="{% url 'ipam:ipaddress_list' %}">IP Addresses</a></li>

--- a/netbox/templates/ipam/ipaddress.html
+++ b/netbox/templates/ipam/ipaddress.html
@@ -156,7 +156,7 @@
         {% if duplicate_ips_table.rows %}
             {% include 'panel_table.html' with table=duplicate_ips_table heading='Duplicate IP Addresses' panel_class='danger' %}
         {% endif %}
-        {% include 'panel_table.html' with table=related_ips_table heading='Related IP Addresses' panel_class='default' %}
+        {% include 'panel_table.html' with table=related_ips_table heading='Related IP Addresses' panel_class='default' panel_id='related' %}
 	</div>
 </div>
 {% endblock %}

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 <li><a href="{% url 'ipam:prefix_list' %}">Prefixes</a></li>

--- a/netbox/templates/ipam/service.html
+++ b/netbox/templates/ipam/service.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 
 {% block content %}
-<div class="row">
+<div class="row sub-header">
     <div class="col-sm-8 col-md-9">
         <ol class="breadcrumb">
             <li><a href="{% url 'ipam:service_list' %}">Services</a></li>

--- a/netbox/templates/ipam/vlan.html
+++ b/netbox/templates/ipam/vlan.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 <li><a href="{% url 'ipam:vlan_list' %}">VLANs</a></li>

--- a/netbox/templates/ipam/vlangroup_vlans.html
+++ b/netbox/templates/ipam/vlangroup_vlans.html
@@ -3,7 +3,7 @@
 {% block title %}{{ vlan_group }} - VLANs{% endblock %}
 
 {% block content %}
-<div class="row">
+<div class="row sub-header">
     <div class="col-sm-12 col-md-12">
         <ol class="breadcrumb">
             <li><a href="{% url 'ipam:vlangroup_list' %}">VLAN Groups</a></li>

--- a/netbox/templates/ipam/vrf.html
+++ b/netbox/templates/ipam/vrf.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 <li><a href="{% url 'ipam:vrf_list' %}">VRFs</a></li>

--- a/netbox/templates/panel_table.html
+++ b/netbox/templates/panel_table.html
@@ -1,6 +1,6 @@
 {% load render_table from django_tables2 %}
 
-<div class="panel panel-{{ panel_class|default:'default' }}">
+<div class="panel panel-{{ panel_class|default:'default' }}" {% if panel_id %}id="{{ panel_id }}"{% endif %}">
     {% if heading %}
         <div class="panel-heading">
             <strong>{{ heading }}</strong>

--- a/netbox/templates/secrets/secret.html
+++ b/netbox/templates/secrets/secret.html
@@ -4,7 +4,7 @@
 {% load secret_helpers %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-md-12">
             <ol class="breadcrumb">
                 <li><a href="{% url 'secrets:secret_list' %}">Secrets</a></li>

--- a/netbox/templates/tenancy/tenant.html
+++ b/netbox/templates/tenancy/tenant.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 <li><a href="{% url 'tenancy:tenant_list' %}">Tenants</a></li>

--- a/netbox/templates/virtualization/cluster.html
+++ b/netbox/templates/virtualization/cluster.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 
 {% block header %}
-    <div class="row" xmlns="http://www.w3.org/1999/html">
+    <div class="row sub-header" xmlns="http://www.w3.org/1999/html">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 <li><a href="{{ cluster.type.get_absolute_url }}">{{ cluster.type }}</a></li>

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 
 {% block header %}
-    <div class="row">
+    <div class="row sub-header">
         <div class="col-sm-8 col-md-9">
             <ol class="breadcrumb">
                 {% if virtualmachine.cluster %}


### PR DESCRIPTION
### Fixes: #2435 

This change hides several elements that make no sense for printing by adapting CSS.
Some classes and ids needed to be inserted into the templates.

Hidden / removed:
- search and tags panels in list views
- navigation tabs
- textual relative URLs for each link (default feature of Bootstrap that makes no sense for netbox)
- sub header (breadcrumbs and search box)
- buttons
- "related" panels: the links don't make sense on paper
- padding at top of page
