### PR TITLE
Fix #5050 by making virtualization.0016_replicate_interfaces depend on dcim.0082_3569_interface_fields

### DIFF
--- a/netbox/virtualization/migrations/0016_replicate_interfaces.py
+++ b/netbox/virtualization/migrations/0016_replicate_interfaces.py
@@ -85,6 +85,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ('ipam', '0037_ipaddress_assignment'),
         ('virtualization', '0015_vminterface'),
+        ('dcim', '0082_3569_interface_fields'),
     ]
 
     operations = [


### PR DESCRIPTION
### Fixes: #5050 

Add a migration dependency so virtualization.0016_replicate_interfaces depends on dcim.0082_3569_interface_fields.

0016_replicate_interfaces copies mode from dcim_interface to virtualization_vminterface. If 0016_replicate_interfaces runs before dcim.0082_3569_interface_fields, it will fail, as prior to dcim.0082_3569_interface_fields the mode field is an integer which permits null, while 0016_replicate_interfaces is expecting this to be a varchar which defaults to empty string - virtualization_vminterface does not permit null so trying to copy null values fails.