### PR TITLE
Fixes #4474: Populating Devive Type Attr in Device Bulk Edit view

### DIFF
--- a/docs/release-notes/version-2.7.md
+++ b/docs/release-notes/version-2.7.md
@@ -16,6 +16,7 @@
 * [#4438](https://github.com/netbox-community/netbox/issues/4438) - Fix exception when disconnecting a cable from a power feed
 * [#4439](https://github.com/netbox-community/netbox/issues/4439) - Tweak display of unset custom integer fields
 * [#4449](https://github.com/netbox-community/netbox/issues/4449) - Fix reservation edit/delete button URLs on rack view
+* [#4471](https://github.com/netbox-community/netbox/issues/4471) - Fix populating Device Type Attribute in Device Bulk Edit view
 
 ---
 

--- a/netbox/project-static/js/forms.js
+++ b/netbox/project-static/js/forms.js
@@ -221,7 +221,7 @@ $(document).ready(function() {
                 var results = data.results;
 
                 results = results.reduce((results,record,idx) => {
-                    record.text = record[element.getAttribute('display-field')] || record.name;
+                    record.text = record[element.getAttribute('display-field')] || record.name || record.model;
                     record.id = record[element.getAttribute('value-field')] || record.id;
                     if(element.getAttribute('disabled-indicator') && record[element.getAttribute('disabled-indicator')]) {
                         // The disabled-indicator equated to true, so we disable this option


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: 4474
<!--
    Please include a summary of the proposed changes below.
-->
I know this is for pre-accepted issue. If accepted, we can go further. 

`form.js` in Bulk Edit view cannot not set record.text because  `element.getAttribute('value-field')` in js cannot find the attribute and Device Type does not have name attribute.

https://github.com/netbox-community/netbox/blob/c593eca9364e0fcca54b7cd4986470da795cb065/netbox/project-static/js/forms.js#L223-L225
