### PR TITLE
Documentation refinement: manage.py rqworker command unknown

### DIFF
--- a/docs/installation/3-http-daemon.md
+++ b/docs/installation/3-http-daemon.md
@@ -134,10 +134,11 @@ command = gunicorn -c /opt/netbox/gunicorn_config.py netbox.wsgi
 directory = /opt/netbox/netbox/
 user = www-data
 
-[program:netbox-rqworker]
-command = python3 /opt/netbox/netbox/manage.py rqworker
-directory = /opt/netbox/netbox/
-user = www-data
+# ### Uncomment when you enabled WEBHOOKS_ENABLE and use REDIS
+# [program:netbox-rqworker]
+# command = python3 /opt/netbox/netbox/manage.py rqworker
+# directory = /opt/netbox/netbox/
+# user = www-data
 ```
 
 Then, restart the supervisor service to detect and run the gunicorn service:


### PR DESCRIPTION
Configuration file template `/etc/supervisor/conf.d/netbox.conf` contains `netbox-rqworker` section. 
In case, you do not enable WEBHOOKS_ENABLE and use REDIS you get this from `supervisor`

 ```no-highlight
Nov 16 07:21:39 localhost supervisord[14968]: 2018-11-16 07:21:39,774 INFO exited: netbox-rqworker (exit status 1; not expected)
Nov 16 07:21:40 localhost supervisord[14968]: 2018-11-16 07:21:40,778 INFO spawned: 'netbox-rqworker' with pid 31816
Nov 16 07:21:41 localhost supervisord[14968]: 2018-11-16 07:21:41,781 INFO success: netbox-rqworker entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
Nov 16 07:21:43 localhost supervisord[14968]: 2018-11-16 07:21:43,008 INFO exited: netbox-rqworker (exit status 1; not expected)
Nov 16 07:21:44 localhost supervisord[14968]: 2018-11-16 07:21:44,012 INFO spawned: 'netbox-rqworker' with pid 31822
Nov 16 07:21:45 localhost supervisord[14968]: 2018-11-16 07:21:45,014 INFO success: netbox-rqworker entered RUNNING state, process has stayed up for > than 1 seconds (startsecs)
```

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:

<!--
    Please include a summary of the proposed changes below.
-->
