### PR TITLE
Closes #3145: Add a "decommissioning" status for cables

### DIFF
--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -2,6 +2,7 @@
 
 ## Enhancements
 
+* [#3145](https://github.com/netbox-community/netbox/issues/3145) - Add a "decommissioning" cable status
 * [#4173](https://github.com/netbox-community/netbox/issues/4173) - Return graceful error message when webhook queuing fails
 
 ## Bug Fixes

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -973,10 +973,12 @@ class CableStatusChoices(ChoiceSet):
 
     STATUS_CONNECTED = 'connected'
     STATUS_PLANNED = 'planned'
+    STATUS_DECOMMISSIONING = 'decommissioning'
 
     CHOICES = (
         (STATUS_CONNECTED, 'Connected'),
         (STATUS_PLANNED, 'Planned'),
+        (STATUS_DECOMMISSIONING, 'Decommissioning'),
     )
 
     LEGACY_MAP = {

--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -61,13 +61,10 @@ POWERFEED_MAX_UTILIZATION_DEFAULT = 80  # Percentage
 # Cabling and connections
 #
 
-# TODO: Replace with CableStatusChoices?
 # Console/power/interface connection statuses
-CONNECTION_STATUS_PLANNED = False
-CONNECTION_STATUS_CONNECTED = True
 CONNECTION_STATUS_CHOICES = [
-    [CONNECTION_STATUS_PLANNED, 'Planned'],
-    [CONNECTION_STATUS_CONNECTED, 'Connected'],
+    [False, 'Not Connected'],
+    [True, 'Connected'],
 ]
 
 # Cable endpoint types

--- a/netbox/dcim/models/__init__.py
+++ b/netbox/dcim/models/__init__.py
@@ -2118,13 +2118,13 @@ class Cable(ChangeLoggedModel):
 
         # Determine overall path status (connected or planned)
         if self.status == CableStatusChoices.STATUS_CONNECTED:
-            path_status = CONNECTION_STATUS_CONNECTED
+            path_status = True
             for segment in a_path[1:] + b_path[1:]:
                 if segment[1] is None or segment[1].status != CableStatusChoices.STATUS_CONNECTED:
-                    path_status = CONNECTION_STATUS_PLANNED
+                    path_status = False
                     break
         else:
-            path_status = CONNECTION_STATUS_PLANNED
+            path_status = False
 
         a_endpoint = a_path[-1][2]
         b_endpoint = b_path[-1][2]

--- a/netbox/dcim/models/__init__.py
+++ b/netbox/dcim/models/__init__.py
@@ -1956,6 +1956,7 @@ class Cable(ChangeLoggedModel):
     STATUS_CLASS_MAP = {
         CableStatusChoices.STATUS_CONNECTED: 'success',
         CableStatusChoices.STATUS_PLANNED: 'info',
+        CableStatusChoices.STATUS_DECOMMISSIONING: 'warning',
     }
 
     class Meta:
@@ -2116,14 +2117,14 @@ class Cable(ChangeLoggedModel):
         b_path = self.termination_a.trace()
 
         # Determine overall path status (connected or planned)
-        if self.status == CableStatusChoices.STATUS_PLANNED:
-            path_status = CONNECTION_STATUS_PLANNED
-        else:
+        if self.status == CableStatusChoices.STATUS_CONNECTED:
             path_status = CONNECTION_STATUS_CONNECTED
             for segment in a_path[1:] + b_path[1:]:
-                if segment[1] is None or segment[1].status == CableStatusChoices.STATUS_PLANNED:
+                if segment[1] is None or segment[1].status != CableStatusChoices.STATUS_CONNECTED:
                     path_status = CONNECTION_STATUS_PLANNED
                     break
+        else:
+            path_status = CONNECTION_STATUS_PLANNED
 
         a_endpoint = a_path[-1][2]
         b_endpoint = b_path[-1][2]

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -2,7 +2,6 @@ from django.core.exceptions import ValidationError
 from django.test import TestCase
 
 from dcim.choices import *
-from dcim.constants import CONNECTION_STATUS_CONNECTED, CONNECTION_STATUS_PLANNED
 from dcim.models import *
 from tenancy.models import Tenant
 
@@ -522,14 +521,14 @@ class CablePathTestCase(TestCase):
         cable3.save()
         interface1 = Interface.objects.get(pk=self.interface1.pk)
         self.assertEqual(interface1.connected_endpoint, self.interface2)
-        self.assertEqual(interface1.connection_status, CONNECTION_STATUS_PLANNED)
+        self.assertFalse(interface1.connection_status)
 
         # Switch third segment from planned to connected
         cable3.status = CableStatusChoices.STATUS_CONNECTED
         cable3.save()
         interface1 = Interface.objects.get(pk=self.interface1.pk)
         self.assertEqual(interface1.connected_endpoint, self.interface2)
-        self.assertEqual(interface1.connection_status, CONNECTION_STATUS_CONNECTED)
+        self.assertTrue(interface1.connection_status)
 
     def test_path_teardown(self):
 
@@ -542,7 +541,7 @@ class CablePathTestCase(TestCase):
         cable3.save()
         interface1 = Interface.objects.get(pk=self.interface1.pk)
         self.assertEqual(interface1.connected_endpoint, self.interface2)
-        self.assertEqual(interface1.connection_status, CONNECTION_STATUS_CONNECTED)
+        self.assertTrue(interface1.connection_status)
 
         # Remove a cable
         cable2.delete()


### PR DESCRIPTION
### Closes #3145

- Add a "decommissioning" status for cables. (`status` was previously a boolean field indicating either "planned" or "connected".)
- Tweak the display values for connection status fields from "planned/connected" to "not connected/connected."