### PR TITLE
Fixes: #3016 - Add wrapper for post_save and post_delete signals

### DIFF
--- a/netbox/circuits/signals.py
+++ b/netbox/circuits/signals.py
@@ -2,9 +2,12 @@ from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.utils import timezone
 
+from extras.signals import disable_for_loaddata
+
 from .models import Circuit, CircuitTermination
 
 
+@disable_for_loaddata
 @receiver((post_save, post_delete), sender=CircuitTermination)
 def update_circuit(instance, **kwargs):
     """

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -1,9 +1,12 @@
 from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 
+from extras.signals import disable_for_loaddata
+
 from .models import Cable, Device, VirtualChassis
 
 
+@disable_for_loaddata
 @receiver(post_save, sender=VirtualChassis)
 def assign_virtualchassis_master(instance, created, **kwargs):
     """
@@ -17,6 +20,7 @@ def assign_virtualchassis_master(instance, created, **kwargs):
             device.save()
 
 
+@disable_for_loaddata
 @receiver(pre_delete, sender=VirtualChassis)
 def clear_virtualchassis_members(instance, **kwargs):
     """
@@ -29,6 +33,7 @@ def clear_virtualchassis_members(instance, **kwargs):
         device.save()
 
 
+@disable_for_loaddata
 @receiver(post_save, sender=Cable)
 def update_connected_endpoints(instance, **kwargs):
     """
@@ -54,6 +59,7 @@ def update_connected_endpoints(instance, **kwargs):
         endpoint_b.save()
 
 
+@disable_for_loaddata
 @receiver(pre_delete, sender=Cable)
 def nullify_connected_endpoints(instance, **kwargs):
     """

--- a/netbox/extras/signals.py
+++ b/netbox/extras/signals.py
@@ -1,6 +1,7 @@
 from cacheops.signals import cache_invalidated, cache_read
 from django.dispatch import Signal
 from prometheus_client import Counter
+from functools import wraps
 
 
 #
@@ -10,6 +11,15 @@ from prometheus_client import Counter
 cacheops_cache_hit = Counter('cacheops_cache_hit', 'Number of cache hits')
 cacheops_cache_miss = Counter('cacheops_cache_miss', 'Number of cache misses')
 cacheops_cache_invalidated = Counter('cacheops_cache_invalidated', 'Number of cache invalidations')
+
+
+def disable_for_loaddata(signal_handler):
+    @wraps(signal_handler)
+    def wrapper(*args, **kwargs):
+        if kwargs['raw']:
+            return
+        signal_handler(*args, **kwargs)
+    return wrapper
 
 
 def cache_read_collector(sender, func, hit, **kwargs):


### PR DESCRIPTION
### Fixes: #3016

This PR adds a wrapper for post_save and post_delete signals to handle when loaddata is called.

Solution was contributed by @Grokzen in his initial description.  Decorator connected to both dcim/signals.py and circuits/signals.py

There is also the ObjectChangedMiddleware which I am not sure if we want to slide it around there as well, or if we need to.