### PR TITLE
Add missing class map field for SLAAC

### DIFF
--- a/netbox/ipam/models.py
+++ b/netbox/ipam/models.py
@@ -669,6 +669,7 @@ class IPAddress(ChangeLoggedModel, CustomFieldModel):
         'reserved': 'info',
         'deprecated': 'danger',
         'dhcp': 'success',
+        'slaac': 'success',
     }
 
     ROLE_CLASS_MAP = {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5042 
<!--
    Please include a summary of the proposed changes below.
-->
Adds the missing status map field for the new ‘SLAAC’ status.

Using the same ‘success’ appearance as ‘DHCP’ made the most sense to me.