### PR TITLE
Fixes #2798: URL encode physical_address in links

### DIFF
--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -139,7 +139,7 @@
                     <td>
                         {% if site.physical_address %}
                             <div class="pull-right">
-                                <a href="http://maps.google.com/?q={{ site.physical_address|oneline }}" target="_blank" class="btn btn-primary btn-xs">
+                                <a href="http://maps.google.com/?q={{ site.physical_address|oneline|urlencode }}" target="_blank" class="btn btn-primary btn-xs">
                                     <i class="glyphicon glyphicon-map-marker"></i> Map it
                                 </a>
                             </div>


### PR DESCRIPTION
### Fixes: #2798
Pass `physical_address` through `urlencode` in "Map it" links

<!--
    Please include a summary of the proposed changes below.
-->
