### PR TITLE
InterfaceIPAddressTable to use non-edit link

### DIFF
--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -385,7 +385,7 @@ class InterfaceIPAddressTable(BaseTable):
     """
     List IP addresses assigned to a specific Interface.
     """
-    address = tables.TemplateColumn(IPADDRESS_ASSIGN_LINK, verbose_name='IP Address')
+    address = tables.TemplateColumn(IPADDRESS_LINK, verbose_name='IP Address')
     vrf = tables.TemplateColumn(VRF_LINK, verbose_name='VRF')
     status = tables.TemplateColumn(STATUS_LABEL)
     tenant = tables.TemplateColumn(template_code=TENANT_LINK)


### PR DESCRIPTION
InterfaceIPAddressTable was using IPADDRESS_ASSIGN_LINK (edit URL with return_url), change to using view-only URL with IPADDRESS_LINK

### Fixes: #4241
Adjusted InterfaceIPAddressTable link object to use the view link to view the IP address page, instead of the edit link to edit the IP address
