### PR TITLE
Clarify how chassis-based switches/routers are supposed to be modelled

### DIFF
--- a/docs/core-functionality/devices.md
+++ b/docs/core-functionality/devices.md
@@ -13,6 +13,10 @@ Some devices house child devices which share physical resources, like space and 
 !!! note
     This parent/child relationship is **not** suitable for modeling chassis-based devices, wherein child members share a common control plane.
 
+    For that application you should create a single Device for the chassis, and add Interfaces directly to it.  Interfaces can be created in bulk using range patterns, e.g. "Gi1/[1-24]".
+
+    Add Inventory Items if you want to record the line cards themselves as separate entities.  There is no explicit relationship between each interface and its line card, but it may be implied by the naming (e.g. interfaces "Gi1/x" are on line card 1)
+
 ## Manufacturers
 
 Each device type must be assigned to a manufacturer. The model number of a device type must be unique to its manufacturer.
@@ -93,6 +97,10 @@ Pass-through ports can also be used to model "bump in the wire" devices, such as
 
 Device bays represent the ability of a device to house child devices. For example, you might install four blade servers into a 2U chassis. The chassis would appear in the rack elevation as a 2U device with four device bays. Each server within it would be defined as a 0U device installed in one of the device bays. Child devices do not appear within rack elevations, but they are included in the "Non-Racked Devices" list within the rack view.
 
+Child devices are first-class Devices in their own right: that is, fully independent managed entities which don't share any control plane with the parent.  Just like normal devices, child devices have their own platform (OS), role, tags, and interfaces.  You cannot create a LAG between interfaces in different child devices.
+
+Therefore, Device bays are **not** suitable for modeling chassis-based switches and routers.  These should instead be modeled as a single Device, with the line cards as Inventory Items.
+
 ## Device Roles
 
 Devices can be organized by functional roles. These roles are fully customizable. For example, you might create roles for core switches, distribution switches, and access switches.
@@ -111,7 +119,7 @@ The assignment of platforms to devices is an optional feature, and may be disreg
 
 # Inventory Items
 
-Inventory items represent hardware components installed within a device, such as a power supply or CPU. Currently, these are used merely for inventory tracking, although future development might see their functionality expand. Like device types, each item can optionally be assigned a manufacturer.
+Inventory items represent hardware components installed within a device, such as a power supply or CPU or line card. Currently, these are used merely for inventory tracking, although future development might see their functionality expand. Like device types, each item can optionally be assigned a manufacturer.
 
 ---
 


### PR DESCRIPTION
### Fixes:

It is a frequent misconception that Device Bays (parent/child) are what you'd use for line cards in a chassis switch or router - e.g. #2752, #2234, #2145, #1760, #1205, #970, #823, #636, #337, various group postings.

This patch expands the documentation to explain how these should be modelled instead.

(Could also link to #824 but I have not done that)