### PR TITLE
Closes #1754: Nested rack groups

### DIFF
--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -96,11 +96,12 @@ class SiteSerializer(TaggitSerializer, CustomFieldModelSerializer):
 
 class RackGroupSerializer(ValidatedModelSerializer):
     site = NestedSiteSerializer()
+    parent = NestedRackGroupSerializer(required=False, allow_null=True)
     rack_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = RackGroup
-        fields = ['id', 'name', 'slug', 'site', 'rack_count']
+        fields = ['id', 'name', 'slug', 'site', 'parent', 'rack_count']
 
 
 class RackRoleSerializer(ValidatedModelSerializer):

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -204,15 +204,18 @@ class RackFilterSet(BaseFilterSet, TenancyFilterSet, CustomFieldFilterSet, Creat
         to_field_name='slug',
         label='Site (slug)',
     )
-    group_id = django_filters.ModelMultipleChoiceFilter(
+    group_id = TreeNodeMultipleChoiceFilter(
         queryset=RackGroup.objects.all(),
-        label='Group (ID)',
+        field_name='group',
+        lookup_expr='in',
+        label='Rack group (ID)',
     )
-    group = django_filters.ModelMultipleChoiceFilter(
-        field_name='group__slug',
+    group = TreeNodeMultipleChoiceFilter(
         queryset=RackGroup.objects.all(),
+        field_name='group',
+        lookup_expr='in',
         to_field_name='slug',
-        label='Group',
+        label='Rack group (slug)',
     )
     status = django_filters.MultipleChoiceFilter(
         choices=RackStatusChoices,
@@ -272,16 +275,18 @@ class RackReservationFilterSet(BaseFilterSet, TenancyFilterSet):
         to_field_name='slug',
         label='Site (slug)',
     )
-    group_id = django_filters.ModelMultipleChoiceFilter(
+    group_id = TreeNodeMultipleChoiceFilter(
+        queryset=RackGroup.objects.all(),
         field_name='rack__group',
-        queryset=RackGroup.objects.all(),
-        label='Group (ID)',
+        lookup_expr='in',
+        label='Rack group (ID)',
     )
-    group = django_filters.ModelMultipleChoiceFilter(
-        field_name='rack__group__slug',
+    group = TreeNodeMultipleChoiceFilter(
         queryset=RackGroup.objects.all(),
+        field_name='rack__group',
+        lookup_expr='in',
         to_field_name='slug',
-        label='Group',
+        label='Rack group (slug)',
     )
     user_id = django_filters.ModelMultipleChoiceFilter(
         queryset=User.objects.all(),
@@ -561,9 +566,10 @@ class DeviceFilterSet(
         to_field_name='slug',
         label='Site name (slug)',
     )
-    rack_group_id = django_filters.ModelMultipleChoiceFilter(
-        field_name='rack__group',
+    rack_group_id = TreeNodeMultipleChoiceFilter(
         queryset=RackGroup.objects.all(),
+        field_name='rack__group',
+        lookup_expr='in',
         label='Rack group (ID)',
     )
     rack_id = django_filters.ModelMultipleChoiceFilter(
@@ -1253,9 +1259,10 @@ class PowerPanelFilterSet(BaseFilterSet):
         to_field_name='slug',
         label='Site name (slug)',
     )
-    rack_group_id = django_filters.ModelMultipleChoiceFilter(
-        field_name='rack_group',
+    rack_group_id = TreeNodeMultipleChoiceFilter(
         queryset=RackGroup.objects.all(),
+        field_name='rack_group',
+        lookup_expr='in',
         label='Rack group (ID)',
     )
 

--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -153,6 +153,16 @@ class RackGroupFilterSet(BaseFilterSet, NameSlugSearchFilterSet):
         to_field_name='slug',
         label='Site (slug)',
     )
+    parent_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=RackGroup.objects.all(),
+        label='Rack group (ID)',
+    )
+    parent = django_filters.ModelMultipleChoiceFilter(
+        field_name='parent__slug',
+        queryset=RackGroup.objects.all(),
+        to_field_name='slug',
+        label='Rack group (slug)',
+    )
 
     class Meta:
         model = RackGroup

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -386,7 +386,17 @@ class RackGroupForm(BootstrapMixin, forms.ModelForm):
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
         widget=APISelect(
-            api_url="/api/dcim/sites/"
+            api_url="/api/dcim/sites/",
+            filter_for={
+                'parent': 'site_id',
+            }
+        )
+    )
+    parent = DynamicModelChoiceField(
+        queryset=RackGroup.objects.all(),
+        required=False,
+        widget=APISelect(
+            api_url="/api/dcim/rack-groups/"
         )
     )
     slug = SlugField()
@@ -394,7 +404,7 @@ class RackGroupForm(BootstrapMixin, forms.ModelForm):
     class Meta:
         model = RackGroup
         fields = (
-            'site', 'name', 'slug',
+            'site', 'parent', 'name', 'slug',
         )
 
 
@@ -405,6 +415,15 @@ class RackGroupCSVForm(forms.ModelForm):
         help_text='Name of parent site',
         error_messages={
             'invalid_choice': 'Site not found.',
+        }
+    )
+    parent = forms.ModelChoiceField(
+        queryset=RackGroup.objects.all(),
+        required=False,
+        to_field_name='name',
+        help_text='Name of parent rack group',
+        error_messages={
+            'invalid_choice': 'Rack group not found.',
         }
     )
 
@@ -426,7 +445,8 @@ class RackGroupFilterForm(BootstrapMixin, forms.Form):
             api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
-                'site': 'region'
+                'site': 'region',
+                'parent': 'region',
             }
         )
     )
@@ -436,6 +456,18 @@ class RackGroupFilterForm(BootstrapMixin, forms.Form):
         required=False,
         widget=APISelectMultiple(
             api_url="/api/dcim/sites/",
+            value_field="slug",
+            filter_for={
+                'parent': 'site',
+            }
+        )
+    )
+    parent = DynamicModelMultipleChoiceField(
+        queryset=RackGroup.objects.all(),
+        to_field_name='slug',
+        required=False,
+        widget=APISelectMultiple(
+            api_url="/api/dcim/rack-groups/",
             value_field="slug",
         )
     )

--- a/netbox/dcim/migrations/0101_nested_rackgroups.py
+++ b/netbox/dcim/migrations/0101_nested_rackgroups.py
@@ -1,0 +1,43 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import mptt.fields
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dcim', '0100_mptt_remove_indexes'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='rackgroup',
+            name='parent',
+            field=mptt.fields.TreeForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.CASCADE, related_name='children', to='dcim.RackGroup'),
+        ),
+        migrations.AddField(
+            model_name='rackgroup',
+            name='level',
+            field=models.PositiveIntegerField(default=0, editable=False),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='rackgroup',
+            name='lft',
+            field=models.PositiveIntegerField(default=1, editable=False),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name='rackgroup',
+            name='rght',
+            field=models.PositiveIntegerField(default=2, editable=False),
+            preserve_default=False,
+        ),
+        # tree_id will be set to a valid value during the following migration (which needs to be a separate migration)
+        migrations.AddField(
+            model_name='rackgroup',
+            name='tree_id',
+            field=models.PositiveIntegerField(db_index=True, default=0, editable=False),
+            preserve_default=False,
+        ),
+    ]

--- a/netbox/dcim/migrations/0102_nested_rackgroups_rebuild.py
+++ b/netbox/dcim/migrations/0102_nested_rackgroups_rebuild.py
@@ -1,0 +1,21 @@
+from django.db import migrations
+
+
+def rebuild_mptt(apps, schema_editor):
+    RackGroup = apps.get_model('dcim', 'RackGroup')
+    for i, rackgroup in enumerate(RackGroup.objects.all(), start=1):
+        RackGroup.objects.filter(pk=rackgroup.pk).update(tree_id=i)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dcim', '0101_nested_rackgroups'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=rebuild_mptt,
+            reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -11,13 +11,13 @@ from .models import (
     VirtualChassis,
 )
 
-REGION_LINK = """
+MPTT_LINK = """
 {% if record.get_children %}
     <span style="padding-left: {{ record.get_ancestors|length }}0px "><i class="fa fa-caret-right"></i>
 {% else %}
     <span style="padding-left: {{ record.get_ancestors|length }}9px">
 {% endif %}
-    <a href="{% url 'dcim:site_list' %}?region={{ record.slug }}">{{ record.name }}</a>
+    <a href="{{ record.get_absolute_url }}">{{ record.name }}</a>
 </span>
 """
 
@@ -214,7 +214,7 @@ def get_component_template_actions(model_name):
 
 class RegionTable(BaseTable):
     pk = ToggleColumn()
-    name = tables.TemplateColumn(template_code=REGION_LINK, orderable=False)
+    name = tables.TemplateColumn(template_code=MPTT_LINK, orderable=False)
     site_count = tables.Column(verbose_name='Sites')
     slug = tables.Column(verbose_name='Slug')
     actions = tables.TemplateColumn(
@@ -250,7 +250,10 @@ class SiteTable(BaseTable):
 
 class RackGroupTable(BaseTable):
     pk = ToggleColumn()
-    name = tables.LinkColumn()
+    name = tables.TemplateColumn(
+        template_code=MPTT_LINK,
+        orderable=False
+    )
     site = tables.LinkColumn(
         viewname='dcim:site',
         args=[Accessor('site.slug')],

--- a/netbox/dcim/tests/test_filters.py
+++ b/netbox/dcim/tests/test_filters.py
@@ -186,12 +186,21 @@ class RackGroupTestCase(TestCase):
         )
         Site.objects.bulk_create(sites)
 
-        rack_groups = (
-            RackGroup(name='Rack Group 1', slug='rack-group-1', site=sites[0]),
-            RackGroup(name='Rack Group 2', slug='rack-group-2', site=sites[1]),
-            RackGroup(name='Rack Group 3', slug='rack-group-3', site=sites[2]),
+        parent_rack_groups = (
+            RackGroup(name='Parent Rack Group 1', slug='parent-rack-group-1', site=sites[0]),
+            RackGroup(name='Parent Rack Group 2', slug='parent-rack-group-2', site=sites[1]),
+            RackGroup(name='Parent Rack Group 3', slug='parent-rack-group-3', site=sites[2]),
         )
-        RackGroup.objects.bulk_create(rack_groups)
+        for rackgroup in parent_rack_groups:
+            rackgroup.save()
+
+        rack_groups = (
+            RackGroup(name='Rack Group 1', slug='rack-group-1', site=sites[0], parent=parent_rack_groups[0]),
+            RackGroup(name='Rack Group 2', slug='rack-group-2', site=sites[1], parent=parent_rack_groups[1]),
+            RackGroup(name='Rack Group 3', slug='rack-group-3', site=sites[2], parent=parent_rack_groups[2]),
+        )
+        for rackgroup in rack_groups:
+            rackgroup.save()
 
     def test_id(self):
         id_list = self.queryset.values_list('id', flat=True)[:2]
@@ -209,15 +218,22 @@ class RackGroupTestCase(TestCase):
     def test_region(self):
         regions = Region.objects.all()[:2]
         params = {'region_id': [regions[0].pk, regions[1].pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'region': [regions[0].slug, regions[1].slug]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_site(self):
         sites = Site.objects.all()[:2]
         params = {'site_id': [sites[0].pk, sites[1].pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'site': [sites[0].slug, sites[1].slug]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
+
+    def test_parent(self):
+        parent_groups = RackGroup.objects.filter(name__startswith='Parent')[:2]
+        params = {'parent_id': [parent_groups[0].pk, parent_groups[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'parent': [parent_groups[0].slug, parent_groups[1].slug]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
@@ -280,7 +296,8 @@ class RackTestCase(TestCase):
             RackGroup(name='Rack Group 2', slug='rack-group-2', site=sites[1]),
             RackGroup(name='Rack Group 3', slug='rack-group-3', site=sites[2]),
         )
-        RackGroup.objects.bulk_create(rack_groups)
+        for rackgroup in rack_groups:
+            rackgroup.save()
 
         rack_roles = (
             RackRole(name='Rack Role 1', slug='rack-role-1'),
@@ -432,7 +449,8 @@ class RackReservationTestCase(TestCase):
             RackGroup(name='Rack Group 2', slug='rack-group-2', site=sites[1]),
             RackGroup(name='Rack Group 3', slug='rack-group-3', site=sites[2]),
         )
-        RackGroup.objects.bulk_create(rack_groups)
+        for rackgroup in rack_groups:
+            rackgroup.save()
 
         racks = (
             Rack(name='Rack 1', site=sites[0], group=rack_groups[0]),
@@ -1146,7 +1164,8 @@ class DeviceTestCase(TestCase):
             RackGroup(name='Rack Group 2', slug='rack-group-2', site=sites[1]),
             RackGroup(name='Rack Group 3', slug='rack-group-3', site=sites[2]),
         )
-        RackGroup.objects.bulk_create(rack_groups)
+        for rackgroup in rack_groups:
+            rackgroup.save()
 
         racks = (
             Rack(name='Rack 1', site=sites[0], group=rack_groups[0]),
@@ -2559,7 +2578,8 @@ class PowerPanelTestCase(TestCase):
             RackGroup(name='Rack Group 2', slug='rack-group-2', site=sites[1]),
             RackGroup(name='Rack Group 3', slug='rack-group-3', site=sites[2]),
         )
-        RackGroup.objects.bulk_create(rack_groups)
+        for rackgroup in rack_groups:
+            rackgroup.save()
 
         power_panels = (
             PowerPanel(name='Power Panel 1', site=sites[0], rack_group=rack_groups[0]),

--- a/netbox/dcim/tests/test_views.py
+++ b/netbox/dcim/tests/test_views.py
@@ -122,11 +122,13 @@ class RackGroupTestCase(ViewTestCases.OrganizationalObjectViewTestCase):
         site = Site(name='Site 1', slug='site-1')
         site.save()
 
-        RackGroup.objects.bulk_create([
+        rack_groups = (
             RackGroup(name='Rack Group 1', slug='rack-group-1', site=site),
             RackGroup(name='Rack Group 2', slug='rack-group-2', site=site),
             RackGroup(name='Rack Group 3', slug='rack-group-3', site=site),
-        ])
+        )
+        for rackgroup in rack_groups:
+            rackgroup.save()
 
         cls.form_data = {
             'name': 'Rack Group X',
@@ -231,7 +233,8 @@ class RackTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             RackGroup(name='Rack Group 1', slug='rack-group-1', site=sites[0]),
             RackGroup(name='Rack Group 2', slug='rack-group-2', site=sites[1])
         )
-        RackGroup.objects.bulk_create(rackgroups)
+        for rackgroup in rackgroups:
+            rackgroup.save()
 
         rackroles = (
             RackRole(name='Rack Role 1', slug='rack-role-1'),
@@ -1570,7 +1573,8 @@ class PowerPanelTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             RackGroup(name='Rack Group 1', slug='rack-group-1', site=sites[0]),
             RackGroup(name='Rack Group 2', slug='rack-group-2', site=sites[1]),
         )
-        RackGroup.objects.bulk_create(rackgroups)
+        for rackgroup in rackgroups:
+            rackgroup.save()
 
         PowerPanel.objects.bulk_create((
             PowerPanel(site=sites[0], rack_group=rackgroups[0], name='Power Panel 1'),

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -266,7 +266,13 @@ class SiteBulkDeleteView(PermissionRequiredMixin, BulkDeleteView):
 
 class RackGroupListView(PermissionRequiredMixin, ObjectListView):
     permission_required = 'dcim.view_rackgroup'
-    queryset = RackGroup.objects.prefetch_related('site').annotate(rack_count=Count('racks'))
+    queryset = RackGroup.objects.add_related_count(
+        RackGroup.objects.all(),
+        Rack,
+        'group',
+        'rack_count',
+        cumulative=True
+    ).prefetch_related('site')
     filterset = filters.RackGroupFilterSet
     filterset_form = forms.RackGroupFilterForm
     table = tables.RackGroupTable


### PR DESCRIPTION
### Closes: #1754

- Adds a `parent` field to dcim.RackGroup to allow recursive nesting (similar to regions)
- Updates all relevant filters on related objects
- Updates/extends tests