### PR TITLE
Fix Primary IP Sorting Issues for Devices and VMs

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -1,5 +1,6 @@
 import django_tables2 as tables
 from django_tables2.utils import Accessor
+from django.conf import settings
 
 from dcim.models import (
     ConsolePort, ConsoleServerPort, Device, DeviceBay, DeviceRole, FrontPort, Interface, InventoryItem, Platform,
@@ -127,11 +128,18 @@ class DeviceTable(BaseTable):
         verbose_name='Type',
         text=lambda record: record.device_type.display_name
     )
-    primary_ip = tables.Column(
-        linkify=True,
-        order_by=('primary_ip6', 'primary_ip4'),
-        verbose_name='IP Address'
-    )
+    if settings.PREFER_IPV4:
+        primary_ip = tables.Column(
+            linkify=True,
+            order_by=('primary_ip4', 'primary_ip6'),
+            verbose_name='IP Address'
+        )
+    else:
+        primary_ip = tables.Column(
+            linkify=True,
+            order_by=('primary_ip6', 'primary_ip4'),
+            verbose_name='IP Address'
+        )
     primary_ip4 = tables.Column(
         linkify=True,
         verbose_name='IPv4 Address'

--- a/netbox/virtualization/tables.py
+++ b/netbox/virtualization/tables.py
@@ -1,5 +1,5 @@
 import django_tables2 as tables
-
+from django.conf import settings
 from dcim.tables.devices import BaseInterfaceTable
 from tenancy.tables import COL_TENANT
 from utilities.tables import (
@@ -125,10 +125,18 @@ class VirtualMachineDetailTable(VirtualMachineTable):
         linkify=True,
         verbose_name='IPv6 Address'
     )
-    primary_ip = tables.Column(
-        linkify=True,
-        verbose_name='IP Address'
-    )
+    if settings.PREFER_IPV4:
+        primary_ip = tables.Column(
+            linkify=True,
+            order_by=('primary_ip4', 'primary_ip6'),
+            verbose_name='IP Address'
+        )
+    else:
+        primary_ip = tables.Column(
+            linkify=True,
+            order_by=('primary_ip6', 'primary_ip4'),
+            verbose_name='IP Address'
+        )
     tags = TagColumn(
         url_name='virtualization:virtualmachine_list'
     )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5819, #5872
<!--
    Please include a summary of the proposed changes below.
-->
Enables ordering by IPv6, followed by IPv4.
Ensures the displayed IP address is IPv6 or IPv4 based on the configuration.