### PR TITLE
Make VLAN deletable even if it has a prefix associated to it

### DIFF
--- a/netbox/ipam/models.py
+++ b/netbox/ipam/models.py
@@ -289,7 +289,7 @@ class Prefix(ChangeLoggedModel, CustomFieldModel):
     )
     vlan = models.ForeignKey(
         to='ipam.VLAN',
-        on_delete=models.PROTECT,
+        on_delete=models.SET_NULL,
         related_name='prefixes',
         blank=True,
         null=True,


### PR DESCRIPTION
### Fixes: #3211 

This PR fixes #3211 by changing the `on_delete` property to `SET_NULL`.

The tests seem to run just fine still, though this _is_ a change in behavior, so beware!

Cheers