### PR TITLE
Closes #4320: Clean up template tags filters

### DIFF
--- a/netbox/templates/circuits/circuit.html
+++ b/netbox/templates/circuits/circuit.html
@@ -119,7 +119,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if circuit.comments %}
-                    {{ circuit.comments|gfm }}
+                    {{ circuit.comments|markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/circuits/circuit.html
+++ b/netbox/templates/circuits/circuit.html
@@ -119,7 +119,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if circuit.comments %}
-                    {{ circuit.comments|markdown }}
+                    {{ circuit.comments|render_markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/circuits/provider.html
+++ b/netbox/templates/circuits/provider.html
@@ -88,11 +88,11 @@
                 </tr>
                 <tr>
                     <td>NOC Contact</td>
-                    <td class="rendered-markdown">{{ provider.noc_contact|markdown|placeholder }}</td>
+                    <td class="rendered-markdown">{{ provider.noc_contact|render_markdown|placeholder }}</td>
                 </tr>
                 <tr>
                     <td>Admin Contact</td>
-                    <td class="rendered-markdown">{{ provider.admin_contact|markdown|placeholder }}</td>
+                    <td class="rendered-markdown">{{ provider.admin_contact|render_markdown|placeholder }}</td>
                 </tr>
                 <tr>
                     <td>Circuits</td>
@@ -110,7 +110,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if provider.comments %}
-                    {{ provider.comments|markdown }}
+                    {{ provider.comments|render_markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/circuits/provider.html
+++ b/netbox/templates/circuits/provider.html
@@ -88,11 +88,11 @@
                 </tr>
                 <tr>
                     <td>NOC Contact</td>
-                    <td class="rendered-markdown">{{ provider.noc_contact|gfm|placeholder }}</td>
+                    <td class="rendered-markdown">{{ provider.noc_contact|markdown|placeholder }}</td>
                 </tr>
                 <tr>
                     <td>Admin Contact</td>
-                    <td class="rendered-markdown">{{ provider.admin_contact|gfm|placeholder }}</td>
+                    <td class="rendered-markdown">{{ provider.admin_contact|markdown|placeholder }}</td>
                 </tr>
                 <tr>
                     <td>Circuits</td>
@@ -110,7 +110,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if provider.comments %}
-                    {{ provider.comments|gfm }}
+                    {{ provider.comments|markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/dcim/cable_connect.html
+++ b/netbox/templates/dcim/cable_connect.html
@@ -53,7 +53,7 @@
                             <div class="form-group">
                                 <label class="col-md-3 control-label required">Type</label>
                                 <div class="col-md-9">
-                                    <p class="form-control-static">{{ termination_a|model_name|capfirst }}</p>
+                                    <p class="form-control-static">{{ termination_a|meta:"verbose_name"|capfirst }}</p>
                                 </div>
                             </div>
                             <div class="form-group">

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -325,7 +325,7 @@
                 </div>
                 <div class="panel-body rendered-markdown">
                     {% if device.comments %}
-                        {{ device.comments|markdown }}
+                        {{ device.comments|render_markdown }}
                     {% else %}
                         <span class="text-muted">None</span>
                     {% endif %}

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -325,7 +325,7 @@
                 </div>
                 <div class="panel-body rendered-markdown">
                     {% if device.comments %}
-                        {{ device.comments|gfm }}
+                        {{ device.comments|markdown }}
                     {% else %}
                         <span class="text-muted">None</span>
                     {% endif %}

--- a/netbox/templates/dcim/devicetype.html
+++ b/netbox/templates/dcim/devicetype.html
@@ -149,7 +149,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if devicetype.comments %}
-                    {{ devicetype.comments|markdown }}
+                    {{ devicetype.comments|render_markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/dcim/devicetype.html
+++ b/netbox/templates/dcim/devicetype.html
@@ -149,7 +149,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if devicetype.comments %}
-                    {{ devicetype.comments|gfm }}
+                    {{ devicetype.comments|markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/dcim/inc/cable_termination.html
+++ b/netbox/templates/dcim/inc/cable_termination.html
@@ -11,7 +11,7 @@
         <tr>
             <td>Type</td>
             <td>
-                {{ termination|model_name|capfirst }}
+                {{ termination|meta:"verbose_name"|capfirst }}
             </td>
         </tr>
         <tr>

--- a/netbox/templates/dcim/inc/cable_trace_end.html
+++ b/netbox/templates/dcim/inc/cable_trace_end.html
@@ -17,7 +17,7 @@
     <div class="panel-body text-center">
         {% if end.device %}
             {# Device component #}
-            {% with model=end|model_name %}
+            {% with model=end|meta:"verbose_name" %}
                 <strong>{{ model|bettertitle }} {{ end }}</strong><br />
                 {% if model == 'interface' %}
                     {{ end.get_type_display }}

--- a/netbox/templates/dcim/powerfeed.html
+++ b/netbox/templates/dcim/powerfeed.html
@@ -158,7 +158,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if powerfeed.comments %}
-                    {{ powerfeed.comments|gfm }}
+                    {{ powerfeed.comments|markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/dcim/powerfeed.html
+++ b/netbox/templates/dcim/powerfeed.html
@@ -158,7 +158,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if powerfeed.comments %}
-                    {{ powerfeed.comments|markdown }}
+                    {{ powerfeed.comments|render_markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/dcim/rack.html
+++ b/netbox/templates/dcim/rack.html
@@ -198,7 +198,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if rack.comments %}
-                    {{ rack.comments|gfm }}
+                    {{ rack.comments|markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/dcim/rack.html
+++ b/netbox/templates/dcim/rack.html
@@ -198,7 +198,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if rack.comments %}
-                    {{ rack.comments|markdown }}
+                    {{ rack.comments|render_markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -143,7 +143,7 @@
                     <td>
                         {% if site.physical_address %}
                             <div class="pull-right noprint">
-                                <a href="http://maps.google.com/?q={{ site.physical_address|oneline|urlencode }}" target="_blank" class="btn btn-primary btn-xs">
+                                <a href="http://maps.google.com/?q={{ site.physical_address|urlencode }}" target="_blank" class="btn btn-primary btn-xs">
                                     <i class="glyphicon glyphicon-map-marker"></i> Map it
                                 </a>
                             </div>

--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -206,7 +206,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if site.comments %}
-                    {{ site.comments|gfm }}
+                    {{ site.comments|markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -206,7 +206,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if site.comments %}
-                    {{ site.comments|markdown }}
+                    {{ site.comments|render_markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/extras/script.html
+++ b/netbox/templates/extras/script.html
@@ -47,7 +47,7 @@
                                     <tr>
                                         <td>{{ forloop.counter }}</td>
                                         <td>{% log_level level %}</td>
-                                        <td class="rendered-markdown">{{ message|gfm }}</td>
+                                        <td class="rendered-markdown">{{ message|markdown }}</td>
                                     </tr>
                                 {% empty %}
                                     <tr>

--- a/netbox/templates/extras/script.html
+++ b/netbox/templates/extras/script.html
@@ -47,7 +47,7 @@
                                     <tr>
                                         <td>{{ forloop.counter }}</td>
                                         <td>{% log_level level %}</td>
-                                        <td class="rendered-markdown">{{ message|markdown }}</td>
+                                        <td class="rendered-markdown">{{ message|render_markdown }}</td>
                                     </tr>
                                 {% empty %}
                                     <tr>

--- a/netbox/templates/extras/tag.html
+++ b/netbox/templates/extras/tag.html
@@ -90,7 +90,7 @@
                 </div>
                 <div class="panel-body rendered-markdown">
                     {% if tag.comments %}
-                        {{ tag.comments|gfm }}
+                        {{ tag.comments|markdown }}
                     {% else %}
                         <span class="text-muted">None</span>
                     {% endif %}

--- a/netbox/templates/extras/tag.html
+++ b/netbox/templates/extras/tag.html
@@ -90,7 +90,7 @@
                 </div>
                 <div class="panel-body rendered-markdown">
                     {% if tag.comments %}
-                        {{ tag.comments|markdown }}
+                        {{ tag.comments|render_markdown }}
                     {% else %}
                         <span class="text-muted">None</span>
                     {% endif %}

--- a/netbox/templates/ipam/ipaddress_edit.html
+++ b/netbox/templates/ipam/ipaddress_edit.html
@@ -35,7 +35,7 @@
             </div>
             <div class="panel-body">
                 <div class="form-group">
-                    <label class="col-md-3 control-label">{{ obj.interface.parent|model_name|bettertitle }}</label>
+                    <label class="col-md-3 control-label">{{ obj.interface.parent|meta:"verbose_name"|bettertitle }}</label>
                     <div class="col-md-9">
                         <p class="form-control-static">
                             <a href="{{ obj.interface.parent.get_absolute_url }}">{{ obj.interface.parent }}</a>

--- a/netbox/templates/tenancy/tenant.html
+++ b/netbox/templates/tenancy/tenant.html
@@ -87,7 +87,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if tenant.comments %}
-                    {{ tenant.comments|gfm }}
+                    {{ tenant.comments|markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/tenancy/tenant.html
+++ b/netbox/templates/tenancy/tenant.html
@@ -87,7 +87,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if tenant.comments %}
-                    {{ tenant.comments|markdown }}
+                    {{ tenant.comments|render_markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/utilities/obj_list.html
+++ b/netbox/templates/utilities/obj_list.html
@@ -15,7 +15,7 @@
         {% export_button content_type %}
     {% endif %}
 </div>
-<h1>{% block title %}{{ content_type.model_class|model_name_plural|bettertitle }}{% endblock %}</h1>
+<h1>{% block title %}{{ content_type.model_class|meta:"verbose_name_plural"|bettertitle }}{% endblock %}</h1>
 <div class="row">
     <div class="col-md-{% if filter_form %}9{% else %}12{% endif %}">
         {% with bulk_edit_url=content_type.model_class|url_name:"bulk_edit" bulk_delete_url=content_type.model_class|url_name:"bulk_delete" %}

--- a/netbox/templates/virtualization/cluster.html
+++ b/netbox/templates/virtualization/cluster.html
@@ -115,7 +115,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if cluster.comments %}
-                    {{ cluster.comments|gfm }}
+                    {{ cluster.comments|markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/virtualization/cluster.html
+++ b/netbox/templates/virtualization/cluster.html
@@ -115,7 +115,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if cluster.comments %}
-                    {{ cluster.comments|markdown }}
+                    {{ cluster.comments|render_markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -152,7 +152,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if virtualmachine.comments %}
-                    {{ virtualmachine.comments|gfm }}
+                    {{ virtualmachine.comments|markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -152,7 +152,7 @@
             </div>
             <div class="panel-body rendered-markdown">
                 {% if virtualmachine.comments %}
-                    {{ virtualmachine.comments|markdown }}
+                    {{ virtualmachine.comments|render_markdown }}
                 {% else %}
                     <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/utilities/templatetags/helpers.py
+++ b/netbox/utilities/templatetags/helpers.py
@@ -93,14 +93,6 @@ def url_name(model, action):
 
 
 @register.filter()
-def contains(value, arg):
-    """
-    Test whether a value contains any of a given set of strings. `arg` should be a comma-separated list of strings.
-    """
-    return any(s in value for s in arg.split(','))
-
-
-@register.filter()
 def bettertitle(value):
     """
     Alternative to the builtin title(); uppercases words without replacing letters that are already uppercase.

--- a/netbox/utilities/templatetags/helpers.py
+++ b/netbox/utilities/templatetags/helpers.py
@@ -21,15 +21,6 @@ register = template.Library()
 #
 
 @register.filter()
-def oneline(value):
-    """
-    Replace each line break with a single space
-    """
-    value = value.replace('\r', '')
-    return value.replace('\n', ' ')
-
-
-@register.filter()
 def placeholder(value):
     """
     Render a muted placeholder if value equates to False.

--- a/netbox/utilities/templatetags/helpers.py
+++ b/netbox/utilities/templatetags/helpers.py
@@ -31,9 +31,8 @@ def placeholder(value):
     return mark_safe(placeholder)
 
 
-# TODO: Rename this filter as py-gfm is no longer in use
 @register.filter(is_safe=True)
-def gfm(value):
+def render_markdown(value):
     """
     Render text as Markdown
     """

--- a/netbox/utilities/templatetags/helpers.py
+++ b/netbox/utilities/templatetags/helpers.py
@@ -62,19 +62,12 @@ def render_yaml(value):
 
 
 @register.filter()
-def model_name(obj):
+def meta(obj, attr):
     """
-    Return the name of the model of the given object
+    Return the specified Meta attribute of a model. This is needed because Django does not permit templates
+    to access attributes which begin with an underscore (e.g. _meta).
     """
-    return obj._meta.verbose_name
-
-
-@register.filter()
-def model_name_plural(obj):
-    """
-    Return the plural name of the model of the given object
-    """
-    return obj._meta.verbose_name_plural
+    return getattr(obj._meta, attr, '')
 
 
 @register.filter()

--- a/netbox/utilities/templatetags/helpers.py
+++ b/netbox/utilities/templatetags/helpers.py
@@ -31,22 +31,6 @@ def placeholder(value):
     return mark_safe(placeholder)
 
 
-@register.filter()
-def getlist(value, arg):
-    """
-    Return all values of a QueryDict key
-    """
-    return value.getlist(arg)
-
-
-@register.filter
-def getkey(value, key):
-    """
-    Return a dictionary item specified by key
-    """
-    return value[key]
-
-
 # TODO: Rename this filter as py-gfm is no longer in use
 @register.filter(is_safe=True)
 def gfm(value):


### PR DESCRIPTION
### Fixes: #4320

- Remove unused template filters
- Rename `gfm` filter to `render_markdown`