### PR TITLE
[Corollary to #4161] Redis Connection Check when Using Sentinel

### DIFF
--- a/netbox/extras/apps.py
+++ b/netbox/extras/apps.py
@@ -8,31 +8,4 @@ class ExtrasConfig(AppConfig):
     name = "extras"
 
     def ready(self):
-
         import extras.signals
-
-        # Check that we can connect to the configured Redis database.
-        try:
-            if settings.WEBHOOKS_REDIS_USING_SENTINEL:
-                sentinel = redis.sentinel.Sentinel(
-                    settings.WEBHOOKS_REDIS_SENTINELS,
-                    socket_timeout=settings.WEBHOOKS_REDIS_DEFAULT_TIMEOUT
-                )
-                rs = sentinel.master_for(
-                    settings.WEBHOOKS_REDIS_SENTINEL_SERVICE,
-                    socket_timeout=settings.WEBHOOKS_REDIS_DEFAULT_TIMEOUT
-                )
-            else:
-                rs = redis.Redis(
-                    host=settings.WEBHOOKS_REDIS_HOST,
-                    port=settings.WEBHOOKS_REDIS_PORT,
-                    db=settings.WEBHOOKS_REDIS_DATABASE,
-                    password=settings.WEBHOOKS_REDIS_PASSWORD or None,
-                    ssl=settings.WEBHOOKS_REDIS_SSL,
-                )
-            rs.ping()
-        except redis.exceptions.ConnectionError:
-            raise ImproperlyConfigured(
-                "Unable to connect to the Redis database. Check that the Redis configuration has been defined in "
-                "configuration.py."
-            )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #3985, #3984, and a bug introduced in #4161
<!--
    Please include a summary of the proposed changes below.
-->

Redis Sentinel support was adding to the settings and configuration, but the `extras` AppConfig was not updated to account for Sentinel when starting the application. Without this fix **it shouldn't cause the application to crash**, but to throw a false positive connection issue. This fixes the check to account for when sentinel is configured
