### PR TITLE
Fixes #3452: Queue deletion ObjectChanges until after response is sent

### DIFF
--- a/netbox/circuits/models.py
+++ b/netbox/circuits/models.py
@@ -270,23 +270,21 @@ class CircuitTermination(CableTermination):
     def __str__(self):
         return 'Side {}'.format(self.get_term_side_display())
 
-    def log_change(self, user, request_id, action):
-        """
-        Reference the parent circuit when recording the change.
-        """
+    def to_objectchange(self, action):
+        # Annotate the parent Circuit
         try:
             related_object = self.circuit
         except Circuit.DoesNotExist:
             # Parent circuit has been deleted
             related_object = None
-        ObjectChange(
-            user=user,
-            request_id=request_id,
+
+        return ObjectChange(
             changed_object=self,
-            related_object=related_object,
+            object_repr=str(self),
             action=action,
+            related_object=related_object,
             object_data=serialize_object(self)
-        ).save()
+        )
 
     @property
     def parent(self):

--- a/netbox/extras/models.py
+++ b/netbox/extras/models.py
@@ -953,8 +953,10 @@ class ObjectChange(models.Model):
     def save(self, *args, **kwargs):
 
         # Record the user's name and the object's representation as static strings
-        self.user_name = self.user.username
-        self.object_repr = str(self.changed_object)
+        if not self.user_name:
+            self.user_name = self.user.username
+        if not self.object_repr:
+            self.object_repr = str(self.changed_object)
 
         return super().save(*args, **kwargs)
 

--- a/netbox/extras/tests/test_tags.py
+++ b/netbox/extras/tests/test_tags.py
@@ -35,9 +35,9 @@ class TaggedItemTest(APITestCase):
 
         site = Site.objects.create(
             name='Test Site',
-            slug='test-site',
-            tags=['Foo', 'Bar', 'Baz']
+            slug='test-site'
         )
+        site.tags.add('Foo', 'Bar', 'Baz')
 
         data = {
             'tags': ['Foo', 'Bar', 'New Tag']

--- a/netbox/extras/tests/test_views.py
+++ b/netbox/extras/tests/test_views.py
@@ -6,6 +6,7 @@ from django.test import Client, TestCase
 from django.urls import reverse
 
 from dcim.models import Site
+from extras.constants import OBJECTCHANGE_ACTION_UPDATE
 from extras.models import ConfigContext, ObjectChange, Tag
 from utilities.testing import create_test_user
 
@@ -82,11 +83,10 @@ class ObjectChangeTestCase(TestCase):
 
         # Create three ObjectChanges
         for i in range(1, 4):
-            site.log_change(
-                user=user,
-                request_id=uuid.uuid4(),
-                action=2
-            )
+            oc = site.to_objectchange(action=OBJECTCHANGE_ACTION_UPDATE)
+            oc.user = user
+            oc.request_id = uuid.uuid4()
+            oc.save()
 
     def test_objectchange_list(self):
 

--- a/netbox/ipam/models.py
+++ b/netbox/ipam/models.py
@@ -647,26 +647,20 @@ class IPAddress(ChangeLoggedModel, CustomFieldModel):
 
         super().save(*args, **kwargs)
 
-    def log_change(self, user, request_id, action):
-        """
-        Include the connected Interface (if any).
-        """
-
-        # It's possible that an IPAddress can be deleted _after_ its parent Interface, in which case trying to resolve
-        # the interface will raise DoesNotExist.
+    def to_objectchange(self, action):
+        # Annotate the assigned Interface (if any)
         try:
             parent_obj = self.interface
         except ObjectDoesNotExist:
             parent_obj = None
 
-        ObjectChange(
-            user=user,
-            request_id=request_id,
+        return ObjectChange(
             changed_object=self,
-            related_object=parent_obj,
+            object_repr=str(self),
             action=action,
+            related_object=parent_obj,
             object_data=serialize_object(self)
-        ).save()
+        )
 
     def to_csv(self):
 

--- a/netbox/utilities/models.py
+++ b/netbox/utilities/models.py
@@ -23,15 +23,14 @@ class ChangeLoggedModel(models.Model):
     class Meta:
         abstract = True
 
-    def log_change(self, user, request_id, action):
+    def to_objectchange(self, action):
         """
-        Create a new ObjectChange representing a change made to this object. This will typically be called automatically
+        Return a new ObjectChange representing a change made to this object. This will typically be called automatically
         by extras.middleware.ChangeLoggingMiddleware.
         """
-        ObjectChange(
-            user=user,
-            request_id=request_id,
+        return ObjectChange(
             changed_object=self,
+            object_repr=str(self),
             action=action,
             object_data=serialize_object(self)
-        ).save()
+        )


### PR DESCRIPTION
### Fixes: #3452

* Replaces `log_change()` with `to_objectchange()`. The later merely returns an unsaved ObjectChange object instead of saving it immediately.
* Queue deletion ObjectChanges in the same manner as create/update ObjectChanges. This ensures that changes are recorded in chronological order, and allows us to easily purge the entire queue in the event of a transaction rollback.