### PR TITLE
Fixes #3941: AttributeError when searching on IP assign

### DIFF
--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -1,3 +1,11 @@
+# v2.7.1 (FUTURE)
+
+## Bug Fixes
+
+* [#3941](https://github.com/netbox-community/netbox/issues/3941) - Fixed exception when attempting to assign IP to interface
+
+---
+
 # v2.7.0 (2020-01-16)
 
 **Note:** This release completely removes the topology map feature ([#2745](https://github.com/netbox-community/netbox/issues/2745)).
@@ -172,7 +180,7 @@ REDIS = {
         'SSL': False,
     }
 }
-``` 
+```
 
 Note that the `CACHE_DATABASE` parameter has been removed and the connection settings have been duplicated for both
 `webhooks` and `caching`. This allows the user to make use of separate Redis instances if desired. It is fine to use the

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -760,7 +760,7 @@ class IPAddressAssignView(PermissionRequiredMixin, View):
                 'vrf', 'tenant', 'interface__device', 'interface__virtual_machine'
             )
             # Limit to 100 results
-            addresses = filters.IPAddressFilter(request.POST, addresses).qs[:100]
+            addresses = filters.IPAddressFilterSet(request.POST, addresses).qs[:100]
             table = tables.IPAddressAssignTable(addresses)
 
         return render(request, 'ipam/ipaddress_assign.html', {


### PR DESCRIPTION
### Fixes: #3941

`filters.IPAddressFilter` has been renamed to `filters.IPAddressFilterSet` but was not updated in this particular view (feature implemented after the rename happened in the 2.7 branch).