### PR TITLE
Display occupied rack units correctly

### DIFF
--- a/netbox/dcim/models/__init__.py
+++ b/netbox/dcim/models/__init__.py
@@ -459,6 +459,21 @@ class RackElevationHelperMixin:
 
         return drawing
 
+    def merge_elevations(self, face):
+        elevation = self.get_rack_units(face=face, expand_devices=False)
+        other_face = DeviceFaceChoices.FACE_FRONT if face==DeviceFaceChoices.FACE_REAR else DeviceFaceChoices.FACE_REAR
+        other = self.get_rack_units(face=other_face)
+
+        unit_cursor = 0
+        for u in elevation:
+            o = other[unit_cursor]
+            if not u['device'] and o['device']:
+                u['device'] = o['device']
+                u['height'] = 1
+            unit_cursor += u.get('height', 1)
+
+        return elevation
+
     def get_elevation_svg(self, face=DeviceFaceChoices.FACE_FRONT, unit_width=230, unit_height=20):
         """
         Return an SVG of the rack elevation
@@ -468,7 +483,7 @@ class RackElevationHelperMixin:
         :param unit_height: Height of each rack unit for the rendered drawing. Note this is not the total
             height of the elevation
         """
-        elevation = self.get_rack_units(face=face, expand_devices=False, always_show_device=True)
+        elevation = self.merge_elevations(face)
         reserved_units = self.get_reserved_units().keys()
 
         return self._draw_elevations(elevation, reserved_units, face, unit_width, unit_height)
@@ -694,7 +709,7 @@ class Rack(ChangeLoggedModel, CustomFieldModel, RackElevationHelperMixin):
     def get_status_class(self):
         return self.STATUS_CLASS_MAP.get(self.status)
 
-    def get_rack_units(self, face=DeviceFaceChoices.FACE_FRONT, exclude=None, expand_devices=True, always_show_device=False):
+    def get_rack_units(self, face=DeviceFaceChoices.FACE_FRONT, exclude=None, expand_devices=True):
         """
         Return a list of rack units as dictionaries. Example: {'device': None, 'face': 0, 'id': 48, 'name': 'U48'}
         Each key 'device' is either a Device or None. By default, multi-U devices are repeated for each U they occupy.
@@ -704,8 +719,6 @@ class Rack(ChangeLoggedModel, CustomFieldModel, RackElevationHelperMixin):
         :param expand_devices: When True, all units that a device occupies will be listed with each containing a
             reference to the device. When False, only the bottom most unit for a device is included and that unit
             contains a height attribute for the device
-        :param always_show_device: When True it will always show the device, no matter its orientation.
-            When False it will only show full-width devices or those with the right orientation in the rack.
         """
 
         elevation = OrderedDict()
@@ -725,11 +738,9 @@ class Rack(ChangeLoggedModel, CustomFieldModel, RackElevationHelperMixin):
             ).filter(
                 rack=self,
                 position__gt=0
+            ).filter(
+                Q(face=face) | Q(device_type__is_full_depth=True)
             )
-            if not always_show_device:
-                queryset = queryset.filter(
-                    Q(face=face) | Q(device_type__is_full_depth=True)
-                )
             for device in queryset:
                 if expand_devices:
                     for u in range(device.position, device.position + device.device_type.u_height):

--- a/netbox/dcim/models/__init__.py
+++ b/netbox/dcim/models/__init__.py
@@ -461,7 +461,7 @@ class RackElevationHelperMixin:
 
     def merge_elevations(self, face):
         elevation = self.get_rack_units(face=face, expand_devices=False)
-        other_face = DeviceFaceChoices.FACE_FRONT if face==DeviceFaceChoices.FACE_REAR else DeviceFaceChoices.FACE_REAR
+        other_face = DeviceFaceChoices.FACE_FRONT if face == DeviceFaceChoices.FACE_REAR else DeviceFaceChoices.FACE_REAR
         other = self.get_rack_units(face=other_face)
 
         unit_cursor = 0


### PR DESCRIPTION
### Fixes: #3965

This PR reintroduces code to mark a slot in the rack elevation as occupied if the other side is occupied. This problem was introduced when @lampwins took over the initial draft that I made, because I didn’t correctly explain the differences of my version of `get_rack_units` to the “vanilla” one. `get_rack_units` now has a flag named `always_show_device` that will even put the device in the elevation even if the face is different.

Cheers
