### PR TITLE
Clarify REMOTE_AUTH_HEADER documentation

### DIFF
--- a/docs/configuration/optional-settings.md
+++ b/docs/configuration/optional-settings.md
@@ -460,7 +460,7 @@ NetBox can be configured to support remote user authentication by inferring user
 
 Default: `'HTTP_REMOTE_USER'`
 
-When remote user authentication is in use, this is the name of the HTTP header which informs NetBox of the currently authenticated user. (Requires `REMOTE_AUTH_ENABLED`.)
+When remote user authentication is in use, this is the name of the HTTP header which informs NetBox of the currently authenticated user. For example, to use the request header `X-Remote-User` it needs to be set to `HTTP_X_REMOTE_USER`. (Requires `REMOTE_AUTH_ENABLED`.)
 
 ---
 


### PR DESCRIPTION
### Fixes: #5364

The documentation doesn't have an example on how to properly use the `REMOTE_AUTH_HEADER ` config setting. This PR adds an example (see #5364).