### PR TITLE
Fixes 3749 attribute error

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -1,3 +1,9 @@
+# v2.6.9 (FUTURE)
+
+## Bug Fixes
+
+* [#3749](https://github.com/netbox-community/netbox/issues/3749) - Fix exception on password change page for local users
+
 # v2.6.8 (2019-12-10)
 
 ## Enhancements

--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -96,7 +96,7 @@ class ChangePasswordView(LoginRequiredMixin, View):
 
     def get(self, request):
         # LDAP users cannot change their password here
-        if getattr(request.user, 'ldap_username'):
+        if getattr(request.user, 'ldap_username', None):
             messages.warning(request, "LDAP-authenticated user credentials cannot be changed within NetBox.")
             return redirect('user:profile')
 


### PR DESCRIPTION
### Fixes: #3749 

No default is specified in `getattr` call which is raising an AttributeError exception for `ldap_user`.