### PR TITLE
Rewrite change logging middleware

### DIFF
--- a/netbox/extras/api/customfields.py
+++ b/netbox/extras/api/customfields.py
@@ -97,13 +97,13 @@ class CustomFieldModelSerializer(ValidatedModelSerializer):
     def __init__(self, *args, **kwargs):
 
         def _populate_custom_fields(instance, fields):
-            custom_fields = {f.name: None for f in fields}
-            for cfv in instance.custom_field_values.all():
-                if cfv.field.type == CF_TYPE_SELECT:
-                    custom_fields[cfv.field.name] = CustomFieldChoiceSerializer(cfv.value).data
+            instance.custom_fields = {}
+            for field in fields:
+                value = instance.cf.get(field.name)
+                if field.type == CF_TYPE_SELECT and value is not None:
+                    instance.custom_fields[field.name] = CustomFieldChoiceSerializer(value).data
                 else:
-                    custom_fields[cfv.field.name] = cfv.value
-            instance.custom_fields = custom_fields
+                    instance.custom_fields[field.name] = value
 
         super().__init__(*args, **kwargs)
 

--- a/netbox/extras/models.py
+++ b/netbox/extras/models.py
@@ -138,16 +138,21 @@ class CustomFieldModel(models.Model):
     class Meta:
         abstract = True
 
+    def cache_custom_fields(self):
+        """
+        Cache all custom field values for this instance
+        """
+        self._cf = {
+            field.name: value for field, value in self.get_custom_fields().items()
+        }
+
     @property
     def cf(self):
         """
         Name-based CustomFieldValue accessor for use in templates
         """
         if self._cf is None:
-            # Cache all custom field values for this instance
-            self._cf = {
-                field.name: value for field, value in self.get_custom_fields().items()
-            }
+            self.cache_custom_fields()
         return self._cf
 
     def get_custom_fields(self):

--- a/netbox/utilities/querysets.py
+++ b/netbox/utilities/querysets.py
@@ -1,0 +1,9 @@
+class DummyQuerySet:
+    """
+    A fake QuerySet that can be used to cache relationships to objects that have been deleted.
+    """
+    def __init__(self, queryset):
+        self._cache = [obj for obj in queryset.all()]
+
+    def all(self):
+        return self._cache

--- a/netbox/utilities/utils.py
+++ b/netbox/utilities/utils.py
@@ -99,7 +99,7 @@ def serialize_object(obj, extra=None):
     # Include any custom fields
     if hasattr(obj, 'get_custom_fields'):
         data['custom_fields'] = {
-            field.name: str(value) for field, value in obj.get_custom_fields().items()
+            field: str(value) for field, value in obj.cf.items()
         }
 
     # Include any tags


### PR DESCRIPTION
### Fixes: #3309

(I hope)

This PR represents a major overhaul of `ObjectChangeMiddleware`. The `handle_deleted_object` signal handler is no longer curried prior to the response being processed, which I believe was responsible for the root issue documented in #3309. Instead of attempting to pass the current request and immediately acting on deleted objects, we now make a copy of the object being deleted and defer processing to until after the request has been completed. This should ensure that the request user has been resolved by the time the change is recorded.

Some changes to custom field processing were also necessary to ensure that the current custom field values are recorded during any change scenario. I've also extended the change logging tests to validate tags and custom fields.