### PR TITLE
Fixes #4989: Fix no vm count for cluster in global search

### DIFF
--- a/docs/release-notes/version-2.8.md
+++ b/docs/release-notes/version-2.8.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+* [#4989](https://github.com/netbox-community/netbox/issues/4989) - Annotate device & vm counts to cluster qeryset for global search
 * [#4992](https://github.com/netbox-community/netbox/issues/4992) - Add `display_name` to nested VRF serializer
 * [#4993](https://github.com/netbox-community/netbox/issues/4993) - Add `cable` to nested CircuitTermination serializer
 

--- a/netbox/netbox/views.py
+++ b/netbox/netbox/views.py
@@ -34,6 +34,7 @@ from secrets.tables import SecretTable
 from tenancy.filters import TenantFilterSet
 from tenancy.models import Tenant
 from tenancy.tables import TenantTable
+from utilities.utils import get_subquery
 from virtualization.filters import ClusterFilterSet, VirtualMachineFilterSet
 from virtualization.models import Cluster, VirtualMachine
 from virtualization.tables import ClusterTable, VirtualMachineDetailTable
@@ -120,7 +121,10 @@ SEARCH_TYPES = OrderedDict((
     # Virtualization
     ('cluster', {
         'permission': 'virtualization.view_cluster',
-        'queryset': Cluster.objects.prefetch_related('type', 'group'),
+        'queryset': Cluster.objects.prefetch_related('type', 'group').annotate(
+            device_count=get_subquery(Device, 'cluster'),
+            vm_count=get_subquery(VirtualMachine, 'cluster')
+        ),
         'filterset': ClusterFilterSet,
         'table': ClusterTable,
         'url': 'virtualization:cluster_list',


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4989 
<!--
    Please include a summary of the proposed changes below.
-->
Display Device & VM count for cluster in global search result