### PR TITLE
4591: make single front/rear port work when between panels

### DIFF
--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -501,9 +501,12 @@ class CablePathTestCase(TestCase):
             Device(device_type=devicetype, device_role=devicerole, name='Panel 2', site=site),
             Device(device_type=devicetype, device_role=devicerole, name='Panel 3', site=site),
             Device(device_type=devicetype, device_role=devicerole, name='Panel 4', site=site),
+            Device(device_type=devicetype, device_role=devicerole, name='Panel 5', site=site),
         )
         Device.objects.bulk_create(patch_panels)
-        for patch_panel in patch_panels:
+
+        # Create patch panels with 4 positions
+        for patch_panel in patch_panels[:4]:
             rearport = RearPort.objects.create(device=patch_panel, name='Rear Port 1', positions=4, type=PortTypeChoices.TYPE_8P8C)
             FrontPort.objects.bulk_create((
                 FrontPort(device=patch_panel, name='Front Port 1', rear_port=rearport, rear_port_position=1, type=PortTypeChoices.TYPE_8P8C),
@@ -513,9 +516,9 @@ class CablePathTestCase(TestCase):
             ))
 
         # Create a 1-on-1 patch panel
-        patch_panel = Device.objects.create(device_type=devicetype, device_role=devicerole, name='Panel 5', site=site)
-        rearport = RearPort.objects.create(device=patch_panel, name='Rear Port 1', positions=1, type=PortTypeChoices.TYPE_8P8C)
-        FrontPort.objects.create(device=patch_panel, name='Front Port 1', rear_port=rearport, rear_port_position=1, type=PortTypeChoices.TYPE_8P8C)
+        for patch_panel in patch_panels[4:]:
+            rearport = RearPort.objects.create(device=patch_panel, name='Rear Port 1', positions=1, type=PortTypeChoices.TYPE_8P8C)
+            FrontPort.objects.create(device=patch_panel, name='Front Port 1', rear_port=rearport, rear_port_position=1, type=PortTypeChoices.TYPE_8P8C)
 
     def test_direct_connection(self):
         """

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -601,6 +601,10 @@ class CablePathTestCase(TestCase):
         self.assertIsNone(endpoint_b.connection_status)
 
         # Recreate cable 1 to test creating the cables in reverse order (RP first, FP second)
+        cable1 = Cable(
+            termination_a=Interface.objects.get(device__name='Device 1', name='Interface 1'),
+            termination_b=FrontPort.objects.get(device__name='Panel 5', name='Front Port 1')
+        )
         cable1.save()
 
         # Refresh endpoints
@@ -712,6 +716,10 @@ class CablePathTestCase(TestCase):
         self.assertIsNone(endpoint_d.connection_status)
 
         # Recreate cable 3 to test reverse order (Panel 5 FP first, RP second)
+        cable3 = Cable(
+            termination_b=RearPort.objects.get(device__name='Panel 1', name='Rear Port 1'),
+            termination_a=RearPort.objects.get(device__name='Panel 5', name='Rear Port 1')
+        )
         cable3.save()
 
         # Refresh endpoints


### PR DESCRIPTION
### Fixes: #4591

This patch considers 1:1 patch panels as cable extenders and will not push/pop the front port position (which is always 1) on the `position_stack`. That way 1:1 panels don't interfere with 1:n patch panels.