### PR TITLE
Indicate when changelog retention configured to be forever.

### DIFF
--- a/netbox/templates/extras/object_changelog.html
+++ b/netbox/templates/extras/object_changelog.html
@@ -8,7 +8,7 @@
         {% include 'inc/paginator.html' with paginator=table.paginator page=table.page %}
     {% if settings.CHANGELOG_RETENTION %}
         <div class="text-muted">
-            Changelog retention: {{ settings.CHANGELOG_RETENTION }} days
+            Changelog retention: {% if settings.CHANGELOG_RETENTION == 0 %}Indefinite{% else %}{{ settings.CHANGELOG_RETENTION }} days{% endif %}
         </div>
     {% endif %}
 {% endblock %}

--- a/netbox/templates/extras/objectchange_list.html
+++ b/netbox/templates/extras/objectchange_list.html
@@ -11,7 +11,7 @@
         {% include 'utilities/obj_table.html' %}
         {% if settings.CHANGELOG_RETENTION %}
             <div class="pull-right text-muted">
-                Changelog retention: {{ settings.CHANGELOG_RETENTION }} days
+                Changelog retention: {% if settings.CHANGELOG_RETENTION == 0 %}Indefinite{% else %}{{ settings.CHANGELOG_RETENTION }} days{% endif %}
             </div>
         {% endif %}
     </div>


### PR DESCRIPTION
### Fixes: #3368

Explicitly state that 0 day changelog retention means keep forever.