### PR TITLE
Closes #4946: Extend ObjectPermission constraints to OR multiple JSON objects

### DIFF
--- a/docs/administration/permissions.md
+++ b/docs/administration/permissions.md
@@ -6,13 +6,15 @@ NetBox v2.9 introduced a new object-based permissions framework, which replace's
 
 ### Example Constraint Definitions
 
-| Query Filter | Permission Constraints |
-| ------------ | --------------------- |
-| `filter(status='active')` | `{"status": "active"}` |
-| `filter(status='active', role='testing')` | `{"status": "active", "role": "testing"}` |
-| `filter(status__in=['planned', 'reserved'])` | `{"status__in": ["planned", "reserved"]}` |
-| `filter(name__startswith('Foo')` | `{"name__startswith": "Foo"}` |
-| `filter(vid__gte=100, vid__lt=200)` | `{"vid__gte": 100, "vid__lt": 200}` |
+| Constraints | Description |
+| ----------- | ----------- |
+| `{"status": "active"}` | Status is active |
+| `{"status__in": ["planned", "reserved"]}` | Status is active **OR** reserved |
+| `{"status": "active", "role": "testing"}` | Status is active **OR** role is testing |
+| `{"name__startswith": "Foo"}` | Name starts with "Foo" (case-sensitive) |
+| `{"name__iendswith": "bar"}` | Name ends with "bar" (case-insensitive) |
+| `{"vid__gte": 100, "vid__lt": 200}` | VLAN ID is greater than or equal to 100 **AND** less than 200 |
+| `[{"vid__lt": 200}, {"status": "reserved"}]` | VLAN ID is less than 200 **OR** status is reserved |
 
 ## Permissions Enforcement
 

--- a/docs/models/users/objectpermission.md
+++ b/docs/models/users/objectpermission.md
@@ -25,9 +25,9 @@ In addition to these, permissions can also grant custom actions that may be requ
 
 ## Constraints
 
-Constraints are expressed as a JSON object representing a [Django query filter](https://docs.djangoproject.com/en/stable/ref/models/querysets/#field-lookups). This is the same syntax that you would pass to the QuerySet `filter()` method when performing a query using the Django ORM. As with query filters, double underscores can be used to traverse related objects or invoke lookup expressions. Some example queries and their corresponding definitions are shown below.
+Constraints are expressed as a JSON object or list representing a [Django query filter](https://docs.djangoproject.com/en/stable/ref/models/querysets/#field-lookups). This is the same syntax that you would pass to the QuerySet `filter()` method when performing a query using the Django ORM. As with query filters, double underscores can be used to traverse related objects or invoke lookup expressions. Some example queries and their corresponding definitions are shown below.
 
-All constraints defined on a permission are applied with a logical AND. For example, suppose you assign a permission for the site model with the following constraints.
+All attributes defined within a single JSON object are applied with a logical AND. For example, suppose you assign a permission for the site model with the following constraints.
 
 ```json
 {
@@ -36,4 +36,20 @@ All constraints defined on a permission are applied with a logical AND. For exam
 }
 ```
 
-The permission will grant access only to sites which have a status of "active" **and** which are assigned to the "Americas" region. To achieve a logical OR with a different set of constraints, simply create another permission assignment for the same model and user/group. 
+The permission will grant access only to sites which have a status of "active" **and** which are assigned to the "Americas" region.
+
+To achieve a logical OR with a different set of constraints, define multiple objects within a list. For example, if you want to constrain the permission to VLANs with an ID between 100 and 199 _or_ a status of "reserved," do the following:
+
+```json
+[
+  {
+    "vid__gte": 100,
+    "vid__lt": 200
+  },
+  {
+    "status": "reserved"
+  }
+]
+```
+
+Additionally, where multiple permissions have been assigned for an object type, their collective constraints will be merged using a logical "OR" operation.

--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -75,7 +75,10 @@ class ObjectPermissionBackend(ModelBackend):
         obj_perm_constraints = self.get_all_permissions(user_obj)[perm]
         constraints = Q()
         for perm_constraints in obj_perm_constraints:
-            if perm_constraints:
+            if type(perm_constraints) is list:
+                for c in obj_perm_constraints:
+                    constraints |= Q(**c)
+            elif perm_constraints:
                 constraints |= Q(**perm_constraints)
             else:
                 # Found ObjectPermission with null constraints; allow model-level access

--- a/netbox/utilities/querysets.py
+++ b/netbox/utilities/querysets.py
@@ -44,8 +44,15 @@ class RestrictedQuerySet(QuerySet):
         else:
             attrs = Q()
             for perm_attrs in user._object_perm_cache[permission_required]:
-                if perm_attrs:
+                if type(perm_attrs) is list:
+                    for p in perm_attrs:
+                        attrs |= Q(**p)
+                elif perm_attrs:
                     attrs |= Q(**perm_attrs)
+                else:
+                    # Any permission with null constraints grants access to _all_ instances
+                    attrs = Q()
+                    break
             qs = self.filter(attrs)
 
         return qs


### PR DESCRIPTION
### Closes: #4946

Allows the user to specify a list of JSON objects to effect a logical OR among them when applying the permission constraints. Support for specifying a single object is maintained as well.