### PR TITLE
#4634 - Correct inventory item table accessor definition on manufacturer column

### DIFF
--- a/docs/release-notes/version-2.8.md
+++ b/docs/release-notes/version-2.8.md
@@ -12,6 +12,7 @@ v2.8.4 (FUTURE)
 * [#4604](https://github.com/netbox-community/netbox/issues/4604) - Multi-position rear ports may only be connected to other rear ports
 * [#4607](https://github.com/netbox-community/netbox/issues/4607) - Missing Contextual help for API Tokens
 * [#4633](https://github.com/netbox-community/netbox/issues/4633) - Bump django-rq to v2.3.2 to fix ImportError with rq 1.4.0
+* [#4634](https://github.com/netbox-community/netbox/issues/4634) - Inventory Item List view exception caused by incorrect accessor definition 
 
 ---
 

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -1195,7 +1195,7 @@ class InventoryItemTable(BaseTable):
         args=[Accessor('device.pk')]
     )
     manufacturer = tables.Column(
-        accessor=Accessor('manufacturer.name')
+        accessor=Accessor('manufacturer')
     )
     discovered = BooleanColumn()
 


### PR DESCRIPTION
### Fixes: #4634

Corrects issue with inventory item list view table accessor being incorrectly defined on the manufacturer column