### PR TITLE
Add health check endpoint

### DIFF
--- a/netbox/netbox/configuration.example.py
+++ b/netbox/netbox/configuration.example.py
@@ -166,6 +166,9 @@ TIME_ZONE = 'UTC'
 # database be configured and accessible by NetBox.
 WEBHOOKS_ENABLED = False
 
+# The health check endpoint reports if NetBox is operational, Set this to True to enable it.
+HEALTH_CHECK_ENABLED = False
+
 # Date/time formatting. See the following link for supported formats:
 # https://docs.djangoproject.com/en/dev/ref/templates/builtins/#date
 DATE_FORMAT = 'N j, Y'

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -92,6 +92,7 @@ SHORT_TIME_FORMAT = getattr(configuration, 'SHORT_TIME_FORMAT', 'H:i:s')
 TIME_FORMAT = getattr(configuration, 'TIME_FORMAT', 'g:i a')
 TIME_ZONE = getattr(configuration, 'TIME_ZONE', 'UTC')
 WEBHOOKS_ENABLED = getattr(configuration, 'WEBHOOKS_ENABLED', False)
+HEALTH_CHECK_ENABLED = getattr(configuration, 'HEALTH_CHECK_ENABLED', False)
 
 
 #
@@ -188,6 +189,9 @@ INSTALLED_APPS = [
 # Only load django-rq if the webhook backend is enabled
 if WEBHOOKS_ENABLED:
     INSTALLED_APPS.append('django_rq')
+
+if HEALTH_CHECK_ENABLED:
+    INSTALLED_APPS.append('watchman')
 
 # Middleware
 MIDDLEWARE = (

--- a/netbox/netbox/urls.py
+++ b/netbox/netbox/urls.py
@@ -79,6 +79,11 @@ if settings.METRICS_ENABLED:
         path('', include('django_prometheus.urls')),
     ]
 
+if settings.HEALTH_CHECK_ENABLED:
+    _patterns += [
+        path(r'health/', include('watchman.urls')),
+    ]
+
 # Prepend BASE_PATH
 urlpatterns = [
     path(r'{}'.format(settings.BASE_PATH), include(_patterns))

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,7 @@ django-tables2==2.0.6
 django-taggit==1.1.0
 django-taggit-serializer==0.1.7
 django-timezone-field==3.0
+django-watchman==0.17.0
 djangorestframework==3.9.4
 drf-yasg[validation]==1.16.0
 graphviz==0.10.1


### PR DESCRIPTION
### Fixes: #3291

Adds a health check endpoint to verify that NetBox is operational. This is very useful if NetBox is running in some kind of HA configuration behind a load balancer.

```
GET /health

{"databases": [{"default": {"ok": true}}], "caches": [{"default": {"ok": true}}], "storage": {"ok": true}}
```