### PR TITLE
fix get parameters lost on create and add another

### DIFF
--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -283,7 +283,11 @@ class ObjectEditView(GetReturnURLMixin, View):
 
                 # If the object has clone_fields, pre-populate a new instance of the form
                 if hasattr(obj, 'clone_fields'):
-                    url = '{}?{}'.format(request.path, prepare_cloned_fields(obj))
+                    params = get_cloned_fields(obj)
+                    for field, value in request.GET.items():
+                        if field not in params:
+                            params[field] = value
+                    url = '{}?{}'.format(request.path, params.urlencode())
                     return redirect(url)
 
                 return redirect(request.get_full_path())


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4629
<!--
    Please include a summary of the proposed changes below.
-->
- add get_clone_fields to get clone fields get parameters as QueryDict
- change prepare_clone_fields to use get_clone_fields and build
querystring with urlencode function instead of manual building.
- add non clone_field GET-parameters to params QueryDict on
ObjectEditView.post()
