### PR TITLE
Add request to Custom Script run, if receiver supports it

### DIFF
--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -235,6 +235,9 @@ class BaseScript:
         # Initiate the log
         self.log = []
 
+        # Declare the placeholder for the current request
+        self.request = None
+
         # Grab some info about the script
         self.filename = inspect.getfile(self.__class__)
         self.source = inspect.getsource(self.__class__)
@@ -337,7 +340,7 @@ def is_variable(obj):
     return isinstance(obj, ScriptVariable)
 
 
-def run_script(script, data, files, commit=True):
+def run_script(script, data, request, commit=True):
     """
     A wrapper for calling Script.run(). This performs error handling and provides a hook for committing changes. It
     exists outside of the Script class to ensure it cannot be overridden by a script author.
@@ -347,8 +350,12 @@ def run_script(script, data, files, commit=True):
     end_time = None
 
     # Add files to form data
+    files = request.FILES
     for field_name, fileobj in files.items():
         data[field_name] = fileobj
+
+    # Add the current request as a property of the script
+    script.request = request
 
     try:
         with transaction.atomic():

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -413,7 +413,7 @@ class ScriptView(PermissionRequiredMixin, View):
 
         if form.is_valid():
             commit = form.cleaned_data.pop('_commit')
-            output, execution_time = run_script(script, form.cleaned_data, request.FILES, commit)
+            output, execution_time = run_script(script, form.cleaned_data, request, commit)
 
         return render(request, 'extras/script.html', {
             'module': module,


### PR DESCRIPTION
### Fixes: #3705 

- Check whether the script.run() method accepts `request` as a keyword argument
- If it does, pass the current request to the method
