### PR TITLE
Fixes #3900: component template related object existance not checked

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -28,6 +28,7 @@
 * [#3872](https://github.com/netbox-community/netbox/issues/3872) - Paginate related IPs of an address
 * [#3876](https://github.com/netbox-community/netbox/issues/3876) - Fixed min/max to ASN input field at the site creation page
 * [#3882](https://github.com/netbox-community/netbox/issues/3882) - Fix filtering of devices by rack group
+* [#3900](https://github.com/netbox-community/netbox/issues/3882) - Fix exception when deleting a device type with templated components
 
 ---
 

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -38,11 +38,18 @@ class ComponentTemplateModel(models.Model):
         raise NotImplementedError()
 
     def to_objectchange(self, action):
+        # Annotate the parent device type
+        try:
+            parent = getattr(self, 'device_type', None)
+        except ObjectDoesNotExist:
+            # The parent device type has already been deleted
+            parent = None
+
         return ObjectChange(
             changed_object=self,
             object_repr=str(self),
             action=action,
-            related_object=self.device_type,
+            related_object=parent,
             object_data=serialize_object(self)
         )
 


### PR DESCRIPTION
### Fixes: #3900

Needed to check whether the `related_object` existed for the component template.

I've checked all other instances of `ObjectChange` and this seems to be the only one missing this check.