### PR TITLE
Fixes #5095: Fix display of assigned prefixes in VLANs list

### DIFF
--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -99,7 +99,7 @@ VLAN_LINK = """
 """
 
 VLAN_PREFIXES = """
-{% for prefix in record.prefixes.unrestricted %}
+{% for prefix in record.prefixes.all %}
     <a href="{% url 'ipam:prefix' pk=prefix.pk %}">{{ prefix }}</a>{% if not forloop.last %}<br />{% endif %}
 {% empty %}
     &mdash;


### PR DESCRIPTION
### Fixes: #5095

Fix template error to properly show prefixes assigned to each VLAN