### PR TITLE
Fixes #2511: Compare object change to the previous change

### DIFF
--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -2,6 +2,7 @@
 
 ## Enhancements
 
+* [#2511](https://github.com/netbox-community/netbox/issues/2511) - Compare object change to the previous change
 * [#3840](https://github.com/netbox-community/netbox/issues/3840) - Enhance search function when selecting VLANs for interface assignment
 * [#4170](https://github.com/netbox-community/netbox/issues/4170) - Improve color contrast in rack elevation drawings
 

--- a/netbox/templates/extras/objectchange.html
+++ b/netbox/templates/extras/objectchange.html
@@ -83,6 +83,35 @@
                     </tr>
                 </table>
             </div>
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <strong>Difference</strong>
+                    <div class="btn-group btn-group-xs pull-right noprint">
+                        <a {% if prev_change %}href="{% url 'extras:objectchange' pk=prev_change.pk %}"{% else %}disabled{% endif %} class="btn btn-default">
+                            <span class="fa fa-chevron-left" aria-hidden="true"></span> Previous
+                        </a>
+                        <a {% if next_change %}href="{% url 'extras:objectchange' pk=next_change.pk %}"{% else %}disabled{% endif %} class="btn btn-default">
+                            Next <span class="fa fa-chevron-right" aria-hidden="true"></span>
+                        </a>
+                    </div>
+                </div>
+                <div class="panel-body">
+                    {% if diff_added == diff_removed %}
+                        <span class="text-muted" style="margin-left: 10px;">
+                            {% if objectchange.action == 'create' %}
+                                Object created
+                            {% elif objectchange.action == 'delete' %}
+                                Object deleted
+                            {% else %}
+                                No changes
+                            {% endif %}
+                        </span>
+                    {% else %}
+                        <pre style="background-color: #ffdce0;">{{ diff_removed|render_json }}</pre>
+                        <pre style="background-color: #cdffd8;">{{ diff_added|render_json }}</pre>
+                    {% endif %}
+                </div>
+            </div>
         </div>
         <div class="col-md-7">
             <div class="panel panel-default">

--- a/netbox/utilities/utils.py
+++ b/netbox/utilities/utils.py
@@ -222,3 +222,19 @@ def querydict_to_dict(querydict):
         key: querydict.get(key) if len(value) == 1 and key != 'pk' else querydict.getlist(key)
         for key, value in querydict.lists()
     }
+
+
+def shallow_compare_dict(source_dict, destination_dict, exclude=None):
+    """
+    Return a new dictionary of the different keys. The values of `destination_dict` are returned. Only the equality of
+    the first layer of keys/values is checked. `exclude` is a list or tuple of keys to be ignored.
+    """
+    difference = {}
+
+    for key in destination_dict:
+        if source_dict.get(key) != destination_dict[key]:
+            if isinstance(exclude, (list, tuple)) and key in exclude:
+                continue
+            difference[key] = destination_dict[key]
+
+    return difference


### PR DESCRIPTION
### Fixes: #2511

Add a difference section to the object change (i.e. `/extras/changelog/{pk}/`) with previous and next buttons.

<img width="817" alt="image" src="https://user-images.githubusercontent.com/34197532/74596136-f1063180-5042-11ea-96cf-762194a03f4b.png">

> While going with a full-blown diff library might provide a nicer-looking diff, like that of GitHub, I've opted for a simpler approach to avoid the additional overhead of another dependency. And it seemed a bit overkill.
