### PR TITLE
Fixes #4100: Added device field to device components filter forms

### DIFF
--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -84,7 +84,18 @@ class DeviceComponentFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         widget=APISelectMultiple(
             api_url="/api/dcim/sites/",
-            value_field="slug"
+            value_field="slug",
+            filter_for={
+                'device_id': 'site',
+            }
+        )
+    )
+    device_id = FilterChoiceField(
+        queryset=Device.objects.all(),
+        required=False,
+        label='Device',
+        widget=APISelectMultiple(
+            api_url='/api/dcim/devices/',
         )
     )
 
@@ -3642,6 +3653,7 @@ class CableFilterForm(BootstrapMixin, forms.Form):
             value_field="slug",
             filter_for={
                 'rack_id': 'site',
+                'device_id': 'site',
             }
         )
     )
@@ -3663,6 +3675,9 @@ class CableFilterForm(BootstrapMixin, forms.Form):
         widget=APISelectMultiple(
             api_url="/api/dcim/racks/",
             null_option=True,
+            filter_for={
+                'device_id': 'rack_id',
+            }
         )
     )
     type = forms.MultipleChoiceField(
@@ -3816,6 +3831,9 @@ class ConsoleConnectionFilterForm(BootstrapMixin, forms.Form):
         widget=APISelectMultiple(
             api_url="/api/dcim/sites/",
             value_field="slug",
+            filter_for={
+                'device_id': 'site',
+            }
         )
     )
     device_id = FilterChoiceField(
@@ -3835,6 +3853,9 @@ class PowerConnectionFilterForm(BootstrapMixin, forms.Form):
         widget=APISelectMultiple(
             api_url="/api/dcim/sites/",
             value_field="slug",
+            filter_for={
+                'device_id': 'site',
+            }
         )
     )
     device_id = FilterChoiceField(
@@ -3854,6 +3875,9 @@ class InterfaceConnectionFilterForm(BootstrapMixin, forms.Form):
         widget=APISelectMultiple(
             api_url="/api/dcim/sites/",
             value_field="slug",
+            filter_for={
+                'device_id': 'site',
+            }
         )
     )
     device_id = FilterChoiceField(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4100 <ISSUE NUMBER GOES HERE>

Added device field to `DeviceComponentFilterForm` from which the device components' filter forms inherit. The `device_id` `filter_for` was missing from the cables' filter forms, so added it there to keep the behavior consistent.