### PR TITLE
Fixes #4139: Extend forms for bulk device component creation

### DIFF
--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -2299,6 +2299,11 @@ class DeviceBulkAddComponentForm(BootstrapMixin, forms.Form):
         label='Name'
     )
 
+    def clean_tags(self):
+        # Because we're feeding TagField data (on the bulk edit form) to another TagField (on the model form), we
+        # must first convert the list of tags to a string.
+        return ','.join(self.cleaned_data.get('tags'))
+
 
 #
 # Console ports
@@ -2355,9 +2360,7 @@ class ConsolePortBulkCreateForm(
     form_from_model(ConsolePort, ['type', 'description', 'tags']),
     DeviceBulkAddComponentForm
 ):
-    tags = TagField(
-        required=False
-    )
+    pass
 
 
 class ConsolePortBulkEditForm(
@@ -2447,9 +2450,7 @@ class ConsoleServerPortBulkCreateForm(
     form_from_model(ConsoleServerPort, ['type', 'description', 'tags']),
     DeviceBulkAddComponentForm
 ):
-    tags = TagField(
-        required=False
-    )
+    pass
 
 
 class ConsoleServerPortBulkEditForm(
@@ -2563,9 +2564,7 @@ class PowerPortBulkCreateForm(
     form_from_model(PowerPort, ['type', 'maximum_draw', 'allocated_draw', 'description', 'tags']),
     DeviceBulkAddComponentForm
 ):
-    tags = TagField(
-        required=False
-    )
+    pass
 
 
 class PowerPortBulkEditForm(
@@ -2685,9 +2684,7 @@ class PowerOutletBulkCreateForm(
     form_from_model(PowerOutlet, ['type', 'feed_leg', 'description', 'tags']),
     DeviceBulkAddComponentForm
 ):
-    tags = TagField(
-        required=False
-    )
+    pass
 
 
 class PowerOutletBulkEditForm(
@@ -2968,9 +2965,7 @@ class InterfaceBulkCreateForm(
     form_from_model(Interface, ['type', 'enabled', 'mtu', 'mgmt_only', 'description', 'tags']),
     DeviceBulkAddComponentForm
 ):
-    tags = TagField(
-        required=False
-    )
+    pass
 
 
 class InterfaceBulkEditForm(
@@ -3241,9 +3236,7 @@ class FrontPortCreateForm(BootstrapMixin, forms.Form):
 #     form_from_model(FrontPort, ['type', 'description', 'tags']),
 #     DeviceBulkAddComponentForm
 # ):
-#     tags = TagField(
-#         required=False
-#     )
+#     pass
 
 
 class FrontPortBulkEditForm(
@@ -3381,9 +3374,7 @@ class RearPortBulkCreateForm(
     form_from_model(RearPort, ['type', 'positions', 'description', 'tags']),
     DeviceBulkAddComponentForm
 ):
-    tags = TagField(
-        required=False
-    )
+    pass
 
 
 class RearPortBulkEditForm(

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -3304,6 +3304,50 @@ class FrontPortCreateForm(BootstrapMixin, forms.Form):
         }
 
 
+# class FrontPortBulkCreateForm(
+#     form_from_model(FrontPort, ['type', 'description', 'tags']),
+#     DeviceBulkAddComponentForm
+# ):
+#     tags = TagField(
+#         required=False
+#     )
+
+
+class FrontPortBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
+    pk = forms.ModelMultipleChoiceField(
+        queryset=FrontPort.objects.all(),
+        widget=forms.MultipleHiddenInput()
+    )
+    type = forms.ChoiceField(
+        choices=add_blank_choice(PortTypeChoices),
+        required=False,
+        widget=StaticSelect2()
+    )
+    description = forms.CharField(
+        max_length=100,
+        required=False
+    )
+
+    class Meta:
+        nullable_fields = [
+            'description',
+        ]
+
+
+class FrontPortBulkRenameForm(BulkRenameForm):
+    pk = forms.ModelMultipleChoiceField(
+        queryset=FrontPort.objects.all(),
+        widget=forms.MultipleHiddenInput
+    )
+
+
+class FrontPortBulkDisconnectForm(ConfirmationForm):
+    pk = forms.ModelMultipleChoiceField(
+        queryset=FrontPort.objects.all(),
+        widget=forms.MultipleHiddenInput
+    )
+
+
 class FrontPortCSVForm(forms.ModelForm):
     device = FlexibleModelChoiceField(
         queryset=Device.objects.all(),
@@ -3350,50 +3394,6 @@ class FrontPortCSVForm(forms.ModelForm):
             )
         else:
             self.fields['rear_port'].queryset = RearPort.objects.none()
-
-
-# class FrontPortBulkCreateForm(
-#     form_from_model(FrontPort, ['type', 'description', 'tags']),
-#     DeviceBulkAddComponentForm
-# ):
-#     tags = TagField(
-#         required=False
-#     )
-
-
-class FrontPortBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
-    pk = forms.ModelMultipleChoiceField(
-        queryset=FrontPort.objects.all(),
-        widget=forms.MultipleHiddenInput()
-    )
-    type = forms.ChoiceField(
-        choices=add_blank_choice(PortTypeChoices),
-        required=False,
-        widget=StaticSelect2()
-    )
-    description = forms.CharField(
-        max_length=100,
-        required=False
-    )
-
-    class Meta:
-        nullable_fields = [
-            'description',
-        ]
-
-
-class FrontPortBulkRenameForm(BulkRenameForm):
-    pk = forms.ModelMultipleChoiceField(
-        queryset=FrontPort.objects.all(),
-        widget=forms.MultipleHiddenInput
-    )
-
-
-class FrontPortBulkDisconnectForm(ConfirmationForm):
-    pk = forms.ModelMultipleChoiceField(
-        queryset=FrontPort.objects.all(),
-        widget=forms.MultipleHiddenInput
-    )
 
 
 #
@@ -3448,31 +3448,13 @@ class RearPortCreateForm(BootstrapMixin, forms.Form):
     )
 
 
-class RearPortCSVForm(forms.ModelForm):
-    device = FlexibleModelChoiceField(
-        queryset=Device.objects.all(),
-        to_field_name='name',
-        help_text='Name or ID of device',
-        error_messages={
-            'invalid_choice': 'Device not found.',
-        }
+class RearPortBulkCreateForm(
+    form_from_model(RearPort, ['type', 'positions', 'description', 'tags']),
+    DeviceBulkAddComponentForm
+):
+    tags = TagField(
+        required=False
     )
-    type = CSVChoiceField(
-        choices=PortTypeChoices,
-    )
-
-    class Meta:
-        model = RearPort
-        fields = RearPort.csv_headers
-
-
-# class RearPortBulkCreateForm(
-#     form_from_model(RearPort, ['type', 'positions', 'description', 'tags']),
-#     DeviceBulkAddComponentForm
-# ):
-#     tags = TagField(
-#         required=False
-#     )
 
 
 class RearPortBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
@@ -3508,6 +3490,24 @@ class RearPortBulkDisconnectForm(ConfirmationForm):
         queryset=RearPort.objects.all(),
         widget=forms.MultipleHiddenInput
     )
+
+
+class RearPortCSVForm(forms.ModelForm):
+    device = FlexibleModelChoiceField(
+        queryset=Device.objects.all(),
+        to_field_name='name',
+        help_text='Name or ID of device',
+        error_messages={
+            'invalid_choice': 'Device not found.',
+        }
+    )
+    type = CSVChoiceField(
+        choices=PortTypeChoices,
+    )
+
+    class Meta:
+        model = RearPort
+        fields = RearPort.csv_headers
 
 
 #

--- a/netbox/dcim/urls.py
+++ b/netbox/dcim/urls.py
@@ -278,7 +278,7 @@ urlpatterns = [
     path('rear-ports/<int:pk>/edit/', views.RearPortEditView.as_view(), name='rearport_edit'),
     path('rear-ports/<int:pk>/delete/', views.RearPortDeleteView.as_view(), name='rearport_delete'),
     path('rear-ports/<int:pk>/trace/', views.CableTraceView.as_view(), name='rearport_trace', kwargs={'model': RearPort}),
-    # path('devices/rear-ports/add/', views.DeviceBulkAddRearPortView.as_view(), name='device_bulk_add_rearport'),
+    path('devices/rear-ports/add/', views.DeviceBulkAddRearPortView.as_view(), name='device_bulk_add_rearport'),
 
     # Device bays
     path('device-bays/', views.DeviceBayListView.as_view(), name='devicebay_list'),

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1986,6 +1986,30 @@ class DeviceBulkAddInterfaceView(PermissionRequiredMixin, BulkComponentCreateVie
     default_return_url = 'dcim:device_list'
 
 
+# class DeviceBulkAddFrontPortView(PermissionRequiredMixin, BulkComponentCreateView):
+#     permission_required = 'dcim.add_frontport'
+#     parent_model = Device
+#     parent_field = 'device'
+#     form = forms.FrontPortBulkCreateForm
+#     model = FrontPort
+#     model_form = forms.FrontPortForm
+#     filterset = filters.DeviceFilterSet
+#     table = tables.DeviceTable
+#     default_return_url = 'dcim:device_list'
+
+
+class DeviceBulkAddRearPortView(PermissionRequiredMixin, BulkComponentCreateView):
+    permission_required = 'dcim.add_rearport'
+    parent_model = Device
+    parent_field = 'device'
+    form = forms.RearPortBulkCreateForm
+    model = RearPort
+    model_form = forms.RearPortForm
+    filterset = filters.DeviceFilterSet
+    table = tables.DeviceTable
+    default_return_url = 'dcim:device_list'
+
+
 class DeviceBulkAddDeviceBayView(PermissionRequiredMixin, BulkComponentCreateView):
     permission_required = 'dcim.add_devicebay'
     parent_model = Device

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1930,7 +1930,7 @@ class DeviceBulkAddConsolePortView(PermissionRequiredMixin, BulkComponentCreateV
     permission_required = 'dcim.add_consoleport'
     parent_model = Device
     parent_field = 'device'
-    form = forms.DeviceBulkAddComponentForm
+    form = forms.ConsolePortBulkCreateForm
     model = ConsolePort
     model_form = forms.ConsolePortForm
     filterset = filters.DeviceFilterSet
@@ -1942,7 +1942,7 @@ class DeviceBulkAddConsoleServerPortView(PermissionRequiredMixin, BulkComponentC
     permission_required = 'dcim.add_consoleserverport'
     parent_model = Device
     parent_field = 'device'
-    form = forms.DeviceBulkAddComponentForm
+    form = forms.ConsoleServerPortBulkCreateForm
     model = ConsoleServerPort
     model_form = forms.ConsoleServerPortForm
     filterset = filters.DeviceFilterSet
@@ -1954,7 +1954,7 @@ class DeviceBulkAddPowerPortView(PermissionRequiredMixin, BulkComponentCreateVie
     permission_required = 'dcim.add_powerport'
     parent_model = Device
     parent_field = 'device'
-    form = forms.DeviceBulkAddComponentForm
+    form = forms.PowerPortBulkCreateForm
     model = PowerPort
     model_form = forms.PowerPortForm
     filterset = filters.DeviceFilterSet
@@ -1966,7 +1966,7 @@ class DeviceBulkAddPowerOutletView(PermissionRequiredMixin, BulkComponentCreateV
     permission_required = 'dcim.add_poweroutlet'
     parent_model = Device
     parent_field = 'device'
-    form = forms.DeviceBulkAddComponentForm
+    form = forms.PowerOutletBulkCreateForm
     model = PowerOutlet
     model_form = forms.PowerOutletForm
     filterset = filters.DeviceFilterSet
@@ -1978,7 +1978,7 @@ class DeviceBulkAddInterfaceView(PermissionRequiredMixin, BulkComponentCreateVie
     permission_required = 'dcim.add_interface'
     parent_model = Device
     parent_field = 'device'
-    form = forms.DeviceBulkAddInterfaceForm
+    form = forms.InterfaceBulkCreateForm
     model = Interface
     model_form = forms.InterfaceForm
     filterset = filters.DeviceFilterSet
@@ -1990,7 +1990,7 @@ class DeviceBulkAddDeviceBayView(PermissionRequiredMixin, BulkComponentCreateVie
     permission_required = 'dcim.add_devicebay'
     parent_model = Device
     parent_field = 'device'
-    form = forms.DeviceBulkAddComponentForm
+    form = forms.DeviceBayBulkCreateForm
     model = DeviceBay
     model_form = forms.DeviceBayForm
     filterset = filters.DeviceFilterSet

--- a/netbox/templates/dcim/device_list.html
+++ b/netbox/templates/dcim/device_list.html
@@ -12,6 +12,7 @@
                 {% if perms.dcim.add_powerport %}<li><a href="{% url 'dcim:device_bulk_add_powerport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="formaction">Power Ports</a></li>{% endif %}
                 {% if perms.dcim.add_poweroutlet %}<li><a href="{% url 'dcim:device_bulk_add_poweroutlet' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="formaction">Power Outlets</a></li>{% endif %}
                 {% if perms.dcim.add_interface %}<li><a href="{% url 'dcim:device_bulk_add_interface' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="formaction">Interfaces</a></li>{% endif %}
+                {% if perms.dcim.add_rearport %}<li><a href="{% url 'dcim:device_bulk_add_rearport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="formaction">Rear Ports</a></li>{% endif %}
                 {% if perms.dcim.add_devicebay %}<li><a href="{% url 'dcim:device_bulk_add_devicebay' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="formaction">Device Bays</a></li>{% endif %}
             </ul>
         </div>

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -126,9 +126,13 @@ def add_blank_choice(choices):
 
 def form_from_model(model, fields):
     """
-    Return a Form class with the specified fields from a model.
+    Return a Form class with the specified fields derived from a model. This is useful when we need a form to be used
+    for creating objects, but want to avoid the model's validation (e.g. for bulk create/edit functions). All fields
+    are marked as not required.
     """
     form_fields = fields_for_model(model, fields=fields)
+    for field in form_fields.values():
+        field.required = False
 
     return type('FormFromModel', (forms.Form,), form_fields)
 

--- a/netbox/utilities/forms.py
+++ b/netbox/utilities/forms.py
@@ -10,6 +10,7 @@ from django.conf import settings
 from django.contrib.postgres.forms.jsonb import JSONField as _JSONField, InvalidJSONInput
 from django.db.models import Count
 from django.forms import BoundField
+from django.forms.models import fields_for_model
 from django.urls import reverse
 
 from .choices import unpack_grouped_choices
@@ -121,6 +122,15 @@ def add_blank_choice(choices):
     Add a blank choice to the beginning of a choices list.
     """
     return ((None, '---------'),) + tuple(choices)
+
+
+def form_from_model(model, fields):
+    """
+    Return a Form class with the specified fields from a model.
+    """
+    form_fields = fields_for_model(model, fields=fields)
+
+    return type('FormFromModel', (forms.Form,), form_fields)
 
 
 #

--- a/netbox/virtualization/forms.py
+++ b/netbox/virtualization/forms.py
@@ -15,7 +15,8 @@ from tenancy.models import Tenant
 from utilities.forms import (
     add_blank_choice, APISelect, APISelectMultiple, BootstrapMixin, BulkEditForm, BulkEditNullBooleanSelect,
     CommentField, ConfirmationForm, CSVChoiceField, DynamicModelChoiceField, DynamicModelMultipleChoiceField,
-    ExpandableNameField, JSONField, SlugField, SmallTextarea, StaticSelect2, StaticSelect2Multiple, TagFilterField,
+    ExpandableNameField, form_from_model, JSONField, SlugField, SmallTextarea, StaticSelect2, StaticSelect2Multiple,
+    TagFilterField,
 )
 from .choices import *
 from .models import Cluster, ClusterGroup, ClusterType, VirtualMachine
@@ -828,23 +829,15 @@ class VirtualMachineBulkAddComponentForm(BootstrapMixin, forms.Form):
     )
 
 
-class VirtualMachineBulkAddInterfaceForm(VirtualMachineBulkAddComponentForm):
+class InterfaceBulkCreateForm(
+    form_from_model(Interface, ['enabled', 'mtu', 'description', 'tags']),
+    VirtualMachineBulkAddComponentForm
+):
     type = forms.ChoiceField(
         choices=VMInterfaceTypeChoices,
         initial=VMInterfaceTypeChoices.TYPE_VIRTUAL,
         widget=forms.HiddenInput()
     )
-    enabled = forms.BooleanField(
-        required=False,
-        initial=True
-    )
-    mtu = forms.IntegerField(
-        required=False,
-        min_value=INTERFACE_MTU_MIN,
-        max_value=INTERFACE_MTU_MAX,
-        label='MTU'
-    )
-    description = forms.CharField(
-        max_length=100,
+    tags = TagField(
         required=False
     )

--- a/netbox/virtualization/forms.py
+++ b/netbox/virtualization/forms.py
@@ -828,6 +828,11 @@ class VirtualMachineBulkAddComponentForm(BootstrapMixin, forms.Form):
         label='Name'
     )
 
+    def clean_tags(self):
+        # Because we're feeding TagField data (on the bulk edit form) to another TagField (on the model form), we
+        # must first convert the list of tags to a string.
+        return ','.join(self.cleaned_data.get('tags'))
+
 
 class InterfaceBulkCreateForm(
     form_from_model(Interface, ['enabled', 'mtu', 'description', 'tags']),
@@ -837,7 +842,4 @@ class InterfaceBulkCreateForm(
         choices=VMInterfaceTypeChoices,
         initial=VMInterfaceTypeChoices.TYPE_VIRTUAL,
         widget=forms.HiddenInput()
-    )
-    tags = TagField(
-        required=False
     )

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -366,7 +366,7 @@ class VirtualMachineBulkAddInterfaceView(PermissionRequiredMixin, BulkComponentC
     permission_required = 'dcim.add_interface'
     parent_model = VirtualMachine
     parent_field = 'virtual_machine'
-    form = forms.VirtualMachineBulkAddInterfaceForm
+    form = forms.InterfaceBulkCreateForm
     model = Interface
     model_form = forms.InterfaceForm
     filterset = filters.VirtualMachineFilterSet


### PR DESCRIPTION
### Fixes: #4139

- Adds a `form_from_model()` utility function to generate forms from modelfields  without incurring validation, etc.
- Extend the component bulk creation forms to support all relevant model fields
- Simplify the component bulk edit forms using `form_from_model()`