### PR TITLE
Fixes #3761: copy button for tokens

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -4,6 +4,7 @@
 
 * [#3152](https://github.com/netbox-community/netbox/issues/3152) - Include direct link to rack elevations on site view
 * [#3441](https://github.com/netbox-community/netbox/issues/3441) - Move virtual machine results near devices in global search
+* [#3761](https://github.com/netbox-community/netbox/issues/3761) - Added copy button for API tokens
 
 ## Bug Fixes
 

--- a/netbox/templates/users/api_tokens.html
+++ b/netbox/templates/users/api_tokens.html
@@ -10,6 +10,7 @@
                 <div class="panel panel-{% if token.is_expired %}danger{% else %}default{% endif %}">
                     <div class="panel-heading">
                         <div class="pull-right noprint">
+                            <a class="btn btn-xs btn-success copy-token" data-clipboard-target="#token_{{ token.pk }}">Copy</a>
                             {% if perms.users.change_token %}
                                 <a href="{% url 'user:token_edit' pk=token.pk %}" class="btn btn-xs btn-warning">Edit</a>
                             {% endif %}
@@ -17,7 +18,8 @@
                                 <a href="{% url 'user:token_delete' pk=token.pk %}" class="btn btn-xs btn-danger">Delete</a>
                             {% endif %}
                         </div>
-                        <i class="fa fa-key"></i> {{ token.key }}
+                        <i class="fa fa-key"></i>
+                        <span id="token_{{ token.pk }}">{{ token.key }}</span>
                         {% if token.is_expired %}
                             <span class="label label-danger">Expired</span>
                         {% endif %}
@@ -65,4 +67,10 @@
             {% endif %}
         </div>
     </div>
+{% endblock %}
+
+{% block javascript %}
+<script type="text/javascript">
+new ClipboardJS('.copy-token');
+</script>
 {% endblock %}


### PR DESCRIPTION
### Fixes: #3761 
Added a copy button.

![image](https://user-images.githubusercontent.com/34197532/70821872-12913580-1dd4-11ea-8e39-cd1457e6d396.png)

I used `btn-success` because it is green/white background/foreground. Using `btn-default` will give it a white/black where the foreground doesn't match the rest of the buttons next to it.
