### PR TITLE
Fixes #5579: mark `ie` and `nie` filter exprs as insensitive

### DIFF
--- a/docs/rest-api/filtering.md
+++ b/docs/rest-api/filtering.md
@@ -78,8 +78,8 @@ String based (char) fields (Name, Address, etc) support these lookup expressions
 - `nisw` - negated case insensitive starts with
 - `iew` - case insensitive ends with
 - `niew` - negated case insensitive ends with
-- `ie` - case sensitive exact match
-- `nie` - negated case sensitive exact match
+- `ie` - case insensitive exact match
+- `nie` - negated case insensitive exact match
 
 ### Foreign Keys & Other Fields
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5579 

mark `ie` and `nie` filter exprs as insensitive
In the documentation the `ie` and `nie` filter expressions are incorrectly marked as senstive matches when they are in fact insensitive.
<!--
    Please include a summary of the proposed changes below.
-->
