### PR TITLE
Fixes #5703: populate vrf and tenant fields when adding ip address

### DIFF
--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -37,7 +37,7 @@ IPADDRESS_LINK = """
 {% if record.pk %}
     <a href="{{ record.get_absolute_url }}">{{ record.address }}</a>
 {% elif perms.ipam.add_ipaddress %}
-    <a href="{% url 'ipam:ipaddress_add' %}?address={{ record.1 }}{% if prefix.vrf %}&vrf={{ prefix.vrf.pk }}{% endif %}{% if prefix.tenant %}&tenant={{ prefix.tenant.pk }}{% endif %}" class="btn btn-xs btn-success">{% if record.0 <= 65536 %}{{ record.0 }}{% else %}Many{% endif %} IP{{ record.0|pluralize }} available</a>
+    <a href="{% url 'ipam:ipaddress_add' %}?address={{ record.1 }}{% if object.vrf %}&vrf={{ object.vrf.pk }}{% endif %}{% if object.tenant %}&tenant={{ object.tenant.pk }}{% endif %}" class="btn btn-xs btn-success">{% if record.0 <= 65536 %}{{ record.0 }}{% else %}Many{% endif %} IP{{ record.0|pluralize }} available</a>
 {% else %}
     {% if record.0 <= 65536 %}{{ record.0 }}{% else %}Many{% endif %} IP{{ record.0|pluralize }} available
 {% endif %}
@@ -50,8 +50,8 @@ IPADDRESS_ASSIGN_LINK = """
 VRF_LINK = """
 {% if record.vrf %}
     <a href="{{ record.vrf.get_absolute_url }}">{{ record.vrf }}</a>
-{% elif prefix.vrf %}
-    {{ prefix.vrf }}
+{% elif object.vrf %}
+    <a href="{{ object.vrf.get_absolute_url }}">{{ object.vrf }}</a>
 {% else %}
     Global
 {% endif %}
@@ -114,6 +114,8 @@ TENANT_LINK = """
     <a href="{% url 'tenancy:tenant' slug=record.tenant.slug %}" title="{{ record.tenant.description }}">{{ record.tenant }}</a>
 {% elif record.vrf.tenant %}
     <a href="{% url 'tenancy:tenant' slug=record.vrf.tenant.slug %}" title="{{ record.vrf.tenant.description }}">{{ record.vrf.tenant }}</a>*
+{% elif object.tenant %}    
+    <a href="{% url 'tenancy:tenant' slug=object.tenant.slug %}" title="{{ object.tenant.description }}">{{ object.tenant }}</a>    
 {% else %}
     &mdash;
 {% endif %}

--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -114,8 +114,8 @@ TENANT_LINK = """
     <a href="{% url 'tenancy:tenant' slug=record.tenant.slug %}" title="{{ record.tenant.description }}">{{ record.tenant }}</a>
 {% elif record.vrf.tenant %}
     <a href="{% url 'tenancy:tenant' slug=record.vrf.tenant.slug %}" title="{{ record.vrf.tenant.description }}">{{ record.vrf.tenant }}</a>*
-{% elif object.tenant %}    
-    <a href="{% url 'tenancy:tenant' slug=object.tenant.slug %}" title="{{ object.tenant.description }}">{{ object.tenant }}</a>    
+{% elif object.tenant %}
+    <a href="{% url 'tenancy:tenant' slug=object.tenant.slug %}" title="{{ object.tenant.description }}">{{ object.tenant }}</a>
 {% else %}
     &mdash;
 {% endif %}


### PR DESCRIPTION
### Fixes: #5703

With this commit behavior of the "+ add new ip address" button and clicking the ".. IPs available" button is now the same (you get to the add IP page where VRF and tenant fields are populated already if the prefix was assigned a VRF or Tenant).

The ".. IPs available" rows of the table overview of IP addresses for a prefix is also fixed (it now displays the VRF of the prefix if it has one instead of incorrectly displaying "Global" and it displays the tenant if the prefix was assigned one).

