### PR TITLE
Limit parent to same site when importing RackGroup

### DIFF
--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -370,6 +370,15 @@ class RackGroupForm(BootstrapMixin, forms.ModelForm):
             'site', 'parent', 'name', 'slug', 'description',
         )
 
+    def __init__(self, data=None, *args, **kwargs):
+        super().__init__(data, *args, **kwargs)
+
+        if data:
+
+            # Limit parent queryset by assigned site
+            params = {f"site__{self.fields['site'].to_field_name}": data.get('site')}
+            self.fields['parent'].queryset = self.fields['parent'].queryset.filter(**params)
+
 
 class RackGroupCSVForm(CSVModelForm):
     site = CSVModelChoiceField(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5247
<!--
    Please include a summary of the proposed changes below.
-->
If multiple sites have the same RackGroup name used within them,
import fails, this limits the parent queryset to parents in the site 
the group is added in. 