### PR TITLE
Add max_requests details to example config

### DIFF
--- a/docs/installation/3-http-daemon.md
+++ b/docs/installation/3-http-daemon.md
@@ -108,7 +108,7 @@ Install gunicorn:
 # pip3 install gunicorn
 ```
 
-Save the following configuration in the root netbox installation path as `gunicorn_config.py` (e.g. `/opt/netbox/gunicorn_config.py` per our example installation). Be sure to verify the location of the gunicorn executable on your server (e.g. `which gunicorn`) and to update the `pythonpath` variable if needed. If using CentOS/RHEL, change the username from `www-data` to `nginx` or `apache`.
+Save the following configuration in the root netbox installation path as `gunicorn_config.py` (e.g. `/opt/netbox/gunicorn_config.py` per our example installation). Be sure to verify the location of the gunicorn executable on your server (e.g. `which gunicorn`) and to update the `pythonpath` variable if needed. If using CentOS/RHEL, change the username from `www-data` to `nginx` or `apache`. More info on `max_requests` information can be found in the [gunicorn docs](https://docs.gunicorn.org/en/stable/settings.html#max-requests).
 
 ```no-highlight
 command = '/usr/bin/gunicorn'
@@ -116,6 +116,8 @@ pythonpath = '/opt/netbox/netbox'
 bind = '127.0.0.1:8001'
 workers = 3
 user = 'www-data'
+max_requests = 1000
+max_requests_jitter = 200
 ```
 
 # supervisord Installation

--- a/docs/installation/3-http-daemon.md
+++ b/docs/installation/3-http-daemon.md
@@ -108,7 +108,7 @@ Install gunicorn:
 # pip3 install gunicorn
 ```
 
-Save the following configuration in the root netbox installation path as `gunicorn_config.py` (e.g. `/opt/netbox/gunicorn_config.py` per our example installation). Be sure to verify the location of the gunicorn executable on your server (e.g. `which gunicorn`) and to update the `pythonpath` variable if needed. If using CentOS/RHEL, change the username from `www-data` to `nginx` or `apache`. More info on `max_requests` information can be found in the [gunicorn docs](https://docs.gunicorn.org/en/stable/settings.html#max-requests).
+Save the following configuration in the root netbox installation path as `gunicorn_config.py` (e.g. `/opt/netbox/gunicorn_config.py` per our example installation). Be sure to verify the location of the gunicorn executable on your server (e.g. `which gunicorn`) and to update the `pythonpath` variable if needed. If using CentOS/RHEL, change the username from `www-data` to `nginx` or `apache`. More info on `max_requests` can be found in the [gunicorn docs](https://docs.gunicorn.org/en/stable/settings.html#max-requests).
 
 ```no-highlight
 command = '/usr/bin/gunicorn'

--- a/docs/installation/3-http-daemon.md
+++ b/docs/installation/3-http-daemon.md
@@ -116,8 +116,8 @@ pythonpath = '/opt/netbox/netbox'
 bind = '127.0.0.1:8001'
 workers = 3
 user = 'www-data'
-max_requests = 1000
-max_requests_jitter = 200
+max_requests = 5000
+max_requests_jitter = 500
 ```
 
 # supervisord Installation


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #3658
Indirectly addresses #3598

I've added the `max_requests` and `max_requests_jitter` parameters to the example gunicorn configuration in the installation docs. A link to the gunicorn docs was also added (as suggested by @kobayashi ) if users want more detail on the parameters.