### PR TITLE
Fixes #3440: Total cable trace length

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -4,6 +4,7 @@
 
 * [#2050](https://github.com/netbox-community/netbox/issues/2050) - Preview image attachments when hovering the link
 * [#3187](https://github.com/netbox-community/netbox/issues/3187) - Add rack selection field to rack elevations
+* [#3440](https://github.com/netbox-community/netbox/issues/3440) - Add total length to cable trace
 
 ## Bug Fixes
 

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -2950,6 +2950,8 @@ class Cable(ChangeLoggedModel):
         # Store the given length (if any) in meters for use in database ordering
         if self.length and self.length_unit:
             self._abs_length = to_meters(self.length, self.length_unit)
+        else:
+            self._abs_length = None
 
         # Store the parent Device for the A and B terminations (if applicable) to enable filtering
         if hasattr(self.termination_a, 'device'):

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1754,10 +1754,13 @@ class CableTraceView(PermissionRequiredMixin, View):
     def get(self, request, model, pk):
 
         obj = get_object_or_404(model, pk=pk)
+        trace = obj.trace(follow_circuits=True)
+        total_length = sum([entry[1]._abs_length for entry in trace if entry[1] and entry[1]._abs_length])
 
         return render(request, 'dcim/cable_trace.html', {
             'obj': obj,
-            'trace': obj.trace(follow_circuits=True),
+            'trace': trace,
+            'total_length': total_length,
         })
 
 

--- a/netbox/templates/dcim/cable_trace.html
+++ b/netbox/templates/dcim/cable_trace.html
@@ -10,7 +10,10 @@
         <div class="col-md-4 col-md-offset-1 text-center">
             <h4>Near End</h4>
         </div>
-        <div class="col-md-4 col-md-offset-3 text-center">
+        <div class="col-md-3 text-center">
+            {% if total_length %}<h5>Total length: {{ total_length|floatformat:"-2" }} Meters<h5>{% endif %}
+        </div>
+        <div class="col-md-4 text-center">
             <h4>Far End</h4>
         </div>
     </div>


### PR DESCRIPTION
### Fixes: #3440

Added total length to the cable trace. The `cable._abs_length` was not being reset to None when the `cable.length` is not set, so that was fixed as well.
