### PR TITLE
Fixes #3898: Call str of cable on delete to save PK in id_string

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -28,6 +28,7 @@
 * [#3872](https://github.com/netbox-community/netbox/issues/3872) - Paginate related IPs of an address
 * [#3876](https://github.com/netbox-community/netbox/issues/3876) - Fixed min/max to ASN input field at the site creation page
 * [#3882](https://github.com/netbox-community/netbox/issues/3882) - Fix filtering of devices by rack group
+* [#3898](https://github.com/netbox-community/netbox/issues/3898) - Fix deleted message being set to None for cable 
 
 ---
 

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -3040,6 +3040,11 @@ class Cable(ChangeLoggedModel):
     def get_absolute_url(self):
         return reverse('dcim:cable', args=[self.pk])
 
+    def delete(self, *args, **kwargs):
+        # Trigger the __str__ method to save the pk into `self.id_string`
+        str(self)
+        super().delete(*args, **kwargs)
+
     def clean(self):
 
         # Validate that termination A exists

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -3027,23 +3027,17 @@ class Cable(ChangeLoggedModel):
             ('termination_b_type', 'termination_b_id'),
         )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # A copy of the PK to be used by __str__ in case the object is deleted
+        self._pk = self.pk
+
     def __str__(self):
-        if self.label:
-            return self.label
-
-        # Save a copy of the PK on the instance since it's nullified if .delete() is called
-        if not hasattr(self, 'id_string'):
-            self.id_string = '#{}'.format(self.pk)
-
-        return self.id_string
+        return self.label or '#{}'.format(self._pk)
 
     def get_absolute_url(self):
         return reverse('dcim:cable', args=[self.pk])
-
-    def delete(self, *args, **kwargs):
-        # Trigger the __str__ method to save the pk into `self.id_string`
-        str(self)
-        super().delete(*args, **kwargs)
 
     def clean(self):
 

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -3141,6 +3141,9 @@ class Cable(ChangeLoggedModel):
 
         super().save(*args, **kwargs)
 
+        # Update the private pk used in __str__ in case this is a new object (i.e. just got its pk)
+        self._pk = self.pk
+
     def to_csv(self):
         return (
             '{}.{}'.format(self.termination_a_type.app_label, self.termination_a_type.model),

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -325,9 +325,12 @@ class CableTestCase(TestCase):
 
     def test_cable_deletion(self):
         """
-        When a Cable is deleted, the `cable` field on its termination points must be nullified.
+        When a Cable is deleted, the `cable` field on its termination points must be nullified. The str() method
+        should still return the PK of the string even after being nullified.
         """
         self.cable.delete()
+        self.assertIsNone(self.cable.pk)
+        self.assertNotEqual(str(self.cable), '#None')
         interface1 = Interface.objects.get(pk=self.interface1.pk)
         self.assertIsNone(interface1.cable)
         interface2 = Interface.objects.get(pk=self.interface2.pk)


### PR DESCRIPTION
### Fixes: #3898

Called the `__str__` method of the cable to create the `self.id_string` attribute if not there. An alternative solution would've been to move the `msg` line before `delete()` is called, but I checked all models' `__str__` method and it's only `Cable` that uses the PK as part of the string.
https://github.com/netbox-community/netbox/blob/b7e78028ce6e998dc9172bd41bc602045daeb1ea/netbox/utilities/views.py#L289-L295