### PR TITLE
Added support for /32 and /128 prefixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ fabfile.py
 gunicorn_config.py
 .DS_Store
 .vscode
+/.vs/ProjectSettings.json
+/.vs

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -649,7 +649,7 @@ class IPAddressView(PermissionRequiredMixin, View):
 
         # Parent prefixes table
         parent_prefixes = Prefix.objects.filter(
-            vrf=ipaddress.vrf, prefix__net_contains=str(ipaddress.address.ip)
+            vrf=ipaddress.vrf, prefix__net_contains_or_equals=str(ipaddress.address.ip)
         ).select_related(
             'site', 'role'
         )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:

<!--
As an ISP, we routinely have to allocate /32 and /128 prefixes as framed routes for our clients on DSL, VDSL connectivity etc.  To do this we pro-grammatically, we need to be able to request /32 prefixes via the API.

Looking through the issue log, I see this has been discussed before but /32 is not considered a prefix but rather an address.  I would argue this isn't the case as framed routes make use of /32 prefixes as do loopback allocations.  We allocate /32 prefixes from our address pools, alongside larger prefixes.  Without this modification we have two issues preventing us from using netbox:
1. We would have to arbitrarily carve out blocks of our public address space for sole use as /32's and then request these allocations as IP addresses.  This makes it confusing to see overall allocation in the UI.
2. We cannot port our existing allocations into netbox from our existing IPAM product and therefore have to run the two product in parallel.

I hope you can see that /32 prefixes do have a place and approve this pull request as otherwise you are excluding organisations from using this brilliant product.


-->
