### PR TITLE
Hide/show available ip addresses and child prefixes in prefix view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ v2.5.8 (FUTURE)
 * [#2923](https://github.com/digitalocean/netbox/issues/2923) - Provider filter form's site field should be blank by default
 * [#2938](https://github.com/digitalocean/netbox/issues/2938) - Enforce deterministic ordering of device components returned by API
 * [#2939](https://github.com/digitalocean/netbox/issues/2939) - Exclude circuit terminations from API interface connections endpoint
+* [#2598](https://github.com/digitalocean/netbox/issues/2598) - Child prefix and ip address view options
 
 ---
 

--- a/docs/configuration/optional-settings.md
+++ b/docs/configuration/optional-settings.md
@@ -255,6 +255,14 @@ Enable this option to run the webhook backend. See the docs section on the webho
 
 ---
 
+## HIDE_AVAILABLE_PREFIXES
+
+Default: False
+
+Enable this option if you want to hide all available child prefixes and child ip addresses that is shown by default if this option is set to False.
+
+---
+
 ## Date and Time Formatting
 
 You may define custom formatting for date and times. For detailed instructions on writing format strings, please see [the Django documentation](https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date).

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -501,8 +501,9 @@ class PrefixPrefixesView(View):
         ).annotate_depth(limit=0)
 
         # Annotate available prefixes
-        if child_prefixes:
-            child_prefixes = add_available_prefixes(prefix.prefix, child_prefixes)
+        if request.GET.get('show_available', None):
+            if child_prefixes:
+                child_prefixes = add_available_prefixes(prefix.prefix, child_prefixes)
 
         prefix_table = tables.PrefixDetailTable(child_prefixes)
         if request.user.has_perm('ipam.change_prefix') or request.user.has_perm('ipam.delete_prefix'):
@@ -541,7 +542,8 @@ class PrefixIPAddressesView(View):
         ipaddresses = prefix.get_child_ips().select_related(
             'vrf', 'interface__device', 'primary_ip4_for', 'primary_ip6_for'
         )
-        ipaddresses = add_available_ipaddresses(prefix.prefix, ipaddresses, prefix.is_pool)
+        if request.GET.get('show_available', None):
+            ipaddresses = add_available_ipaddresses(prefix.prefix, ipaddresses, prefix.is_pool)
 
         ip_table = tables.IPAddressTable(ipaddresses)
         if request.user.has_perm('ipam.change_ipaddress') or request.user.has_perm('ipam.delete_ipaddress'):

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -74,6 +74,7 @@ SHORT_TIME_FORMAT = getattr(configuration, 'SHORT_TIME_FORMAT', 'H:i:s')
 TIME_FORMAT = getattr(configuration, 'TIME_FORMAT', 'g:i a')
 TIME_ZONE = getattr(configuration, 'TIME_ZONE', 'UTC')
 WEBHOOKS_ENABLED = getattr(configuration, 'WEBHOOKS_ENABLED', False)
+HIDE_AVAILABLE_PREFIXES = getattr(configuration, 'HIDE_AVAILABLE_PREFIXES', False)
 
 CSRF_TRUSTED_ORIGINS = ALLOWED_HOSTS
 

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -52,6 +52,12 @@
     </div>
     <h1>{% block title %}{{ prefix }}{% endblock %}</h1>
     {% include 'inc/created_updated.html' with obj=prefix %}
+    <div class="pull-right">
+        <div class="btn-group" role="group">
+            <a href="{{ request.path }}{% querystring request show_available=None %}" class="btn btn-default{% if not request.GET.show_available %} active{% endif %}">Hide available</a>
+            <a href="{{ request.path }}{% querystring request show_available='on' %}" class="btn btn-default{% if request.GET.show_available %} active{% endif %}">Show available</a>
+        </div>
+    </div>
     <ul class="nav nav-tabs" style="margin-bottom: 20px">
         <li role="presentation"{% if not active_tab %} class="active"{% endif %}>
             <a href="{% url 'ipam:prefix' pk=prefix.pk %}">Prefix</a>

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -54,22 +54,22 @@
     {% include 'inc/created_updated.html' with obj=prefix %}
     <div class="pull-right">
         <div class="btn-group" role="group">
-            <a href="{{ request.path }}{% querystring request show_available=None %}" class="btn btn-default{% if not request.GET.show_available %} active{% endif %}">Hide available</a>
-            <a href="{{ request.path }}{% querystring request show_available='on' %}" class="btn btn-default{% if request.GET.show_available %} active{% endif %}">Show available</a>
+            <a href="{{ request.path }}{% querystring request show_available='on' %}" class="btn btn-default{% if show_available %} active{% endif %}">Show available</a>
+	    <a href="{{ request.path }}{% querystring request show_available='off' %}" class="btn btn-default{% if not show_available %} active{% endif %}">Hide available</a>
         </div>
     </div>
     <ul class="nav nav-tabs" style="margin-bottom: 20px">
         <li role="presentation"{% if not active_tab %} class="active"{% endif %}>
-            <a href="{% url 'ipam:prefix' pk=prefix.pk %}{% if request.GET.show_available %}{% querystring request show_available='on' %}{% endif %}">Prefix</a>
+            <a href="{% url 'ipam:prefix' pk=prefix.pk %}">Prefix</a>
         </li>
         <li role="presentation"{% if active_tab == 'prefixes' %} class="active"{% endif %}>
-            <a href="{% url 'ipam:prefix_prefixes' pk=prefix.pk %}{% if request.GET.show_available %}{% querystring request show_available='on' %}{% endif %}">Child Prefixes <span class="badge">{{ prefix.get_child_prefixes.count }}</span></a>
+		<a href="{% url 'ipam:prefix_prefixes' pk=prefix.pk %}">Child Prefixes <span class="badge">{{ prefix.get_child_prefixes.count }}</span></a>
         </li>
         <li role="presentation"{% if active_tab == 'ip-addresses' %} class="active"{% endif %}>
-            <a href="{% url 'ipam:prefix_ipaddresses' pk=prefix.pk %}{% if request.GET.show_available %}{% querystring request show_available='on' %}{% endif %}">IP Addresses <span class="badge">{{ prefix.get_child_ips.count }}</span></a>
+            <a href="{% url 'ipam:prefix_ipaddresses' pk=prefix.pk %}">IP Addresses <span class="badge">{{ prefix.get_child_ips.count }}</span></a>
         </li>
         <li role="presentation"{% if active_tab == 'changelog' %} class="active"{% endif %}>
-            <a href="{% url 'ipam:prefix_changelog' pk=prefix.pk %}{% if request.GET.show_available %}{% querystring request show_available='on' %}{% endif %}">Changelog</a>
+            <a href="{% url 'ipam:prefix_changelog' pk=prefix.pk %}">Changelog</a>
         </li>
     </ul>
 {% endblock %}

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -63,7 +63,7 @@
             <a href="{% url 'ipam:prefix' pk=prefix.pk %}">Prefix</a>
         </li>
         <li role="presentation"{% if active_tab == 'prefixes' %} class="active"{% endif %}>
-		<a href="{% url 'ipam:prefix_prefixes' pk=prefix.pk %}">Child Prefixes <span class="badge">{{ prefix.get_child_prefixes.count }}</span></a>
+            <a href="{% url 'ipam:prefix_prefixes' pk=prefix.pk %}">Child Prefixes <span class="badge">{{ prefix.get_child_prefixes.count }}</span></a>
         </li>
         <li role="presentation"{% if active_tab == 'ip-addresses' %} class="active"{% endif %}>
             <a href="{% url 'ipam:prefix_ipaddresses' pk=prefix.pk %}">IP Addresses <span class="badge">{{ prefix.get_child_ips.count }}</span></a>

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -60,16 +60,16 @@
     </div>
     <ul class="nav nav-tabs" style="margin-bottom: 20px">
         <li role="presentation"{% if not active_tab %} class="active"{% endif %}>
-            <a href="{% url 'ipam:prefix' pk=prefix.pk %}">Prefix</a>
+            <a href="{% url 'ipam:prefix' pk=prefix.pk %}{% if request.GET.show_available %}{% querystring request show_available='on' %}{% endif %}">Prefix</a>
         </li>
         <li role="presentation"{% if active_tab == 'prefixes' %} class="active"{% endif %}>
-            <a href="{% url 'ipam:prefix_prefixes' pk=prefix.pk %}">Child Prefixes <span class="badge">{{ prefix.get_child_prefixes.count }}</span></a>
+            <a href="{% url 'ipam:prefix_prefixes' pk=prefix.pk %}{% if request.GET.show_available %}{% querystring request show_available='on' %}{% endif %}">Child Prefixes <span class="badge">{{ prefix.get_child_prefixes.count }}</span></a>
         </li>
         <li role="presentation"{% if active_tab == 'ip-addresses' %} class="active"{% endif %}>
-            <a href="{% url 'ipam:prefix_ipaddresses' pk=prefix.pk %}">IP Addresses <span class="badge">{{ prefix.get_child_ips.count }}</span></a>
+            <a href="{% url 'ipam:prefix_ipaddresses' pk=prefix.pk %}{% if request.GET.show_available %}{% querystring request show_available='on' %}{% endif %}">IP Addresses <span class="badge">{{ prefix.get_child_ips.count }}</span></a>
         </li>
         <li role="presentation"{% if active_tab == 'changelog' %} class="active"{% endif %}>
-            <a href="{% url 'ipam:prefix_changelog' pk=prefix.pk %}">Changelog</a>
+            <a href="{% url 'ipam:prefix_changelog' pk=prefix.pk %}{% if request.GET.show_available %}{% querystring request show_available='on' %}{% endif %}">Changelog</a>
         </li>
     </ul>
 {% endblock %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
Resubmit of #2702 i did earlier. Branch is rebased on top off develop and tested in a fresh installation of Netbox as requested in previous PR.

### Fixes:
Closes: #2365 
Closes: #2598

<!--
    Please include a summary of the proposed changes below.
-->
### Summary:
I pulled up this code from our internal fork as it should be generic enough and solves 2 issues.

 - Add 2 new buttons, Hide available and Show available to Prefix view.
 - Add in logic into the prefix view to only include IP Addresses and child prefixes if we want to show available items.
 - Default behaviour of showing child prefixes and ip addresses is preserved
 - Added new setting `HIDE_AVAILABLE_PREFIXES` that when set to `True` will flip the default behaviour to always hide available child items. The added buttons will act as explicit indicators and overwrite this effect.

Examples of the new UI can be seen here https://github.com/digitalocean/netbox/issues/2598#issuecomment-447552918