### PR TITLE
Fixes #4016: Removed duplicate tenant field for cluster edit form

### DIFF
--- a/netbox/templates/virtualization/cluster_edit.html
+++ b/netbox/templates/virtualization/cluster_edit.html
@@ -8,7 +8,6 @@
             {% render_field form.name %}
             {% render_field form.type %}
             {% render_field form.group %}
-            {% render_field form.tenant %}
             {% render_field form.site %}
         </div>
     </div>


### PR DESCRIPTION
### Fixes: #4016

Removed the duplicate tenant field (the top one) in the cluster create/edit form `/virtualization/clusters/add/`
<img alt="image" src="https://user-images.githubusercontent.com/34197532/73135494-c1af6680-403a-11ea-9662-f6a3898c8f21.png">
