### PR TITLE
update: autocomplete attr on login fields

### DIFF
--- a/netbox/users/forms.py
+++ b/netbox/users/forms.py
@@ -13,7 +13,7 @@ class LoginForm(BootstrapMixin, AuthenticationForm):
         self.fields['username'].widget.attrs['placeholder'] = ''
         self.fields['password'].widget.attrs['placeholder'] = ''
         self.fields['username'].widget.attrs['autocomplete'] = 'off'
-        self.fields['password'].widget.attrs['autocomplete'] = 'off'
+        self.fields['password'].widget.attrs['autocomplete'] = 'new-password'
 
 
 class PasswordChangeForm(BootstrapMixin, DjangoPasswordChangeForm):

--- a/netbox/users/forms.py
+++ b/netbox/users/forms.py
@@ -12,6 +12,8 @@ class LoginForm(BootstrapMixin, AuthenticationForm):
 
         self.fields['username'].widget.attrs['placeholder'] = ''
         self.fields['password'].widget.attrs['placeholder'] = ''
+        self.fields['username'].widget.attrs['autocomplete'] = 'off'
+        self.fields['password'].widget.attrs['autocomplete'] = 'off'
 
 
 class PasswordChangeForm(BootstrapMixin, DjangoPasswordChangeForm):


### PR DESCRIPTION
Updated the login field autocomplete values in accordance with modern security best practices. 

According to MDN browsers ignore `autocomplete='off'` on password fields, but `autocomplete='new-password'` should do the trick. 

Source: https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion