### PR TITLE
4652: Add `perms` to PluginTemplateExtension context

### DIFF
--- a/netbox/extras/templatetags/plugins.py
+++ b/netbox/extras/templatetags/plugins.py
@@ -18,6 +18,7 @@ def _get_registered_content(obj, method, template_context):
         'object': obj,
         'request': template_context['request'],
         'settings': template_context['settings'],
+        'perms': template_context['perms'],
     }
 
     model_name = obj._meta.label_lower


### PR DESCRIPTION
### Fixes: #4652 

Add `perms` to PluginTemplateExtension context.
