### PR TITLE
Fix #4361 Set correct type of connection_status in swagger schema

### DIFF
--- a/docs/release-notes/version-2.8.md
+++ b/docs/release-notes/version-2.8.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+* [#4361](https://github.com/netbox-community/netbox/issues/4361) - Fix Type of `connection_state` in swagger schema.
 * [#4489](https://github.com/netbox-community/netbox/issues/4489) - Fix display of parent/child role on device type view
 
 ---

--- a/netbox/utilities/custom_inspectors.py
+++ b/netbox/utilities/custom_inspectors.py
@@ -92,7 +92,7 @@ class CustomChoiceFieldInspector(FieldInspector):
                 value_schema = openapi.Schema(type=schema_type, enum=choice_value)
                 value_schema['x-nullable'] = True
 
-            if isinstance(choice_value[0], int):
+            if all(type(x) == int for x in [c for c in choice_value if c is not None]):
                 # Change value_schema for IPAddressFamilyChoices, RackWidthChoices
                 value_schema = openapi.Schema(type=openapi.TYPE_INTEGER, enum=choice_value)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes:#4361
<!--
    Please include a summary of the proposed changes below.
-->

This changes type of `connection_status` from `integer` to `boolean` in properties.
```
"connection_status": {
    "readOnly": true,
    "properties": {
        "value": {
            "x-nullable": true,
            "enum": [
                false,
                true
            ],
            "type": "boolean"
        },
        "label": {
            "enum": [
                "Not Connected",
                "Connected"
            ],
            "type": "string"
        }
    }
}
```
