### PR TITLE
Fixes #3919: Utilization graph bar bounds

### DIFF
--- a/docs/release-notes/version-2.6.md
+++ b/docs/release-notes/version-2.6.md
@@ -7,6 +7,7 @@
 ## Bug Fixes
 
 * [#3914](https://github.com/netbox-community/netbox/issues/3914) - Fix interface filter field when unauthenticated
+* [#3919](https://github.com/netbox-community/netbox/issues/3919) - Fix utilization graph extending out of bounds when utilization > 100%
 
 ---
 
@@ -42,7 +43,7 @@
 * [#3872](https://github.com/netbox-community/netbox/issues/3872) - Paginate related IPs on the IP address view
 * [#3876](https://github.com/netbox-community/netbox/issues/3876) - Fix minimum/maximum value rendering for site ASN field
 * [#3882](https://github.com/netbox-community/netbox/issues/3882) - Fix filtering of devices by rack group
-* [#3898](https://github.com/netbox-community/netbox/issues/3898) - Fix references to deleted cables without a label 
+* [#3898](https://github.com/netbox-community/netbox/issues/3898) - Fix references to deleted cables without a label
 * [#3905](https://github.com/netbox-community/netbox/issues/3905) - Fix divide-by-zero on power feeds with low power values
 
 ---

--- a/netbox/templates/utilities/templatetags/utilization_graph.html
+++ b/netbox/templates/utilities/templatetags/utilization_graph.html
@@ -1,7 +1,7 @@
 <div class="progress text-center">
     {% if utilization < 30 %}<span style="font-size: 12px;">{{ utilization }}%</span>{% endif %}
     <div class="progress-bar progress-bar-{% if utilization >= danger_threshold %}danger{% elif utilization >= warning_threshold %}warning{% else %}success{% endif %}"
-        role="progressbar" aria-valuenow="{{ utilization }}" aria-valuemin="0" aria-valuemax="100" style="width: {{ utilization }}%">
+        role="progressbar" aria-valuenow="{{ utilization }}" aria-valuemin="0" aria-valuemax="100" style="width: {% if utilization > 100 %}100{% else %}{{ utilization }}{% endif %}%">
         {% if utilization >= 30 %}{{ utilization }}%{% endif %}
     </div>
 </div>


### PR DESCRIPTION
### Fixes: #3919 

In the utilization graph, the CSS width attribute of the bar was being set above 100% like the text, instead of maxing at 100% for the width attribute, which moves the text proportionately to right (screenshots in #3919).
