### PR TITLE
Fixes #3100: Change DNSValidator-Regex

### DIFF
--- a/netbox/ipam/validators.py
+++ b/netbox/ipam/validators.py
@@ -2,7 +2,7 @@ from django.core.validators import RegexValidator
 
 
 DNSValidator = RegexValidator(
-    regex='^[0-9A-Za-z.-]+$',
+    regex='^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$',
     message='Only alphanumeric characters, hyphens, and periods are allowed in DNS names',
     code='invalid'
 )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #3100

<!--
    Please include a summary of the proposed changes below.
-->

This Change the Regex for DNSValidator to be valid as per RFC 1123. Originally, RFC 952 specified that hostname segments could not start with a digit. 

From: http://en.wikipedia.org/wiki/Hostname
``
The original specification of hostnames in RFC 952, mandated that labels could not start with a digit or with a hyphen, and must not end with a hyphen. However, a subsequent specification (RFC 1123) permitted hostname labels to start with digits.
``