### PR TITLE
Remove trailing slashes from filesystem paths

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -197,7 +197,7 @@ ROOT_URLCONF = 'netbox.urls'
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [BASE_DIR + '/templates/'],
+        'DIRS': [BASE_DIR + '/templates'],
         'APP_DIRS': True,
         'OPTIONS': {
             'context_processors': [
@@ -223,7 +223,7 @@ USE_I18N = True
 USE_TZ = True
 
 # Static files (CSS, JavaScript, Images)
-STATIC_ROOT = BASE_DIR + '/static/'
+STATIC_ROOT = BASE_DIR + '/static'
 STATIC_URL = '/{}static/'.format(BASE_PATH)
 STATICFILES_DIRS = (
     os.path.join(BASE_DIR, "project-static"),


### PR DESCRIPTION
Paths with trailing slashes do not work on windows, they cause errors such as `django.core.exceptions.SuspiciousFileOperation: The joined path (C:\Projects\netbox\netbox\static\clipboard-2.0.4.min.js) is located outside of the base path component (C:\Projects\netbox\netbox\static\)`.

### Fixes:

#2954 
