### PR TITLE
Fix encoding of plaintext length indicator for secrets (fixes #2473)

### DIFF
--- a/netbox/secrets/models.py
+++ b/netbox/secrets/models.py
@@ -400,8 +400,8 @@ class Secret(ChangeLoggedModel, CustomFieldModel):
         else:
             pad_length = 0
         return (
-            chr(len(s) >> 8).encode() +
-            chr(len(s) % 256).encode() +
+            chr(len(s) >> 8).encode('latin-1') +
+            chr(len(s) % 256).encode('latin-1') +
             s +
             os.urandom(pad_length)
         )

--- a/netbox/secrets/models.py
+++ b/netbox/secrets/models.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import os
+import sys
 
 from Crypto.Cipher import AES, PKCS1_OAEP
 from Crypto.PublicKey import RSA
@@ -399,10 +400,16 @@ class Secret(ChangeLoggedModel, CustomFieldModel):
             pad_length = 16 - ((len(s) + 2) % 16)
         else:
             pad_length = 0
+
+        if sys.version_info[0] < 3:
+            b1 = chr(len(s) >> 8)
+            b2 = chr(len(s) % 256)
+        else:
+            b1 = chr(len(s) >> 8).encode('latin-1')
+            b2 = chr(len(s) % 256).encode('latin-1')
+
         return (
-            chr(len(s) >> 8).encode('latin-1') +
-            chr(len(s) % 256).encode('latin-1') +
-            s +
+            b1 + b2 + s +
             os.urandom(pad_length)
         )
 


### PR DESCRIPTION
### Fixes: #2473 

The encoding of the secret length indicator has likely been broken
since commit b21833f79c86bcdbc5a080703fd15f0e12cfa7a0 which introduced
Py3 support for secrets: the indicator was switched to using UTF-8 byte
strings and this caused the length indicator to consume 3 bytes instead
of just 2 under certain circumstances. For example when the plaintext
secret length is between 128 and 256 bytes long. This is because contrary
to latin-1 encoding, UTF-8 byte sting encoding consumes 2 bytes for
code points > 80. See the table at https://en.wikipedia.org/wiki/UTF-8#Description

The fix is to explicitely use 'latin-1' encoding for the length indicator.
This makes the code behave exactly as it did with the original Python2
implemenation while remaining compatible w/ Py3.

This fix does not alter the unpad/decode code path, only the code path which
encrypts new secrets. In other words, secrets that were stored in a broken state
will remain broken and what worked before will continue to work.

A test case which uses a 171 byte long plaintext string has also been added.
This test triggers the bug when the fix is not present.