### PR TITLE
Override DRF's builtin Bootstrap with NetBox's own more recent copy

### DIFF
--- a/netbox/templates/rest_framework/api.html
+++ b/netbox/templates/rest_framework/api.html
@@ -1,4 +1,10 @@
 {% extends 'rest_framework/base.html' %}
+{% load static %}
+
+{% block bootstrap_theme %}
+    <link rel="stylesheet" type="text/css" href="{% static 'bootstrap-3.4.1-dist/css/bootstrap.min.css' %}"/>
+    <link rel="stylesheet" type="text/css" href="{% static "rest_framework/css/bootstrap-tweaks.css" %}"/>
+{% endblock %}
 
 {% block branding %}
     <a class="navbar-brand" href="/{{ settings.BASE_PATH }}">NetBox</a>


### PR DESCRIPTION
### Fixes: #3560

This is a **temporary** solution to #3560. Ideally I'd prefer to wait until Bootstrap has been updated within DRF and then upgrade DRF to the latest release, but this provides a quick workaround to avoid using the vulnerable Bootstrap package.
