### PR TITLE
Improve API error handling when a list is given as a choice value

### DIFF
--- a/netbox/utilities/api.py
+++ b/netbox/utilities/api.py
@@ -1,4 +1,5 @@
 from collections import OrderedDict
+from collections.abc import Hashable
 
 import pytz
 from django.conf import settings
@@ -101,7 +102,7 @@ class ChoiceField(Field):
                 except ValueError:
                     pass
 
-        if data not in self._choices:
+        if not isinstance(data, Hashable) or data not in self._choices:
             raise ValidationError("{} is not a valid choice.".format(data))
 
         return data


### PR DESCRIPTION
# Fixes:

Return an error message instead of an exception if a user (wrongly) provides a list as a choice value, e.g. `"interface": {"type": [32767]}`

See https://groups.google.com/forum/#!topic/netbox-discuss/H7xIrwVnOSM
