### PR TITLE
Closes #2884 - Removes connection option from wireless interfaces.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ v2.5.7 (FUTURE)
 * [#2888](https://github.com/digitalocean/netbox/issues/2888) - Correct foreground color of device roles in rack elevations
 * [#2893](https://github.com/digitalocean/netbox/issues/2893) - Remove duplicate display of VRF RD on IP address view
 * [#2895](https://github.com/digitalocean/netbox/issues/2895) - Fix filtering of nullable character fields
+* [#2884](https://github.com/digitalocean/netbox/issues/2884) - Remove display of connect option for wireless interfaces
 
 v2.5.6 (2019-02-13)
 

--- a/netbox/templates/dcim/inc/interface.html
+++ b/netbox/templates/dcim/inc/interface.html
@@ -150,7 +150,7 @@
         {% if perms.dcim.change_interface %}
             {% if iface.cable %}
                 {% include 'dcim/inc/cable_toggle_buttons.html' with cable=iface.cable %}
-            {% elif not iface.is_virtual and perms.dcim.add_cable %}
+            {% elif not iface.is_virtual and not iface.is_wireless and perms.dcim.add_cable %}
                 <a href="{% url 'dcim:interface_connect' termination_a_id=iface.pk %}?return_url={{ device.get_absolute_url }}" class="btn btn-success btn-xs" title="Connect">
                     <i class="glyphicon glyphicon-resize-small" aria-hidden="true"></i>
                 </a>


### PR DESCRIPTION
### Fixes: #2884 

This PR removes the "connect" button from wireless interfaces as connecting wireless interfaces was rejected in #2067  and connecting wireless backhauls was rejected in #2730.  This will enforce the behaviour until such a time as a FR is created and approved to connect wireless links.