### PR TITLE
Fixes #3393: Paginate circuits at the provider details view

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -8,8 +8,8 @@
 * [#2589](https://github.com/netbox-community/netbox/issues/2589) - Toggle for showing available prefixes/ip addresses
 * [#3090](https://github.com/netbox-community/netbox/issues/3090) - Add filter field for device interfaces
 * [#3187](https://github.com/netbox-community/netbox/issues/3187) - Add rack selection field to rack elevations
-* [#3440](https://github.com/netbox-community/netbox/issues/3440) - Add total length to cable trace
 * [#3393](https://github.com/netbox-community/netbox/issues/3393) - Paginate the circuits at the provider details view
+* [#3440](https://github.com/netbox-community/netbox/issues/3440) - Add total length to cable trace
 * [#3851](https://github.com/netbox-community/netbox/issues/3851) - Allow passing initial data to custom script forms
 
 ## Bug Fixes

--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -9,6 +9,7 @@
 * [#3090](https://github.com/netbox-community/netbox/issues/3090) - Add filter field for device interfaces
 * [#3187](https://github.com/netbox-community/netbox/issues/3187) - Add rack selection field to rack elevations
 * [#3440](https://github.com/netbox-community/netbox/issues/3440) - Add total length to cable trace
+* [#3393](https://github.com/netbox-community/netbox/issues/3393) - Paginate the circuits at the provider details view
 * [#3851](https://github.com/netbox-community/netbox/issues/3851) - Allow passing initial data to custom script forms
 
 ## Bug Fixes

--- a/netbox/circuits/views.py
+++ b/netbox/circuits/views.py
@@ -39,8 +39,10 @@ class ProviderView(PermissionRequiredMixin, View):
 
         provider = get_object_or_404(Provider, slug=slug)
         circuits = Circuit.objects.filter(provider=provider).prefetch_related('type', 'tenant', 'terminations__site')
-        circuits_table = tables.CircuitTable(circuits, orderable=False)
         show_graphs = Graph.objects.filter(type=GRAPH_TYPE_PROVIDER).exists()
+
+        circuits_table = tables.CircuitTable(circuits, orderable=False)
+        circuits_table.columns.hide('provider')
 
         paginate = {
             'paginator_class': EnhancedPaginator,

--- a/netbox/templates/circuits/provider.html
+++ b/netbox/templates/circuits/provider.html
@@ -125,58 +125,7 @@
             <div class="panel-heading">
                 <strong>Circuits</strong>
             </div>
-            <table class="table table-hover panel-body">
-                <tr>
-                    <th>Circuit ID</th>
-                    <th>Type</th>
-                    <th>Tenant</th>
-                    <th>A Side</th>
-                    <th>Z Side</th>
-                    <th>Description</th>
-                </tr>
-                {% for c in circuits %}
-                    <tr>
-                        <td>
-                            <a href="{% url 'circuits:circuit' pk=c.pk %}">{{ c.cid }}</a>
-                        </td>
-                        <td>
-                            <a href="{% url 'circuits:circuit_list' %}?type={{ c.type.slug }}">{{ c.type }}</a>
-                        </td>
-                        <td>
-                            {% if c.tenant %}
-                                <a href="{% url 'tenancy:tenant' slug=c.tenant.slug %}">{{ c.tenant }}</a>
-                            {% else %}
-                                <span class="text-muted">&mdash;</span>
-                            {% endif %}
-                        </td>
-                        <td>
-                            {% if c.termination_a %}
-                                <a href="{% url 'dcim:site' slug=c.termination_a.site.slug %}">{{ c.termination_a.site }}</a>
-                            {% else %}
-                                <span class="text-muted">&mdash;</span>
-                            {% endif %}
-                        </td>
-                        <td>
-                            {% if c.termination_z %}
-                                <a href="{% url 'dcim:site' slug=c.termination_z.site.slug %}">{{ c.termination_z.site }}</a>
-                            {% else %}
-                                <span class="text-muted">&mdash;</span>
-                            {% endif %}
-                        </td>
-                        <td>
-                            {% if c.description %}
-                                {{ c.description }}
-                            {% else %}
-                                <span class="text-muted">&mdash;</span>
-                            {% endif %}
-                        </td>
-                    </tr>
-                {% empty %}
-                    <tr>
-                        <td colspan="6" class="text-muted">None</td>
-                    </tr>
-                {% endfor %}
-            </table>
+            {% include 'inc/table.html' with table=circuits_table %}
             {% if perms.circuits.add_circuit %}
                 <div class="panel-footer text-right noprint">
                     <a href="{% url 'circuits:circuit_add' %}?provider={{ provider.pk }}" class="btn btn-xs btn-primary">
@@ -185,6 +134,7 @@
                 </div>
             {% endif %}
         </div>
+    {% include 'inc/paginator.html' with paginator=circuits_table.paginator page=circuits_table.page %}
     </div>
 </div>
 {% include 'inc/modal.html' with modal_name='graphs' %}


### PR DESCRIPTION
### Fixes: #3393

Paginated the list of circuits in the provider details view. I've also templated the table which, in addition to looking more consistent with the other tables, also added `Status` column that was not in the table of the provider view.