### PR TITLE
Use NestedInterfaceSerializer in CircuitTerminationSerializer fixes #2528

### DIFF
--- a/netbox/circuits/api/serializers.py
+++ b/netbox/circuits/api/serializers.py
@@ -5,7 +5,7 @@ from taggit_serializer.serializers import TaggitSerializer, TagListSerializerFie
 
 from circuits.constants import CIRCUIT_STATUS_CHOICES
 from circuits.models import Provider, Circuit, CircuitTermination, CircuitType
-from dcim.api.serializers import NestedSiteSerializer, InterfaceSerializer
+from dcim.api.serializers import NestedSiteSerializer, NestedInterfaceSerializer
 from extras.api.customfields import CustomFieldModelSerializer
 from tenancy.api.serializers import NestedTenantSerializer
 from utilities.api import ChoiceField, ValidatedModelSerializer, WritableNestedSerializer
@@ -87,7 +87,7 @@ class NestedCircuitSerializer(WritableNestedSerializer):
 class CircuitTerminationSerializer(ValidatedModelSerializer):
     circuit = NestedCircuitSerializer()
     site = NestedSiteSerializer()
-    interface = InterfaceSerializer(required=False, allow_null=True)
+    interface = NestedInterfaceSerializer()
 
     class Meta:
         model = CircuitTermination

--- a/netbox/circuits/tests/test_api.py
+++ b/netbox/circuits/tests/test_api.py
@@ -10,6 +10,7 @@ from extras.constants import GRAPH_TYPE_PROVIDER
 from extras.models import Graph
 from utilities.testing import APITestCase
 
+
 class ProviderTest(APITestCase):
 
     def setUp(self):


### PR DESCRIPTION
### Fixes: #2528 Unable to Create Circuit Terminations with interface via API

<!--
    Please include a summary of the proposed changes below.
-->

Use NestedInterfaceSerializer() instead of InterfaceSerializer() in CircuitTerminationSerializer