### PR TITLE
Update pillow version to 6.2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ graphviz==0.10.1
 Jinja2==2.10.1
 Markdown==2.6.11
 netaddr==0.7.19
-Pillow==6.0.0
+Pillow==6.2.0
 psycopg2-binary==2.8.3
 py-gfm==0.1.4
 pycryptodome==3.8.2


### PR DESCRIPTION
A new CVE just got reporter regarding Pillow, it's affecting all version prior to 6.2.0 and currently netbox requires 6.0.0
http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-16865

### Fixes: #3611
Update Pillow version in the requirements.txt file from 6.0.0 to 6.2.0
