### PR TITLE
Fixes #3909: Regression from #3898

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -1,3 +1,11 @@
+# v2.6.13 (FUTURE)
+
+## Bug Fixes
+
+* [#3909](https://github.com/netbox-community/netbox/issues/3909) - Fixed a regression caused by [#3898](https://github.com/netbox-community/netbox/issues/3898) when browsing to device details page
+
+---
+
 # v2.6.12 (2020-01-13)
 
 ## Enhancements
@@ -30,7 +38,7 @@
 * [#3872](https://github.com/netbox-community/netbox/issues/3872) - Paginate related IPs on the IP address view
 * [#3876](https://github.com/netbox-community/netbox/issues/3876) - Fix minimum/maximum value rendering for site ASN field
 * [#3882](https://github.com/netbox-community/netbox/issues/3882) - Fix filtering of devices by rack group
-* [#3898](https://github.com/netbox-community/netbox/issues/3898) - Fix references to deleted cables without a label 
+* [#3898](https://github.com/netbox-community/netbox/issues/3898) - Fix references to deleted cables without a label
 * [#3905](https://github.com/netbox-community/netbox/issues/3905) - Fix divide-by-zero on power feeds with low power values
 
 ---

--- a/netbox/dcim/models.py
+++ b/netbox/dcim/models.py
@@ -3034,7 +3034,7 @@ class Cable(ChangeLoggedModel):
         self._pk = self.pk
 
     def __str__(self):
-        return self.label or '#{}'.format(self._pk)
+        return self.label or '#{}'.format(getattr(self, '_pk', self.pk))
 
     def get_absolute_url(self):
         return reverse('dcim:cable', args=[self.pk])


### PR DESCRIPTION
### Fixes: #3909 

Cable `str` method is being called during the `super()` in `__init__` which is causing an exception when accessing `_pk`. It will now fallback to `self.pk` even if it's None (I didn't go with `self.pk or self._pk` as it may trigger the same issue on a new cable).