### PR TITLE
Hide password change page when user is logged in using LDAP

### DIFF
--- a/netbox/templates/users/_user.html
+++ b/netbox/templates/users/_user.html
@@ -12,9 +12,11 @@
             <li{% ifequal active_tab "profile" %} class="active"{% endifequal %}>
                 <a href="{% url 'user:profile' %}">Profile</a>
             </li>
-            <li{% ifequal active_tab "change_password" %} class="active"{% endifequal %}>
-                <a href="{% url 'user:change_password' %}">Change Password</a>
-            </li>
+            {% if not request.user.ldap_username %}
+                <li{% ifequal active_tab "change_password" %} class="active"{% endifequal %}>
+                    <a href="{% url 'user:change_password' %}">Change Password</a>
+                </li>
+            {% endif %}
             <li{% ifequal active_tab "api_tokens" %} class="active"{% endifequal %}>
                 <a href="{% url 'user:token_list' %}">API Tokens</a>
             </li>

--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -95,6 +95,10 @@ class ChangePasswordView(LoginRequiredMixin, View):
     template_name = 'users/change_password.html'
 
     def get(self, request):
+        # LDAP users cannot change their password here
+        if getattr(request.user, 'ldap_username', None):
+            return redirect('user:profile')
+
         form = PasswordChangeForm(user=request.user)
 
         return render(request, self.template_name, {


### PR DESCRIPTION
### Fixes: #3139

- Hide the change-password menu item when the user has ldap_username set
- The menu item is hidden, but in case the user ends up on the change-password page: eedirect from the change-password page to the profile page when the user has ldap_username set