### PR TITLE
fixes #5108 - correct the runreport management command to work with JobResult model

### DIFF
--- a/netbox/extras/management/commands/runreport.py
+++ b/netbox/extras/management/commands/runreport.py
@@ -1,7 +1,12 @@
+import time
+
+from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
-from extras.reports import get_reports
+from extras.choices import JobResultStatusChoices
+from extras.models import JobResult
+from extras.reports import get_reports, run_report
 
 
 class Command(BaseCommand):
@@ -24,11 +29,29 @@ class Command(BaseCommand):
                     self.stdout.write(
                         "[{:%H:%M:%S}] Running {}...".format(timezone.now(), report.full_name)
                     )
-                    report.run()
+
+                    report_content_type = ContentType.objects.get(app_label='extras', model='report')
+                    job_result = JobResult.enqueue_job(
+                        run_report,
+                        report.full_name,
+                        report_content_type,
+                        None
+                    )
+
+                    # Wait on the job to finish
+                    while job_result.status not in JobResultStatusChoices.TERMINAL_STATE_CHOICES:
+                        time.sleep(1)
+                        job_result = JobResult.objects.get(pk=job_result.pk)
 
                     # Report on success/failure
-                    status = self.style.ERROR('FAILED') if report.failed else self.style.SUCCESS('SUCCESS')
-                    for test_name, attrs in report.result.data.items():
+                    if job_result.status == JobResultStatusChoices.STATUS_FAILED:
+                        status = self.style.ERROR('FAILED')
+                    elif job_result == JobResultStatusChoices.STATUS_ERRORED:
+                        status = self.style.ERROR('ERRORED')
+                    else:
+                        status = self.style.SUCCESS('SUCCESS')
+
+                    for test_name, attrs in job_result.data.items():
                         self.stdout.write(
                             "\t{}: {} success, {} info, {} warning, {} failure".format(
                                 test_name, attrs['success'], attrs['info'], attrs['warning'], attrs['failure']
@@ -36,6 +59,9 @@ class Command(BaseCommand):
                         )
                     self.stdout.write(
                         "[{:%H:%M:%S}] {}: {}".format(timezone.now(), report.full_name, status)
+                    )
+                    self.stdout.write(
+                        "[{:%H:%M:%S}] {}: Duration {}".format(timezone.now(), report.full_name, job_result.duration)
                     )
 
         # Wrap things up


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5108 
<!--
    Please include a summary of the proposed changes below.
-->

This PR fixes the runreport management command to use the JobResult.enqueue_job() pattern. One could argue we could create the JobResult instance out of band and call `run_report()` directly, but I feel doing it the way I have enforces the API pattern in place elsewhere. Also given the realistic longevity of this command, I feel this works well enough.
