### PR TITLE
Make sure systemd doesn't try to start NetBox before Redis is ready

### DIFF
--- a/contrib/netbox.service
+++ b/contrib/netbox.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=NetBox WSGI Service
 Documentation=https://netbox.readthedocs.io/en/stable/
-After=network-online.target
-Wants=network-online.target
+After=redis.service
+Wants=redis.service
 
 [Service]
 Type=simple


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4493
<!--
    Please include a summary of the proposed changes below.
-->
In some cases Redis will take some seconds to become ready.
If NetBox is started with systemd unit file before Redis is ready it will fail with an error.

Changing the After/Wants to redis.service will make sure NetBox start is not attempted before Redis signals it is ready. This needs in `redis.conf`:
```
supervised systemd
```

