### PR TITLE
Role tag letter color adjast to background in VM view. Fixes  #4737

### DIFF
--- a/netbox/virtualization/tables.py
+++ b/netbox/virtualization/tables.py
@@ -29,7 +29,7 @@ VIRTUALMACHINE_STATUS = """
 """
 
 VIRTUALMACHINE_ROLE = """
-{% if record.role %}<label class="label" style="background-color: #{{ record.role.color }}">{{ value }}</label>{% else %}&mdash;{% endif %}
+{% if record.role %}{% load helpers %}<label class="label" style="color: {{ record.role.color|fgcolor }}; background-color: #{{ record.role.color }}">{{ value }}</label>{% else %}&mdash;{% endif %}
 """
 
 VIRTUALMACHINE_PRIMARY_IP = """


### PR DESCRIPTION
I have modified VIRTUALMACHINE_ROLE as template_code used in VirtualMachineTable(BaseTable) class to modify role tag letter color based on to its background. I have used fgcolor filter from helpers. 