### PR TITLE
Add Powerpanel count to home page

### DIFF
--- a/netbox/netbox/views.py
+++ b/netbox/netbox/views.py
@@ -15,7 +15,7 @@ from dcim.filters import (
     VirtualChassisFilter,
 )
 from dcim.models import (
-    Cable, ConsolePort, Device, DeviceType, Interface, PowerFeed, PowerPort, Rack, RackGroup, Site, VirtualChassis
+    Cable, ConsolePort, Device, DeviceType, Interface, PowerPanel, PowerFeed, PowerPort, Rack, RackGroup, Site, VirtualChassis
 )
 from dcim.tables import (
     CableTable, DeviceDetailTable, DeviceTypeTable, PowerFeedTable, RackTable, RackGroupTable, SiteTable,
@@ -196,6 +196,7 @@ class HomeView(View):
             'cable_count': cables.count(),
             'console_connections_count': connected_consoleports.count(),
             'power_connections_count': connected_powerports.count(),
+            'powerpanel_count': PowerPanel.objects.count(),
             'powerfeed_count': PowerFeed.objects.count(),
 
             # IPAM

--- a/netbox/templates/home.html
+++ b/netbox/templates/home.html
@@ -115,6 +115,16 @@
                     {% endif %}
                     <p class="list-group-item-text text-muted">Electrical circuits delivering power from panels</p>
                 </div>
+                <div class="list-group-item">
+                    {% if perms.dcim.view_powerpanel %}
+                        <span class="badge pull-right">{{ stats.powerpanel_count }}</span>
+                        <h4 class="list-group-item-heading"><a href="{% url 'dcim:powerpanel_list' %}">Power Panels</a></h4>
+                    {% else %}
+                        <span class="badge pull-right"><i class="fa fa-lock"></i></span>
+                        <h4 class="list-group-item-heading">Power Panels</h4>
+                    {% endif %}
+                    <p class="list-group-item-text text-muted">Electrical panels receiving utility power</p>
+                </div>
             </div>
         </div>
         <div class="panel panel-default">


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #3307
<!--
    Please include a summary of the proposed changes below.
-->
Adds stats.powerpanel_count and reference on the home page.