### PR TITLE
Proposal to add QSFP+ (64GFC) FibreChannel Interface option re FR #5630

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -686,7 +686,7 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_8GFC_SFP_PLUS = '8gfc-sfpp'
     TYPE_16GFC_SFP_PLUS = '16gfc-sfpp'
     TYPE_32GFC_SFP28 = '32gfc-sfp28'
-    TYPE_64GFC_SFP_PLUS = '64gfc-sfpp'
+    TYPE_64GFC_QSFP_PLUS = '64gfc-sfpp'
     TYPE_128GFC_QSFP28 = '128gfc-sfp28'
 
     # InfiniBand
@@ -802,7 +802,7 @@ class InterfaceTypeChoices(ChoiceSet):
                 (TYPE_8GFC_SFP_PLUS, 'SFP+ (8GFC)'),
                 (TYPE_16GFC_SFP_PLUS, 'SFP+ (16GFC)'),
                 (TYPE_32GFC_SFP28, 'SFP28 (32GFC)'),
-                (TYPE_64GFC_SFP_PLUS, 'QSFP+ (64GFC)'),
+                (TYPE_64GFC_QSFP_PLUS, 'QSFP+ (64GFC)'),
                 (TYPE_128GFC_QSFP28, 'QSFP28 (128GFC)'),
             )
         ),

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -686,7 +686,7 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_8GFC_SFP_PLUS = '8gfc-sfpp'
     TYPE_16GFC_SFP_PLUS = '16gfc-sfpp'
     TYPE_32GFC_SFP28 = '32gfc-sfp28'
-    TYPE_64GFC_QSFP_PLUS = '64gfc-sfpp'
+    TYPE_64GFC_QSFP_PLUS = '64gfc-qsfpp'
     TYPE_128GFC_QSFP28 = '128gfc-sfp28'
 
     # InfiniBand

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -686,6 +686,7 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_8GFC_SFP_PLUS = '8gfc-sfpp'
     TYPE_16GFC_SFP_PLUS = '16gfc-sfpp'
     TYPE_32GFC_SFP28 = '32gfc-sfp28'
+    TYPE_64GFC_SFP_PLUS = '64gfc-sfpp'
     TYPE_128GFC_QSFP28 = '128gfc-sfp28'
 
     # InfiniBand
@@ -801,6 +802,7 @@ class InterfaceTypeChoices(ChoiceSet):
                 (TYPE_8GFC_SFP_PLUS, 'SFP+ (8GFC)'),
                 (TYPE_16GFC_SFP_PLUS, 'SFP+ (16GFC)'),
                 (TYPE_32GFC_SFP28, 'SFP28 (32GFC)'),
+                (TYPE_64GFC_SFP_PLUS, 'QSFPP (64GFC)'),
                 (TYPE_128GFC_QSFP28, 'QSFP28 (128GFC)'),
             )
         ),

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -802,7 +802,7 @@ class InterfaceTypeChoices(ChoiceSet):
                 (TYPE_8GFC_SFP_PLUS, 'SFP+ (8GFC)'),
                 (TYPE_16GFC_SFP_PLUS, 'SFP+ (16GFC)'),
                 (TYPE_32GFC_SFP28, 'SFP28 (32GFC)'),
-                (TYPE_64GFC_SFP_PLUS, 'QSFPP (64GFC)'),
+                (TYPE_64GFC_SFP_PLUS, 'QSFP+ (64GFC)'),
                 (TYPE_128GFC_QSFP28, 'QSFP28 (128GFC)'),
             )
         ),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5630 
<!--
    Please include a summary of the proposed changes below.
-->
This proposal will add the QSFP+ (64GFC) interface type for FibreChannel into the netbox/dcim/choices.py script