### PR TITLE
Update 6-ldap.md - change ldap config example

### DIFF
--- a/docs/installation/6-ldap.md
+++ b/docs/installation/6-ldap.md
@@ -61,8 +61,8 @@ AUTH_LDAP_CONNECTION_OPTIONS = {
 }
 
 # Set the DN and password for the NetBox service account.
-AUTH_LDAP_BIND_DN = "CN=NETBOXSA, OU=Service Accounts,DC=example,DC=com"
-AUTH_LDAP_BIND_PASSWORD = "demo"
+AUTH_LDAP_BIND_DN = 'CN=NETBOXSA, OU=Service Accounts,DC=example,DC=com'
+AUTH_LDAP_BIND_PASSWORD = 'demo'
 
 # Include this setting if you want to ignore certificate errors. This might be needed to accept a self-signed cert.
 # Note that this is a NetBox-specific setting which sets:


### PR DESCRIPTION
When going through the set up I kept getting the error (from logging) "Authentication failed for USERNAME: failed to map the username to DN" I could login with the service account 'netbox' I created to bind. I changed to password of the user to match the service account and it went straight through. Looks like the bind password was being used to login and not the users password. Checked the doc on django https://django-auth-ldap.readthedocs.io/en/latest/reference.html and they have single quotes.

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: <LDAP Setup>
<!--
    Please include a summary of the proposed changes below.
-->
