### PR TITLE
Fixes #4525: Allow passing initial data to custom script MultiObjectVar

### DIFF
--- a/docs/release-notes/version-2.8.md
+++ b/docs/release-notes/version-2.8.md
@@ -15,6 +15,7 @@
 ### Bug Fixes
 
 * [#3304](https://github.com/netbox-community/netbox/issues/3304) - Fix caching invalidation issue related to device/virtual machine primary IP addresses
+* [#4525](https://github.com/netbox-community/netbox/issues/4525) - Allow passing initial data to custom script MultiObjectVar
 * [#4644](https://github.com/netbox-community/netbox/issues/4644) - Fix ordering of services table by parent
 * [#4646](https://github.com/netbox-community/netbox/issues/4646) - Correct UI link for reports with custom name
 * [#4647](https://github.com/netbox-community/netbox/issues/4647) - Fix caching invalidation issue related to assigning new IP addresses to interfaces

--- a/netbox/extras/forms.py
+++ b/netbox/extras/forms.py
@@ -432,11 +432,11 @@ class ScriptForm(BootstrapMixin, forms.Form):
 
     def __init__(self, vars, *args, commit_default=True, **kwargs):
 
-        super().__init__(*args, **kwargs)
-
         # Dynamically populate fields for variables
         for name, var in vars.items():
-            self.fields[name] = var.as_field()
+            self.base_fields[name] = var.as_field()
+
+        super().__init__(*args, **kwargs)
 
         # Toggle default commit behavior based on Meta option
         if not commit_default:


### PR DESCRIPTION
### Fixes: #4525

Extract all values when MultiObjectVar is initialized with a QueryDict