### PR TITLE
Fixes #3872: Limit related IPs table

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -13,6 +13,7 @@
 * [#3856](https://github.com/netbox-community/netbox/issues/3856) - Allow filtering VM interfaces by multiple MAC addresses
 * [#3857](https://github.com/netbox-community/netbox/issues/3857) - Fix group custom links rendering
 * [#3862](https://github.com/netbox-community/netbox/issues/3862) - Allow filtering device components by multiple device names
+* [#3872](https://github.com/netbox-community/netbox/issues/3872) - Limit number of related IPs
 
 ---
 

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -676,8 +676,15 @@ class IPAddressView(PermissionRequiredMixin, View):
             address=str(ipaddress.address)
         ).filter(
             vrf=ipaddress.vrf, address__net_contained_or_equal=str(ipaddress.address)
-        )[:50]
-        related_ips_table = tables.IPAddressTable(list(related_ips), orderable=False)
+        )
+
+        related_ips_table = tables.IPAddressTable(related_ips, orderable=False)
+
+        paginate = {
+            'paginator_class': EnhancedPaginator,
+            'per_page': request.GET.get('per_page', settings.PAGINATE_COUNT)
+        }
+        RequestConfig(request, paginate).configure(related_ips_table)
 
         return render(request, 'ipam/ipaddress.html', {
             'ipaddress': ipaddress,

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -676,7 +676,7 @@ class IPAddressView(PermissionRequiredMixin, View):
             address=str(ipaddress.address)
         ).filter(
             vrf=ipaddress.vrf, address__net_contained_or_equal=str(ipaddress.address)
-        )
+        )[:50]
         related_ips_table = tables.IPAddressTable(list(related_ips), orderable=False)
 
         return render(request, 'ipam/ipaddress.html', {

--- a/netbox/templates/ipam/ipaddress.html
+++ b/netbox/templates/ipam/ipaddress.html
@@ -160,7 +160,7 @@
         {% if duplicate_ips_table.rows %}
             {% include 'panel_table.html' with table=duplicate_ips_table heading='Duplicate IP Addresses' panel_class='danger' %}
         {% endif %}
-        {% include 'panel_table.html' with table=related_ips_table heading='Related IP Addresses' panel_class='default noprint' %}
+        {% include 'utilities/obj_table.html' with table=related_ips_table table_template='panel_table.html' heading='Related IP Addresses' panel_class='default noprint' %}
 	</div>
 </div>
 {% endblock %}


### PR DESCRIPTION
### Fixes: #3872

Limited the related IPs table to 50 entries (currently loads/renders all related IPs). No preference on the number; it just seemed that 50 was good enough for functionality without making the page too long.