### PR TITLE
#3436: Support for bulk deletion via REST API

### DIFF
--- a/docs/rest-api/overview.md
+++ b/docs/rest-api/overview.md
@@ -529,3 +529,17 @@ Note that `DELETE` requests do not return any data: If successful, the API will 
 
 !!! note
     You can run `curl` with the verbose (`-v`) flag to inspect the HTTP response codes.
+
+### Deleting Multiple Objects
+
+NetBox supports the simultaneous deletion of multiple objects of the same type by issuing a `DELETE` request to the model's list endpoint with a list of dictionaries specifying the numeric ID of each object to be deleted. For example, to delete sites with IDs 10, 11, and 12, issue the following request:
+
+```no-highlight
+curl -s -X DELETE \
+-H "Authorization: Token $TOKEN" \
+http://netbox/api/dcim/sites/ \
+--data '[{"id": 10}, {"id": 11}, {"id": 12}]'
+```
+
+!!! note
+    The bulk deletion of objects is an all-or-none operation, meaning that if NetBox fails to delete any of the specified objects (e.g. due a dependency by a related object), the entire operation will be aborted and none of the objects will be deleted.

--- a/netbox/netbox/api.py
+++ b/netbox/netbox/api.py
@@ -4,9 +4,20 @@ from rest_framework import authentication, exceptions
 from rest_framework.pagination import LimitOffsetPagination
 from rest_framework.permissions import DjangoObjectPermissions, SAFE_METHODS
 from rest_framework.renderers import BrowsableAPIRenderer
+from rest_framework.schemas import coreapi
 from rest_framework.utils import formatting
 
 from users.models import Token
+
+
+def is_custom_action(action):
+    return action not in {
+        'retrieve', 'list', 'create', 'update', 'partial_update', 'destroy', 'bulk_destroy'
+    }
+
+
+# Monkey-patch DRF to treat bulk_destroy() as a non-custom action (see #3436)
+coreapi.is_custom_action = is_custom_action
 
 
 #

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -472,6 +472,13 @@ REST_FRAMEWORK = {
     'DEFAULT_VERSION': REST_FRAMEWORK_VERSION,
     'DEFAULT_VERSIONING_CLASS': 'rest_framework.versioning.AcceptHeaderVersioning',
     'PAGE_SIZE': PAGINATE_COUNT,
+    'SCHEMA_COERCE_METHOD_NAMES': {
+        # Default mappings
+        'retrieve': 'read',
+        'destroy': 'delete',
+        # Custom operations
+        'bulk_destroy': 'bulk_delete',
+    },
     'VIEW_NAME_FUNCTION': 'netbox.api.get_view_name',
 }
 


### PR DESCRIPTION
### Closes: #3436

- Extend ModelViewSet with BulkDestroyModelMixin to support bulk deletion of objects
- Modify OrderedDefaultRouter to accept `DELETE` operations on list routes
- Monkey-patch DRF's `is_custom_action()` to avoid SwaggerValidationError resulting from duplicate operation IDs
- Tests & documentation