### PR TITLE
Indicate when cable length is not definitive

### DIFF
--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -480,13 +480,17 @@ class CablePath(models.Model):
 
     def get_total_length(self):
         """
-        Return the sum of the length of each cable in the path.
+        Return a tuple containing the sum of the length of each cable in the path
+        and a flag indicating whether the length is definitive.
         """
         cable_ids = [
             # Starting from the first element, every third element in the path should be a Cable
             decompile_path_node(self.path[i])[1] for i in range(0, len(self.path), 3)
         ]
-        return Cable.objects.filter(id__in=cable_ids).aggregate(total=Sum('_abs_length'))['total']
+        cables = Cable.objects.filter(id__in=cable_ids, _abs_length__isnull=False)
+        total_length = cables.aggregate(total=Sum('_abs_length'))['total']
+        is_definitive = len(cables) == len(cable_ids)
+        return (total_length, is_definitive)
 
     def get_split_nodes(self):
         """

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -2134,10 +2134,14 @@ class PathTraceView(generic.ObjectView):
             else:
                 path = related_paths.first()
 
+        # Get the total length of the cable and whether the length is definitive (fully defined)
+        total_length, is_definitive = path.get_total_length if path else (None, False)
+
         return {
             'path': path,
             'related_paths': related_paths,
-            'total_length': path.get_total_length() if path else None,
+            'total_length': total_length,
+            'is_definitive': is_definitive
         }
 
 

--- a/netbox/templates/dcim/cable_trace.html
+++ b/netbox/templates/dcim/cable_trace.html
@@ -69,7 +69,7 @@
                                     <h5>Total segments: {{ traced_path|length }}</h5>
                                     <h5>Total length:
                                         {% if total_length %}
-                                            {{ total_length|floatformat:"-2" }} Meters /
+                                            {% if not is_definitive %}&gt;{% endif %}{{ total_length|floatformat:"-2" }} Meters /
                                             {{ total_length|meters_to_feet|floatformat:"-2" }} Feet
                                         {% else %}
                                             <span class="text-muted">N/A</span>


### PR DESCRIPTION
indicate to users whether the cable length is
accurate or not.

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5650
<!--
    Please include a summary of the proposed changes below.
-->
CablePath.get_total_length() retrieves Cable objects where _abs_length is not null as well as the id being in the list of IDs for the path. If the number of cables returned is equal to the number of cable IDs in the path, all cables have a length and the length is determined to be definitive.

The total length and whether it is definitive is returned in a tuple.

PathTraceView.get_extra_context handles the new is_definitive flag and returns that to the template.

The cable_trace template checks whether is_definitive is false and if it is, prefixes the total length with a greater than sign indicting that the length of the cable is at least as long as the length shown.

When cable length is definitive:

![Screenshot 2021-01-22 at 16 57 44](https://user-images.githubusercontent.com/1878544/105520850-1bd91b00-5cd3-11eb-9fd9-17e02bea138d.png)
 
When one or more cables have no length defined:

![Screenshot 2021-01-22 at 16 58 08](https://user-images.githubusercontent.com/1878544/105520924-2f848180-5cd3-11eb-9417-76ae5d1e8621.png)