### PR TITLE
fix: add missing password when using redis in sentinel mode

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -391,6 +391,7 @@ if CACHING_REDIS_USING_SENTINEL:
         'locations': CACHING_REDIS_SENTINELS,
         'service_name': CACHING_REDIS_SENTINEL_SERVICE,
         'db': CACHING_REDIS_DATABASE,
+        'password': CACHING_REDIS_PASSWORD,
     }
 else:
     if CACHING_REDIS_SSL:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5752
<!--
    Please include a summary of the proposed changes below.
-->

If you use redis with sentinel and authentication, cacheops has no information about the password, whereas without sentinel it's fine.

Here is the generated runtime issue

```
/opt/netbox/venv/lib/python3.8/site-packages/cacheops/redis.py:19: RuntimeWarning: The cacheops cache is unreachable! Error: Authentication required.
  warnings.warn("The cacheops cache is unreachable! Error: %s" % e, RuntimeWarning)
```
publishing the password field solve the issue