### PR TITLE
allow null region filtering

### DIFF
--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -174,6 +174,16 @@ class SiteTest(APITestCase):
             ['id', 'name', 'slug', 'url']
         )
 
+    def test_list_sites_null_region(self):
+
+        Site.objects.create(name='Test Site Null Region1', slug='test-site-no-region1')
+        Site.objects.create(name='Test Site Null Region2', slug='test-site-no-region2')
+
+        url = reverse('dcim-api:site-list')
+        response = self.client.get('{}?region=null'.format(url), **self.header)
+
+        self.assertEqual(response.data['count'], 2)
+
     def test_create_site(self):
 
         data = {
@@ -1753,7 +1763,8 @@ class DeviceTest(APITestCase):
 
         super().setUp()
 
-        self.site1 = Site.objects.create(name='Test Site 1', slug='test-site-1')
+        region = Region.objects.create(name='Test Region', slug='test-region')
+        self.site1 = Site.objects.create(region=region, name='Test Site 1', slug='test-site-1')
         self.site2 = Site.objects.create(name='Test Site 2', slug='test-site-2')
         manufacturer = Manufacturer.objects.create(name='Test Manufacturer 1', slug='test-manufacturer-1')
         self.devicetype1 = DeviceType.objects.create(
@@ -1827,6 +1838,21 @@ class DeviceTest(APITestCase):
             sorted(response.data['results'][0]),
             ['display_name', 'id', 'name', 'url']
         )
+
+    def test_list_device_null_region(self):
+
+        Device.objects.create(
+            device_type=self.devicetype1,
+            device_role=self.devicerole1,
+            name='Test Device Null Region',
+            site=self.site2,
+            cluster=self.cluster1
+        )
+
+        url = reverse('dcim-api:device-list')
+        response = self.client.get('{}?region=null'.format(url), **self.header)
+
+        self.assertEqual(response.data['count'], 1)
 
     def test_create_device(self):
 

--- a/netbox/utilities/filters.py
+++ b/netbox/utilities/filters.py
@@ -62,13 +62,14 @@ class TreeNodeMultipleChoiceFilter(django_filters.ModelMultipleChoiceFilter):
     Filters for a set of Models, including all descendant models within a Tree.  Example: [<Region: R1>,<Region: R2>]
     """
 
-    def filter(self, qs, value):
-        if settings.FILTERS_NULL_CHOICE_VALUE in value:
-            # Filtering by null value. Example: region=null
-            qs = self.get_method(qs)(**{self.field_name.replace('in', 'isnull'): True})
-            return qs.distinct() if self.distinct else qs
+    def get_filter_predicate(self, v):
+        # null value filtering
+        if v is None:
+            return {self.field_name.replace('in', 'isnull'): True}
+        return super().get_filter_predicate(v)
 
-        value = [node.get_descendants(include_self=True) for node in value]
+    def filter(self, qs, value):
+        value = [node.get_descendants(include_self=True) if not isinstance(node, str) else node for node in value]
         return super().filter(qs, value)
 
 

--- a/netbox/virtualization/tests/test_api.py
+++ b/netbox/virtualization/tests/test_api.py
@@ -350,6 +350,8 @@ class VirtualMachineTest(APITestCase):
                 'B': 2
             }
         )
+        self.virtualmachine_non_region1 = VirtualMachine.objects.create(name='Test Virtual Machine Null Region1', cluster=self.cluster2)
+        self.virtualmachine_non_region2 = VirtualMachine.objects.create(name='Test Virtual Machine Null Region2', cluster=self.cluster2)
 
     def test_get_virtualmachine(self):
 
@@ -363,7 +365,7 @@ class VirtualMachineTest(APITestCase):
         url = reverse('virtualization-api:virtualmachine-list')
         response = self.client.get(url, **self.header)
 
-        self.assertEqual(response.data['count'], 4)
+        self.assertEqual(response.data['count'], 6)
 
     def test_list_virtualmachines_brief(self):
 
@@ -377,12 +379,17 @@ class VirtualMachineTest(APITestCase):
 
     def test_list_virtualmachines_null_region(self):
 
-        VirtualMachine.objects.create(name='Test Virtual Machine Null Region', cluster=self.cluster2)
-
         url = reverse('virtualization-api:virtualmachine-list')
         response = self.client.get('{}?region=null'.format(url), **self.header)
 
-        self.assertEqual(response.data['count'], 1)
+        self.assertEqual(response.data['count'], 2)
+
+    def test_list_virtualmachines_multiple_regions(self):
+
+        url = reverse('virtualization-api:virtualmachine-list')
+        response = self.client.get('{}?region=null&region=test-region-1'.format(url), **self.header)
+
+        self.assertEqual(response.data['count'], 6)
 
     def test_create_virtualmachine(self):
 
@@ -395,7 +402,7 @@ class VirtualMachineTest(APITestCase):
         response = self.client.post(url, data, format='json', **self.header)
 
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
-        self.assertEqual(VirtualMachine.objects.count(), 5)
+        self.assertEqual(VirtualMachine.objects.count(), 7)
         virtualmachine4 = VirtualMachine.objects.get(pk=response.data['id'])
         self.assertEqual(virtualmachine4.name, data['name'])
         self.assertEqual(virtualmachine4.cluster.pk, data['cluster'])
@@ -410,7 +417,7 @@ class VirtualMachineTest(APITestCase):
         response = self.client.post(url, data, format='json', **self.header)
 
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(VirtualMachine.objects.count(), 4)
+        self.assertEqual(VirtualMachine.objects.count(), 6)
 
     def test_create_virtualmachine_bulk(self):
 
@@ -433,7 +440,7 @@ class VirtualMachineTest(APITestCase):
         response = self.client.post(url, data, format='json', **self.header)
 
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
-        self.assertEqual(VirtualMachine.objects.count(), 7)
+        self.assertEqual(VirtualMachine.objects.count(), 9)
         self.assertEqual(response.data[0]['name'], data[0]['name'])
         self.assertEqual(response.data[1]['name'], data[1]['name'])
         self.assertEqual(response.data[2]['name'], data[2]['name'])
@@ -455,7 +462,7 @@ class VirtualMachineTest(APITestCase):
         response = self.client.put(url, data, format='json', **self.header)
 
         self.assertHttpStatus(response, status.HTTP_200_OK)
-        self.assertEqual(VirtualMachine.objects.count(), 4)
+        self.assertEqual(VirtualMachine.objects.count(), 6)
         virtualmachine1 = VirtualMachine.objects.get(pk=response.data['id'])
         self.assertEqual(virtualmachine1.name, data['name'])
         self.assertEqual(virtualmachine1.cluster.pk, data['cluster'])
@@ -468,7 +475,7 @@ class VirtualMachineTest(APITestCase):
         response = self.client.delete(url, **self.header)
 
         self.assertHttpStatus(response, status.HTTP_204_NO_CONTENT)
-        self.assertEqual(VirtualMachine.objects.count(), 3)
+        self.assertEqual(VirtualMachine.objects.count(), 5)
 
     def test_config_context_included_by_default_in_list_view(self):
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #3357 

<!--
    Please include a summary of the proposed changes below.
-->
This fix allows to filter region with null value. The output is like the following.
```
$ curl -X GET -H "Accept: application/json; indent=4" -H "Authorization: Token 0123456789abcdef01234567
89abcdef01234567" "http://127.0.0.1:8000/api/dcim/sites/?region=null"

{                                                                                                   
    "count": 1,                                                                                     
    "next": null,                                                                                   
    "previous": null,                                                                               
    "results": [                                                                                    
        {                                                                                           
            "id": 2,                                                                                
            "name": "site null",                                                                    
            "slug": "site-null",
            "status": {
                "value": 1,
                "label": "Active"
            },
            "region": null,
            "tenant": null,
            "facility": "",
            "asn": null,
            "time_zone": null,
            "description": "",
            "physical_address": "",
            "shipping_address": "",
            "latitude": null,
            "longitude": null,
            "contact_name": "",                                                                     
            "contact_phone": "",
            "contact_email": "",
            "comments": "",
            "tags": [],
            "custom_fields": {},
            "created": "2019-10-04",                                                                
            "last_updated": "2019-10-04T03:50:34.076991Z",                                          
            "circuit_count": null,
            "device_count": null,
            "prefix_count": null,
            "rack_count": null,
            "virtualmachine_count": null,
            "vlan_count": null
        }
    ]
}

```
