### PR TITLE
Error when ContentType is in wrong format

### DIFF
--- a/netbox/utilities/api.py
+++ b/netbox/utilities/api.py
@@ -109,10 +109,10 @@ class ContentTypeField(Field):
         return "{}.{}".format(obj.app_label, obj.model)
 
     def to_internal_value(self, data):
-        app_label, model = data.split('.')
         try:
+            app_label, model = data.split('.')
             return ContentType.objects.get_by_natural_key(app_label=app_label, model=model)
-        except ContentType.DoesNotExist:
+        except (ContentType.DoesNotExist, ValueError):
             raise ValidationError("Invalid content type")
 
 


### PR DESCRIPTION
### Fixes:

When spliting the ContentType returns only one item, assignating the app_label and model fails. The API returns a 500 error.

Ensure that a ValidationError is returned if a ValueError is raised during the assignation