### PR TITLE
Add FilterSet tests for all apps

### DIFF
--- a/netbox/circuits/filters.py
+++ b/netbox/circuits/filters.py
@@ -8,6 +8,13 @@ from utilities.filters import NameSlugSearchFilterSet, NumericInFilter, TagFilte
 from .constants import *
 from .models import Circuit, CircuitTermination, CircuitType, Provider
 
+__all__ = (
+    'CircuitFilter',
+    'CircuitTerminationFilter',
+    'CircuitTypeFilter',
+    'ProviderFilter',
+)
+
 
 class ProviderFilter(CustomFieldFilterSet, CreatedUpdatedFilterSet):
     id__in = NumericInFilter(

--- a/netbox/circuits/tests/test_filters.py
+++ b/netbox/circuits/tests/test_filters.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from circuits.constants import CIRCUIT_STATUS_ACTIVE, CIRCUIT_STATUS_OFFLINE, CIRCUIT_STATUS_PLANNED
-from circuits.filters import CircuitFilter, CircuitTerminationFilter, CircuitTypeFilter, ProviderFilter
+from circuits.filters import *
 from circuits.models import Circuit, CircuitTermination, CircuitType, Provider
 from dcim.models import Region, Site
 

--- a/netbox/circuits/tests/test_filters.py
+++ b/netbox/circuits/tests/test_filters.py
@@ -8,6 +8,7 @@ from dcim.models import Region, Site
 
 class ProviderTestCase(TestCase):
     queryset = Provider.objects.all()
+    filterset = ProviderFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -54,42 +55,43 @@ class ProviderTestCase(TestCase):
 
     def test_name(self):
         params = {'name': ['Provider 1', 'Provider 2']}
-        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['provider-1', 'provider-2']}
-        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_asn(self):
         params = {'asn': ['65001', '65002']}
-        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_account(self):
         params = {'account': ['1234', '2345']}
-        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:3]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class CircuitTypeTestCase(TestCase):
     queryset = CircuitType.objects.all()
+    filterset = CircuitTypeFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -102,19 +104,20 @@ class CircuitTypeTestCase(TestCase):
 
     def test_id(self):
         params = {'id': [self.queryset.first().pk]}
-        self.assertEqual(CircuitTypeFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Circuit Type 1']}
-        self.assertEqual(CircuitTypeFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_slug(self):
         params = {'slug': ['circuit-type-1']}
-        self.assertEqual(CircuitTypeFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class CircuitTestCase(TestCase):
     queryset = Circuit.objects.all()
+    filterset = CircuitFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -166,56 +169,57 @@ class CircuitTestCase(TestCase):
 
     def test_cid(self):
         params = {'cid': ['Test Circuit 1', 'Test Circuit 2']}
-        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_install_date(self):
         params = {'install_date': ['2020-01-01', '2020-01-02']}
-        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_commit_rate(self):
         params = {'commit_rate': ['1000', '2000']}
-        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:3]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_provider(self):
         provider = Provider.objects.first()
         params = {'provider_id': [provider.pk]}
-        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
         params = {'provider': [provider.slug]}
-        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_type(self):
         circuit_type = CircuitType.objects.first()
         params = {'type_id': [circuit_type.pk]}
-        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
         params = {'type': [circuit_type.slug]}
-        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_status(self):
         params = {'status': [CIRCUIT_STATUS_ACTIVE, CIRCUIT_STATUS_PLANNED]}
-        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class CircuitTerminationTestCase(TestCase):
     queryset = CircuitTermination.objects.all()
+    filterset = CircuitTerminationFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -256,28 +260,28 @@ class CircuitTerminationTestCase(TestCase):
 
     def test_term_side(self):
         params = {'term_side': 'A'}
-        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_port_speed(self):
         params = {'port_speed': ['1000', '2000']}
-        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_upstream_speed(self):
         params = {'upstream_speed': ['1000', '2000']}
-        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_xconnect_id(self):
         params = {'xconnect_id': ['ABC', 'DEF']}
-        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_circuit_id(self):
         circuits = Circuit.objects.all()[:2]
         params = {'circuit_id': [circuits[0].pk, circuits[1].pk]}
-        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)

--- a/netbox/circuits/tests/test_filters.py
+++ b/netbox/circuits/tests/test_filters.py
@@ -1,0 +1,283 @@
+from django.test import TestCase
+
+from circuits.constants import CIRCUIT_STATUS_ACTIVE, CIRCUIT_STATUS_OFFLINE, CIRCUIT_STATUS_PLANNED
+from circuits.filters import CircuitFilter, CircuitTerminationFilter, CircuitTypeFilter, ProviderFilter
+from circuits.models import Circuit, CircuitTermination, CircuitType, Provider
+from dcim.models import Region, Site
+
+
+class ProviderTestCase(TestCase):
+    queryset = Provider.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        providers = (
+            Provider(name='Provider 1', slug='provider-1', asn=65001, account='1234'),
+            Provider(name='Provider 2', slug='provider-2', asn=65002, account='2345'),
+            Provider(name='Provider 3', slug='provider-3', asn=65003, account='3456'),
+            Provider(name='Provider 4', slug='provider-4', asn=65004, account='4567'),
+            Provider(name='Provider 5', slug='provider-5', asn=65005, account='5678'),
+        )
+        Provider.objects.bulk_create(providers)
+
+        regions = (
+            Region(name='Test Region 1', slug='test-region-1'),
+            Region(name='Test Region 2', slug='test-region-2'),
+        )
+        # Can't use bulk_create for models with MPTT fields
+        for r in regions:
+            r.save()
+
+        sites = (
+            Site(name='Test Site 1', slug='test-site-1', region=regions[0]),
+            Site(name='Test Site 2', slug='test-site-2', region=regions[1]),
+        )
+        Site.objects.bulk_create(sites)
+
+        circuit_types = (
+            CircuitType(name='Test Circuit Type 1', slug='test-circuit-type-1'),
+            CircuitType(name='Test Circuit Type 2', slug='test-circuit-type-2'),
+        )
+        CircuitType.objects.bulk_create(circuit_types)
+
+        circuits = (
+            Circuit(provider=providers[0], type=circuit_types[0], cid='Test Circuit 1'),
+            Circuit(provider=providers[1], type=circuit_types[1], cid='Test Circuit 1'),
+        )
+        Circuit.objects.bulk_create(circuits)
+
+        CircuitTermination.objects.bulk_create((
+            CircuitTermination(circuit=circuits[0], site=sites[0], term_side='A', port_speed=1000),
+            CircuitTermination(circuit=circuits[1], site=sites[0], term_side='A', port_speed=1000),
+        ))
+
+    def test_name(self):
+        params = {'name': ['Provider 1', 'Provider 2']}
+        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+
+    def test_slug(self):
+        params = {'slug': ['provider-1', 'provider-2']}
+        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+
+    def test_asn(self):
+        params = {'asn': ['65001', '65002']}
+        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+
+    def test_account(self):
+        params = {'account': ['1234', '2345']}
+        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+
+    def test_id__in(self):
+        id_list = self.queryset.values_list('id', flat=True)[:3]
+        params = {'id__in': ','.join([str(id) for id in id_list])}
+        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 3)
+
+    def test_site(self):
+        sites = Site.objects.all()[:2]
+        params = {'site_id': [sites[0].pk, sites[1].pk]}
+        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+        params = {'site': [sites[0].slug, sites[1].slug]}
+        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+
+    def test_region(self):
+        regions = Region.objects.all()[:2]
+        params = {'region_id': [regions[0].pk, regions[1].pk]}
+        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+        params = {'region': [regions[0].slug, regions[1].slug]}
+        self.assertEqual(ProviderFilter(params, self.queryset).qs.count(), 2)
+
+
+class CircuitTypeTestCase(TestCase):
+    queryset = CircuitType.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        CircuitType.objects.bulk_create((
+            CircuitType(name='Circuit Type 1', slug='circuit-type-1'),
+            CircuitType(name='Circuit Type 2', slug='circuit-type-2'),
+            CircuitType(name='Circuit Type 3', slug='circuit-type-3'),
+        ))
+
+    def test_id(self):
+        params = {'id': [self.queryset.first().pk]}
+        self.assertEqual(CircuitTypeFilter(params, self.queryset).qs.count(), 1)
+
+    def test_name(self):
+        params = {'name': ['Circuit Type 1']}
+        self.assertEqual(CircuitTypeFilter(params, self.queryset).qs.count(), 1)
+
+    def test_slug(self):
+        params = {'slug': ['circuit-type-1']}
+        self.assertEqual(CircuitTypeFilter(params, self.queryset).qs.count(), 1)
+
+
+class CircuitTestCase(TestCase):
+    queryset = Circuit.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        regions = (
+            Region(name='Test Region 1', slug='test-region-1'),
+            Region(name='Test Region 2', slug='test-region-2'),
+            Region(name='Test Region 3', slug='test-region-3'),
+        )
+        # Can't use bulk_create for models with MPTT fields
+        for r in regions:
+            r.save()
+
+        sites = (
+            Site(name='Test Site 1', slug='test-site-1', region=regions[0]),
+            Site(name='Test Site 2', slug='test-site-2', region=regions[1]),
+            Site(name='Test Site 3', slug='test-site-3', region=regions[2]),
+        )
+        Site.objects.bulk_create(sites)
+
+        circuit_types = (
+            CircuitType(name='Test Circuit Type 1', slug='test-circuit-type-1'),
+            CircuitType(name='Test Circuit Type 2', slug='test-circuit-type-2'),
+        )
+        CircuitType.objects.bulk_create(circuit_types)
+
+        providers = (
+            Provider(name='Provider 1', slug='provider-1'),
+            Provider(name='Provider 2', slug='provider-2'),
+        )
+        Provider.objects.bulk_create(providers)
+
+        circuits = (
+            Circuit(provider=providers[0], type=circuit_types[0], cid='Test Circuit 1', install_date='2020-01-01', commit_rate=1000, status=CIRCUIT_STATUS_ACTIVE),
+            Circuit(provider=providers[0], type=circuit_types[0], cid='Test Circuit 2', install_date='2020-01-02', commit_rate=2000, status=CIRCUIT_STATUS_ACTIVE),
+            Circuit(provider=providers[0], type=circuit_types[0], cid='Test Circuit 3', install_date='2020-01-03', commit_rate=3000, status=CIRCUIT_STATUS_PLANNED),
+            Circuit(provider=providers[1], type=circuit_types[1], cid='Test Circuit 4', install_date='2020-01-04', commit_rate=4000, status=CIRCUIT_STATUS_PLANNED),
+            Circuit(provider=providers[1], type=circuit_types[1], cid='Test Circuit 5', install_date='2020-01-05', commit_rate=5000, status=CIRCUIT_STATUS_OFFLINE),
+            Circuit(provider=providers[1], type=circuit_types[1], cid='Test Circuit 6', install_date='2020-01-06', commit_rate=6000, status=CIRCUIT_STATUS_OFFLINE),
+        )
+        Circuit.objects.bulk_create(circuits)
+
+        circuit_terminations = ((
+            CircuitTermination(circuit=circuits[0], site=sites[0], term_side='A', port_speed=1000),
+            CircuitTermination(circuit=circuits[1], site=sites[1], term_side='A', port_speed=1000),
+            CircuitTermination(circuit=circuits[2], site=sites[2], term_side='A', port_speed=1000),
+        ))
+        CircuitTermination.objects.bulk_create(circuit_terminations)
+
+    def test_cid(self):
+        params = {'cid': ['Test Circuit 1', 'Test Circuit 2']}
+        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+
+    def test_install_date(self):
+        params = {'install_date': ['2020-01-01', '2020-01-02']}
+        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+
+    def test_commit_rate(self):
+        params = {'commit_rate': ['1000', '2000']}
+        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+
+    def test_id__in(self):
+        id_list = self.queryset.values_list('id', flat=True)[:3]
+        params = {'id__in': ','.join([str(id) for id in id_list])}
+        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 3)
+
+    def test_provider(self):
+        provider = Provider.objects.first()
+        params = {'provider_id': [provider.pk]}
+        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 3)
+        params = {'provider': [provider.slug]}
+        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 3)
+
+    def test_type(self):
+        circuit_type = CircuitType.objects.first()
+        params = {'type_id': [circuit_type.pk]}
+        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 3)
+        params = {'type': [circuit_type.slug]}
+        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 3)
+
+    def test_status(self):
+        params = {'status': [CIRCUIT_STATUS_ACTIVE, CIRCUIT_STATUS_PLANNED]}
+        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 4)
+
+    def test_region(self):
+        regions = Region.objects.all()[:2]
+        params = {'region_id': [regions[0].pk, regions[1].pk]}
+        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+        params = {'region': [regions[0].slug, regions[1].slug]}
+        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+
+    def test_site(self):
+        sites = Site.objects.all()[:2]
+        params = {'site_id': [sites[0].pk, sites[1].pk]}
+        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+        params = {'site': [sites[0].slug, sites[1].slug]}
+        self.assertEqual(CircuitFilter(params, self.queryset).qs.count(), 2)
+
+
+class CircuitTerminationTestCase(TestCase):
+    queryset = CircuitTermination.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        sites = (
+            Site(name='Test Site 1', slug='test-site-1'),
+            Site(name='Test Site 2', slug='test-site-2'),
+            Site(name='Test Site 3', slug='test-site-3'),
+        )
+        Site.objects.bulk_create(sites)
+
+        circuit_types = (
+            CircuitType(name='Test Circuit Type 1', slug='test-circuit-type-1'),
+        )
+        CircuitType.objects.bulk_create(circuit_types)
+
+        providers = (
+            Provider(name='Provider 1', slug='provider-1'),
+        )
+        Provider.objects.bulk_create(providers)
+
+        circuits = (
+            Circuit(provider=providers[0], type=circuit_types[0], cid='Test Circuit 1'),
+            Circuit(provider=providers[0], type=circuit_types[0], cid='Test Circuit 2'),
+            Circuit(provider=providers[0], type=circuit_types[0], cid='Test Circuit 3'),
+        )
+        Circuit.objects.bulk_create(circuits)
+
+        circuit_terminations = ((
+            CircuitTermination(circuit=circuits[0], site=sites[0], term_side='A', port_speed=1000, upstream_speed=1000, xconnect_id='ABC'),
+            CircuitTermination(circuit=circuits[0], site=sites[1], term_side='Z', port_speed=1000, upstream_speed=1000, xconnect_id='DEF'),
+            CircuitTermination(circuit=circuits[1], site=sites[1], term_side='A', port_speed=2000, upstream_speed=2000, xconnect_id='GHI'),
+            CircuitTermination(circuit=circuits[1], site=sites[2], term_side='Z', port_speed=2000, upstream_speed=2000, xconnect_id='JKL'),
+            CircuitTermination(circuit=circuits[2], site=sites[2], term_side='A', port_speed=3000, upstream_speed=3000, xconnect_id='MNO'),
+            CircuitTermination(circuit=circuits[2], site=sites[0], term_side='Z', port_speed=3000, upstream_speed=3000, xconnect_id='PQR'),
+        ))
+        CircuitTermination.objects.bulk_create(circuit_terminations)
+
+    def test_term_side(self):
+        params = {'term_side': 'A'}
+        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 3)
+
+    def test_port_speed(self):
+        params = {'port_speed': ['1000', '2000']}
+        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 4)
+
+    def test_upstream_speed(self):
+        params = {'upstream_speed': ['1000', '2000']}
+        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 4)
+
+    def test_xconnect_id(self):
+        params = {'xconnect_id': ['ABC', 'DEF']}
+        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 2)
+
+    def test_circuit_id(self):
+        circuits = Circuit.objects.all()[:2]
+        params = {'circuit_id': [circuits[0].pk, circuits[1].pk]}
+        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 4)
+
+    def test_site(self):
+        sites = Site.objects.all()[:2]
+        params = {'site_id': [sites[0].pk, sites[1].pk]}
+        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 4)
+        params = {'site': [sites[0].slug, sites[1].slug]}
+        self.assertEqual(CircuitTerminationFilter(params, self.queryset).qs.count(), 4)

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -21,6 +21,45 @@ from .models import (
 )
 
 
+__all__ = (
+    'CableFilter',
+    'ConsoleConnectionFilter',
+    'ConsolePortFilter',
+    'ConsolePortTemplateFilter',
+    'ConsoleServerPortFilter',
+    'ConsoleServerPortTemplateFilter',
+    'DeviceBayFilter',
+    'DeviceBayTemplateFilter',
+    'DeviceFilter',
+    'DeviceRoleFilter',
+    'DeviceTypeFilter',
+    'FrontPortFilter',
+    'FrontPortTemplateFilter',
+    'InterfaceConnectionFilter',
+    'InterfaceFilter',
+    'InterfaceTemplateFilter',
+    'InventoryItemFilter',
+    'ManufacturerFilter',
+    'PlatformFilter',
+    'PowerConnectionFilter',
+    'PowerFeedFilter',
+    'PowerOutletFilter',
+    'PowerOutletTemplateFilter',
+    'PowerPanelFilter',
+    'PowerPortFilter',
+    'PowerPortTemplateFilter',
+    'RackFilter',
+    'RackGroupFilter',
+    'RackReservationFilter',
+    'RackRoleFilter',
+    'RearPortFilter',
+    'RearPortTemplateFilter',
+    'RegionFilter',
+    'SiteFilter',
+    'VirtualChassisFilter',
+)
+
+
 class RegionFilter(NameSlugSearchFilterSet):
     parent_id = django_filters.ModelMultipleChoiceFilter(
         queryset=Region.objects.all(),

--- a/netbox/dcim/tests/test_filters.py
+++ b/netbox/dcim/tests/test_filters.py
@@ -1080,9 +1080,9 @@ class DeviceTestCase(TestCase):
         Cluster.objects.bulk_create(clusters)
 
         devices = (
-            Device(name='Device 1', device_type=device_types[0], device_role=device_roles[0], platform=platforms[0], serial='ABC', asset_tag='1001', site=sites[0], rack=racks[0], position=1, face=RACK_FACE_FRONT, status=DEVICE_STATUS_ACTIVE),
-            Device(name='Device 2', device_type=device_types[1], device_role=device_roles[1], platform=platforms[1], serial='DEF', asset_tag='1002', site=sites[1], rack=racks[1], position=2, face=RACK_FACE_FRONT, status=DEVICE_STATUS_STAGED),
-            Device(name='Device 3', device_type=device_types[2], device_role=device_roles[2], platform=platforms[2], serial='GHI', asset_tag='1003', site=sites[2], rack=racks[2], position=3, face=RACK_FACE_REAR, status=DEVICE_STATUS_FAILED),
+            Device(name='Device 1', device_type=device_types[0], device_role=device_roles[0], platform=platforms[0], serial='ABC', asset_tag='1001', site=sites[0], rack=racks[0], position=1, face=RACK_FACE_FRONT, status=DEVICE_STATUS_ACTIVE, cluster=clusters[0]),
+            Device(name='Device 2', device_type=device_types[1], device_role=device_roles[1], platform=platforms[1], serial='DEF', asset_tag='1002', site=sites[1], rack=racks[1], position=2, face=RACK_FACE_FRONT, status=DEVICE_STATUS_STAGED, cluster=clusters[1]),
+            Device(name='Device 3', device_type=device_types[2], device_role=device_roles[2], platform=platforms[2], serial='GHI', asset_tag='1003', site=sites[2], rack=racks[2], position=3, face=RACK_FACE_REAR, status=DEVICE_STATUS_FAILED, cluster=clusters[2]),
         )
         Device.objects.bulk_create(devices)
 
@@ -1222,7 +1222,7 @@ class DeviceTestCase(TestCase):
 
     def test_cluster(self):
         clusters = Cluster.objects.all()[:2]
-        params = {'rack_id': [clusters[0].pk, clusters[1].pk]}
+        params = {'cluster_id': [clusters[0].pk, clusters[1].pk]}
         self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
 
     def test_model(self):

--- a/netbox/dcim/tests/test_filters.py
+++ b/netbox/dcim/tests/test_filters.py
@@ -60,6 +60,7 @@ class RegionTestCase(TestCase):
 
 class SiteTestCase(TestCase):
     queryset = Site.objects.all()
+    filterset = SiteFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -82,63 +83,64 @@ class SiteTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Site 1', 'Site 2']}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['site-1', 'site-2']}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_facility(self):
         params = {'facility': ['Facility 1', 'Facility 2']}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_asn(self):
         params = {'asn': [65001, 65002]}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_latitude(self):
         params = {'latitude': [10, 20]}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_longitude(self):
         params = {'longitude': [10, 20]}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_contact_name(self):
         params = {'contact_name': ['Contact 1', 'Contact 2']}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_contact_phone(self):
         params = {'contact_phone': ['123-555-0001', '123-555-0002']}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_contact_email(self):
         params = {'contact_email': ['contact1@example.com', 'contact2@example.com']}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_status(self):
         params = {'status': [SITE_STATUS_ACTIVE, SITE_STATUS_PLANNED]}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class RackGroupTestCase(TestCase):
     queryset = RackGroup.objects.all()
+    filterset = RackGroupFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -168,33 +170,34 @@ class RackGroupTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Rack Group 1', 'Rack Group 2']}
-        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['rack-group-1', 'rack-group-2']}
-        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class RackRoleTestCase(TestCase):
     queryset = RackRole.objects.all()
+    filterset = RackRoleFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -209,23 +212,24 @@ class RackRoleTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(RackRoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Rack Role 1', 'Rack Role 2']}
-        self.assertEqual(RackRoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['rack-role-1', 'rack-role-2']}
-        self.assertEqual(RackRoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_color(self):
         params = {'color': ['ff0000', '00ff00']}
-        self.assertEqual(RackRoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class RackTestCase(TestCase):
     queryset = Rack.objects.all()
+    filterset = RackFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -269,99 +273,100 @@ class RackTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Rack 1', 'Rack 2']}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_facility_id(self):
         params = {'facility_id': ['rack-1', 'rack-2']}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_asset_tag(self):
         params = {'asset_tag': ['1001', '1002']}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
         # TODO: Test for multiple values
         params = {'type': RACK_TYPE_2POST}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_width(self):
         # TODO: Test for multiple values
         params = {'width': RACK_WIDTH_19IN}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_u_height(self):
         params = {'u_height': [42, 43]}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_desc_units(self):
         params = {'desc_units': 'true'}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
         params = {'desc_units': 'false'}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_outer_width(self):
         params = {'outer_width': [100, 200]}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_outer_depth(self):
         params = {'outer_depth': [100, 200]}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_outer_unit(self):
         self.assertEqual(Rack.objects.filter(outer_unit__isnull=False).count(), 3)
         params = {'outer_unit': LENGTH_UNIT_MILLIMETER}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_group(self):
         groups = RackGroup.objects.all()[:2]
         params = {'group_id': [groups[0].pk, groups[1].pk]}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'group': [groups[0].slug, groups[1].slug]}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_status(self):
         params = {'status': [RACK_STATUS_ACTIVE, RACK_STATUS_PLANNED]}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_role(self):
         roles = RackRole.objects.all()[:2]
         params = {'role_id': [roles[0].pk, roles[1].pk]}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'role': [roles[0].slug, roles[1].slug]}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_serial(self):
         params = {'serial': 'ABC'}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
         params = {'serial': 'abc'}
-        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class RackReservationTestCase(TestCase):
     queryset = RackReservation.objects.all()
+    filterset = RackReservationFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -404,33 +409,34 @@ class RackReservationTestCase(TestCase):
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_group(self):
         groups = RackGroup.objects.all()[:2]
         params = {'group_id': [groups[0].pk, groups[1].pk]}
-        self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'group': [groups[0].slug, groups[1].slug]}
-        self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_user(self):
         users = User.objects.all()[:2]
         params = {'user_id': [users[0].pk, users[1].pk]}
-        self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         # TODO: Filtering by username is broken
         # params = {'user': [users[0].username, users[1].username]}
-        # self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)
+        # self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class ManufacturerTestCase(TestCase):
     queryset = Manufacturer.objects.all()
+    filterset = ManufacturerFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -445,19 +451,20 @@ class ManufacturerTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(ManufacturerFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Manufacturer 1', 'Manufacturer 2']}
-        self.assertEqual(ManufacturerFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['manufacturer-1', 'manufacturer-2']}
-        self.assertEqual(ManufacturerFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class DeviceTypeTestCase(TestCase):
     queryset = DeviceType.objects.all()
+    filterset = DeviceTypeFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -513,88 +520,89 @@ class DeviceTypeTestCase(TestCase):
 
     def test_model(self):
         params = {'model': ['Model 1', 'Model 2']}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['model-1', 'model-2']}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_part_number(self):
         params = {'part_number': ['Part Number 1', 'Part Number 2']}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_u_height(self):
         params = {'u_height': [1, 2]}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_is_full_depth(self):
         params = {'is_full_depth': 'true'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'is_full_depth': 'false'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_subdevice_role(self):
         params = {'subdevice_role': SUBDEVICE_ROLE_PARENT}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_manufacturer(self):
         manufacturers = Manufacturer.objects.all()[:2]
         params = {'manufacturer_id': [manufacturers[0].pk, manufacturers[1].pk]}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'manufacturer': [manufacturers[0].slug, manufacturers[1].slug]}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_console_ports(self):
         params = {'console_ports': 'true'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'console_ports': 'false'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_console_server_ports(self):
         params = {'console_server_ports': 'true'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'console_server_ports': 'false'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_power_ports(self):
         params = {'power_ports': 'true'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'power_ports': 'false'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_power_outlets(self):
         params = {'power_outlets': 'true'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'power_outlets': 'false'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_interfaces(self):
         params = {'interfaces': 'true'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'interfaces': 'false'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_pass_through_ports(self):
         params = {'pass_through_ports': 'true'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'pass_through_ports': 'false'}
-        self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     # TODO: Add device_bay filter
     # def test_device_bays(self):
     #     params = {'device_bays': 'true'}
-    #     self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 2)
+    #     self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
     #     params = {'device_bays': 'false'}
-    #     self.assertEqual(DeviceTypeFilter(params, self.queryset).qs.count(), 1)
+    #     self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class ConsolePortTemplateTestCase(TestCase):
     queryset = ConsolePortTemplate.objects.all()
+    filterset = ConsolePortTemplateFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -617,20 +625,21 @@ class ConsolePortTemplateTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(ConsolePortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Console Port 1', 'Console Port 2']}
-        self.assertEqual(ConsolePortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_devicetype_id(self):
         device_types = DeviceType.objects.all()[:2]
         params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(ConsolePortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class ConsoleServerPortTemplateTestCase(TestCase):
     queryset = ConsoleServerPortTemplate.objects.all()
+    filterset = ConsoleServerPortTemplateFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -653,20 +662,21 @@ class ConsoleServerPortTemplateTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(ConsoleServerPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Console Server Port 1', 'Console Server Port 2']}
-        self.assertEqual(ConsoleServerPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_devicetype_id(self):
         device_types = DeviceType.objects.all()[:2]
         params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(ConsoleServerPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class PowerPortTemplateTestCase(TestCase):
     queryset = PowerPortTemplate.objects.all()
+    filterset = PowerPortTemplateFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -689,28 +699,29 @@ class PowerPortTemplateTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(PowerPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Power Port 1', 'Power Port 2']}
-        self.assertEqual(PowerPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_devicetype_id(self):
         device_types = DeviceType.objects.all()[:2]
         params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(PowerPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_maximum_draw(self):
         params = {'maximum_draw': [100, 200]}
-        self.assertEqual(PowerPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_allocated_draw(self):
         params = {'allocated_draw': [50, 100]}
-        self.assertEqual(PowerPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class PowerOutletTemplateTestCase(TestCase):
     queryset = PowerOutletTemplate.objects.all()
+    filterset = PowerOutletTemplateFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -733,25 +744,26 @@ class PowerOutletTemplateTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(PowerOutletTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Power Outlet 1', 'Power Outlet 2']}
-        self.assertEqual(PowerOutletTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_devicetype_id(self):
         device_types = DeviceType.objects.all()[:2]
         params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(PowerOutletTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_feed_leg(self):
         # TODO: Support filtering for multiple values
         params = {'feed_leg': POWERFEED_LEG_A}
-        self.assertEqual(PowerOutletTemplateFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class InterfaceTemplateTestCase(TestCase):
     queryset = InterfaceTemplate.objects.all()
+    filterset = InterfaceTemplateFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -774,31 +786,32 @@ class InterfaceTemplateTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(InterfaceTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Interface 1', 'Interface 2']}
-        self.assertEqual(InterfaceTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_devicetype_id(self):
         device_types = DeviceType.objects.all()[:2]
         params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(InterfaceTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
         # TODO: Support filtering for multiple values
         params = {'type': IFACE_TYPE_1GE_FIXED}
-        self.assertEqual(InterfaceTemplateFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_mgmt_only(self):
         params = {'mgmt_only': 'true'}
-        self.assertEqual(InterfaceTemplateFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
         params = {'mgmt_only': 'false'}
-        self.assertEqual(InterfaceTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class FrontPortTemplateTestCase(TestCase):
     queryset = FrontPortTemplate.objects.all()
+    filterset = FrontPortTemplateFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -828,25 +841,26 @@ class FrontPortTemplateTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(FrontPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Front Port 1', 'Front Port 2']}
-        self.assertEqual(FrontPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_devicetype_id(self):
         device_types = DeviceType.objects.all()[:2]
         params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(FrontPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
         # TODO: Support filtering for multiple values
         params = {'type': PORT_TYPE_8P8C}
-        self.assertEqual(FrontPortTemplateFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class RearPortTemplateTestCase(TestCase):
     queryset = RearPortTemplate.objects.all()
+    filterset = RearPortTemplateFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -869,29 +883,30 @@ class RearPortTemplateTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(RearPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Rear Port 1', 'Rear Port 2']}
-        self.assertEqual(RearPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_devicetype_id(self):
         device_types = DeviceType.objects.all()[:2]
         params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(RearPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
         # TODO: Support filtering for multiple values
         params = {'type': PORT_TYPE_8P8C}
-        self.assertEqual(RearPortTemplateFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_positions(self):
         params = {'positions': [1, 2]}
-        self.assertEqual(RearPortTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class DeviceBayTemplateTestCase(TestCase):
     queryset = DeviceBayTemplate.objects.all()
+    filterset = DeviceBayTemplateFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -914,20 +929,21 @@ class DeviceBayTemplateTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(DeviceBayTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Device Bay 1', 'Device Bay 2']}
-        self.assertEqual(DeviceBayTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_devicetype_id(self):
         device_types = DeviceType.objects.all()[:2]
         params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(DeviceBayTemplateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class DeviceRoleTestCase(TestCase):
     queryset = DeviceRole.objects.all()
+    filterset = DeviceRoleFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -942,29 +958,30 @@ class DeviceRoleTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(DeviceRoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Device Role 1', 'Device Role 2']}
-        self.assertEqual(DeviceRoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['device-role-1', 'device-role-2']}
-        self.assertEqual(DeviceRoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_color(self):
         params = {'color': ['ff0000', '00ff00']}
-        self.assertEqual(DeviceRoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_vm_role(self):
         params = {'vm_role': 'true'}
-        self.assertEqual(DeviceRoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'vm_role': 'false'}
-        self.assertEqual(DeviceRoleFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class PlatformTestCase(TestCase):
     queryset = Platform.objects.all()
+    filterset = PlatformFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -986,30 +1003,31 @@ class PlatformTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(PlatformFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Platform 1', 'Platform 2']}
-        self.assertEqual(PlatformFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['platform-1', 'platform-2']}
-        self.assertEqual(PlatformFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_napalm_driver(self):
         params = {'napalm_driver': ['driver-1', 'driver-2']}
-        self.assertEqual(PlatformFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_manufacturer(self):
         manufacturers = Manufacturer.objects.all()[:2]
         params = {'manufacturer_id': [manufacturers[0].pk, manufacturers[1].pk]}
-        self.assertEqual(PlatformFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'manufacturer': [manufacturers[0].slug, manufacturers[1].slug]}
-        self.assertEqual(PlatformFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class DeviceTestCase(TestCase):
     queryset = Device.objects.all()
+    filterset = DeviceFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -1139,178 +1157,179 @@ class DeviceTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Device 1', 'Device 2']}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_asset_tag(self):
         params = {'asset_tag': ['1001', '1002']}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_face(self):
         params = {'face': RACK_FACE_FRONT}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_position(self):
         params = {'position': [1, 2]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_vc_position(self):
         params = {'vc_position': [1, 2]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_vc_priority(self):
         params = {'vc_priority': [1, 2]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_manufacturer(self):
         manufacturers = Manufacturer.objects.all()[:2]
         params = {'manufacturer_id': [manufacturers[0].pk, manufacturers[1].pk]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'manufacturer': [manufacturers[0].slug, manufacturers[1].slug]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_devicetype(self):
         device_types = DeviceType.objects.all()[:2]
         params = {'device_type_id': [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_devicerole(self):
         device_roles = DeviceRole.objects.all()[:2]
         params = {'role_id': [device_roles[0].pk, device_roles[1].pk]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'role': [device_roles[0].slug, device_roles[1].slug]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_platform(self):
         platforms = Platform.objects.all()[:2]
         params = {'platform_id': [platforms[0].pk, platforms[1].pk]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'platform': [platforms[0].slug, platforms[1].slug]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_rackgroup(self):
         rack_groups = RackGroup.objects.all()[:2]
         params = {'rack_group_id': [rack_groups[0].pk, rack_groups[1].pk]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_rack(self):
         racks = Rack.objects.all()[:2]
         params = {'rack_id': [racks[0].pk, racks[1].pk]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_cluster(self):
         clusters = Cluster.objects.all()[:2]
         params = {'cluster_id': [clusters[0].pk, clusters[1].pk]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_model(self):
         params = {'model': ['model-1', 'model-2']}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_status(self):
         params = {'status': [DEVICE_STATUS_ACTIVE, DEVICE_STATUS_STAGED]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_is_full_depth(self):
         params = {'is_full_depth': 'true'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'is_full_depth': 'false'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_mac_address(self):
         params = {'mac_address': ['00-00-00-00-00-01', '00-00-00-00-00-02']}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_serial(self):
         params = {'serial': 'ABC'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
         params = {'serial': 'abc'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_has_primary_ip(self):
         params = {'has_primary_ip': 'true'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'has_primary_ip': 'false'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_virtual_chassis_id(self):
         params = {'virtual_chassis_id': [VirtualChassis.objects.first().pk]}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_virtual_chassis_member(self):
         params = {'virtual_chassis_member': 'true'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'virtual_chassis_member': 'false'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_console_ports(self):
         params = {'console_ports': 'true'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'console_ports': 'false'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_console_server_ports(self):
         params = {'console_server_ports': 'true'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'console_server_ports': 'false'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_power_ports(self):
         params = {'power_ports': 'true'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'power_ports': 'false'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_power_outlets(self):
         params = {'power_outlets': 'true'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'power_outlets': 'false'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_interfaces(self):
         params = {'interfaces': 'true'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'interfaces': 'false'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_pass_through_ports(self):
         params = {'pass_through_ports': 'true'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'pass_through_ports': 'false'}
-        self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     # TODO: Add device_bay filter
     # def test_device_bays(self):
     #     params = {'device_bays': 'true'}
-    #     self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 2)
+    #     self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
     #     params = {'device_bays': 'false'}
-    #     self.assertEqual(DeviceFilter(params, self.queryset).qs.count(), 1)
+    #     self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class ConsolePortTestCase(TestCase):
     queryset = ConsolePort.objects.all()
+    filterset = ConsolePortFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -1349,37 +1368,38 @@ class ConsolePortTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(ConsolePortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Console Port 1', 'Console Port 2']}
-        self.assertEqual(ConsolePortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
         params = {'description': ['First', 'Second']}
-        self.assertEqual(ConsolePortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     # TODO: Fix boolean value
     def test_connection_status(self):
         params = {'connection_status': 'True'}
-        self.assertEqual(ConsolePortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_device(self):
         devices = Device.objects.all()[:2]
         params = {'device_id': [devices[0].pk, devices[1].pk]}
-        self.assertEqual(ConsolePortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'device': [devices[0].name, devices[1].name]}
-        self.assertEqual(ConsolePortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_cabled(self):
         params = {'cabled': 'true'}
-        self.assertEqual(ConsolePortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'cabled': 'false'}
-        self.assertEqual(ConsolePortFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class ConsoleServerPortTestCase(TestCase):
     queryset = ConsoleServerPort.objects.all()
+    filterset = ConsoleServerPortFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -1418,38 +1438,38 @@ class ConsoleServerPortTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(ConsoleServerPortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Console Server Port 1', 'Console Server Port 2']}
-        self.assertEqual(ConsoleServerPortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
         params = {'description': ['First', 'Second']}
-        self.assertEqual(ConsoleServerPortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     # TODO: Fix boolean value
     def test_connection_status(self):
         params = {'connection_status': 'True'}
-        self.assertEqual(ConsoleServerPortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_device(self):
         devices = Device.objects.all()[:2]
         params = {'device_id': [devices[0].pk, devices[1].pk]}
-        self.assertEqual(ConsoleServerPortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'device': [devices[0].name, devices[1].name]}
-        self.assertEqual(ConsoleServerPortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_cabled(self):
         params = {'cabled': 'true'}
-        self.assertEqual(ConsoleServerPortFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'cabled': 'false'}
-        self.assertEqual(ConsoleServerPortFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class PowerPortTestCase(TestCase):
     queryset = PowerPort.objects.all()
-    filter = PowerPortFilter
+    filterset = PowerPortFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -1488,46 +1508,46 @@ class PowerPortTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Power Port 1', 'Power Port 2']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
         params = {'description': ['First', 'Second']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_maximum_draw(self):
         params = {'maximum_draw': [100, 200]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_allocated_draw(self):
         params = {'allocated_draw': [50, 100]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     # TODO: Fix boolean value
     def test_connection_status(self):
         params = {'connection_status': 'True'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_device(self):
         devices = Device.objects.all()[:2]
         params = {'device_id': [devices[0].pk, devices[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'device': [devices[0].name, devices[1].name]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_cabled(self):
         params = {'cabled': 'true'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'cabled': 'false'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class PowerOutletTestCase(TestCase):
     queryset = PowerOutlet.objects.all()
-    filter = PowerOutletFilter
+    filterset = PowerOutletFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -1566,43 +1586,43 @@ class PowerOutletTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Power Outlet 1', 'Power Outlet 2']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
         params = {'description': ['First', 'Second']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_feed_leg(self):
         # TODO: Support filtering for multiple values
         params = {'feed_leg': POWERFEED_LEG_A}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     # TODO: Fix boolean value
     def test_connection_status(self):
         params = {'connection_status': 'True'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_device(self):
         devices = Device.objects.all()[:2]
         params = {'device_id': [devices[0].pk, devices[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'device': [devices[0].name, devices[1].name]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_cabled(self):
         params = {'cabled': 'true'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'cabled': 'false'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class InterfaceTestCase(TestCase):
     queryset = Interface.objects.all()
-    filter = InterfaceFilter
+    filterset = InterfaceFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -1638,72 +1658,72 @@ class InterfaceTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:3]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_name(self):
         params = {'name': ['Interface 1', 'Interface 2']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     # TODO: Fix boolean value
     def test_connection_status(self):
         params = {'connection_status': 'True'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_enabled(self):
         params = {'enabled': 'true'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'enabled': 'false'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_mtu(self):
         params = {'mtu': [100, 200]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_mgmt_only(self):
         params = {'mgmt_only': 'true'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'mgmt_only': 'false'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_mode(self):
         params = {'mode': IFACE_MODE_ACCESS}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_description(self):
         params = {'description': ['First', 'Second']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_device(self):
         devices = Device.objects.all()[:2]
         params = {'device_id': [devices[0].pk, devices[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'device': [devices[0].name, devices[1].name]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_cabled(self):
         params = {'cabled': 'true'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'cabled': 'false'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_kind(self):
         params = {'kind': 'physical'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 6)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
         params = {'kind': 'virtual'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 0)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 0)
 
     def test_mac_address(self):
         params = {'mac_address': ['00-00-00-00-00-01', '00-00-00-00-00-02']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
         params = {'type': [IFACE_TYPE_1GE_FIXED, IFACE_TYPE_1GE_GBIC]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class FrontPortTestCase(TestCase):
     queryset = FrontPort.objects.all()
-    filter = FrontPortFilter
+    filterset = FrontPortFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -1749,38 +1769,38 @@ class FrontPortTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Front Port 1', 'Front Port 2']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
         # TODO: Test for multiple values
         params = {'type': PORT_TYPE_8P8C}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_description(self):
         params = {'description': ['First', 'Second']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_device(self):
         devices = Device.objects.all()[:2]
         params = {'device_id': [devices[0].pk, devices[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'device': [devices[0].name, devices[1].name]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_cabled(self):
         params = {'cabled': 'true'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'cabled': 'false'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class RearPortTestCase(TestCase):
     queryset = RearPort.objects.all()
-    filter = RearPortFilter
+    filterset = RearPortFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -1816,42 +1836,42 @@ class RearPortTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Rear Port 1', 'Rear Port 2']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
         # TODO: Test for multiple values
         params = {'type': PORT_TYPE_8P8C}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_positions(self):
         params = {'positions': [1, 2]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
         params = {'description': ['First', 'Second']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_device(self):
         devices = Device.objects.all()[:2]
         params = {'device_id': [devices[0].pk, devices[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'device': [devices[0].name, devices[1].name]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_cabled(self):
         params = {'cabled': 'true'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'cabled': 'false'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class DeviceBayTestCase(TestCase):
     queryset = DeviceBay.objects.all()
-    filter = DeviceBayFilter
+    filterset = DeviceBayFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -1878,27 +1898,27 @@ class DeviceBayTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Device Bay 1', 'Device Bay 2']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
         params = {'description': ['First', 'Second']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_device(self):
         devices = Device.objects.all()[:2]
         params = {'device_id': [devices[0].pk, devices[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'device': [devices[0].name, devices[1].name]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class InventoryItemTestCase(TestCase):
     queryset = InventoryItem.objects.all()
-    filter = InventoryItemFilter
+    filterset = InventoryItemFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -1952,71 +1972,71 @@ class InventoryItemTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Inventory Item 1', 'Inventory Item 2']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_part_id(self):
         params = {'part_id': ['1001', '1002']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_asset_tag(self):
         params = {'asset_tag': ['1001', '1002']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_discovered(self):
         # TODO: Fix boolean value
         params = {'discovered': True}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'discovered': False}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_device(self):
         # TODO: Allow multiple values
         device = Device.objects.first()
         params = {'device_id': device.pk}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'device': device.name}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_parent_id(self):
         parent_items = InventoryItem.objects.filter(parent__isnull=True)[:2]
         params = {'parent_id': [parent_items[0].pk, parent_items[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_manufacturer(self):
         manufacturers = Manufacturer.objects.all()[:2]
         params = {'manufacturer_id': [manufacturers[0].pk, manufacturers[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'manufacturer': [manufacturers[0].slug, manufacturers[1].slug]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_serial(self):
         params = {'serial': 'ABC'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
         params = {'serial': 'abc'}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class VirtualChassisTestCase(TestCase):
     queryset = VirtualChassis.objects.all()
-    filter = VirtualChassisFilter
+    filterset = VirtualChassisFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -2064,30 +2084,30 @@ class VirtualChassisTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_domain(self):
         params = {'domain': ['Domain 1', 'Domain 2']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class CableTestCase(TestCase):
     queryset = Cable.objects.all()
-    filter = CableFilter
+    filterset = CableFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -2147,57 +2167,57 @@ class CableTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_label(self):
         params = {'label': ['Cable 1', 'Cable 2']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_length(self):
         params = {'length': [10, 20]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_length_unit(self):
         params = {'length_unit': LENGTH_UNIT_FOOT}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_type(self):
         params = {'type': [CABLE_TYPE_CAT3, CABLE_TYPE_CAT5E]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_status(self):
         params = {'status': [CONNECTION_STATUS_CONNECTED]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_color(self):
         params = {'color': ['aa1409', 'f44336']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_device(self):
         devices = Device.objects.all()[:2]
         params = {'device_id': [devices[0].pk, devices[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
         params = {'device': [devices[0].name, devices[1].name]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_rack(self):
         racks = Rack.objects.all()[:2]
         params = {'rack_id': [racks[0].pk, racks[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 5)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
         params = {'rack': [racks[0].name, racks[1].name]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 5)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
 
     def test_site(self):
         site = Site.objects.all()[:2]
         params = {'site_id': [site[0].pk, site[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 5)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
         params = {'site': [site[0].slug, site[1].slug]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 5)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
 
 
 class PowerPanelTestCase(TestCase):
     queryset = PowerPanel.objects.all()
-    filter = PowerPanelFilter
+    filterset = PowerPanelFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -2233,31 +2253,31 @@ class PowerPanelTestCase(TestCase):
 
     def test_name(self):
         params = {'name': ['Power Panel 1', 'Power Panel 2']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_rack_group(self):
         rack_groups = RackGroup.objects.all()[:2]
         params = {'rack_group_id': [rack_groups[0].pk, rack_groups[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class PowerFeedTestCase(TestCase):
     queryset = PowerFeed.objects.all()
-    filter = PowerFeedFilter
+    filterset = PowerFeedFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -2300,60 +2320,60 @@ class PowerFeedTestCase(TestCase):
 
     def test_name(self):
         params = {'name': ['Power Feed 1', 'Power Feed 2']}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_status(self):
         # TODO: Test for multiple values
         params = {'status': POWERFEED_STATUS_ACTIVE}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_type(self):
         params = {'type': POWERFEED_TYPE_PRIMARY}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_supply(self):
         params = {'supply': POWERFEED_SUPPLY_AC}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_phase(self):
         params = {'phase': POWERFEED_PHASE_3PHASE}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_voltage(self):
         params = {'voltage': [100, 200]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_amperage(self):
         params = {'amperage': [100, 200]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_max_utilization(self):
         params = {'max_utilization': [10, 20]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_power_panel_id(self):
         power_panels = PowerPanel.objects.all()[:2]
         params = {'power_panel_id': [power_panels[0].pk, power_panels[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_rack_id(self):
         racks = Rack.objects.all()[:2]
         params = {'rack_id': [racks[0].pk, racks[1].pk]}
-        self.assertEqual(self.filter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 # TODO: Connection filters

--- a/netbox/dcim/tests/test_filters.py
+++ b/netbox/dcim/tests/test_filters.py
@@ -4,9 +4,11 @@ from django.test import TestCase
 from dcim.constants import *
 from dcim.filters import *
 from dcim.models import (
-    Cable, ConsolePortTemplate, ConsoleServerPortTemplate, DeviceBayTemplate, DeviceRole, DeviceType, FrontPortTemplate,
-    InterfaceTemplate, Manufacturer, Platform, PowerFeed, PowerPanel, PowerPortTemplate, PowerOutletTemplate, Rack,
-    RackGroup, RackReservation, RackRole, RearPortTemplate, Region, Site, VirtualChassis,
+    Cable, ConsolePort, ConsolePortTemplate, ConsoleServerPort, ConsoleServerPortTemplate, Device, DeviceBay,
+    DeviceBayTemplate, DeviceRole, DeviceType, FrontPort, FrontPortTemplate, Interface, InterfaceTemplate,
+    InventoryItem, Manufacturer, Platform, PowerFeed, PowerPanel, PowerPort, PowerPortTemplate, PowerOutlet,
+    PowerOutletTemplate, Rack, RackGroup, RackReservation, RackRole, RearPort, RearPortTemplate, Region, Site,
+    VirtualChassis,
 )
 from ipam.models import IPAddress
 from virtualization.models import Cluster, ClusterType

--- a/netbox/dcim/tests/test_filters.py
+++ b/netbox/dcim/tests/test_filters.py
@@ -1,0 +1,427 @@
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from dcim.constants import *
+from dcim.filters import (
+    RackFilter, RackGroupFilter, RackReservationFilter, RackRoleFilter, RegionFilter, SiteFilter,
+)
+from dcim.models import (
+    Rack, RackGroup, RackReservation, RackRole, Region, Site,
+)
+
+
+class RegionTestCase(TestCase):
+    queryset = Region.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        regions = (
+            Region(name='Region 1', slug='region-1'),
+            Region(name='Region 2', slug='region-2'),
+            Region(name='Region 3', slug='region-3'),
+        )
+        for region in regions:
+            region.save()
+
+        child_regions = (
+            Region(name='Region 1A', slug='region-1a', parent=regions[0]),
+            Region(name='Region 1B', slug='region-1b', parent=regions[0]),
+            Region(name='Region 2A', slug='region-2a', parent=regions[1]),
+            Region(name='Region 2B', slug='region-2b', parent=regions[1]),
+            Region(name='Region 3A', slug='region-3a', parent=regions[2]),
+            Region(name='Region 3B', slug='region-3b', parent=regions[2]),
+        )
+        for region in child_regions:
+            region.save()
+
+    def test_id(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id': [str(id) for id in id_list]}
+        self.assertEqual(RegionFilter(params, self.queryset).qs.count(), 2)
+
+    def test_name(self):
+        params = {'name': ['Region 1', 'Region 2']}
+        self.assertEqual(RegionFilter(params, self.queryset).qs.count(), 2)
+
+    def test_slug(self):
+        params = {'slug': ['region-1', 'region-2']}
+        self.assertEqual(RegionFilter(params, self.queryset).qs.count(), 2)
+
+    def test_parent(self):
+        parent_regions = Region.objects.filter(parent__isnull=True)[:2]
+        params = {'parent_id': [parent_regions[0].pk, parent_regions[1].pk]}
+        self.assertEqual(RegionFilter(params, self.queryset).qs.count(), 4)
+        params = {'parent': [parent_regions[0].slug, parent_regions[1].slug]}
+        self.assertEqual(RegionFilter(params, self.queryset).qs.count(), 4)
+
+
+class SiteTestCase(TestCase):
+    queryset = Site.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        regions = (
+            Region(name='Region 1', slug='region-1'),
+            Region(name='Region 2', slug='region-2'),
+            Region(name='Region 3', slug='region-3'),
+        )
+        for region in regions:
+            region.save()
+
+        sites = (
+            Site(name='Site 1', slug='site-1', region=regions[0], status=SITE_STATUS_ACTIVE, facility='Facility 1', asn=65001, latitude=10, longitude=10, contact_name='Contact 1', contact_phone='123-555-0001', contact_email='contact1@example.com'),
+            Site(name='Site 2', slug='site-2', region=regions[1], status=SITE_STATUS_PLANNED, facility='Facility 2', asn=65002, latitude=20, longitude=20, contact_name='Contact 2', contact_phone='123-555-0002', contact_email='contact2@example.com'),
+            Site(name='Site 3', slug='site-3', region=regions[2], status=SITE_STATUS_RETIRED, facility='Facility 3', asn=65003, latitude=30, longitude=30, contact_name='Contact 3', contact_phone='123-555-0003', contact_email='contact3@example.com'),
+        )
+        Site.objects.bulk_create(sites)
+
+    def test_id(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id': [str(id) for id in id_list]}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+
+    def test_name(self):
+        params = {'name': ['Site 1', 'Site 2']}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+
+    def test_slug(self):
+        params = {'slug': ['site-1', 'site-2']}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+
+    def test_facility(self):
+        params = {'facility': ['Facility 1', 'Facility 2']}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+
+    def test_asn(self):
+        params = {'asn': [65001, 65002]}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+
+    def test_latitude(self):
+        params = {'latitude': [10, 20]}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+
+    def test_longitude(self):
+        params = {'longitude': [10, 20]}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+
+    def test_contact_name(self):
+        params = {'contact_name': ['Contact 1', 'Contact 2']}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+
+    def test_contact_phone(self):
+        params = {'contact_phone': ['123-555-0001', '123-555-0002']}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+
+    def test_contact_email(self):
+        params = {'contact_email': ['contact1@example.com', 'contact2@example.com']}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+
+    def test_id__in(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id__in': ','.join([str(id) for id in id_list])}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+
+    def test_status(self):
+        params = {'status': [SITE_STATUS_ACTIVE, SITE_STATUS_PLANNED]}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+
+    def test_region(self):
+        regions = Region.objects.all()[:2]
+        params = {'region_id': [regions[0].pk, regions[1].pk]}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+        params = {'region': [regions[0].slug, regions[1].slug]}
+        self.assertEqual(SiteFilter(params, self.queryset).qs.count(), 2)
+
+
+class RackGroupTestCase(TestCase):
+    queryset = RackGroup.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        regions = (
+            Region(name='Region 1', slug='region-1'),
+            Region(name='Region 2', slug='region-2'),
+            Region(name='Region 3', slug='region-3'),
+        )
+        for region in regions:
+            region.save()
+
+        sites = (
+            Site(name='Site 1', slug='site-1', region=regions[0]),
+            Site(name='Site 2', slug='site-2', region=regions[1]),
+            Site(name='Site 3', slug='site-3', region=regions[2]),
+        )
+        Site.objects.bulk_create(sites)
+
+        rack_groups = (
+            RackGroup(name='Rack Group 1', slug='rack-group-1', site=sites[0]),
+            RackGroup(name='Rack Group 2', slug='rack-group-2', site=sites[1]),
+            RackGroup(name='Rack Group 3', slug='rack-group-3', site=sites[2]),
+        )
+        RackGroup.objects.bulk_create(rack_groups)
+
+    def test_id(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id': [str(id) for id in id_list]}
+        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+
+    def test_name(self):
+        params = {'name': ['Rack Group 1', 'Rack Group 2']}
+        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+
+    def test_slug(self):
+        params = {'slug': ['rack-group-1', 'rack-group-2']}
+        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+
+    def test_region(self):
+        regions = Region.objects.all()[:2]
+        params = {'region_id': [regions[0].pk, regions[1].pk]}
+        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+        params = {'region': [regions[0].slug, regions[1].slug]}
+        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+
+    def test_site(self):
+        sites = Site.objects.all()[:2]
+        params = {'site_id': [sites[0].pk, sites[1].pk]}
+        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+        params = {'site': [sites[0].slug, sites[1].slug]}
+        self.assertEqual(RackGroupFilter(params, self.queryset).qs.count(), 2)
+
+
+class RackRoleTestCase(TestCase):
+    queryset = RackRole.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        rack_roles = (
+            RackRole(name='Rack Role 1', slug='rack-role-1', color='ff0000'),
+            RackRole(name='Rack Role 2', slug='rack-role-2', color='00ff00'),
+            RackRole(name='Rack Role 3', slug='rack-role-3', color='0000ff'),
+        )
+        RackRole.objects.bulk_create(rack_roles)
+
+    def test_id(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id': [str(id) for id in id_list]}
+        self.assertEqual(RackRoleFilter(params, self.queryset).qs.count(), 2)
+
+    def test_name(self):
+        params = {'name': ['Rack Role 1', 'Rack Role 2']}
+        self.assertEqual(RackRoleFilter(params, self.queryset).qs.count(), 2)
+
+    def test_slug(self):
+        params = {'slug': ['rack-role-1', 'rack-role-2']}
+        self.assertEqual(RackRoleFilter(params, self.queryset).qs.count(), 2)
+
+    def test_color(self):
+        params = {'color': ['ff0000', '00ff00']}
+        self.assertEqual(RackRoleFilter(params, self.queryset).qs.count(), 2)
+
+
+class RackTestCase(TestCase):
+    queryset = Rack.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        regions = (
+            Region(name='Region 1', slug='region-1'),
+            Region(name='Region 2', slug='region-2'),
+            Region(name='Region 3', slug='region-3'),
+        )
+        for region in regions:
+            region.save()
+
+        sites = (
+            Site(name='Site 1', slug='site-1', region=regions[0]),
+            Site(name='Site 2', slug='site-2', region=regions[1]),
+            Site(name='Site 3', slug='site-3', region=regions[2]),
+        )
+        Site.objects.bulk_create(sites)
+
+        rack_groups = (
+            RackGroup(name='Rack Group 1', slug='rack-group-1', site=sites[0]),
+            RackGroup(name='Rack Group 2', slug='rack-group-2', site=sites[1]),
+            RackGroup(name='Rack Group 3', slug='rack-group-3', site=sites[2]),
+        )
+        RackGroup.objects.bulk_create(rack_groups)
+
+        rack_roles = (
+            RackRole(name='Rack Role 1', slug='rack-role-1'),
+            RackRole(name='Rack Role 2', slug='rack-role-2'),
+            RackRole(name='Rack Role 3', slug='rack-role-3'),
+        )
+        RackRole.objects.bulk_create(rack_roles)
+
+        racks = (
+            Rack(name='Rack 1', facility_id='rack-1', site=sites[0], group=rack_groups[0], status=RACK_STATUS_ACTIVE, role=rack_roles[0], serial='ABC', asset_tag='1001', type=RACK_TYPE_2POST, width=RACK_WIDTH_19IN, u_height=42, desc_units=False, outer_width=100, outer_depth=100, outer_unit=LENGTH_UNIT_MILLIMETER),
+            Rack(name='Rack 2', facility_id='rack-2', site=sites[1], group=rack_groups[1], status=RACK_STATUS_PLANNED, role=rack_roles[1], serial='DEF', asset_tag='1002', type=RACK_TYPE_4POST, width=RACK_WIDTH_19IN, u_height=43, desc_units=False, outer_width=200, outer_depth=200, outer_unit=LENGTH_UNIT_MILLIMETER),
+            Rack(name='Rack 3', facility_id='rack-3', site=sites[2], group=rack_groups[2], status=RACK_STATUS_RESERVED, role=rack_roles[2], serial='GHI', asset_tag='1003', type=RACK_TYPE_CABINET, width=RACK_WIDTH_23IN, u_height=44, desc_units=True, outer_width=300, outer_depth=300, outer_unit=LENGTH_UNIT_INCH),
+        )
+        Rack.objects.bulk_create(racks)
+
+    def test_id(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id': [str(id) for id in id_list]}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_name(self):
+        params = {'name': ['Rack 1', 'Rack 2']}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_facility_id(self):
+        params = {'facility_id': ['rack-1', 'rack-2']}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_asset_tag(self):
+        params = {'asset_tag': ['1001', '1002']}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_type(self):
+        # TODO: Test for multiple values
+        params = {'type': RACK_TYPE_2POST}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 1)
+
+    def test_width(self):
+        # TODO: Test for multiple values
+        params = {'width': RACK_WIDTH_19IN}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_u_height(self):
+        params = {'u_height': [42, 43]}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_desc_units(self):
+        params = {'desc_units': 'true'}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 1)
+        params = {'desc_units': 'false'}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_outer_width(self):
+        params = {'outer_width': [100, 200]}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_outer_depth(self):
+        params = {'outer_depth': [100, 200]}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_outer_unit(self):
+        self.assertEqual(Rack.objects.filter(outer_unit__isnull=False).count(), 3)
+        params = {'outer_unit': LENGTH_UNIT_MILLIMETER}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_id__in(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id__in': ','.join([str(id) for id in id_list])}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_region(self):
+        regions = Region.objects.all()[:2]
+        params = {'region_id': [regions[0].pk, regions[1].pk]}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        params = {'region': [regions[0].slug, regions[1].slug]}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_site(self):
+        sites = Site.objects.all()[:2]
+        params = {'site_id': [sites[0].pk, sites[1].pk]}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        params = {'site': [sites[0].slug, sites[1].slug]}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_group(self):
+        groups = RackGroup.objects.all()[:2]
+        params = {'group_id': [groups[0].pk, groups[1].pk]}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        params = {'group': [groups[0].slug, groups[1].slug]}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_status(self):
+        params = {'status': [RACK_STATUS_ACTIVE, RACK_STATUS_PLANNED]}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_role(self):
+        roles = RackRole.objects.all()[:2]
+        params = {'role_id': [roles[0].pk, roles[1].pk]}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+        params = {'role': [roles[0].slug, roles[1].slug]}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 2)
+
+    def test_serial(self):
+        params = {'serial': 'ABC'}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 1)
+        params = {'serial': 'abc'}
+        self.assertEqual(RackFilter(params, self.queryset).qs.count(), 1)
+
+
+class RackReservationTestCase(TestCase):
+    queryset = RackReservation.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        sites = (
+            Site(name='Site 1', slug='site-1'),
+            Site(name='Site 2', slug='site-2'),
+            Site(name='Site 3', slug='site-3'),
+        )
+        Site.objects.bulk_create(sites)
+
+        rack_groups = (
+            RackGroup(name='Rack Group 1', slug='rack-group-1', site=sites[0]),
+            RackGroup(name='Rack Group 2', slug='rack-group-2', site=sites[1]),
+            RackGroup(name='Rack Group 3', slug='rack-group-3', site=sites[2]),
+        )
+        RackGroup.objects.bulk_create(rack_groups)
+
+        racks = (
+            Rack(name='Rack 1', site=sites[0], group=rack_groups[0]),
+            Rack(name='Rack 2', site=sites[1], group=rack_groups[1]),
+            Rack(name='Rack 3', site=sites[2], group=rack_groups[2]),
+        )
+        Rack.objects.bulk_create(racks)
+
+        users = (
+            User(username='User 1'),
+            User(username='User 2'),
+            User(username='User 3'),
+        )
+        User.objects.bulk_create(users)
+
+        reservations = (
+            RackReservation(rack=racks[0], units=[1, 2, 3], user=users[0]),
+            RackReservation(rack=racks[1], units=[4, 5, 6], user=users[1]),
+            RackReservation(rack=racks[2], units=[7, 8, 9], user=users[2]),
+        )
+        RackReservation.objects.bulk_create(reservations)
+
+    def test_id__in(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id__in': ','.join([str(id) for id in id_list])}
+        self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)
+
+    def test_site(self):
+        sites = Site.objects.all()[:2]
+        params = {'site_id': [sites[0].pk, sites[1].pk]}
+        self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)
+        params = {'site': [sites[0].slug, sites[1].slug]}
+        self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)
+
+    def test_group(self):
+        groups = RackGroup.objects.all()[:2]
+        params = {'group_id': [groups[0].pk, groups[1].pk]}
+        self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)
+        params = {'group': [groups[0].slug, groups[1].slug]}
+        self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)
+
+    def test_user(self):
+        users = User.objects.all()[:2]
+        params = {'user_id': [users[0].pk, users[1].pk]}
+        self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)
+        # TODO: Filtering by username is broken
+        # params = {'user': [users[0].username, users[1].username]}
+        # self.assertEqual(RackReservationFilter(params, self.queryset).qs.count(), 2)

--- a/netbox/extras/filters.py
+++ b/netbox/extras/filters.py
@@ -8,6 +8,20 @@ from .constants import *
 from .models import ConfigContext, CustomField, Graph, ExportTemplate, ObjectChange, Tag, TopologyMap
 
 
+__all__ = (
+    'ConfigContextFilter',
+    'CreatedUpdatedFilterSet',
+    'CustomFieldFilter',
+    'CustomFieldFilterSet',
+    'ExportTemplateFilter',
+    'GraphFilter',
+    'LocalConfigContextFilter',
+    'ObjectChangeFilter',
+    'TagFilter',
+    'TopologyMapFilter',
+)
+
+
 class CustomFieldFilter(django_filters.Filter):
     """
     Filter objects by the presence of a CustomFieldValue. The filter's name is used as the CustomField name.

--- a/netbox/extras/tests/test_filters.py
+++ b/netbox/extras/tests/test_filters.py
@@ -1,0 +1,181 @@
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase
+
+from dcim.models import DeviceRole, Platform, Region, Site
+from extras.constants import *
+from extras.filters import *
+from extras.models import ConfigContext, ExportTemplate, Graph
+from tenancy.models import Tenant, TenantGroup
+
+
+class GraphTestCase(TestCase):
+    queryset = Graph.objects.all()
+    filterset = GraphFilter
+
+    @classmethod
+    def setUpTestData(cls):
+
+        graphs = (
+            Graph(name='Graph 1', type=GRAPH_TYPE_DEVICE, source='http://example.com/1'),
+            Graph(name='Graph 2', type=GRAPH_TYPE_INTERFACE, source='http://example.com/2'),
+            Graph(name='Graph 3', type=GRAPH_TYPE_SITE, source='http://example.com/3'),
+        )
+        Graph.objects.bulk_create(graphs)
+
+    def test_name(self):
+        params = {'name': 'Graph 1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_type(self):
+        params = {'type': GRAPH_TYPE_DEVICE}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+
+class ExportTemplateTestCase(TestCase):
+    queryset = ExportTemplate.objects.all()
+    filterset = ExportTemplateFilter
+
+    @classmethod
+    def setUpTestData(cls):
+
+        content_types = ContentType.objects.filter(model__in=['site', 'rack', 'device'])
+
+        export_templates = (
+            ExportTemplate(name='Export Template 1', content_type=content_types[0], template_language=TEMPLATE_LANGUAGE_DJANGO, template_code='TESTING'),
+            ExportTemplate(name='Export Template 2', content_type=content_types[1], template_language=TEMPLATE_LANGUAGE_JINJA2, template_code='TESTING'),
+            ExportTemplate(name='Export Template 3', content_type=content_types[2], template_language=TEMPLATE_LANGUAGE_JINJA2, template_code='TESTING'),
+        )
+        ExportTemplate.objects.bulk_create(export_templates)
+
+    def test_name(self):
+        params = {'name': 'Export Template 1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_content_type(self):
+        params = {'content_type': ContentType.objects.get(model='site').pk}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_template_language(self):
+        params = {'template_language': TEMPLATE_LANGUAGE_JINJA2}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+
+class ConfigContextTestCase(TestCase):
+    queryset = ConfigContext.objects.all()
+    filterset = ConfigContextFilter
+
+    @classmethod
+    def setUpTestData(cls):
+
+        regions = (
+            Region(name='Test Region 1', slug='test-region-1'),
+            Region(name='Test Region 2', slug='test-region-2'),
+            Region(name='Test Region 3', slug='test-region-3'),
+        )
+        # Can't use bulk_create for models with MPTT fields
+        for r in regions:
+            r.save()
+
+        sites = (
+            Site(name='Test Site 1', slug='test-site-1'),
+            Site(name='Test Site 2', slug='test-site-2'),
+            Site(name='Test Site 3', slug='test-site-3'),
+        )
+        Site.objects.bulk_create(sites)
+
+        device_roles = (
+            DeviceRole(name='Device Role 1', slug='device-role-1'),
+            DeviceRole(name='Device Role 2', slug='device-role-2'),
+            DeviceRole(name='Device Role 3', slug='device-role-3'),
+        )
+        DeviceRole.objects.bulk_create(device_roles)
+
+        platforms = (
+            Platform(name='Platform 1', slug='platform-1'),
+            Platform(name='Platform 2', slug='platform-2'),
+            Platform(name='Platform 3', slug='platform-3'),
+        )
+        Platform.objects.bulk_create(platforms)
+
+        tenant_groups = (
+            TenantGroup(name='Tenant Group 1', slug='tenant-group-1'),
+            TenantGroup(name='Tenant Group 2', slug='tenant-group-2'),
+            TenantGroup(name='Tenant Group 3', slug='tenant-group-3'),
+        )
+        TenantGroup.objects.bulk_create(tenant_groups)
+
+        tenants = (
+            Tenant(name='Tenant 1', slug='tenant-1'),
+            Tenant(name='Tenant 2', slug='tenant-2'),
+            Tenant(name='Tenant 3', slug='tenant-3'),
+        )
+        Tenant.objects.bulk_create(tenants)
+
+        for i in range(0, 3):
+            is_active = bool(i % 2)
+            c = ConfigContext.objects.create(
+                name='Config Context {}'.format(i + 1),
+                is_active=is_active,
+                data='{"foo": 123}'
+            )
+            c.regions.set([regions[i]])
+            c.sites.set([sites[i]])
+            c.roles.set([device_roles[i]])
+            c.platforms.set([platforms[i]])
+            c.tenant_groups.set([tenant_groups[i]])
+            c.tenants.set([tenants[i]])
+
+    def test_name(self):
+        params = {'name': 'Config Context 1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_is_active(self):
+        params = {'is_active': True}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {'is_active': False}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_region(self):
+        regions = Region.objects.all()[:2]
+        params = {'region_id': [regions[0].pk, regions[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'region': [regions[0].slug, regions[1].slug]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_site(self):
+        sites = Site.objects.all()[:2]
+        params = {'site_id': [sites[0].pk, sites[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'site': [sites[0].slug, sites[1].slug]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_role(self):
+        device_roles = DeviceRole.objects.all()[:2]
+        params = {'role_id': [device_roles[0].pk, device_roles[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'role': [device_roles[0].slug, device_roles[1].slug]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_platform(self):
+        platforms = Platform.objects.all()[:2]
+        params = {'platform_id': [platforms[0].pk, platforms[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'platform': [platforms[0].slug, platforms[1].slug]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_tenant_group(self):
+        tenant_groups = TenantGroup.objects.all()[:2]
+        params = {'tenant_group_id': [tenant_groups[0].pk, tenant_groups[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'tenant_group': [tenant_groups[0].slug, tenant_groups[1].slug]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_tenant_(self):
+        tenants = Tenant.objects.all()[:2]
+        params = {'tenant_id': [tenants[0].pk, tenants[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'tenant': [tenants[0].slug, tenants[1].slug]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+
+# TODO: ObjectChangeFilter test

--- a/netbox/ipam/filters.py
+++ b/netbox/ipam/filters.py
@@ -13,6 +13,19 @@ from .constants import *
 from .models import Aggregate, IPAddress, Prefix, RIR, Role, Service, VLAN, VLANGroup, VRF
 
 
+__all__ = (
+    'AggregateFilter',
+    'IPAddressFilter',
+    'PrefixFilter',
+    'RIRFilter',
+    'RoleFilter',
+    'ServiceFilter',
+    'VLANFilter',
+    'VLANGroupFilter',
+    'VRFFilter',
+)
+
+
 class VRFFilter(TenancyFilterSet, CustomFieldFilterSet, CreatedUpdatedFilterSet):
     id__in = NumericInFilter(
         field_name='id',

--- a/netbox/ipam/tests/test_filters.py
+++ b/netbox/ipam/tests/test_filters.py
@@ -1,0 +1,416 @@
+from django.test import TestCase
+
+from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Region, Site
+from ipam.constants import *
+from ipam.filters import AggregateFilter, IPAddressFilter, PrefixFilter, RIRFilter, RoleFilter, VLANFilter, VRFFilter
+from ipam.models import Aggregate, IPAddress, Prefix, RIR, Role, VLAN, VRF
+from virtualization.models import Cluster, ClusterType, VirtualMachine
+
+
+class VRFTestCase(TestCase):
+    queryset = VRF.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        vrfs = (
+            VRF(name='VRF 1', rd='65000:100', enforce_unique=False),
+            VRF(name='VRF 2', rd='65000:200', enforce_unique=False),
+            VRF(name='VRF 3', rd='65000:300', enforce_unique=False),
+            VRF(name='VRF 4', rd='65000:400', enforce_unique=True),
+            VRF(name='VRF 5', rd='65000:500', enforce_unique=True),
+            VRF(name='VRF 6', rd='65000:600', enforce_unique=True),
+        )
+        VRF.objects.bulk_create(vrfs)
+
+    def test_name(self):
+        params = {'name': ['VRF 1', 'VRF 2']}
+        self.assertEqual(VRFFilter(params, self.queryset).qs.count(), 2)
+
+    def test_rd(self):
+        params = {'rd': ['65000:100', '65000:200']}
+        self.assertEqual(VRFFilter(params, self.queryset).qs.count(), 2)
+
+    def test_enforce_unique(self):
+        params = {'enforce_unique': 'true'}
+        self.assertEqual(VRFFilter(params, self.queryset).qs.count(), 3)
+        params = {'enforce_unique': 'false'}
+        self.assertEqual(VRFFilter(params, self.queryset).qs.count(), 3)
+
+    def test_id__in(self):
+        id_list = self.queryset.values_list('id', flat=True)[:3]
+        params = {'id__in': ','.join([str(id) for id in id_list])}
+        self.assertEqual(VRFFilter(params, self.queryset).qs.count(), 3)
+
+
+class RIRTestCase(TestCase):
+    queryset = RIR.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        rirs = (
+            RIR(name='RIR 1', slug='rir-1', is_private=False),
+            RIR(name='RIR 2', slug='rir-2', is_private=False),
+            RIR(name='RIR 3', slug='rir-3', is_private=False),
+            RIR(name='RIR 4', slug='rir-4', is_private=True),
+            RIR(name='RIR 5', slug='rir-5', is_private=True),
+            RIR(name='RIR 6', slug='rir-6', is_private=True),
+        )
+        RIR.objects.bulk_create(rirs)
+
+    def test_name(self):
+        params = {'name': ['RIR 1', 'RIR 2']}
+        self.assertEqual(RIRFilter(params, self.queryset).qs.count(), 2)
+
+    def test_slug(self):
+        params = {'slug': ['rir-1', 'rir-2']}
+        self.assertEqual(RIRFilter(params, self.queryset).qs.count(), 2)
+
+    def test_is_private(self):
+        params = {'is_private': 'true'}
+        self.assertEqual(RIRFilter(params, self.queryset).qs.count(), 3)
+        params = {'is_private': 'false'}
+        self.assertEqual(RIRFilter(params, self.queryset).qs.count(), 3)
+
+    def test_id__in(self):
+        id_list = self.queryset.values_list('id', flat=True)[:3]
+        params = {'id__in': ','.join([str(id) for id in id_list])}
+        self.assertEqual(RIRFilter(params, self.queryset).qs.count(), 3)
+
+
+class AggregateTestCase(TestCase):
+    queryset = Aggregate.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        rirs = (
+            RIR(name='RIR 1', slug='rir-1'),
+            RIR(name='RIR 2', slug='rir-2'),
+            RIR(name='RIR 3', slug='rir-3'),
+        )
+        RIR.objects.bulk_create(rirs)
+
+        aggregates = (
+            Aggregate(family=4, prefix='10.1.0.0/16', rir=rirs[0], date_added='2020-01-01'),
+            Aggregate(family=4, prefix='10.2.0.0/16', rir=rirs[0], date_added='2020-01-02'),
+            Aggregate(family=4, prefix='10.3.0.0/16', rir=rirs[1], date_added='2020-01-03'),
+            Aggregate(family=6, prefix='2001:db8:1::/48', rir=rirs[1], date_added='2020-01-04'),
+            Aggregate(family=6, prefix='2001:db8:2::/48', rir=rirs[2], date_added='2020-01-05'),
+            Aggregate(family=6, prefix='2001:db8:3::/48', rir=rirs[2], date_added='2020-01-06'),
+        )
+        Aggregate.objects.bulk_create(aggregates)
+
+    def test_family(self):
+        params = {'family': '4'}
+        self.assertEqual(AggregateFilter(params, self.queryset).qs.count(), 3)
+
+    def test_date_added(self):
+        params = {'date_added': ['2020-01-01', '2020-01-02']}
+        self.assertEqual(AggregateFilter(params, self.queryset).qs.count(), 2)
+
+    # TODO: Test for multiple values
+    def test_prefix(self):
+        params = {'prefix': '10.1.0.0/16'}
+        self.assertEqual(AggregateFilter(params, self.queryset).qs.count(), 1)
+
+    def test_rir(self):
+        rirs = RIR.objects.all()[:2]
+        params = {'rir_id': [rirs[0].pk, rirs[1].pk]}
+        self.assertEqual(AggregateFilter(params, self.queryset).qs.count(), 4)
+        params = {'rir': [rirs[0].slug, rirs[1].slug]}
+        self.assertEqual(AggregateFilter(params, self.queryset).qs.count(), 4)
+
+
+class RoleTestCase(TestCase):
+    queryset = Role.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        roles = (
+            Role(name='Role 1', slug='role-1'),
+            Role(name='Role 2', slug='role-2'),
+            Role(name='Role 3', slug='role-3'),
+        )
+        Role.objects.bulk_create(roles)
+
+    def test_id(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id': [str(id) for id in id_list]}
+        self.assertEqual(RoleFilter(params, self.queryset).qs.count(), 2)
+
+    def test_name(self):
+        params = {'name': ['Role 1', 'Role 2']}
+        self.assertEqual(RoleFilter(params, self.queryset).qs.count(), 2)
+
+    def test_slug(self):
+        params = {'slug': ['role-1', 'role-2']}
+        self.assertEqual(RoleFilter(params, self.queryset).qs.count(), 2)
+
+
+class PrefixTestCase(TestCase):
+    queryset = Prefix.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        regions = (
+            Region(name='Test Region 1', slug='test-region-1'),
+            Region(name='Test Region 2', slug='test-region-2'),
+            Region(name='Test Region 3', slug='test-region-3'),
+        )
+        # Can't use bulk_create for models with MPTT fields
+        for r in regions:
+            r.save()
+
+        sites = (
+            Site(name='Test Site 1', slug='test-site-1', region=regions[0]),
+            Site(name='Test Site 2', slug='test-site-2', region=regions[1]),
+            Site(name='Test Site 3', slug='test-site-3', region=regions[2]),
+        )
+        Site.objects.bulk_create(sites)
+
+        vrfs = (
+            VRF(name='VRF 1', rd='65000:100'),
+            VRF(name='VRF 2', rd='65000:200'),
+            VRF(name='VRF 3', rd='65000:300'),
+        )
+        VRF.objects.bulk_create(vrfs)
+
+        vlans = (
+            VLAN(vid=1, name='VLAN 1'),
+            VLAN(vid=2, name='VLAN 2'),
+            VLAN(vid=3, name='VLAN 3'),
+        )
+        VLAN.objects.bulk_create(vlans)
+
+        roles = (
+            Role(name='Role 1', slug='role-1'),
+            Role(name='Role 2', slug='role-2'),
+            Role(name='Role 3', slug='role-3'),
+        )
+        Role.objects.bulk_create(roles)
+
+        prefixes = (
+            Prefix(family=4, prefix='10.0.0.0/24', site=None, vrf=None, vlan=None, role=None, is_pool=True),
+            Prefix(family=4, prefix='10.0.1.0/24', site=sites[0], vrf=vrfs[0], vlan=vlans[0], role=roles[0]),
+            Prefix(family=4, prefix='10.0.2.0/24', site=sites[1], vrf=vrfs[1], vlan=vlans[1], role=roles[1], status=PREFIX_STATUS_DEPRECATED),
+            Prefix(family=4, prefix='10.0.3.0/24', site=sites[2], vrf=vrfs[2], vlan=vlans[2], role=roles[2], status=PREFIX_STATUS_RESERVED),
+            Prefix(family=6, prefix='2001:db8::/64', site=None, vrf=None, vlan=None, role=None, is_pool=True),
+            Prefix(family=6, prefix='2001:db8:0:1::/64', site=sites[0], vrf=vrfs[0], vlan=vlans[0], role=roles[0]),
+            Prefix(family=6, prefix='2001:db8:0:2::/64', site=sites[1], vrf=vrfs[1], vlan=vlans[1], role=roles[1], status=PREFIX_STATUS_DEPRECATED),
+            Prefix(family=6, prefix='2001:db8:0:3::/64', site=sites[2], vrf=vrfs[2], vlan=vlans[2], role=roles[2], status=PREFIX_STATUS_RESERVED),
+            Prefix(family=4, prefix='10.0.0.0/16'),
+            Prefix(family=6, prefix='2001:db8::/32'),
+        )
+        Prefix.objects.bulk_create(prefixes)
+
+    def test_family(self):
+        params = {'family': '6'}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 5)
+
+    def test_is_pool(self):
+        params = {'is_pool': 'true'}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 2)
+        params = {'is_pool': 'false'}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 8)
+
+    def test_id__in(self):
+        id_list = self.queryset.values_list('id', flat=True)[:3]
+        params = {'id__in': ','.join([str(id) for id in id_list])}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 3)
+
+    def test_within(self):
+        params = {'within': '10.0.0.0/16'}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+
+    def test_within_include(self):
+        params = {'within_include': '10.0.0.0/16'}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 5)
+
+    def test_contains(self):
+        params = {'contains': '10.0.1.0/24'}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 2)
+        params = {'contains': '2001:db8:0:1::/64'}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 2)
+
+    def test_mask_length(self):
+        params = {'mask_length': '24'}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+
+    def test_vrf(self):
+        vrfs = VRF.objects.all()[:2]
+        params = {'vrf_id': [vrfs[0].pk, vrfs[1].pk]}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        params = {'vrf': [vrfs[0].rd, vrfs[1].rd]}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+
+    def test_region(self):
+        regions = Region.objects.all()[:2]
+        params = {'region_id': [regions[0].pk, regions[1].pk]}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        params = {'region': [regions[0].slug, regions[1].slug]}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+
+    def test_site(self):
+        sites = Site.objects.all()[:2]
+        params = {'site_id': [sites[0].pk, sites[1].pk]}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        params = {'site': [sites[0].slug, sites[1].slug]}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+
+    def test_vlan(self):
+        vlans = VLAN.objects.all()[:2]
+        params = {'vlan_id': [vlans[0].pk, vlans[1].pk]}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        # TODO: Test for multiple values
+        params = {'vlan_vid': vlans[0].vid}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 2)
+
+    def test_role(self):
+        roles = Role.objects.all()[:2]
+        params = {'role_id': [roles[0].pk, roles[1].pk]}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        params = {'role': [roles[0].slug, roles[1].slug]}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+
+    def test_status(self):
+        params = {'status': [PREFIX_STATUS_DEPRECATED, PREFIX_STATUS_RESERVED]}
+        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+
+
+class IPAddressTestCase(TestCase):
+    queryset = IPAddress.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        vrfs = (
+            VRF(name='VRF 1', rd='65000:100'),
+            VRF(name='VRF 2', rd='65000:200'),
+            VRF(name='VRF 3', rd='65000:300'),
+        )
+        VRF.objects.bulk_create(vrfs)
+
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        manufacturer = Manufacturer.objects.create(name='Manufacturer 1', slug='manufacturer-1')
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model='Device Type 1')
+        device_role = DeviceRole.objects.create(name='Device Role 1', slug='device-role-1')
+
+        devices = (
+            Device(device_type=device_type, name='Device 1', site=site, device_role=device_role),
+            Device(device_type=device_type, name='Device 2', site=site, device_role=device_role),
+            Device(device_type=device_type, name='Device 3', site=site, device_role=device_role),
+        )
+        Device.objects.bulk_create(devices)
+
+        clustertype = ClusterType.objects.create(name='Cluster Type 1', slug='cluster-type-1')
+        cluster = Cluster.objects.create(type=clustertype, name='Cluster 1')
+
+        virtual_machines = (
+            VirtualMachine(name='Virtual Machine 1', cluster=cluster),
+            VirtualMachine(name='Virtual Machine 2', cluster=cluster),
+            VirtualMachine(name='Virtual Machine 3', cluster=cluster),
+        )
+        VirtualMachine.objects.bulk_create(virtual_machines)
+
+        interfaces = (
+            Interface(device=devices[0], name='Interface 1'),
+            Interface(device=devices[1], name='Interface 2'),
+            Interface(device=devices[2], name='Interface 3'),
+            Interface(virtual_machine=virtual_machines[0], name='Interface 1'),
+            Interface(virtual_machine=virtual_machines[1], name='Interface 2'),
+            Interface(virtual_machine=virtual_machines[2], name='Interface 3'),
+        )
+        Interface.objects.bulk_create(interfaces)
+
+        ipaddresses = (
+            IPAddress(family=4, address='10.0.0.1/24', vrf=None, interface=None, status=IPADDRESS_STATUS_ACTIVE, role=None, dns_name='ipaddress-a'),
+            IPAddress(family=4, address='10.0.0.2/24', vrf=vrfs[0], interface=interfaces[0], status=IPADDRESS_STATUS_ACTIVE, role=None, dns_name='ipaddress-b'),
+            IPAddress(family=4, address='10.0.0.3/24', vrf=vrfs[1], interface=interfaces[1], status=IPADDRESS_STATUS_RESERVED, role=IPADDRESS_ROLE_VIP, dns_name='ipaddress-c'),
+            IPAddress(family=4, address='10.0.0.4/24', vrf=vrfs[2], interface=interfaces[2], status=IPADDRESS_STATUS_DEPRECATED, role=IPADDRESS_ROLE_SECONDARY, dns_name='ipaddress-d'),
+            IPAddress(family=6, address='2001:db8::1/64', vrf=None, interface=None, status=IPADDRESS_STATUS_ACTIVE, role=None, dns_name='ipaddress-a'),
+            IPAddress(family=6, address='2001:db8::2/64', vrf=vrfs[0], interface=interfaces[3], status=IPADDRESS_STATUS_ACTIVE, role=None, dns_name='ipaddress-b'),
+            IPAddress(family=6, address='2001:db8::3/64', vrf=vrfs[1], interface=interfaces[4], status=IPADDRESS_STATUS_RESERVED, role=IPADDRESS_ROLE_VIP, dns_name='ipaddress-c'),
+            IPAddress(family=6, address='2001:db8::4/64', vrf=vrfs[2], interface=interfaces[5], status=IPADDRESS_STATUS_DEPRECATED, role=IPADDRESS_ROLE_SECONDARY, dns_name='ipaddress-d'),
+        )
+        IPAddress.objects.bulk_create(ipaddresses)
+
+    def test_family(self):
+        params = {'family': '6'}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+
+    def test_dns_name(self):
+        params = {'dns_name': ['ipaddress-a', 'ipaddress-b']}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+
+    def test_id__in(self):
+        id_list = self.queryset.values_list('id', flat=True)[:3]
+        params = {'id__in': ','.join([str(id) for id in id_list])}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 3)
+
+    def test_parent(self):
+        params = {'parent': '10.0.0.0/24'}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+        params = {'parent': '2001:db8::/64'}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+
+    def filter_address(self):
+        # Check IPv4 and IPv6, with and without a mask
+        params = {'address': '10.0.0.1/24'}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 1)
+        params = {'address': '10.0.0.1'}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 1)
+        params = {'address': '2001:db8::1/64'}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 1)
+        params = {'address': '2001:db8::1'}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 1)
+
+    def test_mask_length(self):
+        params = {'mask_length': '24'}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+
+    def test_vrf(self):
+        vrfs = VRF.objects.all()[:2]
+        params = {'vrf_id': [vrfs[0].pk, vrfs[1].pk]}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+        params = {'vrf': [vrfs[0].rd, vrfs[1].rd]}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+
+    # TODO: Test for multiple values
+    def test_device(self):
+        device = Device.objects.first()
+        params = {'device_id': device.pk}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 1)
+        params = {'device': device.name}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 1)
+
+    def test_virtual_machine(self):
+        vms = VirtualMachine.objects.all()[:2]
+        params = {'virtual_machine_id': [vms[0].pk, vms[1].pk]}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 2)
+        params = {'virtual_machine': [vms[0].name, vms[1].name]}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 2)
+
+    def test_interface(self):
+        interfaces = Interface.objects.all()[:2]
+        params = {'interface_id': [interfaces[0].pk, interfaces[1].pk]}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 2)
+        params = {'interface': ['Interface 1', 'Interface 2']}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+
+    def test_assigned_to_interface(self):
+        params = {'assigned_to_interface': 'true'}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 6)
+        params = {'assigned_to_interface': 'false'}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 2)
+
+    def test_status(self):
+        params = {'status': [PREFIX_STATUS_DEPRECATED, PREFIX_STATUS_RESERVED]}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+
+    def test_role(self):
+        params = {'role': [IPADDRESS_ROLE_SECONDARY, IPADDRESS_ROLE_VIP]}
+        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)

--- a/netbox/ipam/tests/test_filters.py
+++ b/netbox/ipam/tests/test_filters.py
@@ -2,16 +2,14 @@ from django.test import TestCase
 
 from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Region, Site
 from ipam.constants import *
-from ipam.filters import (
-    AggregateFilter, IPAddressFilter, PrefixFilter, RIRFilter, RoleFilter, ServiceFilter, VLANFilter, VLANGroupFilter,
-    VRFFilter,
-)
+from ipam.filters import *
 from ipam.models import Aggregate, IPAddress, Prefix, RIR, Role, Service, VLAN, VLANGroup, VRF
 from virtualization.models import Cluster, ClusterType, VirtualMachine
 
 
 class VRFTestCase(TestCase):
     queryset = VRF.objects.all()
+    filterset = VRFFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -28,26 +26,27 @@ class VRFTestCase(TestCase):
 
     def test_name(self):
         params = {'name': ['VRF 1', 'VRF 2']}
-        self.assertEqual(VRFFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_rd(self):
         params = {'rd': ['65000:100', '65000:200']}
-        self.assertEqual(VRFFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_enforce_unique(self):
         params = {'enforce_unique': 'true'}
-        self.assertEqual(VRFFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
         params = {'enforce_unique': 'false'}
-        self.assertEqual(VRFFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:3]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(VRFFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
 
 class RIRTestCase(TestCase):
     queryset = RIR.objects.all()
+    filterset = RIRFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -64,26 +63,27 @@ class RIRTestCase(TestCase):
 
     def test_name(self):
         params = {'name': ['RIR 1', 'RIR 2']}
-        self.assertEqual(RIRFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['rir-1', 'rir-2']}
-        self.assertEqual(RIRFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_is_private(self):
         params = {'is_private': 'true'}
-        self.assertEqual(RIRFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
         params = {'is_private': 'false'}
-        self.assertEqual(RIRFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:3]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(RIRFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
 
 class AggregateTestCase(TestCase):
     queryset = Aggregate.objects.all()
+    filterset = AggregateFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -107,27 +107,28 @@ class AggregateTestCase(TestCase):
 
     def test_family(self):
         params = {'family': '4'}
-        self.assertEqual(AggregateFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_date_added(self):
         params = {'date_added': ['2020-01-01', '2020-01-02']}
-        self.assertEqual(AggregateFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     # TODO: Test for multiple values
     def test_prefix(self):
         params = {'prefix': '10.1.0.0/16'}
-        self.assertEqual(AggregateFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_rir(self):
         rirs = RIR.objects.all()[:2]
         params = {'rir_id': [rirs[0].pk, rirs[1].pk]}
-        self.assertEqual(AggregateFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'rir': [rirs[0].slug, rirs[1].slug]}
-        self.assertEqual(AggregateFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
 class RoleTestCase(TestCase):
     queryset = Role.objects.all()
+    filterset = RoleFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -142,19 +143,20 @@ class RoleTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(RoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Role 1', 'Role 2']}
-        self.assertEqual(RoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['role-1', 'role-2']}
-        self.assertEqual(RoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class PrefixTestCase(TestCase):
     queryset = Prefix.objects.all()
+    filterset = PrefixFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -212,80 +214,81 @@ class PrefixTestCase(TestCase):
 
     def test_family(self):
         params = {'family': '6'}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 5)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
 
     def test_is_pool(self):
         params = {'is_pool': 'true'}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'is_pool': 'false'}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 8)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:3]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_within(self):
         params = {'within': '10.0.0.0/16'}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_within_include(self):
         params = {'within_include': '10.0.0.0/16'}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 5)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
 
     def test_contains(self):
         params = {'contains': '10.0.1.0/24'}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'contains': '2001:db8:0:1::/64'}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_mask_length(self):
         params = {'mask_length': '24'}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_vrf(self):
         vrfs = VRF.objects.all()[:2]
         params = {'vrf_id': [vrfs[0].pk, vrfs[1].pk]}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'vrf': [vrfs[0].rd, vrfs[1].rd]}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_vlan(self):
         vlans = VLAN.objects.all()[:2]
         params = {'vlan_id': [vlans[0].pk, vlans[1].pk]}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         # TODO: Test for multiple values
         params = {'vlan_vid': vlans[0].vid}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_role(self):
         roles = Role.objects.all()[:2]
         params = {'role_id': [roles[0].pk, roles[1].pk]}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'role': [roles[0].slug, roles[1].slug]}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_status(self):
         params = {'status': [PREFIX_STATUS_DEPRECATED, PREFIX_STATUS_RESERVED]}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
 class IPAddressTestCase(TestCase):
     queryset = IPAddress.objects.all()
+    filterset = IPAddressFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -343,84 +346,85 @@ class IPAddressTestCase(TestCase):
 
     def test_family(self):
         params = {'family': '6'}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_dns_name(self):
         params = {'dns_name': ['ipaddress-a', 'ipaddress-b']}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:3]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_parent(self):
         params = {'parent': '10.0.0.0/24'}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'parent': '2001:db8::/64'}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def filter_address(self):
         # Check IPv4 and IPv6, with and without a mask
         params = {'address': '10.0.0.1/24'}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
         params = {'address': '10.0.0.1'}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
         params = {'address': '2001:db8::1/64'}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
         params = {'address': '2001:db8::1'}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_mask_length(self):
         params = {'mask_length': '24'}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_vrf(self):
         vrfs = VRF.objects.all()[:2]
         params = {'vrf_id': [vrfs[0].pk, vrfs[1].pk]}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'vrf': [vrfs[0].rd, vrfs[1].rd]}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     # TODO: Test for multiple values
     def test_device(self):
         device = Device.objects.first()
         params = {'device_id': device.pk}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
         params = {'device': device.name}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_virtual_machine(self):
         vms = VirtualMachine.objects.all()[:2]
         params = {'virtual_machine_id': [vms[0].pk, vms[1].pk]}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'virtual_machine': [vms[0].name, vms[1].name]}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_interface(self):
         interfaces = Interface.objects.all()[:2]
         params = {'interface_id': [interfaces[0].pk, interfaces[1].pk]}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'interface': ['Interface 1', 'Interface 2']}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_assigned_to_interface(self):
         params = {'assigned_to_interface': 'true'}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 6)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
         params = {'assigned_to_interface': 'false'}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_status(self):
         params = {'status': [PREFIX_STATUS_DEPRECATED, PREFIX_STATUS_RESERVED]}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_role(self):
         params = {'role': [IPADDRESS_ROLE_SECONDARY, IPADDRESS_ROLE_VIP]}
-        self.assertEqual(IPAddressFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
 class VLANGroupTestCase(TestCase):
     queryset = VLANGroup.objects.all()
+    filterset = VLANGroupFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -452,33 +456,34 @@ class VLANGroupTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(VLANGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['VLAN Group 1', 'VLAN Group 2']}
-        self.assertEqual(VLANGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['vlan-group-1', 'vlan-group-2']}
-        self.assertEqual(VLANGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(VLANGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(VLANGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(VLANGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(VLANGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class VLANTestCase(TestCase):
     queryset = VLAN.objects.all()
+    filterset = VLANFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -525,52 +530,53 @@ class VLANTestCase(TestCase):
 
     def test_name(self):
         params = {'name': ['VLAN 101', 'VLAN 102']}
-        self.assertEqual(VLANFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_rd(self):
         params = {'vid': ['101', '201', '301']}
-        self.assertEqual(VLANFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:3]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(VLANFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(VLANFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(VLANFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(VLANFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(VLANFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_group(self):
         groups = VLANGroup.objects.all()[:2]
         params = {'group_id': [groups[0].pk, groups[1].pk]}
-        self.assertEqual(VLANFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'group': [groups[0].slug, groups[1].slug]}
-        self.assertEqual(VLANFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_role(self):
         roles = Role.objects.all()[:2]
         params = {'role_id': [roles[0].pk, roles[1].pk]}
-        self.assertEqual(VLANFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'role': [roles[0].slug, roles[1].slug]}
-        self.assertEqual(VLANFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_status(self):
         params = {'status': [VLAN_STATUS_ACTIVE, VLAN_STATUS_DEPRECATED]}
-        self.assertEqual(PrefixFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
 class ServiceTestCase(TestCase):
     queryset = Service.objects.all()
+    filterset = ServiceFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -610,30 +616,30 @@ class ServiceTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:3]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(ServiceFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_name(self):
         params = {'name': ['Service 1', 'Service 2']}
-        self.assertEqual(ServiceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_protocol(self):
         params = {'protocol': IP_PROTOCOL_TCP}
-        self.assertEqual(ServiceFilter(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_port(self):
         params = {'port': ['1001', '1002', '1003']}
-        self.assertEqual(ServiceFilter(params, self.queryset).qs.count(), 3)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_device(self):
         devices = Device.objects.all()[:2]
         params = {'device_id': [devices[0].pk, devices[1].pk]}
-        self.assertEqual(ServiceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'device': [devices[0].name, devices[1].name]}
-        self.assertEqual(ServiceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_virtual_machine(self):
         vms = VirtualMachine.objects.all()[:2]
         params = {'virtual_machine_id': [vms[0].pk, vms[1].pk]}
-        self.assertEqual(ServiceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'virtual_machine': [vms[0].name, vms[1].name]}
-        self.assertEqual(ServiceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)

--- a/netbox/secrets/filters.py
+++ b/netbox/secrets/filters.py
@@ -7,6 +7,12 @@ from utilities.filters import NameSlugSearchFilterSet, NumericInFilter, TagFilte
 from .models import Secret, SecretRole
 
 
+__all__ = (
+    'SecretFilter',
+    'SecretRoleFilter',
+)
+
+
 class SecretRoleFilter(NameSlugSearchFilterSet):
 
     class Meta:

--- a/netbox/secrets/tests/test_filters.py
+++ b/netbox/secrets/tests/test_filters.py
@@ -1,0 +1,90 @@
+from django.test import TestCase
+
+from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
+from secrets.filters import SecretFilter, SecretRoleFilter
+from secrets.models import Secret, SecretRole
+
+
+class SecretRoleTestCase(TestCase):
+    queryset = SecretRole.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        roles = (
+            SecretRole(name='Secret Role 1', slug='secret-role-1'),
+            SecretRole(name='Secret Role 2', slug='secret-role-2'),
+            SecretRole(name='Secret Role 3', slug='secret-role-3'),
+        )
+        SecretRole.objects.bulk_create(roles)
+
+    def test_id(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id': [str(id) for id in id_list]}
+        self.assertEqual(SecretRoleFilter(params, self.queryset).qs.count(), 2)
+
+    def test_name(self):
+        params = {'name': ['Secret Role 1', 'Secret Role 2']}
+        self.assertEqual(SecretRoleFilter(params, self.queryset).qs.count(), 2)
+
+    def test_slug(self):
+        params = {'slug': ['secret-role-1', 'secret-role-2']}
+        self.assertEqual(SecretRoleFilter(params, self.queryset).qs.count(), 2)
+
+
+class SecretTestCase(TestCase):
+    queryset = Secret.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        manufacturer = Manufacturer.objects.create(name='Manufacturer 1', slug='manufacturer-1')
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model='Device Type 1')
+        device_role = DeviceRole.objects.create(name='Device Role 1', slug='device-role-1')
+
+        devices = (
+            Device(device_type=device_type, name='Device 1', site=site, device_role=device_role),
+            Device(device_type=device_type, name='Device 2', site=site, device_role=device_role),
+            Device(device_type=device_type, name='Device 3', site=site, device_role=device_role),
+        )
+        Device.objects.bulk_create(devices)
+
+        roles = (
+            SecretRole(name='Secret Role 1', slug='secret-role-1'),
+            SecretRole(name='Secret Role 2', slug='secret-role-2'),
+            SecretRole(name='Secret Role 3', slug='secret-role-3'),
+        )
+        SecretRole.objects.bulk_create(roles)
+
+        secrets = (
+            Secret(device=devices[0], role=roles[0], name='Secret 1', plaintext='SECRET DATA'),
+            Secret(device=devices[1], role=roles[1], name='Secret 2', plaintext='SECRET DATA'),
+            Secret(device=devices[2], role=roles[2], name='Secret 3', plaintext='SECRET DATA'),
+        )
+        # Must call save() to encrypt Secrets
+        for s in secrets:
+            s.save()
+
+    def test_name(self):
+        params = {'name': ['Secret 1', 'Secret 2']}
+        self.assertEqual(SecretFilter(params, self.queryset).qs.count(), 2)
+
+    def test_id__in(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id__in': ','.join([str(id) for id in id_list])}
+        self.assertEqual(SecretFilter(params, self.queryset).qs.count(), 2)
+
+    def test_role(self):
+        roles = SecretRole.objects.all()[:2]
+        params = {'role_id': [roles[0].pk, roles[1].pk]}
+        self.assertEqual(SecretFilter(params, self.queryset).qs.count(), 2)
+        params = {'role': [roles[0].slug, roles[1].slug]}
+        self.assertEqual(SecretFilter(params, self.queryset).qs.count(), 2)
+
+    def test_device(self):
+        devices = Device.objects.all()[:2]
+        params = {'device_id': [devices[0].pk, devices[1].pk]}
+        self.assertEqual(SecretFilter(params, self.queryset).qs.count(), 2)
+        params = {'device': [devices[0].name, devices[1].name]}
+        self.assertEqual(SecretFilter(params, self.queryset).qs.count(), 2)

--- a/netbox/secrets/tests/test_filters.py
+++ b/netbox/secrets/tests/test_filters.py
@@ -1,12 +1,13 @@
 from django.test import TestCase
 
 from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Site
-from secrets.filters import SecretFilter, SecretRoleFilter
+from secrets.filters import *
 from secrets.models import Secret, SecretRole
 
 
 class SecretRoleTestCase(TestCase):
     queryset = SecretRole.objects.all()
+    filterset = SecretRoleFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -21,19 +22,20 @@ class SecretRoleTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(SecretRoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Secret Role 1', 'Secret Role 2']}
-        self.assertEqual(SecretRoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['secret-role-1', 'secret-role-2']}
-        self.assertEqual(SecretRoleFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class SecretTestCase(TestCase):
     queryset = Secret.objects.all()
+    filterset = SecretFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -68,23 +70,23 @@ class SecretTestCase(TestCase):
 
     def test_name(self):
         params = {'name': ['Secret 1', 'Secret 2']}
-        self.assertEqual(SecretFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(SecretFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_role(self):
         roles = SecretRole.objects.all()[:2]
         params = {'role_id': [roles[0].pk, roles[1].pk]}
-        self.assertEqual(SecretFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'role': [roles[0].slug, roles[1].slug]}
-        self.assertEqual(SecretFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_device(self):
         devices = Device.objects.all()[:2]
         params = {'device_id': [devices[0].pk, devices[1].pk]}
-        self.assertEqual(SecretFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'device': [devices[0].name, devices[1].name]}
-        self.assertEqual(SecretFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)

--- a/netbox/tenancy/filters.py
+++ b/netbox/tenancy/filters.py
@@ -6,6 +6,12 @@ from utilities.filters import NameSlugSearchFilterSet, NumericInFilter, TagFilte
 from .models import Tenant, TenantGroup
 
 
+__all__ = (
+    'TenantFilter',
+    'TenantGroupFilter',
+)
+
+
 class TenantGroupFilter(NameSlugSearchFilterSet):
 
     class Meta:

--- a/netbox/tenancy/tests/test_filters.py
+++ b/netbox/tenancy/tests/test_filters.py
@@ -1,11 +1,12 @@
 from django.test import TestCase
 
-from tenancy.filters import TenantFilter, TenantGroupFilter
+from tenancy.filters import *
 from tenancy.models import Tenant, TenantGroup
 
 
 class TenantGroupTestCase(TestCase):
     queryset = TenantGroup.objects.all()
+    filterset = TenantGroupFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -20,19 +21,20 @@ class TenantGroupTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(TenantGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Tenant Group 1', 'Tenant Group 2']}
-        self.assertEqual(TenantGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['tenant-group-1', 'tenant-group-2']}
-        self.assertEqual(TenantGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class TenantTestCase(TestCase):
     queryset = Tenant.objects.all()
+    filterset = TenantFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -53,20 +55,20 @@ class TenantTestCase(TestCase):
 
     def test_name(self):
         params = {'name': ['Tenant 1', 'Tenant 2']}
-        self.assertEqual(TenantFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['tenant-1', 'tenant-2']}
-        self.assertEqual(TenantFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(TenantFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_group(self):
         group = TenantGroup.objects.all()[:2]
         params = {'group_id': [group[0].pk, group[1].pk]}
-        self.assertEqual(TenantFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'group': [group[0].slug, group[1].slug]}
-        self.assertEqual(TenantFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)

--- a/netbox/tenancy/tests/test_filters.py
+++ b/netbox/tenancy/tests/test_filters.py
@@ -1,0 +1,72 @@
+from django.test import TestCase
+
+from tenancy.filters import TenantFilter, TenantGroupFilter
+from tenancy.models import Tenant, TenantGroup
+
+
+class TenantGroupTestCase(TestCase):
+    queryset = TenantGroup.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        groups = (
+            TenantGroup(name='Tenant Group 1', slug='tenant-group-1'),
+            TenantGroup(name='Tenant Group 2', slug='tenant-group-2'),
+            TenantGroup(name='Tenant Group 3', slug='tenant-group-3'),
+        )
+        TenantGroup.objects.bulk_create(groups)
+
+    def test_id(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id': [str(id) for id in id_list]}
+        self.assertEqual(TenantGroupFilter(params, self.queryset).qs.count(), 2)
+
+    def test_name(self):
+        params = {'name': ['Tenant Group 1', 'Tenant Group 2']}
+        self.assertEqual(TenantGroupFilter(params, self.queryset).qs.count(), 2)
+
+    def test_slug(self):
+        params = {'slug': ['tenant-group-1', 'tenant-group-2']}
+        self.assertEqual(TenantGroupFilter(params, self.queryset).qs.count(), 2)
+
+
+class TenantTestCase(TestCase):
+    queryset = Tenant.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        groups = (
+            TenantGroup(name='Tenant Group 1', slug='tenant-group-1'),
+            TenantGroup(name='Tenant Group 2', slug='tenant-group-2'),
+            TenantGroup(name='Tenant Group 3', slug='tenant-group-3'),
+        )
+        TenantGroup.objects.bulk_create(groups)
+
+        tenants = (
+            Tenant(name='Tenant 1', slug='tenant-1', group=groups[0]),
+            Tenant(name='Tenant 2', slug='tenant-2', group=groups[1]),
+            Tenant(name='Tenant 3', slug='tenant-3', group=groups[2]),
+        )
+        Tenant.objects.bulk_create(tenants)
+
+    def test_name(self):
+        params = {'name': ['Tenant 1', 'Tenant 2']}
+        self.assertEqual(TenantFilter(params, self.queryset).qs.count(), 2)
+
+    def test_slug(self):
+        params = {'slug': ['tenant-1', 'tenant-2']}
+        self.assertEqual(TenantFilter(params, self.queryset).qs.count(), 2)
+
+    def test_id__in(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id__in': ','.join([str(id) for id in id_list])}
+        self.assertEqual(TenantFilter(params, self.queryset).qs.count(), 2)
+
+    def test_group(self):
+        group = TenantGroup.objects.all()[:2]
+        params = {'group_id': [group[0].pk, group[1].pk]}
+        self.assertEqual(TenantFilter(params, self.queryset).qs.count(), 2)
+        params = {'group': [group[0].slug, group[1].slug]}
+        self.assertEqual(TenantFilter(params, self.queryset).qs.count(), 2)

--- a/netbox/virtualization/filters.py
+++ b/netbox/virtualization/filters.py
@@ -1,7 +1,5 @@
 import django_filters
 from django.db.models import Q
-from netaddr import EUI
-from netaddr.core import AddrFormatError
 
 from dcim.models import DeviceRole, Interface, Platform, Region, Site
 from extras.filters import CustomFieldFilterSet, CreatedUpdatedFilterSet
@@ -11,6 +9,15 @@ from utilities.filters import (
 )
 from .constants import *
 from .models import Cluster, ClusterGroup, ClusterType, VirtualMachine
+
+
+__all__ = (
+    'ClusterFilter',
+    'ClusterGroupFilter',
+    'ClusterTypeFilter',
+    'InterfaceFilter',
+    'VirtualMachineFilter',
+)
 
 
 class ClusterTypeFilter(NameSlugSearchFilterSet):

--- a/netbox/virtualization/tests/test_filters.py
+++ b/netbox/virtualization/tests/test_filters.py
@@ -1,0 +1,365 @@
+from django.test import TestCase
+
+from dcim.models import DeviceRole, Interface, Platform, Region, Site
+from virtualization.constants import *
+from virtualization.filters import (
+    ClusterFilter, ClusterGroupFilter, ClusterTypeFilter, InterfaceFilter, VirtualMachineFilter,
+)
+from virtualization.models import Cluster, ClusterGroup, ClusterType, VirtualMachine
+
+
+class ClusterTypeTestCase(TestCase):
+    queryset = ClusterType.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        cluster_types = (
+            ClusterType(name='Cluster Type 1', slug='cluster-type-1'),
+            ClusterType(name='Cluster Type 2', slug='cluster-type-2'),
+            ClusterType(name='Cluster Type 3', slug='cluster-type-3'),
+        )
+        ClusterType.objects.bulk_create(cluster_types)
+
+    def test_id(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id': [str(id) for id in id_list]}
+        self.assertEqual(ClusterTypeFilter(params, self.queryset).qs.count(), 2)
+
+    def test_name(self):
+        params = {'name': ['Cluster Type 1', 'Cluster Type 2']}
+        self.assertEqual(ClusterTypeFilter(params, self.queryset).qs.count(), 2)
+
+    def test_slug(self):
+        params = {'slug': ['cluster-type-1', 'cluster-type-2']}
+        self.assertEqual(ClusterTypeFilter(params, self.queryset).qs.count(), 2)
+
+
+class ClusterGroupTestCase(TestCase):
+    queryset = ClusterGroup.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        cluster_groups = (
+            ClusterGroup(name='Cluster Group 1', slug='cluster-group-1'),
+            ClusterGroup(name='Cluster Group 2', slug='cluster-group-2'),
+            ClusterGroup(name='Cluster Group 3', slug='cluster-group-3'),
+        )
+        ClusterGroup.objects.bulk_create(cluster_groups)
+
+    def test_id(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id': [str(id) for id in id_list]}
+        self.assertEqual(ClusterGroupFilter(params, self.queryset).qs.count(), 2)
+
+    def test_name(self):
+        params = {'name': ['Cluster Group 1', 'Cluster Group 2']}
+        self.assertEqual(ClusterGroupFilter(params, self.queryset).qs.count(), 2)
+
+    def test_slug(self):
+        params = {'slug': ['cluster-group-1', 'cluster-group-2']}
+        self.assertEqual(ClusterGroupFilter(params, self.queryset).qs.count(), 2)
+
+
+class ClusterTestCase(TestCase):
+    queryset = Cluster.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        cluster_types = (
+            ClusterType(name='Cluster Type 1', slug='cluster-type-1'),
+            ClusterType(name='Cluster Type 2', slug='cluster-type-2'),
+            ClusterType(name='Cluster Type 3', slug='cluster-type-3'),
+        )
+        ClusterType.objects.bulk_create(cluster_types)
+
+        cluster_groups = (
+            ClusterGroup(name='Cluster Group 1', slug='cluster-group-1'),
+            ClusterGroup(name='Cluster Group 2', slug='cluster-group-2'),
+            ClusterGroup(name='Cluster Group 3', slug='cluster-group-3'),
+        )
+        ClusterGroup.objects.bulk_create(cluster_groups)
+
+        regions = (
+            Region(name='Test Region 1', slug='test-region-1'),
+            Region(name='Test Region 2', slug='test-region-2'),
+            Region(name='Test Region 3', slug='test-region-3'),
+        )
+        # Can't use bulk_create for models with MPTT fields
+        for r in regions:
+            r.save()
+
+        sites = (
+            Site(name='Test Site 1', slug='test-site-1', region=regions[0]),
+            Site(name='Test Site 2', slug='test-site-2', region=regions[1]),
+            Site(name='Test Site 3', slug='test-site-3', region=regions[2]),
+        )
+        Site.objects.bulk_create(sites)
+
+        clusters = (
+            Cluster(name='Cluster 1', type=cluster_types[0], group=cluster_groups[0], site=sites[0]),
+            Cluster(name='Cluster 2', type=cluster_types[1], group=cluster_groups[1], site=sites[1]),
+            Cluster(name='Cluster 3', type=cluster_types[2], group=cluster_groups[2], site=sites[2]),
+        )
+        Cluster.objects.bulk_create(clusters)
+
+    def test_name(self):
+        params = {'name': ['Cluster 1', 'Cluster 2']}
+        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+
+    def test_id__in(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id__in': ','.join([str(id) for id in id_list])}
+        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+
+    def test_region(self):
+        regions = Region.objects.all()[:2]
+        params = {'region_id': [regions[0].pk, regions[1].pk]}
+        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        params = {'region': [regions[0].slug, regions[1].slug]}
+        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+
+    def test_site(self):
+        sites = Site.objects.all()[:2]
+        params = {'site_id': [sites[0].pk, sites[1].pk]}
+        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        params = {'site': [sites[0].slug, sites[1].slug]}
+        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+
+    def test_group(self):
+        groups = ClusterGroup.objects.all()[:2]
+        params = {'group_id': [groups[0].pk, groups[1].pk]}
+        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        params = {'group': [groups[0].slug, groups[1].slug]}
+        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+
+    def test_type(self):
+        types = ClusterType.objects.all()[:2]
+        params = {'type_id': [types[0].pk, types[1].pk]}
+        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        params = {'type': [types[0].slug, types[1].slug]}
+        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+
+
+class VirtualMachineTestCase(TestCase):
+    queryset = VirtualMachine.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        cluster_types = (
+            ClusterType(name='Cluster Type 1', slug='cluster-type-1'),
+            ClusterType(name='Cluster Type 2', slug='cluster-type-2'),
+            ClusterType(name='Cluster Type 3', slug='cluster-type-3'),
+        )
+        ClusterType.objects.bulk_create(cluster_types)
+
+        cluster_groups = (
+            ClusterGroup(name='Cluster Group 1', slug='cluster-group-1'),
+            ClusterGroup(name='Cluster Group 2', slug='cluster-group-2'),
+            ClusterGroup(name='Cluster Group 3', slug='cluster-group-3'),
+        )
+        ClusterGroup.objects.bulk_create(cluster_groups)
+
+        regions = (
+            Region(name='Test Region 1', slug='test-region-1'),
+            Region(name='Test Region 2', slug='test-region-2'),
+            Region(name='Test Region 3', slug='test-region-3'),
+        )
+        # Can't use bulk_create for models with MPTT fields
+        for r in regions:
+            r.save()
+
+        sites = (
+            Site(name='Test Site 1', slug='test-site-1', region=regions[0]),
+            Site(name='Test Site 2', slug='test-site-2', region=regions[1]),
+            Site(name='Test Site 3', slug='test-site-3', region=regions[2]),
+        )
+        Site.objects.bulk_create(sites)
+
+        clusters = (
+            Cluster(name='Cluster 1', type=cluster_types[0], group=cluster_groups[0], site=sites[0]),
+            Cluster(name='Cluster 2', type=cluster_types[1], group=cluster_groups[1], site=sites[1]),
+            Cluster(name='Cluster 3', type=cluster_types[2], group=cluster_groups[2], site=sites[2]),
+        )
+        Cluster.objects.bulk_create(clusters)
+
+        platforms = (
+            Platform(name='Platform 1', slug='platform-1'),
+            Platform(name='Platform 2', slug='platform-2'),
+            Platform(name='Platform 3', slug='platform-3'),
+        )
+        Platform.objects.bulk_create(platforms)
+
+        roles = (
+            DeviceRole(name='Device Role 1', slug='device-role-1'),
+            DeviceRole(name='Device Role 2', slug='device-role-2'),
+            DeviceRole(name='Device Role 3', slug='device-role-3'),
+        )
+        DeviceRole.objects.bulk_create(roles)
+
+        vms = (
+            VirtualMachine(name='Virtual Machine 1', cluster=clusters[0], platform=platforms[0], role=roles[0], status=DEVICE_STATUS_ACTIVE, vcpus=1, memory=1, disk=1),
+            VirtualMachine(name='Virtual Machine 2', cluster=clusters[1], platform=platforms[1], role=roles[1], status=DEVICE_STATUS_STAGED, vcpus=2, memory=2, disk=2),
+            VirtualMachine(name='Virtual Machine 3', cluster=clusters[2], platform=platforms[2], role=roles[2], status=DEVICE_STATUS_OFFLINE, vcpus=3, memory=3, disk=3),
+        )
+        VirtualMachine.objects.bulk_create(vms)
+
+        interfaces = (
+            Interface(virtual_machine=vms[0], name='Interface 1', mac_address='00-00-00-00-00-01'),
+            Interface(virtual_machine=vms[1], name='Interface 2', mac_address='00-00-00-00-00-02'),
+            Interface(virtual_machine=vms[2], name='Interface 3', mac_address='00-00-00-00-00-03'),
+        )
+        Interface.objects.bulk_create(interfaces)
+
+    def test_id(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id': [str(id) for id in id_list]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_name(self):
+        params = {'name': ['Virtual Machine 1', 'Virtual Machine 2']}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_vcpus(self):
+        params = {'vcpus': [1, 2]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_memory(self):
+        params = {'memory': [1, 2]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_disk(self):
+        params = {'disk': [1, 2]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_id__in(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id__in': ','.join([str(id) for id in id_list])}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_status(self):
+        params = {'status': [DEVICE_STATUS_ACTIVE, DEVICE_STATUS_STAGED]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_cluster_group(self):
+        groups = ClusterGroup.objects.all()[:2]
+        params = {'cluster_group_id': [groups[0].pk, groups[1].pk]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        params = {'cluster_group': [groups[0].slug, groups[1].slug]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_cluster_type(self):
+        types = ClusterType.objects.all()[:2]
+        params = {'cluster_type_id': [types[0].pk, types[1].pk]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        params = {'cluster_type': [types[0].slug, types[1].slug]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_cluster(self):
+        clusters = Cluster.objects.all()[:2]
+        params = {'cluster_id': [clusters[0].pk, clusters[1].pk]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        # TODO: 'cluster' should match on name
+        # params = {'cluster': [clusters[0].name, clusters[1].name]}
+        # self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_region(self):
+        regions = Region.objects.all()[:2]
+        params = {'region_id': [regions[0].pk, regions[1].pk]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        params = {'region': [regions[0].slug, regions[1].slug]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_site(self):
+        sites = Site.objects.all()[:2]
+        params = {'site_id': [sites[0].pk, sites[1].pk]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        params = {'site': [sites[0].slug, sites[1].slug]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_role(self):
+        roles = DeviceRole.objects.all()[:2]
+        params = {'role_id': [roles[0].pk, roles[1].pk]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        params = {'role': [roles[0].slug, roles[1].slug]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_platform(self):
+        platforms = Platform.objects.all()[:2]
+        params = {'platform_id': [platforms[0].pk, platforms[1].pk]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        params = {'platform': [platforms[0].slug, platforms[1].slug]}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+    def test_mac_address(self):
+        params = {'mac_address': ['00-00-00-00-00-01', '00-00-00-00-00-02']}
+        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+
+
+class InterfaceTestCase(TestCase):
+    queryset = Interface.objects.all()
+
+    @classmethod
+    def setUpTestData(cls):
+
+        cluster_types = (
+            ClusterType(name='Cluster Type 1', slug='cluster-type-1'),
+            ClusterType(name='Cluster Type 2', slug='cluster-type-2'),
+            ClusterType(name='Cluster Type 3', slug='cluster-type-3'),
+        )
+        ClusterType.objects.bulk_create(cluster_types)
+
+        clusters = (
+            Cluster(name='Cluster 1', type=cluster_types[0]),
+            Cluster(name='Cluster 2', type=cluster_types[1]),
+            Cluster(name='Cluster 3', type=cluster_types[2]),
+        )
+        Cluster.objects.bulk_create(clusters)
+
+        vms = (
+            VirtualMachine(name='Virtual Machine 1', cluster=clusters[0]),
+            VirtualMachine(name='Virtual Machine 2', cluster=clusters[1]),
+            VirtualMachine(name='Virtual Machine 3', cluster=clusters[2]),
+        )
+        VirtualMachine.objects.bulk_create(vms)
+
+        interfaces = (
+            Interface(virtual_machine=vms[0], name='Interface 1', enabled=True, mtu=100, mac_address='00-00-00-00-00-01'),
+            Interface(virtual_machine=vms[1], name='Interface 2', enabled=True, mtu=200, mac_address='00-00-00-00-00-02'),
+            Interface(virtual_machine=vms[2], name='Interface 3', enabled=False, mtu=300, mac_address='00-00-00-00-00-03'),
+        )
+        Interface.objects.bulk_create(interfaces)
+
+    def test_id(self):
+        id_list = self.queryset.values_list('id', flat=True)[:2]
+        params = {'id': [str(id) for id in id_list]}
+        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
+
+    def test_name(self):
+        params = {'name': ['Interface 1', 'Interface 2']}
+        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
+
+    def test_assigned_to_interface(self):
+        params = {'enabled': 'true'}
+        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
+        params = {'enabled': 'false'}
+        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 1)
+
+    def test_mtu(self):
+        params = {'mtu': [100, 200]}
+        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
+
+    def test_virtual_machine(self):
+        vms = VirtualMachine.objects.all()[:2]
+        params = {'virtual_machine_id': [vms[0].pk, vms[1].pk]}
+        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
+        params = {'virtual_machine': [vms[0].name, vms[1].name]}
+        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
+
+    # TODO: Test for multiple values
+    def test_mac_address(self):
+        params = {'mac_address': '00-00-00-00-00-01'}
+        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 1)

--- a/netbox/virtualization/tests/test_filters.py
+++ b/netbox/virtualization/tests/test_filters.py
@@ -359,7 +359,6 @@ class InterfaceTestCase(TestCase):
         params = {'virtual_machine': [vms[0].name, vms[1].name]}
         self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
 
-    # TODO: Test for multiple values
     def test_mac_address(self):
-        params = {'mac_address': '00-00-00-00-00-01'}
-        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 1)
+        params = {'mac_address': ['00-00-00-00-00-01', '00-00-00-00-00-02']}
+        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)

--- a/netbox/virtualization/tests/test_filters.py
+++ b/netbox/virtualization/tests/test_filters.py
@@ -2,14 +2,13 @@ from django.test import TestCase
 
 from dcim.models import DeviceRole, Interface, Platform, Region, Site
 from virtualization.constants import *
-from virtualization.filters import (
-    ClusterFilter, ClusterGroupFilter, ClusterTypeFilter, InterfaceFilter, VirtualMachineFilter,
-)
+from virtualization.filters import *
 from virtualization.models import Cluster, ClusterGroup, ClusterType, VirtualMachine
 
 
 class ClusterTypeTestCase(TestCase):
     queryset = ClusterType.objects.all()
+    filterset = ClusterTypeFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -24,19 +23,20 @@ class ClusterTypeTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(ClusterTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Cluster Type 1', 'Cluster Type 2']}
-        self.assertEqual(ClusterTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['cluster-type-1', 'cluster-type-2']}
-        self.assertEqual(ClusterTypeFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class ClusterGroupTestCase(TestCase):
     queryset = ClusterGroup.objects.all()
+    filterset = ClusterGroupFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -51,19 +51,20 @@ class ClusterGroupTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(ClusterGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Cluster Group 1', 'Cluster Group 2']}
-        self.assertEqual(ClusterGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['cluster-group-1', 'cluster-group-2']}
-        self.assertEqual(ClusterGroupFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class ClusterTestCase(TestCase):
     queryset = Cluster.objects.all()
+    filterset = ClusterFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -107,44 +108,45 @@ class ClusterTestCase(TestCase):
 
     def test_name(self):
         params = {'name': ['Cluster 1', 'Cluster 2']}
-        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_group(self):
         groups = ClusterGroup.objects.all()[:2]
         params = {'group_id': [groups[0].pk, groups[1].pk]}
-        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'group': [groups[0].slug, groups[1].slug]}
-        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
         types = ClusterType.objects.all()[:2]
         params = {'type_id': [types[0].pk, types[1].pk]}
-        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'type': [types[0].slug, types[1].slug]}
-        self.assertEqual(ClusterFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class VirtualMachineTestCase(TestCase):
     queryset = VirtualMachine.objects.all()
+    filterset = VirtualMachineFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -217,90 +219,91 @@ class VirtualMachineTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Virtual Machine 1', 'Virtual Machine 2']}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_vcpus(self):
         params = {'vcpus': [1, 2]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_memory(self):
         params = {'memory': [1, 2]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_disk(self):
         params = {'disk': [1, 2]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_id__in(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id__in': ','.join([str(id) for id in id_list])}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_status(self):
         params = {'status': [DEVICE_STATUS_ACTIVE, DEVICE_STATUS_STAGED]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_cluster_group(self):
         groups = ClusterGroup.objects.all()[:2]
         params = {'cluster_group_id': [groups[0].pk, groups[1].pk]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'cluster_group': [groups[0].slug, groups[1].slug]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_cluster_type(self):
         types = ClusterType.objects.all()[:2]
         params = {'cluster_type_id': [types[0].pk, types[1].pk]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'cluster_type': [types[0].slug, types[1].slug]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_cluster(self):
         clusters = Cluster.objects.all()[:2]
         params = {'cluster_id': [clusters[0].pk, clusters[1].pk]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         # TODO: 'cluster' should match on name
         # params = {'cluster': [clusters[0].name, clusters[1].name]}
-        # self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        # self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'site': [sites[0].slug, sites[1].slug]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_role(self):
         roles = DeviceRole.objects.all()[:2]
         params = {'role_id': [roles[0].pk, roles[1].pk]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'role': [roles[0].slug, roles[1].slug]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_platform(self):
         platforms = Platform.objects.all()[:2]
         params = {'platform_id': [platforms[0].pk, platforms[1].pk]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'platform': [platforms[0].slug, platforms[1].slug]}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_mac_address(self):
         params = {'mac_address': ['00-00-00-00-00-01', '00-00-00-00-00-02']}
-        self.assertEqual(VirtualMachineFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class InterfaceTestCase(TestCase):
     queryset = Interface.objects.all()
+    filterset = InterfaceFilter
 
     @classmethod
     def setUpTestData(cls):
@@ -336,29 +339,29 @@ class InterfaceTestCase(TestCase):
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
         params = {'id': [str(id) for id in id_list]}
-        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_name(self):
         params = {'name': ['Interface 1', 'Interface 2']}
-        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_assigned_to_interface(self):
         params = {'enabled': 'true'}
-        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'enabled': 'false'}
-        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_mtu(self):
         params = {'mtu': [100, 200]}
-        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_virtual_machine(self):
         vms = VirtualMachine.objects.all()[:2]
         params = {'virtual_machine_id': [vms[0].pk, vms[1].pk]}
-        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'virtual_machine': [vms[0].name, vms[1].name]}
-        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_mac_address(self):
         params = {'mac_address': ['00-00-00-00-00-01', '00-00-00-00-00-02']}
-        self.assertEqual(InterfaceFilter(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)


### PR DESCRIPTION
### Fixes: #3834

Introduces `test_filters.py` within the `tests/` directory under each app. Includes tests for _almost_ every FilterSet (waiting on v2.7 to finish a few of them).
