### PR TITLE
Note about systemd service user/group

### DIFF
--- a/docs/installation/3-http-daemon.md
+++ b/docs/installation/3-http-daemon.md
@@ -125,6 +125,10 @@ We'll use systemd to control the daemonization of NetBox services. First, copy `
 
 !!! note
     These service files assume that gunicorn is installed at `/usr/local/bin/gunicorn`. If the output of `which gunicorn` indicates a different path, you'll need to correct the `ExecStart` path in both files.
+    
+!!! note
+    Make sure these service files are running under the correct user/group. For example in CentOS you should change the user and group from "www-data" -> "apache"
+    
 
 Then, start the `netbox` and `netbox-rq` services and enable them to initiate at boot time:
 


### PR DESCRIPTION
On CentOS the default apache user is apache. On Ubuntu this is www-data. I think including a note about this in  the documentation is important.

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:A documentation problem. No issue is needed for this change to be merged as it is not modifing code. Let me know if I am wrong.
<!--
Adds a note letting users know to make sure there systemd unit files are running under the correct user/group
-->
