### PR TITLE
Release v2.7.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 ![NetBox](docs/netbox_logo.svg "NetBox logo")
 
-**The [2020 NetBox user survey](https://docs.google.com/forms/d/1OVZuC4kQ-6kJbVf0bDB6vgkL9H96xF6phvYzby23elk/edit) is open!** Your feedback helps guide the project's long-term development.
-
 NetBox is an IP address management (IPAM) and data center infrastructure
 management (DCIM) tool. Initially conceived by the network engineering team at
 [DigitalOcean](https://www.digitalocean.com/), NetBox was developed specifically

--- a/contrib/apache.conf
+++ b/contrib/apache.conf
@@ -1,0 +1,26 @@
+<VirtualHost *:443>
+    ProxyPreserveHost On
+
+    # CHANGE THIS TO YOUR SERVER'S NAME
+    ServerName netbox.example.com
+
+    SSLEngine on
+    SSLCertificateFile /etc/ssl/certs/netbox.crt
+    SSLCertificateKeyFile /etc/ssl/private/netbox.key
+
+    Alias /static /opt/netbox/netbox/static
+
+    <Directory /opt/netbox/netbox/static>
+        Options Indexes FollowSymLinks MultiViews
+        AllowOverride None
+        Require all granted
+    </Directory>
+
+    <Location /static>
+        ProxyPass !
+    </Location>
+
+    RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
+    ProxyPass / http://127.0.0.1:8001/
+    ProxyPassReverse / http://127.0.0.1:8001/
+</VirtualHost>

--- a/contrib/nginx.conf
+++ b/contrib/nginx.conf
@@ -1,0 +1,29 @@
+server {
+    listen 443 ssl;
+
+    # CHANGE THIS TO YOUR SERVER'S NAME
+    server_name netbox.example.com;
+
+    ssl_certificate /etc/ssl/certs/netbox.crt;
+    ssl_certificate_key /etc/ssl/private/netbox.key;
+
+    client_max_body_size 25m;
+
+    location /static/ {
+        alias /opt/netbox/netbox/static/;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:8001;
+        proxy_set_header X-Forwarded-Host $http_host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}
+
+server {
+    # Redirect HTTP traffic to HTTPS
+    listen 80;
+    server_name _;
+    return 301 https://$host$request_uri;
+}

--- a/docs/additional-features/webhooks.md
+++ b/docs/additional-features/webhooks.md
@@ -71,3 +71,36 @@ If no body template is specified, the request body will be populated with a JSON
 When a change is detected, any resulting webhooks are placed into a Redis queue for processing. This allows the user's request to complete without needing to wait for the outgoing webhook(s) to be processed. The webhooks are then extracted from the queue by the `rqworker` process and HTTP requests are sent to their respective destinations. The current webhook queue and any failed webhooks can be inspected in the admin UI under Django RQ > Queues.
 
 A request is considered successful if the response has a 2XX status code; otherwise, the request is marked as having failed. Failed requests may be retried manually via the admin UI.
+
+## Troubleshooting
+
+To assist with verifying that the content of outgoing webhooks is rendered correctly, NetBox provides a simple HTTP listener that can be run locally to receive and display webhook requests. First, modify the target URL of the desired webhook to `http://localhost:9000/`. This will instruct NetBox to send the request to the local server on TCP port 9000. Then, start the webhook receiver service from the NetBox root directory:
+
+```no-highlight
+$ python netbox/manage.py webhook_receiver
+Listening on port http://localhost:9000. Stop with CONTROL-C.
+```
+
+You can test the receiver itself by sending any HTTP request to it. For example:
+
+```no-highlight
+$ curl -X POST http://localhost:9000 --data '{"foo": "bar"}'
+```
+
+The server will print output similar to the following:
+
+```no-highlight
+[1] Tue, 07 Apr 2020 17:44:02 GMT 127.0.0.1 "POST / HTTP/1.1" 200 -
+Host: localhost:9000
+User-Agent: curl/7.58.0
+Accept: */*
+Content-Length: 14
+Content-Type: application/x-www-form-urlencoded
+
+{"foo": "bar"}
+------------
+```
+
+Note that `webhook_receiver` does not actually _do_ anything with the information received: It merely prints the request headers and body for inspection.
+
+Now, when the NetBox webhook is triggered and processed, you should see its headers and content appear in the terminal where the webhook receiver is listening. If you don't, check that the `rqworker` process is running and that webhook events are being placed into the queue (visible under the NetBox admin UI).

--- a/docs/installation/4-http-daemon.md
+++ b/docs/installation/4-http-daemon.md
@@ -52,7 +52,7 @@ Finally, restart the `nginx` service to use the new configuration.
 Begin by installing Apache:
 
 ```no-highlight
-# apt-get install -y apache2 libapache2-mod-wsgi-py3
+# apt-get install -y apache2
 ```
 
 Next, copy the default configuration file to `/etc/apache2/sites-available/`. Be sure to modify the `ServerName` parameter appropriately.

--- a/docs/installation/4-http-daemon.md
+++ b/docs/installation/4-http-daemon.md
@@ -27,38 +27,10 @@ The following will serve as a minimal nginx configuration. Be sure to modify you
 # apt-get install -y nginx
 ```
 
-Once nginx is installed, save the following configuration to `/etc/nginx/sites-available/netbox`. Be sure to replace `netbox.example.com` with the domain name or IP address of your installation. (This should match the value configured for `ALLOWED_HOSTS` in `configuration.py`.)
+Once nginx is installed, copy the default nginx configuration file to `/etc/nginx/sites-available/netbox`. Be sure to replace `netbox.example.com` with the domain name or IP address of your installation. (This should match the value configured for `ALLOWED_HOSTS` in `configuration.py`.)
 
-```nginx
-server {
-    listen 443 ssl;
-
-    server_name netbox.example.com;
-
-    ssl_certificate /etc/ssl/certs/netbox.crt;
-    ssl_certificate_key /etc/ssl/private/netbox.key;
-
-    client_max_body_size 25m;
-
-    location /static/ {
-        alias /opt/netbox/netbox/static/;
-    }
-
-    location / {
-        proxy_pass http://127.0.0.1:8001;
-        proxy_set_header X-Forwarded-Host $http_host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-}
-
-server {
-    # Redirect HTTP traffic to HTTPS
-    listen 80;
-    server_name _;
-    return 301 https://$host$request_uri;
-}
-
+```no-highlight
+# cp /opt/netbox/contrib/nginx.conf /etc/nginx/sites-available/netbox
 ```
 
 Then, delete `/etc/nginx/sites-enabled/default` and create a symlink in the `sites-enabled` directory to the configuration file you just created.
@@ -69,7 +41,7 @@ Then, delete `/etc/nginx/sites-enabled/default` and create a symlink in the `sit
 # ln -s /etc/nginx/sites-available/netbox
 ```
 
-Restart the nginx service to use the new configuration.
+Finally, restart the `nginx` service to use the new configuration.
 
 ```no-highlight
 # service nginx restart
@@ -77,51 +49,25 @@ Restart the nginx service to use the new configuration.
 
 ### Option B: Apache
 
+Begin by installing Apache:
+
 ```no-highlight
 # apt-get install -y apache2 libapache2-mod-wsgi-py3
 ```
 
-Once Apache is installed, proceed with the following configuration (Be sure to modify the `ServerName` appropriately):
+Next, copy the default configuration file to `/etc/apache2/sites-available/`. Be sure to modify the `ServerName` parameter appropriately.
 
-```apache
-<VirtualHost *:443>
-    ProxyPreserveHost On
-
-    ServerName netbox.example.com
-
-    SSLEngine on
-    SSLCertificateFile /etc/ssl/certs/netbox.crt
-    SSLCertificateKeyFile /etc/ssl/private/netbox.key
-
-    Alias /static /opt/netbox/netbox/static
-
-    <Directory /opt/netbox/netbox/static>
-        Options Indexes FollowSymLinks MultiViews
-        AllowOverride None
-        Require all granted
-    </Directory>
-
-    <Location /static>
-        ProxyPass !
-    </Location>
-
-    RequestHeader set "X-Forwarded-Proto" expr=%{REQUEST_SCHEME}
-    ProxyPass / http://127.0.0.1:8001/
-    ProxyPassReverse / http://127.0.0.1:8001/
-</VirtualHost>
+```no-highlight
+# cp /opt/netbox/contrib/apache.conf /etc/apache2/sites-available/netbox.conf
 ```
 
-Save the contents of the above example in `/etc/apache2/sites-available/netbox.conf`.
-
-Finally, ensure that the required Apache modules are enabled, enable the `netbox` site and reload Apache:
+Finally, ensure that the required Apache modules are enabled, enable the `netbox` site, and reload Apache:
 
 ```no-highlight
 # a2enmod ssl proxy proxy_http headers
 # a2ensite netbox
 # service apache2 restart
 ```
-
-To enable SSL, consider this guide on [securing Apache with Let's Encrypt](https://www.digitalocean.com/community/tutorials/how-to-secure-apache-with-let-s-encrypt-on-ubuntu-16-04).
 
 !!! note
     Certain components of NetBox (such as the display of rack elevation diagrams) rely on the use of embedded objects. Ensure that your HTTP server configuration does not override the `X-Frame-Options` response header set by NetBox.

--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -1,6 +1,6 @@
 # NetBox v2.7 Release Notes
 
-## v2.7.12 (FUTURE)
+## v2.7.12 (2020-04-08)
 
 ### Enhancements
 

--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -6,6 +6,7 @@
 
 * [#3676](https://github.com/netbox-community/netbox/issues/3676) - Reference VRF by name rather than RD during IP/prefix import
 * [#4147](https://github.com/netbox-community/netbox/issues/4147) - Use absolute URLs in rack elevation SVG renderings
+* [#4448](https://github.com/netbox-community/netbox/issues/4448) - Allow connecting cables between two circuit terminations
 
 ### Bug Fixes
 

--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -7,6 +7,7 @@
 * [#3676](https://github.com/netbox-community/netbox/issues/3676) - Reference VRF by name rather than RD during IP/prefix import
 * [#4147](https://github.com/netbox-community/netbox/issues/4147) - Use absolute URLs in rack elevation SVG renderings
 * [#4448](https://github.com/netbox-community/netbox/issues/4448) - Allow connecting cables between two circuit terminations
+* [#4460](https://github.com/netbox-community/netbox/issues/4460) - Add the `webhook_receiver` management command to assist in troubleshooting outgoing webhooks
 
 ### Bug Fixes
 

--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -10,7 +10,7 @@
 
 ### Bug Fixes
 
-* [#4396](https://github.com/netbox-community/netbox/issues/4395) - Fix typing of count_ipaddresses on interface serializer
+* [#4395](https://github.com/netbox-community/netbox/issues/4395) - Fix typing of count_ipaddresses on interface serializer
 * [#4418](https://github.com/netbox-community/netbox/issues/4418) - Fail cleanly when trying to import multiple device types simultaneously
 * [#4438](https://github.com/netbox-community/netbox/issues/4438) - Fix exception when disconnecting a cable from a power feed
 * [#4439](https://github.com/netbox-community/netbox/issues/4439) - Tweak display of unset custom integer fields

--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -1,5 +1,13 @@
 # NetBox v2.7 Release Notes
 
+## v2.7.12 (FUTURE)
+
+### Enhancements
+
+* [#3676](https://github.com/netbox-community/netbox/issues/3676) - Reference VRF by name rather than RD during IP/prefix import
+
+---
+
 ## v2.7.11 (2020-03-27)
 
 ### Enhancements

--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 * [#4418](https://github.com/netbox-community/netbox/issues/4418) - Fail cleanly when trying to import multiple device types simultaneously
+* [#4438](https://github.com/netbox-community/netbox/issues/4438) - Fix exception when disconnecting a cable from a power feed
 * [#4439](https://github.com/netbox-community/netbox/issues/4439) - Tweak display of unset custom integer fields
 
 ---

--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -6,6 +6,10 @@
 
 * [#3676](https://github.com/netbox-community/netbox/issues/3676) - Reference VRF by name rather than RD during IP/prefix import
 
+### Bug Fixes
+
+* [#4418](https://github.com/netbox-community/netbox/issues/4418) - Fail cleanly when trying to import multiple device types simultaneously
+
 ---
 
 ## v2.7.11 (2020-03-27)

--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 * [#3676](https://github.com/netbox-community/netbox/issues/3676) - Reference VRF by name rather than RD during IP/prefix import
+* [#4147](https://github.com/netbox-community/netbox/issues/4147) - Use absolute URLs in rack elevation SVG renderings
 
 ### Bug Fixes
 

--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+* [#4396](https://github.com/netbox-community/netbox/issues/4395) - Fix typing of count_ipaddresses on interface serializer
 * [#4418](https://github.com/netbox-community/netbox/issues/4418) - Fail cleanly when trying to import multiple device types simultaneously
 * [#4438](https://github.com/netbox-community/netbox/issues/4438) - Fix exception when disconnecting a cable from a power feed
 * [#4439](https://github.com/netbox-community/netbox/issues/4439) - Tweak display of unset custom integer fields

--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -11,6 +11,7 @@
 * [#4418](https://github.com/netbox-community/netbox/issues/4418) - Fail cleanly when trying to import multiple device types simultaneously
 * [#4438](https://github.com/netbox-community/netbox/issues/4438) - Fix exception when disconnecting a cable from a power feed
 * [#4439](https://github.com/netbox-community/netbox/issues/4439) - Tweak display of unset custom integer fields
+* [#4449](https://github.com/netbox-community/netbox/issues/4449) - Fix reservation edit/delete button URLs on rack view
 
 ---
 

--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 * [#4418](https://github.com/netbox-community/netbox/issues/4418) - Fail cleanly when trying to import multiple device types simultaneously
+* [#4439](https://github.com/netbox-community/netbox/issues/4439) - Tweak display of unset custom integer fields
 
 ---
 

--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -530,6 +530,7 @@ class InterfaceSerializer(TaggitSerializer, ConnectedEndpointSerializer):
     )
     cable = NestedCableSerializer(read_only=True)
     tags = TagListSerializerField(required=False)
+    count_ipaddresses = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = Interface

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -225,7 +225,8 @@ class RackViewSet(CustomFieldModelViewSet):
                 unit_width=data['unit_width'],
                 unit_height=data['unit_height'],
                 legend_width=data['legend_width'],
-                include_images=data['include_images']
+                include_images=data['include_images'],
+                base_url=request.build_absolute_uri('/')
             )
             return HttpResponse(drawing.tostring(), content_type='image/svg+xml')
 

--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -92,5 +92,5 @@ COMPATIBLE_TERMINATION_TYPES = {
     'interface': ['interface', 'circuittermination', 'frontport', 'rearport'],
     'frontport': ['consoleport', 'consoleserverport', 'interface', 'frontport', 'rearport', 'circuittermination'],
     'rearport': ['consoleport', 'consoleserverport', 'interface', 'frontport', 'rearport', 'circuittermination'],
-    'circuittermination': ['interface', 'frontport', 'rearport'],
+    'circuittermination': ['interface', 'frontport', 'rearport', 'circuittermination'],
 }

--- a/netbox/dcim/elevations.py
+++ b/netbox/dcim/elevations.py
@@ -15,10 +15,15 @@ class RackElevationSVG:
 
     :param rack: A NetBox Rack instance
     :param include_images: If true, the SVG document will embed front/rear device face images, where available
+    :param base_url: Base URL for links within the SVG document. If none, links will be relative.
     """
-    def __init__(self, rack, include_images=True):
+    def __init__(self, rack, include_images=True, base_url=None):
         self.rack = rack
         self.include_images = include_images
+        if base_url is not None:
+            self.base_url = base_url.rstrip('/')
+        else:
+            self.base_url = ''
 
     def _get_device_description(self, device):
         return '{} ({}) — {} ({}U) {} {}'.format(
@@ -69,7 +74,7 @@ class RackElevationSVG:
         color = device.device_role.color
         link = drawing.add(
             drawing.a(
-                href=reverse('dcim:device', kwargs={'pk': device.pk}),
+                href='{}{}'.format(self.base_url, reverse('dcim:device', kwargs={'pk': device.pk})),
                 target='_top',
                 fill='black'
             )
@@ -81,7 +86,7 @@ class RackElevationSVG:
 
         # Embed front device type image if one exists
         if self.include_images and device.device_type.front_image:
-            url = device.device_type.front_image.url
+            url = '{}{}'.format(self.base_url, device.device_type.front_image.url)
             image = drawing.image(href=url, insert=start, size=end, class_='device-image')
             image.fit(scale='slice')
             link.add(image)

--- a/netbox/dcim/models/__init__.py
+++ b/netbox/dcim/models/__init__.py
@@ -1905,6 +1905,10 @@ class PowerFeed(ChangeLoggedModel, CableTermination, CustomFieldModel):
 
         super().save(*args, **kwargs)
 
+    @property
+    def parent(self):
+        return self.power_panel
+
     def get_type_class(self):
         return self.TYPE_CLASS_MAP.get(self.type)
 

--- a/netbox/dcim/models/__init__.py
+++ b/netbox/dcim/models/__init__.py
@@ -682,7 +682,8 @@ class Rack(ChangeLoggedModel, CustomFieldModel):
             unit_width=RACK_ELEVATION_UNIT_WIDTH_DEFAULT,
             unit_height=RACK_ELEVATION_UNIT_HEIGHT_DEFAULT,
             legend_width=RACK_ELEVATION_LEGEND_WIDTH_DEFAULT,
-            include_images=True
+            include_images=True,
+            base_url=None
     ):
         """
         Return an SVG of the rack elevation
@@ -693,8 +694,9 @@ class Rack(ChangeLoggedModel, CustomFieldModel):
             height of the elevation
         :param legend_width: Width of the unit legend, in pixels
         :param include_images: Embed front/rear device images where available
+        :param base_url: Base URL for links and images. If none, URLs will be relative.
         """
-        elevation = RackElevationSVG(self, include_images=include_images)
+        elevation = RackElevationSVG(self, include_images=include_images, base_url=base_url)
 
         return elevation.render(face, unit_width, unit_height, legend_width)
 

--- a/netbox/extras/admin.py
+++ b/netbox/extras/admin.py
@@ -1,7 +1,6 @@
 from django import forms
 from django.contrib import admin
 
-from netbox.admin import admin_site
 from utilities.forms import LaxURLField
 from .models import CustomField, CustomFieldChoice, CustomLink, Graph, ExportTemplate, ReportResult, Webhook
 from .reports import get_report
@@ -35,7 +34,7 @@ class WebhookForm(forms.ModelForm):
             order_content_types(self.fields['obj_type'])
 
 
-@admin.register(Webhook, site=admin_site)
+@admin.register(Webhook)
 class WebhookAdmin(admin.ModelAdmin):
     list_display = [
         'name', 'models', 'payload_url', 'http_content_type', 'enabled', 'type_create', 'type_update', 'type_delete',
@@ -93,7 +92,7 @@ class CustomFieldChoiceAdmin(admin.TabularInline):
     extra = 5
 
 
-@admin.register(CustomField, site=admin_site)
+@admin.register(CustomField)
 class CustomFieldAdmin(admin.ModelAdmin):
     inlines = [CustomFieldChoiceAdmin]
     list_display = [
@@ -135,7 +134,7 @@ class CustomLinkForm(forms.ModelForm):
         self.fields['content_type'].choices.insert(0, ('', '---------'))
 
 
-@admin.register(CustomLink, site=admin_site)
+@admin.register(CustomLink)
 class CustomLinkAdmin(admin.ModelAdmin):
     list_display = [
         'name', 'content_type', 'group_name', 'weight',
@@ -150,7 +149,7 @@ class CustomLinkAdmin(admin.ModelAdmin):
 # Graphs
 #
 
-@admin.register(Graph, site=admin_site)
+@admin.register(Graph)
 class GraphAdmin(admin.ModelAdmin):
     list_display = [
         'name', 'type', 'weight', 'template_language', 'source',
@@ -178,7 +177,7 @@ class ExportTemplateForm(forms.ModelForm):
         self.fields['content_type'].choices.insert(0, ('', '---------'))
 
 
-@admin.register(ExportTemplate, site=admin_site)
+@admin.register(ExportTemplate)
 class ExportTemplateAdmin(admin.ModelAdmin):
     list_display = [
         'name', 'content_type', 'description', 'mime_type', 'file_extension',
@@ -193,7 +192,7 @@ class ExportTemplateAdmin(admin.ModelAdmin):
 # Reports
 #
 
-@admin.register(ReportResult, site=admin_site)
+@admin.register(ReportResult)
 class ReportResultAdmin(admin.ModelAdmin):
     list_display = [
         'report', 'active', 'created', 'user', 'passing',

--- a/netbox/extras/management/commands/webhook_receiver.py
+++ b/netbox/extras/management/commands/webhook_receiver.py
@@ -1,0 +1,85 @@
+import sys
+from http.server import HTTPServer, BaseHTTPRequestHandler
+
+from django.core.management.base import BaseCommand
+
+
+request_counter = 1
+
+
+class WebhookHandler(BaseHTTPRequestHandler):
+    show_headers = True
+
+    def __getattr__(self, item):
+
+        # Return the same method for any type of HTTP request (GET, POST, etc.)
+        if item.startswith('do_'):
+            return self.do_ANY
+
+        raise AttributeError
+
+    def log_message(self, format_str, *args):
+        global request_counter
+
+        print("[{}] {} {} {}".format(
+            request_counter,
+            self.date_time_string(),
+            self.address_string(),
+            format_str % args
+        ))
+
+    def do_ANY(self):
+        global request_counter
+
+        # Send a 200 response regardless of the request content
+        self.send_response(200)
+        self.end_headers()
+        self.wfile.write(b'Webhook received!\n')
+
+        request_counter += 1
+
+        # Print the request headers to stdout
+        if self.show_headers:
+            for k, v in self.headers.items():
+                print('{}: {}'.format(k, v))
+            print()
+
+        # Print the request body (if any)
+        content_length = self.headers.get('Content-Length')
+        if content_length is not None:
+            body = self.rfile.read(int(content_length))
+            print(body.decode('utf-8'))
+        else:
+            print('(No body)')
+
+        print('------------')
+
+
+class Command(BaseCommand):
+    help = "Start a simple listener to display received HTTP requests"
+
+    default_port = 9000
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--port', type=int, default=self.default_port,
+            help="Optional port number (default: {})".format(self.default_port)
+        )
+        parser.add_argument(
+            "--no-headers", action='store_true', dest='no_headers',
+            help="Hide HTTP request headers"
+        )
+
+    def handle(self, *args, **options):
+        port = options['port']
+        quit_command = 'CTRL-BREAK' if sys.platform == 'win32' else 'CONTROL-C'
+
+        WebhookHandler.show_headers = not options['no_headers']
+
+        self.stdout.write('Listening on port http://localhost:{}. Stop with {}.'.format(port, quit_command))
+        httpd = HTTPServer(('localhost', port), WebhookHandler)
+
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            self.stdout.write("\nExiting...")

--- a/netbox/ipam/forms.py
+++ b/netbox/ipam/forms.py
@@ -335,9 +335,9 @@ class PrefixForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
 class PrefixCSVForm(CustomFieldModelCSVForm):
     vrf = FlexibleModelChoiceField(
         queryset=VRF.objects.all(),
-        to_field_name='rd',
+        to_field_name='name',
         required=False,
-        help_text='Route distinguisher of parent VRF (or {ID})',
+        help_text='Name of parent VRF (or {ID})',
         error_messages={
             'invalid_choice': 'VRF not found.',
         }
@@ -739,9 +739,9 @@ class IPAddressBulkAddForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
 class IPAddressCSVForm(CustomFieldModelCSVForm):
     vrf = FlexibleModelChoiceField(
         queryset=VRF.objects.all(),
-        to_field_name='rd',
+        to_field_name='name',
         required=False,
-        help_text='Route distinguisher of parent VRF (or {ID})',
+        help_text='Name of parent VRF (or {ID})',
         error_messages={
             'invalid_choice': 'VRF not found.',
         }

--- a/netbox/ipam/tests/test_views.py
+++ b/netbox/ipam/tests/test_views.py
@@ -180,10 +180,10 @@ class PrefixTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         }
 
         cls.csv_data = (
-            "prefix,status",
-            "10.4.0.0/16,Active",
-            "10.5.0.0/16,Active",
-            "10.6.0.0/16,Active",
+            "vrf,prefix,status",
+            "VRF 1,10.4.0.0/16,Active",
+            "VRF 1,10.5.0.0/16,Active",
+            "VRF 1,10.6.0.0/16,Active",
         )
 
         cls.bulk_edit_data = {
@@ -207,6 +207,7 @@ class IPAddressTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             VRF(name='VRF 1', rd='65000:1'),
             VRF(name='VRF 2', rd='65000:2'),
         )
+        VRF.objects.bulk_create(vrfs)
 
         IPAddress.objects.bulk_create([
             IPAddress(family=4, address=IPNetwork('192.0.2.1/24'), vrf=vrfs[0]),
@@ -228,10 +229,10 @@ class IPAddressTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         }
 
         cls.csv_data = (
-            "address,status",
-            "192.0.2.4/24,Active",
-            "192.0.2.5/24,Active",
-            "192.0.2.6/24,Active",
+            "vrf,address,status",
+            "VRF 1,192.0.2.4/24,Active",
+            "VRF 1,192.0.2.5/24,Active",
+            "VRF 1,192.0.2.6/24,Active",
         )
 
         cls.bulk_edit_data = {

--- a/netbox/netbox/admin.py
+++ b/netbox/netbox/admin.py
@@ -1,20 +1,13 @@
 from django.conf import settings
-from django.contrib.admin import AdminSite
-from django.contrib.auth.admin import GroupAdmin, UserAdmin
-from django.contrib.auth.models import Group, User
+from django.contrib.admin import site as admin_site
+from taggit.models import Tag
 
 
-class NetBoxAdminSite(AdminSite):
-    """
-    Custom admin site
-    """
-    site_header = 'NetBox Administration'
-    site_title = 'NetBox'
-    site_url = '/{}'.format(settings.BASE_PATH)
+# Override default AdminSite attributes so we can avoid creating and
+# registering our own class
+admin_site.site_header = 'NetBox Administration'
+admin_site.site_title = 'NetBox'
+admin_site.site_url = '/{}'.format(settings.BASE_PATH)
 
-
-admin_site = NetBoxAdminSite(name='admin')
-
-# Register external models
-admin_site.register(Group, GroupAdmin)
-admin_site.register(User, UserAdmin)
+# Unregister the unused stock Tag model provided by django-taggit
+admin_site.unregister(Tag)

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -15,7 +15,7 @@ from django.core.validators import URLValidator
 # Environment setup
 #
 
-VERSION = '2.7.12-dev'
+VERSION = '2.7.12'
 
 # Hostname
 HOSTNAME = platform.node()

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -15,7 +15,7 @@ from django.core.validators import URLValidator
 # Environment setup
 #
 
-VERSION = '2.7.11'
+VERSION = '2.7.12-dev'
 
 # Hostname
 HOSTNAME = platform.node()

--- a/netbox/secrets/admin.py
+++ b/netbox/secrets/admin.py
@@ -1,12 +1,11 @@
 from django.contrib import admin, messages
 from django.shortcuts import redirect, render
 
-from netbox.admin import admin_site
 from .forms import ActivateUserKeyForm
 from .models import UserKey
 
 
-@admin.register(UserKey, site=admin_site)
+@admin.register(UserKey)
 class UserKeyAdmin(admin.ModelAdmin):
     actions = ['activate_selected']
     list_display = ['user', 'is_filled', 'is_active', 'created']

--- a/netbox/templates/circuits/inc/circuit_termination.html
+++ b/netbox/templates/circuits/inc/circuit_termination.html
@@ -66,6 +66,7 @@
                                         <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='interface' %}?return_url={{ device.get_absolute_url }}">Interface</a></li>
                                         <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='front-port' %}?return_url={{ device.get_absolute_url }}">Front Port</a></li>
                                         <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='rear-port' %}?return_url={{ device.get_absolute_url }}">Rear Port</a></li>
+                                        <li><a href="{% url 'circuits:circuittermination_connect' termination_a_id=termination.pk termination_b_type='circuit-termination' %}?return_url={{ device.get_absolute_url }}">Circuit Termination</a></li>
                                     </ul>
                                 </span>
                             </div>

--- a/netbox/templates/dcim/rack.html
+++ b/netbox/templates/dcim/rack.html
@@ -287,12 +287,12 @@
                             </td>
                             <td class="text-right noprint">
                                 {% if perms.dcim.change_rackreservation %}
-                                    <a href="{% url 'dcim:rackreservation_edit' pk=resv.pk %}&return_url={{ rack.get_absolute_url }}" class="btn btn-warning btn-xs" title="Edit reservation">
+                                    <a href="{% url 'dcim:rackreservation_edit' pk=resv.pk %}?return_url={{ rack.get_absolute_url }}" class="btn btn-warning btn-xs" title="Edit reservation">
                                         <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
                                     </a>
                                 {% endif %}
                                 {% if perms.dcim.delete_rackreservation %}
-                                    <a href="{% url 'dcim:rackreservation_delete' pk=resv.pk %}&return_url={{ rack.get_absolute_url }}" class="btn btn-danger btn-xs" title="Delete reservation">
+                                    <a href="{% url 'dcim:rackreservation_delete' pk=resv.pk %}?return_url={{ rack.get_absolute_url }}" class="btn btn-danger btn-xs" title="Delete reservation">
                                         <i class="glyphicon glyphicon-trash" aria-hidden="true"></i>
                                     </a>
                                 {% endif %}

--- a/netbox/templates/inc/custom_fields_panel.html
+++ b/netbox/templates/inc/custom_fields_panel.html
@@ -15,7 +15,7 @@
                                 <i class="glyphicon glyphicon-remove text-danger" title="False"></i>
                             {% elif field.type == 'url' and value %}
                                 <a href="{{ value }}">{{ value|truncatechars:70 }}</a>
-                            {% elif value %}
+                            {% elif value is not None %}
                                 {{ value }}
                             {% elif field.required %}
                                 <span class="text-warning">Not defined</span>

--- a/netbox/templates/inc/custom_fields_panel.html
+++ b/netbox/templates/inc/custom_fields_panel.html
@@ -15,7 +15,7 @@
                                 <i class="glyphicon glyphicon-remove text-danger" title="False"></i>
                             {% elif field.type == 'url' and value %}
                                 <a href="{{ value }}">{{ value|truncatechars:70 }}</a>
-                            {% elif field.type == 'integer' or value %}
+                            {% elif value %}
                                 {{ value }}
                             {% elif field.required %}
                                 <span class="text-warning">Not defined</span>

--- a/netbox/users/admin.py
+++ b/netbox/users/admin.py
@@ -3,14 +3,13 @@ from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin as UserAdmin_
 from django.contrib.auth.models import User
 
-from netbox.admin import admin_site
 from .models import Token
 
 # Unregister the built-in UserAdmin so that we can use our custom admin view below
-admin_site.unregister(User)
+admin.site.unregister(User)
 
 
-@admin.register(User, site=admin_site)
+@admin.register(User)
 class UserAdmin(UserAdmin_):
     list_display = [
         'username', 'email', 'first_name', 'last_name', 'is_superuser', 'is_staff', 'is_active'
@@ -30,7 +29,7 @@ class TokenAdminForm(forms.ModelForm):
         model = Token
 
 
-@admin.register(Token, site=admin_site)
+@admin.register(Token)
 class TokenAdmin(admin.ModelAdmin):
     form = TokenAdminForm
     list_display = [


### PR DESCRIPTION
### Enhancements

* [#3676](https://github.com/netbox-community/netbox/issues/3676) - Reference VRF by name rather than RD during IP/prefix import
* [#4147](https://github.com/netbox-community/netbox/issues/4147) - Use absolute URLs in rack elevation SVG renderings
* [#4448](https://github.com/netbox-community/netbox/issues/4448) - Allow connecting cables between two circuit terminations
* [#4460](https://github.com/netbox-community/netbox/issues/4460) - Add the `webhook_receiver` management command to assist in troubleshooting outgoing webhooks

### Bug Fixes

* [#4395](https://github.com/netbox-community/netbox/issues/4395) - Fix typing of count_ipaddresses on interface serializer
* [#4418](https://github.com/netbox-community/netbox/issues/4418) - Fail cleanly when trying to import multiple device types simultaneously
* [#4438](https://github.com/netbox-community/netbox/issues/4438) - Fix exception when disconnecting a cable from a power feed
* [#4439](https://github.com/netbox-community/netbox/issues/4439) - Tweak display of unset custom integer fields
* [#4449](https://github.com/netbox-community/netbox/issues/4449) - Fix reservation edit/delete button URLs on rack view