### PR TITLE
 Fixes #3031: Select2 creates multiple tags for tags with spaces

### DIFF
--- a/netbox/project-static/js/forms.js
+++ b/netbox/project-static/js/forms.js
@@ -267,6 +267,10 @@ $(document).ready(function() {
 
             processResults: function (data) {
                 var results = $.map(data.results, function (obj) {
+                    // If tag contains space add double quotes
+                    if (/\s/.test(obj.name))
+                        obj.name = '"' + obj.name + '"'
+
                     return {
                         id: obj.name,
                         text: obj.name


### PR DESCRIPTION
### Fixes: #3031 Issue with Select2 and Tags with Spaces

In the form when processing results for Tags, add double quotes if it contains a space.