### PR TITLE
Switch from "pycryptodome" to "pycryptodomex"

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -81,4 +81,4 @@ py-gfm
 
 # Extensive cryptographic library (fork of pycrypto)
 # https://github.com/Legrandin/pycryptodome
-pycryptodome
+pycryptodomex

--- a/netbox/secrets/api/views.py
+++ b/netbox/secrets/api/views.py
@@ -1,6 +1,6 @@
 import base64
 
-from Crypto.PublicKey import RSA
+from Cryptodome.PublicKey import RSA
 from django.db.models import Count
 from django.http import HttpResponseBadRequest
 from rest_framework.exceptions import ValidationError

--- a/netbox/secrets/forms.py
+++ b/netbox/secrets/forms.py
@@ -1,5 +1,5 @@
-from Crypto.Cipher import PKCS1_OAEP
-from Crypto.PublicKey import RSA
+from Cryptodome.Cipher import PKCS1_OAEP
+from Cryptodome.PublicKey import RSA
 from django import forms
 from taggit.forms import TagField
 

--- a/netbox/secrets/models.py
+++ b/netbox/secrets/models.py
@@ -1,9 +1,9 @@
 import os
 import sys
 
-from Crypto.Cipher import AES, PKCS1_OAEP
-from Crypto.PublicKey import RSA
-from Crypto.Util import strxor
+from Cryptodome.Cipher import AES, PKCS1_OAEP
+from Cryptodome.PublicKey import RSA
+from Cryptodome.Util import strxor
 from django.conf import settings
 from django.contrib.auth.hashers import make_password, check_password
 from django.contrib.auth.models import Group, User

--- a/netbox/secrets/tests/test_models.py
+++ b/netbox/secrets/tests/test_models.py
@@ -1,6 +1,6 @@
 import string
 
-from Crypto.PublicKey import RSA
+from Cryptodome.PublicKey import RSA
 from django.conf import settings
 from django.contrib.auth.models import User
 from django.core.exceptions import ValidationError

--- a/old_requirements.txt
+++ b/old_requirements.txt
@@ -1,3 +1,4 @@
 django-rest-swagger
 psycopg2
 pycrypto
+pycryptodome

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,4 +19,4 @@ netaddr==0.7.19
 Pillow==6.2.0
 psycopg2-binary==2.8.3
 py-gfm==0.1.4
-pycryptodome==3.8.2
+pycryptodomex==3.8.2


### PR DESCRIPTION
### Fixes: #3689

When NetBox is used outside an virtualenv it can happen that there's a
Python package conflict between "pycryptodome", which is required by
NetBox, and "pycrypto", which some other package requires.

Thus switch from "pycryptodome" to its library independent variant
"pycryptodomex". The latter one uses "Cryptodome" as package name
instead of "Crypto".

My tests were so far:

- Login/Logoff -> OK
- Unlock/Lock secrets via private key -> OK
- Create new user key pair -> OK
- Activate new user key pair -> OK
- Unlock/Lock secrets with new user key pair -> OK