### PR TITLE
Fix #4274: Set correct value schema for int typed ChoiceField

### DIFF
--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -10,6 +10,7 @@
 ## Bug Fixes
 
 * [#4277](https://github.com/netbox-community/netbox/issues/4277) - Fix filtering of clusters by tenant
+* [#4274](https://github.com/netbox-community/netbox/issues/4274) - Fix incorrect schema definition of `int` type choicefields
 * [#4282](https://github.com/netbox-community/netbox/issues/4282) - Fix label on export button for device types
 * [#4285](https://github.com/netbox-community/netbox/issues/4285) - Include A/Z termination sites in provider circuits table
 * [#4295](https://github.com/netbox-community/netbox/issues/4295) - Fix assignment of parent LAG during interface bulk edit

--- a/netbox/utilities/custom_inspectors.py
+++ b/netbox/utilities/custom_inspectors.py
@@ -89,6 +89,10 @@ class CustomChoiceFieldInspector(FieldInspector):
                 value_schema = openapi.Schema(type=schema_type)
                 value_schema['x-nullable'] = True
 
+            if isinstance(choices[0], int):
+                # Change value_schema for IPAddressFamilyChoices, RackWidthChoices
+                value_schema = openapi.Schema(type=openapi.TYPE_INTEGER)
+
             schema = SwaggerType(type=openapi.TYPE_OBJECT, required=["label", "value"], properties={
                 "label": openapi.Schema(type=openapi.TYPE_STRING),
                 "value": value_schema


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4274
<!--
    Please include a summary of the proposed changes below.
-->
This changes value schema from string to integer.
 
```
"family": {
  "title": "Family",
  "required": [
    "label",
    "value"
  ],
  "type": "object",
  "properties": {
    "label": {
      "type": "string"
    },
    "value": {
      "type": "integer"
    }
  },
  "readOnly": true
},
```
