### PR TITLE
Implemented WebRequestContext for emulating HTTP requests for ORM operations

### DIFF
--- a/docs/administration/netbox-shell.md
+++ b/docs/administration/netbox-shell.md
@@ -201,3 +201,19 @@ To delete multiple objects at once, call `delete()` on a filtered queryset. It's
 
 !!! warning
     Deletions are immediate and irreversible. Always consider the impact of deleting objects carefully before calling `delete()` on an instance or queryset.
+
+## Change Logging and Webhooks
+
+Note that NetBox's change logging and webhook processing features operate under the context of an HTTP request. As such, these functions do not work automatically when using the ORM directly, either through the nbshell or otherwise. A special context manager is provided to allow these features to operate under an emulated HTTP request context. This context manager must be explicitly invoked for change log entries and webhooks to be created when interacting with objects through the ORM. Here is an example using the `WebRequestContext` context manager within the nbshell:
+
+```
+>>> from dcim.models import Site
+>>> from extras.context_managers import WebRequestContext
+>>> user = User.objects.get(username="andersonjd")
+>>> with WebRequestContext(user):
+...     lax = Site(name="LAX")
+...     lax.clean()
+...     lax.save()
+```
+
+A `User` object must be provided. A `WSGIRequest` may optionally be passed and one will automatically be created if not provided.

--- a/netbox/extras/tests/test_context_managers.py
+++ b/netbox/extras/tests/test_context_managers.py
@@ -1,0 +1,76 @@
+import django_rq
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.auth.models import User
+from django.test import TestCase
+
+from dcim.models import Site
+from extras.choices import *
+from extras.context_managers import WebRequestContext
+from extras.models import ObjectChange, Webhook
+
+
+class WebRequestContextTestCase(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            username='jacob',
+            email='jacob@example.com',
+            password='top_secret'
+        )
+
+        site_ct = ContentType.objects.get_for_model(Site)
+        DUMMY_URL = "http://localhost/"
+        DUMMY_SECRET = "LOOKATMEIMASECRETSTRING"
+
+        webhooks = Webhook.objects.bulk_create((
+            Webhook(name='Site Create Webhook', type_create=True, payload_url=DUMMY_URL, secret=DUMMY_SECRET),
+        ))
+        for webhook in webhooks:
+            webhook.content_types.set([site_ct])
+
+        self.queue = django_rq.get_queue('default')
+        self.queue.empty()  # Begin each test with an empty queue
+
+    def test_user_object_type_error(self):
+
+        with self.assertRaises(TypeError):
+            with WebRequestContext("a string is not a user object"):
+                pass
+
+    def test_request_object_type_error(self):
+
+        class NotARequest:
+            pass
+
+        with self.assertRaises(TypeError):
+            with WebRequestContext(self.user, NotARequest()):
+                pass
+
+    def test_change_log_created(self):
+
+        with WebRequestContext(self.user):
+            site = Site(name='Test Site 1')
+            site.save()
+
+        site = Site.objects.get(name='Test Site 1')
+        oc_list = ObjectChange.objects.filter(
+            changed_object_type=ContentType.objects.get_for_model(Site),
+            changed_object_id=site.pk
+        ).order_by('pk')
+        self.assertEqual(len(oc_list), 1)
+        self.assertEqual(oc_list[0].changed_object, site)
+        self.assertEqual(oc_list[0].action, ObjectChangeActionChoices.ACTION_CREATE)
+
+    def test_change_webhook_enqueued(self):
+
+        with WebRequestContext(self.user):
+            site = Site(name='Test Site 2')
+            site.save()
+
+        # Verify that a job was queued for the object creation webhook
+        site = Site.objects.get(name='Test Site 2')
+        self.assertEqual(self.queue.count, 1)
+        job = self.queue.jobs[0]
+        self.assertEqual(job.args[0], Webhook.objects.get(type_create=True))
+        self.assertEqual(job.args[1]['id'], site.pk)
+        self.assertEqual(job.args[2], 'site')


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #4932
<!--
    Please include a summary of the proposed changes below.
-->

This implements a new `WebRequestContext` context manager for emulating HTTP requests for ORM use. The primary need is for easily enabling change logging and webhooks when interacting with the ORM directly, and outside of the context of an HTTP request.

You will likely note the use of `RequestFactory` for creating the "fake" request object. I feel this is the safest way of doing this because it ensures we don't break anything in the future if we require more context from the request than just the user. When looking at the internals of `RequestFactory`, there is nothing specific to its primary usage in testing that should cause any issues here. I started down the path of doing pretty much the same thing it does to create a bare-bones `WSGIRequest` object and then decided this would be a better, cleaner approach.
