### PR TITLE
Fixes 5194 logger should be initialized elsewhere.

### DIFF
--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -136,6 +136,9 @@ class RemoteUserBackend(_RemoteUserBackend):
 class LDAPBackend:
 
     def __new__(cls, *args, **kwargs):
+        # Enable logging for django_auth_ldap
+        ldap_logger = logging.getLogger('django_auth_ldap')
+        
         try:
             import ldap
             from django_auth_ldap.backend import LDAPBackend as LDAPBackend_, LDAPSettings
@@ -171,10 +174,5 @@ class LDAPBackend:
         # Optionally disable strict certificate checking
         if getattr(ldap_config, 'LDAP_IGNORE_CERT_ERRORS', False):
             ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
-
-        # Enable logging for django_auth_ldap
-        ldap_logger = logging.getLogger('django_auth_ldap')
-        ldap_logger.addHandler(logging.StreamHandler())
-        ldap_logger.setLevel(logging.DEBUG)
 
         return obj


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: 5194
<!--
    Please include a summary of the proposed changes below.
-->
After digging into the CPU usage in our environment I generated several flamegraphs to determine what function was using the CPU time.  I found most of the time being spent in addHandler on line 177.  The addHandler and setLevel I believe should be handled by the LOGGING definition in configuration.py or as documented [here](https://netbox.readthedocs.io/en/stable/installation/6-ldap/) in ldap_config.py.  I also moved the ldap_logger definition to the beginning of the __new__ method as this follow existing standards.  Please let me know if something else, like docs, should be changed and I'd be happy to make those changes.