### PR TITLE
Release v2.9.1 - 2020-08-22

### DIFF
--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -4,8 +4,15 @@
 
 Prior to upgrading your NetBox instance, be sure to carefully review all [release notes](../../release-notes/) that have been published since your current version was released. Although the upgrade process typically does not involve additional work, certain releases may introduce breaking or backward-incompatible changes. These are called out in the release notes under the version in which the change went into effect.
 
-!!! note
-    Beginning with version 2.8, NetBox requires Python 3.6 or later.
+## Update Dependencies to Required Versions
+
+NetBox v2.9.0 and later requires the following:
+
+| Dependency | Minimum Version |
+|------------|-----------------|
+| Python     | 3.6             |
+| PostgreSQL | 9.6             |
+| Redis      | 4.0             |
 
 ## Install the Latest Code
 

--- a/docs/models/dcim/interface.md
+++ b/docs/models/dcim/interface.md
@@ -4,7 +4,7 @@ Interfaces in NetBox represent network interfaces used to exchange data with con
 
 Interfaces may be physical or virtual in nature, but only physical interfaces may be connected via cables. Cables can connect interfaces to pass-through ports, circuit terminations, or other interfaces.
 
-Physical interfaces may be arranged into a link aggregation group (LAG) and associated with a parent LAG (virtual) interface. Like all virtual interfaces, LAG interfaces cannot be connected physically.
+Physical interfaces may be arranged into a link aggregation group (LAG) and associated with a parent LAG (virtual) interface. LAG interfaces can be recursively nested to model bonding of trunk groups. Like all virtual interfaces, LAG interfaces cannot be connected physically.
 
 IP addresses can be assigned to interfaces. VLANs can also be assigned to each interface as either tagged or untagged. (An interface may have only one untagged VLAN.)
 

--- a/docs/models/ipam/ipaddress.md
+++ b/docs/models/ipam/ipaddress.md
@@ -10,6 +10,7 @@ Each IP address can also be assigned an operational status and a functional role
 * Reserved
 * Deprecated
 * DHCP
+* SLAAC (IPv6 Stateless Address Autoconfiguration)
 
 Roles are used to indicate some special attribute of an IP address; for example, use as a loopback or as the the virtual IP for a VRRP group. (Note that functional roles are conceptual in nature, and thus cannot be customized by the user.) Available roles include:
 

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -7,6 +7,7 @@
 * [#4540](https://github.com/netbox-community/netbox/issues/4540) - Add IP address status type for SLAAC
 * [#4814](https://github.com/netbox-community/netbox/issues/4814) - Allow nested LAG interfaces
 * [#4991](https://github.com/netbox-community/netbox/issues/4991) - Add Python and NetBox versions to error page
+* [#5033](https://github.com/netbox-community/netbox/issues/5033) - Support backward compatibility for `REMOTE_AUTH_BACKEND` configuration parameter
 
 ---
 
@@ -66,7 +67,8 @@ Two new REST API endpoints have been added to facilitate the retrieval and manip
 
 ### Configuration Changes
 
-* If in use, LDAP authentication must be enabled by setting `REMOTE_AUTH_BACKEND` to `'netbox.authentication.LDAPBackend'`. (LDAP configuration parameters in `ldap_config.py` remain unchanged.)
+* If using NetBox's built-in remote authentication backend, update `REMOTE_AUTH_BACKEND` to `'netbox.authentication.RemoteUserBackend'`, as the authentication class has moved.
+* If using LDAP authentication, set `REMOTE_AUTH_BACKEND` to `'netbox.authentication.LDAPBackend'`. (LDAP configuration parameters in `ldap_config.py` remain unchanged.)
 * `REMOTE_AUTH_DEFAULT_PERMISSIONS` now takes a dictionary rather than a list. This is a mapping of permission names to a dictionary of constraining attributes, or `None`. For example, `['dcim.add_site', 'dcim.change_site']` would become `{'dcim.add_site': None, 'dcim.change_site': None}`.
 
 ### REST API Changes

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -1,5 +1,13 @@
 # NetBox v2.9
 
+## v2.9.1 (FUTURE)
+
+### Enhancements
+
+* [#4991](https://github.com/netbox-community/netbox/issues/4991) - Add Python and NetBox versions to error page
+
+---
+
 ## v2.9.0 (2020-08-21)
 
 ### New Features

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -13,6 +13,8 @@
 
 ## v2.9.0 (2020-08-21)
 
+**Note:** Redis 4.0 or later is required for this release.
+
 ### New Features
 
 #### Object-Based Permissions ([#554](https://github.com/netbox-community/netbox/issues/554))

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 * [#4540](https://github.com/netbox-community/netbox/issues/4540) - Add IP address status type for SLAAC
+* [#4814](https://github.com/netbox-community/netbox/issues/4814) - Allow nested LAG interfaces
 * [#4991](https://github.com/netbox-community/netbox/issues/4991) - Add Python and NetBox versions to error page
 
 ---

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+* [#4540](https://github.com/netbox-community/netbox/issues/4540) - Add IP address status type for SLAAC
 * [#4991](https://github.com/netbox-community/netbox/issues/4991) - Add Python and NetBox versions to error page
 
 ---

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -1,6 +1,6 @@
 # NetBox v2.9
 
-## v2.9.1 (FUTURE)
+## v2.9.1 (2020-08-22)
 
 ### Enhancements
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -76,6 +76,7 @@ nav:
         - User Preferences: 'development/user-preferences.md'
         - Release Checklist: 'development/release-checklist.md'
     - Release Notes:
+        - Version 2.9: 'release-notes/version-2.9.md'
         - Version 2.8: 'release-notes/version-2.8.md'
         - Version 2.7: 'release-notes/version-2.7.md'
         - Version 2.6: 'release-notes/version-2.6.md'

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -2686,7 +2686,10 @@ class InterfaceForm(InterfaceCommonForm, BootstrapMixin, forms.ModelForm):
         device_query = Q(device=device)
         if device.virtual_chassis:
             device_query |= Q(device__virtual_chassis=device.virtual_chassis)
-        self.fields['lag'].queryset = Interface.objects.filter(device_query, type=InterfaceTypeChoices.TYPE_LAG)
+        self.fields['lag'].queryset = Interface.objects.filter(
+            device_query,
+            type=InterfaceTypeChoices.TYPE_LAG
+        ).exclude(pk=self.instance.pk)
 
         # Add current site to VLANs query params
         self.fields['untagged_vlan'].widget.add_query_param('site_id', device.site.pk)

--- a/netbox/ipam/choices.py
+++ b/netbox/ipam/choices.py
@@ -41,12 +41,14 @@ class IPAddressStatusChoices(ChoiceSet):
     STATUS_RESERVED = 'reserved'
     STATUS_DEPRECATED = 'deprecated'
     STATUS_DHCP = 'dhcp'
+    STATUS_SLAAC = 'slaac'
 
     CHOICES = (
         (STATUS_ACTIVE, 'Active'),
         (STATUS_RESERVED, 'Reserved'),
         (STATUS_DEPRECATED, 'Deprecated'),
         (STATUS_DHCP, 'DHCP'),
+        (STATUS_SLAAC, 'SLAAC'),
     )
 
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -142,6 +142,13 @@ if type(REMOTE_AUTH_DEFAULT_PERMISSIONS) is not dict:
         )
     except TypeError:
         raise ImproperlyConfigured("REMOTE_AUTH_DEFAULT_PERMISSIONS must be a dictionary.")
+# Backward compatibility for REMOTE_AUTH_BACKEND
+if REMOTE_AUTH_BACKEND == 'utilities.auth_backends.RemoteUserBackend':
+    warnings.warn(
+        "RemoteUserBackend has moved! Please update your configuration to:\n"
+        "    REMOTE_AUTH_BACKEND='netbox.authentication.RemoteUserBackend'"
+    )
+    REMOTE_AUTH_BACKEND = 'netbox.authentication.RemoteUserBackend'
 
 
 #

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -16,7 +16,7 @@ from django.core.validators import URLValidator
 # Environment setup
 #
 
-VERSION = '2.9.1-dev'
+VERSION = '2.9.1'
 
 # Hostname
 HOSTNAME = platform.node()

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -16,7 +16,7 @@ from django.core.validators import URLValidator
 # Environment setup
 #
 
-VERSION = '2.9.0'
+VERSION = '2.9.1-dev'
 
 # Hostname
 HOSTNAME = platform.node()

--- a/netbox/templates/500.html
+++ b/netbox/templates/500.html
@@ -31,7 +31,10 @@
                             The complete exception is provided below:
                         </p>
 <pre><strong>{{ exception }}</strong><br />
-{{ error }}</pre>
+{{ error }}
+
+Python version: {{ python_version }}
+NetBox version: {{ netbox_version }}</pre>
                         <p>
                             If further assistance is required, please post to the <a href="https://groups.google.com/forum/#!forum/netbox-discuss">NetBox mailing list</a>.
                         </p>

--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -1,8 +1,10 @@
 import logging
+import platform
 import re
 import sys
 from copy import deepcopy
 
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.contrib.contenttypes.models import ContentType
@@ -1421,6 +1423,8 @@ def server_error(request, template_name=ERROR_500_TEMPLATE_NAME):
     type_, error, traceback = sys.exc_info()
 
     return HttpResponseServerError(template.render({
+        'python_version': platform.python_version(),
+        'netbox_version': settings.VERSION,
         'exception': str(type_),
         'error': error,
     }))


### PR DESCRIPTION
### Enhancements

* [#4540](https://github.com/netbox-community/netbox/issues/4540) - Add IP address status type for SLAAC
* [#4814](https://github.com/netbox-community/netbox/issues/4814) - Allow nested LAG interfaces
* [#4991](https://github.com/netbox-community/netbox/issues/4991) - Add Python and NetBox versions to error page
* [#5033](https://github.com/netbox-community/netbox/issues/5033) - Support backward compatibility for `REMOTE_AUTH_BACKEND` configuration parameter