### PR TITLE
Add a link to my Helm chart for Kubernetes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ and run `upgrade.sh`.
 * [Docker container](https://github.com/netbox-community/netbox-docker) (via [@cimnine](https://github.com/cimnine))
 * [Vagrant deployment](https://github.com/ryanmerolle/netbox-vagrant) (via [@ryanmerolle](https://github.com/ryanmerolle))
 * [Ansible deployment](https://github.com/lae/ansible-role-netbox) (via [@lae](https://github.com/lae))
+* [Kubernetes Helm chart](https://github.com/bootc/netbox-chart) (via [@bootc](https://github.com/bootc))
 
 # Related projects
 


### PR DESCRIPTION
I've written and will continue to maintain a Helm chart to aid in deploying NetBox on Kubernetes. This adds a link to the README file so that people who may be interested in it can find it.

The chart is currently in use both by myself and my employer and possibly others, and I intend for it to be a production-ready means to deploy NetBox on Kubernetes. I would be very happy to discuss transferring ownership of the chart to the netbox-community group, as well if that would be preferable.

The chart uses netbox-docker, but I'm submitting this here based on advice from https://github.com/netbox-community/netbox-docker/pull/147.