### PR TITLE
Treat minified/packed JS/CSS files as binary. Fixes #4862

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,5 @@
 *.sh text eol=lf
+# Treat minified or packed JS/CSS files as binary, as they're not meant to be human-readable
+*.min.* binary
+*.map binary
+*.pack.js binary


### PR DESCRIPTION
### Fixes: #4862 

Mark some non-human-readable file types as binary in the `.gitattributes`.