### PR TITLE
#4880: Fix remove untagged-vlans if not assigned in bulk interfaces edit

### DIFF
--- a/docs/release-notes/version-2.8.md
+++ b/docs/release-notes/version-2.8.md
@@ -6,6 +6,7 @@
 
 * [#4875](https://github.com/netbox-community/netbox/issues/4875) - Fix documentation for image attachments
 * [#4876](https://github.com/netbox-community/netbox/issues/4876) - Fix labels for sites in staging or decommissioning status
+* [#4880](https://github.com/netbox-community/netbox/issues/4880) - Fix remove tagged vlans if not assigned in bulk interface editting
 
 ---
 

--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -721,8 +721,8 @@ class BulkEditView(GetReturnURLMixin, View):
 
                                 # ManyToManyFields
                                 elif isinstance(model_field, ManyToManyField):
-                                    getattr(obj, name).set(form.cleaned_data[name])
-
+                                    if form.cleaned_data[name].count() > 0:
+                                        getattr(obj, name).set(form.cleaned_data[name])
                                 # Normal fields
                                 elif form.cleaned_data[name] not in (None, ''):
                                     setattr(obj, name, form.cleaned_data[name])


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4880 
<!--
    Please include a summary of the proposed changes below.
-->
This makes an object not set attribute value if no QuerySet.