### PR TITLE
Fix #3853 Dead role link in Config Contexts

### DIFF
--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -1382,6 +1382,9 @@ class DeviceRole(ChangeLoggedModel):
     def __str__(self):
         return self.name
 
+    def get_absolute_url(self):
+        return "{}?role={}".format(reverse('dcim:device_list'), self.slug)
+
     def to_csv(self):
         return (
             self.name,

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -238,7 +238,7 @@
                     <tr>
                         <td>Role</td>
                         <td>
-                            <a href="{% url 'dcim:device_list' %}?role={{ device.device_role.slug }}">{{ device.device_role }}</a>
+                            <a href="{{ device.device_role.get_absolute_url }}">{{ device.device_role }}</a>
                         </td>
                     </tr>
                     <tr>


### PR DESCRIPTION
### Fixes: #3853
The config context template calls get_absolute_url from the model DeviceRole. This method was not implemented on this model.
This result in a dead link on the config context view.

I implemented get_absolute_url on DeviceRole model.
I also updated the dcim/device template to use this method instead of the hardcoded url for consistency: the platforme link on this view used the get_absolute_url method of the Platform model.