### PR TITLE
Correct documentation relative links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /netbox/scripts/*
 !/netbox/scripts/__init__.py
 /netbox/static
+site/*
 .idea
 /*.sh
 !upgrade.sh

--- a/docs/configuration/optional-settings.md
+++ b/docs/configuration/optional-settings.md
@@ -207,7 +207,7 @@ The file path to the location where media files (such as image attachments) are 
 
 Default: False
 
-Toggle exposing Prometheus metrics at `/metrics`. See the [Prometheus Metrics](../additional-features/prometheus-metrics/) documentation for more details.
+Toggle exposing Prometheus metrics at `/metrics`. See the [Prometheus Metrics](../additional-features/prometheus-metrics.md) documentation for more details.
 
 ---
 
@@ -305,7 +305,7 @@ The time zone NetBox will use when dealing with dates and times. It is recommend
 
 Default: False
 
-Enable this option to run the webhook backend. See the docs section on the webhook backend [here](../additional-features/webhooks/) for more information on setup and use.
+Enable this option to run the webhook backend. See the docs section on the webhook backend [here](../additional-features/webhooks.md) for more information on setup and use.
 
 ---
 


### PR DESCRIPTION
Was looking at the documentation for enabling webhooks
([this](https://netbox.readthedocs.io/en/stable/configuration/optional-settings/#webhooks_enabled)
paragraph), and the link points to a non-existing page
(https://netbox.readthedocs.io/en/stable/configuration/additional-features/webhooks/).
This is due to an incorrect relative link. Similarly for the prometheus
configuration.

Adding also git ignore for the site/ dir, generated by mkdoc, when
building the documentation locally.