### PR TITLE
dcim: fix tooltips in svg rack display

### DIFF
--- a/netbox/dcim/models/__init__.py
+++ b/netbox/dcim/models/__init__.py
@@ -395,13 +395,22 @@ class RackElevationHelperMixin:
                 fill='black'
             )
         )
+        link.set_desc('{} — {} ({}U) {} {}'.format(
+            device.device_role, device.device_type.display_name,
+            device.device_type.u_height, device.asset_tag or '', device.serial or ''
+        ))
         link.add(drawing.rect(start, end, fill='#{}'.format(color)))
         hex_color = '#{}'.format(foreground_color(color))
         link.add(drawing.text(str(device), insert=text, fill=hex_color))
 
     @staticmethod
     def _draw_device_rear(drawing, device, start, end, text):
-        drawing.add(drawing.rect(start, end, class_="blocked"))
+        rect = drawing.rect(start, end, class_="blocked")
+        rect.set_desc('{} — {} ({}U) {} {}'.format(
+            device.device_role, device.device_type.display_name,
+            device.device_type.u_height, device.asset_tag or '', device.serial or ''
+        ))
+        drawing.add(rect)
         drawing.add(drawing.text(str(device), insert=text))
 
     @staticmethod


### PR DESCRIPTION
### Fixes: #3963

This PR fixes #3963 by adding a `title` to the individual slots of the element. Those are rendered as follows:

<img width="308" alt="Bildschirmfoto 2020-01-21 um 16 19 01" src="https://user-images.githubusercontent.com/7725188/72817391-fb165980-3c69-11ea-8eb0-a1cd3c49c7e9.png">

So they aren’t quite as pretty and feature-rich as the old ones, but they show the same information. To emulate the old ones we have to tinker a little with JavaScript I fear, and I don’t feel equipped to do that in the SVG context.

@candlerb can you confirm that this is what you expected?

Cheers
