### PR TITLE
Clarify use of "runreport" CLI

### DIFF
--- a/docs/additional-features/reports.md
+++ b/docs/additional-features/reports.md
@@ -128,4 +128,4 @@ Reports can be run on the CLI by invoking the management command:
 python3 manage.py runreport <module>
 ```
 
-One or more report modules may be specified.
+where ``<module>`` is the name of the python file in the ``reports`` directory without the ``.py`` extension.  One or more report modules may be specified.


### PR DESCRIPTION
### Fixes:

Minor documentation enhancement about how correctly to invoke `runreport`.

The behaviour of runreport is confusing if you don't know exactly what to do.  Suppose you create `reports/foo-bar.py` containing `class FooBar`.  The following commands all just return `[hh:mm:ss] Finished` without any error - but nothing is executed, and there is no indication why not.

```
python3 manage.py runreport FooBar
python3 manage.py runreport foo-bar.py
python3 manage.py runreport reports/foo-bar.py
```

It took me a while to work out that the correct command is:

```
python3 manage.py runreport foo-bar
```
