### PR TITLE
Fix type of count_ipaddresses in interface

### DIFF
--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -530,6 +530,7 @@ class InterfaceSerializer(TaggitSerializer, ConnectedEndpointSerializer):
     )
     cable = NestedCableSerializer(read_only=True)
     tags = TagListSerializerField(required=False)
+    count_ipaddresses = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = Interface


### PR DESCRIPTION
### Fixes: #4395

This uses an explicit definition of the field type in the serialiser to fix the swagger type.
Confirmed by running locally.