### PR TITLE
Docs fix: Django templating language is no longer supported for export templates

### DIFF
--- a/docs/additional-features/export-templates.md
+++ b/docs/additional-features/export-templates.md
@@ -4,10 +4,7 @@ NetBox allows users to define custom templates that can be used when exporting o
 
 Each export template is associated with a certain type of object. For instance, if you create an export template for VLANs, your custom template will appear under the "Export" button on the VLANs list.
 
-Export templates may be written in Jinja2 or [Django's template language](https://docs.djangoproject.com/en/stable/ref/templates/language/), which is very similar to Jinja2.
-
-!!! warning
-    Support for Django's native templating logic will be removed in NetBox v2.10.
+Export templates must be written in [Jinja2](https://jinja.palletsprojects.com/).
 
 The list of objects returned from the database when rendering an export template is stored in the `queryset` variable, which you'll typically want to iterate through using a `for` loop. Object properties can be access by name. For example:
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: n/a
<!--
    Please include a summary of the proposed changes below.
-->

Export templates dropped support for Django templating in d1071b79e3a1a4ce2d8ba8c0a4eba37f24f3e626 but the docs weren't updated to reflect this. This addresses that minor docs issue.