### PR TITLE
Make obj_edit form buttons float on the side

### DIFF
--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -590,3 +590,14 @@ td .progress {
 textarea {
     font-family: Consolas, Lucida Console, monospace;
 }
+
+/* display form buttons always */
+@media (min-width: 992px) {
+  #form-buttons {
+    position: fixed;
+    bottom: 5em;
+  }
+  #form-buttons button {
+    margin-bottom: 5px;
+  }
+}

--- a/netbox/templates/utilities/obj_edit.html
+++ b/netbox/templates/utilities/obj_edit.html
@@ -30,7 +30,7 @@
             </div>
         </div>
         <div class="row">
-            <div class="col-md-6 col-md-offset-3 text-right">
+            <div class="col-md-3 col-md-offset-9" id="form-buttons">
                 {% block buttons %}
                     {% if obj.pk %}
                         <button type="submit" name="_update" class="btn btn-primary">Update</button>


### PR DESCRIPTION
### Fixes: #2237

This PR fixes by #2237 in the simplest way possible: by some CSS trickery on the `buttons` block inside `obj_edit.html`. That means this currently only extends to object edit forms, but could be extended fairly easily to, says, bulk delete views (if any other views should be patched as well, hit me up)!

To mimic bootstrap behavior, this only applies if the page width is more than `992px`, which is when bootstrap starts extending the form to the full page width.

Cheers