### PR TITLE
Fixes #3377: Cascade power draw calculation on all downstream power ports

### DIFF
--- a/netbox/dcim/migrations/0099_outlet_related_powerports.py
+++ b/netbox/dcim/migrations/0099_outlet_related_powerports.py
@@ -1,0 +1,76 @@
+import sys
+
+from django.db import migrations, models
+
+
+def update_related_powerports(apps, schema_editor):
+    PowerPort = apps.get_model('dcim', 'PowerPort')
+    PowerOutlet = apps.get_model('dcim', 'PowerOutlet')
+
+    poweroutlet_count = PowerOutlet.objects.count()
+
+    if 'test' not in sys.argv:
+        print("\n    Updating power outlets with related power ports...")
+
+    for i, poweroutlet in enumerate(PowerOutlet.objects.all(), start=1):
+        if not i % 100 and 'test' not in sys.argv:
+            print("      [{}/{}]".format(i, poweroutlet_count))
+
+        # Copy of PowerOutlet.calculate_upstream_powerports
+        upstream_powerports = PowerPort.objects.none()
+
+        if poweroutlet.power_port:
+            next_powerports = PowerPort.objects.filter(pk=poweroutlet.power_port.pk)
+
+            while next_powerports.exists():
+                upstream_powerports |= next_powerports
+
+                # Prevent loops by excluding those already matched
+                next_powerports = PowerPort.objects.exclude(
+                    pk__in=upstream_powerports,
+                ).filter(
+                    poweroutlets__connected_endpoint__in=upstream_powerports,
+                )
+
+        # Copy of PowerOutlet.calculate_downstream_powerports
+        downstream_powerports = PowerPort.objects.none()
+
+        if hasattr(poweroutlet, 'connected_endpoint'):
+            next_powerports = PowerPort.objects.filter(pk=poweroutlet.connected_endpoint.pk)
+
+            while next_powerports.exists():
+                downstream_powerports |= next_powerports
+
+                # Prevent loops by excluding those already matched
+                next_powerports = PowerPort.objects.exclude(
+                    pk__in=downstream_powerports,
+                ).filter(
+                    _connected_poweroutlet__power_port__in=downstream_powerports,
+                )
+
+        poweroutlet.upstream_powerports.set(upstream_powerports)
+        poweroutlet.downstream_powerports.set(downstream_powerports)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dcim', '0098_devicetype_images'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='poweroutlet',
+            name='downstream_powerports',
+            field=models.ManyToManyField(blank=True, related_name='upstream_poweroutlets', to='dcim.PowerPort'),
+        ),
+        migrations.AddField(
+            model_name='poweroutlet',
+            name='upstream_powerports',
+            field=models.ManyToManyField(blank=True, related_name='downstream_poweroutlets', to='dcim.PowerPort'),
+        ),
+        migrations.RunPython(
+            code=update_related_powerports,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/netbox/dcim/migrations/0099_outlet_related_powerports.py
+++ b/netbox/dcim/migrations/0099_outlet_related_powerports.py
@@ -48,8 +48,8 @@ def update_related_powerports(apps, schema_editor):
                     _connected_poweroutlet__power_port__in=downstream_powerports,
                 )
 
-        poweroutlet.upstream_powerports.set(upstream_powerports)
-        poweroutlet.downstream_powerports.set(downstream_powerports)
+        poweroutlet._upstream_powerports.set(upstream_powerports)
+        poweroutlet._downstream_powerports.set(downstream_powerports)
 
 
 class Migration(migrations.Migration):
@@ -61,13 +61,13 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name='poweroutlet',
-            name='downstream_powerports',
-            field=models.ManyToManyField(blank=True, related_name='upstream_poweroutlets', to='dcim.PowerPort'),
+            name='_downstream_powerports',
+            field=models.ManyToManyField(blank=True, related_name='_upstream_poweroutlets', to='dcim.PowerPort'),
         ),
         migrations.AddField(
             model_name='poweroutlet',
-            name='upstream_powerports',
-            field=models.ManyToManyField(blank=True, related_name='downstream_poweroutlets', to='dcim.PowerPort'),
+            name='_upstream_powerports',
+            field=models.ManyToManyField(blank=True, related_name='_downstream_poweroutlets', to='dcim.PowerPort'),
         ),
         migrations.RunPython(
             code=update_related_powerports,

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -399,7 +399,7 @@ class PowerPort(CableTermination, ComponentModel):
                 outlets = PowerOutlet.objects.filter(power_port=self)
 
             # The outlets are used as extra to invalidate the cache when an outlet's leg is changed
-            @cached_as(self, extra=outlets)
+            @cached_as(self, extra=list(outlets.values_list('pk', flat=True)))
             def _stats():
                 # Power ports drawing power from the local outlets
                 return PowerPort.objects.filter(

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -403,7 +403,7 @@ class PowerPort(CableTermination, ComponentModel):
             def _stats():
                 # Power ports drawing power from the local outlets
                 return PowerPort.objects.filter(
-                    pk__in=outlets.values_list('downstream_powerports', flat=True),
+                    pk__in=outlets.values_list('_downstream_powerports', flat=True),
                 ).aggregate(
                     Sum('allocated_draw'),
                     Sum('maximum_draw'),
@@ -489,14 +489,14 @@ class PowerOutlet(CableTermination, ComponentModel):
         choices=CONNECTION_STATUS_CHOICES,
         blank=True
     )
-    downstream_powerports = models.ManyToManyField(
+    _downstream_powerports = models.ManyToManyField(
         to='dcim.PowerPort',
-        related_name='upstream_poweroutlets',
+        related_name='_upstream_poweroutlets',
         blank=True
     )
-    upstream_powerports = models.ManyToManyField(
+    _upstream_powerports = models.ManyToManyField(
         to='dcim.PowerPort',
-        related_name='downstream_poweroutlets',
+        related_name='_downstream_poweroutlets',
         blank=True
     )
     tags = TaggableManager(through=TaggedItem)
@@ -581,15 +581,15 @@ class PowerOutlet(CableTermination, ComponentModel):
         upstream_powerports = self.calculate_upstream_powerports()
         downstream_powerports = self.calculate_downstream_powerports()
 
-        old_parents = PowerOutlet.objects.filter(connected_endpoint__in=self.upstream_powerports.all())
+        old_parents = PowerOutlet.objects.filter(connected_endpoint__in=self._upstream_powerports.all())
         new_parents = PowerOutlet.objects.filter(connected_endpoint__in=upstream_powerports)
 
         for outlet in old_parents | new_parents:
-            outlet.upstream_powerports.set(outlet.calculate_upstream_powerports())
-            outlet.downstream_powerports.set(outlet.calculate_downstream_powerports())
+            outlet._upstream_powerports.set(outlet.calculate_upstream_powerports())
+            outlet._downstream_powerports.set(outlet.calculate_downstream_powerports())
 
-        self.upstream_powerports.set(self.calculate_upstream_powerports())
-        self.downstream_powerports.set(self.calculate_downstream_powerports())
+        self._upstream_powerports.set(self.calculate_upstream_powerports())
+        self._downstream_powerports.set(self.calculate_downstream_powerports())
 
 
 #

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -708,17 +708,17 @@ class PowerCalculationTestCase(TestCase):
 
         # With a loop in the topology, all of the outlets affected by the loop have the same children. power_outlet12
         # is not part of the loop and should only have one child, power_port21.
-        self.assertEqual(self.power_outlet12.downstream_powerports.count(), 1)
-        self.assertEqual(self.power_outlet13.downstream_powerports.count(), 4)
-        self.assertEqual(self.power_outlet34.downstream_powerports.count(), 4)
-        self.assertEqual(self.power_outlet41.downstream_powerports.count(), 4)
+        self.assertEqual(self.power_outlet12._downstream_powerports.count(), 1)
+        self.assertEqual(self.power_outlet13._downstream_powerports.count(), 4)
+        self.assertEqual(self.power_outlet34._downstream_powerports.count(), 4)
+        self.assertEqual(self.power_outlet41._downstream_powerports.count(), 4)
 
         # When a loop-causing cable is removed, the downstream_powerports of the other outlets in the loop should be
         # updated appropriately. This test is necessary because, in a loop, each outlet is upstream and downstream of
         # every other outlet in that loop.
         loop_cable.delete()
 
-        self.assertEqual(self.power_outlet12.downstream_powerports.count(), 1)
-        self.assertEqual(self.power_outlet13.downstream_powerports.count(), 2)
-        self.assertEqual(self.power_outlet34.downstream_powerports.count(), 1)
-        self.assertEqual(self.power_outlet41.downstream_powerports.count(), 0)
+        self.assertEqual(self.power_outlet12._downstream_powerports.count(), 1)
+        self.assertEqual(self.power_outlet13._downstream_powerports.count(), 2)
+        self.assertEqual(self.power_outlet34._downstream_powerports.count(), 1)
+        self.assertEqual(self.power_outlet41._downstream_powerports.count(), 0)

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -393,11 +393,16 @@
                                     <tr>
                                         <td style="padding-left: 20px">Leg {{ leg.name }}</td>
                                         <td>{{ leg.outlet_count }}</td>
-                                        <td>{{ leg.allocated }}</td>
-                                        <td>{{ powerfeed.available_power|divide:3 }}VA</td>
-                                        {% with phase_available=powerfeed.available_power|divide:3 %}
-                                            <td>{% utilization_graph leg.allocated|percentage:phase_available %}</td>
-                                        {% endwith %}
+                                        <td>{{ leg.allocated }}VA</td>
+                                        {% if powerfeed.available_power %}
+                                            <td>{{ powerfeed.available_power|divide:3 }}VA</td>
+                                            {% with phase_available=powerfeed.available_power|divide:3 %}
+                                                <td>{% utilization_graph leg.allocated|percentage:phase_available %}</td>
+                                            {% endwith %}
+                                        {% else %}
+                                            <td class="text-muted">&mdash;</td>
+                                            <td class="text-muted">&mdash;</td>
+                                        {% endif %}
                                     </tr>
                                 {% endfor %}
                             {% endwith %}

--- a/netbox/templates/dcim/powerfeed.html
+++ b/netbox/templates/dcim/powerfeed.html
@@ -110,7 +110,7 @@
                         {% if utilization %}
                             <td>
                                 {{ utilization.allocated }}VA / {{ powerfeed.available_power }}VA
-                                {% if powerfeed.available_power > 0 %}
+                                {% if powerfeed.available_power %}
                                     {% utilization_graph utilization.allocated|percentage:powerfeed.available_power %}
                                 {% endif %}
                             </td>


### PR DESCRIPTION
### Fixes: #3377

During the calculation of power draw, include all downstream power ports (i.e. non-immediate). To maintain efficiency, each power outlet caches the upstream and downstream power ports.

A power topology change will update the cached fields. The trigger for a topology change is the cable being updated/deleted (in `dcim.signals`).

`downstream_powerports` flattens what would otherwise be a recursive process during power calculation to a single query.

`upstream_powerports` is used as part of the power calculation to update the cached fields for any power outlet affected by the topology change.

> This PR is a refactor following the extended discussion in #3916, which has more information on this topic.