### PR TITLE
Fix use of `URLValidator` to correctly validate `RELEASE_CHECK_URL`

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -123,13 +123,16 @@ TIME_ZONE = getattr(configuration, 'TIME_ZONE', 'UTC')
 
 # Validate update repo URL and timeout
 if RELEASE_CHECK_URL:
-    try:
-        URLValidator(RELEASE_CHECK_URL)
-    except ValidationError:
-        raise ImproperlyConfigured(
+    validator = URLValidator(
+        message=(
             "RELEASE_CHECK_URL must be a valid API URL. Example: "
             "https://api.github.com/repos/netbox-community/netbox"
         )
+    )
+    try:
+        validator(RELEASE_CHECK_URL)
+    except ValidationError as err:
+        raise ImproperlyConfigured(str(err))
 
 # Enforce a minimum cache timeout for update checks
 if RELEASE_CHECK_TIMEOUT < 3600:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5977 
<!--
    Please include a summary of the proposed changes below.
-->

This is a minor patch that makes the test in `netbox.settings` to correctly validate that `RELEASE_CHECK_URL` is a valid URL. I wasn't able to find a place where these settings are tested in the test suite, so I am providing some interactive Python shell output to illustrate the fix:

```
In [1]: from django.core.validators import URLValidator

In [2]: from django.core.exceptions import ImproperlyConfigured, ValidationError

In [3]: RELEASE_CHECK_URL = 'bogus url'

In [4]: if RELEASE_CHECK_URL:
   ...:     validator = URLValidator(
   ...:         message=(
   ...:             "RELEASE_CHECK_URL must be a valid API URL. Example: "
   ...:             "https://api.github.com/repos/netbox-community/netbox"
   ...:         )
   ...:     )
   ...:     try:
   ...:         validator(RELEASE_CHECK_URL)
   ...:     except ValidationError as err:
   ...:         raise ImproperlyConfigured(str(err))
   ...:
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
<ipython-input-4-8bf07c825907> in <module>
      8     try:
----> 9         validator(RELEASE_CHECK_URL)
     10     except ValidationError as err:

~/Library/Caches/pypoetry/virtualenvs/nautobot-b2ttWva6-py3.8/lib/python3.8/site-packages/django/core/validators.py in __call__(self, value)
    104         if scheme not in self.schemes:
--> 105             raise ValidationError(self.message, code=self.code)
    106

ValidationError: ['RELEASE_CHECK_URL must be a valid API URL. Example: https://api.github.com/repos/netbox-community/netbox']

During handling of the above exception, another exception occurred:

ImproperlyConfigured                      Traceback (most recent call last)
<ipython-input-4-8bf07c825907> in <module>
      9         validator(RELEASE_CHECK_URL)
     10     except ValidationError as err:
---> 11         raise ImproperlyConfigured(str(err))
     12

ImproperlyConfigured: ['RELEASE_CHECK_URL must be a valid API URL. Example: https://api.github.com/repos/netbox-community/netbox']
```