### PR TITLE
4708: more flexible checks on RearPort usage

### DIFF
--- a/netbox/circuits/models.py
+++ b/netbox/circuits/models.py
@@ -300,6 +300,9 @@ class CircuitTermination(CableTermination):
         blank=True
     )
 
+    # Paths do not end on cable terminations, they continue at the other end of the circuit
+    is_path_endpoint = False
+
     class Meta:
         ordering = ['circuit', 'term_side']
         unique_together = ['circuit', 'term_side']

--- a/netbox/circuits/models.py
+++ b/netbox/circuits/models.py
@@ -303,6 +303,9 @@ class CircuitTermination(CableTermination):
     # Paths do not end on cable terminations, they continue at the other end of the circuit
     is_path_endpoint = False
 
+    # But they are a possible connected endpoint
+    is_connected_endpoint = True
+
     class Meta:
         ordering = ['circuit', 'term_side']
         unique_together = ['circuit', 'term_side']

--- a/netbox/circuits/models.py
+++ b/netbox/circuits/models.py
@@ -300,9 +300,6 @@ class CircuitTermination(CableTermination):
         blank=True
     )
 
-    # Paths do not end on cable terminations, they continue at the other end of the circuit
-    is_path_endpoint = False
-
     # But they are a possible connected endpoint
     is_connected_endpoint = True
 

--- a/netbox/circuits/models.py
+++ b/netbox/circuits/models.py
@@ -300,9 +300,6 @@ class CircuitTermination(CableTermination):
         blank=True
     )
 
-    # But they are a possible connected endpoint
-    is_connected_endpoint = True
-
     class Meta:
         ordering = ['circuit', 'term_side']
         unique_together = ['circuit', 'term_side']

--- a/netbox/dcim/models/__init__.py
+++ b/netbox/dcim/models/__init__.py
@@ -2191,17 +2191,18 @@ class Cable(ChangeLoggedModel):
                 f"Incompatible termination types: {self.termination_a_type} and {self.termination_b_type}"
             )
 
-        # A RearPort with multiple positions must be connected to a RearPort with an equal number of positions
+        # A RearPort with multiple positions must be connected to a RearPort with an equal number of positions, or a
+        # FrontPort
         for term_a, term_b in [
             (self.termination_a, self.termination_b),
             (self.termination_b, self.termination_a)
         ]:
             if isinstance(term_a, RearPort) and term_a.positions > 1:
-                if not isinstance(term_b, RearPort):
+                if not isinstance(term_b, (FrontPort, RearPort)):
                     raise ValidationError(
-                        "Rear ports with multiple positions may only be connected to other rear ports"
+                        "Rear ports with multiple positions may only be connected to other pass-through ports"
                     )
-                elif term_a.positions != term_b.positions:
+                if isinstance(term_b, RearPort) and term_a.positions != term_b.positions:
                     raise ValidationError(
                         f"{term_a} has {term_a.positions} position(s) but {term_b} has {term_b.positions}. "
                         f"Both terminations must have the same number of positions."

--- a/netbox/dcim/models/__init__.py
+++ b/netbox/dcim/models/__init__.py
@@ -2191,20 +2191,20 @@ class Cable(ChangeLoggedModel):
                 f"Incompatible termination types: {self.termination_a_type} and {self.termination_b_type}"
             )
 
-        # A RearPort with multiple positions must be connected to a RearPort with an equal number of positions, or a
-        # FrontPort
+        # Check that a RearPort isn't connected to something silly
         for term_a, term_b in [
             (self.termination_a, self.termination_b),
             (self.termination_b, self.termination_a)
         ]:
             if isinstance(term_a, RearPort) and term_a.positions > 1:
-                if not isinstance(term_b, (FrontPort, RearPort)):
+                if term_b.is_path_endpoint:
                     raise ValidationError(
                         "Rear ports with multiple positions may only be connected to other pass-through ports"
                     )
-                if isinstance(term_b, RearPort) and term_a.positions != term_b.positions:
+                if isinstance(term_b, RearPort) and term_b.positions > 1 and term_a.positions != term_b.positions:
                     raise ValidationError(
-                        f"{term_a} has {term_a.positions} position(s) but {term_b} has {term_b.positions}. "
+                        f"{term_a} of {term_a.device} has {term_a.positions} position(s) but "
+                        f"{term_b} of {term_b.device} has {term_b.positions}. "
                         f"Both terminations must have the same number of positions."
                     )
 

--- a/netbox/dcim/models/__init__.py
+++ b/netbox/dcim/models/__init__.py
@@ -2191,7 +2191,8 @@ class Cable(ChangeLoggedModel):
                 f"Incompatible termination types: {self.termination_a_type} and {self.termination_b_type}"
             )
 
-        # Check that a RearPort isn't connected to something silly
+        # Check that a RearPort with multiple positions isn't connected to an endpoint
+        # or a RearPort with a different number of positions.
         for term_a, term_b in [
             (self.termination_a, self.termination_b),
             (self.termination_b, self.termination_a)

--- a/netbox/dcim/models/__init__.py
+++ b/netbox/dcim/models/__init__.py
@@ -2129,6 +2129,7 @@ class Cable(ChangeLoggedModel):
         return reverse('dcim:cable', args=[self.pk])
 
     def clean(self):
+        from circuits.models import CircuitTermination
 
         # Validate that termination A exists
         if not hasattr(self, 'termination_a_type'):
@@ -2198,7 +2199,7 @@ class Cable(ChangeLoggedModel):
             (self.termination_b, self.termination_a)
         ]:
             if isinstance(term_a, RearPort) and term_a.positions > 1:
-                if term_b.is_path_endpoint:
+                if not isinstance(term_b, (FrontPort, RearPort, CircuitTermination)):
                     raise ValidationError(
                         "Rear ports with multiple positions may only be connected to other pass-through ports"
                     )

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -86,9 +86,6 @@ class CableTermination(models.Model):
         object_id_field='termination_b_id'
     )
 
-    # Whether this class is always an endpoint for cable traces
-    is_path_endpoint = True
-
     # Whether this class can be a connected endpoint
     is_connected_endpoint = True
 
@@ -900,9 +897,6 @@ class FrontPort(CableTermination, ComponentModel):
 
     csv_headers = ['device', 'name', 'type', 'rear_port', 'rear_port_position', 'description']
 
-    # Whether this class is always an endpoint for cable traces
-    is_path_endpoint = False
-
     # Whether this class can be a connected endpoint
     is_connected_endpoint = False
 
@@ -972,9 +966,6 @@ class RearPort(CableTermination, ComponentModel):
     tags = TaggableManager(through=TaggedItem)
 
     csv_headers = ['device', 'name', 'type', 'positions', 'description']
-
-    # Whether this class is always an endpoint for cable traces
-    is_path_endpoint = False
 
     # Whether this class can be a connected endpoint
     is_connected_endpoint = False

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -86,9 +86,6 @@ class CableTermination(models.Model):
         object_id_field='termination_b_id'
     )
 
-    # Whether this class can be a connected endpoint
-    is_connected_endpoint = True
-
     class Meta:
         abstract = True
 
@@ -897,9 +894,6 @@ class FrontPort(CableTermination, ComponentModel):
 
     csv_headers = ['device', 'name', 'type', 'rear_port', 'rear_port_position', 'description']
 
-    # Whether this class can be a connected endpoint
-    is_connected_endpoint = False
-
     class Meta:
         ordering = ('device', '_name')
         unique_together = (
@@ -966,9 +960,6 @@ class RearPort(CableTermination, ComponentModel):
     tags = TaggableManager(through=TaggedItem)
 
     csv_headers = ['device', 'name', 'type', 'positions', 'description']
-
-    # Whether this class can be a connected endpoint
-    is_connected_endpoint = False
 
     class Meta:
         ordering = ('device', '_name')

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -120,7 +120,9 @@ class CableTermination(models.Model):
                 # Retrieve the corresponding RearPort from database to ensure we have an up-to-date instance
                 peer_port = RearPort.objects.get(pk=termination.rear_port.pk)
 
-                # Don't use the stack for 1-on-1 ports, they don't have to come in pairs
+                # Don't use the stack for RearPorts with a single position. Only remember the position at
+                # many-to-one points so we can select the correct FrontPort when we reach the corresponding
+                # one-to-many point.
                 if peer_port.positions > 1:
                     position_stack.append(termination.rear_port_position)
 
@@ -141,7 +143,7 @@ class CableTermination(models.Model):
                             termination, termination.positions, position
                         ))
                 else:
-                    # Don't use the stack for 1-on-1 ports, they don't have to come in pairs
+                    # Don't use the stack for RearPorts with a single position. The only possible position is 1.
                     position = 1
 
                 try:

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -124,7 +124,7 @@ class CableTermination(models.Model):
                 # many-to-one points so we can select the correct FrontPort when we reach the corresponding
                 # one-to-many point.
                 if peer_port.positions > 1:
-                    position_stack.append(termination.rear_port_position)
+                    position_stack.append(termination)
 
                 return peer_port
 
@@ -135,7 +135,8 @@ class CableTermination(models.Model):
                     if not position_stack:
                         raise CableTraceSplit(termination)
 
-                    position = position_stack.pop()
+                    front_port = position_stack.pop()
+                    position = front_port.rear_port_position
 
                     # Validate the position
                     if position not in range(1, termination.positions + 1):

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -86,7 +86,11 @@ class CableTermination(models.Model):
         object_id_field='termination_b_id'
     )
 
+    # Whether this class is always an endpoint for cable traces
     is_path_endpoint = True
+
+    # Whether this class can be a connected endpoint
+    is_connected_endpoint = True
 
     class Meta:
         abstract = True
@@ -895,7 +899,12 @@ class FrontPort(CableTermination, ComponentModel):
     tags = TaggableManager(through=TaggedItem)
 
     csv_headers = ['device', 'name', 'type', 'rear_port', 'rear_port_position', 'description']
+
+    # Whether this class is always an endpoint for cable traces
     is_path_endpoint = False
+
+    # Whether this class can be a connected endpoint
+    is_connected_endpoint = False
 
     class Meta:
         ordering = ('device', '_name')
@@ -963,7 +972,12 @@ class RearPort(CableTermination, ComponentModel):
     tags = TaggableManager(through=TaggedItem)
 
     csv_headers = ['device', 'name', 'type', 'positions', 'description']
+
+    # Whether this class is always an endpoint for cable traces
     is_path_endpoint = False
+
+    # Whether this class can be a connected endpoint
+    is_connected_endpoint = False
 
     class Meta:
         ordering = ('device', '_name')

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -61,7 +61,7 @@ def update_connected_endpoints(instance, **kwargs):
                 break
 
         endpoint_a = path[0][0]
-        endpoint_b = path[-1][2]
+        endpoint_b = path[-1][2] if not split_ends and not position_stack else None
 
         if getattr(endpoint_a, 'is_path_endpoint', False) and getattr(endpoint_b, 'is_path_endpoint', False):
             logger.debug("Updating path endpoints: {} <---> {}".format(endpoint_a, endpoint_b))

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -4,7 +4,7 @@ from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 
 from .choices import CableStatusChoices
-from .models import Cable, Device, FrontPort, RearPort, VirtualChassis
+from .models import Cable, CableTermination, Device, FrontPort, RearPort, VirtualChassis
 
 
 @receiver(post_save, sender=VirtualChassis)
@@ -63,8 +63,9 @@ def update_connected_endpoints(instance, **kwargs):
         endpoint_a = path[0][0]
         endpoint_b = path[-1][2] if not split_ends and not position_stack else None
 
-        # Patch panel ports are not connected endpoints, everything else is
-        if not isinstance(endpoint_a, (FrontPort, RearPort)) and not isinstance(endpoint_b, (FrontPort, RearPort)):
+        # Patch panel ports are not connected endpoints, all other cable terminations are
+        if isinstance(endpoint_a, CableTermination) and not isinstance(endpoint_a, (FrontPort, RearPort)) and \
+                isinstance(endpoint_b, CableTermination) and not isinstance(endpoint_b, (FrontPort, RearPort)):
             logger.debug("Updating path endpoints: {} <---> {}".format(endpoint_a, endpoint_b))
             endpoint_a.connected_endpoint = endpoint_b
             endpoint_a.connection_status = path_status

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -4,7 +4,7 @@ from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 
 from .choices import CableStatusChoices
-from .models import Cable, Device, VirtualChassis
+from .models import Cable, Device, FrontPort, RearPort, VirtualChassis
 
 
 @receiver(post_save, sender=VirtualChassis)
@@ -63,7 +63,8 @@ def update_connected_endpoints(instance, **kwargs):
         endpoint_a = path[0][0]
         endpoint_b = path[-1][2] if not split_ends and not position_stack else None
 
-        if getattr(endpoint_a, 'is_connected_endpoint', False) and getattr(endpoint_b, 'is_connected_endpoint', False):
+        # Patch panel ports are not connected endpoints, everything else is
+        if not isinstance(endpoint_a, (FrontPort, RearPort)) and not isinstance(endpoint_b, (FrontPort, RearPort)):
             logger.debug("Updating path endpoints: {} <---> {}".format(endpoint_a, endpoint_b))
             endpoint_a.connected_endpoint = endpoint_b
             endpoint_a.connection_status = path_status

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -52,7 +52,7 @@ def update_connected_endpoints(instance, **kwargs):
     # Update any endpoints for this Cable.
     endpoints = instance.termination_a.get_path_endpoints() + instance.termination_b.get_path_endpoints()
     for endpoint in endpoints:
-        path, split_ends = endpoint.trace()
+        path, split_ends, position_stack = endpoint.trace()
         # Determine overall path status (connected or planned)
         path_status = True
         for segment in path:

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -63,7 +63,7 @@ def update_connected_endpoints(instance, **kwargs):
         endpoint_a = path[0][0]
         endpoint_b = path[-1][2] if not split_ends and not position_stack else None
 
-        if getattr(endpoint_a, 'is_path_endpoint', False) and getattr(endpoint_b, 'is_path_endpoint', False):
+        if getattr(endpoint_a, 'is_connected_endpoint', False) and getattr(endpoint_b, 'is_connected_endpoint', False):
             logger.debug("Updating path endpoints: {} <---> {}".format(endpoint_a, endpoint_b))
             endpoint_a.connected_endpoint = endpoint_b
             endpoint_a.connection_status = path_status

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -501,9 +501,12 @@ class CablePathTestCase(TestCase):
             Device(device_type=devicetype, device_role=devicerole, name='Panel 2', site=site),
             Device(device_type=devicetype, device_role=devicerole, name='Panel 3', site=site),
             Device(device_type=devicetype, device_role=devicerole, name='Panel 4', site=site),
+            Device(device_type=devicetype, device_role=devicerole, name='Panel 5', site=site),
         )
         Device.objects.bulk_create(patch_panels)
-        for patch_panel in patch_panels:
+
+        # Create patch panels with 4 positions
+        for patch_panel in patch_panels[:4]:
             rearport = RearPort.objects.create(device=patch_panel, name='Rear Port 1', positions=4, type=PortTypeChoices.TYPE_8P8C)
             FrontPort.objects.bulk_create((
                 FrontPort(device=patch_panel, name='Front Port 1', rear_port=rearport, rear_port_position=1, type=PortTypeChoices.TYPE_8P8C),
@@ -513,9 +516,9 @@ class CablePathTestCase(TestCase):
             ))
 
         # Create a 1-on-1 patch panel
-        patch_panel = Device.objects.create(device_type=devicetype, device_role=devicerole, name='Panel 5', site=site)
-        rearport = RearPort.objects.create(device=patch_panel, name='Rear Port 1', positions=1, type=PortTypeChoices.TYPE_8P8C)
-        FrontPort.objects.create(device=patch_panel, name='Front Port 1', rear_port=rearport, rear_port_position=1, type=PortTypeChoices.TYPE_8P8C)
+        for patch_panel in patch_panels[4:]:
+            rearport = RearPort.objects.create(device=patch_panel, name='Rear Port 1', positions=1, type=PortTypeChoices.TYPE_8P8C)
+            FrontPort.objects.create(device=patch_panel, name='Front Port 1', rear_port=rearport, rear_port_position=1, type=PortTypeChoices.TYPE_8P8C)
 
     def test_direct_connection(self):
         """

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -370,9 +370,13 @@ class CableTestCase(TestCase):
         self.patch_pannel = Device.objects.create(
             device_type=devicetype, device_role=devicerole, name='TestPatchPannel', site=site
         )
-        self.rear_port = RearPort.objects.create(device=self.patch_pannel, name='R1', type=1000)
-        self.front_port = FrontPort.objects.create(
-            device=self.patch_pannel, name='F1', type=1000, rear_port=self.rear_port
+        self.rear_port1 = RearPort.objects.create(device=self.patch_pannel, name='RP1', type='8p8c')
+        self.front_port1 = FrontPort.objects.create(
+            device=self.patch_pannel, name='FP1', type='8p8c', rear_port=self.rear_port1, rear_port_position=1
+        )
+        self.rear_port2 = RearPort.objects.create(device=self.patch_pannel, name='RP2', type='8p8c', positions=2)
+        self.front_port2 = FrontPort.objects.create(
+            device=self.patch_pannel, name='FP2', type='8p8c', rear_port=self.rear_port2, rear_port_position=1
         )
 
     def test_cable_creation(self):
@@ -426,7 +430,7 @@ class CableTestCase(TestCase):
         """
         A cable cannot connect a front port to its corresponding rear port
         """
-        cable = Cable(termination_a=self.front_port, termination_b=self.rear_port)
+        cable = Cable(termination_a=self.front_port1, termination_b=self.rear_port1)
         with self.assertRaises(ValidationError):
             cable.clean()
 
@@ -438,6 +442,23 @@ class CableTestCase(TestCase):
         cable = Cable(termination_a=self.interface2, termination_b=self.interface1)
         with self.assertRaises(ValidationError):
             cable.clean()
+
+    def test_multipos_rearport_connections(self):
+        """
+        A RearPort with more than one position can only be connected to another RearPort with the same number of
+        positions.
+        """
+        with self.assertRaises(
+            ValidationError,
+                msg='Connecting a single-position RearPort to a multi-position RearPort should fail'
+        ):
+            Cable(termination_a=self.rear_port1, termination_b=self.rear_port2).full_clean()
+
+        with self.assertRaises(
+            ValidationError,
+                msg='Connecting a multi-position RearPort to an Interface should fail'
+        ):
+            Cable(termination_a=self.rear_port2, termination_b=self.interface1).full_clean()
 
     def test_cable_cannot_terminate_to_a_virtual_inteface(self):
         """
@@ -502,6 +523,7 @@ class CablePathTestCase(TestCase):
             Device(device_type=devicetype, device_role=devicerole, name='Panel 3', site=site),
             Device(device_type=devicetype, device_role=devicerole, name='Panel 4', site=site),
             Device(device_type=devicetype, device_role=devicerole, name='Panel 5', site=site),
+            Device(device_type=devicetype, device_role=devicerole, name='Panel 6', site=site),
         )
         Device.objects.bulk_create(patch_panels)
 
@@ -557,27 +579,26 @@ class CablePathTestCase(TestCase):
         self.assertIsNone(endpoint_a.connection_status)
         self.assertIsNone(endpoint_b.connection_status)
 
-    def test_connection_via_single_rear_port(self):
+    def test_connection_rear_port_to_interface(self):
         """
-        Test a connection which passes through a single front/rear port pair.
+        Test a connection which passes through a single front/rear port pair, where the rear port has a single position.
 
                      1               2
-        [Device 1] ----- [Panel 1] ----- [Device 2]
+        [Device 1] ----- [Panel 5] ----- [Device 2]
              Iface1     FP1     RP1     Iface1
-
-        TODO: Panel 1's rear port has multiple front ports. Should this even work?
         """
-        # Create cables (FP first, RP second)
+        # Create cables
         cable1 = Cable(
             termination_a=Interface.objects.get(device__name='Device 1', name='Interface 1'),
-            termination_b=FrontPort.objects.get(device__name='Panel 1', name='Front Port 1')
+            termination_b=FrontPort.objects.get(device__name='Panel 5', name='Front Port 1')
         )
         cable1.full_clean()
         cable1.save()
         cable2 = Cable(
-            termination_b=RearPort.objects.get(device__name='Panel 1', name='Rear Port 1'),
-            termination_a=Interface.objects.get(device__name='Device 2', name='Interface 1')
+            termination_a=RearPort.objects.get(device__name='Panel 5', name='Rear Port 1'),
+            termination_b=Interface.objects.get(device__name='Device 2', name='Interface 1')
         )
+        self.assertEqual(cable2.termination_a.positions, 1)  # Sanity check
         cable2.full_clean()
         cable2.save()
 
@@ -682,7 +703,7 @@ class CablePathTestCase(TestCase):
 
     def test_connection_via_nested_one_on_one_port(self):
         """
-        Test a connection which passes through a single front/rear port pair between two multi-port MUXes.
+        Test a connection which passes through a single front/rear port pair between two multi-position rear ports.
 
         Test two connections via patched rear ports:
             Device 1 <---> Device 2
@@ -1147,31 +1168,31 @@ class CablePathTestCase(TestCase):
     def test_connection_via_patched_circuit(self):
         """
                      1               2               3               4
-        [Device 1] ----- [Panel 1] ----- [Circuit] ----- [Panel 2] ----- [Device 2]
+        [Device 1] ----- [Panel 5] ----- [Circuit] ----- [Panel 6] ----- [Device 2]
              Iface1     FP1     RP1     A         Z     RP1     FP1     Iface1
 
         """
         # Create cables
         cable1 = Cable(
             termination_a=Interface.objects.get(device__name='Device 1', name='Interface 1'),
-            termination_b=FrontPort.objects.get(device__name='Panel 1', name='Front Port 1')
+            termination_b=FrontPort.objects.get(device__name='Panel 5', name='Front Port 1')
         )
         cable1.full_clean()
         cable1.save()
         cable2 = Cable(
-            termination_a=RearPort.objects.get(device__name='Panel 1', name='Rear Port 1'),
+            termination_a=RearPort.objects.get(device__name='Panel 5', name='Rear Port 1'),
             termination_b=CircuitTermination.objects.get(term_side='A')
         )
         cable2.full_clean()
         cable2.save()
         cable3 = Cable(
             termination_a=CircuitTermination.objects.get(term_side='Z'),
-            termination_b=RearPort.objects.get(device__name='Panel 2', name='Rear Port 1')
+            termination_b=RearPort.objects.get(device__name='Panel 6', name='Rear Port 1')
         )
         cable3.full_clean()
         cable3.save()
         cable4 = Cable(
-            termination_a=FrontPort.objects.get(device__name='Panel 2', name='Front Port 1'),
+            termination_a=FrontPort.objects.get(device__name='Panel 6', name='Front Port 1'),
             termination_b=Interface.objects.get(device__name='Device 2', name='Interface 1')
         )
         cable4.full_clean()

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -572,11 +572,13 @@ class CablePathTestCase(TestCase):
             termination_a=Interface.objects.get(device__name='Device 1', name='Interface 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 1', name='Front Port 1')
         )
+        cable1.full_clean()
         cable1.save()
         cable2 = Cable(
             termination_b=RearPort.objects.get(device__name='Panel 1', name='Rear Port 1'),
             termination_a=Interface.objects.get(device__name='Device 2', name='Interface 1')
         )
+        cable2.full_clean()
         cable2.save()
 
         # Retrieve endpoints
@@ -615,11 +617,13 @@ class CablePathTestCase(TestCase):
             termination_a=Interface.objects.get(device__name='Device 1', name='Interface 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 5', name='Front Port 1')
         )
+        cable1.full_clean()
         cable1.save()
         cable2 = Cable(
             termination_b=RearPort.objects.get(device__name='Panel 5', name='Rear Port 1'),
             termination_a=Interface.objects.get(device__name='Device 2', name='Interface 1')
         )
+        cable2.full_clean()
         cable2.save()
 
         # Retrieve endpoints
@@ -650,6 +654,7 @@ class CablePathTestCase(TestCase):
             termination_a=Interface.objects.get(device__name='Device 1', name='Interface 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 5', name='Front Port 1')
         )
+        cable1.full_clean()
         cable1.save()
 
         # Refresh endpoints
@@ -698,31 +703,37 @@ class CablePathTestCase(TestCase):
             termination_a=Interface.objects.get(device__name='Device 1', name='Interface 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 1', name='Front Port 1')
         )
+        cable1.full_clean()
         cable1.save()
         cable2 = Cable(
             termination_b=FrontPort.objects.get(device__name='Panel 2', name='Front Port 1'),
             termination_a=Interface.objects.get(device__name='Device 2', name='Interface 1')
         )
+        cable2.full_clean()
         cable2.save()
         cable3 = Cable(
             termination_b=RearPort.objects.get(device__name='Panel 1', name='Rear Port 1'),
             termination_a=RearPort.objects.get(device__name='Panel 5', name='Rear Port 1')
         )
+        cable3.full_clean()
         cable3.save()
         cable4 = Cable(
             termination_b=FrontPort.objects.get(device__name='Panel 5', name='Front Port 1'),
             termination_a=RearPort.objects.get(device__name='Panel 2', name='Rear Port 1')
         )
+        cable4.full_clean()
         cable4.save()
         cable5 = Cable(
             termination_b=FrontPort.objects.get(device__name='Panel 1', name='Front Port 2'),
             termination_a=Interface.objects.get(device__name='Device 3', name='Interface 1')
         )
+        cable5.full_clean()
         cable5.save()
         cable6 = Cable(
             termination_b=FrontPort.objects.get(device__name='Panel 2', name='Front Port 2'),
             termination_a=Interface.objects.get(device__name='Device 4', name='Interface 1')
         )
+        cable6.full_clean()
         cable6.save()
 
         # Retrieve endpoints
@@ -765,6 +776,7 @@ class CablePathTestCase(TestCase):
             termination_b=RearPort.objects.get(device__name='Panel 1', name='Rear Port 1'),
             termination_a=RearPort.objects.get(device__name='Panel 5', name='Rear Port 1')
         )
+        cable3.full_clean()
         cable3.save()
 
         # Refresh endpoints
@@ -823,28 +835,33 @@ class CablePathTestCase(TestCase):
             termination_a=Interface.objects.get(device__name='Device 1', name='Interface 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 1', name='Front Port 1')
         )
+        cable1.full_clean()
         cable1.save()
         cable2 = Cable(
             termination_a=Interface.objects.get(device__name='Device 2', name='Interface 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 2', name='Front Port 1')
         )
+        cable2.full_clean()
         cable2.save()
 
         cable3 = Cable(
             termination_a=RearPort.objects.get(device__name='Panel 1', name='Rear Port 1'),
             termination_b=RearPort.objects.get(device__name='Panel 2', name='Rear Port 1')
         )
+        cable3.full_clean()
         cable3.save()
 
         cable4 = Cable(
             termination_a=Interface.objects.get(device__name='Device 3', name='Interface 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 1', name='Front Port 2')
         )
+        cable4.full_clean()
         cable4.save()
         cable5 = Cable(
             termination_a=Interface.objects.get(device__name='Device 4', name='Interface 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 2', name='Front Port 2')
         )
+        cable5.full_clean()
         cable5.save()
 
         # Retrieve endpoints
@@ -903,43 +920,51 @@ class CablePathTestCase(TestCase):
             termination_a=Interface.objects.get(device__name='Device 1', name='Interface 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 1', name='Front Port 1')
         )
+        cable1.full_clean()
         cable1.save()
         cable2 = Cable(
             termination_a=FrontPort.objects.get(device__name='Panel 2', name='Front Port 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 3', name='Front Port 1')
         )
+        cable2.full_clean()
         cable2.save()
         cable3 = Cable(
             termination_a=FrontPort.objects.get(device__name='Panel 4', name='Front Port 1'),
             termination_b=Interface.objects.get(device__name='Device 2', name='Interface 1')
         )
+        cable3.full_clean()
         cable3.save()
 
         cable4 = Cable(
             termination_a=RearPort.objects.get(device__name='Panel 1', name='Rear Port 1'),
             termination_b=RearPort.objects.get(device__name='Panel 2', name='Rear Port 1')
         )
+        cable4.full_clean()
         cable4.save()
         cable5 = Cable(
             termination_a=RearPort.objects.get(device__name='Panel 3', name='Rear Port 1'),
             termination_b=RearPort.objects.get(device__name='Panel 4', name='Rear Port 1')
         )
+        cable5.full_clean()
         cable5.save()
 
         cable6 = Cable(
             termination_a=Interface.objects.get(device__name='Device 3', name='Interface 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 1', name='Front Port 2')
         )
+        cable6.full_clean()
         cable6.save()
         cable7 = Cable(
             termination_a=FrontPort.objects.get(device__name='Panel 2', name='Front Port 2'),
             termination_b=FrontPort.objects.get(device__name='Panel 3', name='Front Port 2')
         )
+        cable7.full_clean()
         cable7.save()
         cable8 = Cable(
             termination_a=FrontPort.objects.get(device__name='Panel 4', name='Front Port 2'),
             termination_b=Interface.objects.get(device__name='Device 4', name='Interface 1')
         )
+        cable8.full_clean()
         cable8.save()
 
         # Retrieve endpoints
@@ -999,38 +1024,45 @@ class CablePathTestCase(TestCase):
             termination_a=Interface.objects.get(device__name='Device 1', name='Interface 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 1', name='Front Port 1')
         )
+        cable1.full_clean()
         cable1.save()
         cable2 = Cable(
             termination_a=FrontPort.objects.get(device__name='Panel 4', name='Front Port 1'),
             termination_b=Interface.objects.get(device__name='Device 2', name='Interface 1')
         )
+        cable2.full_clean()
         cable2.save()
 
         cable3 = Cable(
             termination_a=RearPort.objects.get(device__name='Panel 1', name='Rear Port 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 2', name='Front Port 1')
         )
+        cable3.full_clean()
         cable3.save()
         cable4 = Cable(
             termination_a=RearPort.objects.get(device__name='Panel 2', name='Rear Port 1'),
             termination_b=RearPort.objects.get(device__name='Panel 3', name='Rear Port 1')
         )
+        cable4.full_clean()
         cable4.save()
         cable5 = Cable(
             termination_a=FrontPort.objects.get(device__name='Panel 3', name='Front Port 1'),
             termination_b=RearPort.objects.get(device__name='Panel 4', name='Rear Port 1')
         )
+        cable5.full_clean()
         cable5.save()
 
         cable6 = Cable(
             termination_a=Interface.objects.get(device__name='Device 3', name='Interface 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 1', name='Front Port 2')
         )
+        cable6.full_clean()
         cable6.save()
         cable7 = Cable(
             termination_a=FrontPort.objects.get(device__name='Panel 4', name='Front Port 2'),
             termination_b=Interface.objects.get(device__name='Device 4', name='Interface 1')
         )
+        cable7.full_clean()
         cable7.save()
 
         # Retrieve endpoints
@@ -1080,11 +1112,13 @@ class CablePathTestCase(TestCase):
             termination_a=Interface.objects.get(device__name='Device 1', name='Interface 1'),
             termination_b=CircuitTermination.objects.get(term_side='A')
         )
+        cable1.full_clean()
         cable1.save()
         cable2 = Cable(
             termination_a=CircuitTermination.objects.get(term_side='Z'),
             termination_b=Interface.objects.get(device__name='Device 2', name='Interface 1')
         )
+        cable2.full_clean()
         cable2.save()
 
         # Retrieve endpoints
@@ -1122,21 +1156,25 @@ class CablePathTestCase(TestCase):
             termination_a=Interface.objects.get(device__name='Device 1', name='Interface 1'),
             termination_b=FrontPort.objects.get(device__name='Panel 1', name='Front Port 1')
         )
+        cable1.full_clean()
         cable1.save()
         cable2 = Cable(
             termination_a=RearPort.objects.get(device__name='Panel 1', name='Rear Port 1'),
             termination_b=CircuitTermination.objects.get(term_side='A')
         )
+        cable2.full_clean()
         cable2.save()
         cable3 = Cable(
             termination_a=CircuitTermination.objects.get(term_side='Z'),
             termination_b=RearPort.objects.get(device__name='Panel 2', name='Rear Port 1')
         )
+        cable3.full_clean()
         cable3.save()
         cable4 = Cable(
             termination_a=FrontPort.objects.get(device__name='Panel 2', name='Front Port 1'),
             termination_b=Interface.objects.get(device__name='Device 2', name='Interface 1')
         )
+        cable4.full_clean()
         cable4.save()
 
         # Retrieve endpoints

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -601,6 +601,10 @@ class CablePathTestCase(TestCase):
         self.assertIsNone(endpoint_b.connection_status)
 
         # Recreate cable 1 to test creating the cables in reverse order (RP first, FP second)
+        cable1 = Cable(
+            termination_a=Interface.objects.get(device__name='Device 1', name='Interface 1'),
+            termination_b=FrontPort.objects.get(device__name='Panel 5', name='Front Port 1')
+        )
         cable1.save()
 
         # Refresh endpoints
@@ -712,6 +716,10 @@ class CablePathTestCase(TestCase):
         self.assertIsNone(endpoint_d.connection_status)
 
         # Recreate cable 3 to test reverse order (Panel 5 FP first, RP second)
+        cable3 = Cable(
+            termination_b=RearPort.objects.get(device__name='Panel 1', name='Rear Port 1'),
+            termination_a=RearPort.objects.get(device__name='Panel 5', name='Rear Port 1')
+        )
         cable3.save()
 
         # Refresh endpoints

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -2066,6 +2066,7 @@ class CableTraceView(PermissionRequiredMixin, View):
             'obj': obj,
             'trace': path,
             'split_ends': split_ends,
+            'position_stack': position_stack,
             'total_length': total_length,
         })
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -2057,7 +2057,7 @@ class CableTraceView(PermissionRequiredMixin, View):
     def get(self, request, model, pk):
 
         obj = get_object_or_404(model, pk=pk)
-        path, split_ends = obj.trace()
+        path, split_ends, position_stack = obj.trace()
         total_length = sum(
             [entry[1]._abs_length for entry in path if entry[1] and entry[1]._abs_length]
         )

--- a/netbox/templates/dcim/cable_trace.html
+++ b/netbox/templates/dcim/cable_trace.html
@@ -88,6 +88,10 @@
                     </table>
                 </div>
             </div>
+        {% elif position_stack %}
+            <div class="col-md-11 col-md-offset-1">
+                <h3 class="text-warning text-center">Multiple possible paths end at this point. No connection established!</h3>
+            </div>
         {% else %}
             <div class="col-md-11 col-md-offset-1">
                 <h3 class="text-success text-center">Trace completed!</h3>

--- a/netbox/templates/dcim/cable_trace.html
+++ b/netbox/templates/dcim/cable_trace.html
@@ -90,7 +90,13 @@
             </div>
         {% elif position_stack %}
             <div class="col-md-11 col-md-offset-1">
-                <h3 class="text-warning text-center">Multiple possible paths end at this point. No connection established!</h3>
+                <h3 class="text-warning text-center">
+                    {% with last_position=position_stack|last %}
+                        Trace completed, but there is no Front Port corresponding to
+                        <a href="{{ last_position.device.get_absolute_url }}">{{ last_position.device }}</a> {{ last_position }}.<br>
+                        Therefore no end-to-end connection can be established.
+                    {% endwith %}
+                </h3>
             </div>
         {% else %}
             <div class="col-md-11 col-md-offset-1">


### PR DESCRIPTION
### Fixes: #4708

Alternative solution to #4708 that allows users to use RearPort in more complex ways without causing an IntegrityError with connected endpoints.

This implementation changes `trace()` to return the `position_stack` to the caller, which allows the caller to determine whether the returned path is end-to-end (nothing left on the stack) or whether it went through a FrontPort->RearPort without going through the corresponding RearPort->FrontPort (stack is not empty).

Adapted the `update_connected_endpoints` signal handler to consider an endpoint unconnected when the stack is not empty. This prevents the IntegrityError from occurring as connected endpoints are now only established for one-to-one paths.