### PR TITLE
#3240: Use correct serializer class for available-prefixes POST

### DIFF
--- a/netbox/ipam/api/views.py
+++ b/netbox/ipam/api/views.py
@@ -74,6 +74,11 @@ class PrefixViewSet(CustomFieldModelViewSet):
     serializer_class = serializers.PrefixSerializer
     filterset_class = filters.PrefixFilterSet
 
+    def get_serializer_class(self):
+        if self.action == "available_prefixes" and self.request.method == "POST":
+            return serializers.PrefixLengthSerializer
+        return super().get_serializer_class()
+
     @swagger_auto_schema(method='get', responses={200: serializers.AvailablePrefixSerializer(many=True)})
     @swagger_auto_schema(method='post', responses={201: serializers.AvailablePrefixSerializer(many=True)})
     @action(detail=True, url_path='available-prefixes', methods=['get', 'post'])


### PR DESCRIPTION
### Fixes: #3240 

The `/ipam/prefixes/{id}/available-prefixes/` API endpoint is asymmetric in terms of what serializer it uses for `GET` (`PrefixSerializer`) versus `POST` (`PrefixLengthSerializer`). By adding an appropriate implementation of `get_serializer_class` we can reflect this asymmetry and ensure that the Swagger API docs are correctly generated:

![image](https://user-images.githubusercontent.com/5603551/87347492-52163080-c521-11ea-8ce0-88c0ea18a875.png)
