### PR TITLE
Closes #2693 - Adds additional colors for cables & roles

### DIFF
--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -119,11 +119,6 @@ label.required {
 input[name="pk"] {
     margin-top: 0;
 }
-/* Get around the background color problem if someone chooses white for the background */
-label[style="background-color: #ffffff"] {
-    color: #000000;
-}
-
 
 /* Tables */
 th.pk, td.pk {

--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -119,6 +119,11 @@ label.required {
 input[name="pk"] {
     margin-top: 0;
 }
+/* Get around the background color problem if someone chooses white for the background */
+label[style="background-color: #ffffff"] {
+    color: #000000;
+}
+
 
 /* Tables */
 th.pk, td.pk {

--- a/netbox/utilities/constants.py
+++ b/netbox/utilities/constants.py
@@ -2,6 +2,7 @@ COLOR_CHOICES = (
     ('aa1409', 'Dark red'),
     ('f44336', 'Red'),
     ('e91e63', 'Pink'),
+    ('ffe4e1', 'Rose'),
     ('ff66ff', 'Fuschia'),
     ('9c27b0', 'Purple'),
     ('673ab7', 'Dark purple'),
@@ -10,6 +11,7 @@ COLOR_CHOICES = (
     ('03a9f4', 'Light blue'),
     ('00bcd4', 'Cyan'),
     ('009688', 'Teal'),
+    ('00ffff', 'Aqua'),
     ('2f6a31', 'Dark green'),
     ('4caf50', 'Green'),
     ('8bc34a', 'Light green'),
@@ -23,4 +25,5 @@ COLOR_CHOICES = (
     ('9e9e9e', 'Grey'),
     ('607d8b', 'Dark grey'),
     ('111111', 'Black'),
+    ('ffffff', 'White'),
 )


### PR DESCRIPTION
### Fixes: #2693 

Adds to the color picker:

* White
* Rose
* Aqua

Additionally matches on the background color white on a label and reverses the font color to black.