### PR TITLE
Fixes #3090: Interface filtering

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -4,6 +4,8 @@
 
 * [#3090](https://github.com/netbox-community/netbox/issues/3090) - Add filter field for device interfaces
 
+---
+
 # v2.6.11 (2020-01-03)
 
 ## Bug Fixes

--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -1,3 +1,9 @@
+# v2.6.12 (FUTURE)
+
+## Enhancements
+
+* [#3090](https://github.com/netbox-community/netbox/issues/3090) - Add filter field for device interfaces
+
 # v2.6.11 (2020-01-03)
 
 ## Bug Fixes

--- a/netbox/project-static/js/forms.js
+++ b/netbox/project-static/js/forms.js
@@ -7,7 +7,7 @@ $(document).ready(function() {
 
     // "Toggle" checkbox for object lists (PK column)
     $('input:checkbox.toggle').click(function() {
-        $(this).closest('table').find('input:checkbox[name=pk]').prop('checked', $(this).prop('checked'));
+        $(this).closest('table').find('input:checkbox[name=pk]:visible').prop('checked', $(this).prop('checked'));
 
         // Show the "select all" box if present
         if ($(this).is(':checked')) {

--- a/netbox/project-static/js/forms.js
+++ b/netbox/project-static/js/forms.js
@@ -400,8 +400,8 @@ $(document).ready(function() {
     window.addEventListener('hashchange', headerOffsetScroll);
 
     // Offset between the preview window and the window edges
-    const IMAGE_PREVIEW_OFFSET_X = 20
-    const IMAGE_PREVIEW_OFFSET_Y = 10
+    const IMAGE_PREVIEW_OFFSET_X = 20;
+    const IMAGE_PREVIEW_OFFSET_Y = 10;
 
     // Preview an image attachment when the link is hovered over
     $('a.image-preview').on('mouseover', function(e) {
@@ -435,6 +435,6 @@ $(document).ready(function() {
 
     // Fade the image out; it will be deleted when another one is previewed
     $('a.image-preview').on('mouseout', function() {
-        $('#image-preview-window').fadeOut('fast')
+        $('#image-preview-window').fadeOut('fast');
     });
 });

--- a/netbox/project-static/js/interface_toggles.js
+++ b/netbox/project-static/js/interface_toggles.js
@@ -1,0 +1,30 @@
+// Toggle the display of IP addresses under interfaces
+$('button.toggle-ips').click(function() {
+    var selected = $(this).attr('selected');
+    if (selected) {
+        $('#interfaces_table tr.ipaddresses').hide();
+    } else {
+        $('#interfaces_table tr.ipaddresses').show();
+    }
+    $(this).attr('selected', !selected);
+    $(this).children('span').toggleClass('glyphicon-check glyphicon-unchecked');
+    return false;
+});
+
+// Inteface filtering
+$('input.interface-filter').on('input', function() {
+    var filter = new RegExp(this.value);
+
+    for (interface of $(this).closest('form').find('tbody > tr')) {
+        // Slice off 'interface_' at the start of the ID
+        if (filter && filter.test(interface.id.slice(10))) {
+            // Match the toggle in case the filter now matches the interface
+            $(interface).find('input:checkbox[name=pk]').prop('checked', $('input.toggle').prop('checked'));
+            $(interface).show();
+        } else {
+            // Uncheck to prevent actions from including it when it doesn't match
+            $(interface).find('input:checkbox[name=pk]').prop('checked', false);
+            $(interface).hide();
+        }
+    }
+});

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -557,7 +557,7 @@
                             </button>
                         </div>
                         <div class="col-md-2 pull-right noprint">
-                            <input class="form-control interface-filter" type="text" placeholder="Filter (RegExp)" style="height: 24px" />
+                            <input class="form-control interface-filter" type="text" placeholder="Filter (RegExp)" style="height: 23px" />
                         </div>
                     </div>
                     <table id="interfaces_table" class="table table-hover table-headings panel-body component-list">

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -557,7 +557,7 @@
                             </button>
                         </div>
                         <div class="col-md-2 pull-right noprint">
-                            <input class="form-control interface-filter" type="text" placeholder="Filter (RegExp)" style="height: 23px" />
+                            <input class="form-control interface-filter" type="text" placeholder="Filter" title="RegEx-enabled" style="height: 23px" />
                         </div>
                     </div>
                     <table id="interfaces_table" class="table table-hover table-headings panel-body component-list">

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -903,35 +903,8 @@ function toggleConnection(elem) {
 $(".cable-toggle").click(function() {
     return toggleConnection($(this));
 });
-// Toggle the display of IP addresses under interfaces
-$('button.toggle-ips').click(function() {
-    var selected = $(this).attr('selected');
-    if (selected) {
-        $('#interfaces_table tr.ipaddresses').hide();
-    } else {
-        $('#interfaces_table tr.ipaddresses').show();
-    }
-    $(this).attr('selected', !selected);
-    $(this).children('span').toggleClass('glyphicon-check glyphicon-unchecked');
-    return false;
-});
-$('input.interface-filter').on('input', function() {
-    var filter = new RegExp(this.value);
-
-    for (interface of $(this).closest('form').find('tbody > tr')) {
-        // Slice off 'interface_' at the start of the ID
-        if (filter && filter.test(interface.id.slice(10))) {
-            // Match the toggle in case the filter now matches the interface
-            $(interface).find('input:checkbox[name=pk]').prop('checked', $('input.toggle').prop('checked'));
-            $(interface).show();
-        } else {
-            // Uncheck to prevent actions from including it when it doesn't match
-            $(interface).find('input:checkbox[name=pk]').prop('checked', false);
-            $(interface).hide();
-        }
-    }
-});
 </script>
+<script src="{% static 'js/interface_toggles.js' %}?v{{ settings.VERSION }}"></script>
 <script src="{% static 'js/graphs.js' %}?v{{ settings.VERSION }}"></script>
 <script src="{% static 'js/secrets.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock %}

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -556,6 +556,9 @@
                                 <span class="glyphicon glyphicon-check" aria-hidden="true"></span> Show IPs
                             </button>
                         </div>
+                        <div class="col-md-2 pull-right noprint">
+                            <input class="form-control interface-filter" type="text" placeholder="Filter (RegExp)" style="height: 24px" />
+                        </div>
                     </div>
                     <table id="interfaces_table" class="table table-hover table-headings panel-body component-list">
                         <thead>
@@ -911,6 +914,22 @@ $('button.toggle-ips').click(function() {
     $(this).attr('selected', !selected);
     $(this).children('span').toggleClass('glyphicon-check glyphicon-unchecked');
     return false;
+});
+$('input.interface-filter').on('input', function() {
+    var filter = new RegExp(this.value);
+
+    for (interface of $(this).closest('form').find('tbody > tr')) {
+        // Slice off 'interface_' at the start of the ID
+        if (filter && filter.test(interface.id.slice(10))) {
+            // Match the toggle in case the filter now matches the interface
+            $(interface).find('input:checkbox[name=pk]').prop('checked', $('input.toggle').prop('checked'));
+            $(interface).show();
+        } else {
+            // Uncheck to prevent actions from including it when it doesn't match
+            $(interface).find('input:checkbox[name=pk]').prop('checked', false);
+            $(interface).hide();
+        }
+    }
 });
 </script>
 <script src="{% static 'js/graphs.js' %}?v{{ settings.VERSION }}"></script>

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -254,7 +254,7 @@
                     </button>
                 </div>
                 <div class="col-md-2 pull-right noprint">
-                    <input class="form-control interface-filter" type="text" placeholder="Filter (RegExp)" style="height: 24px" />
+                    <input class="form-control interface-filter" type="text" placeholder="Filter (RegExp)" style="height: 23px" />
                 </div>
             </div>
             <table id="interfaces_table" class="table table-hover table-headings panel-body component-list">

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -1,5 +1,6 @@
 {% extends '_base.html' %}
 {% load custom_links %}
+{% load static %}
 {% load helpers %}
 
 {% block header %}
@@ -315,34 +316,5 @@
 {% endblock %}
 
 {% block javascript %}
-<script type="text/javascript">
-// Toggle the display of IP addresses under interfaces
-$('button.toggle-ips').click(function() {
-    var selected = $(this).attr('selected');
-    if (selected) {
-        $('#interfaces_table tr.ipaddresses').hide();
-    } else {
-        $('#interfaces_table tr.ipaddresses').show();
-    }
-    $(this).attr('selected', !selected);
-    $(this).children('span').toggleClass('glyphicon-check glyphicon-unchecked');
-    return false;
-});
-$('input.interface-filter').on('input', function() {
-    var filter = new RegExp(this.value);
-
-    for (interface of $(this).closest('form').find('tbody > tr')) {
-        // Slice off 'interface_' at the start of the ID
-        if (filter && filter.test(interface.id.slice(10))) {
-            // Match the toggle in case the filter now matches the interface
-            $(interface).find('input:checkbox[name=pk]').prop('checked', $('input.toggle').prop('checked'));
-            $(interface).show();
-        } else {
-            // Uncheck to prevent actions from including it when it doesn't match
-            $(interface).find('input:checkbox[name=pk]').prop('checked', false);
-            $(interface).hide();
-        }
-    }
-});
-</script>
+<script src="{% static 'js/interface_toggles.js' %}?v{{ settings.VERSION }}"></script>
 {% endblock %}

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -253,6 +253,9 @@
                         <span class="glyphicon glyphicon-check" aria-hidden="true"></span> Show IPs
                     </button>
                 </div>
+                <div class="col-md-2 pull-right noprint">
+                    <input class="form-control interface-filter" type="text" placeholder="Filter (RegExp)" style="height: 24px" />
+                </div>
             </div>
             <table id="interfaces_table" class="table table-hover table-headings panel-body component-list">
                 <thead>
@@ -324,6 +327,22 @@ $('button.toggle-ips').click(function() {
     $(this).attr('selected', !selected);
     $(this).children('span').toggleClass('glyphicon-check glyphicon-unchecked');
     return false;
+});
+$('input.interface-filter').on('input', function() {
+    var filter = new RegExp(this.value);
+
+    for (interface of $(this).closest('form').find('tbody > tr')) {
+        // Slice off 'interface_' at the start of the ID
+        if (filter && filter.test(interface.id.slice(10))) {
+            // Match the toggle in case the filter now matches the interface
+            $(interface).find('input:checkbox[name=pk]').prop('checked', $('input.toggle').prop('checked'));
+            $(interface).show();
+        } else {
+            // Uncheck to prevent actions from including it when it doesn't match
+            $(interface).find('input:checkbox[name=pk]').prop('checked', false);
+            $(interface).hide();
+        }
+    }
 });
 </script>
 {% endblock %}

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -255,7 +255,7 @@
                     </button>
                 </div>
                 <div class="col-md-2 pull-right noprint">
-                    <input class="form-control interface-filter" type="text" placeholder="Filter (RegExp)" style="height: 23px" />
+                    <input class="form-control interface-filter" type="text" placeholder="Filter" title="RegEx-enabled" style="height: 23px" />
                 </div>
             </div>
             <table id="interfaces_table" class="table table-hover table-headings panel-body component-list">


### PR DESCRIPTION
### Fixes: #3090

Add a filter for device interfaces that updates the selection as changed. It is RegEx based just because it is convenient for actions that span multiple chassises, like creating an MC-LAG.

![interface-filter](https://user-images.githubusercontent.com/34197532/71746439-ced69c80-2e64-11ea-925d-c4f19fce1c16.gif)
