### PR TITLE
Add Cable count to home page

### DIFF
--- a/netbox/netbox/views.py
+++ b/netbox/netbox/views.py
@@ -14,7 +14,7 @@ from dcim.filters import (
     DeviceFilter, DeviceTypeFilter, RackFilter, RackGroupFilter, SiteFilter, VirtualChassisFilter
 )
 from dcim.models import (
-    ConsolePort, Device, DeviceType, Interface, PowerPort, Rack, RackGroup, Site, VirtualChassis
+    Cable, ConsolePort, Device, DeviceType, Interface, PowerPort, Rack, RackGroup, Site, VirtualChassis
 )
 from dcim.tables import (
     DeviceDetailTable, DeviceTypeTable, RackTable, RackGroupTable, SiteTable, VirtualChassisTable
@@ -166,6 +166,7 @@ class HomeView(View):
             _connected_interface__isnull=False,
             pk__lt=F('_connected_interface')
         )
+        cables = Cable.objects.all()
 
         stats = {
 
@@ -177,6 +178,7 @@ class HomeView(View):
             'rack_count': Rack.objects.count(),
             'device_count': Device.objects.count(),
             'interface_connections_count': connected_interfaces.count(),
+            'cable_count': cables.count(),
             'console_connections_count': connected_consoleports.count(),
             'power_connections_count': connected_powerports.count(),
 

--- a/netbox/templates/home.html
+++ b/netbox/templates/home.html
@@ -39,6 +39,8 @@
                 </div>
                 <div class="list-group-item">
                     <h4 class="list-group-item-heading">Connections</h4>
+                    <span class="badge pull-right">{{ stats.cable_count }}</span>
+                    <p style="padding-left: 20px;"><a href="{% url 'dcim:cable_list' %}">Cables</a></p>
                     <span class="badge pull-right">{{ stats.interface_connections_count }}</span>
                     <p style="padding-left: 20px;"><a href="{% url 'dcim:interface_connections_list' %}">Interfaces</a></p>
                     <span class="badge pull-right">{{ stats.console_connections_count }}</span>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:
https://github.com/digitalocean/netbox/issues/2555
<!--
    Please include a summary of the proposed changes below.
-->

Add in stats.cable.count and add Cables to home page under devices (next to connections)