### PR TITLE
Closes #3801: Change DeviceType export from CSV to YAML

### DIFF
--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -235,6 +235,7 @@ PATCH) to maintain backward compatibility. This behavior will be discontinued be
 * [#3664](https://github.com/digitalocean/netbox/issues/3664) - Enable applying configuration contexts by tags
 * [#3706](https://github.com/digitalocean/netbox/issues/3706) - Increase `available_power` maximum value on PowerFeed
 * [#3731](https://github.com/digitalocean/netbox/issues/3731) - Change Graph.type to a ContentType foreign key field
+* [#3801](https://github.com/digitalocean/netbox/issues/3801) - Use YAML for export of device types
 
 ## Bug Fixes (From Beta)
 

--- a/netbox/dcim/tests/test_views.py
+++ b/netbox/dcim/tests/test_views.py
@@ -1,5 +1,6 @@
 import urllib.parse
 
+import yaml
 from django.test import Client, TestCase
 from django.urls import reverse
 
@@ -326,6 +327,17 @@ class DeviceTypeTestCase(TestCase):
 
         response = self.client.get('{}?{}'.format(url, urllib.parse.urlencode(params)))
         self.assertEqual(response.status_code, 200)
+
+    def test_devicetype_export(self):
+
+        url = reverse('dcim:devicetype_list')
+
+        response = self.client.get('{}?export'.format(url))
+        self.assertEqual(response.status_code, 200)
+        data = list(yaml.load_all(response.content, Loader=yaml.SafeLoader))
+        self.assertEqual(len(data), 3)
+        self.assertEqual(data[0]['manufacturer'], 'Manufacturer 1')
+        self.assertEqual(data[0]['model'], 'Device Type 1')
 
     def test_devicetype(self):
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -2056,7 +2056,8 @@ class ConsoleConnectionsListView(PermissionRequiredMixin, ObjectListView):
                 obj.get_connection_status_display(),
             ])
             csv_data.append(csv)
-        return csv_data
+
+        return '\n'.join(csv_data)
 
 
 class PowerConnectionsListView(PermissionRequiredMixin, ObjectListView):
@@ -2087,7 +2088,8 @@ class PowerConnectionsListView(PermissionRequiredMixin, ObjectListView):
                 obj.get_connection_status_display(),
             ])
             csv_data.append(csv)
-        return csv_data
+
+        return '\n'.join(csv_data)
 
 
 class InterfaceConnectionsListView(PermissionRequiredMixin, ObjectListView):
@@ -2126,7 +2128,8 @@ class InterfaceConnectionsListView(PermissionRequiredMixin, ObjectListView):
                 obj.get_connection_status_display(),
             ])
             csv_data.append(csv)
-        return csv_data
+
+        return '\n'.join(csv_data)
 
 
 #


### PR DESCRIPTION
### Fixes: #3801 

Switch the DeviceType list view export format from CSV to YAML. This allows users to create definitions for the [device type library](https://github.com/netbox-community/devicetype-library) with minimal editing.