### PR TITLE
[Fix #4171] fix extraneous formatting of notice boxes in required settings doc

### DIFF
--- a/docs/configuration/required-settings.md
+++ b/docs/configuration/required-settings.md
@@ -80,11 +80,11 @@ REDIS = {
 }
 ```
 
-!!! note:
+!!! note
     If you are upgrading from a version prior to v2.7, please note that the Redis connection configuration settings have
     changed. Manual modification to bring the `REDIS` section inline with the above specification is necessary
 
-!!! warning:
+!!! note
     It is highly recommended to keep the webhook and cache databases separate. Using the same database number on the
     same Redis instance for both may result in webhook processing data being lost during cache flushing events.
 
@@ -124,7 +124,7 @@ REDIS = {
 }
 ```
 
-!!! note:
+!!! note
     It is possible to have only one or the other Redis configurations to use Sentinel functionality. It is possible
     for example to have the webhook use sentinel via `HOST`/`PORT` and for caching to use Sentinel via 
     `SENTINELS`/`SENTINEL_SERVICE`.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4171
<!--
    Please include a summary of the proposed changes below.
-->
Removes a `:` character from a few notice boxes in the required settings page that break their formatting from markdown
