### PR TITLE
Add nullable and blank=True on VRF-RD

### DIFF
--- a/netbox/ipam/models.py
+++ b/netbox/ipam/models.py
@@ -29,6 +29,8 @@ class VRF(ChangeLoggedModel, CustomFieldModel):
     rd = models.CharField(
         max_length=21,
         unique=True,
+        null=True,
+        blank=True,
         verbose_name='Route distinguisher'
     )
     tenant = models.ForeignKey(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:

#2805 #2804 

As discussed, even without RD can be a use case.
In order to realize this, we allowed null for rd and blank permission to make it not required at add
<!--
    Please include a summary of the proposed changes below.
-->
