### PR TITLE
Fixes #4150: Replace OrderedDict with Dict when rendering YAML

### DIFF
--- a/netbox/utilities/templatetags/helpers.py
+++ b/netbox/utilities/templatetags/helpers.py
@@ -82,7 +82,7 @@ def render_yaml(value):
     """
     Render a dictionary as formatted YAML.
     """
-    return yaml.dump(dict(value))
+    return yaml.dump(json.loads(json.dumps(value)))
 
 
 @register.filter()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4150

To strip down any YAML tags, the dictionary is first (de)serialized into JSON prior to being dumped into YAML.