### PR TITLE
Redirect users away from /login, if they are already logged in 

### DIFF
--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -36,6 +36,15 @@ class LoginView(View):
         return super().dispatch(*args, **kwargs)
 
     def get(self, request):
+        if request.user.is_authenticated:
+            # Already logged-in, determine where to redirect
+            redirect_to = request.GET.get('next', reverse('home'))
+            if redirect_to and not is_safe_url(url=redirect_to, allowed_hosts=request.get_host()):
+                logger.warning(f"Ignoring unsafe 'next' URL passed to login form: {redirect_to}")
+                redirect_to = reverse('home')
+
+            return HttpResponseRedirect(redirect_to)
+
         form = LoginForm(request)
 
         return render(request, self.template_name, {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4977 
<!--
    Please include a summary of the proposed changes below.
-->

Before returning the login form, the corresponding method now checks if the user is already logged in. when this is the case, the user get's redirected.