### PR TITLE
#3381: Update docs to note correct path for netbox/project-static/

### DIFF
--- a/docs/installation/3-http-daemon.md
+++ b/docs/installation/3-http-daemon.md
@@ -24,7 +24,7 @@ server {
     client_max_body_size 25m;
 
     location /static/ {
-        alias /opt/netbox/netbox/static/;
+        alias /opt/netbox/netbox/project-static/;
     }
 
     location / {
@@ -67,12 +67,12 @@ Once Apache is installed, proceed with the following configuration (Be sure to m
 
     ServerName netbox.example.com
 
-    Alias /static /opt/netbox/netbox/static
+    Alias /static /opt/netbox/netbox/project-static
 
     # Needed to allow token-based API authentication
     WSGIPassAuthorization on
 
-    <Directory /opt/netbox/netbox/static>
+    <Directory /opt/netbox/netbox/project-static>
         Options Indexes FollowSymLinks MultiViews
         AllowOverride None
         Require all granted


### PR DESCRIPTION
typo in documentation:

https://netbox.readthedocs.io/en/stable/installation/3-http-daemon/

The file location of the /static URI should point to `/opt/netbox/netbox/project-static` rather than `/opt/netbox/netbox/static`.

### Fixes:

the patch in this pull request fixes #3555 and #3381.