### PR TITLE
Report inconsistent values when migrating custom field data

### DIFF
--- a/netbox/extras/migrations/0051_migrate_customfields.py
+++ b/netbox/extras/migrations/0051_migrate_customfields.py
@@ -67,7 +67,7 @@ def migrate_customfieldvalues(apps, schema_editor):
         cf_data = model.objects.filter(pk=cfv.obj_id).values('custom_field_data').first()
         try:
             cf_data['custom_field_data'][cfv.field.name] = deserialize_value(cfv.field, cfv.serialized_value)
-        except ValueError as e:
+        except Exception as e:
             print(f'{cfv.field.name} ({cfv.field.type}): {cfv.serialized_value} ({cfv.pk})')
             raise e
         model.objects.filter(pk=cfv.obj_id).update(**cf_data)


### PR DESCRIPTION
### Fixes: #5573

During migration,  if a customfieldvalue references a non-existent object, it bombs out with:

```
TypeError: 'NoneType' object is not subscriptable
```

but gives no indication of what data item caused the error.

With this change, the exception still occurs, but the offending data item is printed first (as was already the case for `ValueError` only).