### PR TITLE
implemented #3606 - added stale bot config

### DIFF
--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -6,6 +6,7 @@ daysUntilClose: 7
 exemptLabels:
   - "status: accepted"
   - "status: gathering feedback"
+  - "status: blocked"
 # Label to use when marking an issue as stale
 staleLabel: wontfix
 # Comment to post when marking an issue as stale. Set to `false` to disable

--- a/.github/stale.yaml
+++ b/.github/stale.yaml
@@ -1,0 +1,22 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 14
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - "status: accepted"
+  - "status: gathering feedback"
+# Label to use when marking an issue as stale
+staleLabel: wontfix
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. NetBox
+  is governed by a small group of core maintainers which means not all opened
+  issues may receive direct feedback. Please see our [contributing guide](https://github.com/netbox-community/netbox/blob/develop/CONTRIBUTING.md).
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed due to lack of activity. In an
+  effort to reduce noise, please do not comment any further. Note that the
+  core maintainers may elect to reopen this issue at a later date if deemed
+  necessary.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,29 @@ feedback. **Do not** comment on an issue just to show your support (give the
 top post a :+1: instead) or ask for an ETA. These comments will be deleted to
 reduce noise in the discussion.
 
+## Issue Lifecycle
+
+When a correctly formatted issue is submitted it is evaluated by a moderator
+who may elect to immediately label the issue as accepted in addition to another
+issue type label. In other cases, the issue may be labeled as "status: gathering feedback"
+which will often be accompanied by a comment from a moderator asking for further dialog from the community.
+If an issue is labeled as "status: revisions needed" a moderator has identified a problem with
+the issue itself and is asking for the submitter himself to update the original post with
+the requested information. If the original post is not updated in a reasonable amount of time,
+the issue will be closed as invalid.
+ 
+The core maintainers group has chosen to make use of the GitHub Stale bot to aid in issue management.
+ 
+* Issues will be marked as stale after 14 days of no activity.
+ 
+* Then after 7 more days of inactivity, the issue will be closed.
+ 
+* Any issue with either the "status: accepted" or "status: gathering feedback" labels applied will be exempt from all Stale bot actions.
+ 
+It is natural that some new issues get more attention than others. Often this is a metric of an issues's
+overall usefulness to the project. In other cases in which issues merely get lost in the shuffle,
+notifications from Stale bot can bring renewed attention to potentially meaningful issues.
+
 ## Maintainer Guidance
 
 * Maintainers are expected to contribute at least four hours per week to the


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #3606 

Added .github/stale.yaml config and added the "Issue Lifecycle" section to the contributing guide.

<!--
    Please include a summary of the proposed changes below.
-->
