### PR TITLE
Fix: #4549 encode webhook body in utf-8

### DIFF
--- a/docs/release-notes/version-2.8.md
+++ b/docs/release-notes/version-2.8.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 * [#4527](https://github.com/netbox-community/netbox/issues/4527) - Fix assignment of certain tags to config contexts
+* [#4549](https://github.com/netbox-community/netbox/issues/4549) - Fix encoding unicode webhook body data
 
 ---
 

--- a/netbox/extras/webhooks.py
+++ b/netbox/extras/webhooks.py
@@ -17,7 +17,7 @@ def generate_signature(request_body, secret):
     """
     hmac_prep = hmac.new(
         key=secret.encode('utf8'),
-        msg=request_body.encode('utf8'),
+        msg=request_body,
         digestmod=hashlib.sha512
     )
     return hmac_prep.hexdigest()

--- a/netbox/extras/webhooks_worker.py
+++ b/netbox/extras/webhooks_worker.py
@@ -46,7 +46,7 @@ def process_webhook(webhook, data, model_name, event, timestamp, username, reque
         'method': webhook.http_method,
         'url': webhook.payload_url,
         'headers': headers,
-        'data': body,
+        'data': body.encode('utf8'),
     }
     logger.info(
         "Sending {} request to {} ({} {})".format(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4549
<!--
    Please include a summary of the proposed changes below.
-->
This makes webhook body encoded in utf-8.
Here's an example output of `logger.debug(params)`
```
{'method': 'POST', 'url': 'http://127.0.0.1:3000/tests', 'headers': {'Content-Type': 'application/json'}, 'data': b'{"text": " [device] Name:abc\xd0\x90\xd0\x92\xd0\x93, ID:29 was updated by admin"}'}
```