### PR TITLE
Add tags example to custom scripts documentation

### DIFF
--- a/docs/additional-features/custom-scripts.md
+++ b/docs/additional-features/custom-scripts.md
@@ -237,6 +237,7 @@ class NewBranchScript(Script):
             status=SiteStatusChoices.STATUS_PLANNED
         )
         site.save()
+        site.tags.add("colo", "test") # Unlike other object attributes, any time you want to add tags to an object, you must do so AFTER the object has been saved.
         self.log_success("Created new site: {}".format(site))
 
         # Create access switches


### PR DESCRIPTION
### Fixes: #4410
Adds to the sample script with an example of the proper way how to add tags to objects since it uses the django-taggit functionality.