### PR TITLE
Fix Power Feed page to render Custom Fields and Tags

### DIFF
--- a/netbox/templates/dcim/powerfeed.html
+++ b/netbox/templates/dcim/powerfeed.html
@@ -121,6 +121,8 @@
                 </tr>
             </table>
         </div>
+        {% include 'inc/custom_fields_panel.html' with obj=powerfeed %}
+        {% include 'extras/inc/tags_panel.html' with tags=powerfeed.tags.all url='dcim:powerfeed_list' %}
         <div class="panel panel-default">
             <div class="panel-heading">
                 <strong>Comments</strong>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4213  

This PR includes the necessary html template files to render any `Custom Fields` and/or `Tags` on a Power Feed object with viewing the object at the `https://{domain}/dcim/power-feeds/{id}/` endpoint. 

Before:
![CaptureBroken](https://user-images.githubusercontent.com/13769890/74965743-6410fe80-53db-11ea-8656-e8b007fc0d58.PNG)

After:
![Capture](https://user-images.githubusercontent.com/13769890/74965751-67a48580-53db-11ea-9423-2e75c3bcf5a5.PNG)
