### PR TITLE
#4470 correct Ubuntu package name

### DIFF
--- a/docs/installation/migrating-to-systemd.md
+++ b/docs/installation/migrating-to-systemd.md
@@ -7,7 +7,7 @@ This document contains instructions for migrating from a legacy NetBox deploymen
 ### Uninstall supervisord
 
 ```no-highlight
-# apt-get remove -y supervisord
+# apt-get remove -y supervisor
 ```
 
 ### Configure systemd


### PR DESCRIPTION
### Fixes: #4470
correct Ubuntu package name  in documentation section Migrating to systemd