### PR TITLE
Fixes #3876: Min/max values for ASN field

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -21,6 +21,7 @@
 * [#3862](https://github.com/netbox-community/netbox/issues/3862) - Allow filtering device components by multiple device names
 * [#3864](https://github.com/netbox-community/netbox/issues/3864) - Disallow /0 masks
 * [#3872](https://github.com/netbox-community/netbox/issues/3872) - Paginate related IPs of an address
+* [#3876](https://github.com/netbox-community/netbox/issues/3876) - Fixed min/max to ASN input field at the site creation page
 
 ---
 

--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -1,4 +1,8 @@
 
+# BGP ASN bounds
+BGP_ASN_MIN = 1
+BGP_ASN_MAX = 2**32 - 1
+
 # Rack types
 RACK_TYPE_2POST = 100
 RACK_TYPE_4POST = 200

--- a/netbox/dcim/fields.py
+++ b/netbox/dcim/fields.py
@@ -3,16 +3,18 @@ from django.core.validators import MinValueValidator, MaxValueValidator
 from django.db import models
 from netaddr import AddrFormatError, EUI, mac_unix_expanded
 
+from .constants import *
+
 
 class ASNField(models.BigIntegerField):
     description = "32-bit ASN field"
     default_validators = [
-        MinValueValidator(1),
-        MaxValueValidator(4294967295),
+        MinValueValidator(BGP_ASN_MIN),
+        MaxValueValidator(BGP_ASN_MAX),
     ]
 
     def formfield(self, **kwargs):
-        defaults = {'min_value': 1, 'max_value': 4294967295}
+        defaults = {'min_value': BGP_ASN_MIN, 'max_value': BGP_ASN_MAX}
         defaults.update(**kwargs)
         return super().formfield(**defaults)
 

--- a/netbox/dcim/fields.py
+++ b/netbox/dcim/fields.py
@@ -11,6 +11,11 @@ class ASNField(models.BigIntegerField):
         MaxValueValidator(4294967295),
     ]
 
+    def formfield(self, **kwargs):
+        defaults = {'min_value': 1, 'max_value': 4294967295}
+        defaults.update(**kwargs)
+        return super().formfield(**defaults)
+
 
 class mac_unix_expanded_uppercase(mac_unix_expanded):
     word_fmt = '%.2X'

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -292,8 +292,8 @@ class SiteBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditFor
         )
     )
     asn = forms.IntegerField(
-        min_value=1,
-        max_value=4294967295,
+        min_value=BGP_ASN_MIN,
+        max_value=BGP_ASN_MAX,
         required=False,
         label='ASN'
     )


### PR DESCRIPTION
### Fixes: #3876 

`ASNField` inherits from `models.BigIntegerField` which is defaulting to long numbers in the `min` and `max` attributes of the input field.