### PR TITLE
Fixes #2598: Toggle for showing available prefixes/ip addresses

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -2,7 +2,6 @@
 
 ## Enhancements
 
-* [#2589](https://github.com/netbox-community/netbox/issues/2589) - Toggle for showing available prefixes/ip addresses
 * [#2892](https://github.com/netbox-community/netbox/issues/2892) - Extend admin UI to allow deleting old report results
 * [#3062](https://github.com/netbox-community/netbox/issues/3062) - Add `assigned_to_interface` filter for IP addresses
 * [#3461](https://github.com/netbox-community/netbox/issues/3461) - Fail gracefully on custom link rendering exception

--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-* [#2365](https://github.com/netbox-community/netbox/issues/2365) - Toggle for showing available prefixes/ip addresses
+* [#2589](https://github.com/netbox-community/netbox/issues/2589) - Toggle for showing available prefixes/ip addresses
 * [#2892](https://github.com/netbox-community/netbox/issues/2892) - Extend admin UI to allow deleting old report results
 * [#3062](https://github.com/netbox-community/netbox/issues/3062) - Add `assigned_to_interface` filter for IP addresses
 * [#3461](https://github.com/netbox-community/netbox/issues/3461) - Fail gracefully on custom link rendering exception

--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -1,3 +1,9 @@
+# v2.6.12 (FUTURE)
+
+## Enhancements
+
+* [#2589](https://github.com/netbox-community/netbox/issues/2589) - Toggle for showing available prefixes/ip addresses
+
 # v2.6.11 (2020-01-03)
 
 ## Bug Fixes

--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -2,6 +2,7 @@
 
 ## Enhancements
 
+* [#2365](https://github.com/netbox-community/netbox/issues/2365) - Toggle for showing available prefixes/ip addresses
 * [#3705](https://github.com/netbox-community/netbox/issues/3705) - Provide request context when executing custom scripts
 * [#3762](https://github.com/netbox-community/netbox/issues/3762) - Add date/time picker widgets
 * [#3788](https://github.com/netbox-community/netbox/issues/3788) - Enable partial search for inventory items

--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -4,6 +4,8 @@
 
 * [#2589](https://github.com/netbox-community/netbox/issues/2589) - Toggle for showing available prefixes/ip addresses
 
+---
+
 # v2.6.11 (2020-01-03)
 
 ## Bug Fixes

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -334,12 +334,8 @@ class AggregateView(PermissionRequiredMixin, View):
             limit=0
         )
 
-        # Update the ipam_show_available cookie if request specifies it
-        if request.GET.get('show_available'):
-            request.session['ipam_show_available'] = request.GET.get('show_available') == 'true'
-
-        # Add available prefixes to the table if the cookie requested it
-        if request.session.get('ipam_show_available'):
+        # Add available prefixes to the table if requested
+        if request.GET.get('show_available', False):
             child_prefixes = add_available_prefixes(aggregate.prefix, child_prefixes)
 
         prefix_table = tables.PrefixDetailTable(child_prefixes)
@@ -363,7 +359,7 @@ class AggregateView(PermissionRequiredMixin, View):
             'aggregate': aggregate,
             'prefix_table': prefix_table,
             'permissions': permissions,
-            'show_available': request.session.get('ipam_show_available', False),
+            'show_available': request.GET.get('show_available', False),
         })
 
 
@@ -519,12 +515,8 @@ class PrefixPrefixesView(PermissionRequiredMixin, View):
             'site', 'vlan', 'role',
         ).annotate_depth(limit=0)
 
-        # Update the ipam_show_available cookie if request specifies it
-        if request.GET.get('show_available'):
-            request.session['ipam_show_available'] = request.GET.get('show_available') == 'true'
-
-        # Add available prefixes to the table if the cookie requested it
-        if child_prefixes and request.session.get('ipam_show_available'):
+        # Add available prefixes to the table if requested
+        if child_prefixes and request.GET.get('show_available', False):
             child_prefixes = add_available_prefixes(prefix.prefix, child_prefixes)
 
         prefix_table = tables.PrefixDetailTable(child_prefixes)
@@ -551,7 +543,7 @@ class PrefixPrefixesView(PermissionRequiredMixin, View):
             'permissions': permissions,
             'bulk_querystring': 'vrf_id={}&within={}'.format(prefix.vrf.pk if prefix.vrf else '0', prefix.prefix),
             'active_tab': 'prefixes',
-            'show_available': request.session.get('ipam_show_available', False),
+            'show_available': request.GET.get('show_available', False),
         })
 
 
@@ -567,12 +559,8 @@ class PrefixIPAddressesView(PermissionRequiredMixin, View):
             'vrf', 'interface__device', 'primary_ip4_for', 'primary_ip6_for'
         )
 
-        # Update the ipam_show_available cookie if request specifies it
-        if request.GET.get('show_available'):
-            request.session['ipam_show_available'] = request.GET.get('show_available') == 'true'
-
-        # Add available IP addresses to the table if the cookie requested it
-        if request.session.get('ipam_show_available'):
+        # Add available IP addresses to the table if requested
+        if request.GET.get('show_available', False):
             ipaddresses = add_available_ipaddresses(prefix.prefix, ipaddresses, prefix.is_pool)
 
         ip_table = tables.IPAddressTable(ipaddresses)
@@ -599,7 +587,7 @@ class PrefixIPAddressesView(PermissionRequiredMixin, View):
             'permissions': permissions,
             'bulk_querystring': 'vrf_id={}&parent={}'.format(prefix.vrf.pk if prefix.vrf else '0', prefix.prefix),
             'active_tab': 'ip-addresses',
-            'show_available': request.session.get('ipam_show_available', False),
+            'show_available': request.GET.get('show_available', False),
         })
 
 

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -335,7 +335,7 @@ class AggregateView(PermissionRequiredMixin, View):
         )
 
         # Add available prefixes to the table if requested
-        if request.GET.get('show_available', False):
+        if request.GET.get('show_available', 'true') == 'true':
             child_prefixes = add_available_prefixes(aggregate.prefix, child_prefixes)
 
         prefix_table = tables.PrefixDetailTable(child_prefixes)
@@ -359,7 +359,7 @@ class AggregateView(PermissionRequiredMixin, View):
             'aggregate': aggregate,
             'prefix_table': prefix_table,
             'permissions': permissions,
-            'show_available': request.GET.get('show_available', False),
+            'show_available': request.GET.get('show_available', 'true') == 'true',
         })
 
 
@@ -516,7 +516,7 @@ class PrefixPrefixesView(PermissionRequiredMixin, View):
         ).annotate_depth(limit=0)
 
         # Add available prefixes to the table if requested
-        if child_prefixes and request.GET.get('show_available', False):
+        if child_prefixes and request.GET.get('show_available', 'true') == 'true':
             child_prefixes = add_available_prefixes(prefix.prefix, child_prefixes)
 
         prefix_table = tables.PrefixDetailTable(child_prefixes)
@@ -543,7 +543,7 @@ class PrefixPrefixesView(PermissionRequiredMixin, View):
             'permissions': permissions,
             'bulk_querystring': 'vrf_id={}&within={}'.format(prefix.vrf.pk if prefix.vrf else '0', prefix.prefix),
             'active_tab': 'prefixes',
-            'show_available': request.GET.get('show_available', False),
+            'show_available': request.GET.get('show_available', 'true') == 'true',
         })
 
 
@@ -560,7 +560,7 @@ class PrefixIPAddressesView(PermissionRequiredMixin, View):
         )
 
         # Add available IP addresses to the table if requested
-        if request.GET.get('show_available', False):
+        if request.GET.get('show_available', 'true') == 'true':
             ipaddresses = add_available_ipaddresses(prefix.prefix, ipaddresses, prefix.is_pool)
 
         ip_table = tables.IPAddressTable(ipaddresses)
@@ -587,7 +587,7 @@ class PrefixIPAddressesView(PermissionRequiredMixin, View):
             'permissions': permissions,
             'bulk_querystring': 'vrf_id={}&parent={}'.format(prefix.vrf.pk if prefix.vrf else '0', prefix.prefix),
             'active_tab': 'ip-addresses',
-            'show_available': request.GET.get('show_available', False),
+            'show_available': request.GET.get('show_available', 'true') == 'true',
         })
 
 

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -363,7 +363,7 @@ class AggregateView(PermissionRequiredMixin, View):
             'aggregate': aggregate,
             'prefix_table': prefix_table,
             'permissions': permissions,
-            'show_available': request.session.get('ipam_show_available'),
+            'show_available': request.session.get('ipam_show_available', False),
         })
 
 
@@ -551,7 +551,7 @@ class PrefixPrefixesView(PermissionRequiredMixin, View):
             'permissions': permissions,
             'bulk_querystring': 'vrf_id={}&within={}'.format(prefix.vrf.pk if prefix.vrf else '0', prefix.prefix),
             'active_tab': 'prefixes',
-            'show_available': request.session.get('ipam_show_available'),
+            'show_available': request.session.get('ipam_show_available', False),
         })
 
 
@@ -599,7 +599,7 @@ class PrefixIPAddressesView(PermissionRequiredMixin, View):
             'permissions': permissions,
             'bulk_querystring': 'vrf_id={}&parent={}'.format(prefix.vrf.pk if prefix.vrf else '0', prefix.prefix),
             'active_tab': 'ip-addresses',
-            'show_available': request.session.get('ipam_show_available'),
+            'show_available': request.session.get('ipam_show_available', False),
         })
 
 

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -335,7 +335,7 @@ class AggregateView(PermissionRequiredMixin, View):
         )
 
         # Update the ipam_show_available cookie if request specifies it
-        if request.GET.get('show_available') is not None:
+        if request.GET.get('show_available'):
             request.session['ipam_show_available'] = request.GET.get('show_available') == 'true'
 
         # Add available prefixes to the table if the cookie requested it
@@ -520,7 +520,7 @@ class PrefixPrefixesView(PermissionRequiredMixin, View):
         ).annotate_depth(limit=0)
 
         # Update the ipam_show_available cookie if request specifies it
-        if request.GET.get('show_available') is not None:
+        if request.GET.get('show_available'):
             request.session['ipam_show_available'] = request.GET.get('show_available') == 'true'
 
         # Add available prefixes to the table if the cookie requested it
@@ -568,7 +568,7 @@ class PrefixIPAddressesView(PermissionRequiredMixin, View):
         )
 
         # Update the ipam_show_available cookie if request specifies it
-        if request.GET.get('show_available') is not None:
+        if request.GET.get('show_available'):
             request.session['ipam_show_available'] = request.GET.get('show_available') == 'true'
 
         # Add available IP addresses to the table if the cookie requested it

--- a/netbox/templates/ipam/aggregate.html
+++ b/netbox/templates/ipam/aggregate.html
@@ -40,6 +40,14 @@
     </div>
     <h1>{% block title %}{{ aggregate }}{% endblock %}</h1>
     {% include 'inc/created_updated.html' with obj=aggregate %}
+    {% if show_available is not None %}
+        <div class="pull-right">
+            <div class="btn-group" role="group">
+                <a href="{{ request.path }}{% querystring request show_available='true' %}" class="btn btn-default{% if show_available %} active disabled{% endif %}">Show available</a>
+                <a href="{{ request.path }}{% querystring request show_available='false' %}" class="btn btn-default{% if not show_available %} active disabled{% endif %}">Hide available</a>
+            </div>
+        </div>
+    {% endif %}
     <div class="pull-right noprint">
         {% custom_links aggregate %}
     </div>

--- a/netbox/templates/ipam/aggregate.html
+++ b/netbox/templates/ipam/aggregate.html
@@ -40,14 +40,7 @@
     </div>
     <h1>{% block title %}{{ aggregate }}{% endblock %}</h1>
     {% include 'inc/created_updated.html' with obj=aggregate %}
-    {% if show_available is not None %}
-        <div class="pull-right">
-            <div class="btn-group" role="group">
-                <a href="{{ request.path }}{% querystring request show_available='true' %}" class="btn btn-default{% if show_available %} active disabled{% endif %}">Show available</a>
-                <a href="{{ request.path }}{% querystring request show_available='false' %}" class="btn btn-default{% if not show_available %} active disabled{% endif %}">Hide available</a>
-            </div>
-        </div>
-    {% endif %}
+    {% include 'ipam/inc/toggle_available.html' %}
     <div class="pull-right noprint">
         {% custom_links aggregate %}
     </div>

--- a/netbox/templates/ipam/inc/toggle_available.html
+++ b/netbox/templates/ipam/inc/toggle_available.html
@@ -1,0 +1,9 @@
+{% load helpers %}
+{% if show_available is not None %}
+    <div class="pull-right">
+        <div class="btn-group" role="group">
+            <a href="{{ request.path }}{% querystring request show_available='true' %}" class="btn btn-default{% if show_available %} active disabled{% endif %}">Show available</a>
+            <a href="{{ request.path }}{% querystring request show_available='false' %}" class="btn btn-default{% if not show_available %} active disabled{% endif %}">Hide available</a>
+        </div>
+    </div>
+{% endif %}

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -53,14 +53,7 @@
     </div>
     <h1>{% block title %}{{ prefix }}{% endblock %}</h1>
     {% include 'inc/created_updated.html' with obj=prefix %}
-    {% if show_available is not None %}
-        <div class="pull-right">
-            <div class="btn-group" role="group">
-                <a href="{{ request.path }}{% querystring request show_available='true' %}" class="btn btn-default{% if show_available %} active disabled{% endif %}">Show available</a>
-                <a href="{{ request.path }}{% querystring request show_available='false' %}" class="btn btn-default{% if not show_available %} active disabled{% endif %}">Hide available</a>
-            </div>
-        </div>
-    {% endif %}
+    {% include 'ipam/inc/toggle_available.html' %}
     <div class="pull-right noprint">
         {% custom_links prefix %}
     </div>

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -53,6 +53,14 @@
     </div>
     <h1>{% block title %}{{ prefix }}{% endblock %}</h1>
     {% include 'inc/created_updated.html' with obj=prefix %}
+    {% if show_available is not None %}
+        <div class="pull-right">
+            <div class="btn-group" role="group">
+                <a href="{{ request.path }}{% querystring request show_available='true' %}" class="btn btn-default{% if show_available %} active disabled{% endif %}">Show available</a>
+                <a href="{{ request.path }}{% querystring request show_available='false' %}" class="btn btn-default{% if not show_available %} active disabled{% endif %}">Hide available</a>
+            </div>
+        </div>
+    {% endif %}
     <div class="pull-right noprint">
         {% custom_links prefix %}
     </div>


### PR DESCRIPTION
### Fixes: #2598

Adds a cookie-based toggle to showing/hiding available prefixes and IP addresses