### PR TITLE
Release v2.4.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ v2.4.7 (FUTURE)
 * [#2502](https://github.com/digitalocean/netbox/issues/2502) - Allow duplicate VIPs inside a uniqueness-enforced VRF
 * [#2514](https://github.com/digitalocean/netbox/issues/2514) - Prevent new connections to already connected interfaces
 * [#2515](https://github.com/digitalocean/netbox/issues/2515) - Only use django-rq admin tmeplate if webhooks are enabled
-* [#2528](https://github.com/digitalocean/netbox/issues/2528) - 
+* [#2528](https://github.com/digitalocean/netbox/issues/2528) - Enable creating circuit terminations with interface assignment via API
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ v2.4.7 (FUTURE)
 * [#2514](https://github.com/digitalocean/netbox/issues/2514) - Prevent new connections to already connected interfaces
 * [#2515](https://github.com/digitalocean/netbox/issues/2515) - Only use django-rq admin tmeplate if webhooks are enabled
 * [#2528](https://github.com/digitalocean/netbox/issues/2528) - Enable creating circuit terminations with interface assignment via API
+* [#2549](https://github.com/digitalocean/netbox/issues/2549) - Changed naming of `peer_device` and `peer_interface` on API /dcim/connected-device/ endpoint to use underscores
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v2.4.7 (FUTURE)
 
 ## Bug Fixes
 
+* [#2502](https://github.com/digitalocean/netbox/issues/2502) - Allow duplicate VIPs inside a uniqueness-enforced VRF
 * [#2514](https://github.com/digitalocean/netbox/issues/2514) - Prevent new connections to already connected interfaces
 * [#2515](https://github.com/digitalocean/netbox/issues/2515) - Only use django-rq admin tmeplate if webhooks are enabled
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v2.4.7 (FUTURE)
 
 ## Bug Fixes
 
+* [#2427](https://github.com/digitalocean/netbox/issues/2427) - Allow filtering of interfaces by assigned VLAN or VLAN ID
 * [#2502](https://github.com/digitalocean/netbox/issues/2502) - Allow duplicate VIPs inside a uniqueness-enforced VRF
 * [#2514](https://github.com/digitalocean/netbox/issues/2514) - Prevent new connections to already connected interfaces
 * [#2515](https://github.com/digitalocean/netbox/issues/2515) - Only use django-rq admin tmeplate if webhooks are enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-v2.4.7 (FUTURE)
+v2.4.7 (2018-11-06)
 
 ## Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v2.4.7 (FUTURE)
 
 ## Bug Fixes
 
+* [#2514](https://github.com/digitalocean/netbox/issues/2514) - Prevent new connections to already connected interfaces
 * [#2515](https://github.com/digitalocean/netbox/issues/2515) - Only use django-rq admin tmeplate if webhooks are enabled
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v2.4.7 (FUTURE)
+
+## Bug Fixes
+
+* [#2515](https://github.com/digitalocean/netbox/issues/2515) - Only use django-rq admin tmeplate if webhooks are enabled
+
+---
+
 v2.4.6 (2018-10-05)
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 v2.4.7 (FUTURE)
 
-## Bug Fixes
+## Enhancements
 
 * [#2427](https://github.com/digitalocean/netbox/issues/2427) - Allow filtering of interfaces by assigned VLAN or VLAN ID
+* [#2512](https://github.com/digitalocean/netbox/issues/2512) - Add device field to inventory item filter form
+
+## Bug Fixes
+
 * [#2502](https://github.com/digitalocean/netbox/issues/2502) - Allow duplicate VIPs inside a uniqueness-enforced VRF
 * [#2514](https://github.com/digitalocean/netbox/issues/2514) - Prevent new connections to already connected interfaces
 * [#2515](https://github.com/digitalocean/netbox/issues/2515) - Only use django-rq admin tmeplate if webhooks are enabled

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ v2.4.7 (FUTURE)
 * [#2502](https://github.com/digitalocean/netbox/issues/2502) - Allow duplicate VIPs inside a uniqueness-enforced VRF
 * [#2514](https://github.com/digitalocean/netbox/issues/2514) - Prevent new connections to already connected interfaces
 * [#2515](https://github.com/digitalocean/netbox/issues/2515) - Only use django-rq admin tmeplate if webhooks are enabled
+* [#2528](https://github.com/digitalocean/netbox/issues/2528) - 
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@ v2.4.7 (FUTURE)
 
 ## Enhancements
 
+* [#2388](https://github.com/digitalocean/netbox/issues/2388) - Enable filtering of devices/VMs by region
 * [#2427](https://github.com/digitalocean/netbox/issues/2427) - Allow filtering of interfaces by assigned VLAN or VLAN ID
 * [#2512](https://github.com/digitalocean/netbox/issues/2512) - Add device field to inventory item filter form
 

--- a/docs/additional-features/webhooks.md
+++ b/docs/additional-features/webhooks.md
@@ -4,6 +4,14 @@ A webhook defines an HTTP request that is sent to an external application when c
 
 An optional secret key can be configured for each webhook. This will append a `X-Hook-Signature` header to the request, consisting of a HMAC (SHA-512) hex digest of the request body using the secret as the key. This digest can be used by the receiver to authenticate the request's content.
 
+## Installation
+
+If you are upgrading from a previous version of Netbox and want to enable the webhook feature, please follow the directions listed in the sections below.
+
+* [Install Redis server and djano-rq package](../installation/2-netbox/#install-python-packages)
+* [Modify configuration to enable webhooks](../installation/2-netbox/#webhooks-configuration)
+* [Create supervisord program to run the rqworker process](../installation/3-http-daemon/#supervisord-installation)
+
 ## Requests
 
 The webhook POST request is structured as so (assuming `application/json` as the Content-Type):

--- a/docs/core-functionality/devices.md
+++ b/docs/core-functionality/devices.md
@@ -101,7 +101,7 @@ Device bays represent the ability of a device to house child devices. For exampl
 
 A platform defines the type of software running on a device or virtual machine. This can be helpful when it is necessary to distinguish between, for instance, different feature sets. Note that two devices of the same type may be assigned different platforms: for example, one Juniper MX240 running Junos 14 and another running Junos 15.
 
-The platform model is also used to indicate which [NAPALM](https://napalm-automation.net/) driver NetBox should use when connecting to a remote device. The name of the driver along with optional parameters are stored with the platform. See the [API documentation](api/napalm-integration.md) for more information on NAPALM integration.
+The platform model is also used to indicate which [NAPALM](https://napalm-automation.net/) driver NetBox should use when connecting to a remote device. The name of the driver along with optional parameters are stored with the platform.
 
 The assignment of platforms to devices is an optional feature, and may be disregarded if not desired.
 

--- a/docs/core-functionality/devices.md
+++ b/docs/core-functionality/devices.md
@@ -58,7 +58,7 @@ A device is said to be full depth if its installation on one rack face prevents 
 
 ## Device Roles
 
-Devices can be organized by functional roles. These roles are fully cusomizable. For example, you might create roles for core switches, distribution switches, and access switches.
+Devices can be organized by functional roles. These roles are fully customizable. For example, you might create roles for core switches, distribution switches, and access switches.
 
 ---
 

--- a/docs/core-functionality/ipam.md
+++ b/docs/core-functionality/ipam.md
@@ -4,7 +4,7 @@ The first step to documenting your IP space is to define its scope by creating a
 
 * 10.0.0.0/8 (RFC 1918)
 * 100.64.0.0/10 (RFC 6598)
-* 172.16.0.0/20 (RFC 1918)
+* 172.16.0.0/12 (RFC 1918)
 * 192.168.0.0/16 (RFC 1918)
 * One or more /48s within fd00::/8 (IPv6 unique local addressing)
 

--- a/docs/installation/2-netbox.md
+++ b/docs/installation/2-netbox.md
@@ -71,7 +71,7 @@ Checking connectivity... done.
 
     `# chown -R netbox:netbox /opt/netbox/netbox/media/`
 
-## Install Python Packages
+# Install Python Packages
 
 Install the required Python packages using pip. (If you encounter any compilation errors during this step, ensure that you've installed all of the system dependencies listed above.)
 
@@ -82,7 +82,7 @@ Install the required Python packages using pip. (If you encounter any compilatio
 !!! note
     If you encounter errors while installing the required packages, check that you're running a recent version of pip (v9.0.1 or higher) with the command `pip3 -V`.
 
-### NAPALM Automation (Optional)
+## NAPALM Automation (Optional)
 
 NetBox supports integration with the [NAPALM automation](https://napalm-automation.net/) library. NAPALM allows NetBox to fetch live data from devices and return it to a requester via its REST API. Installation of NAPALM is optional. To enable it, install the `napalm` package using pip or pip3:
 
@@ -90,7 +90,7 @@ NetBox supports integration with the [NAPALM automation](https://napalm-automati
 # pip3 install napalm
 ```
 
-### Webhooks (Optional)
+## Webhooks (Optional)
 
 [Webhooks](../data-model/extras/#webhooks) allow NetBox to integrate with external services by pushing out a notification each time a relevant object is created, updated, or deleted. Enabling the webhooks feature requires [Redis](https://redis.io/), a lightweight in-memory database. You may opt to install a Redis sevice locally (see below) or connect to an external one.
 

--- a/netbox/circuits/api/serializers.py
+++ b/netbox/circuits/api/serializers.py
@@ -4,8 +4,8 @@ from rest_framework import serializers
 from taggit_serializer.serializers import TaggitSerializer, TagListSerializerField
 
 from circuits.constants import CIRCUIT_STATUS_CHOICES
-from circuits.models import Provider, Circuit, CircuitTermination, CircuitType
-from dcim.api.serializers import NestedSiteSerializer, InterfaceSerializer
+from circuits.models import Circuit, CircuitTermination, CircuitType, Provider
+from dcim.api.serializers import NestedInterfaceSerializer, NestedSiteSerializer
 from extras.api.customfields import CustomFieldModelSerializer
 from tenancy.api.serializers import NestedTenantSerializer
 from utilities.api import ChoiceField, ValidatedModelSerializer, WritableNestedSerializer
@@ -87,7 +87,7 @@ class NestedCircuitSerializer(WritableNestedSerializer):
 class CircuitTerminationSerializer(ValidatedModelSerializer):
     circuit = NestedCircuitSerializer()
     site = NestedSiteSerializer()
-    interface = InterfaceSerializer(required=False, allow_null=True)
+    interface = NestedInterfaceSerializer(required=False, allow_null=True)
 
     class Meta:
         model = CircuitTermination

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -429,7 +429,13 @@ class ConnectedDeviceViewSet(ViewSet):
     def list(self, request):
 
         peer_device_name = request.query_params.get(self._device_param.name)
+        if not peer_device_name:
+            # TODO: remove this after 2.4 as the switch to using underscores is a breaking change
+            peer_device_name = request.query_params.get('peer-device')
         peer_interface_name = request.query_params.get(self._interface_param.name)
+        if not peer_interface_name:
+            # TODO: remove this after 2.4 as the switch to using underscores is a breaking change
+            peer_interface_name = request.query_params.get('peer-interface')
         if not peer_device_name or not peer_interface_name:
             raise MissingFilterException(detail='Request must include "peer_device" and "peer_interface" filters.')
 

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -412,13 +412,13 @@ class ConnectedDeviceViewSet(ViewSet):
     interface. This is useful in a situation where a device boots with no configuration, but can detect its neighbors
     via a protocol such as LLDP. Two query parameters must be included in the request:
 
-    * `peer-device`: The name of the peer device
-    * `peer-interface`: The name of the peer interface
+    * `peer_device`: The name of the peer device
+    * `peer_interface`: The name of the peer interface
     """
     permission_classes = [IsAuthenticatedOrLoginNotRequired]
-    _device_param = Parameter('peer-device', 'query',
+    _device_param = Parameter('peer_device', 'query',
                               description='The name of the peer device', required=True, type=openapi.TYPE_STRING)
-    _interface_param = Parameter('peer-interface', 'query',
+    _interface_param = Parameter('peer_interface', 'query',
                                  description='The name of the peer interface', required=True, type=openapi.TYPE_STRING)
 
     def get_view_name(self):
@@ -431,7 +431,7 @@ class ConnectedDeviceViewSet(ViewSet):
         peer_device_name = request.query_params.get(self._device_param.name)
         peer_interface_name = request.query_params.get(self._interface_param.name)
         if not peer_device_name or not peer_interface_name:
-            raise MissingFilterException(detail='Request must include "peer-device" and "peer-interface" filters.')
+            raise MissingFilterException(detail='Request must include "peer_device" and "peer_interface" filters.')
 
         # Determine local interface from peer interface's connection
         peer_interface = get_object_or_404(Interface, device__name=peer_device_name, name=peer_interface_name)

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -707,6 +707,15 @@ class InventoryItemFilter(DeviceComponentFilterSet):
         method='search',
         label='Search',
     )
+    device_id = django_filters.ModelChoiceFilter(
+        queryset=Device.objects.all(),
+        label='Device (ID)',
+    )
+    device = django_filters.ModelChoiceFilter(
+        queryset=Device.objects.all(),
+        to_field_name='name',
+        label='Device (name)',
+    )
     parent_id = django_filters.ModelMultipleChoiceFilter(
         queryset=InventoryItem.objects.all(),
         label='Parent inventory item (ID)',

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -635,6 +635,14 @@ class InterfaceFilter(django_filters.FilterSet):
     tag = django_filters.CharFilter(
         name='tags__slug',
     )
+    vlan_id = django_filters.CharFilter(
+        method='filter_vlan_by_pk',
+        name='vlan_pk',
+    )
+    vlan = django_filters.CharFilter(
+        method='filter_vlan_by_id',
+        name='vid',
+    )
 
     class Meta:
         model = Interface
@@ -648,6 +656,12 @@ class InterfaceFilter(django_filters.FilterSet):
             return queryset.filter(pk__in=vc_interface_ids).order_naturally(ordering)
         except Device.DoesNotExist:
             return queryset.none()
+
+    def filter_vlan_by_pk(self, queryset, name, value):
+        return queryset.filter(Q(untagged_vlan_id=value) | Q(tagged_vlans=value))
+
+    def filter_vlan_by_id(self, queryset, name, value):
+        return queryset.filter(Q(untagged_vlan_id__vid=value) | Q(tagged_vlans__vid=value))
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -636,12 +636,12 @@ class InterfaceFilter(django_filters.FilterSet):
         name='tags__slug',
     )
     vlan_id = django_filters.CharFilter(
-        method='filter_vlan_by_pk',
-        name='vlan_pk',
+        method='filter_vlan_id',
+        label='Assigned VLAN'
     )
     vlan = django_filters.CharFilter(
-        method='filter_vlan_by_id',
-        name='vid',
+        method='filter_vlan',
+        label='Assigned VID'
     )
 
     class Meta:
@@ -657,11 +657,23 @@ class InterfaceFilter(django_filters.FilterSet):
         except Device.DoesNotExist:
             return queryset.none()
 
-    def filter_vlan_by_pk(self, queryset, name, value):
-        return queryset.filter(Q(untagged_vlan_id=value) | Q(tagged_vlans=value))
+    def filter_vlan_id(self, queryset, name, value):
+        value = value.strip()
+        if not value:
+            return queryset
+        return queryset.filter(
+            Q(untagged_vlan_id=value) |
+            Q(tagged_vlans=value)
+        )
 
-    def filter_vlan_by_id(self, queryset, name, value):
-        return queryset.filter(Q(untagged_vlan_id__vid=value) | Q(tagged_vlans__vid=value))
+    def filter_vlan(self, queryset, name, value):
+        value = value.strip()
+        if not value:
+            return queryset
+        return queryset.filter(
+            Q(untagged_vlan_id__vid=value) |
+            Q(tagged_vlans__vid=value)
+        )
 
     def filter_type(self, queryset, name, value):
         value = value.strip().lower()

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -2201,6 +2201,7 @@ class InventoryItemBulkEditForm(BootstrapMixin, BulkEditForm):
 class InventoryItemFilterForm(BootstrapMixin, forms.Form):
     model = InventoryItem
     q = forms.CharField(required=False, label='Search')
+    device = forms.CharField(required=False, label='Device name')
     manufacturer = FilterChoiceField(
         queryset=Manufacturer.objects.annotate(filter_count=Count('inventory_items')),
         to_field_name='slug',

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1328,7 +1328,7 @@ class ConsolePortConnectionForm(BootstrapMixin, ChainedFieldsMixin, forms.ModelF
         label='Port',
         widget=APISelect(
             api_url='/api/dcim/console-server-ports/?device_id={{console_server}}',
-            disabled_indicator='connected_console',
+            disabled_indicator='is_connected',
         )
     )
 
@@ -1419,7 +1419,7 @@ class ConsoleServerPortConnectionForm(BootstrapMixin, ChainedFieldsMixin, forms.
         label='Port',
         widget=APISelect(
             api_url='/api/dcim/console-ports/?device_id={{device}}',
-            disabled_indicator='cs_port'
+            disabled_indicator='is_connected'
         )
     )
     connection_status = forms.BooleanField(
@@ -1597,7 +1597,7 @@ class PowerPortConnectionForm(BootstrapMixin, ChainedFieldsMixin, forms.ModelFor
         label='Outlet',
         widget=APISelect(
             api_url='/api/dcim/power-outlets/?device_id={{pdu}}',
-            disabled_indicator='connected_port'
+            disabled_indicator='is_connected'
         )
     )
 
@@ -1688,7 +1688,7 @@ class PowerOutletConnectionForm(BootstrapMixin, ChainedFieldsMixin, forms.Form):
         label='Port',
         widget=APISelect(
             api_url='/api/dcim/power-ports/?device_id={{device}}',
-            disabled_indicator='power_outlet'
+            disabled_indicator='is_connected'
         )
     )
     connection_status = forms.BooleanField(

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1108,6 +1108,11 @@ class DeviceBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditF
 class DeviceFilterForm(BootstrapMixin, CustomFieldFilterForm):
     model = Device
     q = forms.CharField(required=False, label='Search')
+    region = FilterTreeNodeMultipleChoiceField(
+        queryset=Region.objects.all(),
+        to_field_name='slug',
+        required=False,
+    )
     site = FilterChoiceField(
         queryset=Site.objects.annotate(filter_count=Count('devices')),
         to_field_name='slug',

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -3053,7 +3053,7 @@ class ConnectedDeviceTest(APITestCase):
     def test_get_connected_device(self):
 
         url = reverse('dcim-api:connected-device-list')
-        response = self.client.get(url + '?peer-device=TestDevice2&peer-interface=eth0', **self.header)
+        response = self.client.get(url + '?peer_device=TestDevice2&peer_interface=eth0', **self.header)
 
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.data['name'], self.device1.name)

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -1955,7 +1955,7 @@ class ConsolePortTest(APITestCase):
 
         self.assertEqual(
             sorted(response.data['results'][0]),
-            ['device', 'id', 'name', 'url']
+            ['device', 'id', 'is_connected', 'name', 'url']
         )
 
     def test_create_consoleport(self):
@@ -2070,7 +2070,7 @@ class ConsoleServerPortTest(APITestCase):
 
         self.assertEqual(
             sorted(response.data['results'][0]),
-            ['device', 'id', 'name', 'url']
+            ['device', 'id', 'is_connected', 'name', 'url']
         )
 
     def test_create_consoleserverport(self):
@@ -2181,7 +2181,7 @@ class PowerPortTest(APITestCase):
 
         self.assertEqual(
             sorted(response.data['results'][0]),
-            ['device', 'id', 'name', 'url']
+            ['device', 'id', 'is_connected', 'name', 'url']
         )
 
     def test_create_powerport(self):
@@ -2296,7 +2296,7 @@ class PowerOutletTest(APITestCase):
 
         self.assertEqual(
             sorted(response.data['results'][0]),
-            ['device', 'id', 'name', 'url']
+            ['device', 'id', 'is_connected', 'name', 'url']
         )
 
     def test_create_poweroutlet(self):
@@ -2432,7 +2432,7 @@ class InterfaceTest(APITestCase):
 
         self.assertEqual(
             sorted(response.data['results'][0]),
-            ['device', 'id', 'name', 'url']
+            ['device', 'id', 'is_connected', 'name', 'url']
         )
 
     def test_create_interface(self):

--- a/netbox/ipam/models.py
+++ b/netbox/ipam/models.py
@@ -596,11 +596,11 @@ class IPAddress(ChangeLoggedModel, CustomFieldModel):
         if self.address:
 
             # Enforce unique IP space (if applicable)
-            if self.role not in IPADDRESS_ROLES_NONUNIQUE and (
+            if self.role not in IPADDRESS_ROLES_NONUNIQUE and ((
                 self.vrf is None and settings.ENFORCE_GLOBAL_UNIQUE
             ) or (
                 self.vrf and self.vrf.enforce_unique
-            ):
+            )):
                 duplicate_ips = self.get_duplicates()
                 if duplicate_ips:
                     raise ValidationError({

--- a/netbox/netbox/admin.py
+++ b/netbox/netbox/admin.py
@@ -23,8 +23,9 @@ admin_site.register(User, UserAdmin)
 admin_site.register(Tag, TagAdmin)
 
 # Modify the template to include an RQ link if django_rq is installed (see RQ_SHOW_ADMIN_LINK)
-try:
-    import django_rq
-    admin_site.index_template = 'django_rq/index.html'
-except ImportError:
-    pass
+if settings.WEBHOOKS_ENABLED:
+    try:
+        import django_rq
+        admin_site.index_template = 'django_rq/index.html'
+    except ImportError:
+        pass

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -22,7 +22,7 @@ if sys.version_info[0] < 3:
         DeprecationWarning
     )
 
-VERSION = '2.4.6'
+VERSION = '2.4.7-dev'
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -22,7 +22,7 @@ if sys.version_info[0] < 3:
         DeprecationWarning
     )
 
-VERSION = '2.4.7-dev'
+VERSION = '2.4.7'
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/netbox/virtualization/filters.py
+++ b/netbox/virtualization/filters.py
@@ -1,11 +1,12 @@
 from __future__ import unicode_literals
 
 import django_filters
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from netaddr import EUI
 from netaddr.core import AddrFormatError
 
-from dcim.models import DeviceRole, Interface, Platform, Site
+from dcim.models import DeviceRole, Interface, Platform, Region, Site
 from extras.filters import CustomFieldFilterSet
 from tenancy.models import Tenant
 from utilities.filters import NumericInFilter
@@ -116,6 +117,16 @@ class VirtualMachineFilter(CustomFieldFilterSet):
         queryset=Cluster.objects.all(),
         label='Cluster (ID)',
     )
+    region_id = django_filters.NumberFilter(
+        method='filter_region',
+        name='pk',
+        label='Region (ID)',
+    )
+    region = django_filters.CharFilter(
+        method='filter_region',
+        name='slug',
+        label='Region (slug)',
+    )
     site_id = django_filters.ModelMultipleChoiceFilter(
         name='cluster__site',
         queryset=Site.objects.all(),
@@ -171,6 +182,16 @@ class VirtualMachineFilter(CustomFieldFilterSet):
         return queryset.filter(
             Q(name__icontains=value) |
             Q(comments__icontains=value)
+        )
+
+    def filter_region(self, queryset, name, value):
+        try:
+            region = Region.objects.get(**{name: value})
+        except ObjectDoesNotExist:
+            return queryset.none()
+        return queryset.filter(
+            Q(cluster__site__region=region) |
+            Q(cluster__site__region__in=region.get_descendants())
         )
 
 

--- a/netbox/virtualization/forms.py
+++ b/netbox/virtualization/forms.py
@@ -16,8 +16,8 @@ from tenancy.models import Tenant
 from utilities.forms import (
     AnnotatedMultipleChoiceField, APISelect, APISelectMultiple, BootstrapMixin, BulkEditForm, BulkEditNullBooleanSelect,
     ChainedFieldsMixin, ChainedModelChoiceField, ChainedModelMultipleChoiceField, CommentField, ComponentForm,
-    ConfirmationForm, CSVChoiceField, ExpandableNameField, FilterChoiceField, JSONField, SlugField, SmallTextarea,
-    add_blank_choice
+    ConfirmationForm, CSVChoiceField, ExpandableNameField, FilterChoiceField, FilterTreeNodeMultipleChoiceField,
+    JSONField, SlugField, SmallTextarea, add_blank_choice,
 )
 from .constants import VM_STATUS_CHOICES
 from .models import Cluster, ClusterGroup, ClusterType, VirtualMachine
@@ -385,6 +385,11 @@ class VirtualMachineFilterForm(BootstrapMixin, CustomFieldFilterForm):
     cluster_id = FilterChoiceField(
         queryset=Cluster.objects.annotate(filter_count=Count('virtual_machines')),
         label='Cluster'
+    )
+    region = FilterTreeNodeMultipleChoiceField(
+        queryset=Region.objects.all(),
+        to_field_name='slug',
+        required=False,
     )
     site = FilterChoiceField(
         queryset=Site.objects.annotate(filter_count=Count('clusters__virtual_machines')),

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,10 +14,10 @@ Markdown==2.6.11
 natsort==5.3.3
 ncclient==0.6.0
 netaddr==0.7.19
-paramiko==2.4.1
+paramiko==2.4.2
 Pillow==5.2.0
 psycopg2-binary==2.7.5
 py-gfm==0.1.3
-pycryptodome==3.6.4
+pycryptodome==3.6.6
 xmltodict==0.11.0
 


### PR DESCRIPTION
## Enhancements

* [#2388](https://github.com/digitalocean/netbox/issues/2388) - Enable filtering of devices/VMs by region
* [#2427](https://github.com/digitalocean/netbox/issues/2427) - Allow filtering of interfaces by assigned VLAN or VLAN ID
* [#2512](https://github.com/digitalocean/netbox/issues/2512) - Add device field to inventory item filter form

## Bug Fixes

* [#2502](https://github.com/digitalocean/netbox/issues/2502) - Allow duplicate VIPs inside a uniqueness-enforced VRF
* [#2514](https://github.com/digitalocean/netbox/issues/2514) - Prevent new connections to already connected interfaces
* [#2515](https://github.com/digitalocean/netbox/issues/2515) - Only use django-rq admin tmeplate if webhooks are enabled
* [#2528](https://github.com/digitalocean/netbox/issues/2528) - Enable creating circuit terminations with interface assignment via API
* [#2549](https://github.com/digitalocean/netbox/issues/2549) - Changed naming of `peer_device` and `peer_interface` on API /dcim/connected-device/ endpoint to use underscores
