### PR TITLE
Retrieve port-id in LLDP tab

### DIFF
--- a/netbox/templates/dcim/device_lldp_neighbors.html
+++ b/netbox/templates/dcim/device_lldp_neighbors.html
@@ -52,10 +52,10 @@
 <script type="text/javascript">
 $(document).ready(function() {
     $.ajax({
-        url: "{% url 'dcim-api:device-napalm' pk=device.pk %}?method=get_lldp_neighbors",
+        url: "{% url 'dcim-api:device-napalm' pk=device.pk %}?method=get_lldp_neighbors_detail",
         dataType: 'json',
         success: function(json) {
-            $.each(json['get_lldp_neighbors'], function(iface, neighbors) {
+            $.each(json['get_lldp_neighbors_detail'], function(iface, neighbors) {
                 var neighbor = neighbors[0];
                 var row = $('#' + iface.split(".")[0].replace(/([\/:])/g, "\\$1"));
 
@@ -69,8 +69,8 @@ $(document).ready(function() {
                 }
 
                 // Clean up hostnames/interfaces learned via LLDP
-                var neighbor_host = neighbor['hostname'] || ""; // sanitize hostname if it's null to avoid breaking the split func
-                var neighbor_port = neighbor['port'] || ""; // sanitize port if it's null to avoid breaking the split func
+                var neighbor_host = neighbor['remote_system_name'] || ""; // sanitize hostname if it's null to avoid breaking the split func
+                var neighbor_port = neighbor['remote_port'] || ""; // sanitize port if it's null to avoid breaking the split func
                 var lldp_device = neighbor_host.split(".")[0];  // Strip off any trailing domain name
                 var lldp_interface = neighbor_port.split(".")[0];   // Strip off any trailing subinterface ID
 


### PR DESCRIPTION
### Fixes: #3629 
This fix allows to retrieve, LLDP port-id from NAPALM driver instead of port description.