### PR TITLE
Fixes #4039: LDAP Documentation

### DIFF
--- a/docs/installation/4-ldap.md
+++ b/docs/installation/4-ldap.md
@@ -110,8 +110,8 @@ AUTH_LDAP_USER_FLAGS_BY_GROUP = {
 AUTH_LDAP_FIND_GROUP_PERMS = True
 
 # Cache groups for one hour to reduce LDAP traffic
-AUTH_LDAP_CACHE_GROUPS = True
-AUTH_LDAP_GROUP_CACHE_TIMEOUT = 3600
+AUTH_LDAP_CACHE_TIMEOUT = 3600
+
 ```
 
 * `is_active` - All users must be mapped to at least this group to enable authentication. Without this, users cannot log in.


### PR DESCRIPTION
### Fixes: #4039
use new ldap cache configuration in documentation

django-ldap-auth uses new configuration for caching as of [1.6.0](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-cache-timeout)

Reference to settings.py configuration: https://github.com/netbox-community/netbox/commit/695a07daf4837a9b49888fbc0bd76d063e500dcd#diff-a1b75c101e583ea1264c4c0c390db558R297