### PR TITLE
Don't ignore ImportErrors raised when loading a plugin. Fixes #4805

### DIFF
--- a/netbox/extras/plugins/__init__.py
+++ b/netbox/extras/plugins/__init__.py
@@ -1,7 +1,5 @@
 import collections
-import importlib
 import inspect
-import sys
 from packaging import version
 
 from django.apps import AppConfig
@@ -11,6 +9,8 @@ from django.template.loader import get_template
 
 from extras.registry import registry
 from utilities.choices import ButtonColorChoices
+
+from extras.plugins.utils import import_object
 
 
 # Initialize plugin registry stores
@@ -61,26 +61,14 @@ class PluginConfig(AppConfig):
     def ready(self):
 
         # Register template content
-        module, attr = f"{self.__module__}.{self.template_extensions}".rsplit('.', 1)
-        spec = importlib.util.find_spec(module)
-        if spec is not None:
-            template_content = importlib.util.module_from_spec(spec)
-            sys.modules[module] = template_content
-            spec.loader.exec_module(template_content)
-            if hasattr(template_content, attr):
-                template_extensions = getattr(template_content, attr)
-                register_template_extensions(template_extensions)
+        template_extensions = import_object(f"{self.__module__}.{self.template_extensions}")
+        if template_extensions is not None:
+            register_template_extensions(template_extensions)
 
         # Register navigation menu items (if defined)
-        module, attr = f"{self.__module__}.{self.menu_items}".rsplit('.', 1)
-        spec = importlib.util.find_spec(module)
-        if spec is not None:
-            navigation = importlib.util.module_from_spec(spec)
-            sys.modules[module] = navigation
-            spec.loader.exec_module(navigation)
-            if hasattr(navigation, attr):
-                menu_items = getattr(navigation, attr)
-                register_menu_items(self.verbose_name, menu_items)
+        menu_items = import_object(f"{self.__module__}.{self.menu_items}")
+        if menu_items is not None:
+            register_menu_items(self.verbose_name, menu_items)
 
     @classmethod
     def validate(cls, user_config):

--- a/netbox/extras/plugins/urls.py
+++ b/netbox/extras/plugins/urls.py
@@ -1,11 +1,10 @@
-import importlib
-import sys
-
 from django.apps import apps
 from django.conf import settings
 from django.conf.urls import include
 from django.contrib.admin.views.decorators import staff_member_required
 from django.urls import path
+
+from extras.plugins.utils import import_object
 
 from . import views
 
@@ -26,29 +25,15 @@ for plugin_path in settings.PLUGINS:
     base_url = getattr(app, 'base_url') or app.label
 
     # Check if the plugin specifies any base URLs
-    spec = importlib.util.find_spec(f"{plugin_path}.urls")
-    if spec is not None:
-        # The plugin has a .urls module - import it
-        urls = importlib.util.module_from_spec(spec)
-        sys.modules[f"{plugin_path}.urls"] = urls
-        spec.loader.exec_module(urls)
-        if hasattr(urls, "urlpatterns"):
-            urlpatterns = urls.urlpatterns
-            plugin_patterns.append(
-                path(f"{base_url}/", include((urlpatterns, app.label)))
-            )
+    urlpatterns = import_object(f"{plugin_path}.urls.urlpatterns")
+    if urlpatterns is not None:
+        plugin_patterns.append(
+            path(f"{base_url}/", include((urlpatterns, app.label)))
+        )
 
     # Check if the plugin specifies any API URLs
-    spec = importlib.util.find_spec(f"{plugin_path}.api")
-    if spec is not None:
-        spec = importlib.util.find_spec(f"{plugin_path}.api.urls")
-        if spec is not None:
-            # The plugin has a .api.urls module - import it
-            api_urls = importlib.util.module_from_spec(spec)
-            sys.modules[f"{plugin_path}.api.urls"] = api_urls
-            spec.loader.exec_module(api_urls)
-            if hasattr(api_urls, "urlpatterns"):
-                urlpatterns = api_urls.urlpatterns
-                plugin_api_patterns.append(
-                    path(f"{base_url}/", include((urlpatterns, f"{app.label}-api")))
-                )
+    urlpatterns = import_object(f"{plugin_path}.api.urls.urlpatterns")
+    if urlpatterns is not None:
+        plugin_api_patterns.append(
+            path(f"{base_url}/", include((urlpatterns, f"{app.label}-api")))
+        )

--- a/netbox/extras/plugins/urls.py
+++ b/netbox/extras/plugins/urls.py
@@ -1,9 +1,11 @@
+import importlib
+import sys
+
 from django.apps import apps
 from django.conf import settings
 from django.conf.urls import include
 from django.contrib.admin.views.decorators import staff_member_required
 from django.urls import path
-from django.utils.module_loading import import_string
 
 from . import views
 
@@ -24,19 +26,29 @@ for plugin_path in settings.PLUGINS:
     base_url = getattr(app, 'base_url') or app.label
 
     # Check if the plugin specifies any base URLs
-    try:
-        urlpatterns = import_string(f"{plugin_path}.urls.urlpatterns")
-        plugin_patterns.append(
-            path(f"{base_url}/", include((urlpatterns, app.label)))
-        )
-    except ImportError:
-        pass
+    spec = importlib.util.find_spec(f"{plugin_path}.urls")
+    if spec is not None:
+        # The plugin has a .urls module - import it
+        urls = importlib.util.module_from_spec(spec)
+        sys.modules[f"{plugin_path}.urls"] = urls
+        spec.loader.exec_module(urls)
+        if hasattr(urls, "urlpatterns"):
+            urlpatterns = urls.urlpatterns
+            plugin_patterns.append(
+                path(f"{base_url}/", include((urlpatterns, app.label)))
+            )
 
     # Check if the plugin specifies any API URLs
-    try:
-        urlpatterns = import_string(f"{plugin_path}.api.urls.urlpatterns")
-        plugin_api_patterns.append(
-            path(f"{base_url}/", include((urlpatterns, f"{app.label}-api")))
-        )
-    except ImportError:
-        pass
+    spec = importlib.util.find_spec(f"{plugin_path}.api")
+    if spec is not None:
+        spec = importlib.util.find_spec(f"{plugin_path}.api.urls")
+        if spec is not None:
+            # The plugin has a .api.urls module - import it
+            api_urls = importlib.util.module_from_spec(spec)
+            sys.modules[f"{plugin_path}.api.urls"] = api_urls
+            spec.loader.exec_module(api_urls)
+            if hasattr(api_urls, "urlpatterns"):
+                urlpatterns = api_urls.urlpatterns
+                plugin_api_patterns.append(
+                    path(f"{base_url}/", include((urlpatterns, f"{app.label}-api")))
+                )

--- a/netbox/extras/plugins/utils.py
+++ b/netbox/extras/plugins/utils.py
@@ -1,0 +1,33 @@
+import importlib.util
+import sys
+
+
+def import_object(module_and_object):
+    """
+    Import a specific object from a specific module by name, such as "extras.plugins.utils.import_object".
+
+    Returns the imported object, or None if it doesn't exist.
+    """
+    target_module_name, object_name = module_and_object.rsplit('.', 1)
+    module_hierarchy = target_module_name.split('.')
+
+    # Iterate through the module hierarchy, checking for the existence of each successive submodule.
+    # We have to do this rather than jumping directly to calling find_spec(target_module_name)
+    # because find_spec will raise a ModuleNotFoundError if any parent module of target_module_name does not exist.
+    module_name = ""
+    for module_component in module_hierarchy:
+        module_name = f"{module_name}.{module_component}" if module_name else module_component
+        spec = importlib.util.find_spec(module_name)
+        if spec is None:
+            # No such module
+            return None
+
+    # Okay, target_module_name exists. Load it if not already loaded
+    if target_module_name in sys.modules:
+        module = sys.modules[target_module_name]
+    else:
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[target_module_name] = module
+        spec.loader.exec_module(module)
+
+    return getattr(module, object_name, None)


### PR DESCRIPTION
### Fixes: #4805

Django's `import_string` function is convenient to use, but it's difficult to distinguish between an `ImportError` raised by this function (because the string describes a module/object that does not exist) versus an `ImportError` raised by incorrect code in the module being imported. When NetBox is loading a plugin, the former should be ignored (as a plugin is not required to implement all possible entry points supported by the plugins API) but we are incorrectly ignoring the latter as well (which represent a real bug in the plugin code, and should not be ignored).

Solution: move away from the use of `import_string` to use more granular functions from `importlib` that let us distinguish between "module does not exist" and "module exists but throws an `ImportError` while being loaded".

Example of a plugin error now being correctly raised rather than caught:

```
netbox_1    | Exception in thread django-main-thread:
netbox_1    | Traceback (most recent call last):
netbox_1    |   File "/usr/local/lib/python3.7/threading.py", line 926, in _bootstrap_inner
netbox_1    |     self.run()
netbox_1    |   File "/usr/local/lib/python3.7/threading.py", line 870, in run
netbox_1    |     self._target(*self._args, **self._kwargs)
netbox_1    |   File "/usr/local/lib/python3.7/site-packages/django/utils/autoreload.py", line 53, in wrapper
netbox_1    |     fn(*args, **kwargs)
netbox_1    |   File "/usr/local/lib/python3.7/site-packages/django/core/management/commands/runserver.py", line 109, in inner_run
netbox_1    |     autoreload.raise_last_exception()
netbox_1    |   File "/usr/local/lib/python3.7/site-packages/django/utils/autoreload.py", line 76, in raise_last_exception
netbox_1    |     raise _exception[1]
netbox_1    |   File "/usr/local/lib/python3.7/site-packages/django/core/management/__init__.py", line 357, in execute
netbox_1    |     autoreload.check_errors(django.setup)()
netbox_1    |   File "/usr/local/lib/python3.7/site-packages/django/utils/autoreload.py", line 53, in wrapper
netbox_1    |     fn(*args, **kwargs)
netbox_1    |   File "/usr/local/lib/python3.7/site-packages/django/__init__.py", line 24, in setup
netbox_1    |     apps.populate(settings.INSTALLED_APPS)
netbox_1    |   File "/usr/local/lib/python3.7/site-packages/django/apps/registry.py", line 122, in populate
netbox_1    |     app_config.ready()
netbox_1    |   File "/opt/netbox/netbox/extras/plugins/__init__.py", line 77, in ready
netbox_1    |     spec.loader.exec_module(navigation)
netbox_1    |   File "<frozen importlib._bootstrap_external>", line 728, in exec_module
netbox_1    |   File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
netbox_1    |   File "/plugins/myplugin/navigation.py", line 6, in <module>
netbox_1    |     import foo
netbox_1    | ModuleNotFoundError: No module named 'foo'
```