### PR TITLE
Toggle for available child prefixes and ip addresses in prefix view

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -504,8 +504,9 @@ class PrefixPrefixesView(View):
         ).annotate_depth(limit=0)
 
         # Annotate available prefixes
-        if child_prefixes:
-            child_prefixes = add_available_prefixes(prefix.prefix, child_prefixes)
+        if request.GET.get('show_available', None):
+            if child_prefixes:
+                child_prefixes = add_available_prefixes(prefix.prefix, child_prefixes)
 
         prefix_table = tables.PrefixDetailTable(child_prefixes)
         if request.user.has_perm('ipam.change_prefix') or request.user.has_perm('ipam.delete_prefix'):
@@ -544,7 +545,8 @@ class PrefixIPAddressesView(View):
         ipaddresses = prefix.get_child_ips().select_related(
             'vrf', 'interface__device', 'primary_ip4_for', 'primary_ip6_for'
         )
-        ipaddresses = add_available_ipaddresses(prefix.prefix, ipaddresses, prefix.is_pool)
+        if request.GET.get('show_available', None):
+            ipaddresses = add_available_ipaddresses(prefix.prefix, ipaddresses, prefix.is_pool)
 
         ip_table = tables.IPAddressTable(ipaddresses)
         if request.user.has_perm('ipam.change_ipaddress') or request.user.has_perm('ipam.delete_ipaddress'):

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -52,6 +52,12 @@
     </div>
     <h1>{% block title %}{{ prefix }}{% endblock %}</h1>
     {% include 'inc/created_updated.html' with obj=prefix %}
+    <div class="pull-right">
+        <div class="btn-group" role="group">
+            <a href="{{ request.path }}{% querystring request show_available=None %}" class="btn btn-default{% if not request.GET.show_available %} active{% endif %}">Hide available</a>
+            <a href="{{ request.path }}{% querystring request show_available='on' %}" class="btn btn-default{% if request.GET.show_available %} active{% endif %}">Show available</a>
+        </div>
+    </div>
     <ul class="nav nav-tabs" style="margin-bottom: 20px">
         <li role="presentation"{% if not active_tab %} class="active"{% endif %}>
             <a href="{% url 'ipam:prefix' pk=prefix.pk %}">Prefix</a>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:
 Resolves #2365 & #2598

<!--
    Please include a summary of the proposed changes below.
-->
### Summary:
I pulled up this code from our internal fork as it should be generic enough and solves 2 issues.

Branch is still WIP as i have not yet validated it against the latest code release.

 - Add 2 new buttons, Hide available and Show available to Prefix view.
 - Add in logic into the prefix view to only include IP Addresses if we want to show available addresses
 - This changes the default mode to NOT show available IPAddresses in the prefix view.

Examples of the new UI can be seen here https://github.com/digitalocean/netbox/issues/2598#issuecomment-447552918