### PR TITLE
Fixes #3905: divide by zero on power feeds with low values

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -28,6 +28,7 @@
 * [#3872](https://github.com/netbox-community/netbox/issues/3872) - Paginate related IPs of an address
 * [#3876](https://github.com/netbox-community/netbox/issues/3876) - Fixed min/max to ASN input field at the site creation page
 * [#3882](https://github.com/netbox-community/netbox/issues/3882) - Fix filtering of devices by rack group
+* [#3905](https://github.com/netbox-community/netbox/issues/3905) - Fix divide-by-zero on power feeds with low power values
 
 ---
 

--- a/netbox/templates/dcim/powerfeed.html
+++ b/netbox/templates/dcim/powerfeed.html
@@ -112,7 +112,9 @@
                         {% if utilization %}
                             <td>
                                 {{ utilization.allocated }}VA / {{ powerfeed.available_power }}VA
-                                {% utilization_graph utilization.allocated|percentage:powerfeed.available_power %}
+                                {% if powerfeed.available_power > 0 %}
+                                    {% utilization_graph utilization.allocated|percentage:powerfeed.available_power %}
+                                {% endif %}
                             </td>
                         {% else %}
                             <td class="text-muted">N/A</td>


### PR DESCRIPTION
### Fixes: #3905

The `available_power` attribute had the possibility of being set to 0. It'll now be set to 1 if the calculation returns 0.
 