### PR TITLE
Closes 5586: Adds name, master, and master_id filtering

### DIFF
--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -1016,6 +1016,16 @@ class VirtualChassisFilterSet(BaseFilterSet):
         method='search',
         label='Search',
     )
+    master_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=Device.objects.all(),
+        label='Master (ID)',
+    )
+    master = django_filters.ModelMultipleChoiceFilter(
+        field_name='master__name',
+        queryset=Device.objects.all(),
+        to_field_name='name',
+        label='Master (name)',
+    )
     region_id = TreeNodeMultipleChoiceFilter(
         queryset=Region.objects.all(),
         field_name='master__site__region',
@@ -1055,7 +1065,7 @@ class VirtualChassisFilterSet(BaseFilterSet):
 
     class Meta:
         model = VirtualChassis
-        fields = ['id', 'domain']
+        fields = ['id', 'domain', 'name']
 
     def search(self, queryset, name, value):
         if not value.strip():

--- a/netbox/dcim/tests/test_filters.py
+++ b/netbox/dcim/tests/test_filters.py
@@ -2399,9 +2399,9 @@ class VirtualChassisTestCase(TestCase):
         Device.objects.bulk_create(devices)
 
         virtual_chassis = (
-            VirtualChassis(master=devices[0], domain='Domain 1'),
-            VirtualChassis(master=devices[2], domain='Domain 2'),
-            VirtualChassis(master=devices[4], domain='Domain 3'),
+            VirtualChassis(name='VC 1', master=devices[0], domain='Domain 1'),
+            VirtualChassis(name='VC 2', master=devices[2], domain='Domain 2'),
+            VirtualChassis(name='VC 3', master=devices[4], domain='Domain 3'),
         )
         VirtualChassis.objects.bulk_create(virtual_chassis)
 
@@ -2415,6 +2415,17 @@ class VirtualChassisTestCase(TestCase):
 
     def test_domain(self):
         params = {'domain': ['Domain 1', 'Domain 2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_master(self):
+        masters = Device.objects.all()
+        params = {'master_id': [masters[0].pk, masters[2].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'master': [masters[0].name, masters[2].name]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_name(self):
+        params = {'name': ['VC 1', 'VC 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5586 
<!--
    Please include a summary of the proposed changes below.
-->

This implements filtering logic on `name`, `master -> name`, and `master_id`.

Updated the corresponding tests by adding `name` to the VC objects in the tests, and then referencing the correct VC devices that are added as master's within the VCs.
