### PR TITLE
Adds support for multi select custom fields

### DIFF
--- a/docs/release-notes/version-2.10.md
+++ b/docs/release-notes/version-2.10.md
@@ -62,6 +62,7 @@ All end-to-end cable paths are now cached using the new CablePath backend model.
 
 ### Enhancements
 
+* [#5451](https://github.com/netbox-community/netbox/issues/5451) - Add ability to create multi selection custom fields
 * [#609](https://github.com/netbox-community/netbox/issues/609) - Add min/max value and regex validation for custom fields
 * [#1503](https://github.com/netbox-community/netbox/issues/1503) - Allow assigment of secrets to virtual machines
 * [#1692](https://github.com/netbox-community/netbox/issues/1692) - Allow assigment of inventory items to parent items in web UI

--- a/netbox/extras/admin.py
+++ b/netbox/extras/admin.py
@@ -114,7 +114,7 @@ class CustomFieldAdmin(admin.ModelAdmin):
         }),
         ('Choices', {
             'description': 'A selection field must have two or more choices assigned to it.',
-            'fields': ('choices',)
+            'fields': ('choices','multiple_selection')
         })
     )
 

--- a/netbox/extras/tests/test_customfields.py
+++ b/netbox/extras/tests/test_customfields.py
@@ -90,6 +90,38 @@ class CustomFieldTest(TestCase):
         # Delete the custom field
         cf.delete()
 
+    def test_multiple_select_field(self):
+        obj_type = ContentType.objects.get_for_model(Site)
+
+        # Create a custom field
+        cf = CustomField(
+            type=CustomFieldTypeChoices.TYPE_SELECT,
+            name='my_field',
+            required=False,
+            choices=['Option A', 'Option B', 'Option C'],
+            multiple_selection=True
+        )
+        cf.save()
+        cf.content_types.set([obj_type])
+
+        # Assign a value to the first Site
+        site = Site.objects.first()
+        site.custom_field_data[cf.name] = ['Option A', 'Option B']
+        site.save()
+
+        # Retrieve the stored value
+        site.refresh_from_db()
+        self.assertEqual(site.custom_field_data[cf.name], ['Option A', 'Option B'])
+
+        # Delete the stored value
+        site.custom_field_data.pop(cf.name)
+        site.save()
+        site.refresh_from_db()
+        self.assertIsNone(site.custom_field_data.get(cf.name))
+
+        # Delete the custom field
+        cf.delete()
+
 
 class CustomFieldManagerTest(TestCase):
 

--- a/netbox/templates/inc/custom_fields_panel.html
+++ b/netbox/templates/inc/custom_fields_panel.html
@@ -15,6 +15,8 @@
                                 <i class="mdi mdi-close-thick text-danger" title="False"></i>
                             {% elif field.type == 'url' and value %}
                                 <a href="{{ value }}">{{ value|truncatechars:70 }}</a>
+                            {% elif field.type == 'select' and field.multiple_selection == True and value is not None %}
+                                {{ value|join:", " }}
                             {% elif value is not None %}
                                 {{ value }}
                             {% elif field.required %}


### PR DESCRIPTION
### Fixes: #5451

Since in 2.10 custom fields are now represented as JSON, it is quite easy to allow multiple selection option custom fields. Before the JSON change, this feature would have required a many-to-many relationship.

For CSV importing the field, I'm not too sure how feasibile it would be for multiple choices, looking for some suggestions on this.