### PR TITLE
Fixes #3815: Select2 width handling via theme

### DIFF
--- a/netbox/project-static/js/forms.js
+++ b/netbox/project-static/js/forms.js
@@ -103,14 +103,16 @@ $(document).ready(function() {
         placeholder: "---------",
         theme: "bootstrap",
         templateResult: colorPickerClassCopy,
-        templateSelection: colorPickerClassCopy
+        templateSelection: colorPickerClassCopy,
+        width: "off"
     });
 
     // Static choice selection
     $('.netbox-select2-static').select2({
         allowClear: true,
         placeholder: "---------",
-        theme: "bootstrap"
+        theme: "bootstrap",
+        width: "off"
     });
 
     // API backed selection
@@ -120,6 +122,7 @@ $(document).ready(function() {
         allowClear: true,
         placeholder: "---------",
         theme: "bootstrap",
+        width: "off",
         ajax: {
             delay: 500,
 
@@ -299,7 +302,7 @@ $(document).ready(function() {
         multiple: true,
         allowClear: true,
         placeholder: "Tags",
-
+        width: "off",
         ajax: {
             delay: 250,
             url: netbox_api_path + "extras/tags/",

--- a/netbox/project-static/js/forms.js
+++ b/netbox/project-static/js/forms.js
@@ -302,6 +302,7 @@ $(document).ready(function() {
         multiple: true,
         allowClear: true,
         placeholder: "Tags",
+        theme: "bootstrap",
         width: "off",
         ajax: {
             delay: 250,


### PR DESCRIPTION
### Fixes: #3815

Turn off the static width by Select2 as the bootstrap theme is handling it; Select2 is setting it just a touch too small.

The tag's `select2` didn't have the theme so had to add it. Alternatively, I could leave the width as is for the tag and remove the theme (as it was), though I don't know if it was missing for a reason.