### PR TITLE
Closes #3310: Pre-select site/rack for B side when creating a new cable

### DIFF
--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -1,5 +1,9 @@
 # v2.7.3 (FUTURE)
 
+## Enhancements
+
+* [#3310](https://github.com/netbox-community/netbox/issues/3310) - Pre-select site/rack for B side when creating a new cable
+
 ## Bug Fixes
 
 * [#3983](https://github.com/netbox-community/netbox/issues/3983) - Permit the creation of multiple unnamed devices

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -3168,6 +3168,11 @@ class ConnectCableToDeviceForm(BootstrapMixin, ChainedFieldsMixin, forms.ModelFo
             'termination_b_site', 'termination_b_rack', 'termination_b_device', 'termination_b_id', 'type', 'status',
             'label', 'color', 'length', 'length_unit',
         ]
+        widgets = {
+            'status': StaticSelect2,
+            'type': StaticSelect2,
+            'length_unit': StaticSelect2,
+        }
 
 
 class ConnectCableToConsolePortForm(ConnectCableToDeviceForm):
@@ -3363,6 +3368,11 @@ class CableForm(BootstrapMixin, forms.ModelForm):
         fields = [
             'type', 'status', 'label', 'color', 'length', 'length_unit',
         ]
+        widgets = {
+            'status': StaticSelect2,
+            'type': StaticSelect2,
+            'length_unit': StaticSelect2,
+        }
 
 
 class CableCSVForm(forms.ModelForm):

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1945,6 +1945,12 @@ class CableCreateView(PermissionRequiredMixin, GetReturnURLMixin, View):
         # Parse initial data manually to avoid setting field values as lists
         initial_data = {k: request.GET[k] for k in request.GET}
 
+        # Set initial site and rack based on side A termination (if not already set)
+        if 'termination_b_site' not in initial_data:
+            initial_data['termination_b_site'] = getattr(self.obj.termination_a.parent, 'site', None)
+        if 'termination_b_rack' not in initial_data:
+            initial_data['termination_b_rack'] = getattr(self.obj.termination_a.parent, 'rack', None)
+
         form = self.form_class(instance=self.obj, initial=initial_data)
 
         return render(request, self.template_name, {

--- a/netbox/templates/dcim/cable_connect.html
+++ b/netbox/templates/dcim/cable_connect.html
@@ -144,25 +144,8 @@
             </div>
         </div>
         <div class="row">
-            <div class="col-md-4 col-md-offset-4">
-                <div class="panel panel-default">
-                    <div class="panel-heading"><strong>Cable</strong></div>
-                    <div class="panel-body">
-                        {% render_field form.status %}
-                        {% render_field form.type %}
-                        {% render_field form.label %}
-                        {% render_field form.color %}
-                        <div class="form-group">
-                            <label class="col-md-3 control-label" for="id_length">{{ form.length.label }}</label>
-                            <div class="col-md-6">
-                                {{ form.length }}
-                            </div>
-                            <div class="col-md-3">
-                                {{ form.length_unit }}
-                            </div>
-                        </div>
-                    </div>
-                </div>
+            <div class="col-md-6 col-md-offset-3">
+                {% include 'dcim/inc/cable_form.html' %}
             </div>
         </div>
         <div class="form-group">

--- a/netbox/templates/dcim/cable_edit.html
+++ b/netbox/templates/dcim/cable_edit.html
@@ -1,23 +1,5 @@
 {% extends 'utilities/obj_edit.html' %}
-{% load form_helpers %}
 
 {% block form %}
-    <div class="panel panel-default">
-        <div class="panel-heading"><strong>Cable</strong></div>
-        <div class="panel-body">
-            {% render_field form.type %}
-            {% render_field form.status %}
-            {% render_field form.label %}
-            {% render_field form.color %}
-            <div class="form-group">
-                <label class="col-md-3 control-label" for="id_length">{{ form.length.label }}</label>
-                <div class="col-md-6">
-                    {{ form.length }}
-                </div>
-                <div class="col-md-3">
-                    {{ form.length_unit }}
-                </div>
-            </div>
-        </div>
-    </div>
+    {% include 'dcim/inc/cable_form.html' %}
 {% endblock %}

--- a/netbox/templates/dcim/inc/cable_form.html
+++ b/netbox/templates/dcim/inc/cable_form.html
@@ -1,0 +1,19 @@
+{% load form_helpers %}
+<div class="panel panel-default">
+    <div class="panel-heading"><strong>Cable</strong></div>
+    <div class="panel-body">
+        {% render_field form.status %}
+        {% render_field form.type %}
+        {% render_field form.label %}
+        {% render_field form.color %}
+        <div class="form-group">
+            <label class="col-md-3 control-label" for="id_length">{{ form.length.label }}</label>
+            <div class="col-md-5">
+                {{ form.length }}
+            </div>
+            <div class="col-md-4">
+                {{ form.length_unit }}
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
### Fixes: #3310

- Set initial data for the termination B site and rack fields in CableCreateView
- Merge redundant forms templates into `dcim/inc/cable_form.html`
- Preserve widget and style changes from PR #3893