### PR TITLE
Fixes #3857: Fix group custom links rendering

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -10,6 +10,7 @@
 * [#3589](https://github.com/netbox-community/netbox/issues/3589) - Fix validation on tagged VLANs of an interface
 * [#3853](https://github.com/netbox-community/netbox/issues/3853) - Fix device role link on config context view
 * [#3856](https://github.com/netbox-community/netbox/issues/3856) - Allow filtering VM interfaces by multiple MAC addresses
+* [#3857](https://github.com/netbox-community/netbox/issues/3857) - Fix group custom links rendering
 
 ---
 

--- a/netbox/extras/templatetags/custom_links.py
+++ b/netbox/extras/templatetags/custom_links.py
@@ -68,8 +68,9 @@ def custom_links(obj):
                 text_rendered = render_jinja2(cl.text, context)
                 if text_rendered:
                     link_target = ' target="_blank"' if cl.new_window else ''
+                    link_rendered = render_jinja2(cl.url, context)
                     links_rendered.append(
-                        GROUP_LINK.format(cl.url, link_target, cl.text)
+                        GROUP_LINK.format(link_rendered, link_target, text_rendered)
                     )
             except Exception as e:
                 links_rendered.append(


### PR DESCRIPTION
### Fixes: #3857

Group custom links were not being rendered. The template text was being instead.

Credit goes to @rodvand for practically fixing this one.
