### PR TITLE
Move device component creation logic out of Device model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+v2.6.3 (FUTURE)
+
+## Bug Fixes
+
+* [#3405](https://github.com/netbox-community/netbox/issues/3405) - Fix population of power port/outlet details on device creation
+
+---
+
 v2.6.2 (2019-08-02)
 
 ## Enhancements

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -1,6 +1,5 @@
 from django.test import TestCase
 
-from dcim.constants import *
 from dcim.models import *
 
 
@@ -150,6 +149,137 @@ class RackTestCase(TestCase):
             face=None,
         )
         self.assertTrue(pdu)
+
+
+class DeviceTestCase(TestCase):
+
+    def setUp(self):
+
+        self.site = Site.objects.create(name='Test Site 1', slug='test-site-1')
+        manufacturer = Manufacturer.objects.create(name='Test Manufacturer 1', slug='test-manufacturer-1')
+        self.device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model='Test Device Type 1', slug='test-device-type-1'
+        )
+        self.device_role = DeviceRole.objects.create(
+            name='Test Device Role 1', slug='test-device-role-1', color='ff0000'
+        )
+
+        # Create DeviceType components
+        ConsolePortTemplate(
+            device_type=self.device_type,
+            name='Console Port 1'
+        ).save()
+
+        ConsoleServerPortTemplate(
+            device_type=self.device_type,
+            name='Console Server Port 1'
+        ).save()
+
+        ppt = PowerPortTemplate(
+            device_type=self.device_type,
+            name='Power Port 1',
+            maximum_draw=1000,
+            allocated_draw=500
+        )
+        ppt.save()
+
+        PowerOutletTemplate(
+            device_type=self.device_type,
+            name='Power Outlet 1',
+            power_port=ppt,
+            feed_leg=POWERFEED_LEG_A
+        ).save()
+
+        InterfaceTemplate(
+            device_type=self.device_type,
+            name='Interface 1',
+            type=IFACE_TYPE_1GE_FIXED,
+            mgmt_only=True
+        ).save()
+
+        rpt = RearPortTemplate(
+            device_type=self.device_type,
+            name='Rear Port 1',
+            type=PORT_TYPE_8P8C,
+            positions=8
+        )
+        rpt.save()
+
+        FrontPortTemplate(
+            device_type=self.device_type,
+            name='Front Port 1',
+            type=PORT_TYPE_8P8C,
+            rear_port=rpt,
+            rear_port_position=2
+        ).save()
+
+        DeviceBayTemplate(
+            device_type=self.device_type,
+            name='Device Bay 1'
+        ).save()
+
+    def test_device_creation(self):
+        """
+        Ensure that all Device components are copied automatically from the DeviceType.
+        """
+        d = Device(
+            site=self.site,
+            device_type=self.device_type,
+            device_role=self.device_role,
+            name='Test Device 1'
+        )
+        d.save()
+
+        ConsolePort.objects.get(
+            device=d,
+            name='Console Port 1'
+        )
+
+        ConsoleServerPort.objects.get(
+            device=d,
+            name='Console Server Port 1'
+        )
+
+        pp = PowerPort.objects.get(
+            device=d,
+            name='Power Port 1',
+            maximum_draw=1000,
+            allocated_draw=500
+        )
+
+        PowerOutlet.objects.get(
+            device=d,
+            name='Power Outlet 1',
+            power_port=pp,
+            feed_leg=POWERFEED_LEG_A
+        )
+
+        Interface.objects.get(
+            device=d,
+            name='Interface 1',
+            type=IFACE_TYPE_1GE_FIXED,
+            mgmt_only=True
+        )
+
+        rp = RearPort.objects.get(
+            device=d,
+            name='Rear Port 1',
+            type=PORT_TYPE_8P8C,
+            positions=8
+        )
+
+        FrontPort.objects.get(
+            device=d,
+            name='Front Port 1',
+            type=PORT_TYPE_8P8C,
+            rear_port=rp,
+            rear_port_position=2
+        )
+
+        DeviceBay.objects.get(
+            device=d,
+            name='Device Bay 1'
+        )
 
 
 class CableTestCase(TestCase):


### PR DESCRIPTION
### Fixes: #3405

Move the logic for automatic creation of components on new devices from the Device model to the individual component templates models, via an `instantiate()` method. This helps ensure that new fields are incorporated as they are added to the models.

Also adds a test to validate automatic component instantiation when a new device is created.