### PR TITLE
upgrade.sh: make sure we are in the right directory

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -5,6 +5,8 @@
 # Once the script completes, remember to restart the WSGI service (e.g.
 # gunicorn or uWSGI).
 
+cd "$(dirname "$0")"
+
 PYTHON="python3"
 PIP="pip3"
 


### PR DESCRIPTION
### Fixes: #3141

This sets current directory to the director that upgrade.sh is in.
