### PR TITLE
Fixes #4027: Repair schema migration for IP addresses with DHCP status

### DIFF
--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -17,6 +17,7 @@
 * [#4008](https://github.com/netbox-community/netbox/issues/4008) - Toggle rack elevation face using front/rear strings
 * [#4017](https://github.com/netbox-community/netbox/issues/4017) - Remove redundant tenant field from cluster form
 * [#4019](https://github.com/netbox-community/netbox/issues/4019) - Restore border around background devices in rack elevations
+* [#4027](https://github.com/netbox-community/netbox/issues/4027) - Repair schema migration for #3569 to convert IP addresses with DHCP status
 * [#4028](https://github.com/netbox-community/netbox/issues/4028) - Correct URL patterns to match Unicode characters in tag slugs
 
 ---

--- a/netbox/ipam/migrations/0029_3569_ipaddress_fields.py
+++ b/netbox/ipam/migrations/0029_3569_ipaddress_fields.py
@@ -2,10 +2,10 @@ from django.db import migrations, models
 
 
 IPADDRESS_STATUS_CHOICES = (
-    (0, 'container'),
     (1, 'active'),
     (2, 'reserved'),
     (3, 'deprecated'),
+    (5, 'dhcp'),
 )
 
 IPADDRESS_ROLE_CHOICES = (

--- a/netbox/ipam/migrations/0034_fix_ipaddress_status_dhcp.py
+++ b/netbox/ipam/migrations/0034_fix_ipaddress_status_dhcp.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+def ipaddress_status_dhcp_to_slug(apps, schema_editor):
+    IPAddress = apps.get_model('ipam', 'IPAddress')
+    IPAddress.objects.filter(status='5').update(status='dhcp')
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ipam', '0033_deterministic_ordering'),
+    ]
+
+    operations = [
+        # Fixes a missed integer substitution from #3569; see bug #4027. The original migration has also been fixed,
+        # so this can be omitted when squashing in the future.
+        migrations.RunPython(
+            code=ipaddress_status_dhcp_to_slug
+        ),
+    ]


### PR DESCRIPTION
### Fixes: #4027

- Fix the original schema migration (for consistency)
- Introduce a new migration under IPAM to apply the change for users who have already upgraded. (This has no effect if all instances with `status=5` have already been updated.)