### PR TITLE
Fix the handling of shared IPs (VIP, VRRF, etc.) when unique IP space enforcement is set.

### DIFF
--- a/netbox/ipam/models.py
+++ b/netbox/ipam/models.py
@@ -596,11 +596,11 @@ class IPAddress(ChangeLoggedModel, CustomFieldModel):
         if self.address:
 
             # Enforce unique IP space (if applicable)
-            if self.role not in IPADDRESS_ROLES_NONUNIQUE and (
+            if self.role not in IPADDRESS_ROLES_NONUNIQUE and ((
                 self.vrf is None and settings.ENFORCE_GLOBAL_UNIQUE
             ) or (
                 self.vrf and self.vrf.enforce_unique
-            ):
+            )):
                 duplicate_ips = self.get_duplicates()
                 if duplicate_ips:
                     raise ValidationError({


### PR DESCRIPTION
### Fixes: #2501

It's not possible to create duplicate shared IPs in a VRF when unique IP space enforcement is on. 

This is due missing parentheses around the whole logical-OR statement which causes "**[...] or (
self.vrf and self.vrf.enforce_unique)**" to be always true and thus goes further to the duplicate IP address check instead of skipping this check.

Add parentheses for the logical OR-statement that checks the conditions if unique IP space enforcement is on and if the IP address is duplicate.