### PR TITLE
Fix custom scripts attributes usage and examples

### DIFF
--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -201,13 +201,13 @@ class BaseScript:
         self.source = inspect.getsource(self.__class__)
 
     def __str__(self):
-        return getattr(self.Meta, 'name', self.__class__.__name__)
+        return getattr(self, 'name', self.__class__.__name__)
 
     def _get_vars(self):
         vars = OrderedDict()
 
-        # Infer order from Meta.field_order (Python 3.5 and lower)
-        field_order = getattr(self.Meta, 'field_order', [])
+        # Infer order from self.field_order (Python 3.5 and lower)
+        field_order = getattr(self, 'field_order', [])
         for name in field_order:
             vars[name] = getattr(self, name)
 

--- a/netbox/scripts/examples.py
+++ b/netbox/scripts/examples.py
@@ -6,9 +6,9 @@ from extras.scripts import *
 
 
 class NewBranchScript(Script):
-    script_name = "New Branch"
-    script_description = "Provision a new branch site"
-    script_fields = ['site_name', 'switch_count', 'switch_model']
+    name = "New Branch"
+    description = "Provision a new branch site"
+    field_order = ['site_name', 'switch_count', 'switch_model']
 
     site_name = StringVar(
         description="Name of the new site"

--- a/netbox/templates/extras/script.html
+++ b/netbox/templates/extras/script.html
@@ -16,7 +16,7 @@
         </div>
     </div>
     <h1>{{ script }}</h1>
-    <p>{{ script.Meta.description }}</p>
+    <p>{{ script.description }}</p>
     <ul class="nav nav-tabs" role="tablist">
         <li role="presentation" class="active">
             <a href="#run" role="tab" data-toggle="tab" class="active">Run</a>

--- a/netbox/templates/extras/script_list.html
+++ b/netbox/templates/extras/script_list.html
@@ -21,7 +21,7 @@
                                     <td>
                                         <a href="{% url 'extras:script' module=module name=class_name %}" name="script.{{ class_name }}"><strong>{{ script }}</strong></a>
                                     </td>
-                                    <td>{{ script.Meta.description }}</td>
+                                    <td>{{ script.description }}</td>
                                 </tr>
                             {% endfor %}
                         </tbody>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:

<!--
    Please include a summary of the proposed changes below.
-->
This fix the custom script attributes usage and examples:
- the human-friendly name of the script and its description are displayed in scripts list and script pages
- the field_order is used to display the script form
