### PR TITLE
Fixes #3589: Interface VLAN filtering

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -1,3 +1,11 @@
+# v2.6.12 (FUTURE)
+
+## Bug Fixes
+
+* [#3589](https://github.com/netbox-community/netbox/issues/3589) - Fix validation on tagged VLANs of an interface
+
+---
+
 # v2.6.11 (2020-01-03)
 
 ## Bug Fixes
@@ -24,7 +32,6 @@
 ## Bug Fixes
 
 * [#3106](https://github.com/netbox-community/netbox/issues/3106) - Restrict queryset of chained fields when form validation fails
-* [#3589](https://github.com/netbox-community/netbox/issues/3589) - Limit the list of available VLANs to those valid and perform input validation on the tagged VLANs
 * [#3695](https://github.com/netbox-community/netbox/issues/3695) - Include A/Z termination sites for circuits in global search
 * [#3712](https://github.com/netbox-community/netbox/issues/3712) - Scrolling to target (hash) did not account for the header size
 * [#3780](https://github.com/netbox-community/netbox/issues/3780) - Fix AttributeError exception in API docs

--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -9,6 +9,7 @@
 ## Bug Fixes
 
 * [#3106](https://github.com/netbox-community/netbox/issues/3106) - Restrict queryset of chained fields when form validation fails
+* [#3589](https://github.com/netbox-community/netbox/issues/3589) - Limit the list of available VLANs to those valid and perform input validation on the tagged VLANs
 * [#3695](https://github.com/netbox-community/netbox/issues/3695) - Include A/Z termination sites for circuits in global search
 * [#3712](https://github.com/netbox-community/netbox/issues/3712) - Scrolling to target (hash) did not account for the header size
 * [#3780](https://github.com/netbox-community/netbox/issues/3780) - Fix AttributeError exception in API docs

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -2236,36 +2236,6 @@ class InterfaceForm(InterfaceCommonForm, BootstrapMixin, forms.ModelForm):
                 device__in=[self.instance.device, self.instance.device.get_vc_master()], type=IFACE_TYPE_LAG
             )
 
-        # Limit VLan choices to those in: global vlans, global groups, the current site's group, the current site
-        vlan_choices = []
-        global_vlans = VLAN.objects.filter(site=None, group=None)
-        vlan_choices.append(
-            ('Global', [(vlan.pk, vlan) for vlan in global_vlans])
-        )
-        for group in VLANGroup.objects.filter(site=None):
-            global_group_vlans = VLAN.objects.filter(group=group)
-            vlan_choices.append(
-                (group.name, [(vlan.pk, vlan) for vlan in global_group_vlans])
-            )
-
-        site = getattr(self.instance.parent, 'site', None)
-        if site is not None:
-
-            # Add non-grouped site VLANs
-            site_vlans = VLAN.objects.filter(site=site, group=None)
-            vlan_choices.append((site.name, [(vlan.pk, vlan) for vlan in site_vlans]))
-
-            # Add grouped site VLANs
-            for group in VLANGroup.objects.filter(site=site):
-                site_group_vlans = VLAN.objects.filter(group=group)
-                vlan_choices.append((
-                    '{} / {}'.format(group.site.name, group.name),
-                    [(vlan.pk, vlan) for vlan in site_group_vlans]
-                ))
-
-        self.fields['untagged_vlan'].choices = [(None, '---------')] + vlan_choices
-        self.fields['tagged_vlans'].choices = vlan_choices
-
 
 class InterfaceCreateForm(InterfaceCommonForm, ComponentForm, forms.Form):
     name_pattern = ExpandableNameField(
@@ -2345,36 +2315,6 @@ class InterfaceCreateForm(InterfaceCommonForm, ComponentForm, forms.Form):
             )
         else:
             self.fields['lag'].queryset = Interface.objects.none()
-
-        # Limit VLan choices to those in: global vlans, global groups, the current site's group, the current site
-        vlan_choices = []
-        global_vlans = VLAN.objects.filter(site=None, group=None)
-        vlan_choices.append(
-            ('Global', [(vlan.pk, vlan) for vlan in global_vlans])
-        )
-        for group in VLANGroup.objects.filter(site=None):
-            global_group_vlans = VLAN.objects.filter(group=group)
-            vlan_choices.append(
-                (group.name, [(vlan.pk, vlan) for vlan in global_group_vlans])
-            )
-
-        site = getattr(self.parent, 'site', None)
-        if site is not None:
-
-            # Add non-grouped site VLANs
-            site_vlans = VLAN.objects.filter(site=site, group=None)
-            vlan_choices.append((site.name, [(vlan.pk, vlan) for vlan in site_vlans]))
-
-            # Add grouped site VLANs
-            for group in VLANGroup.objects.filter(site=site):
-                site_group_vlans = VLAN.objects.filter(group=group)
-                vlan_choices.append((
-                    '{} / {}'.format(group.site.name, group.name),
-                    [(vlan.pk, vlan) for vlan in site_group_vlans]
-                ))
-
-        self.fields['untagged_vlan'].choices = [(None, '---------')] + vlan_choices
-        self.fields['tagged_vlans'].choices = vlan_choices
 
 
 class InterfaceBulkEditForm(InterfaceCommonForm, BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
@@ -2457,36 +2397,6 @@ class InterfaceBulkEditForm(InterfaceCommonForm, BootstrapMixin, AddRemoveTagsFo
             )
         else:
             self.fields['lag'].choices = []
-
-        # Limit VLan choices to those in: global vlans, global groups, the current site's group, the current site
-        vlan_choices = []
-        global_vlans = VLAN.objects.filter(site=None, group=None)
-        vlan_choices.append(
-            ('Global', [(vlan.pk, vlan) for vlan in global_vlans])
-        )
-        for group in VLANGroup.objects.filter(site=None):
-            global_group_vlans = VLAN.objects.filter(group=group)
-            vlan_choices.append(
-                (group.name, [(vlan.pk, vlan) for vlan in global_group_vlans])
-            )
-        if self.parent_obj is not None:
-            site = getattr(self.parent_obj, 'site', None)
-            if site is not None:
-
-                # Add non-grouped site VLANs
-                site_vlans = VLAN.objects.filter(site=site, group=None)
-                vlan_choices.append((site.name, [(vlan.pk, vlan) for vlan in site_vlans]))
-
-                # Add grouped site VLANs
-                for group in VLANGroup.objects.filter(site=site):
-                    site_group_vlans = VLAN.objects.filter(group=group)
-                    vlan_choices.append((
-                        '{} / {}'.format(group.site.name, group.name),
-                        [(vlan.pk, vlan) for vlan in site_group_vlans]
-                    ))
-
-        self.fields['untagged_vlan'].choices = [(None, '---------')] + vlan_choices
-        self.fields['tagged_vlans'].choices = vlan_choices
 
 
 class InterfaceBulkRenameForm(BulkRenameForm):

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -76,12 +76,14 @@ class InterfaceCommonForm:
 
         # Validate tagged VLANs; must be a global VLAN or in the same site
         else:
-            for tagged_vlan in tagged_vlans:
-                if tagged_vlan.site not in [self.cleaned_data['device'].site, None]:
-                    raise forms.ValidationError({
-                        'tagged_vlans': "The tagged VLAN ({}) must belong to the same site as the interface's parent "
-                                         "device/VM, or it must be global".format(tagged_vlan)
-                    })
+            valid_sites = [None, self.cleaned_data['device'].site]
+            invalid_vlans = [str(v) for v in tagged_vlans if v.site not in valid_sites]
+
+            if invalid_vlans:
+                raise forms.ValidationError({
+                    'tagged_vlans': "The tagged VLANs ({}) must belong to the same site as the interface's parent "
+                                    "device/VM, or they must be global".format(', '.join(invalid_vlans))
+                })
 
 
 class BulkRenameForm(forms.Form):

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -2185,6 +2185,9 @@ class InterfaceForm(InterfaceCommonForm, BootstrapMixin, forms.ModelForm):
         widget=APISelect(
             api_url="/api/ipam/vlans/",
             display_field='display_name',
+            additional_query_params={
+                'site_id': 'null'
+            },
             full=True
         )
     )
@@ -2194,6 +2197,9 @@ class InterfaceForm(InterfaceCommonForm, BootstrapMixin, forms.ModelForm):
         widget=APISelectMultiple(
             api_url="/api/ipam/vlans/",
             display_field='display_name',
+            additional_query_params={
+                'site_id': 'null'
+            },
             full=True
         )
     )
@@ -2235,6 +2241,10 @@ class InterfaceForm(InterfaceCommonForm, BootstrapMixin, forms.ModelForm):
             self.fields['lag'].queryset = Interface.objects.filter(
                 device__in=[self.instance.device, self.instance.device.get_vc_master()], type=IFACE_TYPE_LAG
             )
+
+        # Add the current site to the list of filtered VLANs
+        self.fields['untagged_vlan'].widget.attrs['1-data-additional-query-param-site_id'] = self.instance.device.site.pk
+        self.fields['tagged_vlans'].widget.attrs['1-data-additional-query-param-site_id'] = self.instance.device.site.pk
 
 
 class InterfaceCreateForm(InterfaceCommonForm, ComponentForm, forms.Form):
@@ -2287,6 +2297,9 @@ class InterfaceCreateForm(InterfaceCommonForm, ComponentForm, forms.Form):
         widget=APISelect(
             api_url="/api/ipam/vlans/",
             display_field='display_name',
+            additional_query_params={
+                'site_id': 'null'
+            },
             full=True
         )
     )
@@ -2296,6 +2309,9 @@ class InterfaceCreateForm(InterfaceCommonForm, ComponentForm, forms.Form):
         widget=APISelectMultiple(
             api_url="/api/ipam/vlans/",
             display_field='display_name',
+            additional_query_params={
+                'site_id': 'null'
+            },
             full=True
         )
     )
@@ -2315,6 +2331,10 @@ class InterfaceCreateForm(InterfaceCommonForm, ComponentForm, forms.Form):
             )
         else:
             self.fields['lag'].queryset = Interface.objects.none()
+
+        # Add the current site to the list of filtered VLANs
+        self.fields['untagged_vlan'].widget.attrs['1-data-additional-query-param-site_id'] = self.parent.site.pk
+        self.fields['tagged_vlans'].widget.attrs['1-data-additional-query-param-site_id'] = self.parent.site.pk
 
 
 class InterfaceBulkEditForm(InterfaceCommonForm, BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
@@ -2367,6 +2387,9 @@ class InterfaceBulkEditForm(InterfaceCommonForm, BootstrapMixin, AddRemoveTagsFo
         widget=APISelect(
             api_url="/api/ipam/vlans/",
             display_field='display_name',
+            additional_query_params={
+                'site_id': 'null'
+            },
             full=True
         )
     )
@@ -2376,6 +2399,9 @@ class InterfaceBulkEditForm(InterfaceCommonForm, BootstrapMixin, AddRemoveTagsFo
         widget=APISelectMultiple(
             api_url="/api/ipam/vlans/",
             display_field='display_name',
+            additional_query_params={
+                'site_id': 'null'
+            },
             full=True
         )
     )
@@ -2397,6 +2423,10 @@ class InterfaceBulkEditForm(InterfaceCommonForm, BootstrapMixin, AddRemoveTagsFo
             )
         else:
             self.fields['lag'].choices = []
+
+        # Add the current site to the list of filtered VLANs
+        self.fields['untagged_vlan'].widget.attrs['1-data-additional-query-param-site_id'] = self.parent_obj.site.pk
+        self.fields['tagged_vlans'].widget.attrs['1-data-additional-query-param-site_id'] = self.parent_obj.site.pk
 
 
 class InterfaceBulkRenameForm(BulkRenameForm):

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -2210,9 +2210,6 @@ class InterfaceForm(InterfaceCommonForm, BootstrapMixin, forms.ModelForm):
         widget=APISelect(
             api_url="/api/ipam/vlans/",
             display_field='display_name',
-            additional_query_params={
-                'site_id': 'null'
-            },
             full=True
         )
     )
@@ -2222,9 +2219,6 @@ class InterfaceForm(InterfaceCommonForm, BootstrapMixin, forms.ModelForm):
         widget=APISelectMultiple(
             api_url="/api/ipam/vlans/",
             display_field='display_name',
-            additional_query_params={
-                'site_id': 'null'
-            },
             full=True
         )
     )
@@ -2266,10 +2260,6 @@ class InterfaceForm(InterfaceCommonForm, BootstrapMixin, forms.ModelForm):
             self.fields['lag'].queryset = Interface.objects.filter(
                 device__in=[self.instance.device, self.instance.device.get_vc_master()], type=IFACE_TYPE_LAG
             )
-
-        # Add the current site to the list of filtered VLANs
-        self.fields['untagged_vlan'].widget.attrs['1-data-additional-query-param-site_id'] = self.instance.device.site.pk
-        self.fields['tagged_vlans'].widget.attrs['1-data-additional-query-param-site_id'] = self.instance.device.site.pk
 
 
 class InterfaceCreateForm(InterfaceCommonForm, ComponentForm, forms.Form):
@@ -2322,9 +2312,6 @@ class InterfaceCreateForm(InterfaceCommonForm, ComponentForm, forms.Form):
         widget=APISelect(
             api_url="/api/ipam/vlans/",
             display_field='display_name',
-            additional_query_params={
-                'site_id': 'null'
-            },
             full=True
         )
     )
@@ -2334,9 +2321,6 @@ class InterfaceCreateForm(InterfaceCommonForm, ComponentForm, forms.Form):
         widget=APISelectMultiple(
             api_url="/api/ipam/vlans/",
             display_field='display_name',
-            additional_query_params={
-                'site_id': 'null'
-            },
             full=True
         )
     )
@@ -2356,10 +2340,6 @@ class InterfaceCreateForm(InterfaceCommonForm, ComponentForm, forms.Form):
             )
         else:
             self.fields['lag'].queryset = Interface.objects.none()
-
-        # Add the current site to the list of filtered VLANs
-        self.fields['untagged_vlan'].widget.attrs['1-data-additional-query-param-site_id'] = self.parent.site.pk
-        self.fields['tagged_vlans'].widget.attrs['1-data-additional-query-param-site_id'] = self.parent.site.pk
 
 
 class InterfaceBulkEditForm(InterfaceCommonForm, BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
@@ -2412,9 +2392,6 @@ class InterfaceBulkEditForm(InterfaceCommonForm, BootstrapMixin, AddRemoveTagsFo
         widget=APISelect(
             api_url="/api/ipam/vlans/",
             display_field='display_name',
-            additional_query_params={
-                'site_id': 'null'
-            },
             full=True
         )
     )
@@ -2424,9 +2401,6 @@ class InterfaceBulkEditForm(InterfaceCommonForm, BootstrapMixin, AddRemoveTagsFo
         widget=APISelectMultiple(
             api_url="/api/ipam/vlans/",
             display_field='display_name',
-            additional_query_params={
-                'site_id': 'null'
-            },
             full=True
         )
     )
@@ -2448,10 +2422,6 @@ class InterfaceBulkEditForm(InterfaceCommonForm, BootstrapMixin, AddRemoveTagsFo
             )
         else:
             self.fields['lag'].choices = []
-
-        # Add the current site to the list of filtered VLANs
-        self.fields['untagged_vlan'].widget.attrs['1-data-additional-query-param-site_id'] = self.parent_obj.site.pk
-        self.fields['tagged_vlans'].widget.attrs['1-data-additional-query-param-site_id'] = self.parent_obj.site.pk
 
 
 class InterfaceBulkRenameForm(BulkRenameForm):

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -75,7 +75,7 @@ class InterfaceCommonForm:
             self.cleaned_data['tagged_vlans'] = []
 
         # Validate tagged VLANs; must be a global VLAN or in the same site
-        else:
+        elif self.cleaned_data['mode'] == IFACE_MODE_TAGGED:
             valid_sites = [None, self.cleaned_data['device'].site]
             invalid_vlans = [str(v) for v in tagged_vlans if v.site not in valid_sites]
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -74,7 +74,7 @@ class InterfaceCommonForm:
         elif self.cleaned_data['mode'] == IFACE_MODE_TAGGED_ALL:
             self.cleaned_data['tagged_vlans'] = []
 
-        # Validate tagged VLANs; must be a global VLAN or in the same site 
+        # Validate tagged VLANs; must be a global VLAN or in the same site
         else:
             for tagged_vlan in tagged_vlans:
                 if tagged_vlan.site not in [self.cleaned_data['device'].site, None]:

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -74,6 +74,15 @@ class InterfaceCommonForm:
         elif self.cleaned_data['mode'] == IFACE_MODE_TAGGED_ALL:
             self.cleaned_data['tagged_vlans'] = []
 
+        # Validate tagged VLANs; must be a global VLAN or in the same site 
+        else:
+            for tagged_vlan in tagged_vlans:
+                if tagged_vlan.site not in [self.cleaned_data['device'].site, None]:
+                    raise forms.ValidationError({
+                        'tagged_vlans': "The tagged VLAN ({}) must belong to the same site as the interface's parent "
+                                         "device/VM, or it must be global".format(tagged_vlan)
+                    })
+
 
 class BulkRenameForm(forms.Form):
     """


### PR DESCRIPTION
### Fixes: #3589

* Perform validation on the tagged VLANs similar to that which is already performed on the untagged VLAN
* Removes the legacy choices filter that is no longer used because the API-based select widgets override the choices
* Limit the select filter to only global VLANs or VLANs in the same site as the device

> Because there currently isn't a way to specify multiple values for the same parameter, I had to work around it.
