### PR TITLE
5197: Limit main IPAddress view to a max of 10 duplicate addresses; add new duplicates view

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -527,7 +527,8 @@ class IPAddressView(ObjectView):
         # Exclude anycast IPs if this IP is anycast
         if ipaddress.role == IPAddressRoleChoices.ROLE_ANYCAST:
             duplicate_ips = duplicate_ips.exclude(role=IPAddressRoleChoices.ROLE_ANYCAST)
-        duplicate_ips_table = tables.IPAddressTable(list(duplicate_ips), orderable=False)
+        # Limit to a maximum of 10 duplicates displayed here
+        duplicate_ips_table = tables.IPAddressTable(duplicate_ips[:10], orderable=False)
 
         # Related IP table
         related_ips = IPAddress.objects.restrict(request.user, 'view').exclude(
@@ -547,6 +548,7 @@ class IPAddressView(ObjectView):
             'ipaddress': ipaddress,
             'parent_prefixes_table': parent_prefixes_table,
             'duplicate_ips_table': duplicate_ips_table,
+            'more_duplicate_ips': duplicate_ips.count() > 10,
             'related_ips_table': related_ips_table,
         })
 

--- a/netbox/templates/ipam/ipaddress.html
+++ b/netbox/templates/ipam/ipaddress.html
@@ -3,6 +3,7 @@
 {% load custom_links %}
 {% load helpers %}
 {% load plugins %}
+{% load render_table from django_tables2 %}
 
 {% block header %}
     <div class="row noprint">
@@ -159,7 +160,24 @@
 	<div class="col-md-8">
         {% include 'panel_table.html' with table=parent_prefixes_table heading='Parent Prefixes' %}
         {% if duplicate_ips_table.rows %}
-            {% include 'panel_table.html' with table=duplicate_ips_table heading='Duplicate IP Addresses' panel_class='danger' %}
+            {# Custom version of panel_table.html #}
+            <div class="panel panel-danger">
+                <div class="panel-heading">
+                    <strong>Duplicate IP Addresses</strong>
+                    {% if more_duplicate_ips %}
+                    <div class="pull-right">
+                        <a type="button" class="btn btn-primary btn-xs"
+                        {% if ipaddress.vrf %}
+                        href="{% url 'ipam:ipaddress_list' %}?address={{ ipaddress.address.ip }}&vrf_id={{ ipaddress.vrf.pk }}"
+                        {% else %}
+                        href="{% url 'ipam:ipaddress_list' %}?address={{ ipaddress.address.ip }}&vrf_id=null"
+                        {% endif %}
+                        >Show all</a>
+                    </div>
+                    {% endif %}
+                </div>
+                {% render_table duplicate_ips_table 'inc/table.html' %}
+            </div>
         {% endif %}
         {% include 'utilities/obj_table.html' with table=related_ips_table table_template='panel_table.html' heading='Related IP Addresses' panel_class='default noprint' %}
         {% plugin_right_page ipaddress %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5197 
<!--
    Please include a summary of the proposed changes below.
-->

- Limit number of duplicate addresses in main IPAddressView to a maximum of 10
- If more than 10 duplicate addresses exist, add a "View all..." link to the duplicate address table
- This link leads to a new IPAddressDuplicatesView which provides a paginated table of all duplicate IPs.

Tested with 1000 duplicate addresses; main view loads quickly as does the new view with default pagination settings.

![image](https://user-images.githubusercontent.com/5603551/94938475-ddf38500-049e-11eb-956a-e6e01e1b3f0e.png)

![image](https://user-images.githubusercontent.com/5603551/94938520-ea77dd80-049e-11eb-8870-2d4b079b77ba.png)

