### PR TITLE
Fixing #5282 - moving logging configuration from to configuration.py

### DIFF
--- a/docs/installation/6-ldap.md
+++ b/docs/installation/6-ldap.md
@@ -143,17 +143,29 @@ AUTH_LDAP_CACHE_TIMEOUT = 3600
 
 `systemctl restart netbox` restarts the Netbox service, and initiates any changes made to `ldap_config.py`. If there are syntax errors present, the NetBox process will not spawn an instance, and errors should be logged to `/var/log/messages`.
 
-For troubleshooting LDAP user/group queries, add the following lines to the start of `ldap_config.py` after `import ldap`.
+For troubleshooting LDAP user/group queries, add or merge the following [logging](/configuration/optional-settings.md#logging) configuration to `configuration.py`:
 
 ```python
-import logging, logging.handlers
 logfile = "/opt/netbox/logs/django-ldap-debug.log"
-my_logger = logging.getLogger('django_auth_ldap')
-my_logger.setLevel(logging.DEBUG)
-handler = logging.handlers.RotatingFileHandler(
-    logfile, maxBytes=1024 * 500, backupCount=5
-)
-my_logger.addHandler(handler)
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {
+        'netbox_auth_log': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': logfile,
+            'maxBytes': 1024 * 500,
+            'backupCount': 5,
+        },
+    },
+    'loggers': {
+        'django_auth_ldap': {
+            'handlers': ['netbox_auth_log'],
+            'level': 'DEBUG',
+        },
+    },
+}
 ```
 
 Ensure the file and path specified in logfile exist and are writable and executable by the application service account. Restart the netbox service and attempt to log into the site to trigger log entries to this file.

--- a/docs/installation/6-ldap.md
+++ b/docs/installation/6-ldap.md
@@ -146,15 +146,14 @@ AUTH_LDAP_CACHE_TIMEOUT = 3600
 For troubleshooting LDAP user/group queries, add or merge the following [logging](/configuration/optional-settings.md#logging) configuration to `configuration.py`:
 
 ```python
-logfile = "/opt/netbox/logs/django-ldap-debug.log"
 LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "handlers": {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
         'netbox_auth_log': {
             'level': 'DEBUG',
             'class': 'logging.handlers.RotatingFileHandler',
-            'filename': logfile,
+            'filename': '/opt/netbox/logs/django-ldap-debug.log',
             'maxBytes': 1024 * 500,
             'backupCount': 5,
         },

--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -172,9 +172,4 @@ class LDAPBackend:
         if getattr(ldap_config, 'LDAP_IGNORE_CERT_ERRORS', False):
             ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
 
-        # Enable logging for django_auth_ldap
-        ldap_logger = logging.getLogger('django_auth_ldap')
-        ldap_logger.addHandler(logging.StreamHandler())
-        ldap_logger.setLevel(logging.INFO)
-
         return obj


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5282
<!--
    Please include a summary of the proposed changes below.
-->

This PR removes the logging configuration from authentication.py and moves it to configuration.py with all other logging config.  The troubleshooting LDAP docs have also been updated to reflect the change.