### PR TITLE
Fixes: #5847 - Provide custom CSS for pagination chevrons

### DIFF
--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -177,6 +177,10 @@ nav ul.pagination {
     margin-top: 0;
     margin-bottom: 8px !important;
 }
+.pagination > li > a > .mdi::before {
+    top: 0;
+    font-size: 14px;
+}
 
 /* Devices */
 table.component-list td.subtable {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5847 
<!--
    Please include a summary of the proposed changes below.
-->
Added specific CSS for the .mdi class inside the pagination links reducing the top spacing and bringing the font size down slightly. This reduces the size of the bounding box slightly to bring it inline with the adjacent page number boxes as shown below.

![Screenshot 2021-02-22 at 23 27 09](https://user-images.githubusercontent.com/1878544/108784046-64038b80-7566-11eb-8922-1444d1d52340.png)
