### PR TITLE
Fix SyntaxWarning errors on run

### DIFF
--- a/netbox/utilities/api.py
+++ b/netbox/utilities/api.py
@@ -113,7 +113,7 @@ class ChoiceField(serializers.Field):
         return super().validate_empty_values(data)
 
     def to_representation(self, obj):
-        if obj is '':
+        if obj == '':
             return None
         return OrderedDict([
             ('value', obj),
@@ -121,7 +121,7 @@ class ChoiceField(serializers.Field):
         ])
 
     def to_internal_value(self, data):
-        if data is '':
+        if data == '':
             if self.allow_blank:
                 return data
             raise ValidationError("This field may not be blank.")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: <#5296>
<!--
    Please include a summary of the proposed changes below.
-->

This fixes the SyntaxWarning errors when running netbox.

>  /opt/netbox/netbox/utilities/api.py:116: SyntaxWarning: "is" with a literal. Did you mean "=="?
>   if obj is '':
> /opt/netbox/netbox/utilities/api.py:124: SyntaxWarning: "is" with a literal. Did you mean "=="?
>   if data is '':