### PR TITLE
Closes #1792 - Add CustomFieldChoices API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ to now use "Extras | Tag."
 * [#2643](https://github.com/digitalocean/netbox/issues/2643) - Add `description` field to console/power components and device bays
 * [#2791](https://github.com/digitalocean/netbox/issues/2791) - Add a comment field for tags
 * [#2926](https://github.com/digitalocean/netbox/issues/2926) - Add changelog to the Tag model
+* [#1792](https://github.com/digitalocean/netbox/issues/1792) - Add CustomFieldChoices API endpoint
 
 ---
 

--- a/netbox/extras/api/urls.py
+++ b/netbox/extras/api/urls.py
@@ -17,6 +17,9 @@ router.APIRootView = ExtrasRootView
 # Field choices
 router.register(r'_choices', views.ExtrasFieldChoicesViewSet, basename='field-choice')
 
+# Custom field choices
+router.register(r'_custom_field_choices', views.CustomFieldChoicesViewSet, base_name='custom-field-choice')
+
 # Graphs
 router.register(r'graphs', views.GraphViewSet)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #1792

<!--
    Please include a summary of the proposed changes below.
-->
This PR implements a new API endpoint for CustomFieldChoices that enables a consumer of the API to make calls to get the Primary Key ID:s for each custom field choice that is implemented on the server. 

The new API endpoint is `/api/extras/_custom_field_choices/`

Example API output

```
{
  ...
  "archiving.retention": {
    "Archiving 13 Months": 493,
    "Archiving 7 Years": 494,
    "Archiving 10 Years": 495,
    "Other": 496
  },
  "backup.database.dbfrequency": {
    "1 per day": 515,
    "1 per hour": 516
  },
  ...
}
```

If you have a external service that want to integrate and set custom field choice, right now you have to hardcode the field values on the external side of the API. This is not good as the values is probably different between different installations and not guaranteed to be consistent. With this PR implemented the workflow will be that the external party have to lookup all customfieldchoices that is interesting and cache them locally on their end and then when they make API calls and they want to set a customfield value to a choice, they us the ID they get out from this api endpoint. If you do not want to cache the values you can just lookup the ID before each call.
