### PR TITLE
Add missing libjpeg-dev dependency in docs

### DIFF
--- a/docs/installation/3-netbox.md
+++ b/docs/installation/3-netbox.md
@@ -12,7 +12,7 @@ Begin by installing all system packages required by NetBox and its dependencies.
 ### Ubuntu
 
 ```no-highlight
-sudo apt install -y python3 python3-pip python3-venv python3-dev build-essential libxml2-dev libxslt1-dev libffi-dev libpq-dev libssl-dev zlib1g-dev
+sudo apt install -y python3 python3-pip python3-venv python3-dev build-essential libxml2-dev libxslt1-dev libffi-dev libpq-dev libssl-dev zlib1g-dev libjpeg-dev
 ```
 
 ### CentOS


### PR DESCRIPTION
Fixes https://github.com/netbox-community/netbox/issues/5803

### Fixes: #5803 
Add missing libjpeg-dev dependency in installation docs to avoid Pillow build fails.