### PR TITLE
Fixes #3668: use `q` to search when assigning IP

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -4,6 +4,7 @@
 
 * [#2050](https://github.com/netbox-community/netbox/issues/2050) - Preview image attachments when hovering the link
 * [#3187](https://github.com/netbox-community/netbox/issues/3187) - Add rack selection field to rack elevations
+* [#3668](https://github.com/netbox-community/netbox/issues/3668) - Search by DNS name when assigning IP address
 
 ## Bug Fixes
 

--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -4,6 +4,7 @@
 
 * [#2050](https://github.com/netbox-community/netbox/issues/2050) - Preview image attachments when hovering the link
 * [#2589](https://github.com/netbox-community/netbox/issues/2589) - Toggle for showing available prefixes/ip addresses
+* [#3009](https://github.com/netbox-community/netbox/issues/3009) - Search by description when assigning IP address
 * [#3090](https://github.com/netbox-community/netbox/issues/3090) - Add filter field for device interfaces
 * [#3187](https://github.com/netbox-community/netbox/issues/3187) - Add rack selection field to rack elevations
 * [#3440](https://github.com/netbox-community/netbox/issues/3440) - Add total length to cable trace

--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -4,6 +4,7 @@
 
 * [#2050](https://github.com/netbox-community/netbox/issues/2050) - Preview image attachments when hovering the link
 * [#2589](https://github.com/netbox-community/netbox/issues/2589) - Toggle for showing available prefixes/ip addresses
+* [#3009](https://github.com/netbox-community/netbox/issues/3009) - Search by description when assigning IP address
 * [#3187](https://github.com/netbox-community/netbox/issues/3187) - Add rack selection field to rack elevations
 * [#3668](https://github.com/netbox-community/netbox/issues/3668) - Search by DNS name when assigning IP address
 * [#3851](https://github.com/netbox-community/netbox/issues/3851) - Allow passing initial data to custom script forms

--- a/netbox/ipam/forms.py
+++ b/netbox/ipam/forms.py
@@ -933,7 +933,7 @@ class IPAddressBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEd
 
 
 class IPAddressAssignForm(BootstrapMixin, forms.Form):
-    vrf = forms.ModelChoiceField(
+    vrf_id = forms.ModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
         label='VRF',
@@ -942,13 +942,9 @@ class IPAddressAssignForm(BootstrapMixin, forms.Form):
             api_url="/api/ipam/vrfs/"
         )
     )
-    address = forms.CharField(
-        label='IP Address',
+    q = forms.CharField(
         required=False,
-    )
-    dns_name = forms.CharField(
-        label='DNS Name',
-        required=False,
+        label='Search',
     )
 
 

--- a/netbox/ipam/forms.py
+++ b/netbox/ipam/forms.py
@@ -943,7 +943,12 @@ class IPAddressAssignForm(BootstrapMixin, forms.Form):
         )
     )
     address = forms.CharField(
-        label='IP Address'
+        label='IP Address',
+        required=False,
+    )
+    dns_name = forms.CharField(
+        label='DNS Name',
+        required=False,
     )
 
 

--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -373,7 +373,7 @@ class IPAddressAssignTable(BaseTable):
 
     class Meta(BaseTable.Meta):
         model = IPAddress
-        fields = ('address', 'vrf', 'status', 'role', 'tenant', 'parent', 'interface', 'description')
+        fields = ('address', 'dns_name', 'vrf', 'status', 'role', 'tenant', 'parent', 'interface', 'description')
         orderable = False
 
 

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -745,6 +745,7 @@ class IPAddressAssignView(PermissionRequiredMixin, View):
             ).filter(
                 vrf=form.cleaned_data['vrf'],
                 address__istartswith=form.cleaned_data['address'],
+                dns_name__icontains=form.cleaned_data['dns_name'],
             )[:100]  # Limit to 100 results
             table = tables.IPAddressAssignTable(queryset)
 

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -749,14 +749,12 @@ class IPAddressAssignView(PermissionRequiredMixin, View):
 
         if form.is_valid():
 
-            queryset = IPAddress.objects.prefetch_related(
+            addresses = IPAddress.objects.prefetch_related(
                 'vrf', 'tenant', 'interface__device', 'interface__virtual_machine'
-            ).filter(
-                vrf=form.cleaned_data['vrf'],
-                address__istartswith=form.cleaned_data['address'],
-                dns_name__icontains=form.cleaned_data['dns_name'],
-            )[:100]  # Limit to 100 results
-            table = tables.IPAddressAssignTable(queryset)
+            )
+            # Limit to 100 results
+            addresses = filters.IPAddressFilter(request.POST, addresses).qs[:100]
+            table = tables.IPAddressAssignTable(addresses)
 
         return render(request, 'ipam/ipaddress_assign.html', {
             'form': form,

--- a/netbox/templates/ipam/ipaddress_assign.html
+++ b/netbox/templates/ipam/ipaddress_assign.html
@@ -24,9 +24,8 @@
             <div class="panel panel-default">
                 <div class="panel-heading"><strong>Select IP Address</strong></div>
                 <div class="panel-body">
-                    {% render_field form.vrf %}
-                    {% render_field form.address %}
-                    {% render_field form.dns_name %}
+                    {% render_field form.vrf_id %}
+                    {% render_field form.q %}
                 </div>
             </div>
             </div>

--- a/netbox/templates/ipam/ipaddress_assign.html
+++ b/netbox/templates/ipam/ipaddress_assign.html
@@ -26,6 +26,7 @@
                 <div class="panel-body">
                     {% render_field form.vrf %}
                     {% render_field form.address %}
+                    {% render_field form.dns_name %}
                 </div>
             </div>
             </div>


### PR DESCRIPTION
### Fixes: #3009
### Fixes: #3668

Search by address (starting with), DNS name (icontains), or description (icontains) when assigning an IP address.