### PR TITLE
Fixes 3712

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -7,6 +7,7 @@
 ## Bug Fixes
 
 * [#3695](https://github.com/netbox-community/netbox/issues/3695) - Include A/Z termination sites for circuits in global search
+* [#3712](https://github.com/netbox-community/netbox/issues/3712) - Scrolling to target (hash) did not account for the header size
 * [#3780](https://github.com/netbox-community/netbox/issues/3780) - Fix AttributeError exception in API docs
 
 ---

--- a/netbox/project-static/js/forms.js
+++ b/netbox/project-static/js/forms.js
@@ -353,4 +353,19 @@ $(document).ready(function() {
         });
         $('select#id_mode').trigger('change');
     }
+
+    // Scroll up an offset equal to the first nav element if a hash is present
+    // Cannot use '#navbar' because it is not always visible, like in small windows
+    function headerOffsetScroll() {
+        if (window.location.hash) {
+            // Short wait needed to allow the page to scroll to the element
+            setTimeout(function() {
+                window.scrollBy(0, -$('nav').height())
+            }, 10);
+        }
+    }
+
+    // Account for the header height when hash-scrolling
+    window.addEventListener('load', headerOffsetScroll);
+    window.addEventListener('hashchange', headerOffsetScroll);
 });


### PR DESCRIPTION
### Fixes: #3712
Account for the header (navigation bar) when scrolling to target (hash), like when clicking on the parent LAG shortcut on a member interface in the device view.