### PR TITLE
Fixes #3206: Unable to connect to rear ports

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1736,6 +1736,7 @@ class CableCreateView(PermissionRequiredMixin, GetReturnURLMixin, View):
             'power-outlet': forms.ConnectCableToPowerOutletForm,
             'interface': forms.ConnectCableToInterfaceForm,
             'front-port': forms.ConnectCableToFrontPortForm,
+            'rear-port': forms.ConnectCableToRearPortForm,
             'power-feed': forms.ConnectCableToPowerFeedForm,
             'circuit-termination': forms.ConnectCableToCircuitTerminationForm,
         }[termination_b_type_name]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #3206

<!--
    Please include a summary of the proposed changes below.
-->
The mapping from type name to connection form was missing for a rear-port connection, this adds said mapping