### PR TITLE
Updated device.html's Platform text into a link (#3430)

### DIFF
--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -239,7 +239,7 @@
                         <td>Platform</td>
                         <td>
                             {% if device.platform %}
-                                <span>{{ device.platform }}</span>
+                                <a href="{% url 'dcim:device_list' %}?platform={{ device.platform.slug }}">{{ device.platform }}</a>
                             {% else %}
                                 <span class="text-muted">None</span>
                             {% endif %}


### PR DESCRIPTION
... that leads to device list for that platform.


### Fixes:

In reference to #3430, this changes the plaintext "Platform" text on the Device specific page into a link that leads to the device list for that specific platform. This is useful for tracking purposes of deployments of new software on devices (in all reality, it just saves a couple clicks and some copy and pasting one would have to do).


### Before
![Screen Shot 2019-08-16 at 4 40 06 AM](https://user-images.githubusercontent.com/5675626/63169032-6729cd00-bffb-11e9-9ca0-5d535c166459.png)

### After
![Screen Shot 2019-08-16 at 7 30 41 AM](https://user-images.githubusercontent.com/5675626/63169073-7c066080-bffb-11e9-8bb4-bd7c5f4b1d8e.png)
