### PR TITLE
3457 Display cable colors in device interface list

### DIFF
--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -457,6 +457,14 @@ table.report th a {
     width: 80px;
     border: 1px solid grey;
 }
+.inline-color-block {
+    display: inline-block;
+    width: 1.5em;
+    height: 1.5em;
+    border: 1px solid grey;
+    border-radius: .25em;
+    vertical-align: middle;
+}
 .text-nowrap {
     white-space: nowrap;
 }

--- a/netbox/templates/dcim/inc/interface.html
+++ b/netbox/templates/dcim/inc/interface.html
@@ -48,6 +48,9 @@
     <td class="text-nowrap">
         {% if iface.cable %}
             <a href="{{ iface.cable.get_absolute_url }}">{{ iface.cable }}</a>
+            {% if iface.cable.color %}
+            <span class="inline-color-block" style="background-color: #{{ iface.cable.color }}">&nbsp;</span>
+            {% endif %}
             <a href="{% url 'dcim:interface_trace' pk=iface.pk %}" class="btn btn-primary btn-xs" title="Trace">
                 <i class="fa fa-share-alt" aria-hidden="true"></i>
             </a>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #3457
<!--
    Please include a summary of the proposed changes below.
-->

This adds a small informative colour block next to the cable name/ID for all connected interfaces which have a cable colour defined.  
I tried the suggestion in the parent issue to instead make the cable link/button itself into the cable colour, but doing this without making the text difficult to read - and without losing the visual denotion that the cable name/ID is a link to said cable - proved difficult.

![Screenshot_20191106_100908](https://user-images.githubusercontent.com/534460/68284530-fcc67d00-007d-11ea-9a25-352dcbc34eba.png)
![Screenshot_20191106_101919](https://user-images.githubusercontent.com/534460/68285089-eb31a500-007e-11ea-88bf-fb7a877ca8ca.png)