### PR TITLE
Closes #2487: Enable brief API output utilizing nested serializers

### DIFF
--- a/netbox/circuits/tests/test_api.py
+++ b/netbox/circuits/tests/test_api.py
@@ -56,6 +56,16 @@ class ProviderTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_providers_brief(self):
+
+        url = reverse('circuits-api:provider-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
+
     def test_create_provider(self):
 
         data = {
@@ -147,6 +157,16 @@ class CircuitTypeTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_circuittypes_brief(self):
+
+        url = reverse('circuits-api:circuittype-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
+
     def test_create_circuittype(self):
 
         data = {
@@ -215,6 +235,16 @@ class CircuitTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_circuits_brief(self):
+
+        url = reverse('circuits-api:circuit-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['cid', 'id', 'url']
+        )
 
     def test_create_circuit(self):
 

--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -492,6 +492,15 @@ class ConsolePortSerializer(TaggitSerializer, ValidatedModelSerializer):
         fields = ['id', 'device', 'name', 'cs_port', 'connection_status', 'tags']
 
 
+class NestedConsolePortSerializer(TaggitSerializer, ValidatedModelSerializer):
+    url = serializers.HyperlinkedIdentityField(view_name='dcim-api:consoleport-detail')
+    device = NestedDeviceSerializer(read_only=True)
+
+    class Meta:
+        model = ConsolePort
+        fields = ['id', 'url', 'device', 'name']
+
+
 #
 # Power outlets
 #
@@ -527,6 +536,15 @@ class PowerPortSerializer(TaggitSerializer, ValidatedModelSerializer):
     class Meta:
         model = PowerPort
         fields = ['id', 'device', 'name', 'power_outlet', 'connection_status', 'tags']
+
+
+class NestedPowerPortSerializer(TaggitSerializer, ValidatedModelSerializer):
+    url = serializers.HyperlinkedIdentityField(view_name='dcim-api:powerport-detail')
+    device = NestedDeviceSerializer(read_only=True)
+
+    class Meta:
+        model = PowerPort
+        fields = ['id', 'url', 'device', 'name']
 
 
 #
@@ -652,10 +670,11 @@ class DeviceBaySerializer(TaggitSerializer, ValidatedModelSerializer):
 
 class NestedDeviceBaySerializer(WritableNestedSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:devicebay-detail')
+    device = NestedDeviceSerializer(read_only=True)
 
     class Meta:
         model = DeviceBay
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'device', 'name']
 
 
 #

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -238,6 +238,11 @@ class DeviceViewSet(CustomFieldModelViewSet):
         """
         if self.action == 'retrieve':
             return serializers.DeviceWithConfigContextSerializer
+
+        request = self.get_serializer_context()['request']
+        if request.query_params.get('brief', False):
+            return serializers.NestedDeviceSerializer
+
         return serializers.DeviceSerializer
 
     @action(detail=True, url_path='napalm')

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -44,6 +44,16 @@ class RegionTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_regions_brief(self):
+
+        url = reverse('dcim-api:region-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
+
     def test_create_region(self):
 
         data = {
@@ -158,6 +168,16 @@ class SiteTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_sites_brief(self):
+
+        url = reverse('dcim-api:site-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
+
     def test_create_site(self):
 
         data = {
@@ -262,6 +282,16 @@ class RackGroupTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_rackgroups_brief(self):
+
+        url = reverse('dcim-api:rackgroup-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
+
     def test_create_rackgroup(self):
 
         data = {
@@ -359,6 +389,16 @@ class RackRoleTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_rackroles_brief(self):
+
+        url = reverse('dcim-api:rackrole-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
 
     def test_create_rackrole(self):
 
@@ -476,6 +516,16 @@ class RackTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_racks_brief(self):
+
+        url = reverse('dcim-api:rack-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['display_name', 'id', 'name', 'url']
+        )
 
     def test_create_rack(self):
 
@@ -693,6 +743,16 @@ class ManufacturerTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_manufacturers_brief(self):
+
+        url = reverse('dcim-api:manufacturer-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
+
     def test_create_manufacturer(self):
 
         data = {
@@ -791,6 +851,16 @@ class DeviceTypeTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_devicetypes_brief(self):
+
+        url = reverse('dcim-api:devicetype-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'manufacturer', 'model', 'slug', 'url']
+        )
 
     def test_create_devicetype(self):
 
@@ -1496,6 +1566,16 @@ class DeviceRoleTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_deviceroles_brief(self):
+
+        url = reverse('dcim-api:devicerole-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
+
     def test_create_devicerole(self):
 
         data = {
@@ -1593,6 +1673,16 @@ class PlatformTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_platforms_brief(self):
+
+        url = reverse('dcim-api:platform-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
 
     def test_create_platform(self):
 
@@ -1722,6 +1812,16 @@ class DeviceTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_devices_brief(self):
+
+        url = reverse('dcim-api:device-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['display_name', 'id', 'name', 'url']
+        )
+
     def test_create_device(self):
 
         data = {
@@ -1848,6 +1948,16 @@ class ConsolePortTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_consoleports_brief(self):
+
+        url = reverse('dcim-api:consoleport-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['device', 'id', 'name', 'url']
+        )
+
     def test_create_consoleport(self):
 
         data = {
@@ -1953,6 +2063,16 @@ class ConsoleServerPortTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_consoleserverports_brief(self):
+
+        url = reverse('dcim-api:consoleserverport-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['device', 'id', 'name', 'url']
+        )
+
     def test_create_consoleserverport(self):
 
         data = {
@@ -2053,6 +2173,16 @@ class PowerPortTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_powerports_brief(self):
+
+        url = reverse('dcim-api:powerport-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['device', 'id', 'name', 'url']
+        )
 
     def test_create_powerport(self):
 
@@ -2158,6 +2288,16 @@ class PowerOutletTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_poweroutlets_brief(self):
+
+        url = reverse('dcim-api:poweroutlet-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['device', 'id', 'name', 'url']
+        )
 
     def test_create_poweroutlet(self):
 
@@ -2284,6 +2424,16 @@ class InterfaceTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_interfaces_brief(self):
+
+        url = reverse('dcim-api:interface-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['device', 'id', 'name', 'url']
+        )
 
     def test_create_interface(self):
 
@@ -2455,6 +2605,16 @@ class DeviceBayTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_devicebays_brief(self):
+
+        url = reverse('dcim-api:devicebay-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['device', 'id', 'name', 'url']
+        )
 
     def test_create_devicebay(self):
 
@@ -2778,6 +2938,16 @@ class InterfaceConnectionTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_interfaceconnections_brief(self):
+
+        url = reverse('dcim-api:interfaceconnection-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['connection_status', 'id', 'url']
+        )
+
     def test_create_interfaceconnection(self):
 
         data = {
@@ -2972,6 +3142,16 @@ class VirtualChassisTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 2)
+
+    def test_list_virtualchassis_brief(self):
+
+        url = reverse('dcim-api:virtualchassis-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'url']
+        )
 
     def test_create_virtualchassis(self):
 

--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -34,6 +34,16 @@ class VRFTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_vrfs_brief(self):
+
+        url = reverse('ipam-api:vrf-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'rd', 'url']
+        )
+
     def test_create_vrf(self):
 
         data = {
@@ -124,6 +134,16 @@ class RIRTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_rirs_brief(self):
+
+        url = reverse('ipam-api:rir-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
 
     def test_create_rir(self):
 
@@ -218,6 +238,16 @@ class AggregateTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_aggregates_brief(self):
+
+        url = reverse('ipam-api:aggregate-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['family', 'id', 'prefix','url']
+        )
+
     def test_create_aggregate(self):
 
         data = {
@@ -309,6 +339,16 @@ class RoleTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_roles_brief(self):
+
+        url = reverse('ipam-api:role-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
+
     def test_create_role(self):
 
         data = {
@@ -397,12 +437,22 @@ class PrefixTest(APITestCase):
 
         self.assertEqual(response.data['prefix'], str(self.prefix1.prefix))
 
-    def test_list_prefixs(self):
+    def test_list_prefixes(self):
 
         url = reverse('ipam-api:prefix-list')
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_prefixes_brief(self):
+
+        url = reverse('ipam-api:prefix-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['family', 'id', 'prefix', 'url']
+        )
 
     def test_create_prefix(self):
 
@@ -630,6 +680,16 @@ class IPAddressTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_ipaddresses_brief(self):
+
+        url = reverse('ipam-api:ipaddress-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['address', 'family', 'id', 'url']
+        )
+
     def test_create_ipaddress(self):
 
         data = {
@@ -717,6 +777,16 @@ class VLANGroupTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_vlangroups_brief(self):
+
+        url = reverse('ipam-api:vlangroup-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
 
     def test_create_vlangroup(self):
 
@@ -808,6 +878,16 @@ class VLANTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_vlans_brief(self):
+
+        url = reverse('ipam-api:vlan-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['display_name', 'id', 'name', 'url', 'vid']
+        )
 
     def test_create_vlan(self):
 

--- a/netbox/project-static/js/forms.js
+++ b/netbox/project-static/js/forms.js
@@ -82,7 +82,7 @@ $(document).ready(function() {
             }
 
             if ($(parent).val() || $(parent).attr('nullable') == 'true') {
-                var api_url = child_field.attr('api-url') + '&limit=0';
+                var api_url = child_field.attr('api-url') + '&limit=0&brief';
                 var disabled_indicator = child_field.attr('disabled-indicator');
                 var initial_value = child_field.attr('initial');
                 var display_field = child_field.attr('display-field') || 'name';

--- a/netbox/project-static/js/forms.js
+++ b/netbox/project-static/js/forms.js
@@ -82,7 +82,7 @@ $(document).ready(function() {
             }
 
             if ($(parent).val() || $(parent).attr('nullable') == 'true') {
-                var api_url = child_field.attr('api-url') + '&limit=0&brief';
+                var api_url = child_field.attr('api-url') + '&limit=0&brief=1';
                 var disabled_indicator = child_field.attr('disabled-indicator');
                 var initial_value = child_field.attr('initial');
                 var display_field = child_field.attr('display-field') || 'name';

--- a/netbox/secrets/tests/test_api.py
+++ b/netbox/secrets/tests/test_api.py
@@ -73,6 +73,16 @@ class SecretRoleTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_secretroles_brief(self):
+
+        url = reverse('secrets-api:secretrole-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
+
     def test_create_secretrole(self):
 
         data = {

--- a/netbox/tenancy/tests/test_api.py
+++ b/netbox/tenancy/tests/test_api.py
@@ -31,6 +31,16 @@ class TenantGroupTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_tenantgroups_brief(self):
+
+        url = reverse('tenancy-api:tenantgroup-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
+
     def test_create_tenantgroup(self):
 
         data = {
@@ -123,6 +133,16 @@ class TenantTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_tenants_brief(self):
+
+        url = reverse('tenancy-api:tenant-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
 
     def test_create_tenant(self):
 

--- a/netbox/utilities/api.py
+++ b/netbox/utilities/api.py
@@ -197,7 +197,7 @@ class ModelViewSet(_ModelViewSet):
         # If 'brief' has been passed as a query param, find and return the nested serializer for this model, if one
         # exists
         request = self.get_serializer_context()['request']
-        if 'brief' in request.query_params:
+        if request.query_params.get('brief', False):
             serializer_class = get_serializer_for_model(self.queryset.model, prefix='Nested')
             if serializer_class is not None:
                 return serializer_class

--- a/netbox/utilities/api.py
+++ b/netbox/utilities/api.py
@@ -192,6 +192,19 @@ class ModelViewSet(_ModelViewSet):
 
         return super(ModelViewSet, self).get_serializer(*args, **kwargs)
 
+    def get_serializer_class(self):
+
+        # If 'brief' has been passed as a query param, find and return the nested serializer for this model, if one
+        # exists
+        request = self.get_serializer_context()['request']
+        if 'brief' in request.query_params:
+            serializer_class = get_serializer_for_model(self.queryset.model, prefix='Nested')
+            if serializer_class is not None:
+                return serializer_class
+
+        # Fall back to the hard-coded serializer class
+        return self.serializer_class
+
 
 class FieldChoicesViewSet(ViewSet):
     """

--- a/netbox/virtualization/api/serializers.py
+++ b/netbox/virtualization/api/serializers.py
@@ -169,7 +169,8 @@ class InterfaceSerializer(TaggitSerializer, ValidatedModelSerializer):
 
 class NestedInterfaceSerializer(WritableNestedSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='virtualization-api:interface-detail')
+    virtual_machine = NestedVirtualMachineSerializer(read_only=True)
 
     class Meta:
         model = Interface
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'virtual_machine', 'name']

--- a/netbox/virtualization/api/views.py
+++ b/netbox/virtualization/api/views.py
@@ -56,6 +56,11 @@ class VirtualMachineViewSet(CustomFieldModelViewSet):
         """
         if self.action == 'retrieve':
             return serializers.VirtualMachineWithConfigContextSerializer
+
+        request = self.get_serializer_context()['request']
+        if request.query_params.get('brief', False):
+            return serializers.NestedVirtualMachineSerializer
+
         return serializers.VirtualMachineSerializer
 
 
@@ -65,3 +70,10 @@ class InterfaceViewSet(ModelViewSet):
     ).select_related('virtual_machine').prefetch_related('tags')
     serializer_class = serializers.InterfaceSerializer
     filter_class = filters.InterfaceFilter
+
+    def get_serializer_class(self):
+        request = self.get_serializer_context()['request']
+        if request.query_params.get('brief', False):
+            # Override get_serializer_for_model(), which will return the DCIM NestedInterfaceSerializer
+            return serializers.NestedInterfaceSerializer
+        return serializers.InterfaceSerializer

--- a/netbox/virtualization/tests/test_api.py
+++ b/netbox/virtualization/tests/test_api.py
@@ -35,6 +35,16 @@ class ClusterTypeTest(APITestCase):
 
         self.assertEqual(response.data['count'], 3)
 
+    def test_list_clustertypes_brief(self):
+
+        url = reverse('virtualization-api:clustertype-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
+
     def test_create_clustertype(self):
 
         data = {
@@ -125,6 +135,16 @@ class ClusterGroupTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_clustergroups_brief(self):
+
+        url = reverse('virtualization-api:clustergroup-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'slug', 'url']
+        )
 
     def test_create_clustergroup(self):
 
@@ -219,6 +239,16 @@ class ClusterTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_clusters_brief(self):
+
+        url = reverse('virtualization-api:cluster-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'url']
+        )
 
     def test_create_cluster(self):
 
@@ -323,6 +353,16 @@ class VirtualMachineTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_virtualmachines_brief(self):
+
+        url = reverse('virtualization-api:virtualmachine-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'url']
+        )
 
     def test_create_virtualmachine(self):
 
@@ -446,6 +486,16 @@ class InterfaceTest(APITestCase):
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['count'], 3)
+
+    def test_list_interfaces_brief(self):
+
+        url = reverse('virtualization-api:interface-list')
+        response = self.client.get('{}?brief=1'.format(url), **self.header)
+
+        self.assertEqual(
+            sorted(response.data['results'][0]),
+            ['id', 'name', 'url', 'virtual_machine']
+        )
 
     def test_create_interface(self):
 


### PR DESCRIPTION
### Fixes: #2487

Minimize API output when `?brief` is passed as a query parameter.