### PR TITLE
Fixes #4010: Fixes IP addresses table when filtering interfaces

### DIFF
--- a/netbox/project-static/js/interface_toggles.js
+++ b/netbox/project-static/js/interface_toggles.js
@@ -2,9 +2,9 @@
 $('button.toggle-ips').click(function() {
     var selected = $(this).attr('selected');
     if (selected) {
-        $('#interfaces_table tr.ipaddresses').hide();
+        $('#interfaces_table tr.interface:visible + tr.ipaddresses').hide();
     } else {
-        $('#interfaces_table tr.ipaddresses').show();
+        $('#interfaces_table tr.interface:visible + tr.ipaddresses').show();
     }
     $(this).attr('selected', !selected);
     $(this).children('span').toggleClass('glyphicon-check glyphicon-unchecked');
@@ -14,10 +14,11 @@ $('button.toggle-ips').click(function() {
 // Inteface filtering
 $('input.interface-filter').on('input', function() {
     var filter = new RegExp(this.value);
+    var interface;
 
-    for (interface of $(this).closest('div.panel').find('tbody > tr')) {
+    for (interface of $('#interfaces_table > tbody > tr')) {
         // Slice off 'interface_' at the start of the ID
-        if (filter && filter.test(interface.id.slice(10))) {
+        if (filter.test(interface.id.slice(10))) {
             // Match the toggle in case the filter now matches the interface
             $(interface).find('input:checkbox[name=pk]').prop('checked', $('input.toggle').prop('checked'));
             $(interface).show();
@@ -26,5 +27,10 @@ $('input.interface-filter').on('input', function() {
             $(interface).find('input:checkbox[name=pk]').prop('checked', false);
             $(interface).hide();
         }
+    }
+
+    // Show the ip addresses table row for the visible (matched) interfaces, if checked
+    if ($('button.toggle-ips').attr('selected')) {
+        $('#interfaces_table > tbody > tr:visible').next('tr.ipaddresses').show();
     }
 });

--- a/netbox/project-static/js/interface_toggles.js
+++ b/netbox/project-static/js/interface_toggles.js
@@ -16,21 +16,20 @@ $('input.interface-filter').on('input', function() {
     var filter = new RegExp(this.value);
     var interface;
 
-    for (interface of $('#interfaces_table > tbody > tr')) {
+    for (interface of $('#interfaces_table > tbody > tr.interface')) {
         // Slice off 'interface_' at the start of the ID
         if (filter.test(interface.id.slice(10))) {
             // Match the toggle in case the filter now matches the interface
             $(interface).find('input:checkbox[name=pk]').prop('checked', $('input.toggle').prop('checked'));
             $(interface).show();
+            if ($('button.toggle-ips').attr('selected')) {
+                $(interface).next('tr.ipaddresses').show();
+            }
         } else {
             // Uncheck to prevent actions from including it when it doesn't match
             $(interface).find('input:checkbox[name=pk]').prop('checked', false);
             $(interface).hide();
+            $(interface).next('tr.ipaddresses').hide();
         }
-    }
-
-    // Show the ip addresses table row for the visible (matched) interfaces, if checked
-    if ($('button.toggle-ips').attr('selected')) {
-        $('#interfaces_table > tbody > tr:visible').next('tr.ipaddresses').show();
     }
 });


### PR DESCRIPTION
### Fixes: #4010

The IP addresses table and its toggle were not being considered by the filter.