### PR TITLE
Fixes #3895: Elevations filter regression

### DIFF
--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -739,7 +739,7 @@ class RackElevationFilterForm(RackFilterForm):
 
         # Filter the rack field based on the site and group
         self.fields['site'].widget.add_filter_for('id', 'site')
-        self.fields['rack_group_id'].widget.add_filter_for('id', 'group_id')
+        self.fields['group_id'].widget.add_filter_for('id', 'group_id')
 
 
 #


### PR DESCRIPTION
### Fixes: #3895

`RackElevationFilterForm` inherits from `RackFilterForm` which uses `group_id`. Didn't put a changelog entry since v2.6.12 is not out of dev.