### PR TITLE
Employ signals to update child objects when RackGroup/Rack site assignment changes

### DIFF
--- a/netbox/dcim/models/racks.py
+++ b/netbox/dcim/models/racks.py
@@ -326,22 +326,6 @@ class Rack(ChangeLoggedModel, CustomFieldModel):
                         'group': "Rack group must be from the same site, {}.".format(self.site)
                     })
 
-    def save(self, *args, **kwargs):
-
-        # Record the original site assignment for this rack.
-        _site_id = None
-        if self.pk:
-            _site_id = Rack.objects.get(pk=self.pk).site_id
-
-        super().save(*args, **kwargs)
-
-        # Update racked devices if the assigned Site has been changed.
-        if _site_id is not None and self.site_id != _site_id:
-            devices = Device.objects.filter(rack=self)
-            for device in devices:
-                device.site = self.site
-                device.save()
-
     def to_csv(self):
         return (
             self.site.name,

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -2,13 +2,12 @@ import logging
 
 from cacheops import invalidate_obj
 from django.contrib.contenttypes.models import ContentType
-from django.db.models import Q
 from django.db.models.signals import post_save, post_delete, pre_delete
 from django.db import transaction
 from django.dispatch import receiver
 
 from .choices import CableStatusChoices
-from .models import Cable, CablePath, Device, PathEndpoint, Rack, RackGroup, VirtualChassis
+from .models import Cable, CablePath, Device, PathEndpoint, PowerPanel, Rack, RackGroup, VirtualChassis
 
 
 def create_cablepath(node):
@@ -54,6 +53,9 @@ def handle_rackgroup_site_change(instance, created, **kwargs):
         for rack in Rack.objects.filter(group=instance).exclude(site=instance.site):
             rack.site = instance.site
             rack.save()
+        for powerpanel in PowerPanel.objects.filter(rack_group=instance).exclude(site=instance.site):
+            powerpanel.site = instance.site
+            powerpanel.save()
 
 
 @receiver(post_save, sender=Rack)

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -29,6 +29,8 @@ class RackGroupTestCase(TestCase):
         rack1 = Rack.objects.create(site=site_a, group=rackgroup_a1, name='Rack 1')
         rack2 = Rack.objects.create(site=site_a, group=rackgroup_a2, name='Rack 2')
 
+        powerpanel1 = PowerPanel.objects.create(site=site_a, rack_group=rackgroup_a1, name='Power Panel 1')
+
         # Move RackGroup A1 to Site B
         rackgroup_a1.site = site_b
         rackgroup_a1.save()
@@ -38,6 +40,7 @@ class RackGroupTestCase(TestCase):
         self.assertEqual(RackGroup.objects.get(pk=rackgroup_a2.pk).site, site_b)
         self.assertEqual(Rack.objects.get(pk=rack1.pk).site, site_b)
         self.assertEqual(Rack.objects.get(pk=rack2.pk).site, site_b)
+        self.assertEqual(PowerPanel.objects.get(pk=powerpanel1.pk).site, site_b)
 
 
 class RackTestCase(TestCase):


### PR DESCRIPTION
### Fixes: #5311

- Remove custom logic from `Rack.save()`
- Add signal receivers to handle site assignment changes for racks and rack groups
- Add tests to cover all cases defined in #5311