### PR TITLE
Exclude /metrics from LOGIN_REQUIRED

### DIFF
--- a/netbox/utilities/middleware.py
+++ b/netbox/utilities/middleware.py
@@ -21,7 +21,7 @@ class LoginRequiredMiddleware(object):
             # Redirect unauthenticated requests to the login page. API requests are exempt from redirection as the API
             # performs its own authentication. Also metrics can be read without login.
             api_path = reverse('api-root')
-            if not request.path_info.startswith(api_path, '/metrics') and request.path_info != settings.LOGIN_URL:
+            if not request.path_info.startswith((api_path, '/metrics')) and request.path_info != settings.LOGIN_URL:
                 return HttpResponseRedirect('{}?next={}'.format(settings.LOGIN_URL, request.path_info))
         return self.get_response(request)
 

--- a/netbox/utilities/middleware.py
+++ b/netbox/utilities/middleware.py
@@ -21,8 +21,9 @@ class LoginRequiredMiddleware(object):
             # Redirect unauthenticated requests to the login page. API requests are exempt from redirection as the API
             # performs its own authentication. Also metrics can be read without login.
             api_path = reverse('api-root')
-            if (not (request.path_info.startswith(api_path) or request.path_info.startswith('/metrics'))
-              and request.path_info != settings.LOGIN_URL):
+            if (not (request.path_info.startswith(api_path) or
+                     request.path_info.startswith('/metrics')) and
+                    request.path_info != settings.LOGIN_URL):
                 return HttpResponseRedirect('{}?next={}'.format(settings.LOGIN_URL, request.path_info))
         return self.get_response(request)
 

--- a/netbox/utilities/middleware.py
+++ b/netbox/utilities/middleware.py
@@ -19,9 +19,10 @@ class LoginRequiredMiddleware(object):
     def __call__(self, request):
         if LOGIN_REQUIRED and not request.user.is_authenticated:
             # Redirect unauthenticated requests to the login page. API requests are exempt from redirection as the API
-            # performs its own authentication.
+            # performs its own authentication. Also metrics can be read without login.
             api_path = reverse('api-root')
-            if not request.path_info.startswith(api_path) and request.path_info != settings.LOGIN_URL:
+            if (not (request.path_info.startswith(api_path) or request.path_info.startswith('/metrics'))
+              and request.path_info != settings.LOGIN_URL):
                 return HttpResponseRedirect('{}?next={}'.format(settings.LOGIN_URL, request.path_info))
         return self.get_response(request)
 

--- a/netbox/utilities/middleware.py
+++ b/netbox/utilities/middleware.py
@@ -21,9 +21,7 @@ class LoginRequiredMiddleware(object):
             # Redirect unauthenticated requests to the login page. API requests are exempt from redirection as the API
             # performs its own authentication. Also metrics can be read without login.
             api_path = reverse('api-root')
-            if (not (request.path_info.startswith(api_path) or
-                     request.path_info.startswith('/metrics')) and
-                    request.path_info != settings.LOGIN_URL):
+            if not request.path_info.startswith(api_path, '/metrics') and request.path_info != settings.LOGIN_URL:
                 return HttpResponseRedirect('{}?next={}'.format(settings.LOGIN_URL, request.path_info))
         return self.get_response(request)
 


### PR DESCRIPTION
### Fixes:
Regarding #3123: 
With `LOGIN_REQUIRED` enabled, `/metrics` can't be accessed. This is not feasible for Prometheus. This change excludes `/metrics` from `LOGIN_REQUIRED` the same way as `/api` is excluded.