### PR TITLE
Do not fail silently when ldap_config yields an ImportError itself

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -382,8 +382,11 @@ CSRF_TRUSTED_ORIGINS = ALLOWED_HOSTS
 
 try:
     from netbox import ldap_config as LDAP_CONFIG
-except ImportError:
-    LDAP_CONFIG = None
+except ImportError as ie:
+    if ie.name == 'netbox':
+        LDAP_CONFIG = None
+    else:
+        raise ie
 
 if LDAP_CONFIG is not None:
 


### PR DESCRIPTION
### Fixes: #4662 
