### PR TITLE
Fixes #3822:  device bay edit

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -14,6 +14,7 @@
 * [#3780](https://github.com/netbox-community/netbox/issues/3780) - Fix AttributeError exception in API docs
 * [#3809](https://github.com/netbox-community/netbox/issues/3809) - Filter platform by manufacturer when editing devices
 * [#3811](https://github.com/netbox-community/netbox/issues/3811) - Fix filtering of racks by group on device list
+* [#3822](https://github.com/netbox-community/netbox/issues/3822) - Fix failure to update device bay from edit page
 
 ---
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -3189,10 +3189,11 @@ class DeviceBayForm(BootstrapMixin, forms.ModelForm):
     class Meta:
         model = DeviceBay
         fields = [
-            'device', 'name', 'description', 'tags',
+            'device', 'installed_device', 'name', 'description', 'tags',
         ]
         widgets = {
             'device': forms.HiddenInput(),
+            'installed_device': forms.HiddenInput(),
         }
 
 

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -2597,7 +2597,7 @@ class DeviceBay(ComponentModel):
         # Check that the installed device is not already installed elsewhere
         if self.installed_device:
             current_bay = DeviceBay.objects.filter(installed_device=self.installed_device).first()
-            if current_bay != self:
+            if current_bay and current_bay != self:
                 raise ValidationError({
                     'installed_device': "Cannot install the specified device; device is already installed in {}".format(
                         current_bay

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -2597,7 +2597,7 @@ class DeviceBay(ComponentModel):
         # Check that the installed device is not already installed elsewhere
         if self.installed_device:
             current_bay = DeviceBay.objects.filter(installed_device=self.installed_device).first()
-            if current_bay:
+            if current_bay != self:
                 raise ValidationError({
                     'installed_device': "Cannot install the specified device; device is already installed in {}".format(
                         current_bay


### PR DESCRIPTION
### Fixes: #3822

The edit form for the device bay was missing `installed_device` as a hidden input field.

When fixing the above issue, I noticed that there was a logic issue in the model of `DeviceBay` in that it did not allow updates once created and a device is installed because of the `current_bay` of the installed device condition. This was fixed by allowing the update to go through if the current_bay is the bay to be updated, or, stated differently, fail if current_bay is not the bay to be updated.

> You could also exclude `self` from the query for `current_bay`. Not sure which is the better approach.