### PR TITLE
Add grey border around color-block

### DIFF
--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -559,6 +559,7 @@ table.report th a {
 .color-block {
     display: block;
     width: 80px;
+    border: 1px solid grey;
 }
 .text-nowrap {
     white-space: nowrap;


### PR DESCRIPTION
### Fixes:

Fixes #3184, in the spirit of DTSSTCPW, by adding a grey border around all color bars.