### PR TITLE
Fixes #3812: Only preload selected options for API-based select

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -5,6 +5,7 @@
 * [#3705](https://github.com/netbox-community/netbox/issues/3705) - Provide request context when executing custom scripts
 * [#3762](https://github.com/netbox-community/netbox/issues/3762) - Add date/time picker widgets
 * [#3788](https://github.com/netbox-community/netbox/issues/3788) - Enable partial search for inventory items
+* [#3812](https://github.com/netbox-community/netbox/issues/3812) - Optimize size of pages containing a dynamic selection field
 
 ## Bug Fixes
 

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -285,7 +285,7 @@ class APISelect(SelectWithDisabled):
         name of the query param and the value if the query param's value.
     :param null_option: If true, include the static null option in the selection list.
     """
-    # Only preload the selected option; new options are dynamically displayed and added via the API
+    # Only preload the selected option(s); new options are dynamically displayed and added via the API
     template_name = 'widgets/select_api.html'
 
     def __init__(

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -285,6 +285,8 @@ class APISelect(SelectWithDisabled):
         name of the query param and the value if the query param's value.
     :param null_option: If true, include the static null option in the selection list.
     """
+    # Only preload the selected option; new options are dynamically displayed and added via the API
+    template_name = 'widgets/select_api.html'
 
     def __init__(
         self,

--- a/netbox/utilities/templates/widgets/select_api.html
+++ b/netbox/utilities/templates/widgets/select_api.html
@@ -1,0 +1,5 @@
+<select name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>{% for group_name, group_choices, group_index in widget.optgroups %}{% if group_name %}
+  <optgroup label="{{ group_name }}">{% endif %}{% for widget in group_choices %}{% if widget.attrs.selected %}
+  {% include widget.template_name %}{% endif %}{% endfor %}{% if group_name %}
+  </optgroup>{% endif %}{% endfor %}
+</select>


### PR DESCRIPTION
### Fixes: #3812
For API-based select fields, only preload the selected options. Other options are dynamically displayed and added via the API when selected.

#### Example for `APISelect`
No selection:
```html
<select name="device_role" class="netbox-select2-api form-control select2-hidden-accessible" data-url="/api/dcim/device-roles/" required="" placeholder="Device role" id="id_device_role" tabindex="-1" aria-hidden="true">
  <option value="" selected="">---------</option>
</select>
```

After selection:
```html
<select name="device_role" class="netbox-select2-api form-control select2-hidden-accessible" data-url="/api/dcim/device-roles/" required="" placeholder="Device role" id="id_device_role" tabindex="-1" aria-hidden="true">
  <option value="" selected="">---------</option>
  <option value="1">Access</option>
</select>
```

Existing selection:
```html
<select name="device_role" class="netbox-select2-api form-control select2-hidden-accessible" data-url="/api/dcim/device-roles/" required="" placeholder="Device role" id="id_device_role" tabindex="-1" aria-hidden="true">
  <option value="1" selected="">Access</option>
</select>
```

#### Example for `APISelectMultiple`

> This is output is from tagged VLANs which may change because of #3589. The list of choices is being manually overridden so that's why they're being created. In reality, the list isn't being used because the API select is dynamically fetching the options and their groups.

No selection:
```html
<select name="tagged_vlans" class="netbox-select2-api form-control select2-hidden-accessible" data-url="/api/ipam/vlans/" data-full="" display-field="display_name" data-multiple="1" placeholder="None" id="id_tagged_vlans" multiple="" tabindex="-1" aria-hidden="true">
  <optgroup label="Global">
  </optgroup>
  <optgroup label="global-group-1">
  </optgroup>
  <optgroup label="London">
  </optgroup>
</select>
```
> Groups are still created if present.

After selection (multiple):
```html
<select name="tagged_vlans" class="netbox-select2-api form-control select2-hidden-accessible" data-url="/api/ipam/vlans/" data-full="" display-field="display_name" data-multiple="1" placeholder="None" id="id_tagged_vlans" multiple="" tabindex="-1" aria-hidden="true">
  <optgroup label="Global">
  </optgroup>
  <optgroup label="global-group-1">
  </optgroup>
  <optgroup label="London">
  </optgroup>
  <option value="1">1 (vlan1)</option>
  <option value="2">2 (vlan2)</option>
</select>
```

Existing selection (multiple):
```html
<select name="tagged_vlans" class="netbox-select2-api form-control select2-hidden-accessible" data-url="/api/ipam/vlans/" data-full="" display-field="display_name" data-multiple="1" placeholder="None" id="id_tagged_vlans" multiple="" tabindex="-1" aria-hidden="true">
  <optgroup label="Global">
    <option value="2" selected="">2 (vlan2)</option>
  </optgroup>
  <optgroup label="global-group-1">
  </optgroup>
  <optgroup label="London">
    <option value="1" selected="">1 (vlan1)</option>
  </optgroup>
</select>
```