### PR TITLE
Fixes #3914: Interface filter field when unauthenticated

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -1,3 +1,11 @@
+# v2.6.13 (FUTURE)
+
+## Bug Fixes
+
+* [#3914](https://github.com/netbox-community/netbox/issues/3914) - Fix interface filter field when unauthenticated
+
+---
+
 # v2.6.12 (2020-01-13)
 
 ## Enhancements

--- a/netbox/project-static/js/interface_toggles.js
+++ b/netbox/project-static/js/interface_toggles.js
@@ -15,7 +15,7 @@ $('button.toggle-ips').click(function() {
 $('input.interface-filter').on('input', function() {
     var filter = new RegExp(this.value);
 
-    for (interface of $(this).closest('form').find('tbody > tr')) {
+    for (interface of $(this).closest('div.panel').find('tbody > tr')) {
         // Slice off 'interface_' at the start of the ID
         if (filter && filter.test(interface.id.slice(10))) {
             // Match the toggle in case the filter now matches the interface


### PR DESCRIPTION
### Fixes: #3914 

The selector relied on the `form` element is isn't present when unauthenticated. Fixed this by using the `div.panel` instead.