### PR TITLE
Show virtual machines on Cluster page

### DIFF
--- a/netbox/templates/virtualization/cluster.html
+++ b/netbox/templates/virtualization/cluster.html
@@ -151,8 +151,25 @@
                 </form>
             {% endif %}
         </div>
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <strong>Virtual Machines</strong>
+            </div>
+            {% include 'responsive_table.html' with table=virtual_machine_table %}
+            {% if perms.virtualization.change_cluster %}
+                <div class="panel-footer noprint">
+                    <div class="pull-right">
+                        <a href="{% url 'virtualization:cluster_add_virtualmachines' pk=cluster.pk %}?site={{ cluster.site.pk }}" class="btn btn-primary btn-xs">
+                            <span class="glyphicon glyphicon-plus" aria-hidden="true"></span>
+                            Add virtual machines
+                        </a>
+                    </div>
+                    <div class="clearfix"></div>
+                </div>
+            {% endif %}
+        </div>
         {% plugin_right_page cluster %}
-	</div>
+    </div>
 </div>
 <div class="row">
     <div class="col-md-12">

--- a/netbox/templates/virtualization/cluster_add_virtualmachines.html
+++ b/netbox/templates/virtualization/cluster_add_virtualmachines.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+{% load static %}
+{% load form_helpers %}
+
+{% block content %}
+    <form action="." method="post" class="form form-horizontal">
+        {% csrf_token %}
+        {% for field in form.hidden_fields %}
+            {{ field }}
+        {% endfor %}
+        <div class="row">
+            <div class="col-md-6 col-md-offset-3">
+                <h3>{% block title %}Add Virtual Machines to Cluster {{ cluster }}{% endblock %}</h3>
+                {% if form.non_field_errors %}
+                    <div class="panel panel-danger">
+                        <div class="panel-heading"><strong>Errors</strong></div>
+                        <div class="panel-body">
+                            {{ form.non_field_errors }}
+                        </div>
+                    </div>
+                {% endif %}
+                <div class="panel panel-default">
+                    <div class="panel-heading"><strong>Virtual Machine Selection</strong></div>
+                    <div class="panel-body">
+                        {% render_form form %}
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="row">
+            <div class="col-md-6 col-md-offset-3 text-right noprint">
+                <button type="submit" name="_add" class="btn btn-primary">Add Virtual Machines</button>
+                <a href="{{ return_url }}" class="btn btn-default">Cancel</a>
+            </div>
+        </div>
+    </form>
+{% endblock %}

--- a/netbox/virtualization/forms.py
+++ b/netbox/virtualization/forms.py
@@ -276,6 +276,28 @@ class ClusterRemoveDevicesForm(ConfirmationForm):
     )
 
 
+class ClusterAddVirtualMachinesForm(BootstrapMixin, forms.Form):
+    virtualmachines = DynamicModelMultipleChoiceField(
+        queryset=VirtualMachine.objects.all(),
+    )
+
+    class Meta:
+        fields = [
+            'virtualmachines',
+        ]
+
+    def __init__(self, cluster, *args, **kwargs):
+
+        self.cluster = cluster
+
+        super().__init__(*args, **kwargs)
+
+        self.fields['virtualmachines'].choices = []
+
+    def clean(self):
+        super().clean()
+
+
 #
 # Virtual Machines
 #

--- a/netbox/virtualization/urls.py
+++ b/netbox/virtualization/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     path('clusters/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='cluster_changelog', kwargs={'model': Cluster}),
     path('clusters/<int:pk>/devices/add/', views.ClusterAddDevicesView.as_view(), name='cluster_add_devices'),
     path('clusters/<int:pk>/devices/remove/', views.ClusterRemoveDevicesView.as_view(), name='cluster_remove_devices'),
+    path('clusters/<int:pk>/virtual-machines/add/', views.ClusterAddVirtualMachinesView.as_view(), name='cluster_add_virtualmachines'),
 
     # Virtual machines
     path('virtual-machines/', views.VirtualMachineListView.as_view(), name='virtualmachine_list'),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5425
<!--
    Please include a summary of the proposed changes below.
-->
This PR fixes the above issue by adding a table of the associated virtual machines to the Cluster detail page. It also adds an "add virtual machines" button to quickly add virtual machines to a cluster.