### PR TITLE
Fixes: #3132: Add circuittermination to the choices API for cable endpoints

### DIFF
--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -360,7 +360,7 @@ CONNECTION_STATUS_CHOICES = [
 
 # Cable endpoint types
 CABLE_TERMINATION_TYPES = [
-    'consoleport', 'consoleserverport', 'interface', 'poweroutlet', 'powerport', 'frontport', 'rearport',
+    'consoleport', 'consoleserverport', 'interface', 'poweroutlet', 'powerport', 'frontport', 'rearport', 'circuittermination',
 ]
 
 # Cable types


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #3132

<!--
    Please include a summary of the proposed changes below.
-->
Cables can connect to circuit terminations, but the choices API doesn't currently reflect that, showing only DCIM object types as valid for `cable:termination_a_type`/`cable:termination_b_type` - this adds `circuits.circuittermination` as an entry in the choices API.