### PR TITLE
Fixes #4442: Set X_FRAME_OPTIONS for Django 3.x

### DIFF
--- a/docs/configuration/optional-settings.md
+++ b/docs/configuration/optional-settings.md
@@ -472,3 +472,9 @@ SHORT_TIME_FORMAT = 'H:i:s'          # 13:23:00
 DATETIME_FORMAT = 'N j, Y g:i a'     # June 26, 2016 1:23 p.m.
 SHORT_DATETIME_FORMAT = 'Y-m-d H:i'  # 2016-06-27 13:23
 ```
+
+## X_FRAME_OPTIONS
+
+Default: SAMEORIGIN
+
+Clickjacking middleware to protect against malicious embedding of elements of this site in another, which needs to be relaxed so that embedded Rack SVGs display.  For more information please see [the Django documentation](https://docs.djangoproject.com/en/3.0/ref/settings/#std:setting-X_FRAME_OPTIONS)

--- a/netbox/netbox/configuration.example.py
+++ b/netbox/netbox/configuration.example.py
@@ -231,3 +231,7 @@ TIME_FORMAT = 'g:i a'
 SHORT_TIME_FORMAT = 'H:i:s'
 DATETIME_FORMAT = 'N j, Y g:i a'
 SHORT_DATETIME_FORMAT = 'Y-m-d H:i'
+
+# Embedded objects needed for Rack SVG
+# https://docs.djangoproject.com/en/3.0/ref/settings/#std:setting-X_FRAME_OPTIONS
+X_FRAME_OPTIONS = 'SAMEORIGIN'

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -111,6 +111,7 @@ SHORT_DATETIME_FORMAT = getattr(configuration, 'SHORT_DATETIME_FORMAT', 'Y-m-d H
 SHORT_TIME_FORMAT = getattr(configuration, 'SHORT_TIME_FORMAT', 'H:i:s')
 TIME_FORMAT = getattr(configuration, 'TIME_FORMAT', 'g:i a')
 TIME_ZONE = getattr(configuration, 'TIME_ZONE', 'UTC')
+X_FRAME_OPTIONS = getattr(configuration, 'X_FRAME_OPTIONS', 'SAMEORIGIN')
 
 # Validate update repo URL and timeout
 if RELEASE_CHECK_URL:


### PR DESCRIPTION

### Fixes: 4442

Add configuration option for X_FRAME_OPTIONS to settings.py as the defaults have changed in Django 3.x from SAMEORIGIN to DENY which prevents embedding Rack SVG objects