### PR TITLE
Fixes #4024: Update nginx documentation

### DIFF
--- a/docs/installation/3-http-daemon.md
+++ b/docs/installation/3-http-daemon.md
@@ -29,7 +29,7 @@ server {
 
     location / {
         proxy_pass http://127.0.0.1:8001;
-        proxy_set_header X-Forwarded-Host $server_name;
+        proxy_set_header X-Forwarded-Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
     }


### PR DESCRIPTION
### Fixes: #4024

With the current nginx configuration, the server port cannot be changed. If you change the port, the first call to the API will work but the second one (from next field of JSON response) will not work because the port used for this request will be always 80.

More details on this discussion: https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/netbox-discuss/Jyefr2hO14E/93s6SdvoEQAJ
