### PR TITLE
Show exception description on failure to render graphviz

### DIFF
--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -99,10 +99,9 @@ class TopologyMapViewSet(ModelViewSet):
 
         try:
             data = tmap.render(img_format=img_format)
-        except Exception:
+        except Exception as e:
             return HttpResponse(
-                "There was an error generating the requested graph. Ensure that the GraphViz executables have been "
-                "installed correctly."
+                "There was an error generating the requested graph: %s" % e
             )
 
         response = HttpResponse(data, content_type='image/{}'.format(img_format))


### PR DESCRIPTION
### Fixes:

Show the actual exception description when graphviz fails to render.

If the dot executable is missing, the exception now becomes:

> There was an error generating the requested graph: failed to execute ['dot', '-Tpng'], make sure the Graphviz executables are on your systems' PATH

which is similar to the current message.  But this is not the only problem which can occur; those other problems should now be easier to diagnose.