### PR TITLE
Switch to systemd

### DIFF
--- a/docs/additional-features/prometheus-metrics.md
+++ b/docs/additional-features/prometheus-metrics.md
@@ -27,8 +27,8 @@ When deploying NetBox in a multiprocess mannor--such as using Gunicorn as recome
 to collect metrics from all the worker processes. This can be any arbitrary directory to which the processes have read/write access. This directory is then made available by use of the
 `prometheus_multiproc_dir` environment variable.
 
-This can be setup by first creating a shared directory and then adding this line (with the appropriate directory) to the `[program:netbox]` section of the supervisor config file.
+This can be setup by first creating a shared directory and then adding this line (with the appropriate directory) to the `[Service]` section of the systemd unit file.
 
 ```
-environment=prometheus_multiproc_dir=/tmp/prometheus_metrics
+Environment=prometheus_multiproc_dir=/tmp/prometheus_metrics
 ```


### PR DESCRIPTION
Example for setting environment in a systemd unit file instead of legacy supervisor config.

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: <ISSUE NUMBER GOES HERE>
<!--
    Please include a summary of the proposed changes below.
-->
