### PR TITLE
Closes #3663: API filter by created, last_updated

### DIFF
--- a/netbox/circuits/filters.py
+++ b/netbox/circuits/filters.py
@@ -2,14 +2,14 @@ import django_filters
 from django.db.models import Q
 
 from dcim.models import Region, Site
-from extras.filters import CustomFieldFilterSet
+from extras.filters import CustomFieldFilterSet, ChangeLoggedFilter
 from tenancy.filtersets import TenancyFilterSet
 from utilities.filters import NameSlugSearchFilterSet, NumericInFilter, TagFilter, TreeNodeMultipleChoiceFilter
 from .constants import *
 from .models import Circuit, CircuitTermination, CircuitType, Provider
 
 
-class ProviderFilter(CustomFieldFilterSet):
+class ProviderFilter(CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -54,7 +54,7 @@ class CircuitTypeFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class CircuitFilter(CustomFieldFilterSet, TenancyFilterSet):
+class CircuitFilter(CustomFieldFilterSet, TenancyFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'

--- a/netbox/circuits/filters.py
+++ b/netbox/circuits/filters.py
@@ -2,14 +2,14 @@ import django_filters
 from django.db.models import Q
 
 from dcim.models import Region, Site
-from extras.filters import CustomFieldFilterSet, ChangeLoggedFilter
+from extras.filters import CustomFieldFilterSet, CreatedUpdatedFilter
 from tenancy.filtersets import TenancyFilterSet
 from utilities.filters import NameSlugSearchFilterSet, NumericInFilter, TagFilter, TreeNodeMultipleChoiceFilter
 from .constants import *
 from .models import Circuit, CircuitTermination, CircuitType, Provider
 
 
-class ProviderFilter(CustomFieldFilterSet, ChangeLoggedFilter):
+class ProviderFilter(CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -54,7 +54,7 @@ class CircuitTypeFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class CircuitFilter(CustomFieldFilterSet, TenancyFilterSet, ChangeLoggedFilter):
+class CircuitFilter(CustomFieldFilterSet, TenancyFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -2,7 +2,7 @@ import django_filters
 from django.contrib.auth.models import User
 from django.db.models import Q
 
-from extras.filters import CustomFieldFilterSet, LocalConfigContextFilter
+from extras.filters import CustomFieldFilterSet, LocalConfigContextFilter, ChangeLoggedFilter
 from tenancy.filtersets import TenancyFilterSet
 from tenancy.models import Tenant
 from utilities.constants import COLOR_CHOICES
@@ -38,7 +38,7 @@ class RegionFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class SiteFilter(TenancyFilterSet, CustomFieldFilterSet):
+class SiteFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -116,7 +116,7 @@ class RackRoleFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug', 'color']
 
 
-class RackFilter(TenancyFilterSet, CustomFieldFilterSet):
+class RackFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -251,7 +251,7 @@ class ManufacturerFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class DeviceTypeFilter(CustomFieldFilterSet):
+class DeviceTypeFilter(CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -423,7 +423,7 @@ class PlatformFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug', 'napalm_driver']
 
 
-class DeviceFilter(LocalConfigContextFilter, TenancyFilterSet, CustomFieldFilterSet):
+class DeviceFilter(LocalConfigContextFilter, TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -1096,7 +1096,7 @@ class PowerPanelFilter(django_filters.FilterSet):
         return queryset.filter(qs_filter)
 
 
-class PowerFeedFilter(CustomFieldFilterSet):
+class PowerFeedFilter(CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -2,7 +2,7 @@ import django_filters
 from django.contrib.auth.models import User
 from django.db.models import Q
 
-from extras.filters import CustomFieldFilterSet, LocalConfigContextFilter, ChangeLoggedFilter
+from extras.filters import CustomFieldFilterSet, LocalConfigContextFilter, CreatedUpdatedFilter
 from tenancy.filtersets import TenancyFilterSet
 from tenancy.models import Tenant
 from utilities.constants import COLOR_CHOICES
@@ -38,7 +38,7 @@ class RegionFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class SiteFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
+class SiteFilter(TenancyFilterSet, CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -116,7 +116,7 @@ class RackRoleFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug', 'color']
 
 
-class RackFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
+class RackFilter(TenancyFilterSet, CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -251,7 +251,7 @@ class ManufacturerFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class DeviceTypeFilter(CustomFieldFilterSet, ChangeLoggedFilter):
+class DeviceTypeFilter(CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -423,7 +423,7 @@ class PlatformFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug', 'napalm_driver']
 
 
-class DeviceFilter(LocalConfigContextFilter, TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
+class DeviceFilter(LocalConfigContextFilter, TenancyFilterSet, CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -1096,7 +1096,7 @@ class PowerPanelFilter(django_filters.FilterSet):
         return queryset.filter(qs_filter)
 
 
-class PowerFeedFilter(CustomFieldFilterSet, ChangeLoggedFilter):
+class PowerFeedFilter(CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'

--- a/netbox/extras/filters.py
+++ b/netbox/extras/filters.py
@@ -241,3 +241,23 @@ class ObjectChangeFilter(django_filters.FilterSet):
             Q(user_name__icontains=value) |
             Q(object_repr__icontains=value)
         )
+
+class ChangeLoggedFilter(django_filters.FilterSet):
+    created = django_filters.DateFilter()
+    created__gte = django_filters.DateFilter(
+        field_name='created',
+        lookup_expr='gte'
+    )
+    created__lte = django_filters.DateFilter(
+        field_name='created',
+        lookup_expr='lte'
+    )
+    last_updated = django_filters.DateTimeFilter()
+    last_updated__gte = django_filters.DateTimeFilter(
+        field_name='last_updated',
+        lookup_expr='gte'
+    )
+    last_updated__lte = django_filters.DateTimeFilter(
+        field_name='last_updated',
+        lookup_expr='lte'
+    )

--- a/netbox/extras/filters.py
+++ b/netbox/extras/filters.py
@@ -242,6 +242,7 @@ class ObjectChangeFilter(django_filters.FilterSet):
             Q(object_repr__icontains=value)
         )
 
+
 class ChangeLoggedFilter(django_filters.FilterSet):
     created = django_filters.DateFilter()
     created__gte = django_filters.DateFilter(

--- a/netbox/extras/filters.py
+++ b/netbox/extras/filters.py
@@ -243,7 +243,7 @@ class ObjectChangeFilter(django_filters.FilterSet):
         )
 
 
-class ChangeLoggedFilter(django_filters.FilterSet):
+class CreatedUpdatedFilter(django_filters.FilterSet):
     created = django_filters.DateFilter()
     created__gte = django_filters.DateFilter(
         field_name='created',

--- a/netbox/ipam/filters.py
+++ b/netbox/ipam/filters.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 from netaddr.core import AddrFormatError
 
 from dcim.models import Site, Device, Interface
-from extras.filters import CustomFieldFilterSet
+from extras.filters import CustomFieldFilterSet, ChangeLoggedFilter
 from tenancy.filtersets import TenancyFilterSet
 from utilities.filters import NameSlugSearchFilterSet, NumericInFilter, TagFilter
 from virtualization.models import VirtualMachine
@@ -13,7 +13,7 @@ from .constants import *
 from .models import Aggregate, IPAddress, Prefix, RIR, Role, Service, VLAN, VLANGroup, VRF
 
 
-class VRFFilter(TenancyFilterSet, CustomFieldFilterSet):
+class VRFFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -49,7 +49,7 @@ class RIRFilter(NameSlugSearchFilterSet):
         fields = ['name', 'slug', 'is_private']
 
 
-class AggregateFilter(CustomFieldFilterSet):
+class AggregateFilter(CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -110,7 +110,7 @@ class RoleFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class PrefixFilter(TenancyFilterSet, CustomFieldFilterSet):
+class PrefixFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -247,7 +247,7 @@ class PrefixFilter(TenancyFilterSet, CustomFieldFilterSet):
         return queryset.filter(prefix__net_mask_length=value)
 
 
-class IPAddressFilter(TenancyFilterSet, CustomFieldFilterSet):
+class IPAddressFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -384,7 +384,7 @@ class VLANGroupFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class VLANFilter(TenancyFilterSet, CustomFieldFilterSet):
+class VLANFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -444,7 +444,7 @@ class VLANFilter(TenancyFilterSet, CustomFieldFilterSet):
         return queryset.filter(qs_filter)
 
 
-class ServiceFilter(django_filters.FilterSet):
+class ServiceFilter(django_filters.FilterSet, ChangeLoggedFilter):
     q = django_filters.CharFilter(
         method='search',
         label='Search',

--- a/netbox/ipam/filters.py
+++ b/netbox/ipam/filters.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 from netaddr.core import AddrFormatError
 
 from dcim.models import Site, Device, Interface
-from extras.filters import CustomFieldFilterSet, ChangeLoggedFilter
+from extras.filters import CustomFieldFilterSet, CreatedUpdatedFilter
 from tenancy.filtersets import TenancyFilterSet
 from utilities.filters import NameSlugSearchFilterSet, NumericInFilter, TagFilter
 from virtualization.models import VirtualMachine
@@ -13,7 +13,7 @@ from .constants import *
 from .models import Aggregate, IPAddress, Prefix, RIR, Role, Service, VLAN, VLANGroup, VRF
 
 
-class VRFFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
+class VRFFilter(TenancyFilterSet, CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -49,7 +49,7 @@ class RIRFilter(NameSlugSearchFilterSet):
         fields = ['name', 'slug', 'is_private']
 
 
-class AggregateFilter(CustomFieldFilterSet, ChangeLoggedFilter):
+class AggregateFilter(CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -110,7 +110,7 @@ class RoleFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class PrefixFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
+class PrefixFilter(TenancyFilterSet, CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -247,7 +247,7 @@ class PrefixFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
         return queryset.filter(prefix__net_mask_length=value)
 
 
-class IPAddressFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
+class IPAddressFilter(TenancyFilterSet, CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -384,7 +384,7 @@ class VLANGroupFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class VLANFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
+class VLANFilter(TenancyFilterSet, CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -444,7 +444,7 @@ class VLANFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
         return queryset.filter(qs_filter)
 
 
-class ServiceFilter(ChangeLoggedFilter):
+class ServiceFilter(CreatedUpdatedFilter):
     q = django_filters.CharFilter(
         method='search',
         label='Search',

--- a/netbox/ipam/filters.py
+++ b/netbox/ipam/filters.py
@@ -444,7 +444,7 @@ class VLANFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
         return queryset.filter(qs_filter)
 
 
-class ServiceFilter(django_filters.FilterSet, ChangeLoggedFilter):
+class ServiceFilter(ChangeLoggedFilter):
     q = django_filters.CharFilter(
         method='search',
         label='Search',

--- a/netbox/secrets/filters.py
+++ b/netbox/secrets/filters.py
@@ -2,7 +2,7 @@ import django_filters
 from django.db.models import Q
 
 from dcim.models import Device
-from extras.filters import CustomFieldFilterSet
+from extras.filters import CustomFieldFilterSet, ChangeLoggedFilter
 from utilities.filters import NameSlugSearchFilterSet, NumericInFilter, TagFilter
 from .models import Secret, SecretRole
 
@@ -14,7 +14,7 @@ class SecretRoleFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class SecretFilter(CustomFieldFilterSet):
+class SecretFilter(CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'

--- a/netbox/secrets/filters.py
+++ b/netbox/secrets/filters.py
@@ -2,7 +2,7 @@ import django_filters
 from django.db.models import Q
 
 from dcim.models import Device
-from extras.filters import CustomFieldFilterSet, ChangeLoggedFilter
+from extras.filters import CustomFieldFilterSet, CreatedUpdatedFilter
 from utilities.filters import NameSlugSearchFilterSet, NumericInFilter, TagFilter
 from .models import Secret, SecretRole
 
@@ -14,7 +14,7 @@ class SecretRoleFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class SecretFilter(CustomFieldFilterSet, ChangeLoggedFilter):
+class SecretFilter(CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'

--- a/netbox/tenancy/filters.py
+++ b/netbox/tenancy/filters.py
@@ -1,7 +1,7 @@
 import django_filters
 from django.db.models import Q
 
-from extras.filters import CustomFieldFilterSet, ChangeLoggedFilter
+from extras.filters import CustomFieldFilterSet, CreatedUpdatedFilter
 from utilities.filters import NameSlugSearchFilterSet, NumericInFilter, TagFilter
 from .models import Tenant, TenantGroup
 
@@ -13,7 +13,7 @@ class TenantGroupFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class TenantFilter(CustomFieldFilterSet, ChangeLoggedFilter):
+class TenantFilter(CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'

--- a/netbox/tenancy/filters.py
+++ b/netbox/tenancy/filters.py
@@ -1,7 +1,7 @@
 import django_filters
 from django.db.models import Q
 
-from extras.filters import CustomFieldFilterSet
+from extras.filters import CustomFieldFilterSet, ChangeLoggedFilter
 from utilities.filters import NameSlugSearchFilterSet, NumericInFilter, TagFilter
 from .models import Tenant, TenantGroup
 
@@ -13,7 +13,7 @@ class TenantGroupFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class TenantFilter(CustomFieldFilterSet):
+class TenantFilter(CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'

--- a/netbox/virtualization/filters.py
+++ b/netbox/virtualization/filters.py
@@ -4,7 +4,7 @@ from netaddr import EUI
 from netaddr.core import AddrFormatError
 
 from dcim.models import DeviceRole, Interface, Platform, Region, Site
-from extras.filters import CustomFieldFilterSet, ChangeLoggedFilter
+from extras.filters import CustomFieldFilterSet, CreatedUpdatedFilter
 from tenancy.filtersets import TenancyFilterSet
 from utilities.filters import (
     MultiValueMACAddressFilter, NameSlugSearchFilterSet, NumericInFilter, TagFilter, TreeNodeMultipleChoiceFilter,
@@ -27,7 +27,7 @@ class ClusterGroupFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class ClusterFilter(CustomFieldFilterSet, ChangeLoggedFilter):
+class ClusterFilter(CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -81,7 +81,7 @@ class ClusterFilter(CustomFieldFilterSet, ChangeLoggedFilter):
         )
 
 
-class VirtualMachineFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
+class VirtualMachineFilter(TenancyFilterSet, CustomFieldFilterSet, CreatedUpdatedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'

--- a/netbox/virtualization/filters.py
+++ b/netbox/virtualization/filters.py
@@ -4,7 +4,7 @@ from netaddr import EUI
 from netaddr.core import AddrFormatError
 
 from dcim.models import DeviceRole, Interface, Platform, Region, Site
-from extras.filters import CustomFieldFilterSet
+from extras.filters import CustomFieldFilterSet, ChangeLoggedFilter
 from tenancy.filtersets import TenancyFilterSet
 from utilities.filters import (
     MultiValueMACAddressFilter, NameSlugSearchFilterSet, NumericInFilter, TagFilter, TreeNodeMultipleChoiceFilter,
@@ -27,7 +27,7 @@ class ClusterGroupFilter(NameSlugSearchFilterSet):
         fields = ['id', 'name', 'slug']
 
 
-class ClusterFilter(CustomFieldFilterSet):
+class ClusterFilter(CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'
@@ -81,7 +81,7 @@ class ClusterFilter(CustomFieldFilterSet):
         )
 
 
-class VirtualMachineFilter(TenancyFilterSet, CustomFieldFilterSet):
+class VirtualMachineFilter(TenancyFilterSet, CustomFieldFilterSet, ChangeLoggedFilter):
     id__in = NumericInFilter(
         field_name='id',
         lookup_expr='in'


### PR DESCRIPTION
### Fixes: #3663: API filter by created, last_updated
Creating a new class that the applicable existing FilterSets inherit. I think it makes sense to have exact, gte, and lte filters for the created and last_updated fields.
