### PR TITLE
Some additional fixes to scripts/reports background running (2.9)

### DIFF
--- a/netbox/extras/choices.py
+++ b/netbox/extras/choices.py
@@ -127,7 +127,7 @@ class TemplateLanguageChoices(ChoiceSet):
 class LogLevelChoices(ChoiceSet):
 
     LOG_DEFAULT = 'default'
-    LOG_SUCCESS = 'sucess'
+    LOG_SUCCESS = 'success'
     LOG_INFO = 'info'
     LOG_WARNING = 'warning'
     LOG_FAILURE = 'failure'


### PR DESCRIPTION
### Fixes: #2006 

Follow-up to #4799. Fixes two issues:

1) `success` log result was misspelled as `sucess`, which was causing display issues in the result detail view (since `label-sucess` (sic) is not a defined Bootstrap style).
2) If a script was run with `commit=False`, its JobResult status would remain as `running` indefinitely even after the script execution had actually completed.