### PR TITLE
Fixes #4580: Add id field filters for ipaddress, prefix and vlan

### DIFF
--- a/netbox/ipam/filters.py
+++ b/netbox/ipam/filters.py
@@ -206,7 +206,7 @@ class PrefixFilterSet(BaseFilterSet, TenancyFilterSet, CustomFieldFilterSet, Cre
 
     class Meta:
         model = Prefix
-        fields = ('is_pool',)
+        fields = ('id', 'is_pool',)
 
     def search(self, queryset, name, value):
         if not value.strip():
@@ -345,7 +345,7 @@ class IPAddressFilterSet(BaseFilterSet, TenancyFilterSet, CustomFieldFilterSet, 
 
     class Meta:
         model = IPAddress
-        fields = ('dns_name',)
+        fields = ('id', 'dns_name',)
 
     def search(self, queryset, name, value):
         if not value.strip():
@@ -478,7 +478,7 @@ class VLANFilterSet(BaseFilterSet, TenancyFilterSet, CustomFieldFilterSet, Creat
 
     class Meta:
         model = VLAN
-        fields = ['vid', 'name']
+        fields = ['id', 'vid', 'name']
 
     def search(self, queryset, name, value):
         if not value.strip():


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4580 
<!--
    Please include a summary of the proposed changes below.
-->

Allow user to batch fetch ipaddress, prefix and vlan resources. Several resources in Netbox ex interface does reference multiple vlans, would be nice to be able to fetch all related resources at once. 

This seem to have been possible before with `id__in` that was remove with #4313 
