### PR TITLE
Set nat_outside as not required in the IPAddressSerializer

### DIFF
--- a/netbox/ipam/api/serializers.py
+++ b/netbox/ipam/api/serializers.py
@@ -195,7 +195,7 @@ class IPAddressSerializer(TaggitSerializer, CustomFieldModelSerializer):
     role = ChoiceField(choices=IPADDRESS_ROLE_CHOICES, required=False, allow_null=True)
     interface = IPAddressInterfaceSerializer(required=False, allow_null=True)
     nat_inside = NestedIPAddressSerializer(required=False, allow_null=True)
-    nat_outside = NestedIPAddressSerializer(read_only=True)
+    nat_outside = NestedIPAddressSerializer(required=False, read_only=True)
     tags = TagListSerializerField(required=False)
 
     class Meta:


### PR DESCRIPTION
### Fixes:
in 2.5.7, Nat outside is currently defined as a mandatory field in the API specification file
<img width="805" alt="Screen Shot 2019-03-14 at 10 47 14 AM" src="https://user-images.githubusercontent.com/304126/54381205-66ef6500-464a-11e9-9369-495c95822be6.png">

This PR add the option `required=False` to the field `nat_outside` in the IPAddressSerializer to indicate this field as non-mandatory