### PR TITLE
Closes #4401: Simplify registration process for pluin menu items

### DIFF
--- a/docs/plugins/development.md
+++ b/docs/plugins/development.md
@@ -106,6 +106,7 @@ class AnimalSoundsConfig(PluginConfig):
 * `max_version`: Maximum version of NetBox with which the plugin is compatible
 * `middleware`: A list of middleware classes to append after NetBox's build-in middleware.
 * `caching_config`: Plugin-specific cache configuration
+* `menu_items`: The dotted path to the list of menu items provided by the plugin (default: `navigation.menu_items`)
 
 ### Install the Plugin for Development
 
@@ -271,24 +272,36 @@ With these three components in place, we can request `/api/plugins/animal-sounds
 
 ## Navigation Menu Items
 
-To make its views easily accessible to users, a plugin can inject items in NetBox's navigation menu. This is done by instantiating NetBox's `PluginNavMenuLink` class. Each instance of this class appears in the navigation menu under the header for its plugin. We'll create a link in the file `navigation.py`:
+To make its views easily accessible to users, a plugin can inject items in NetBox's navigation menu. Menu items are added by defining a list of PluginNavMenuLink instances. By default, this should be a variable named `menu_items` in the file `navigations.py`. An example is shown below.
 
 ```python
-from extras.plugins import PluginNavMenuLink
+from extras.plugins import PluginNavMenuButton, PluginNavMenuLink
+from utilities.choices import ButtonColorChoices
 
-class RandomSoundLink(PluginNavMenuLink):
-    link = 'plugins:netbox_animal_sounds:random_sound'
-    link_text = 'Random sound'
+menu_items = (
+    PluginNavMenuLink(
+        link='plugins:netbox_animal_sounds:random_sound',
+        link_text='Random sound',
+        buttons=(
+            PluginNavMenuButton('home', 'Button A', 'fa-info', ButtonColorChoices.BLUE),
+            PluginNavMenuButton('home', 'Button B', 'fa-warning', ButtonColorChoices.GREEN),
+        )
+    ),
+)
 ```
 
-Once we have our menu item defined, we need to register it in `signals.py`:
+A `PluginNavMenuLink` has the following attributes:
 
-```python
-from django.dispatch import receiver
-from extras.plugins.signals import register_nav_menu_link_classes
-from .navigation import RandomSoundLink
+* `link` - The name of the URL path to which this menu item links
+* `link_text` - The text presented to the user
+* `permission` - The name of the permission required to display this link (optional)
+* `buttons` - An iterable of PluginNavMenuButton instances to display (optional)
 
-@receiver(register_nav_menu_link_classes)
-def nav_menu_link_classes(**kwargs):
-    return [RandomSoundLink]
-```
+
+A `PluginNavMenuButton` has the following attributes:
+
+* `link` - The name of the URL path to which this menu item links
+* `title` - The tooltip text (displayed when the mouse hovers over the button)
+* `color` - Button color (one of the choices provided by `ButtonColorChoices`)
+* `icon_class` - Button icon CSS class
+* `permission` - The name of the permission required to display this button (optional)

--- a/netbox/extras/plugins/__init__.py
+++ b/netbox/extras/plugins/__init__.py
@@ -46,22 +46,18 @@ class PluginConfig(AppConfig):
     # Caching configuration
     caching_config = {}
 
+    # Default integration paths. Plugin authors can override these to customize the paths to
+    # integrated components.
+    menu_items = 'navigation.menu_items'
+
     def ready(self):
 
         # Register navigation menu items (if defined)
-        register_menu_items(self.verbose_name, self.get_menu_items())
-
-    def get_menu_items(self):
-        """
-        Default method to import navigation menu items for a plugin from the default location (menu_items in a
-        file named navigation.py). This method may be overridden by a plugin author to import menu items from
-        a different location if needed.
-        """
         try:
-            menu_items = import_string(f"{self.__module__}.navigation.menu_items")
-            return menu_items
+            menu_items = import_string(f"{self.__module__}.{self.menu_items}")
+            register_menu_items(self.verbose_name, menu_items)
         except ImportError:
-            return []
+            pass
 
 
 #

--- a/netbox/extras/plugins/__init__.py
+++ b/netbox/extras/plugins/__init__.py
@@ -170,7 +170,7 @@ class PluginNavMenuLink:
     def __init__(self, link, link_text, permission=None, buttons=None):
         self.link = link
         self.link_text = link_text
-        self.link_permission = permission
+        self.permission = permission
         if buttons is None:
             self.buttons = []
         else:

--- a/netbox/extras/plugins/context_processors.py
+++ b/netbox/extras/plugins/context_processors.py
@@ -1,12 +1,10 @@
-from . import get_nav_menu_link_classes
+from extras.registry import registry
 
 
 def nav_menu_links(request):
     """
     Retrieve and expose all plugin registered nav links
     """
-    nav_menu_links = get_nav_menu_link_classes()
-
     return {
-        'plugin_nav_menu_links': nav_menu_links
+        'plugin_nav_menu_links': registry['plugin_nav_menu_links']
     }

--- a/netbox/extras/plugins/signals.py
+++ b/netbox/extras/plugins/signals.py
@@ -32,11 +32,3 @@ This signal collects template content classes which render content for object de
 register_detail_page_content_classes = PluginSignal(
     providing_args=[]
 )
-
-
-"""
-This signal collects nav menu link classes
-"""
-register_nav_menu_link_classes = PluginSignal(
-    providing_args=[]
-)

--- a/netbox/templates/inc/plugin_nav_menu_items.html
+++ b/netbox/templates/inc/plugin_nav_menu_items.html
@@ -4,8 +4,8 @@
         {% for section_name, link_items in plugin_nav_menu_links.items %}
             <li class="dropdown-header">{{ section_name }}</li>
             {% for link_item in link_items %}
-                {% if link_item.link_permission %}
-                    <li{% if not link_item.link_permission in perms %} class="disabled"{% endif %}>
+                {% if link_item.permission %}
+                    <li{% if not link_item.permission in perms %} class="disabled"{% endif %}>
                 {% else %}
                     <li>
                 {% endif %}


### PR DESCRIPTION
### Closes: #4401

- Automatically import `menu_items` from a plugin's `navigation.py` (if it exists)
- Declare `get_menu_items()` on PluginConfig to allow a plugin author to override the default behavior
- Require instantiating PluginNavMenuLink to create menu items to enforce requires attributes

An example `navigation.py` within a plugin looks like this:

```python
from extras.plugins import PluginNavMenuButton, PluginNavMenuLink
from utilities.choices import ButtonColorChoices

menu_items = (
    PluginNavMenuLink(
        link='plugins:plugin_name:view_a',
        link_text='Link 1',
        buttons=(
            PluginNavMenuButton('view_foo', 'Button A', 'fa-info', ButtonColorChoices.BLUE),
            PluginNavMenuButton('view_bar', 'Button B', 'fa-warning', ButtonColorChoices.GREEN),
        )
    ),
    PluginNavMenuLink(
        link='plugins:plugin_name:view_b',
        link_text='Link 2'
    ),
)
```

Edit: Will also update the docs accordingly if this is agreed upon.