### PR TITLE
Fixes #3623: Word expansion for interfaces

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -4,6 +4,7 @@
 
 * [#2050](https://github.com/netbox-community/netbox/issues/2050) - Preview image attachments when hovering the link
 * [#3187](https://github.com/netbox-community/netbox/issues/3187) - Add rack selection field to rack elevations
+* [#3623](https://github.com/netbox-community/netbox/issues/3623) - Add word expansion during interface creation
 
 ## Bug Fixes
 

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -65,6 +65,9 @@ def parse_alphanumeric_range(string):
                 values.append(begin)
             # Range-based
             else:
+                # Not a valid range (more than a single character)
+                if not len(begin) == len(end) == 1:
+                    raise forms.ValidationError('Range "{}" is invalid.'.format(dash_range))
                 for n in list(range(ord(begin), ord(end) + 1)):
                     values.append(chr(n))
     return values
@@ -486,6 +489,7 @@ class ExpandableNameField(forms.CharField):
                              'Mixed cases and types within a single range are not supported.<br />' \
                              'Examples:<ul><li><code>ge-0/0/[0-23,25,30]</code></li>' \
                              '<li><code>e[0-3][a-d,f]</code></li>' \
+                             '<li><code>[xe,ge]-0/0/0</code></li>' \
                              '<li><code>e[0-3,a-d,f]</code></li></ul>'
 
     def to_python(self, value):

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -60,8 +60,13 @@ def parse_alphanumeric_range(string):
             for n in list(range(int(begin), int(end) + 1)):
                 values.append(n)
         else:
-            for n in list(range(ord(begin), ord(end) + 1)):
-                values.append(chr(n))
+            # Value-based
+            if begin == end:
+                values.append(begin)
+            # Range-based
+            else:
+                for n in list(range(ord(begin), ord(end) + 1)):
+                    values.append(chr(n))
     return values
 
 

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -128,6 +128,38 @@ class ExpandIPAddress(TestCase):
 
         self.assertEqual(sorted(expand_ipaddress_pattern(input, 6)), output)
 
-    # TODO: negative tests
+    def test_invalid_address_family(self):
+        with self.assertRaisesRegex(Exception, 'Invalid IP address family: 5'):
+            sorted(expand_ipaddress_pattern(None, 5))
+
+    def test_invalid_non_pattern(self):
+        with self.assertRaises(ValueError):
+            sorted(expand_ipaddress_pattern('1.2.3.4/32', 4))
+
+    def test_invalid_range(self):
+        with self.assertRaises(ValueError):
+            sorted(expand_ipaddress_pattern('1.2.3.[4-]/32', 4))
+
+        with self.assertRaises(ValueError):
+            sorted(expand_ipaddress_pattern('1.2.3.[-4]/32', 4))
+
+        with self.assertRaises(ValueError):
+            sorted(expand_ipaddress_pattern('1.2.3.[4--5]/32', 4))
+
+    def test_invalid_range_bounds(self):
+        self.assertEqual(sorted(expand_ipaddress_pattern('1.2.3.[4-3]/32', 6)), [])
+
+    def test_invalid_set(self):
+        with self.assertRaises(ValueError):
+            sorted(expand_ipaddress_pattern('1.2.3.[4]/32', 4))
+
+        with self.assertRaises(ValueError):
+            sorted(expand_ipaddress_pattern('1.2.3.[4,]/32', 4))
+
+        with self.assertRaises(ValueError):
+            sorted(expand_ipaddress_pattern('1.2.3.[,4]/32', 4))
+
+        with self.assertRaises(ValueError):
+            sorted(expand_ipaddress_pattern('1.2.3.[4,,5]/32', 4))
 
 # TODO: alphanumeric

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -14,7 +14,7 @@ class ExpandIPAddress(TestCase):
             '1.2.3.10/32',
         ])
 
-        self.assertEqual(sorted(list(expand_ipaddress_pattern(input, 4))), output)
+        self.assertEqual(sorted(expand_ipaddress_pattern(input, 4)), output)
 
     def test_ipv4_set(self):
         input = '1.2.3.[4,44]/32'
@@ -23,7 +23,7 @@ class ExpandIPAddress(TestCase):
             '1.2.3.44/32',
         ])
 
-        self.assertEqual(sorted(list(expand_ipaddress_pattern(input, 4))), output)
+        self.assertEqual(sorted(expand_ipaddress_pattern(input, 4)), output)
 
     def test_ipv4_multiple_ranges(self):
         input = '1.[9-10].3.[9-11]/32'
@@ -36,7 +36,7 @@ class ExpandIPAddress(TestCase):
             '1.10.3.11/32',
         ])
 
-        self.assertEqual(sorted(list(expand_ipaddress_pattern(input, 4))), output)
+        self.assertEqual(sorted(expand_ipaddress_pattern(input, 4)), output)
 
     def test_ipv4_multiple_sets(self):
         input = '1.[2,22].3.[4,44]/32'
@@ -47,8 +47,7 @@ class ExpandIPAddress(TestCase):
             '1.22.3.44/32',
         ])
 
-        self.assertEqual(sorted(list(expand_ipaddress_pattern(input, 4))), output)
-
+        self.assertEqual(sorted(expand_ipaddress_pattern(input, 4)), output)
 
     def test_ipv4_set_and_range(self):
         input = '1.[2,22].3.[9-11]/32'
@@ -61,7 +60,7 @@ class ExpandIPAddress(TestCase):
             '1.22.3.11/32',
         ])
 
-        self.assertEqual(sorted(list(expand_ipaddress_pattern(input, 4))), output)
+        self.assertEqual(sorted(expand_ipaddress_pattern(input, 4)), output)
 
     # TODO: IPv6
     # TODO: negative tests

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -62,7 +62,72 @@ class ExpandIPAddress(TestCase):
 
         self.assertEqual(sorted(expand_ipaddress_pattern(input, 4)), output)
 
-    # TODO: IPv6
+    def test_ipv6_range(self):
+        input = 'fec::abcd:[9-b]/64'
+        output = sorted([
+            'fec::abcd:9/64',
+            'fec::abcd:a/64',
+            'fec::abcd:b/64',
+        ])
+
+        self.assertEqual(sorted(expand_ipaddress_pattern(input, 6)), output)
+
+    def test_ipv6_range_multichar_field(self):
+        input = 'fec::abcd:[f-11]/64'
+        output = sorted([
+            'fec::abcd:f/64',
+            'fec::abcd:10/64',
+            'fec::abcd:11/64',
+        ])
+
+        self.assertEqual(sorted(expand_ipaddress_pattern(input, 6)), output)
+
+    def test_ipv6_set(self):
+        input = 'fec::abcd:[9,ab]/64'
+        output = sorted([
+            'fec::abcd:9/64',
+            'fec::abcd:ab/64',
+        ])
+
+        self.assertEqual(sorted(expand_ipaddress_pattern(input, 6)), output)
+
+    def test_ipv6_multiple_ranges(self):
+        input = 'fec::[1-2]bcd:[9-b]/64'
+        output = sorted([
+            'fec::1bcd:9/64',
+            'fec::1bcd:a/64',
+            'fec::1bcd:b/64',
+            'fec::2bcd:9/64',
+            'fec::2bcd:a/64',
+            'fec::2bcd:b/64',
+        ])
+
+        self.assertEqual(sorted(expand_ipaddress_pattern(input, 6)), output)
+
+    def test_ipv6_multiple_sets(self):
+        input = 'fec::[a,f]bcd:[9,ab]/64'
+        output = sorted([
+            'fec::abcd:9/64',
+            'fec::abcd:ab/64',
+            'fec::fbcd:9/64',
+            'fec::fbcd:ab/64',
+        ])
+
+        self.assertEqual(sorted(expand_ipaddress_pattern(input, 6)), output)
+
+    def test_ipv6_set_and_range(self):
+        input = 'fec::[dead,beaf]:[9-b]/64'
+        output = sorted([
+            'fec::dead:9/64',
+            'fec::dead:a/64',
+            'fec::dead:b/64',
+            'fec::beaf:9/64',
+            'fec::beaf:a/64',
+            'fec::beaf:b/64',
+        ])
+
+        self.assertEqual(sorted(expand_ipaddress_pattern(input, 6)), output)
+
     # TODO: negative tests
 
 # TODO: alphanumeric

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -1,0 +1,69 @@
+from django.test import TestCase
+
+from utilities.forms import *
+
+
+class ExpandIPAddress(TestCase):
+    """
+    Validate the operation of expand_ipaddress_pattern().
+    """
+    def test_ipv4_range(self):
+        input = '1.2.3.[9-10]/32'
+        output = sorted([
+            '1.2.3.9/32',
+            '1.2.3.10/32',
+        ])
+
+        self.assertEqual(sorted(list(expand_ipaddress_pattern(input, 4))), output)
+
+    def test_ipv4_set(self):
+        input = '1.2.3.[4,44]/32'
+        output = sorted([
+            '1.2.3.4/32',
+            '1.2.3.44/32',
+        ])
+
+        self.assertEqual(sorted(list(expand_ipaddress_pattern(input, 4))), output)
+
+    def test_ipv4_multiple_ranges(self):
+        input = '1.[9-10].3.[9-11]/32'
+        output = sorted([
+            '1.9.3.9/32',
+            '1.9.3.10/32',
+            '1.9.3.11/32',
+            '1.10.3.9/32',
+            '1.10.3.10/32',
+            '1.10.3.11/32',
+        ])
+
+        self.assertEqual(sorted(list(expand_ipaddress_pattern(input, 4))), output)
+
+    def test_ipv4_multiple_sets(self):
+        input = '1.[2,22].3.[4,44]/32'
+        output = sorted([
+            '1.2.3.4/32',
+            '1.2.3.44/32',
+            '1.22.3.4/32',
+            '1.22.3.44/32',
+        ])
+
+        self.assertEqual(sorted(list(expand_ipaddress_pattern(input, 4))), output)
+
+
+    def test_ipv4_set_and_range(self):
+        input = '1.[2,22].3.[9-11]/32'
+        output = sorted([
+            '1.2.3.9/32',
+            '1.2.3.10/32',
+            '1.2.3.11/32',
+            '1.22.3.9/32',
+            '1.22.3.10/32',
+            '1.22.3.11/32',
+        ])
+
+        self.assertEqual(sorted(list(expand_ipaddress_pattern(input, 4))), output)
+
+    # TODO: IPv6
+    # TODO: negative tests
+
+# TODO: alphanumeric


### PR DESCRIPTION
### Fixes: #3623 

Word expansion for interfaces. Just needed accept non-ranges as values. Also added graceful handling to ranges with more than a single character (currently throws an `ord` error because it has more than one character in a range's beginning or end).

> I could not, for the life of me, think of a better example of word expansion than `[xe,ge]-0/0/0`. I'm open for suggestions.