### PR TITLE
Update comment for RELEASE_CHECK_TIMEOUT.

### DIFF
--- a/netbox/netbox/configuration.example.py
+++ b/netbox/netbox/configuration.example.py
@@ -179,7 +179,7 @@ PAGINATE_COUNT = 50
 # prefer IPv4 instead.
 PREFER_IPV4 = False
 
-# This determines how often the GitHub API is called to check the latest release of NetBox. Must be at least 1 hour.
+# This determines how often the GitHub API is called to check the latest release of NetBox in seconds. Must be at least 1 hour.
 RELEASE_CHECK_TIMEOUT = 24 * 3600
 
 # This repository is used to check whether there is a new release of NetBox available. Set to None to disable the


### PR DESCRIPTION
### Fixes: #4425
Add a comment to describe the unit of RELEASE_CHECK_TIMEOUT in the configuration example file.