### PR TITLE
Expand Webhook Documentation #2347

### DIFF
--- a/docs/additional-features/webhooks.md
+++ b/docs/additional-features/webhooks.md
@@ -4,6 +4,14 @@ A webhook defines an HTTP request that is sent to an external application when c
 
 An optional secret key can be configured for each webhook. This will append a `X-Hook-Signature` header to the request, consisting of a HMAC (SHA-512) hex digest of the request body using the secret as the key. This digest can be used by the receiver to authenticate the request's content.
 
+## Installation
+
+If you are upgrading from a previous version of Netbox and want to enable the webhook feature, please follow the directions listed in the sections below.
+
+* [Install Redis server and djano-rq package](../installation/2-netbox/#install-python-packages)
+* [Modify configuration to enable webhooks](../installation/2-netbox/#webhooks-configuration)
+* [Create supervisord program to run the rqworker process](../installation/3-http-daemon/#supervisord-installation)
+
 ## Requests
 
 The webhook POST request is structured as so (assuming `application/json` as the Content-Type):

--- a/docs/installation/2-netbox.md
+++ b/docs/installation/2-netbox.md
@@ -71,7 +71,7 @@ Checking connectivity... done.
 
     `# chown -R netbox:netbox /opt/netbox/netbox/media/`
 
-## Install Python Packages
+# Install Python Packages
 
 Install the required Python packages using pip. (If you encounter any compilation errors during this step, ensure that you've installed all of the system dependencies listed above.)
 
@@ -82,7 +82,7 @@ Install the required Python packages using pip. (If you encounter any compilatio
 !!! note
     If you encounter errors while installing the required packages, check that you're running a recent version of pip (v9.0.1 or higher) with the command `pip3 -V`.
 
-### NAPALM Automation (Optional)
+## NAPALM Automation (Optional)
 
 NetBox supports integration with the [NAPALM automation](https://napalm-automation.net/) library. NAPALM allows NetBox to fetch live data from devices and return it to a requester via its REST API. Installation of NAPALM is optional. To enable it, install the `napalm` package using pip or pip3:
 
@@ -90,7 +90,7 @@ NetBox supports integration with the [NAPALM automation](https://napalm-automati
 # pip3 install napalm
 ```
 
-### Webhooks (Optional)
+## Webhooks (Optional)
 
 [Webhooks](../data-model/extras/#webhooks) allow NetBox to integrate with external services by pushing out a notification each time a relevant object is created, updated, or deleted. Enabling the webhooks feature requires [Redis](https://redis.io/), a lightweight in-memory database. You may opt to install a Redis sevice locally (see below) or connect to an external one.
 


### PR DESCRIPTION
### Fixes:  Expand Webhook Documentation #2347

Add text to Webhooks documentation to link users to installing required packages and making necessary config changes.  Links are provided as to not duplicate instructions.