### PR TITLE
Display borders around devices in rack elevations

### DIFF
--- a/netbox/dcim/models/__init__.py
+++ b/netbox/dcim/models/__init__.py
@@ -395,7 +395,7 @@ class RackElevationHelperMixin:
                 fill='black'
             )
         )
-        link.add(drawing.rect(start, end, fill='#{}'.format(color)))
+        link.add(drawing.rect(start, end, style='fill: #{}'.format(color), class_='slot'))
         hex_color = '#{}'.format(foreground_color(color))
         link.add(drawing.text(device.name, insert=text, fill=hex_color))
 


### PR DESCRIPTION
### Fixes: #3964

This PR fixes #3964 by moving away from a property an inline style for the fill, and adding the right class to a slot. Why an inline style? Because I learned that the override chain for properties in SVG is a little counterintuitive:

- Properties such as `<rect fill="#eee">` bind least strongly.
- External stylesheets bind more strongly.
- Inline style such as `<rect style="fill: #eee">` binds most strongly, and can be overridden only by using `!important`.

Funny, no? Anyway, now the classes are set correctly, and the borders are back!

Cheers