### PR TITLE
Fixes #3864: Limit number of related IPs

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -10,6 +10,7 @@
 * [#3589](https://github.com/netbox-community/netbox/issues/3589) - Fix validation on tagged VLANs of an interface
 * [#3853](https://github.com/netbox-community/netbox/issues/3853) - Fix device role link on config context view
 * [#3856](https://github.com/netbox-community/netbox/issues/3856) - Allow filtering VM interfaces by multiple MAC addresses
+* [#3864](https://github.com/netbox-community/netbox/issues/3864) - Limit number of related IPs
 
 ---
 

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -676,7 +676,7 @@ class IPAddressView(PermissionRequiredMixin, View):
             address=str(ipaddress.address)
         ).filter(
             vrf=ipaddress.vrf, address__net_contained_or_equal=str(ipaddress.address)
-        )
+        )[:50]
         related_ips_table = tables.IPAddressTable(list(related_ips), orderable=False)
 
         return render(request, 'ipam/ipaddress.html', {


### PR DESCRIPTION
### Fixes: #3864 

Limited the related IPs table to 50 entries (currently loads/renders all related IPs). No preference on the number; it just seemed that 50 was good enough for functionality without making the page too long.