### PR TITLE
Release v2.9.3

### DIFF
--- a/docs/installation/3-netbox.md
+++ b/docs/installation/3-netbox.md
@@ -25,7 +25,7 @@ Begin by installing all system packages required by NetBox and its dependencies.
 Before continuing with either platform, update pip (Python's package management tool) to its latest release:
 
 ```no-highlight
-# pip install --upgrade pip
+# pip3 install --upgrade pip
 ```
 
 ## Download NetBox

--- a/docs/plugins/development.md
+++ b/docs/plugins/development.md
@@ -328,6 +328,9 @@ A `PluginMenuButton` has the following attributes:
 * `color` - One of the choices provided by `ButtonColorChoices` (optional)
 * `permissions` - A list of permissions required to display this button (optional)
 
+!!! note
+    Any buttons associated within a menu item will be shown only if the user has permission to view the link, regardless of what permissions are set on the buttons.
+
 ## Extending Core Templates
 
 Plugins can inject custom content into certain areas of the detail views of applicable models. This is accomplished by subclassing `PluginTemplateExtension`, designating a particular NetBox model, and defining the desired methods to render custom content. Four methods are available:

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -8,6 +8,7 @@
 * [#5074](https://github.com/netbox-community/netbox/issues/5074) - Fix inclusion of VC member interfaces when viewing VC master
 * [#5078](https://github.com/netbox-community/netbox/issues/5078) - Fix assignment of existing IP addresses to interfaces via web UI
 * [#5081](https://github.com/netbox-community/netbox/issues/5081) - Fix exception during webhook processing with custom select field
+* [#5085](https://github.com/netbox-community/netbox/issues/5085) - Fix ordering by assignment in IP addresses table
 * [#5087](https://github.com/netbox-community/netbox/issues/5087) - Restore label field when editing console server ports, power ports, and power outlets
 
 ---

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -1,6 +1,6 @@
 # NetBox v2.9
 
-## v2.9.3 (FUTURE)
+## v2.9.3 (2020-09-04)
 
 ### Enhancements
 

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -6,6 +6,7 @@
 
 * [#5063](https://github.com/netbox-community/netbox/issues/5063) - Fix "add device" link in rack elevations for opposite side of half-depth devices
 * [#5074](https://github.com/netbox-community/netbox/issues/5074) - Fix inclusion of VC member interfaces when viewing VC master
+* [#5081](https://github.com/netbox-community/netbox/issues/5081) - Fix exception during webhook processing with custom select field
 
 ---
 

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -10,6 +10,7 @@
 * [#5081](https://github.com/netbox-community/netbox/issues/5081) - Fix exception during webhook processing with custom select field
 * [#5085](https://github.com/netbox-community/netbox/issues/5085) - Fix ordering by assignment in IP addresses table
 * [#5087](https://github.com/netbox-community/netbox/issues/5087) - Restore label field when editing console server ports, power ports, and power outlets
+* [#5090](https://github.com/netbox-community/netbox/issues/5090) - Fix status display for console/power/interface connections
 
 ---
 

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+* [#4977](https://github.com/netbox-community/netbox/issues/4977) - Redirect authenticated users from login view
 * [#5072](https://github.com/netbox-community/netbox/issues/5072) - Add REST API filters for image attachments
 * [#5080](https://github.com/netbox-community/netbox/issues/5080) - Add 8P6C, 8P4C, 8P2C port types
 
@@ -18,6 +19,7 @@
 * [#5089](https://github.com/netbox-community/netbox/issues/5089) - Redirect to device view after editing component
 * [#5090](https://github.com/netbox-community/netbox/issues/5090) - Fix status display for console/power/interface connections
 * [#5091](https://github.com/netbox-community/netbox/issues/5091) - Avoid KeyError when handling invalid table preferences
+* [#5095](https://github.com/netbox-community/netbox/issues/5095) - Avoid KeyError when handling invalid table preferences
 
 ---
 

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -1,5 +1,13 @@
 # NetBox v2.9
 
+## v2.9.3 (FUTURE)
+
+### Bug Fixes
+
+* [#5063](https://github.com/netbox-community/netbox/issues/5063) - Fix "add device" link in rack elevations for opposite side of half-depth devices
+
+---
+
 ## v2.9.2 (2020-08-27)
 
 ### Enhancements

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 * [#4977](https://github.com/netbox-community/netbox/issues/4977) - Redirect authenticated users from login view
+* [#5048](https://github.com/netbox-community/netbox/issues/5048) - Show the device/VM name when editing a component
 * [#5072](https://github.com/netbox-community/netbox/issues/5072) - Add REST API filters for image attachments
 * [#5080](https://github.com/netbox-community/netbox/issues/5080) - Add 8P6C, 8P4C, 8P2C port types
 

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+* [#5046](https://github.com/netbox-community/netbox/issues/5046) - Disabled plugin menu items are no longer clickable
 * [#5063](https://github.com/netbox-community/netbox/issues/5063) - Fix "add device" link in rack elevations for opposite side of half-depth devices
 * [#5074](https://github.com/netbox-community/netbox/issues/5074) - Fix inclusion of VC member interfaces when viewing VC master
 * [#5078](https://github.com/netbox-community/netbox/issues/5078) - Fix assignment of existing IP addresses to interfaces via web UI

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -4,6 +4,7 @@
 
 ### Enhancements
 
+* [#5072](https://github.com/netbox-community/netbox/issues/5072) - Add REST API filters for image attachments
 * [#5080](https://github.com/netbox-community/netbox/issues/5080) - Add 8P6C, 8P4C, 8P2C port types
 
 ### Bug Fixes

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -15,6 +15,7 @@
 * [#5085](https://github.com/netbox-community/netbox/issues/5085) - Fix ordering by assignment in IP addresses table
 * [#5087](https://github.com/netbox-community/netbox/issues/5087) - Restore label field when editing console server ports, power ports, and power outlets
 * [#5090](https://github.com/netbox-community/netbox/issues/5090) - Fix status display for console/power/interface connections
+* [#5091](https://github.com/netbox-community/netbox/issues/5091) - Avoid KeyError when handling invalid table preferences
 
 ---
 

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -8,6 +8,7 @@
 * [#5074](https://github.com/netbox-community/netbox/issues/5074) - Fix inclusion of VC member interfaces when viewing VC master
 * [#5078](https://github.com/netbox-community/netbox/issues/5078) - Fix assignment of existing IP addresses to interfaces via web UI
 * [#5081](https://github.com/netbox-community/netbox/issues/5081) - Fix exception during webhook processing with custom select field
+* [#5087](https://github.com/netbox-community/netbox/issues/5087) - Restore label field when editing console server ports, power ports, and power outlets
 
 ---
 

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -21,7 +21,7 @@
 * [#5089](https://github.com/netbox-community/netbox/issues/5089) - Redirect to device view after editing component
 * [#5090](https://github.com/netbox-community/netbox/issues/5090) - Fix status display for console/power/interface connections
 * [#5091](https://github.com/netbox-community/netbox/issues/5091) - Avoid KeyError when handling invalid table preferences
-* [#5095](https://github.com/netbox-community/netbox/issues/5095) - Avoid KeyError when handling invalid table preferences
+* [#5095](https://github.com/netbox-community/netbox/issues/5095) - Show assigned prefixes in VLANs list
 
 ---
 

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -14,6 +14,7 @@
 * [#5081](https://github.com/netbox-community/netbox/issues/5081) - Fix exception during webhook processing with custom select field
 * [#5085](https://github.com/netbox-community/netbox/issues/5085) - Fix ordering by assignment in IP addresses table
 * [#5087](https://github.com/netbox-community/netbox/issues/5087) - Restore label field when editing console server ports, power ports, and power outlets
+* [#5089](https://github.com/netbox-community/netbox/issues/5089) - Redirect to device view after editing component
 * [#5090](https://github.com/netbox-community/netbox/issues/5090) - Fix status display for console/power/interface connections
 * [#5091](https://github.com/netbox-community/netbox/issues/5091) - Avoid KeyError when handling invalid table preferences
 

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -6,6 +6,7 @@
 
 * [#5063](https://github.com/netbox-community/netbox/issues/5063) - Fix "add device" link in rack elevations for opposite side of half-depth devices
 * [#5074](https://github.com/netbox-community/netbox/issues/5074) - Fix inclusion of VC member interfaces when viewing VC master
+* [#5078](https://github.com/netbox-community/netbox/issues/5078) - Fix assignment of existing IP addresses to interfaces via web UI
 * [#5081](https://github.com/netbox-community/netbox/issues/5081) - Fix exception during webhook processing with custom select field
 
 ---

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -2,6 +2,10 @@
 
 ## v2.9.3 (FUTURE)
 
+### Enhancements
+
+* [#5080](https://github.com/netbox-community/netbox/issues/5080) - Add 8P6C, 8P4C, 8P2C port types
+
 ### Bug Fixes
 
 * [#5063](https://github.com/netbox-community/netbox/issues/5063) - Fix "add device" link in rack elevations for opposite side of half-depth devices

--- a/docs/release-notes/version-2.9.md
+++ b/docs/release-notes/version-2.9.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * [#5063](https://github.com/netbox-community/netbox/issues/5063) - Fix "add device" link in rack elevations for opposite side of half-depth devices
+* [#5074](https://github.com/netbox-community/netbox/issues/5074) - Fix inclusion of VC member interfaces when viewing VC master
 
 ---
 

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -814,6 +814,9 @@ class InterfaceModeChoices(ChoiceSet):
 class PortTypeChoices(ChoiceSet):
 
     TYPE_8P8C = '8p8c'
+    TYPE_8P6C = '8p6c'
+    TYPE_8P4C = '8p4c'
+    TYPE_8P2C = '8p2c'
     TYPE_110_PUNCH = '110-punch'
     TYPE_BNC = 'bnc'
     TYPE_MRJ21 = 'mrj21'
@@ -833,6 +836,9 @@ class PortTypeChoices(ChoiceSet):
             'Copper',
             (
                 (TYPE_8P8C, '8P8C'),
+                (TYPE_8P6C, '8P6C'),
+                (TYPE_8P4C, '8P4C'),
+                (TYPE_8P2C, '8P2C'),
                 (TYPE_110_PUNCH, '110 Punch'),
                 (TYPE_BNC, 'BNC'),
                 (TYPE_MRJ21, 'MRJ21'),

--- a/netbox/dcim/elevations.py
+++ b/netbox/dcim/elevations.py
@@ -149,7 +149,7 @@ class RackElevationSVG:
         unit_cursor = 0
         for u in elevation:
             o = other[unit_cursor]
-            if not u['device'] and o['device']:
+            if not u['device'] and o['device'] and o['device'].device_type.is_full_depth:
                 u['device'] = o['device']
                 u['height'] = 1
             unit_cursor += u.get('height', 1)

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -2317,7 +2317,7 @@ class ConsoleServerPortForm(BootstrapMixin, forms.ModelForm):
     class Meta:
         model = ConsoleServerPort
         fields = [
-            'device', 'name', 'type', 'description', 'tags',
+            'device', 'name', 'label', 'type', 'description', 'tags',
         ]
         widgets = {
             'device': forms.HiddenInput(),
@@ -2390,7 +2390,7 @@ class PowerPortForm(BootstrapMixin, forms.ModelForm):
     class Meta:
         model = PowerPort
         fields = [
-            'device', 'name', 'type', 'maximum_draw', 'allocated_draw', 'description', 'tags',
+            'device', 'name', 'label', 'type', 'maximum_draw', 'allocated_draw', 'description', 'tags',
         ]
         widgets = {
             'device': forms.HiddenInput(),
@@ -2479,7 +2479,7 @@ class PowerOutletForm(BootstrapMixin, forms.ModelForm):
     class Meta:
         model = PowerOutlet
         fields = [
-            'device', 'name', 'type', 'power_port', 'feed_leg', 'description', 'tags',
+            'device', 'name', 'label', 'type', 'power_port', 'feed_leg', 'description', 'tags',
         ]
         widgets = {
             'device': forms.HiddenInput(),

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -152,6 +152,10 @@ INTERFACE_TAGGED_VLANS = """
 {% endfor %}
 """
 
+CONNECTION_STATUS = """
+<span class="label label-{% if record.connection_status %}success{% else %}danger{% endif %}">{{ record.get_connection_status_display }}</span>
+"""
+
 
 #
 # Regions
@@ -916,7 +920,10 @@ class ConsoleConnectionTable(BaseTable):
     name = tables.Column(
         verbose_name='Console Port'
     )
-    connection_status = BooleanColumn()
+    connection_status = tables.TemplateColumn(
+        template_code=CONNECTION_STATUS,
+        verbose_name='Status'
+    )
 
     class Meta(BaseTable.Meta):
         model = ConsolePort
@@ -940,6 +947,10 @@ class PowerConnectionTable(BaseTable):
     )
     name = tables.Column(
         verbose_name='Power Port'
+    )
+    connection_status = tables.TemplateColumn(
+        template_code=CONNECTION_STATUS,
+        verbose_name='Status'
     )
 
     class Meta(BaseTable.Meta):
@@ -971,6 +982,10 @@ class InterfaceConnectionTable(BaseTable):
         accessor=Accessor('_connected_interface'),
         args=[Accessor('_connected_interface__pk')],
         verbose_name='Interface B'
+    )
+    connection_status = tables.TemplateColumn(
+        template_code=CONNECTION_STATUS,
+        verbose_name='Status'
     )
 
     class Meta(BaseTable.Meta):

--- a/netbox/dcim/tables.py
+++ b/netbox/dcim/tables.py
@@ -912,12 +912,14 @@ class ConsoleConnectionTable(BaseTable):
         verbose_name='Console Server'
     )
     connected_endpoint = tables.Column(
+        linkify=True,
         verbose_name='Port'
     )
     device = tables.Column(
         linkify=True
     )
     name = tables.Column(
+        linkify=True,
         verbose_name='Console Port'
     )
     connection_status = tables.TemplateColumn(
@@ -940,12 +942,14 @@ class PowerConnectionTable(BaseTable):
     )
     outlet = tables.Column(
         accessor=Accessor('_connected_poweroutlet'),
+        linkify=True,
         verbose_name='Outlet'
     )
     device = tables.Column(
         linkify=True
     )
     name = tables.Column(
+        linkify=True,
         verbose_name='Power Port'
     )
     connection_status = tables.TemplateColumn(

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1233,6 +1233,7 @@ class ConsolePortCreateView(ComponentCreateView):
 class ConsolePortEditView(ObjectEditView):
     queryset = ConsolePort.objects.all()
     model_form = forms.ConsolePortForm
+    template_name = 'dcim/device_component_edit.html'
 
 
 class ConsolePortDeleteView(ObjectDeleteView):
@@ -1292,6 +1293,7 @@ class ConsoleServerPortCreateView(ComponentCreateView):
 class ConsoleServerPortEditView(ObjectEditView):
     queryset = ConsoleServerPort.objects.all()
     model_form = forms.ConsoleServerPortForm
+    template_name = 'dcim/device_component_edit.html'
 
 
 class ConsoleServerPortDeleteView(ObjectDeleteView):
@@ -1351,6 +1353,7 @@ class PowerPortCreateView(ComponentCreateView):
 class PowerPortEditView(ObjectEditView):
     queryset = PowerPort.objects.all()
     model_form = forms.PowerPortForm
+    template_name = 'dcim/device_component_edit.html'
 
 
 class PowerPortDeleteView(ObjectDeleteView):
@@ -1410,6 +1413,7 @@ class PowerOutletCreateView(ComponentCreateView):
 class PowerOutletEditView(ObjectEditView):
     queryset = PowerOutlet.objects.all()
     model_form = forms.PowerOutletForm
+    template_name = 'dcim/device_component_edit.html'
 
 
 class PowerOutletDeleteView(ObjectDeleteView):
@@ -1561,6 +1565,7 @@ class FrontPortCreateView(ComponentCreateView):
 class FrontPortEditView(ObjectEditView):
     queryset = FrontPort.objects.all()
     model_form = forms.FrontPortForm
+    template_name = 'dcim/device_component_edit.html'
 
 
 class FrontPortDeleteView(ObjectDeleteView):
@@ -1620,6 +1625,7 @@ class RearPortCreateView(ComponentCreateView):
 class RearPortEditView(ObjectEditView):
     queryset = RearPort.objects.all()
     model_form = forms.RearPortForm
+    template_name = 'dcim/device_component_edit.html'
 
 
 class RearPortDeleteView(ObjectDeleteView):
@@ -1679,6 +1685,7 @@ class DeviceBayCreateView(ComponentCreateView):
 class DeviceBayEditView(ObjectEditView):
     queryset = DeviceBay.objects.all()
     model_form = forms.DeviceBayForm
+    template_name = 'dcim/device_component_edit.html'
 
 
 class DeviceBayDeleteView(ObjectDeleteView):

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1033,7 +1033,7 @@ class DeviceView(ObjectView):
         )
 
         # Interfaces
-        interfaces = device.vc_interfaces.restrict(request.user, 'view').filter(device=device).prefetch_related(
+        interfaces = device.vc_interfaces.restrict(request.user, 'view').prefetch_related(
             Prefetch('ip_addresses', queryset=IPAddress.objects.restrict(request.user)),
             Prefetch('member_interfaces', queryset=Interface.objects.restrict(request.user)),
             'lag', '_connected_interface__device', '_connected_circuittermination__circuit', 'cable',

--- a/netbox/extras/api/customfields.py
+++ b/netbox/extras/api/customfields.py
@@ -158,7 +158,7 @@ class CustomFieldModelSerializer(ValidatedModelSerializer):
         instance.custom_fields = {}
         for field in custom_fields:
             value = instance.cf.get(field.name)
-            if field.type == CustomFieldTypeChoices.TYPE_SELECT and value is not None:
+            if field.type == CustomFieldTypeChoices.TYPE_SELECT and value:
                 instance.custom_fields[field.name] = CustomFieldChoiceSerializer(value).data
             else:
                 instance.custom_fields[field.name] = value

--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -140,6 +140,7 @@ class ImageAttachmentViewSet(ModelViewSet):
     metadata_class = ContentTypeMetadata
     queryset = ImageAttachment.objects.all()
     serializer_class = serializers.ImageAttachmentSerializer
+    filterset_class = filters.ImageAttachmentFilterSet
 
 
 #

--- a/netbox/extras/filters.py
+++ b/netbox/extras/filters.py
@@ -7,7 +7,7 @@ from tenancy.models import Tenant, TenantGroup
 from utilities.filters import BaseFilterSet
 from virtualization.models import Cluster, ClusterGroup
 from .choices import *
-from .models import ConfigContext, CustomField, Graph, ExportTemplate, ObjectChange, JobResult, Tag
+from .models import ConfigContext, CustomField, ExportTemplate, Graph, ImageAttachment, JobResult, ObjectChange, Tag
 
 
 __all__ = (
@@ -17,6 +17,7 @@ __all__ = (
     'CustomFieldFilterSet',
     'ExportTemplateFilterSet',
     'GraphFilterSet',
+    'ImageAttachmentFilterSet',
     'LocalConfigContextFilterSet',
     'ObjectChangeFilterSet',
     'TagFilterSet',
@@ -102,6 +103,13 @@ class ExportTemplateFilterSet(BaseFilterSet):
     class Meta:
         model = ExportTemplate
         fields = ['id', 'content_type', 'name', 'template_language']
+
+
+class ImageAttachmentFilterSet(BaseFilterSet):
+
+    class Meta:
+        model = ImageAttachment
+        fields = ['id', 'content_type', 'object_id', 'name']
 
 
 class TagFilterSet(BaseFilterSet):

--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -415,6 +415,10 @@ class IPAddressDetailTable(IPAddressTable):
     tenant = tables.TemplateColumn(
         template_code=COL_TENANT
     )
+    assigned = tables.BooleanColumn(
+        accessor='assigned_object_id',
+        verbose_name='Assigned'
+    )
     tags = TagColumn(
         url_name='ipam:ipaddress_list'
     )

--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -99,7 +99,7 @@ VLAN_LINK = """
 """
 
 VLAN_PREFIXES = """
-{% for prefix in record.prefixes.unrestricted %}
+{% for prefix in record.prefixes.all %}
     <a href="{% url 'ipam:prefix' pk=prefix.pk %}">{{ prefix }}</a>{% if not forloop.last %}<br />{% endif %}
 {% empty %}
     &mdash;

--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -67,11 +67,7 @@ IPADDRESS_LINK = """
 """
 
 IPADDRESS_ASSIGN_LINK = """
-{% if request.GET %}
-    <a href="{% url 'ipam:ipaddress_edit' pk=record.pk %}?interface={{ request.GET.interface }}&return_url={{ request.GET.return_url }}">{{ record }}</a>
-{% else %}
-    <a href="{% url 'ipam:ipaddress_edit' pk=record.pk %}?interface={{ record.interface.pk }}&return_url={{ request.path }}">{{ record }}</a>
-{% endif %}
+<a href="{% url 'ipam:ipaddress_edit' pk=record.pk %}?{% if request.GET.interface %}interface={{ request.GET.interface }}{% elif request.GET.vminterface %}vminterface={{ request.GET.vminterface }}{% endif %}&return_url={{ request.GET.return_url }}">{{ record }}</a>
 """
 
 VRF_LINK = """

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -582,7 +582,7 @@ class IPAddressAssignView(ObjectView):
     def dispatch(self, request, *args, **kwargs):
 
         # Redirect user if an interface has not been provided
-        if 'interface' not in request.GET:
+        if 'interface' not in request.GET and 'vminterface' not in request.GET:
             return redirect('ipam:ipaddress_add')
 
         return super().dispatch(request, *args, **kwargs)
@@ -609,7 +609,7 @@ class IPAddressAssignView(ObjectView):
         return render(request, 'ipam/ipaddress_assign.html', {
             'form': form,
             'table': table,
-            'return_url': request.GET.get('return_url', ''),
+            'return_url': request.GET.get('return_url'),
         })
 
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -16,7 +16,7 @@ from django.core.validators import URLValidator
 # Environment setup
 #
 
-VERSION = '2.9.3-dev'
+VERSION = '2.9.3'
 
 # Hostname
 HOSTNAME = platform.node()

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -16,7 +16,7 @@ from django.core.validators import URLValidator
 # Environment setup
 #
 
-VERSION = '2.9.2'
+VERSION = '2.9.3-dev'
 
 # Hostname
 HOSTNAME = platform.node()

--- a/netbox/templates/dcim/device_component_edit.html
+++ b/netbox/templates/dcim/device_component_edit.html
@@ -1,0 +1,16 @@
+{% extends 'utilities/obj_edit.html' %}
+{% load form_helpers %}
+
+{% block form_fields %}
+    {% if form.instance.device %}
+        <div class="form-group">
+            <label class="col-md-3 control-label required" for="id_device">Device</label>
+            <div class="col-md-9">
+                <p class="form-control-static">
+                    <a href="{{ form.instance.device.get_absolute_url }}">{{ form.instance.device }}</a>
+                </p>
+            </div>
+        </div>
+    {% endif %}
+    {% render_form form %}
+{% endblock %}

--- a/netbox/templates/dcim/inc/consoleport.html
+++ b/netbox/templates/dcim/inc/consoleport.html
@@ -66,7 +66,7 @@
             </span>
         {% endif %}
         {% if perms.dcim.change_consoleport %}
-            <a href="{% url 'dcim:consoleport_edit' pk=cp.pk %}" title="Edit port" class="btn btn-info btn-xs">
+            <a href="{% url 'dcim:consoleport_edit' pk=cp.pk %}?return_url={{ device.get_absolute_url }}" title="Edit port" class="btn btn-info btn-xs">
                 <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
             </a>
         {% endif %}

--- a/netbox/templates/dcim/inc/consoleserverport.html
+++ b/netbox/templates/dcim/inc/consoleserverport.html
@@ -68,7 +68,7 @@
             </span>
         {% endif %}
         {% if perms.dcim.change_consoleserverport %}
-            <a href="{% url 'dcim:consoleserverport_edit' pk=csp.pk %}" title="Edit port" class="btn btn-info btn-xs">
+            <a href="{% url 'dcim:consoleserverport_edit' pk=csp.pk %}?return_url={{ device.get_absolute_url }}" title="Edit port" class="btn btn-info btn-xs">
                 <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
             </a>
         {% endif %}

--- a/netbox/templates/dcim/inc/devicebay.html
+++ b/netbox/templates/dcim/inc/devicebay.html
@@ -52,7 +52,7 @@
                     <i class="glyphicon glyphicon-plus" aria-hidden="true" title="Install device"></i>
                 </a>
             {% endif %}
-            <a href="{% url 'dcim:devicebay_edit' pk=devicebay.pk %}" class="btn btn-info btn-xs">
+            <a href="{% url 'dcim:devicebay_edit' pk=devicebay.pk %}?return_url={{ device.get_absolute_url }}" class="btn btn-info btn-xs">
                 <i class="glyphicon glyphicon-pencil" aria-hidden="true" title="Edit device bay"></i>
             </a>
         {% endif %}

--- a/netbox/templates/dcim/inc/poweroutlet.html
+++ b/netbox/templates/dcim/inc/poweroutlet.html
@@ -81,7 +81,7 @@
             </a>
         {% endif %}
         {% if perms.dcim.change_poweroutlet %}
-            <a href="{% url 'dcim:poweroutlet_edit' pk=po.pk %}" title="Edit outlet" class="btn btn-info btn-xs">
+            <a href="{% url 'dcim:poweroutlet_edit' pk=po.pk %}?return_url={{ device.get_absolute_url }}" title="Edit outlet" class="btn btn-info btn-xs">
                 <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
             </a>
         {% endif %}

--- a/netbox/templates/dcim/inc/powerport.html
+++ b/netbox/templates/dcim/inc/powerport.html
@@ -78,7 +78,7 @@
             </span>
         {% endif %}
         {% if perms.dcim.change_powerport %}
-            <a href="{% url 'dcim:powerport_edit' pk=pp.pk %}" title="Edit port" class="btn btn-info btn-xs">
+            <a href="{% url 'dcim:powerport_edit' pk=pp.pk %}?return_url={{ device.get_absolute_url }}" title="Edit port" class="btn btn-info btn-xs">
                 <i class="glyphicon glyphicon-pencil" aria-hidden="true"></i>
             </a>
         {% endif %}

--- a/netbox/templates/dcim/interface_edit.html
+++ b/netbox/templates/dcim/interface_edit.html
@@ -5,6 +5,16 @@
     <div class="panel panel-default">
         <div class="panel-heading"><strong>Interface</strong></div>
         <div class="panel-body">
+            {% if form.instance.device %}
+                <div class="form-group">
+                    <label class="col-md-3 control-label required" for="id_device">Device</label>
+                    <div class="col-md-9">
+                        <p class="form-control-static">
+                            <a href="{{ form.instance.device.get_absolute_url }}">{{ form.instance.device }}</a>
+                        </p>
+                    </div>
+                </div>
+            {% endif %}
             {% render_field form.name %}
             {% render_field form.label %}
             {% render_field form.type %}
@@ -14,6 +24,11 @@
             {% render_field form.mtu %}
             {% render_field form.mgmt_only %}
             {% render_field form.description %}
+        </div>
+    </div>
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>802.1Q Switching</strong></div>
+        <div class="panel-body">
             {% render_field form.mode %}
             {% render_field form.untagged_vlan %}
             {% render_field form.tagged_vlans %}

--- a/netbox/templates/inc/plugin_menu_items.html
+++ b/netbox/templates/inc/plugin_menu_items.html
@@ -5,18 +5,22 @@
         {% for section_name, menu_items in registry.plugin_menu_items.items %}
             <li class="dropdown-header">{{ section_name }}</li>
             {% for menu_item in menu_items %}
-                <li{% if menu_item.permissions and not request.user|has_perms:menu_item.permissions %} class="disabled"{% endif %}>
-                    {% if menu_item.buttons %}
-                        <div class="buttons pull-right">
-                            {% for button in menu_item.buttons %}
-                                {% if not button.permissions or request.user|has_perms:button.permissions %}
-                                    <a href="{% url button.link %}" class="btn btn-xs btn-{{ button.color }}" title="{{ button.title }}"><i class="{{ button.icon_class }}"></i></a>
-                                {% endif %}
-                            {% endfor %}
-                        </div>
-                    {% endif %}
-                    <a href="{% url menu_item.link %}">{{ menu_item.link_text }}</a>
-                </li>
+                {% if not menu_item.permissions or request.user|has_perms:menu_item.permissions %}
+                    <li>
+                        {% if menu_item.buttons %}
+                            <div class="buttons pull-right">
+                                {% for button in menu_item.buttons %}
+                                    {% if not button.permissions or request.user|has_perms:button.permissions %}
+                                        <a href="{% url button.link %}" class="btn btn-xs btn-{{ button.color }}" title="{{ button.title }}"><i class="{{ button.icon_class }}"></i></a>
+                                    {% endif %}
+                                {% endfor %}
+                            </div>
+                        {% endif %}
+                        <a href="{% url menu_item.link %}">{{ menu_item.link_text }}</a>
+                    </li>
+                {% else %}
+                    <li class="disabled"><a href="#">{{ menu_item.link_text }}</a></li>
+                {% endif %}
             {% endfor %}
             {% if not forloop.last %}
                 <li class="divider"></li>

--- a/netbox/templates/utilities/obj_edit.html
+++ b/netbox/templates/utilities/obj_edit.html
@@ -31,7 +31,9 @@
                     <div class="panel panel-default">
                         <div class="panel-heading"><strong>{{ obj_type|capfirst }}</strong></div>
                         <div class="panel-body">
-                            {% render_form form %}
+                            {% block form_fields %}
+                                {% render_form form %}
+                            {% endblock %}
                         </div>
                     </div>
                 {% endblock %}

--- a/netbox/templates/virtualization/virtualmachine_component_add.html
+++ b/netbox/templates/virtualization/virtualmachine_component_add.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 {% load form_helpers %}
 
-{% block title %}Create {{ component_type }} ({{ parent }}){% endblock %}
+{% block title %}Create {{ component_type }}{% endblock %}
 
 {% block content %}
 <form action="" method="post" class="form form-horizontal">

--- a/netbox/templates/virtualization/vminterface_edit.html
+++ b/netbox/templates/virtualization/vminterface_edit.html
@@ -5,14 +5,34 @@
     <div class="panel panel-default">
         <div class="panel-heading"><strong>Interface</strong></div>
         <div class="panel-body">
+            {% if form.instance.virtual_machine %}
+                <div class="form-group">
+                    <label class="col-md-3 control-label required" for="id_device">Virtual Machine</label>
+                    <div class="col-md-9">
+                        <p class="form-control-static">
+                            <a href="{{ form.instance.virtual_machine.get_absolute_url }}">{{ form.instance.virtual_machine }}</a>
+                        </p>
+                    </div>
+                </div>
+            {% endif %}
             {% render_field form.name %}
             {% render_field form.enabled %}
             {% render_field form.mac_address %}
             {% render_field form.mtu %}
             {% render_field form.description %}
+        </div>
+    </div>
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>802.1Q Switching</strong></div>
+        <div class="panel-body">
             {% render_field form.mode %}
             {% render_field form.untagged_vlan %}
             {% render_field form.tagged_vlans %}
+        </div>
+    </div>
+    <div class="panel panel-default">
+        <div class="panel-heading"><strong>Tags</strong></div>
+        <div class="panel-body">
             {% render_field form.tags %}
         </div>
     </div>

--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -36,6 +36,15 @@ class LoginView(View):
         return super().dispatch(*args, **kwargs)
 
     def get(self, request):
+        if request.user.is_authenticated:
+            # Already logged-in, determine where to redirect
+            redirect_to = request.GET.get('next', reverse('home'))
+            if redirect_to and not is_safe_url(url=redirect_to, allowed_hosts=request.get_host()):
+                logger.warning(f"Ignoring unsafe 'next' URL passed to login form: {redirect_to}")
+                redirect_to = reverse('home')
+
+            return HttpResponseRedirect(redirect_to)
+
         form = LoginForm(request)
 
         return render(request, self.template_name, {

--- a/netbox/utilities/tables.py
+++ b/netbox/utilities/tables.py
@@ -44,7 +44,7 @@ class BaseTable(tables.Table):
                     self.columns.show(name)
                 else:
                     self.columns.hide(name)
-            self.sequence = columns
+            self.sequence = [c for c in columns if c in self.base_columns]
 
             # Always include PK and actions column, if defined on the table
             if pk:


### PR DESCRIPTION
### Enhancements

* [#4977](https://github.com/netbox-community/netbox/issues/4977) - Redirect authenticated users from login view
* [#5048](https://github.com/netbox-community/netbox/issues/5048) - Show the device/VM name when editing a component
* [#5072](https://github.com/netbox-community/netbox/issues/5072) - Add REST API filters for image attachments
* [#5080](https://github.com/netbox-community/netbox/issues/5080) - Add 8P6C, 8P4C, 8P2C port types

### Bug Fixes

* [#5046](https://github.com/netbox-community/netbox/issues/5046) - Disabled plugin menu items are no longer clickable
* [#5063](https://github.com/netbox-community/netbox/issues/5063) - Fix "add device" link in rack elevations for opposite side of half-depth devices
* [#5074](https://github.com/netbox-community/netbox/issues/5074) - Fix inclusion of VC member interfaces when viewing VC master
* [#5078](https://github.com/netbox-community/netbox/issues/5078) - Fix assignment of existing IP addresses to interfaces via web UI
* [#5081](https://github.com/netbox-community/netbox/issues/5081) - Fix exception during webhook processing with custom select field
* [#5085](https://github.com/netbox-community/netbox/issues/5085) - Fix ordering by assignment in IP addresses table
* [#5087](https://github.com/netbox-community/netbox/issues/5087) - Restore label field when editing console server ports, power ports, and power outlets
* [#5089](https://github.com/netbox-community/netbox/issues/5089) - Redirect to device view after editing component
* [#5090](https://github.com/netbox-community/netbox/issues/5090) - Fix status display for console/power/interface connections
* [#5091](https://github.com/netbox-community/netbox/issues/5091) - Avoid KeyError when handling invalid table preferences
* [#5095](https://github.com/netbox-community/netbox/issues/5095) - Show assigned prefixes in VLANs list