### PR TITLE
add rack width of 21 inches for ETSI racks

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -57,11 +57,13 @@ class RackWidthChoices(ChoiceSet):
 
     WIDTH_10IN = 10
     WIDTH_19IN = 19
+    WIDTH_21IN = 21
     WIDTH_23IN = 23
 
     CHOICES = (
         (WIDTH_10IN, '10 inches'),
         (WIDTH_19IN, '19 inches'),
+        (WIDTH_21IN, '21 inches'),
         (WIDTH_23IN, '23 inches'),
     )
 


### PR DESCRIPTION
### Fixes: 4464
This adds a new choice for rack widths named 21 inches.
ETSI styled racks have a width of 21 inches and are common in european telecommunication segment.
