### PR TITLE
Fix error message on trying to delete protected models

### DIFF
--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -972,7 +972,7 @@ class VLANTest(APITestCase):
         response = self.client.delete(url, **self.header)
 
         # can't use assertHttpStatus here because we don't have response.data
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 409)
 
         content = json.loads(response.content.decode('utf-8'))
         self.assertIn('detail', content)

--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -1,3 +1,5 @@
+import json
+
 from django.urls import reverse
 from netaddr import IPNetwork
 from rest_framework import status
@@ -870,6 +872,8 @@ class VLANTest(APITestCase):
         self.vlan2 = VLAN.objects.create(vid=2, name='Test VLAN 2')
         self.vlan3 = VLAN.objects.create(vid=3, name='Test VLAN 3')
 
+        self.prefix1 = Prefix.objects.create(prefix=IPNetwork('192.168.1.0/24'))
+
     def test_get_vlan(self):
 
         url = reverse('ipam-api:vlan-detail', kwargs={'pk': self.vlan1.pk})
@@ -959,6 +963,20 @@ class VLANTest(APITestCase):
 
         self.assertHttpStatus(response, status.HTTP_204_NO_CONTENT)
         self.assertEqual(VLAN.objects.count(), 2)
+
+    def test_delete_vlan_with_prefix(self):
+        self.prefix1.vlan = self.vlan1
+        self.prefix1.save()
+
+        url = reverse('ipam-api:vlan-detail', kwargs={'pk': self.vlan1.pk})
+        response = self.client.delete(url, **self.header)
+
+        # can't use assertHttpStatus here because we don't have response.data
+        self.assertEqual(response.status_code, 403)
+
+        content = json.loads(response.content.decode('utf-8'))
+        self.assertIn('detail', content)
+        self.assertTrue(content['detail'].startswith('You tried deleting a model that is protected by:'))
 
 
 class ServiceTest(APITestCase):

--- a/netbox/utilities/middleware.py
+++ b/netbox/utilities/middleware.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.db import ProgrammingError
-from django.http import Http404, HttpResponseRedirect, JsonResponse
-from django.db.models import ProtectedError
+from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
 
 from .views import server_error
@@ -62,11 +61,6 @@ class ExceptionHandlingMiddleware(object):
         # Ignore Http404s (defer to Django's built-in 404 handling)
         if isinstance(exception, Http404):
             return
-
-        elif isinstance(exception, ProtectedError):
-            models = '\n'.join('- {} ({})'.format(o, o._meta) for o in exception.protected_objects.all())
-            msg = 'You tried deleting a model that is protected by:\n{}'.format(models)
-            return JsonResponse({'detail': msg}, status=403)
 
         # Determine the type of exception. If it's a common issue, return a custom error page with instructions.
         custom_template = None


### PR DESCRIPTION
### Fixes: #3211

This PR fixes the error returned by Netbox on `models.ProtectedError` by extending the current error-handling middleware. The middleware returns a message mimicking the other API error messages, because it should only be triggered on API calls (though I’m not 100% sure this invariant holds).

I’m not completely certain this is the right API/UX yet. It certainly feels better than what was there before, but maybe not completely right?

A test case is included.

Cheers