### PR TITLE
Add Py3 migration notes for CentOS

### DIFF
--- a/docs/installation/migrating-to-python3.md
+++ b/docs/installation/migrating-to-python3.md
@@ -51,26 +51,27 @@ Ensure EPEL is installed:
 # yum install -y epel-release
 ```
 
-Install Python3:
+Install Python3 and pip3, Python's package management tool:
 
 ```no-highlight
 # yum install -y python36 python36-devel python36-setuptools
+# python3.6 -m ensurepip --default-pip
 ```
 
 Install the Python3 packages required by NetBox:
 
 ```no-highlight
-# python3.6 -m pip install -r requirements.txt
+# pip3 install -r requirements.txt
 ```
 
 Replace gunicorn with the Python3 version:
 
 ```no-highlight
-# python3.6 -m pip install gunicorn
+# pip3 install gunicorn
 ```
 
 If using LDAP authentication, install the `django-auth-ldap` package:
 
 ```no-highlight
-# python3.6 -m pip install django-auth-ldap
+# pip3 install django-auth-ldap
 ```

--- a/docs/installation/migrating-to-python3.md
+++ b/docs/installation/migrating-to-python3.md
@@ -36,3 +36,41 @@ If using LDAP authentication, install the `django-auth-ldap` package:
 ```no-highlight
 # pip3 install django-auth-ldap
 ```
+
+## CentOS/RHEL
+
+Remove the Python2 version of gunicorn:
+
+```no-highlight
+# pip uninstall -y gunicorn
+```
+
+Ensure EPEL is installed:
+
+```no-highlight
+# yum install -y epel-release
+```
+
+Install Python3:
+
+```no-highlight
+# yum install -y python36 python36-devel python36-setuptools
+```
+
+Install the Python3 packages required by NetBox:
+
+```no-highlight
+# python3.6 -m pip install -r requirements.txt
+```
+
+Replace gunicorn with the Python3 version:
+
+```no-highlight
+# python3.6 -m pip install gunicorn
+```
+
+If using LDAP authentication, install the `django-auth-ldap` package:
+
+```no-highlight
+# python3.6 -m pip install django-auth-ldap
+```


### PR DESCRIPTION
Documentation updates per https://groups.google.com/forum/#!topic/netbox-discuss/Zmn0rTtYdsg

(also pip isn't available from EPEL - I think `python3.6 -m ensurepip` installs it system wide but I haven't tried it/nor have a centos box handy so didn't mention it here)