### PR TITLE
Closes #4869: Enable to search by MAC Address

### DIFF
--- a/docs/release-notes/version-2.8.md
+++ b/docs/release-notes/version-2.8.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+* [#4869](https://github.com/netbox-community/netbox/issues/4869) - Allow global search by MAC address
 * [#4898](https://github.com/netbox-community/netbox/issues/4898) - Add MAC address search field to interfaces list
 * [#4899](https://github.com/netbox-community/netbox/issues/4899) - Add MAC address column to interfaces table
 

--- a/netbox/netbox/views.py
+++ b/netbox/netbox/views.py
@@ -13,14 +13,14 @@ from circuits.filters import CircuitFilterSet, ProviderFilterSet
 from circuits.models import Circuit, Provider
 from circuits.tables import CircuitTable, ProviderTable
 from dcim.filters import (
-    CableFilterSet, DeviceFilterSet, DeviceTypeFilterSet, PowerFeedFilterSet, RackFilterSet, RackGroupFilterSet, SiteFilterSet,
+    CableFilterSet, DeviceFilterSet, DeviceTypeFilterSet, InterfaceFilterSet, PowerFeedFilterSet, RackFilterSet, RackGroupFilterSet, SiteFilterSet,
     VirtualChassisFilterSet,
 )
 from dcim.models import (
     Cable, ConsolePort, Device, DeviceType, Interface, PowerPanel, PowerFeed, PowerPort, Rack, RackGroup, Site, VirtualChassis
 )
 from dcim.tables import (
-    CableTable, DeviceTable, DeviceTypeTable, PowerFeedTable, RackTable, RackGroupTable, SiteTable,
+    CableTable, DeviceTable, DeviceTypeTable, InterfaceDetailTable, PowerFeedTable, RackTable, RackGroupTable, SiteTable,
     VirtualChassisTable,
 )
 from extras.models import ObjectChange, ReportResult
@@ -95,6 +95,15 @@ SEARCH_TYPES = OrderedDict((
         'filterset': DeviceFilterSet,
         'table': DeviceTable,
         'url': 'dcim:device_list',
+    }),
+    ('interface', {
+        'permission': 'dcim.view_interface',
+        'queryset': Interface.objects.prefetch_related(
+            'device', 'virtual_machine',
+        ),
+        'filterset': InterfaceFilterSet,
+        'table': InterfaceDetailTable,
+        'url': 'dcim:interface_list',
     }),
     ('virtualchassis', {
         'permission': 'dcim.view_virtualchassis',


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4869 
<!--
    Please include a summary of the proposed changes below.
-->
This enables to search interface objects by mac address in global search box.
