### PR TITLE
Closes #4374: Automatically derive API endpoint for dynamic choice fields

### DIFF
--- a/netbox/circuits/forms.py
+++ b/netbox/circuits/forms.py
@@ -334,6 +334,9 @@ class CircuitFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm
 #
 
 class CircuitTerminationForm(BootstrapMixin, forms.ModelForm):
+    site = DynamicModelChoiceField(
+        queryset=Site.objects.all()
+    )
 
     class Meta:
         model = CircuitTermination
@@ -347,7 +350,4 @@ class CircuitTerminationForm(BootstrapMixin, forms.ModelForm):
         }
         widgets = {
             'term_side': forms.HiddenInput(),
-            'site': APISelect(
-                api_url="/api/dcim/sites/"
-            )
         }

--- a/netbox/circuits/forms.py
+++ b/netbox/circuits/forms.py
@@ -113,7 +113,6 @@ class ProviderFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
                 'site': 'region'
@@ -125,7 +124,6 @@ class ProviderFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
         )
     )
@@ -167,16 +165,10 @@ class CircuitTypeCSVForm(forms.ModelForm):
 
 class CircuitForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     provider = DynamicModelChoiceField(
-        queryset=Provider.objects.all(),
-        widget=APISelect(
-            api_url="/api/circuits/providers/"
-        )
+        queryset=Provider.objects.all()
     )
     type = DynamicModelChoiceField(
-        queryset=CircuitType.objects.all(),
-        widget=APISelect(
-            api_url="/api/circuits/circuit-types/"
-        )
+        queryset=CircuitType.objects.all()
     )
     comments = CommentField()
     tags = TagField(
@@ -245,17 +237,11 @@ class CircuitBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEdit
     )
     type = DynamicModelChoiceField(
         queryset=CircuitType.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/circuits/circuit-types/"
-        )
+        required=False
     )
     provider = DynamicModelChoiceField(
         queryset=Provider.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/circuits/providers/"
-        )
+        required=False
     )
     status = forms.ChoiceField(
         choices=add_blank_choice(CircuitStatusChoices),
@@ -265,10 +251,7 @@ class CircuitBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEdit
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/tenancy/tenants/"
-        )
+        required=False
     )
     commit_rate = forms.IntegerField(
         required=False,
@@ -303,7 +286,6 @@ class CircuitFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/circuits/circuit-types/",
             value_field="slug",
         )
     )
@@ -312,7 +294,6 @@ class CircuitFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/circuits/providers/",
             value_field="slug",
         )
     )
@@ -326,7 +307,6 @@ class CircuitFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
                 'site': 'region'
@@ -338,7 +318,6 @@ class CircuitFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
         )
     )

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -71,7 +71,6 @@ class DeviceComponentFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url='/api/dcim/regions/',
             value_field='slug',
             filter_for={
                 'site': 'region'
@@ -83,7 +82,6 @@ class DeviceComponentFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
             filter_for={
                 'device_id': 'site',
@@ -93,10 +91,7 @@ class DeviceComponentFilterForm(BootstrapMixin, forms.Form):
     device_id = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
         required=False,
-        label='Device',
-        widget=APISelectMultiple(
-            api_url='/api/dcim/devices/',
-        )
+        label='Device'
     )
 
 
@@ -327,10 +322,7 @@ class SiteBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditFor
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/tenancy/tenants",
-        )
+        required=False
     )
     asn = forms.IntegerField(
         min_value=BGP_ASN_MIN,
@@ -371,7 +363,6 @@ class SiteFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
         )
     )
@@ -384,10 +375,7 @@ class SiteFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm):
 
 class RackGroupForm(BootstrapMixin, forms.ModelForm):
     site = DynamicModelChoiceField(
-        queryset=Site.objects.all(),
-        widget=APISelect(
-            api_url="/api/dcim/sites/"
-        )
+        queryset=Site.objects.all()
     )
     slug = SlugField()
 
@@ -423,7 +411,6 @@ class RackGroupFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
                 'site': 'region'
@@ -435,7 +422,6 @@ class RackGroupFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
         )
     )
@@ -475,7 +461,6 @@ class RackForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
         widget=APISelect(
-            api_url="/api/dcim/sites/",
             filter_for={
                 'group': 'site_id',
             }
@@ -483,17 +468,11 @@ class RackForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     )
     group = DynamicModelChoiceField(
         queryset=RackGroup.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url='/api/dcim/rack-groups/',
-        )
+        required=False
     )
     role = DynamicModelChoiceField(
         queryset=RackRole.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url='/api/dcim/rack-roles/',
-        )
+        required=False
     )
     comments = CommentField()
     tags = TagField(
@@ -617,7 +596,6 @@ class RackBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditFor
         queryset=Site.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/dcim/sites",
             filter_for={
                 'group': 'site_id',
             }
@@ -625,17 +603,11 @@ class RackBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditFor
     )
     group = DynamicModelChoiceField(
         queryset=RackGroup.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/rack-groups",
-        )
+        required=False
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/tenancy/tenants",
-        )
+        required=False
     )
     status = forms.ChoiceField(
         choices=add_blank_choice(RackStatusChoices),
@@ -645,10 +617,7 @@ class RackBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditFor
     )
     role = DynamicModelChoiceField(
         queryset=RackRole.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/rack-roles",
-        )
+        required=False
     )
     serial = forms.CharField(
         max_length=50,
@@ -714,7 +683,6 @@ class RackFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
                 'site': 'region'
@@ -726,7 +694,6 @@ class RackFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
             filter_for={
                 'group_id': 'site'
@@ -740,7 +707,6 @@ class RackFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm):
         required=False,
         label='Rack group',
         widget=APISelectMultiple(
-            api_url="/api/dcim/rack-groups/",
             null_option=True
         )
     )
@@ -754,7 +720,6 @@ class RackFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/rack-roles/",
             value_field="slug",
             null_option=True,
         )
@@ -773,7 +738,6 @@ class RackElevationFilterForm(RackFilterForm):
         label='Rack',
         required=False,
         widget=APISelectMultiple(
-            api_url='/api/dcim/racks/',
             display_field='display_name',
         )
     )
@@ -909,10 +873,7 @@ class RackReservationBulkEditForm(BootstrapMixin, BulkEditForm):
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/tenancy/tenant",
-        )
+        required=False
     )
     description = forms.CharField(
         max_length=100,
@@ -934,7 +895,6 @@ class RackReservationFilterForm(BootstrapMixin, TenancyFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
         )
     )
@@ -943,7 +903,6 @@ class RackReservationFilterForm(BootstrapMixin, TenancyFilterForm):
         required=False,
         label='Rack group',
         widget=APISelectMultiple(
-            api_url="/api/dcim/rack-groups/",
             null_option=True,
         )
     )
@@ -980,10 +939,7 @@ class ManufacturerCSVForm(forms.ModelForm):
 
 class DeviceTypeForm(BootstrapMixin, CustomFieldModelForm):
     manufacturer = DynamicModelChoiceField(
-        queryset=Manufacturer.objects.all(),
-        widget=APISelect(
-            api_url="/api/dcim/manufacturers/",
-        )
+        queryset=Manufacturer.objects.all()
     )
     slug = SlugField(
         slug_source='model'
@@ -1024,10 +980,7 @@ class DeviceTypeBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkE
     )
     manufacturer = DynamicModelChoiceField(
         queryset=Manufacturer.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/manufacturers"
-        )
+        required=False
     )
     u_height = forms.IntegerField(
         min_value=1,
@@ -1054,7 +1007,6 @@ class DeviceTypeFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/manufacturers/",
             value_field="slug",
         )
     )
@@ -1126,10 +1078,7 @@ class ConsolePortTemplateForm(BootstrapMixin, forms.ModelForm):
 
 class ConsolePortTemplateCreateForm(BootstrapMixin, forms.Form):
     device_type = DynamicModelChoiceField(
-        queryset=DeviceType.objects.all(),
-        widget=APISelect(
-            api_url='/api/dcim/device-types/'
-        )
+        queryset=DeviceType.objects.all()
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -1169,10 +1118,7 @@ class ConsoleServerPortTemplateForm(BootstrapMixin, forms.ModelForm):
 
 class ConsoleServerPortTemplateCreateForm(BootstrapMixin, forms.Form):
     device_type = DynamicModelChoiceField(
-        queryset=DeviceType.objects.all(),
-        widget=APISelect(
-            api_url='/api/dcim/device-types/'
-        )
+        queryset=DeviceType.objects.all()
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -1212,10 +1158,7 @@ class PowerPortTemplateForm(BootstrapMixin, forms.ModelForm):
 
 class PowerPortTemplateCreateForm(BootstrapMixin, forms.Form):
     device_type = DynamicModelChoiceField(
-        queryset=DeviceType.objects.all(),
-        widget=APISelect(
-            api_url='/api/dcim/device-types/'
-        )
+        queryset=DeviceType.objects.all()
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -1285,10 +1228,7 @@ class PowerOutletTemplateForm(BootstrapMixin, forms.ModelForm):
 
 class PowerOutletTemplateCreateForm(BootstrapMixin, forms.Form):
     device_type = DynamicModelChoiceField(
-        queryset=DeviceType.objects.all(),
-        widget=APISelect(
-            api_url='/api/dcim/device-types/'
-        )
+        queryset=DeviceType.objects.all()
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -1354,10 +1294,7 @@ class InterfaceTemplateForm(BootstrapMixin, forms.ModelForm):
 
 class InterfaceTemplateCreateForm(BootstrapMixin, forms.Form):
     device_type = DynamicModelChoiceField(
-        queryset=DeviceType.objects.all(),
-        widget=APISelect(
-            api_url='/api/dcim/device-types/'
-        )
+        queryset=DeviceType.objects.all()
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -1417,10 +1354,7 @@ class FrontPortTemplateForm(BootstrapMixin, forms.ModelForm):
 
 class FrontPortTemplateCreateForm(BootstrapMixin, forms.Form):
     device_type = DynamicModelChoiceField(
-        queryset=DeviceType.objects.all(),
-        widget=APISelect(
-            api_url='/api/dcim/device-types/'
-        )
+        queryset=DeviceType.objects.all()
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -1511,10 +1445,7 @@ class RearPortTemplateForm(BootstrapMixin, forms.ModelForm):
 
 class RearPortTemplateCreateForm(BootstrapMixin, forms.Form):
     device_type = DynamicModelChoiceField(
-        queryset=DeviceType.objects.all(),
-        widget=APISelect(
-            api_url='/api/dcim/device-types/'
-        )
+        queryset=DeviceType.objects.all()
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -1560,10 +1491,7 @@ class DeviceBayTemplateForm(BootstrapMixin, forms.ModelForm):
 
 class DeviceBayTemplateCreateForm(BootstrapMixin, forms.Form):
     device_type = DynamicModelChoiceField(
-        queryset=DeviceType.objects.all(),
-        widget=APISelect(
-            api_url='/api/dcim/device-types/'
-        )
+        queryset=DeviceType.objects.all()
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -1732,10 +1660,7 @@ class DeviceRoleCSVForm(forms.ModelForm):
 class PlatformForm(BootstrapMixin, forms.ModelForm):
     manufacturer = DynamicModelChoiceField(
         queryset=Manufacturer.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/manufacturers/",
-        )
+        required=False
     )
     slug = SlugField(
         max_length=64
@@ -1779,7 +1704,6 @@ class DeviceForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
         widget=APISelect(
-            api_url="/api/dcim/sites/",
             filter_for={
                 'rack': 'site_id'
             }
@@ -1789,7 +1713,6 @@ class DeviceForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
         queryset=Rack.objects.all(),
         required=False,
         widget=APISelect(
-            api_url='/api/dcim/racks/',
             display_field='display_name'
         )
     )
@@ -1806,7 +1729,6 @@ class DeviceForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
         queryset=Manufacturer.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/dcim/manufacturers/",
             filter_for={
                 'device_type': 'manufacturer_id',
                 'platform': 'manufacturer_id'
@@ -1816,21 +1738,16 @@ class DeviceForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     device_type = DynamicModelChoiceField(
         queryset=DeviceType.objects.all(),
         widget=APISelect(
-            api_url='/api/dcim/device-types/',
             display_field='model'
         )
     )
     device_role = DynamicModelChoiceField(
-        queryset=DeviceRole.objects.all(),
-        widget=APISelect(
-            api_url='/api/dcim/device-roles/'
-        )
+        queryset=DeviceRole.objects.all()
     )
     platform = DynamicModelChoiceField(
         queryset=Platform.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/dcim/platforms/",
             additional_query_params={
                 "manufacturer_id": "null"
             }
@@ -1840,7 +1757,6 @@ class DeviceForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
         queryset=ClusterGroup.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/virtualization/cluster-groups/",
             filter_for={
                 'cluster': 'group_id'
             },
@@ -1851,10 +1767,7 @@ class DeviceForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     )
     cluster = DynamicModelChoiceField(
         queryset=Cluster.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url='/api/virtualization/clusters/',
-        )
+        required=False
     )
     comments = CommentField()
     tags = TagField(required=False)
@@ -2158,32 +2071,19 @@ class DeviceBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditF
     )
     device_type = DynamicModelChoiceField(
         queryset=DeviceType.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/device-types/",
-            display_field='display_name'
-        )
+        required=False
     )
     device_role = DynamicModelChoiceField(
         queryset=DeviceRole.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/device-roles/"
-        )
+        required=False
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/tenancy/tenants/"
-        )
+        required=False
     )
     platform = DynamicModelChoiceField(
         queryset=Platform.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/platforms/"
-        )
+        required=False
     )
     status = forms.ChoiceField(
         choices=add_blank_choice(DeviceStatusChoices),
@@ -2217,7 +2117,6 @@ class DeviceFilterForm(BootstrapMixin, LocalConfigContextFilterForm, TenancyFilt
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
                 'site': 'region'
@@ -2229,7 +2128,6 @@ class DeviceFilterForm(BootstrapMixin, LocalConfigContextFilterForm, TenancyFilt
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
             filter_for={
                 'rack_group_id': 'site',
@@ -2242,7 +2140,6 @@ class DeviceFilterForm(BootstrapMixin, LocalConfigContextFilterForm, TenancyFilt
         required=False,
         label='Rack group',
         widget=APISelectMultiple(
-            api_url="/api/dcim/rack-groups/",
             filter_for={
                 'rack_id': 'group_id',
             }
@@ -2253,7 +2150,6 @@ class DeviceFilterForm(BootstrapMixin, LocalConfigContextFilterForm, TenancyFilt
         required=False,
         label='Rack',
         widget=APISelectMultiple(
-            api_url="/api/dcim/racks/",
             null_option=True,
         )
     )
@@ -2262,7 +2158,6 @@ class DeviceFilterForm(BootstrapMixin, LocalConfigContextFilterForm, TenancyFilt
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/device-roles/",
             value_field="slug",
         )
     )
@@ -2271,7 +2166,6 @@ class DeviceFilterForm(BootstrapMixin, LocalConfigContextFilterForm, TenancyFilt
         required=False,
         label='Manufacturer',
         widget=APISelectMultiple(
-            api_url="/api/dcim/manufacturers/",
             filter_for={
                 'device_type_id': 'manufacturer_id',
             }
@@ -2282,7 +2176,6 @@ class DeviceFilterForm(BootstrapMixin, LocalConfigContextFilterForm, TenancyFilt
         required=False,
         label='Model',
         widget=APISelectMultiple(
-            api_url="/api/dcim/device-types/",
             display_field="model",
         )
     )
@@ -2291,7 +2184,6 @@ class DeviceFilterForm(BootstrapMixin, LocalConfigContextFilterForm, TenancyFilt
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/platforms/",
             value_field="slug",
             null_option=True,
         )
@@ -2435,10 +2327,7 @@ class ConsolePortForm(BootstrapMixin, forms.ModelForm):
 
 class ConsolePortCreateForm(BootstrapMixin, forms.Form):
     device = DynamicModelChoiceField(
-        queryset=Device.objects.prefetch_related('device_type__manufacturer'),
-        widget=APISelect(
-            api_url="/api/dcim/devices/",
-        )
+        queryset=Device.objects.prefetch_related('device_type__manufacturer')
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -2525,10 +2414,7 @@ class ConsoleServerPortForm(BootstrapMixin, forms.ModelForm):
 
 class ConsoleServerPortCreateForm(BootstrapMixin, forms.Form):
     device = DynamicModelChoiceField(
-        queryset=Device.objects.prefetch_related('device_type__manufacturer'),
-        widget=APISelect(
-            api_url="/api/dcim/devices/",
-        )
+        queryset=Device.objects.prefetch_related('device_type__manufacturer')
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -2629,10 +2515,7 @@ class PowerPortForm(BootstrapMixin, forms.ModelForm):
 
 class PowerPortCreateForm(BootstrapMixin, forms.Form):
     device = DynamicModelChoiceField(
-        queryset=Device.objects.prefetch_related('device_type__manufacturer'),
-        widget=APISelect(
-            api_url="/api/dcim/devices/",
-        )
+        queryset=Device.objects.prefetch_related('device_type__manufacturer')
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -2752,10 +2635,7 @@ class PowerOutletForm(BootstrapMixin, forms.ModelForm):
 
 class PowerOutletCreateForm(BootstrapMixin, forms.Form):
     device = DynamicModelChoiceField(
-        queryset=Device.objects.prefetch_related('device_type__manufacturer'),
-        widget=APISelect(
-            api_url="/api/dcim/devices/",
-        )
+        queryset=Device.objects.prefetch_related('device_type__manufacturer')
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -2927,7 +2807,6 @@ class InterfaceForm(InterfaceCommonForm, BootstrapMixin, forms.ModelForm):
         required=False,
         label='Untagged VLAN',
         widget=APISelect(
-            api_url="/api/ipam/vlans/",
             display_field='display_name',
             full=True,
             additional_query_params={
@@ -2940,7 +2819,6 @@ class InterfaceForm(InterfaceCommonForm, BootstrapMixin, forms.ModelForm):
         required=False,
         label='Tagged VLANs',
         widget=APISelectMultiple(
-            api_url="/api/ipam/vlans/",
             display_field='display_name',
             full=True,
             additional_query_params={
@@ -2992,10 +2870,7 @@ class InterfaceForm(InterfaceCommonForm, BootstrapMixin, forms.ModelForm):
 
 class InterfaceCreateForm(BootstrapMixin, InterfaceCommonForm, forms.Form):
     device = DynamicModelChoiceField(
-        queryset=Device.objects.prefetch_related('device_type__manufacturer'),
-        widget=APISelect(
-            api_url="/api/dcim/devices/",
-        )
+        queryset=Device.objects.prefetch_related('device_type__manufacturer')
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -3045,7 +2920,6 @@ class InterfaceCreateForm(BootstrapMixin, InterfaceCommonForm, forms.Form):
         queryset=VLAN.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/ipam/vlans/",
             display_field='display_name',
             full=True,
             additional_query_params={
@@ -3057,7 +2931,6 @@ class InterfaceCreateForm(BootstrapMixin, InterfaceCommonForm, forms.Form):
         queryset=VLAN.objects.all(),
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/ipam/vlans/",
             display_field='display_name',
             full=True,
             additional_query_params={
@@ -3204,7 +3077,6 @@ class InterfaceBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
         queryset=VLAN.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/ipam/vlans/",
             display_field='display_name',
             full=True,
             additional_query_params={
@@ -3216,7 +3088,6 @@ class InterfaceBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
         queryset=VLAN.objects.all(),
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/ipam/vlans/",
             display_field='display_name',
             full=True,
             additional_query_params={
@@ -3318,10 +3189,7 @@ class FrontPortForm(BootstrapMixin, forms.ModelForm):
 # TODO: Merge with FrontPortTemplateCreateForm to remove duplicate logic
 class FrontPortCreateForm(BootstrapMixin, forms.Form):
     device = DynamicModelChoiceField(
-        queryset=Device.objects.prefetch_related('device_type__manufacturer'),
-        widget=APISelect(
-            api_url="/api/dcim/devices/",
-        )
+        queryset=Device.objects.prefetch_related('device_type__manufacturer')
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -3501,10 +3369,7 @@ class RearPortForm(BootstrapMixin, forms.ModelForm):
 
 class RearPortCreateForm(BootstrapMixin, forms.Form):
     device = DynamicModelChoiceField(
-        queryset=Device.objects.prefetch_related('device_type__manufacturer'),
-        widget=APISelect(
-            api_url="/api/dcim/devices/",
-        )
+        queryset=Device.objects.prefetch_related('device_type__manufacturer')
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -3590,7 +3455,6 @@ class ConnectCableToDeviceForm(BootstrapMixin, forms.ModelForm):
         label='Site',
         required=False,
         widget=APISelect(
-            api_url='/api/dcim/sites/',
             filter_for={
                 'termination_b_rack': 'site_id',
                 'termination_b_device': 'site_id',
@@ -3602,7 +3466,6 @@ class ConnectCableToDeviceForm(BootstrapMixin, forms.ModelForm):
         label='Rack',
         required=False,
         widget=APISelect(
-            api_url='/api/dcim/racks/',
             filter_for={
                 'termination_b_device': 'rack_id',
             },
@@ -3616,7 +3479,6 @@ class ConnectCableToDeviceForm(BootstrapMixin, forms.ModelForm):
         label='Device',
         required=False,
         widget=APISelect(
-            api_url='/api/dcim/devices/',
             display_field='display_name',
             filter_for={
                 'termination_b_id': 'device_id',
@@ -3716,7 +3578,6 @@ class ConnectCableToCircuitTerminationForm(BootstrapMixin, forms.ModelForm):
         label='Provider',
         required=False,
         widget=APISelect(
-            api_url='/api/circuits/providers/',
             filter_for={
                 'termination_b_circuit': 'provider_id',
             }
@@ -3727,7 +3588,6 @@ class ConnectCableToCircuitTerminationForm(BootstrapMixin, forms.ModelForm):
         label='Site',
         required=False,
         widget=APISelect(
-            api_url='/api/dcim/sites/',
             filter_for={
                 'termination_b_circuit': 'site_id',
             }
@@ -3737,7 +3597,6 @@ class ConnectCableToCircuitTerminationForm(BootstrapMixin, forms.ModelForm):
         queryset=Circuit.objects.all(),
         label='Circuit',
         widget=APISelect(
-            api_url='/api/circuits/circuits/',
             display_field='cid',
             filter_for={
                 'termination_b_id': 'circuit_id',
@@ -3768,7 +3627,6 @@ class ConnectCableToPowerFeedForm(BootstrapMixin, forms.ModelForm):
         label='Site',
         required=False,
         widget=APISelect(
-            api_url='/api/dcim/sites/',
             display_field='cid',
             filter_for={
                 'termination_b_rackgroup': 'site_id',
@@ -3781,7 +3639,6 @@ class ConnectCableToPowerFeedForm(BootstrapMixin, forms.ModelForm):
         label='Rack Group',
         required=False,
         widget=APISelect(
-            api_url='/api/dcim/rack-groups/',
             display_field='cid',
             filter_for={
                 'termination_b_powerpanel': 'rackgroup_id',
@@ -3793,7 +3650,6 @@ class ConnectCableToPowerFeedForm(BootstrapMixin, forms.ModelForm):
         label='Power Panel',
         required=False,
         widget=APISelect(
-            api_url='/api/dcim/power-panels/',
             filter_for={
                 'termination_b_id': 'power_panel_id',
             }
@@ -4018,7 +3874,6 @@ class CableFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
             filter_for={
                 'rack_id': 'site',
@@ -4031,7 +3886,6 @@ class CableFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/tenancy/tenants/",
             value_field='slug',
             filter_for={
                 'device_id': 'tenant',
@@ -4043,7 +3897,6 @@ class CableFilterForm(BootstrapMixin, forms.Form):
         required=False,
         label='Rack',
         widget=APISelectMultiple(
-            api_url="/api/dcim/racks/",
             null_option=True,
             filter_for={
                 'device_id': 'rack_id',
@@ -4068,10 +3921,7 @@ class CableFilterForm(BootstrapMixin, forms.Form):
     device_id = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
         required=False,
-        label='Device',
-        widget=APISelectMultiple(
-            api_url='/api/dcim/devices/',
-        )
+        label='Device'
     )
 
 
@@ -4101,10 +3951,7 @@ class DeviceBayForm(BootstrapMixin, forms.ModelForm):
 
 class DeviceBayCreateForm(BootstrapMixin, forms.Form):
     device = DynamicModelChoiceField(
-        queryset=Device.objects.prefetch_related('device_type__manufacturer'),
-        widget=APISelect(
-            api_url="/api/dcim/devices/",
-        )
+        queryset=Device.objects.prefetch_related('device_type__manufacturer')
     )
     name_pattern = ExpandableNameField(
         label='Name'
@@ -4202,7 +4049,6 @@ class ConsoleConnectionFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
             filter_for={
                 'device_id': 'site',
@@ -4212,10 +4058,7 @@ class ConsoleConnectionFilterForm(BootstrapMixin, forms.Form):
     device_id = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
         required=False,
-        label='Device',
-        widget=APISelectMultiple(
-            api_url='/api/dcim/devices/',
-        )
+        label='Device'
     )
 
 
@@ -4225,7 +4068,6 @@ class PowerConnectionFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
             filter_for={
                 'device_id': 'site',
@@ -4235,10 +4077,7 @@ class PowerConnectionFilterForm(BootstrapMixin, forms.Form):
     device_id = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
         required=False,
-        label='Device',
-        widget=APISelectMultiple(
-            api_url='/api/dcim/devices/',
-        )
+        label='Device'
     )
 
 
@@ -4248,7 +4087,6 @@ class InterfaceConnectionFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
             filter_for={
                 'device_id': 'site',
@@ -4258,10 +4096,7 @@ class InterfaceConnectionFilterForm(BootstrapMixin, forms.Form):
     device_id = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
         required=False,
-        label='Device',
-        widget=APISelectMultiple(
-            api_url='/api/dcim/devices/',
-        )
+        label='Device'
     )
 
 
@@ -4271,17 +4106,11 @@ class InterfaceConnectionFilterForm(BootstrapMixin, forms.Form):
 
 class InventoryItemForm(BootstrapMixin, forms.ModelForm):
     device = DynamicModelChoiceField(
-        queryset=Device.objects.prefetch_related('device_type__manufacturer'),
-        widget=APISelect(
-            api_url="/api/dcim/devices/"
-        )
+        queryset=Device.objects.prefetch_related('device_type__manufacturer')
     )
     manufacturer = DynamicModelChoiceField(
         queryset=Manufacturer.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/manufacturers/"
-        )
+        required=False
     )
     tags = TagField(
         required=False
@@ -4296,20 +4125,14 @@ class InventoryItemForm(BootstrapMixin, forms.ModelForm):
 
 class InventoryItemCreateForm(BootstrapMixin, forms.Form):
     device = DynamicModelChoiceField(
-        queryset=Device.objects.prefetch_related('device_type__manufacturer'),
-        widget=APISelect(
-            api_url="/api/dcim/devices/",
-        )
+        queryset=Device.objects.prefetch_related('device_type__manufacturer')
     )
     name_pattern = ExpandableNameField(
         label='Name'
     )
     manufacturer = DynamicModelChoiceField(
         queryset=Manufacturer.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/manufacturers/"
-        )
+        required=False
     )
     part_id = forms.CharField(
         max_length=50,
@@ -4361,17 +4184,11 @@ class InventoryItemBulkEditForm(BootstrapMixin, BulkEditForm):
     )
     device = DynamicModelChoiceField(
         queryset=Device.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/devices/"
-        )
+        required=False
     )
     manufacturer = DynamicModelChoiceField(
         queryset=Manufacturer.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/manufacturers/"
-        )
+        required=False
     )
     part_id = forms.CharField(
         max_length=50,
@@ -4400,7 +4217,6 @@ class InventoryItemFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
                 'site': 'region'
@@ -4412,7 +4228,6 @@ class InventoryItemFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
             filter_for={
                 'device_id': 'site'
@@ -4422,17 +4237,13 @@ class InventoryItemFilterForm(BootstrapMixin, forms.Form):
     device_id = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
         required=False,
-        label='Device',
-        widget=APISelect(
-            api_url='/api/dcim/devices/',
-        )
+        label='Device'
     )
     manufacturer = DynamicModelMultipleChoiceField(
         queryset=Manufacturer.objects.all(),
         to_field_name='slug',
         required=False,
         widget=APISelect(
-            api_url="/api/dcim/manufacturers/",
             value_field="slug",
         )
     )
@@ -4530,7 +4341,6 @@ class VCMemberSelectForm(BootstrapMixin, forms.Form):
         queryset=Site.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/dcim/sites/",
             filter_for={
                 'rack': 'site_id',
                 'device': 'site_id',
@@ -4541,7 +4351,6 @@ class VCMemberSelectForm(BootstrapMixin, forms.Form):
         queryset=Rack.objects.all(),
         required=False,
         widget=APISelect(
-            api_url='/api/dcim/racks/',
             filter_for={
                 'device': 'rack_id'
             },
@@ -4555,7 +4364,6 @@ class VCMemberSelectForm(BootstrapMixin, forms.Form):
             virtual_chassis__isnull=True
         ),
         widget=APISelect(
-            api_url='/api/dcim/devices/',
             display_field='display_name',
             disabled_indicator='virtual_chassis'
         )
@@ -4581,7 +4389,6 @@ class VirtualChassisFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
                 'site': 'region'
@@ -4593,7 +4400,6 @@ class VirtualChassisFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
         )
     )
@@ -4602,7 +4408,6 @@ class VirtualChassisFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/tenancy/tenant-groups/",
             value_field="slug",
             null_option=True,
             filter_for={
@@ -4615,7 +4420,6 @@ class VirtualChassisFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/tenancy/tenants/",
             value_field="slug",
             null_option=True,
         )
@@ -4631,7 +4435,6 @@ class PowerPanelForm(BootstrapMixin, forms.ModelForm):
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
         widget=APISelect(
-            api_url="/api/dcim/sites/",
             filter_for={
                 'rack_group': 'site_id',
             }
@@ -4639,10 +4442,7 @@ class PowerPanelForm(BootstrapMixin, forms.ModelForm):
     )
     rack_group = DynamicModelChoiceField(
         queryset=RackGroup.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url='/api/dcim/rack-groups/',
-        )
+        required=False
     )
 
     class Meta:
@@ -4696,7 +4496,6 @@ class PowerPanelBulkEditForm(BootstrapMixin, BulkEditForm):
         queryset=Site.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/dcim/sites/",
             filter_for={
                 'rack_group': 'site_id',
             }
@@ -4704,10 +4503,7 @@ class PowerPanelBulkEditForm(BootstrapMixin, BulkEditForm):
     )
     rack_group = DynamicModelChoiceField(
         queryset=RackGroup.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/rack-groups/"
-        )
+        required=False
     )
 
     class Meta:
@@ -4727,7 +4523,6 @@ class PowerPanelFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
                 'site': 'region'
@@ -4739,7 +4534,6 @@ class PowerPanelFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
             filter_for={
                 'rack_group_id': 'site',
@@ -4751,7 +4545,6 @@ class PowerPanelFilterForm(BootstrapMixin, CustomFieldFilterForm):
         required=False,
         label='Rack group (ID)',
         widget=APISelectMultiple(
-            api_url="/api/dcim/rack-groups/",
             null_option=True,
         )
     )
@@ -4766,7 +4559,6 @@ class PowerFeedForm(BootstrapMixin, CustomFieldModelForm):
         queryset=Site.objects.all(),
         required=False,
         widget=APISelect(
-            api_url='/api/dcim/sites/',
             filter_for={
                 'power_panel': 'site_id',
                 'rack': 'site_id',
@@ -4774,17 +4566,11 @@ class PowerFeedForm(BootstrapMixin, CustomFieldModelForm):
         )
     )
     power_panel = DynamicModelChoiceField(
-        queryset=PowerPanel.objects.all(),
-        widget=APISelect(
-            api_url="/api/dcim/power-panels/"
-        )
+        queryset=PowerPanel.objects.all()
     )
     rack = DynamicModelChoiceField(
         queryset=Rack.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/racks/"
-        )
+        required=False
     )
     comments = CommentField()
     tags = TagField(
@@ -4900,7 +4686,6 @@ class PowerFeedBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEd
         queryset=PowerPanel.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/dcim/power-panels/",
             filter_for={
                 'rackgroup': 'site_id',
             }
@@ -4908,10 +4693,7 @@ class PowerFeedBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEd
     )
     rack = DynamicModelChoiceField(
         queryset=Rack.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/racks",
-        )
+        required=False
     )
     status = forms.ChoiceField(
         choices=add_blank_choice(PowerFeedStatusChoices),
@@ -4968,7 +4750,6 @@ class PowerFeedFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
                 'site': 'region'
@@ -4980,7 +4761,6 @@ class PowerFeedFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
             filter_for={
                 'power_panel_id': 'site',
@@ -4993,7 +4773,6 @@ class PowerFeedFilterForm(BootstrapMixin, CustomFieldFilterForm):
         required=False,
         label='Power panel',
         widget=APISelectMultiple(
-            api_url="/api/dcim/power-panels/",
             null_option=True,
         )
     )
@@ -5002,7 +4781,6 @@ class PowerFeedFilterForm(BootstrapMixin, CustomFieldFilterForm):
         required=False,
         label='Rack',
         widget=APISelectMultiple(
-            api_url="/api/dcim/racks/",
             null_option=True,
         )
     )

--- a/netbox/extras/forms.py
+++ b/netbox/extras/forms.py
@@ -198,60 +198,36 @@ class ConfigContextForm(BootstrapMixin, forms.ModelForm):
     )
     sites = DynamicModelMultipleChoiceField(
         queryset=Site.objects.all(),
-        required=False,
-        widget=APISelectMultiple(
-            api_url="/api/dcim/sites/"
-        )
+        required=False
     )
     roles = DynamicModelMultipleChoiceField(
         queryset=DeviceRole.objects.all(),
-        required=False,
-        widget=APISelectMultiple(
-            api_url="/api/dcim/device-roles/"
-        )
+        required=False
     )
     platforms = DynamicModelMultipleChoiceField(
         queryset=Platform.objects.all(),
-        required=False,
-        widget=APISelectMultiple(
-            api_url="/api/dcim/platforms/"
-        )
+        required=False
     )
     cluster_groups = DynamicModelMultipleChoiceField(
         queryset=ClusterGroup.objects.all(),
-        required=False,
-        widget=APISelectMultiple(
-            api_url="/api/virtualization/cluster-groups/"
-        )
+        required=False
     )
     clusters = DynamicModelMultipleChoiceField(
         queryset=Cluster.objects.all(),
-        required=False,
-        widget=APISelectMultiple(
-            api_url="/api/virtualization/clusters/"
-        )
+        required=False
     )
     tenant_groups = DynamicModelMultipleChoiceField(
         queryset=TenantGroup.objects.all(),
-        required=False,
-        widget=APISelectMultiple(
-            api_url="/api/tenancy/tenant-groups/"
-        )
+        required=False
     )
     tenants = DynamicModelMultipleChoiceField(
         queryset=Tenant.objects.all(),
-        required=False,
-        widget=APISelectMultiple(
-            api_url="/api/tenancy/tenants/"
-        )
+        required=False
     )
     tags = DynamicModelMultipleChoiceField(
         queryset=Tag.objects.all(),
         to_field_name='slug',
-        required=False,
-        widget=APISelectMultiple(
-            api_url="/api/extras/tags/"
-        )
+        required=False
     )
     data = JSONField(
         label=''
@@ -299,7 +275,6 @@ class ConfigContextFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
         )
     )
@@ -308,7 +283,6 @@ class ConfigContextFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
         )
     )
@@ -317,7 +291,6 @@ class ConfigContextFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/device-roles/",
             value_field="slug",
         )
     )
@@ -326,7 +299,6 @@ class ConfigContextFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/platforms/",
             value_field="slug",
         )
     )
@@ -335,24 +307,19 @@ class ConfigContextFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/virtualization/cluster-groups/",
             value_field="slug",
         )
     )
     cluster_id = DynamicModelMultipleChoiceField(
         queryset=Cluster.objects.all(),
         required=False,
-        label='Cluster',
-        widget=APISelectMultiple(
-            api_url="/api/virtualization/clusters/",
-        )
+        label='Cluster'
     )
     tenant_group = DynamicModelMultipleChoiceField(
         queryset=TenantGroup.objects.all(),
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/tenancy/tenant-groups/",
             value_field="slug",
         )
     )
@@ -361,7 +328,6 @@ class ConfigContextFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/tenancy/tenants/",
             value_field="slug",
         )
     )
@@ -370,7 +336,6 @@ class ConfigContextFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/extras/tags/",
             value_field="slug",
         )
     )

--- a/netbox/ipam/forms.py
+++ b/netbox/ipam/forms.py
@@ -606,12 +606,11 @@ class IPAddressForm(BootstrapMixin, TenancyForm, ReturnURLForm, CustomFieldModel
             }
         )
     )
-    nat_vrf = forms.ModelChoiceField(
+    nat_vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
         label='VRF',
         widget=APISelect(
-            api_url="/api/ipam/vrfs/",
             filter_for={
                 'nat_inside': 'vrf_id'
             }

--- a/netbox/ipam/forms.py
+++ b/netbox/ipam/forms.py
@@ -78,10 +78,7 @@ class VRFBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditForm
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/tenancy/tenants/"
-        )
+        required=False
     )
     enforce_unique = forms.NullBooleanField(
         required=False,
@@ -150,10 +147,7 @@ class RIRFilterForm(BootstrapMixin, forms.Form):
 
 class AggregateForm(BootstrapMixin, CustomFieldModelForm):
     rir = DynamicModelChoiceField(
-        queryset=RIR.objects.all(),
-        widget=APISelect(
-            api_url="/api/ipam/rirs/"
-        )
+        queryset=RIR.objects.all()
     )
     tags = TagField(
         required=False
@@ -196,10 +190,7 @@ class AggregateBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEd
     rir = DynamicModelChoiceField(
         queryset=RIR.objects.all(),
         required=False,
-        label='RIR',
-        widget=APISelect(
-            api_url="/api/ipam/rirs/"
-        )
+        label='RIR'
     )
     date_added = forms.DateField(
         required=False
@@ -236,7 +227,6 @@ class AggregateFilterForm(BootstrapMixin, CustomFieldFilterForm):
         required=False,
         label='RIR',
         widget=APISelectMultiple(
-            api_url="/api/ipam/rirs/",
             value_field="slug",
         )
     )
@@ -276,16 +266,12 @@ class PrefixForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
-        label='VRF',
-        widget=APISelect(
-            api_url="/api/ipam/vrfs/",
-        )
+        label='VRF'
     )
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/dcim/sites/",
             filter_for={
                 'vlan_group': 'site_id',
                 'vlan': 'site_id',
@@ -300,7 +286,6 @@ class PrefixForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
         required=False,
         label='VLAN group',
         widget=APISelect(
-            api_url='/api/ipam/vlan-groups/',
             filter_for={
                 'vlan': 'group_id'
             },
@@ -314,16 +299,12 @@ class PrefixForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
         required=False,
         label='VLAN',
         widget=APISelect(
-            api_url='/api/ipam/vlans/',
             display_field='display_name'
         )
     )
     role = DynamicModelChoiceField(
         queryset=Role.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/ipam/roles/"
-        )
+        required=False
     )
     tags = TagField(required=False)
 
@@ -447,18 +428,12 @@ class PrefixBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditF
     )
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/sites/"
-        )
+        required=False
     )
     vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
-        label='VRF',
-        widget=APISelect(
-            api_url="/api/ipam/vrfs/"
-        )
+        label='VRF'
     )
     prefix_length = forms.IntegerField(
         min_value=PREFIX_LENGTH_MIN,
@@ -467,10 +442,7 @@ class PrefixBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditF
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/tenancy/tenants/"
-        )
+        required=False
     )
     status = forms.ChoiceField(
         choices=add_blank_choice(PrefixStatusChoices),
@@ -479,10 +451,7 @@ class PrefixBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditF
     )
     role = DynamicModelChoiceField(
         queryset=Role.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/ipam/roles/"
-        )
+        required=False
     )
     is_pool = forms.NullBooleanField(
         required=False,
@@ -536,7 +505,6 @@ class PrefixFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm)
         required=False,
         label='VRF',
         widget=APISelectMultiple(
-            api_url="/api/ipam/vrfs/",
             null_option=True,
         )
     )
@@ -550,7 +518,6 @@ class PrefixFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm)
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
                 'site': 'region'
@@ -562,7 +529,6 @@ class PrefixFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm)
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
             null_option=True,
         )
@@ -572,7 +538,6 @@ class PrefixFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm)
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/ipam/roles/",
             value_field="slug",
             null_option=True,
         )
@@ -603,17 +568,13 @@ class IPAddressForm(BootstrapMixin, TenancyForm, ReturnURLForm, CustomFieldModel
     vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
-        label='VRF',
-        widget=APISelect(
-            api_url="/api/ipam/vrfs/"
-        )
+        label='VRF'
     )
     nat_site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
         required=False,
         label='Site',
         widget=APISelect(
-            api_url="/api/dcim/sites/",
             filter_for={
                 'nat_rack': 'site_id',
                 'nat_device': 'site_id'
@@ -625,7 +586,6 @@ class IPAddressForm(BootstrapMixin, TenancyForm, ReturnURLForm, CustomFieldModel
         required=False,
         label='Rack',
         widget=APISelect(
-            api_url='/api/dcim/racks/',
             display_field='display_name',
             filter_for={
                 'nat_device': 'rack_id'
@@ -640,7 +600,6 @@ class IPAddressForm(BootstrapMixin, TenancyForm, ReturnURLForm, CustomFieldModel
         required=False,
         label='Device',
         widget=APISelect(
-            api_url='/api/dcim/devices/',
             display_field='display_name',
             filter_for={
                 'nat_inside': 'device_id'
@@ -663,7 +622,6 @@ class IPAddressForm(BootstrapMixin, TenancyForm, ReturnURLForm, CustomFieldModel
         required=False,
         label='IP Address',
         widget=APISelect(
-            api_url='/api/ipam/ip-addresses/',
             display_field='address'
         )
     )
@@ -761,10 +719,7 @@ class IPAddressBulkAddForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
-        label='VRF',
-        widget=APISelect(
-            api_url="/api/ipam/vrfs/"
-        )
+        label='VRF'
     )
 
     class Meta:
@@ -913,10 +868,7 @@ class IPAddressBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEd
     vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
-        label='VRF',
-        widget=APISelect(
-            api_url="/api/ipam/vrfs/"
-        )
+        label='VRF'
     )
     mask_length = forms.IntegerField(
         min_value=IPADDRESS_MASK_LENGTH_MIN,
@@ -925,10 +877,7 @@ class IPAddressBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEd
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/tenancy/tenants/"
-        )
+        required=False
     )
     status = forms.ChoiceField(
         choices=add_blank_choice(IPAddressStatusChoices),
@@ -960,10 +909,7 @@ class IPAddressAssignForm(BootstrapMixin, forms.Form):
         queryset=VRF.objects.all(),
         required=False,
         label='VRF',
-        empty_label='Global',
-        widget=APISelect(
-            api_url="/api/ipam/vrfs/"
-        )
+        empty_label='Global'
     )
     q = forms.CharField(
         required=False,
@@ -1007,7 +953,6 @@ class IPAddressFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterFo
         required=False,
         label='VRF',
         widget=APISelectMultiple(
-            api_url="/api/ipam/vrfs/",
             null_option=True,
         )
     )
@@ -1038,10 +983,7 @@ class IPAddressFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterFo
 class VLANGroupForm(BootstrapMixin, forms.ModelForm):
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/sites/"
-        )
+        required=False
     )
     slug = SlugField()
 
@@ -1078,7 +1020,6 @@ class VLANGroupFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
                 'site': 'region',
@@ -1090,7 +1031,6 @@ class VLANGroupFilterForm(BootstrapMixin, forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
             null_option=True,
         )
@@ -1106,7 +1046,6 @@ class VLANForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
         queryset=Site.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/dcim/sites/",
             filter_for={
                 'group': 'site_id'
             },
@@ -1117,17 +1056,11 @@ class VLANForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     )
     group = DynamicModelChoiceField(
         queryset=VLANGroup.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url='/api/ipam/vlan-groups/',
-        )
+        required=False
     )
     role = DynamicModelChoiceField(
         queryset=Role.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/ipam/roles/"
-        )
+        required=False
     )
     tags = TagField(required=False)
 
@@ -1222,24 +1155,15 @@ class VLANBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditFor
     )
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/sites/"
-        )
+        required=False
     )
     group = DynamicModelChoiceField(
         queryset=VLANGroup.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/ipam/vlan-groups/"
-        )
+        required=False
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/tenancy/tenants/"
-        )
+        required=False
     )
     status = forms.ChoiceField(
         choices=add_blank_choice(VLANStatusChoices),
@@ -1248,10 +1172,7 @@ class VLANBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditFor
     )
     role = DynamicModelChoiceField(
         queryset=Role.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/ipam/roles/"
-        )
+        required=False
     )
     description = forms.CharField(
         max_length=100,
@@ -1276,7 +1197,6 @@ class VLANFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
                 'site': 'region',
@@ -1289,7 +1209,6 @@ class VLANFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field="slug",
             null_option=True,
         )
@@ -1299,7 +1218,6 @@ class VLANFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm):
         required=False,
         label='VLAN group',
         widget=APISelectMultiple(
-            api_url="/api/ipam/vlan-groups/",
             null_option=True,
         )
     )
@@ -1313,7 +1231,6 @@ class VLANFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/ipam/roles/",
             value_field="slug",
             null_option=True,
         )

--- a/netbox/secrets/forms.py
+++ b/netbox/secrets/forms.py
@@ -72,10 +72,7 @@ class SecretRoleCSVForm(forms.ModelForm):
 
 class SecretForm(BootstrapMixin, CustomFieldModelForm):
     device = DynamicModelChoiceField(
-        queryset=Device.objects.all(),
-        widget=APISelect(
-            api_url="/api/dcim/devices/"
-        )
+        queryset=Device.objects.all()
     )
     plaintext = forms.CharField(
         max_length=SECRET_PLAINTEXT_MAX_LENGTH,
@@ -94,10 +91,7 @@ class SecretForm(BootstrapMixin, CustomFieldModelForm):
         widget=forms.PasswordInput()
     )
     role = DynamicModelChoiceField(
-        queryset=SecretRole.objects.all(),
-        widget=APISelect(
-            api_url="/api/secrets/secret-roles/"
-        )
+        queryset=SecretRole.objects.all()
     )
     tags = TagField(
         required=False
@@ -166,10 +160,7 @@ class SecretBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditF
     )
     role = DynamicModelChoiceField(
         queryset=SecretRole.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/secrets/secret-roles/"
-        )
+        required=False
     )
     name = forms.CharField(
         max_length=100,
@@ -193,7 +184,6 @@ class SecretFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/secrets/secret-roles/",
             value_field="slug",
         )
     )

--- a/netbox/tenancy/forms.py
+++ b/netbox/tenancy/forms.py
@@ -44,10 +44,7 @@ class TenantForm(BootstrapMixin, CustomFieldModelForm):
     slug = SlugField()
     group = DynamicModelChoiceField(
         queryset=TenantGroup.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/tenancy/tenant-groups/"
-        )
+        required=False
     )
     comments = CommentField()
     tags = TagField(
@@ -89,10 +86,7 @@ class TenantBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditF
     )
     group = DynamicModelChoiceField(
         queryset=TenantGroup.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/tenancy/tenant-groups/"
-        )
+        required=False
     )
 
     class Meta:
@@ -112,7 +106,6 @@ class TenantFilterForm(BootstrapMixin, CustomFieldFilterForm):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/tenancy/tenant-groups/",
             value_field="slug",
             null_option=True,
         )
@@ -129,7 +122,6 @@ class TenancyForm(forms.Form):
         queryset=TenantGroup.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/tenancy/tenant-groups/",
             filter_for={
                 'tenant': 'group_id',
             },
@@ -140,10 +132,7 @@ class TenancyForm(forms.Form):
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url='/api/tenancy/tenants/'
-        )
+        required=False
     )
 
     def __init__(self, *args, **kwargs):
@@ -164,7 +153,6 @@ class TenancyFilterForm(forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/tenancy/tenant-groups/",
             value_field="slug",
             null_option=True,
             filter_for={
@@ -177,7 +165,6 @@ class TenancyFilterForm(forms.Form):
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/tenancy/tenants/",
             value_field="slug",
             null_option=True,
         )

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.contrib.postgres.forms.jsonb import JSONField as _JSONField, InvalidJSONInput
 from django.db.models import Count
 from django.forms import BoundField
+from django.urls import reverse
 
 from .choices import unpack_grouped_choices
 from .constants import *
@@ -269,7 +270,7 @@ class APISelect(SelectWithDisabled):
     """
     def __init__(
         self,
-        api_url,
+        api_url=None,
         display_field=None,
         value_field=None,
         disabled_indicator=None,
@@ -285,7 +286,8 @@ class APISelect(SelectWithDisabled):
         super().__init__(*args, **kwargs)
 
         self.attrs['class'] = 'netbox-select2-api'
-        self.attrs['data-url'] = '/{}{}'.format(settings.BASE_PATH, api_url.lstrip('/'))  # Inject BASE_PATH
+        if api_url:
+            self.attrs['data-url'] = '/{}{}'.format(settings.BASE_PATH, api_url.lstrip('/'))  # Inject BASE_PATH
         if full:
             self.attrs['data-full'] = full
         if display_field:
@@ -566,6 +568,10 @@ class TagFilterField(forms.MultipleChoiceField):
 
 class DynamicModelChoiceMixin:
     filter = django_filters.ModelChoiceFilter
+    widget = APISelect
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def get_bound_field(self, form, field_name):
         bound_field = BoundField(form, self, field_name)
@@ -578,6 +584,14 @@ class DynamicModelChoiceMixin:
             self.queryset = filter.filter(self.queryset, data)
         else:
             self.queryset = self.queryset.none()
+
+        # Set the data URL on the APISelect widget (if not already set)
+        widget = bound_field.field.widget
+        if not widget.attrs.get('data-url'):
+            app_label = self.queryset.model._meta.app_label
+            model_name = self.queryset.model._meta.model_name
+            data_url = reverse('{}-api:{}-list'.format(app_label, model_name))
+            widget.attrs['data-url'] = data_url
 
         return bound_field
 
@@ -595,6 +609,7 @@ class DynamicModelMultipleChoiceField(DynamicModelChoiceMixin, forms.ModelMultip
     A multiple-choice version of DynamicModelChoiceField.
     """
     filter = django_filters.ModelMultipleChoiceFilter
+    widget = APISelectMultiple
 
 
 class LaxURLField(forms.URLField):

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -253,7 +253,7 @@ class APISelect(SelectWithDisabled):
     """
     A select widget populated via an API call
 
-    :param api_url: API URL
+    :param api_url: API endpoint URL. Required if not set automatically by the parent field.
     :param display_field: (Optional) Field to display for child in selection list. Defaults to `name`.
     :param value_field: (Optional) Field to use for the option value in selection list. Defaults to `id`.
     :param disabled_indicator: (Optional) Mark option as disabled if this field equates true.

--- a/netbox/virtualization/forms.py
+++ b/netbox/virtualization/forms.py
@@ -9,7 +9,7 @@ from dcim.models import Device, DeviceRole, Interface, Platform, Rack, Region, S
 from extras.forms import (
     AddRemoveTagsForm, CustomFieldBulkEditForm, CustomFieldModelCSVForm, CustomFieldModelForm, CustomFieldFilterForm,
 )
-from ipam.models import IPAddress, VLANGroup, VLAN
+from ipam.models import IPAddress, VLAN
 from tenancy.forms import TenancyFilterForm, TenancyForm
 from tenancy.models import Tenant
 from utilities.forms import (
@@ -77,24 +77,15 @@ class ClusterGroupCSVForm(forms.ModelForm):
 
 class ClusterForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     type = DynamicModelChoiceField(
-        queryset=ClusterType.objects.all(),
-        widget=APISelect(
-            api_url="/api/virtualization/cluster-types/"
-        )
+        queryset=ClusterType.objects.all()
     )
     group = DynamicModelChoiceField(
         queryset=ClusterGroup.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/virtualization/cluster-groups/"
-        )
+        required=False
     )
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/sites/"
-        )
+        required=False
     )
     comments = CommentField()
     tags = TagField(
@@ -157,31 +148,19 @@ class ClusterBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEdit
     )
     type = DynamicModelChoiceField(
         queryset=ClusterType.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/virtualization/cluster-types/"
-        )
+        required=False
     )
     group = DynamicModelChoiceField(
         queryset=ClusterGroup.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/virtualization/cluster-groups/"
-        )
+        required=False
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/tenancy/tenants/"
-        )
+        required=False
     )
     site = DynamicModelChoiceField(
         queryset=Site.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url="/api/dcim/sites/"
-        )
+        required=False
     )
     comments = CommentField(
         widget=SmallTextarea,
@@ -205,7 +184,6 @@ class ClusterFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/virtualization/cluster-types/",
             value_field='slug',
         )
     )
@@ -214,7 +192,6 @@ class ClusterFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/regions/",
             value_field="slug",
             filter_for={
                 'site': 'region'
@@ -226,7 +203,6 @@ class ClusterFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/dcim/sites/",
             value_field='slug',
             null_option=True,
         )
@@ -236,7 +212,6 @@ class ClusterFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFilterForm
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/virtualization/cluster-groups/",
             value_field='slug',
             null_option=True,
         )
@@ -249,7 +224,6 @@ class ClusterAddDevicesForm(BootstrapMixin, forms.Form):
         queryset=Region.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/dcim/regions/",
             filter_for={
                 "site": "region_id",
             },
@@ -262,7 +236,6 @@ class ClusterAddDevicesForm(BootstrapMixin, forms.Form):
         queryset=Site.objects.all(),
         required=False,
         widget=APISelect(
-            api_url='/api/dcim/sites/',
             filter_for={
                 "rack": "site_id",
                 "devices": "site_id",
@@ -273,7 +246,6 @@ class ClusterAddDevicesForm(BootstrapMixin, forms.Form):
         queryset=Rack.objects.all(),
         required=False,
         widget=APISelect(
-            api_url='/api/dcim/racks/',
             filter_for={
                 "devices": "rack_id"
             },
@@ -285,7 +257,6 @@ class ClusterAddDevicesForm(BootstrapMixin, forms.Form):
     devices = DynamicModelMultipleChoiceField(
         queryset=Device.objects.filter(cluster__isnull=True),
         widget=APISelectMultiple(
-            api_url='/api/dcim/devices/',
             display_field='display_name',
             disabled_indicator='cluster'
         )
@@ -334,7 +305,6 @@ class VirtualMachineForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
         queryset=ClusterGroup.objects.all(),
         required=False,
         widget=APISelect(
-            api_url='/api/virtualization/cluster-groups/',
             filter_for={
                 "cluster": "group_id",
             },
@@ -344,16 +314,12 @@ class VirtualMachineForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
         )
     )
     cluster = DynamicModelChoiceField(
-        queryset=Cluster.objects.all(),
-        widget=APISelect(
-            api_url='/api/virtualization/clusters/'
-        )
+        queryset=Cluster.objects.all()
     )
     role = DynamicModelChoiceField(
         queryset=DeviceRole.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/dcim/device-roles/",
             additional_query_params={
                 "vm_role": "True"
             }
@@ -361,10 +327,7 @@ class VirtualMachineForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     )
     platform = DynamicModelChoiceField(
         queryset=Platform.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url='/api/dcim/platforms/'
-        )
+        required=False
     )
     tags = TagField(
         required=False
@@ -499,10 +462,7 @@ class VirtualMachineBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldB
     )
     cluster = DynamicModelChoiceField(
         queryset=Cluster.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url='/api/virtualization/clusters/'
-        )
+        required=False
     )
     role = DynamicModelChoiceField(
         queryset=DeviceRole.objects.filter(
@@ -510,7 +470,6 @@ class VirtualMachineBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldB
         ),
         required=False,
         widget=APISelect(
-            api_url="/api/dcim/device-roles/",
             additional_query_params={
                 "vm_role": "True"
             }
@@ -518,17 +477,11 @@ class VirtualMachineBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldB
     )
     tenant = DynamicModelChoiceField(
         queryset=Tenant.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url='/api/tenancy/tenants/'
-        )
+        required=False
     )
     platform = DynamicModelChoiceField(
         queryset=Platform.objects.all(),
-        required=False,
-        widget=APISelect(
-            api_url='/api/dcim/platforms/'
-        )
+        required=False
     )
     vcpus = forms.IntegerField(
         required=False,
@@ -568,7 +521,6 @@ class VirtualMachineFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFil
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url='/api/virtualization/cluster-groups/',
             value_field="slug",
             null_option=True,
         )
@@ -578,7 +530,6 @@ class VirtualMachineFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFil
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url='/api/virtualization/cluster-types/',
             value_field="slug",
             null_option=True,
         )
@@ -586,17 +537,13 @@ class VirtualMachineFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFil
     cluster_id = DynamicModelMultipleChoiceField(
         queryset=Cluster.objects.all(),
         required=False,
-        label='Cluster',
-        widget=APISelectMultiple(
-            api_url='/api/virtualization/clusters/',
-        )
+        label='Cluster'
     )
     region = DynamicModelMultipleChoiceField(
         queryset=Region.objects.all(),
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url='/api/dcim/regions/',
             value_field="slug",
             filter_for={
                 'site': 'region'
@@ -608,7 +555,6 @@ class VirtualMachineFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFil
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url='/api/dcim/sites/',
             value_field="slug",
             null_option=True,
         )
@@ -618,7 +564,6 @@ class VirtualMachineFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFil
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url='/api/dcim/device-roles/',
             value_field="slug",
             null_option=True,
             additional_query_params={
@@ -636,7 +581,6 @@ class VirtualMachineFilterForm(BootstrapMixin, TenancyFilterForm, CustomFieldFil
         to_field_name='slug',
         required=False,
         widget=APISelectMultiple(
-            api_url='/api/dcim/platforms/',
             value_field="slug",
             null_option=True,
         )
@@ -657,7 +601,6 @@ class InterfaceForm(BootstrapMixin, forms.ModelForm):
         queryset=VLAN.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/ipam/vlans/",
             display_field='display_name',
             full=True,
             additional_query_params={
@@ -669,7 +612,6 @@ class InterfaceForm(BootstrapMixin, forms.ModelForm):
         queryset=VLAN.objects.all(),
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/ipam/vlans/",
             display_field='display_name',
             full=True,
             additional_query_params={
@@ -766,7 +708,6 @@ class InterfaceCreateForm(BootstrapMixin, forms.Form):
         queryset=VLAN.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/ipam/vlans/",
             display_field='display_name',
             full=True,
             additional_query_params={
@@ -778,7 +719,6 @@ class InterfaceCreateForm(BootstrapMixin, forms.Form):
         queryset=VLAN.objects.all(),
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/ipam/vlans/",
             display_field='display_name',
             full=True,
             additional_query_params={
@@ -836,7 +776,6 @@ class InterfaceBulkEditForm(BootstrapMixin, BulkEditForm):
         queryset=VLAN.objects.all(),
         required=False,
         widget=APISelect(
-            api_url="/api/ipam/vlans/",
             display_field='display_name',
             full=True,
             additional_query_params={
@@ -848,7 +787,6 @@ class InterfaceBulkEditForm(BootstrapMixin, BulkEditForm):
         queryset=VLAN.objects.all(),
         required=False,
         widget=APISelectMultiple(
-            api_url="/api/ipam/vlans/",
             display_field='display_name',
             full=True,
             additional_query_params={


### PR DESCRIPTION
### Fixes: #4374

- Extend DynamicModelChoiceMixin to automatically set the `data-url` attribute on its APISelect widget
- Remove the `api_url` attribute (or the entire widget) from all dynamic choice field instances