### PR TITLE
Closes #5981: Add display field to all REST API serializers

### DIFF
--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -74,6 +74,7 @@ The ObjectChange model (which is used to record the creation, modification, and 
 * [#5451](https://github.com/netbox-community/netbox/issues/5451) - Add support for multiple-selection custom fields
 * [#5608](https://github.com/netbox-community/netbox/issues/5608) - Add REST API endpoint for custom links
 * [#5610](https://github.com/netbox-community/netbox/issues/5610) - Add REST API endpoint for webhooks
+* [#5891](https://github.com/netbox-community/netbox/issues/5891) - Add `display` field to all REST API serializers
 * [#5894](https://github.com/netbox-community/netbox/issues/5894) - Use primary keys when filtering object lists by related objects in the UI
 * [#5895](https://github.com/netbox-community/netbox/issues/5895) - Rename RackGroup to Location
 * [#5901](https://github.com/netbox-community/netbox/issues/5901) - Add `created` and `last_updated` fields to device component models
@@ -87,6 +88,7 @@ The ObjectChange model (which is used to record the creation, modification, and 
 ### REST API Changes
 
 * All primary keys are now 64-bit integers
+* All model serializers now include a `display` field to be used for the presentation of an object to a human user
 * All device components
   * Added support for custom fields
   * Added `created` and `last_updated` fields to track object creation and modification

--- a/netbox/circuits/api/nested_serializers.py
+++ b/netbox/circuits/api/nested_serializers.py
@@ -21,7 +21,7 @@ class NestedProviderSerializer(WritableNestedSerializer):
 
     class Meta:
         model = Provider
-        fields = ['id', 'url', 'name', 'slug', 'circuit_count']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'circuit_count']
 
 
 #
@@ -34,7 +34,7 @@ class NestedCircuitTypeSerializer(WritableNestedSerializer):
 
     class Meta:
         model = CircuitType
-        fields = ['id', 'url', 'name', 'slug', 'circuit_count']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'circuit_count']
 
 
 class NestedCircuitSerializer(WritableNestedSerializer):
@@ -42,7 +42,7 @@ class NestedCircuitSerializer(WritableNestedSerializer):
 
     class Meta:
         model = Circuit
-        fields = ['id', 'url', 'cid']
+        fields = ['id', 'url', 'display', 'cid']
 
 
 class NestedCircuitTerminationSerializer(WritableNestedSerializer):
@@ -51,4 +51,4 @@ class NestedCircuitTerminationSerializer(WritableNestedSerializer):
 
     class Meta:
         model = CircuitTermination
-        fields = ['id', 'url', 'circuit', 'term_side', 'cable', '_occupied']
+        fields = ['id', 'url', 'display', 'circuit', 'term_side', 'cable', '_occupied']

--- a/netbox/circuits/api/serializers.py
+++ b/netbox/circuits/api/serializers.py
@@ -5,7 +5,9 @@ from circuits.models import Provider, Circuit, CircuitTermination, CircuitType
 from dcim.api.nested_serializers import NestedCableSerializer, NestedSiteSerializer
 from dcim.api.serializers import CableTerminationSerializer, ConnectedEndpointSerializer
 from netbox.api import ChoiceField
-from netbox.api.serializers import OrganizationalModelSerializer, PrimaryModelSerializer, WritableNestedSerializer
+from netbox.api.serializers import (
+    BaseModelSerializer, OrganizationalModelSerializer, PrimaryModelSerializer, WritableNestedSerializer
+)
 from tenancy.api.nested_serializers import NestedTenantSerializer
 from .nested_serializers import *
 
@@ -21,8 +23,8 @@ class ProviderSerializer(PrimaryModelSerializer):
     class Meta:
         model = Provider
         fields = [
-            'id', 'url', 'name', 'slug', 'asn', 'account', 'portal_url', 'noc_contact', 'admin_contact', 'comments', 'tags',
-            'custom_fields', 'created', 'last_updated', 'circuit_count',
+            'id', 'url', 'display', 'name', 'slug', 'asn', 'account', 'portal_url', 'noc_contact', 'admin_contact',
+            'comments', 'tags', 'custom_fields', 'created', 'last_updated', 'circuit_count',
         ]
 
 
@@ -37,7 +39,8 @@ class CircuitTypeSerializer(OrganizationalModelSerializer):
     class Meta:
         model = CircuitType
         fields = [
-            'id', 'url', 'name', 'slug', 'description', 'custom_fields', 'created', 'last_updated', 'circuit_count',
+            'id', 'url', 'display', 'name', 'slug', 'description', 'custom_fields', 'created', 'last_updated',
+            'circuit_count',
         ]
 
 
@@ -48,7 +51,7 @@ class CircuitCircuitTerminationSerializer(WritableNestedSerializer, ConnectedEnd
     class Meta:
         model = CircuitTermination
         fields = [
-            'id', 'url', 'site', 'port_speed', 'upstream_speed', 'xconnect_id', 'connected_endpoint',
+            'id', 'url', 'display', 'site', 'port_speed', 'upstream_speed', 'xconnect_id', 'connected_endpoint',
             'connected_endpoint_type', 'connected_endpoint_reachable',
         ]
 
@@ -65,12 +68,13 @@ class CircuitSerializer(PrimaryModelSerializer):
     class Meta:
         model = Circuit
         fields = [
-            'id', 'url', 'cid', 'provider', 'type', 'status', 'tenant', 'install_date', 'commit_rate', 'description',
-            'termination_a', 'termination_z', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
+            'id', 'url', 'display', 'cid', 'provider', 'type', 'status', 'tenant', 'install_date', 'commit_rate',
+            'description', 'termination_a', 'termination_z', 'comments', 'tags', 'custom_fields', 'created',
+            'last_updated',
         ]
 
 
-class CircuitTerminationSerializer(CableTerminationSerializer, ConnectedEndpointSerializer):
+class CircuitTerminationSerializer(BaseModelSerializer, CableTerminationSerializer, ConnectedEndpointSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='circuits-api:circuittermination-detail')
     circuit = NestedCircuitSerializer()
     site = NestedSiteSerializer()
@@ -79,7 +83,7 @@ class CircuitTerminationSerializer(CableTerminationSerializer, ConnectedEndpoint
     class Meta:
         model = CircuitTermination
         fields = [
-            'id', 'url', 'circuit', 'term_side', 'site', 'port_speed', 'upstream_speed', 'xconnect_id', 'pp_info',
-            'description', 'mark_connected', 'cable', 'cable_peer', 'cable_peer_type', 'connected_endpoint',
+            'id', 'url', 'display', 'circuit', 'term_side', 'site', 'port_speed', 'upstream_speed', 'xconnect_id',
+            'pp_info', 'description', 'mark_connected', 'cable', 'cable_peer', 'cable_peer_type', 'connected_endpoint',
             'connected_endpoint_type', 'connected_endpoint_reachable', '_occupied',
         ]

--- a/netbox/circuits/tests/test_api.py
+++ b/netbox/circuits/tests/test_api.py
@@ -17,7 +17,7 @@ class AppTest(APITestCase):
 
 class ProviderTest(APIViewTestCases.APIViewTestCase):
     model = Provider
-    brief_fields = ['circuit_count', 'id', 'name', 'slug', 'url']
+    brief_fields = ['circuit_count', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'Provider 4',
@@ -49,7 +49,7 @@ class ProviderTest(APIViewTestCases.APIViewTestCase):
 
 class CircuitTypeTest(APIViewTestCases.APIViewTestCase):
     model = CircuitType
-    brief_fields = ['circuit_count', 'id', 'name', 'slug', 'url']
+    brief_fields = ['circuit_count', 'display', 'id', 'name', 'slug', 'url']
     create_data = (
         {
             'name': 'Circuit Type 4',
@@ -81,7 +81,7 @@ class CircuitTypeTest(APIViewTestCases.APIViewTestCase):
 
 class CircuitTest(APIViewTestCases.APIViewTestCase):
     model = Circuit
-    brief_fields = ['cid', 'id', 'url']
+    brief_fields = ['cid', 'display', 'id', 'url']
     bulk_update_data = {
         'status': 'planned',
     }
@@ -129,7 +129,7 @@ class CircuitTest(APIViewTestCases.APIViewTestCase):
 
 class CircuitTerminationTest(APIViewTestCases.APIViewTestCase):
     model = CircuitTermination
-    brief_fields = ['_occupied', 'cable', 'circuit', 'id', 'term_side', 'url']
+    brief_fields = ['_occupied', 'cable', 'circuit', 'display', 'id', 'term_side', 'url']
 
     @classmethod
     def setUpTestData(cls):

--- a/netbox/dcim/api/nested_serializers.py
+++ b/netbox/dcim/api/nested_serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from dcim import models
-from netbox.api import WritableNestedSerializer
+from netbox.api.serializers import BaseModelSerializer, WritableNestedSerializer
 
 __all__ = [
     'NestedCableSerializer',
@@ -51,7 +51,7 @@ class NestedRegionSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Region
-        fields = ['id', 'url', 'name', 'slug', 'site_count', '_depth']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'site_count', '_depth']
 
 
 class NestedSiteGroupSerializer(WritableNestedSerializer):
@@ -61,7 +61,7 @@ class NestedSiteGroupSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.SiteGroup
-        fields = ['id', 'url', 'name', 'slug', 'site_count', '_depth']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'site_count', '_depth']
 
 
 class NestedSiteSerializer(WritableNestedSerializer):
@@ -69,7 +69,7 @@ class NestedSiteSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Site
-        fields = ['id', 'url', 'name', 'slug']
+        fields = ['id', 'url', 'display', 'name', 'slug']
 
 
 #
@@ -83,7 +83,7 @@ class NestedLocationSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Location
-        fields = ['id', 'url', 'name', 'slug', 'rack_count', '_depth']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'rack_count', '_depth']
 
 
 class NestedRackRoleSerializer(WritableNestedSerializer):
@@ -92,7 +92,7 @@ class NestedRackRoleSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.RackRole
-        fields = ['id', 'url', 'name', 'slug', 'rack_count']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'rack_count']
 
 
 class NestedRackSerializer(WritableNestedSerializer):
@@ -101,7 +101,7 @@ class NestedRackSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Rack
-        fields = ['id', 'url', 'name', 'display_name', 'device_count']
+        fields = ['id', 'url', 'display', 'name', 'display_name', 'device_count']
 
 
 class NestedRackReservationSerializer(WritableNestedSerializer):
@@ -110,7 +110,7 @@ class NestedRackReservationSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.RackReservation
-        fields = ['id', 'url', 'user', 'units']
+        fields = ['id', 'url', 'display', 'user', 'units']
 
     def get_user(self, obj):
         return obj.user.username
@@ -126,7 +126,7 @@ class NestedManufacturerSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Manufacturer
-        fields = ['id', 'url', 'name', 'slug', 'devicetype_count']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'devicetype_count']
 
 
 class NestedDeviceTypeSerializer(WritableNestedSerializer):
@@ -136,7 +136,7 @@ class NestedDeviceTypeSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.DeviceType
-        fields = ['id', 'url', 'manufacturer', 'model', 'slug', 'display_name', 'device_count']
+        fields = ['id', 'url', 'display', 'manufacturer', 'model', 'slug', 'display_name', 'device_count']
 
 
 class NestedConsolePortTemplateSerializer(WritableNestedSerializer):
@@ -144,7 +144,7 @@ class NestedConsolePortTemplateSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.ConsolePortTemplate
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedConsoleServerPortTemplateSerializer(WritableNestedSerializer):
@@ -152,7 +152,7 @@ class NestedConsoleServerPortTemplateSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.ConsoleServerPortTemplate
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedPowerPortTemplateSerializer(WritableNestedSerializer):
@@ -160,7 +160,7 @@ class NestedPowerPortTemplateSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.PowerPortTemplate
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedPowerOutletTemplateSerializer(WritableNestedSerializer):
@@ -168,7 +168,7 @@ class NestedPowerOutletTemplateSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.PowerOutletTemplate
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedInterfaceTemplateSerializer(WritableNestedSerializer):
@@ -176,7 +176,7 @@ class NestedInterfaceTemplateSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.InterfaceTemplate
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedRearPortTemplateSerializer(WritableNestedSerializer):
@@ -184,7 +184,7 @@ class NestedRearPortTemplateSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.RearPortTemplate
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedFrontPortTemplateSerializer(WritableNestedSerializer):
@@ -192,7 +192,7 @@ class NestedFrontPortTemplateSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.FrontPortTemplate
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedDeviceBayTemplateSerializer(WritableNestedSerializer):
@@ -200,7 +200,7 @@ class NestedDeviceBayTemplateSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.DeviceBayTemplate
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 #
@@ -214,7 +214,7 @@ class NestedDeviceRoleSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.DeviceRole
-        fields = ['id', 'url', 'name', 'slug', 'device_count', 'virtualmachine_count']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'device_count', 'virtualmachine_count']
 
 
 class NestedPlatformSerializer(WritableNestedSerializer):
@@ -224,7 +224,7 @@ class NestedPlatformSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Platform
-        fields = ['id', 'url', 'name', 'slug', 'device_count', 'virtualmachine_count']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'device_count', 'virtualmachine_count']
 
 
 class NestedDeviceSerializer(WritableNestedSerializer):
@@ -232,7 +232,7 @@ class NestedDeviceSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Device
-        fields = ['id', 'url', 'name', 'display_name']
+        fields = ['id', 'url', 'display', 'name', 'display_name']
 
 
 class NestedConsoleServerPortSerializer(WritableNestedSerializer):
@@ -241,7 +241,7 @@ class NestedConsoleServerPortSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.ConsoleServerPort
-        fields = ['id', 'url', 'device', 'name', 'cable', '_occupied']
+        fields = ['id', 'url', 'display', 'device', 'name', 'cable', '_occupied']
 
 
 class NestedConsolePortSerializer(WritableNestedSerializer):
@@ -250,7 +250,7 @@ class NestedConsolePortSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.ConsolePort
-        fields = ['id', 'url', 'device', 'name', 'cable', '_occupied']
+        fields = ['id', 'url', 'display', 'device', 'name', 'cable', '_occupied']
 
 
 class NestedPowerOutletSerializer(WritableNestedSerializer):
@@ -259,7 +259,7 @@ class NestedPowerOutletSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.PowerOutlet
-        fields = ['id', 'url', 'device', 'name', 'cable', '_occupied']
+        fields = ['id', 'url', 'display', 'device', 'name', 'cable', '_occupied']
 
 
 class NestedPowerPortSerializer(WritableNestedSerializer):
@@ -268,7 +268,7 @@ class NestedPowerPortSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.PowerPort
-        fields = ['id', 'url', 'device', 'name', 'cable', '_occupied']
+        fields = ['id', 'url', 'display', 'device', 'name', 'cable', '_occupied']
 
 
 class NestedInterfaceSerializer(WritableNestedSerializer):
@@ -277,7 +277,7 @@ class NestedInterfaceSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Interface
-        fields = ['id', 'url', 'device', 'name', 'cable', '_occupied']
+        fields = ['id', 'url', 'display', 'device', 'name', 'cable', '_occupied']
 
 
 class NestedRearPortSerializer(WritableNestedSerializer):
@@ -286,7 +286,7 @@ class NestedRearPortSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.RearPort
-        fields = ['id', 'url', 'device', 'name', 'cable', '_occupied']
+        fields = ['id', 'url', 'display', 'device', 'name', 'cable', '_occupied']
 
 
 class NestedFrontPortSerializer(WritableNestedSerializer):
@@ -295,7 +295,7 @@ class NestedFrontPortSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.FrontPort
-        fields = ['id', 'url', 'device', 'name', 'cable', '_occupied']
+        fields = ['id', 'url', 'display', 'device', 'name', 'cable', '_occupied']
 
 
 class NestedDeviceBaySerializer(WritableNestedSerializer):
@@ -304,7 +304,7 @@ class NestedDeviceBaySerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.DeviceBay
-        fields = ['id', 'url', 'device', 'name']
+        fields = ['id', 'url', 'display', 'device', 'name']
 
 
 class NestedInventoryItemSerializer(WritableNestedSerializer):
@@ -314,19 +314,19 @@ class NestedInventoryItemSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.InventoryItem
-        fields = ['id', 'url', 'device', 'name', '_depth']
+        fields = ['id', 'url', 'display', 'device', 'name', '_depth']
 
 
 #
 # Cables
 #
 
-class NestedCableSerializer(serializers.ModelSerializer):
+class NestedCableSerializer(BaseModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:cable-detail')
 
     class Meta:
         model = models.Cable
-        fields = ['id', 'url', 'label']
+        fields = ['id', 'url', 'display', 'label']
 
 
 #
@@ -353,7 +353,7 @@ class NestedPowerPanelSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.PowerPanel
-        fields = ['id', 'url', 'name', 'powerfeed_count']
+        fields = ['id', 'url', 'display', 'name', 'powerfeed_count']
 
 
 class NestedPowerFeedSerializer(WritableNestedSerializer):
@@ -361,4 +361,4 @@ class NestedPowerFeedSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.PowerFeed
-        fields = ['id', 'url', 'name', 'cable', '_occupied']
+        fields = ['id', 'url', 'display', 'name', 'cable', '_occupied']

--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -82,7 +82,7 @@ class RegionSerializer(NestedGroupModelSerializer):
     class Meta:
         model = Region
         fields = [
-            'id', 'url', 'name', 'slug', 'parent', 'description', 'custom_fields', 'created', 'last_updated',
+            'id', 'url', 'display', 'name', 'slug', 'parent', 'description', 'custom_fields', 'created', 'last_updated',
             'site_count', '_depth',
         ]
 
@@ -95,7 +95,7 @@ class SiteGroupSerializer(NestedGroupModelSerializer):
     class Meta:
         model = SiteGroup
         fields = [
-            'id', 'url', 'name', 'slug', 'parent', 'description', 'custom_fields', 'created', 'last_updated',
+            'id', 'url', 'display', 'name', 'slug', 'parent', 'description', 'custom_fields', 'created', 'last_updated',
             'site_count', '_depth',
         ]
 
@@ -117,8 +117,8 @@ class SiteSerializer(PrimaryModelSerializer):
     class Meta:
         model = Site
         fields = [
-            'id', 'url', 'name', 'slug', 'status', 'region', 'group', 'tenant', 'facility', 'asn', 'time_zone',
-            'description', 'physical_address', 'shipping_address', 'latitude', 'longitude', 'contact_name',
+            'id', 'url', 'display', 'name', 'slug', 'status', 'region', 'group', 'tenant', 'facility', 'asn',
+            'time_zone', 'description', 'physical_address', 'shipping_address', 'latitude', 'longitude', 'contact_name',
             'contact_phone', 'contact_email', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
             'circuit_count', 'device_count', 'prefix_count', 'rack_count', 'virtualmachine_count', 'vlan_count',
         ]
@@ -137,8 +137,8 @@ class LocationSerializer(NestedGroupModelSerializer):
     class Meta:
         model = Location
         fields = [
-            'id', 'url', 'name', 'slug', 'site', 'parent', 'description', 'custom_fields', 'created', 'last_updated',
-            'rack_count', '_depth',
+            'id', 'url', 'display', 'name', 'slug', 'site', 'parent', 'description', 'custom_fields', 'created',
+            'last_updated', 'rack_count', '_depth',
         ]
 
 
@@ -149,7 +149,7 @@ class RackRoleSerializer(OrganizationalModelSerializer):
     class Meta:
         model = RackRole
         fields = [
-            'id', 'url', 'name', 'slug', 'color', 'description', 'custom_fields', 'created', 'last_updated',
+            'id', 'url', 'display', 'name', 'slug', 'color', 'description', 'custom_fields', 'created', 'last_updated',
             'rack_count',
         ]
 
@@ -170,8 +170,8 @@ class RackSerializer(PrimaryModelSerializer):
     class Meta:
         model = Rack
         fields = [
-            'id', 'url', 'name', 'facility_id', 'display_name', 'site', 'location', 'tenant', 'status', 'role',
-            'serial', 'asset_tag', 'type', 'width', 'u_height', 'desc_units', 'outer_width', 'outer_depth',
+            'id', 'url', 'display', 'name', 'facility_id', 'display_name', 'site', 'location', 'tenant', 'status',
+            'role', 'serial', 'asset_tag', 'type', 'width', 'u_height', 'desc_units', 'outer_width', 'outer_depth',
             'outer_unit', 'comments', 'tags', 'custom_fields', 'created', 'last_updated', 'device_count',
             'powerfeed_count',
         ]
@@ -213,7 +213,10 @@ class RackReservationSerializer(PrimaryModelSerializer):
 
     class Meta:
         model = RackReservation
-        fields = ['id', 'url', 'rack', 'units', 'created', 'user', 'tenant', 'description', 'tags', 'custom_fields']
+        fields = [
+            'id', 'url', 'display', 'rack', 'units', 'created', 'user', 'tenant', 'description', 'tags',
+            'custom_fields',
+        ]
 
 
 class RackElevationDetailFilterSerializer(serializers.Serializer):
@@ -265,8 +268,8 @@ class ManufacturerSerializer(OrganizationalModelSerializer):
     class Meta:
         model = Manufacturer
         fields = [
-            'id', 'url', 'name', 'slug', 'description', 'custom_fields', 'created', 'last_updated', 'devicetype_count',
-            'inventoryitem_count', 'platform_count',
+            'id', 'url', 'display', 'name', 'slug', 'description', 'custom_fields', 'created', 'last_updated',
+            'devicetype_count', 'inventoryitem_count', 'platform_count',
         ]
 
 
@@ -279,9 +282,9 @@ class DeviceTypeSerializer(PrimaryModelSerializer):
     class Meta:
         model = DeviceType
         fields = [
-            'id', 'url', 'manufacturer', 'model', 'slug', 'display_name', 'part_number', 'u_height', 'is_full_depth',
-            'subdevice_role', 'front_image', 'rear_image', 'comments', 'tags', 'custom_fields', 'created',
-            'last_updated', 'device_count',
+            'id', 'url', 'display', 'manufacturer', 'model', 'slug', 'display_name', 'part_number', 'u_height',
+            'is_full_depth', 'subdevice_role', 'front_image', 'rear_image', 'comments', 'tags', 'custom_fields',
+            'created', 'last_updated', 'device_count',
         ]
 
 
@@ -296,7 +299,9 @@ class ConsolePortTemplateSerializer(ValidatedModelSerializer):
 
     class Meta:
         model = ConsolePortTemplate
-        fields = ['id', 'url', 'device_type', 'name', 'label', 'type', 'description', 'created', 'last_updated']
+        fields = [
+            'id', 'url', 'display', 'device_type', 'name', 'label', 'type', 'description', 'created', 'last_updated',
+        ]
 
 
 class ConsoleServerPortTemplateSerializer(ValidatedModelSerializer):
@@ -310,7 +315,9 @@ class ConsoleServerPortTemplateSerializer(ValidatedModelSerializer):
 
     class Meta:
         model = ConsoleServerPortTemplate
-        fields = ['id', 'url', 'device_type', 'name', 'label', 'type', 'description', 'created', 'last_updated']
+        fields = [
+            'id', 'url', 'display', 'device_type', 'name', 'label', 'type', 'description', 'created', 'last_updated',
+        ]
 
 
 class PowerPortTemplateSerializer(ValidatedModelSerializer):
@@ -325,8 +332,8 @@ class PowerPortTemplateSerializer(ValidatedModelSerializer):
     class Meta:
         model = PowerPortTemplate
         fields = [
-            'id', 'url', 'device_type', 'name', 'label', 'type', 'maximum_draw', 'allocated_draw', 'description',
-            'created', 'last_updated',
+            'id', 'url', 'display', 'device_type', 'name', 'label', 'type', 'maximum_draw', 'allocated_draw',
+            'description', 'created', 'last_updated',
         ]
 
 
@@ -350,8 +357,8 @@ class PowerOutletTemplateSerializer(ValidatedModelSerializer):
     class Meta:
         model = PowerOutletTemplate
         fields = [
-            'id', 'url', 'device_type', 'name', 'label', 'type', 'power_port', 'feed_leg', 'description', 'created',
-            'last_updated',
+            'id', 'url', 'display', 'device_type', 'name', 'label', 'type', 'power_port', 'feed_leg', 'description',
+            'created', 'last_updated',
         ]
 
 
@@ -363,7 +370,8 @@ class InterfaceTemplateSerializer(ValidatedModelSerializer):
     class Meta:
         model = InterfaceTemplate
         fields = [
-            'id', 'url', 'device_type', 'name', 'label', 'type', 'mgmt_only', 'description', 'created', 'last_updated',
+            'id', 'url', 'display', 'device_type', 'name', 'label', 'type', 'mgmt_only', 'description', 'created',
+            'last_updated',
         ]
 
 
@@ -375,7 +383,8 @@ class RearPortTemplateSerializer(ValidatedModelSerializer):
     class Meta:
         model = RearPortTemplate
         fields = [
-            'id', 'url', 'device_type', 'name', 'label', 'type', 'positions', 'description', 'created', 'last_updated',
+            'id', 'url', 'display', 'device_type', 'name', 'label', 'type', 'positions', 'description', 'created',
+            'last_updated',
         ]
 
 
@@ -388,8 +397,8 @@ class FrontPortTemplateSerializer(ValidatedModelSerializer):
     class Meta:
         model = FrontPortTemplate
         fields = [
-            'id', 'url', 'device_type', 'name', 'label', 'type', 'rear_port', 'rear_port_position', 'description',
-            'created', 'last_updated',
+            'id', 'url', 'display', 'device_type', 'name', 'label', 'type', 'rear_port', 'rear_port_position',
+            'description', 'created', 'last_updated',
         ]
 
 
@@ -399,7 +408,7 @@ class DeviceBayTemplateSerializer(ValidatedModelSerializer):
 
     class Meta:
         model = DeviceBayTemplate
-        fields = ['id', 'url', 'device_type', 'name', 'label', 'description', 'created', 'last_updated']
+        fields = ['id', 'url', 'display', 'device_type', 'name', 'label', 'description', 'created', 'last_updated']
 
 
 #
@@ -414,8 +423,8 @@ class DeviceRoleSerializer(OrganizationalModelSerializer):
     class Meta:
         model = DeviceRole
         fields = [
-            'id', 'url', 'name', 'slug', 'color', 'vm_role', 'description', 'custom_fields', 'created', 'last_updated',
-            'device_count', 'virtualmachine_count',
+            'id', 'url', 'display', 'name', 'slug', 'color', 'vm_role', 'description', 'custom_fields', 'created',
+            'last_updated', 'device_count', 'virtualmachine_count',
         ]
 
 
@@ -428,8 +437,8 @@ class PlatformSerializer(OrganizationalModelSerializer):
     class Meta:
         model = Platform
         fields = [
-            'id', 'url', 'name', 'slug', 'manufacturer', 'napalm_driver', 'napalm_args', 'description', 'custom_fields',
-            'created', 'last_updated', 'device_count', 'virtualmachine_count',
+            'id', 'url', 'display', 'name', 'slug', 'manufacturer', 'napalm_driver', 'napalm_args', 'description',
+            'custom_fields', 'created', 'last_updated', 'device_count', 'virtualmachine_count',
         ]
 
 
@@ -454,10 +463,10 @@ class DeviceSerializer(PrimaryModelSerializer):
     class Meta:
         model = Device
         fields = [
-            'id', 'url', 'name', 'display_name', 'device_type', 'device_role', 'tenant', 'platform', 'serial',
-            'asset_tag', 'site', 'location', 'rack', 'position', 'face', 'parent_device', 'status', 'primary_ip',
-            'primary_ip4', 'primary_ip6', 'cluster', 'virtual_chassis', 'vc_position', 'vc_priority', 'comments',
-            'local_context_data', 'tags', 'custom_fields', 'created', 'last_updated',
+            'id', 'url', 'display', 'name', 'display_name', 'device_type', 'device_role', 'tenant', 'platform',
+            'serial', 'asset_tag', 'site', 'location', 'rack', 'position', 'face', 'parent_device', 'status',
+            'primary_ip', 'primary_ip4', 'primary_ip6', 'cluster', 'virtual_chassis', 'vc_position', 'vc_priority',
+            'comments', 'local_context_data', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
         validators = []
 
@@ -490,10 +499,10 @@ class DeviceWithConfigContextSerializer(DeviceSerializer):
 
     class Meta(DeviceSerializer.Meta):
         fields = [
-            'id', 'url', 'name', 'display_name', 'device_type', 'device_role', 'tenant', 'platform', 'serial',
-            'asset_tag', 'site', 'location', 'rack', 'position', 'face', 'parent_device', 'status', 'primary_ip',
-            'primary_ip4', 'primary_ip6', 'cluster', 'virtual_chassis', 'vc_position', 'vc_priority', 'comments',
-            'local_context_data', 'tags', 'custom_fields', 'config_context', 'created', 'last_updated',
+            'id', 'url', 'display', 'name', 'display_name', 'device_type', 'device_role', 'tenant', 'platform',
+            'serial', 'asset_tag', 'site', 'location', 'rack', 'position', 'face', 'parent_device', 'status',
+            'primary_ip', 'primary_ip4', 'primary_ip6', 'cluster', 'virtual_chassis', 'vc_position', 'vc_priority',
+            'comments', 'local_context_data', 'tags', 'custom_fields', 'config_context', 'created', 'last_updated',
         ]
 
     @swagger_serializer_method(serializer_or_field=serializers.DictField)
@@ -527,8 +536,8 @@ class ConsoleServerPortSerializer(PrimaryModelSerializer, CableTerminationSerial
     class Meta:
         model = ConsoleServerPort
         fields = [
-            'id', 'url', 'device', 'name', 'label', 'type', 'speed', 'description', 'mark_connected', 'cable',
-            'cable_peer', 'cable_peer_type', 'connected_endpoint', 'connected_endpoint_type',
+            'id', 'url', 'display', 'device', 'name', 'label', 'type', 'speed', 'description', 'mark_connected',
+            'cable', 'cable_peer', 'cable_peer_type', 'connected_endpoint', 'connected_endpoint_type',
             'connected_endpoint_reachable', 'tags', 'custom_fields', 'created', 'last_updated', '_occupied',
         ]
 
@@ -551,8 +560,8 @@ class ConsolePortSerializer(PrimaryModelSerializer, CableTerminationSerializer, 
     class Meta:
         model = ConsolePort
         fields = [
-            'id', 'url', 'device', 'name', 'label', 'type', 'speed', 'description', 'mark_connected', 'cable',
-            'cable_peer', 'cable_peer_type', 'connected_endpoint', 'connected_endpoint_type',
+            'id', 'url', 'display', 'device', 'name', 'label', 'type', 'speed', 'description', 'mark_connected',
+            'cable', 'cable_peer', 'cable_peer_type', 'connected_endpoint', 'connected_endpoint_type',
             'connected_endpoint_reachable', 'tags', 'custom_fields', 'created', 'last_updated', '_occupied',
         ]
 
@@ -580,8 +589,8 @@ class PowerOutletSerializer(PrimaryModelSerializer, CableTerminationSerializer, 
     class Meta:
         model = PowerOutlet
         fields = [
-            'id', 'url', 'device', 'name', 'label', 'type', 'power_port', 'feed_leg', 'description', 'mark_connected',
-            'cable', 'cable_peer', 'cable_peer_type', 'connected_endpoint', 'connected_endpoint_type',
+            'id', 'url', 'display', 'device', 'name', 'label', 'type', 'power_port', 'feed_leg', 'description',
+            'mark_connected', 'cable', 'cable_peer', 'cable_peer_type', 'connected_endpoint', 'connected_endpoint_type',
             'connected_endpoint_reachable', 'tags', 'custom_fields', 'created', 'last_updated', '_occupied',
         ]
 
@@ -599,7 +608,7 @@ class PowerPortSerializer(PrimaryModelSerializer, CableTerminationSerializer, Co
     class Meta:
         model = PowerPort
         fields = [
-            'id', 'url', 'device', 'name', 'label', 'type', 'maximum_draw', 'allocated_draw', 'description',
+            'id', 'url', 'display', 'device', 'name', 'label', 'type', 'maximum_draw', 'allocated_draw', 'description',
             'mark_connected', 'cable', 'cable_peer', 'cable_peer_type', 'connected_endpoint', 'connected_endpoint_type',
             'connected_endpoint_reachable', 'tags', 'custom_fields', 'created', 'last_updated', '_occupied',
         ]
@@ -625,7 +634,7 @@ class InterfaceSerializer(PrimaryModelSerializer, CableTerminationSerializer, Co
     class Meta:
         model = Interface
         fields = [
-            'id', 'url', 'device', 'name', 'label', 'type', 'enabled', 'parent', 'lag', 'mtu', 'mac_address',
+            'id', 'url', 'display', 'device', 'name', 'label', 'type', 'enabled', 'parent', 'lag', 'mtu', 'mac_address',
             'mgmt_only', 'description', 'mode', 'untagged_vlan', 'tagged_vlans', 'mark_connected', 'cable',
             'cable_peer', 'cable_peer_type', 'connected_endpoint', 'connected_endpoint_type',
             'connected_endpoint_reachable', 'tags', 'custom_fields', 'created', 'last_updated', 'count_ipaddresses',
@@ -655,8 +664,8 @@ class RearPortSerializer(PrimaryModelSerializer, CableTerminationSerializer):
     class Meta:
         model = RearPort
         fields = [
-            'id', 'url', 'device', 'name', 'label', 'type', 'positions', 'description', 'mark_connected', 'cable',
-            'cable_peer', 'cable_peer_type', 'tags', 'custom_fields', 'created', 'last_updated', '_occupied',
+            'id', 'url', 'display', 'device', 'name', 'label', 'type', 'positions', 'description', 'mark_connected',
+            'cable', 'cable_peer', 'cable_peer_type', 'tags', 'custom_fields', 'created', 'last_updated', '_occupied',
         ]
 
 
@@ -668,7 +677,7 @@ class FrontPortRearPortSerializer(WritableNestedSerializer):
 
     class Meta:
         model = RearPort
-        fields = ['id', 'url', 'name', 'label']
+        fields = ['id', 'url', 'display', 'name', 'label']
 
 
 class FrontPortSerializer(PrimaryModelSerializer, CableTerminationSerializer):
@@ -681,7 +690,7 @@ class FrontPortSerializer(PrimaryModelSerializer, CableTerminationSerializer):
     class Meta:
         model = FrontPort
         fields = [
-            'id', 'url', 'device', 'name', 'label', 'type', 'rear_port', 'rear_port_position', 'description',
+            'id', 'url', 'display', 'device', 'name', 'label', 'type', 'rear_port', 'rear_port_position', 'description',
             'mark_connected', 'cable', 'cable_peer', 'cable_peer_type', 'tags', 'custom_fields', 'created',
             'last_updated', '_occupied',
         ]
@@ -695,8 +704,8 @@ class DeviceBaySerializer(PrimaryModelSerializer):
     class Meta:
         model = DeviceBay
         fields = [
-            'id', 'url', 'device', 'name', 'label', 'description', 'installed_device', 'tags', 'custom_fields',
-            'created', 'last_updated',
+            'id', 'url', 'display', 'device', 'name', 'label', 'description', 'installed_device', 'tags',
+            'custom_fields', 'created', 'last_updated',
         ]
 
 
@@ -715,8 +724,8 @@ class InventoryItemSerializer(PrimaryModelSerializer):
     class Meta:
         model = InventoryItem
         fields = [
-            'id', 'url', 'device', 'parent', 'name', 'label', 'manufacturer', 'part_id', 'serial', 'asset_tag',
-            'discovered', 'description', 'tags', 'custom_fields', 'created', 'last_updated', '_depth',
+            'id', 'url', 'display', 'device', 'parent', 'name', 'label', 'manufacturer', 'part_id', 'serial',
+            'asset_tag', 'discovered', 'description', 'tags', 'custom_fields', 'created', 'last_updated', '_depth',
         ]
 
 
@@ -740,7 +749,7 @@ class CableSerializer(PrimaryModelSerializer):
     class Meta:
         model = Cable
         fields = [
-            'id', 'url', 'termination_a_type', 'termination_a_id', 'termination_a', 'termination_b_type',
+            'id', 'url', 'display', 'termination_a_type', 'termination_a_id', 'termination_a', 'termination_b_type',
             'termination_b_id', 'termination_b', 'type', 'status', 'label', 'color', 'length', 'length_unit', 'tags',
             'custom_fields',
         ]
@@ -861,7 +870,7 @@ class VirtualChassisSerializer(PrimaryModelSerializer):
 
     class Meta:
         model = VirtualChassis
-        fields = ['id', 'url', 'name', 'domain', 'master', 'tags', 'custom_fields', 'member_count']
+        fields = ['id', 'url', 'display', 'name', 'domain', 'master', 'tags', 'custom_fields', 'member_count']
 
 
 #
@@ -880,7 +889,7 @@ class PowerPanelSerializer(PrimaryModelSerializer):
 
     class Meta:
         model = PowerPanel
-        fields = ['id', 'url', 'site', 'location', 'name', 'tags', 'custom_fields', 'powerfeed_count']
+        fields = ['id', 'url', 'display', 'site', 'location', 'name', 'tags', 'custom_fields', 'powerfeed_count']
 
 
 class PowerFeedSerializer(PrimaryModelSerializer, CableTerminationSerializer, ConnectedEndpointSerializer):
@@ -912,8 +921,8 @@ class PowerFeedSerializer(PrimaryModelSerializer, CableTerminationSerializer, Co
     class Meta:
         model = PowerFeed
         fields = [
-            'id', 'url', 'power_panel', 'rack', 'name', 'status', 'type', 'supply', 'phase', 'voltage', 'amperage',
-            'max_utilization', 'comments', 'mark_connected', 'cable', 'cable_peer', 'cable_peer_type',
+            'id', 'url', 'display', 'power_panel', 'rack', 'name', 'status', 'type', 'supply', 'phase', 'voltage',
+            'amperage', 'max_utilization', 'comments', 'mark_connected', 'cable', 'cable_peer', 'cable_peer_type',
             'connected_endpoint', 'connected_endpoint_type', 'connected_endpoint_reachable', 'tags', 'custom_fields',
             'created', 'last_updated', '_occupied',
         ]

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -895,7 +895,6 @@ class RackElevationFilterForm(RackFilterForm):
         queryset=Rack.objects.all(),
         label=_('Rack'),
         required=False,
-        display_field='display_name',
         query_params={
             'site_id': '$site_id',
             'location_id': '$location_id',
@@ -939,7 +938,6 @@ class RackReservationForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     )
     rack = DynamicModelChoiceField(
         queryset=Rack.objects.all(),
-        display_field='display_name',
         query_params={
             'site_id': '$site',
             'location_id': 'location',
@@ -1076,7 +1074,6 @@ class RackReservationFilterForm(BootstrapMixin, TenancyFilterForm):
     user_id = DynamicModelMultipleChoiceField(
         queryset=User.objects.all(),
         required=False,
-        display_field='username',
         label='User',
         widget=APISelectMultiple(
             api_url='/api/users/users/',
@@ -1276,7 +1273,6 @@ class ComponentTemplateCreateForm(BootstrapMixin, ComponentForm):
     )
     device_type = DynamicModelChoiceField(
         queryset=DeviceType.objects.all(),
-        display_field='model',
         query_params={
             'manufacturer_id': '$manufacturer'
         }
@@ -2030,7 +2026,6 @@ class DeviceForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     location = DynamicModelChoiceField(
         queryset=Location.objects.all(),
         required=False,
-        display_field='display_name',
         query_params={
             'site_id': '$site'
         },
@@ -2041,7 +2036,6 @@ class DeviceForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     rack = DynamicModelChoiceField(
         queryset=Rack.objects.all(),
         required=False,
-        display_field='display_name',
         query_params={
             'site_id': '$site',
             'location_id': 'location',
@@ -2067,7 +2061,6 @@ class DeviceForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     )
     device_type = DynamicModelChoiceField(
         queryset=DeviceType.objects.all(),
-        display_field='model',
         query_params={
             'manufacturer_id': '$manufacturer'
         }
@@ -2343,7 +2336,6 @@ class DeviceBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditF
     device_type = DynamicModelChoiceField(
         queryset=DeviceType.objects.all(),
         required=False,
-        display_field='model',
         query_params={
             'manufacturer_id': '$manufacturer'
         }
@@ -2429,7 +2421,6 @@ class DeviceFilterForm(BootstrapMixin, LocalConfigContextFilterForm, TenancyFilt
     device_type_id = DynamicModelMultipleChoiceField(
         queryset=DeviceType.objects.all(),
         required=False,
-        display_field='model',
         query_params={
             'manufacturer_id': '$manufacturer_id'
         },
@@ -2518,8 +2509,7 @@ class ComponentCreateForm(BootstrapMixin, CustomFieldForm, ComponentForm):
     Base form for the creation of device components (models subclassed from ComponentModel).
     """
     device = DynamicModelChoiceField(
-        queryset=Device.objects.all(),
-        display_field='display_name'
+        queryset=Device.objects.all()
     )
     description = forms.CharField(
         max_length=100,
@@ -3049,7 +3039,6 @@ class InterfaceForm(BootstrapMixin, InterfaceCommonForm, CustomFieldModelForm):
         queryset=Interface.objects.all(),
         required=False,
         label='Parent interface',
-        display_field='display_name',
         query_params={
             'kind': 'physical',
         }
@@ -3058,7 +3047,6 @@ class InterfaceForm(BootstrapMixin, InterfaceCommonForm, CustomFieldModelForm):
         queryset=Interface.objects.all(),
         required=False,
         label='LAG interface',
-        display_field='display_name',
         query_params={
             'type': 'lag',
         }
@@ -3067,7 +3055,6 @@ class InterfaceForm(BootstrapMixin, InterfaceCommonForm, CustomFieldModelForm):
         queryset=VLAN.objects.all(),
         required=False,
         label='Untagged VLAN',
-        display_field='display_name',
         brief_mode=False,
         query_params={
             'site_id': 'null',
@@ -3077,7 +3064,6 @@ class InterfaceForm(BootstrapMixin, InterfaceCommonForm, CustomFieldModelForm):
         queryset=VLAN.objects.all(),
         required=False,
         label='Tagged VLANs',
-        display_field='display_name',
         brief_mode=False,
         query_params={
             'site_id': 'null',
@@ -3133,7 +3119,6 @@ class InterfaceCreateForm(ComponentCreateForm, InterfaceCommonForm):
     parent = DynamicModelChoiceField(
         queryset=Interface.objects.all(),
         required=False,
-        display_field='display_name',
         query_params={
             'device_id': '$device',
             'kind': 'physical',
@@ -3142,7 +3127,6 @@ class InterfaceCreateForm(ComponentCreateForm, InterfaceCommonForm):
     lag = DynamicModelChoiceField(
         queryset=Interface.objects.all(),
         required=False,
-        display_field='display_name',
         query_params={
             'device_id': '$device',
             'type': 'lag',
@@ -3171,7 +3155,6 @@ class InterfaceCreateForm(ComponentCreateForm, InterfaceCommonForm):
     untagged_vlan = DynamicModelChoiceField(
         queryset=VLAN.objects.all(),
         required=False,
-        display_field='display_name',
         brief_mode=False,
         query_params={
             'site_id': 'null',
@@ -3180,7 +3163,6 @@ class InterfaceCreateForm(ComponentCreateForm, InterfaceCommonForm):
     tagged_vlans = DynamicModelMultipleChoiceField(
         queryset=VLAN.objects.all(),
         required=False,
-        display_field='display_name',
         brief_mode=False,
         query_params={
             'site_id': 'null',
@@ -3237,7 +3219,6 @@ class InterfaceBulkEditForm(
     parent = DynamicModelChoiceField(
         queryset=Interface.objects.all(),
         required=False,
-        display_field='display_name',
         query_params={
             'kind': 'physical',
         }
@@ -3245,7 +3226,6 @@ class InterfaceBulkEditForm(
     lag = DynamicModelChoiceField(
         queryset=Interface.objects.all(),
         required=False,
-        display_field='display_name',
         query_params={
             'type': 'lag',
         }
@@ -3262,7 +3242,6 @@ class InterfaceBulkEditForm(
     untagged_vlan = DynamicModelChoiceField(
         queryset=VLAN.objects.all(),
         required=False,
-        display_field='display_name',
         brief_mode=False,
         query_params={
             'site_id': 'null',
@@ -3271,7 +3250,6 @@ class InterfaceBulkEditForm(
     tagged_vlans = DynamicModelMultipleChoiceField(
         queryset=VLAN.objects.all(),
         required=False,
-        display_field='display_name',
         brief_mode=False,
         query_params={
             'site_id': 'null',
@@ -3781,8 +3759,7 @@ class DeviceBayCSVForm(CustomFieldModelCSVForm):
 
 class InventoryItemForm(BootstrapMixin, CustomFieldModelForm):
     device = DynamicModelChoiceField(
-        queryset=Device.objects.all(),
-        display_field='display_name'
+        queryset=Device.objects.all()
     )
     parent = DynamicModelChoiceField(
         queryset=InventoryItem.objects.all(),
@@ -3939,7 +3916,6 @@ class ConnectCableToDeviceForm(BootstrapMixin, CustomFieldModelForm):
         queryset=Rack.objects.all(),
         label='Rack',
         required=False,
-        display_field='display_name',
         null_option='None',
         query_params={
             'site_id': '$termination_b_site'
@@ -3949,7 +3925,6 @@ class ConnectCableToDeviceForm(BootstrapMixin, CustomFieldModelForm):
         queryset=Device.objects.all(),
         label='Device',
         required=False,
-        display_field='display_name',
         query_params={
             'site_id': '$termination_b_site',
             'rack_id': '$termination_b_rack',
@@ -4083,7 +4058,6 @@ class ConnectCableToCircuitTerminationForm(BootstrapMixin, CustomFieldModelForm)
     termination_b_circuit = DynamicModelChoiceField(
         queryset=Circuit.objects.all(),
         label='Circuit',
-        display_field='cid',
         query_params={
             'provider_id': '$termination_b_provider',
             'site_id': '$termination_b_site',
@@ -4092,7 +4066,6 @@ class ConnectCableToCircuitTerminationForm(BootstrapMixin, CustomFieldModelForm)
     termination_b_id = DynamicModelChoiceField(
         queryset=CircuitTermination.objects.all(),
         label='Side',
-        display_field='term_side',
         disabled_indicator='_occupied',
         query_params={
             'circuit_id': '$termination_b_circuit'
@@ -4139,7 +4112,6 @@ class ConnectCableToPowerFeedForm(BootstrapMixin, CustomFieldModelForm):
         queryset=Location.objects.all(),
         label='Location',
         required=False,
-        display_field='cid',
         query_params={
             'site_id': '$termination_b_site'
         }
@@ -4525,7 +4497,6 @@ class VirtualChassisCreateForm(BootstrapMixin, CustomFieldModelForm):
         queryset=Rack.objects.all(),
         required=False,
         null_option='None',
-        display_field='display_name',
         query_params={
             'site_id': '$site'
         }
@@ -4533,7 +4504,6 @@ class VirtualChassisCreateForm(BootstrapMixin, CustomFieldModelForm):
     members = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
         required=False,
-        display_field='display_name',
         query_params={
             'site_id': '$site',
             'rack_id': '$rack',
@@ -4675,14 +4645,12 @@ class VCMemberSelectForm(BootstrapMixin, forms.Form):
         queryset=Rack.objects.all(),
         required=False,
         null_option='None',
-        display_field='display_name',
         query_params={
             'site_id': '$site'
         }
     )
     device = DynamicModelChoiceField(
         queryset=Device.objects.all(),
-        display_field='display_name',
         query_params={
             'site_id': '$site',
             'rack_id': '$rack',
@@ -4943,7 +4911,6 @@ class PowerFeedForm(BootstrapMixin, CustomFieldModelForm):
     rack = DynamicModelChoiceField(
         queryset=Rack.objects.all(),
         required=False,
-        display_field='display_name',
         query_params={
             'site_id': '$site'
         }
@@ -5054,7 +5021,6 @@ class PowerFeedBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEd
     rack = DynamicModelChoiceField(
         queryset=Rack.objects.all(),
         required=False,
-        display_field='display_name'
     )
     status = forms.ChoiceField(
         choices=add_blank_choice(PowerFeedStatusChoices),

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -59,7 +59,7 @@ class Mixins:
 
 class RegionTest(APIViewTestCases.APIViewTestCase):
     model = Region
-    brief_fields = ['_depth', 'id', 'name', 'site_count', 'slug', 'url']
+    brief_fields = ['_depth', 'display', 'id', 'name', 'site_count', 'slug', 'url']
     create_data = [
         {
             'name': 'Region 4',
@@ -88,7 +88,7 @@ class RegionTest(APIViewTestCases.APIViewTestCase):
 
 class SiteTest(APIViewTestCases.APIViewTestCase):
     model = Site
-    brief_fields = ['id', 'name', 'slug', 'url']
+    brief_fields = ['display', 'id', 'name', 'slug', 'url']
     bulk_update_data = {
         'status': 'planned',
     }
@@ -140,7 +140,7 @@ class SiteTest(APIViewTestCases.APIViewTestCase):
 
 class LocationTest(APIViewTestCases.APIViewTestCase):
     model = Location
-    brief_fields = ['_depth', 'id', 'name', 'rack_count', 'slug', 'url']
+    brief_fields = ['_depth', 'display', 'id', 'name', 'rack_count', 'slug', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -187,7 +187,7 @@ class LocationTest(APIViewTestCases.APIViewTestCase):
 
 class RackRoleTest(APIViewTestCases.APIViewTestCase):
     model = RackRole
-    brief_fields = ['id', 'name', 'rack_count', 'slug', 'url']
+    brief_fields = ['display', 'id', 'name', 'rack_count', 'slug', 'url']
     create_data = [
         {
             'name': 'Rack Role 4',
@@ -222,7 +222,7 @@ class RackRoleTest(APIViewTestCases.APIViewTestCase):
 
 class RackTest(APIViewTestCases.APIViewTestCase):
     model = Rack
-    brief_fields = ['device_count', 'display_name', 'id', 'name', 'url']
+    brief_fields = ['device_count', 'display', 'display_name', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'planned',
     }
@@ -310,7 +310,7 @@ class RackTest(APIViewTestCases.APIViewTestCase):
 
 class RackReservationTest(APIViewTestCases.APIViewTestCase):
     model = RackReservation
-    brief_fields = ['id', 'units', 'url', 'user']
+    brief_fields = ['display', 'id', 'units', 'url', 'user']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -361,7 +361,7 @@ class RackReservationTest(APIViewTestCases.APIViewTestCase):
 
 class ManufacturerTest(APIViewTestCases.APIViewTestCase):
     model = Manufacturer
-    brief_fields = ['devicetype_count', 'id', 'name', 'slug', 'url']
+    brief_fields = ['devicetype_count', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'Manufacturer 4',
@@ -393,7 +393,7 @@ class ManufacturerTest(APIViewTestCases.APIViewTestCase):
 
 class DeviceTypeTest(APIViewTestCases.APIViewTestCase):
     model = DeviceType
-    brief_fields = ['device_count', 'display_name', 'id', 'manufacturer', 'model', 'slug', 'url']
+    brief_fields = ['device_count', 'display', 'display_name', 'id', 'manufacturer', 'model', 'slug', 'url']
     bulk_update_data = {
         'part_number': 'ABC123',
     }
@@ -435,7 +435,7 @@ class DeviceTypeTest(APIViewTestCases.APIViewTestCase):
 
 class ConsolePortTemplateTest(APIViewTestCases.APIViewTestCase):
     model = ConsolePortTemplate
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -472,7 +472,7 @@ class ConsolePortTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class ConsoleServerPortTemplateTest(APIViewTestCases.APIViewTestCase):
     model = ConsoleServerPortTemplate
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -509,7 +509,7 @@ class ConsoleServerPortTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class PowerPortTemplateTest(APIViewTestCases.APIViewTestCase):
     model = PowerPortTemplate
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -546,7 +546,7 @@ class PowerPortTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class PowerOutletTemplateTest(APIViewTestCases.APIViewTestCase):
     model = PowerOutletTemplate
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -583,7 +583,7 @@ class PowerOutletTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class InterfaceTemplateTest(APIViewTestCases.APIViewTestCase):
     model = InterfaceTemplate
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -623,7 +623,7 @@ class InterfaceTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class FrontPortTemplateTest(APIViewTestCases.APIViewTestCase):
     model = FrontPortTemplate
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -694,7 +694,7 @@ class FrontPortTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class RearPortTemplateTest(APIViewTestCases.APIViewTestCase):
     model = RearPortTemplate
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -734,7 +734,7 @@ class RearPortTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class DeviceBayTemplateTest(APIViewTestCases.APIViewTestCase):
     model = DeviceBayTemplate
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -774,7 +774,7 @@ class DeviceBayTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class DeviceRoleTest(APIViewTestCases.APIViewTestCase):
     model = DeviceRole
-    brief_fields = ['device_count', 'id', 'name', 'slug', 'url', 'virtualmachine_count']
+    brief_fields = ['device_count', 'display', 'id', 'name', 'slug', 'url', 'virtualmachine_count']
     create_data = [
         {
             'name': 'Device Role 4',
@@ -809,7 +809,7 @@ class DeviceRoleTest(APIViewTestCases.APIViewTestCase):
 
 class PlatformTest(APIViewTestCases.APIViewTestCase):
     model = Platform
-    brief_fields = ['device_count', 'id', 'name', 'slug', 'url', 'virtualmachine_count']
+    brief_fields = ['device_count', 'display', 'id', 'name', 'slug', 'url', 'virtualmachine_count']
     create_data = [
         {
             'name': 'Platform 4',
@@ -841,7 +841,7 @@ class PlatformTest(APIViewTestCases.APIViewTestCase):
 
 class DeviceTest(APIViewTestCases.APIViewTestCase):
     model = Device
-    brief_fields = ['display_name', 'id', 'name', 'url']
+    brief_fields = ['display', 'display_name', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'failed',
     }
@@ -982,7 +982,7 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
 
 class ConsolePortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = ConsolePort
-    brief_fields = ['_occupied', 'cable', 'device', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1021,7 +1021,7 @@ class ConsolePortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCa
 
 class ConsoleServerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = ConsoleServerPort
-    brief_fields = ['_occupied', 'cable', 'device', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1060,7 +1060,7 @@ class ConsoleServerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIView
 
 class PowerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = PowerPort
-    brief_fields = ['_occupied', 'cable', 'device', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1099,7 +1099,7 @@ class PowerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase
 
 class PowerOutletTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = PowerOutlet
-    brief_fields = ['_occupied', 'cable', 'device', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1138,7 +1138,7 @@ class PowerOutletTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCa
 
 class InterfaceTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = Interface
-    brief_fields = ['_occupied', 'cable', 'device', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1196,7 +1196,7 @@ class InterfaceTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase
 
 class FrontPortTest(APIViewTestCases.APIViewTestCase):
     model = FrontPort
-    brief_fields = ['_occupied', 'cable', 'device', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1254,7 +1254,7 @@ class FrontPortTest(APIViewTestCases.APIViewTestCase):
 
 class RearPortTest(APIViewTestCases.APIViewTestCase):
     model = RearPort
-    brief_fields = ['_occupied', 'cable', 'device', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1296,7 +1296,7 @@ class RearPortTest(APIViewTestCases.APIViewTestCase):
 
 class DeviceBayTest(APIViewTestCases.APIViewTestCase):
     model = DeviceBay
-    brief_fields = ['device', 'id', 'name', 'url']
+    brief_fields = ['device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1359,7 +1359,7 @@ class DeviceBayTest(APIViewTestCases.APIViewTestCase):
 
 class InventoryItemTest(APIViewTestCases.APIViewTestCase):
     model = InventoryItem
-    brief_fields = ['_depth', 'device', 'id', 'name', 'url']
+    brief_fields = ['_depth', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1397,7 +1397,7 @@ class InventoryItemTest(APIViewTestCases.APIViewTestCase):
 
 class CableTest(APIViewTestCases.APIViewTestCase):
     model = Cable
-    brief_fields = ['id', 'label', 'url']
+    brief_fields = ['display', 'id', 'label', 'url']
     bulk_update_data = {
         'length': 100,
         'length_unit': 'm',
@@ -1582,7 +1582,7 @@ class VirtualChassisTest(APIViewTestCases.APIViewTestCase):
 
 class PowerPanelTest(APIViewTestCases.APIViewTestCase):
     model = PowerPanel
-    brief_fields = ['id', 'name', 'powerfeed_count', 'url']
+    brief_fields = ['display', 'id', 'name', 'powerfeed_count', 'url']
 
     @classmethod
     def setUpTestData(cls):
@@ -1631,7 +1631,7 @@ class PowerPanelTest(APIViewTestCases.APIViewTestCase):
 
 class PowerFeedTest(APIViewTestCases.APIViewTestCase):
     model = PowerFeed
-    brief_fields = ['_occupied', 'cable', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'planned',
     }

--- a/netbox/extras/api/nested_serializers.py
+++ b/netbox/extras/api/nested_serializers.py
@@ -22,7 +22,7 @@ class NestedWebhookSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Webhook
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedCustomFieldSerializer(WritableNestedSerializer):
@@ -30,7 +30,7 @@ class NestedCustomFieldSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.CustomField
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedCustomLinkSerializer(WritableNestedSerializer):
@@ -38,7 +38,7 @@ class NestedCustomLinkSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.CustomLink
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedConfigContextSerializer(WritableNestedSerializer):
@@ -46,7 +46,7 @@ class NestedConfigContextSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.ConfigContext
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedExportTemplateSerializer(WritableNestedSerializer):
@@ -54,7 +54,7 @@ class NestedExportTemplateSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.ExportTemplate
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedImageAttachmentSerializer(WritableNestedSerializer):
@@ -62,7 +62,7 @@ class NestedImageAttachmentSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.ImageAttachment
-        fields = ['id', 'url', 'name', 'image']
+        fields = ['id', 'url', 'display', 'name', 'image']
 
 
 class NestedJobResultSerializer(serializers.ModelSerializer):

--- a/netbox/extras/api/serializers.py
+++ b/netbox/extras/api/serializers.py
@@ -11,8 +11,9 @@ from dcim.models import Device, DeviceRole, Platform, Rack, Region, Site, SiteGr
 from extras.choices import *
 from extras.models import *
 from extras.utils import FeatureQuery
-from netbox.api import ChoiceField, ContentTypeField, SerializedPKRelatedField, ValidatedModelSerializer
+from netbox.api import ChoiceField, ContentTypeField, SerializedPKRelatedField
 from netbox.api.exceptions import SerializerNotFound
+from netbox.api.serializers import BaseModelSerializer, ValidatedModelSerializer
 from tenancy.api.nested_serializers import NestedTenantSerializer, NestedTenantGroupSerializer
 from tenancy.models import Tenant, TenantGroup
 from users.api.nested_serializers import NestedUserSerializer
@@ -56,9 +57,9 @@ class WebhookSerializer(ValidatedModelSerializer):
     class Meta:
         model = Webhook
         fields = [
-            'id', 'url', 'content_types', 'name', 'type_create', 'type_update', 'type_delete', 'payload_url', 'enabled',
-            'http_method', 'http_content_type', 'additional_headers', 'body_template', 'secret', 'ssl_verification',
-            'ca_file_path',
+            'id', 'url', 'display', 'content_types', 'name', 'type_create', 'type_update', 'type_delete', 'payload_url',
+            'enabled', 'http_method', 'http_content_type', 'additional_headers', 'body_template', 'secret',
+            'ssl_verification', 'ca_file_path',
         ]
 
 
@@ -78,7 +79,7 @@ class CustomFieldSerializer(ValidatedModelSerializer):
     class Meta:
         model = CustomField
         fields = [
-            'id', 'url', 'content_types', 'type', 'name', 'label', 'description', 'required', 'filter_logic',
+            'id', 'url', 'display', 'content_types', 'type', 'name', 'label', 'description', 'required', 'filter_logic',
             'default', 'weight', 'validation_minimum', 'validation_maximum', 'validation_regex', 'choices',
         ]
 
@@ -96,8 +97,8 @@ class CustomLinkSerializer(ValidatedModelSerializer):
     class Meta:
         model = CustomLink
         fields = [
-            'id', 'url', 'content_type', 'name', 'link_text', 'link_url', 'weight', 'group_name', 'button_class',
-            'new_window',
+            'id', 'url', 'display', 'content_type', 'name', 'link_text', 'link_url', 'weight', 'group_name',
+            'button_class', 'new_window',
         ]
 
 
@@ -113,7 +114,10 @@ class ExportTemplateSerializer(ValidatedModelSerializer):
 
     class Meta:
         model = ExportTemplate
-        fields = ['id', 'url', 'content_type', 'name', 'description', 'template_code', 'mime_type', 'file_extension']
+        fields = [
+            'id', 'url', 'display', 'content_type', 'name', 'description', 'template_code', 'mime_type',
+            'file_extension',
+        ]
 
 
 #
@@ -126,7 +130,7 @@ class TagSerializer(ValidatedModelSerializer):
 
     class Meta:
         model = Tag
-        fields = ['id', 'url', 'name', 'slug', 'color', 'description', 'tagged_items']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'color', 'description', 'tagged_items']
 
 
 #
@@ -143,8 +147,8 @@ class ImageAttachmentSerializer(ValidatedModelSerializer):
     class Meta:
         model = ImageAttachment
         fields = [
-            'id', 'url', 'content_type', 'object_id', 'parent', 'name', 'image', 'image_height', 'image_width',
-            'created',
+            'id', 'url', 'display', 'content_type', 'object_id', 'parent', 'name', 'image', 'image_height',
+            'image_width', 'created',
         ]
 
     def validate(self, data):
@@ -248,8 +252,8 @@ class ConfigContextSerializer(ValidatedModelSerializer):
     class Meta:
         model = ConfigContext
         fields = [
-            'id', 'url', 'name', 'weight', 'description', 'is_active', 'regions', 'site_groups', 'sites', 'roles',
-            'platforms', 'cluster_groups', 'clusters', 'tenant_groups', 'tenants', 'tags', 'data', 'created',
+            'id', 'url', 'display', 'name', 'weight', 'description', 'is_active', 'regions', 'site_groups', 'sites',
+            'roles', 'platforms', 'cluster_groups', 'clusters', 'tenant_groups', 'tenants', 'tags', 'data', 'created',
             'last_updated',
         ]
 
@@ -258,7 +262,7 @@ class ConfigContextSerializer(ValidatedModelSerializer):
 # Job Results
 #
 
-class JobResultSerializer(serializers.ModelSerializer):
+class JobResultSerializer(BaseModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='extras-api:jobresult-detail')
     user = NestedUserSerializer(
         read_only=True
@@ -271,7 +275,7 @@ class JobResultSerializer(serializers.ModelSerializer):
     class Meta:
         model = JobResult
         fields = [
-            'id', 'url', 'created', 'completed', 'name', 'obj_type', 'status', 'user', 'data', 'job_id',
+            'id', 'url', 'display', 'created', 'completed', 'name', 'obj_type', 'status', 'user', 'data', 'job_id',
         ]
 
 
@@ -349,7 +353,7 @@ class ScriptOutputSerializer(serializers.Serializer):
 # Change logging
 #
 
-class ObjectChangeSerializer(serializers.ModelSerializer):
+class ObjectChangeSerializer(BaseModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='extras-api:objectchange-detail')
     user = NestedUserSerializer(
         read_only=True
@@ -368,7 +372,7 @@ class ObjectChangeSerializer(serializers.ModelSerializer):
     class Meta:
         model = ObjectChange
         fields = [
-            'id', 'url', 'time', 'user', 'user_name', 'request_id', 'action', 'changed_object_type',
+            'id', 'url', 'display', 'time', 'user', 'user_name', 'request_id', 'action', 'changed_object_type',
             'changed_object_id', 'changed_object', 'prechange_data', 'postchange_data',
         ]
 
@@ -396,13 +400,13 @@ class ObjectChangeSerializer(serializers.ModelSerializer):
 # ContentTypes
 #
 
-class ContentTypeSerializer(serializers.ModelSerializer):
+class ContentTypeSerializer(BaseModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='extras-api:contenttype-detail')
     display_name = serializers.SerializerMethodField()
 
     class Meta:
         model = ContentType
-        fields = ['id', 'url', 'app_label', 'model', 'display_name']
+        fields = ['id', 'url', 'display', 'app_label', 'model', 'display_name']
 
     @swagger_serializer_method(serializer_or_field=serializers.CharField)
     def get_display_name(self, obj):

--- a/netbox/extras/forms.py
+++ b/netbox/extras/forms.py
@@ -399,7 +399,6 @@ class ObjectChangeFilterForm(BootstrapMixin, forms.Form):
     user_id = DynamicModelMultipleChoiceField(
         queryset=User.objects.all(),
         required=False,
-        display_field='username',
         label=_('User'),
         widget=APISelectMultiple(
             api_url='/api/users/users/',
@@ -408,7 +407,6 @@ class ObjectChangeFilterForm(BootstrapMixin, forms.Form):
     changed_object_type_id = DynamicModelMultipleChoiceField(
         queryset=ContentType.objects.all(),
         required=False,
-        display_field='display_name',
         label=_('Object Type'),
         widget=APISelectMultiple(
             api_url='/api/extras/content-types/',

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -32,7 +32,7 @@ class AppTest(APITestCase):
 
 class WebhookTest(APIViewTestCases.APIViewTestCase):
     model = Webhook
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     create_data = [
         {
             'content_types': ['dcim.device', 'dcim.devicetype'],
@@ -86,7 +86,7 @@ class WebhookTest(APIViewTestCases.APIViewTestCase):
 
 class CustomFieldTest(APIViewTestCases.APIViewTestCase):
     model = CustomField
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     create_data = [
         {
             'content_types': ['dcim.site'],
@@ -133,7 +133,7 @@ class CustomFieldTest(APIViewTestCases.APIViewTestCase):
 
 class CustomLinkTest(APIViewTestCases.APIViewTestCase):
     model = CustomLink
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     create_data = [
         {
             'content_type': 'dcim.site',
@@ -187,7 +187,7 @@ class CustomLinkTest(APIViewTestCases.APIViewTestCase):
 
 class ExportTemplateTest(APIViewTestCases.APIViewTestCase):
     model = ExportTemplate
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     create_data = [
         {
             'content_type': 'dcim.device',
@@ -235,7 +235,7 @@ class ExportTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class TagTest(APIViewTestCases.APIViewTestCase):
     model = Tag
-    brief_fields = ['color', 'id', 'name', 'slug', 'url']
+    brief_fields = ['color', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'Tag 4',
@@ -272,7 +272,7 @@ class ImageAttachmentTest(
     APIViewTestCases.DeleteObjectViewTestCase
 ):
     model = ImageAttachment
-    brief_fields = ['id', 'image', 'name', 'url']
+    brief_fields = ['display', 'id', 'image', 'name', 'url']
 
     @classmethod
     def setUpTestData(cls):
@@ -311,7 +311,7 @@ class ImageAttachmentTest(
 
 class ConfigContextTest(APIViewTestCases.APIViewTestCase):
     model = ConfigContext
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     create_data = [
         {
             'name': 'Config Context 4',

--- a/netbox/ipam/api/nested_serializers.py
+++ b/netbox/ipam/api/nested_serializers.py
@@ -27,7 +27,7 @@ class NestedVRFSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.VRF
-        fields = ['id', 'url', 'name', 'rd', 'display_name', 'prefix_count']
+        fields = ['id', 'url', 'display', 'name', 'rd', 'display_name', 'prefix_count']
 
 
 #
@@ -39,7 +39,7 @@ class NestedRouteTargetSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.RouteTarget
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 #
@@ -52,7 +52,7 @@ class NestedRIRSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.RIR
-        fields = ['id', 'url', 'name', 'slug', 'aggregate_count']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'aggregate_count']
 
 
 class NestedAggregateSerializer(WritableNestedSerializer):
@@ -61,7 +61,7 @@ class NestedAggregateSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Aggregate
-        fields = ['id', 'url', 'family', 'prefix']
+        fields = ['id', 'url', 'display', 'family', 'prefix']
 
 
 #
@@ -75,7 +75,7 @@ class NestedRoleSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Role
-        fields = ['id', 'url', 'name', 'slug', 'prefix_count', 'vlan_count']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'prefix_count', 'vlan_count']
 
 
 class NestedVLANGroupSerializer(WritableNestedSerializer):
@@ -84,7 +84,7 @@ class NestedVLANGroupSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.VLANGroup
-        fields = ['id', 'url', 'name', 'slug', 'vlan_count']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'vlan_count']
 
 
 class NestedVLANSerializer(WritableNestedSerializer):
@@ -92,7 +92,7 @@ class NestedVLANSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.VLAN
-        fields = ['id', 'url', 'vid', 'name', 'display_name']
+        fields = ['id', 'url', 'display', 'vid', 'name', 'display_name']
 
 
 #
@@ -105,7 +105,7 @@ class NestedPrefixSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Prefix
-        fields = ['id', 'url', 'family', 'prefix']
+        fields = ['id', 'url', 'display', 'family', 'prefix']
 
 
 #
@@ -118,7 +118,7 @@ class NestedIPAddressSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.IPAddress
-        fields = ['id', 'url', 'family', 'address']
+        fields = ['id', 'url', 'display', 'family', 'address']
 
 
 #
@@ -130,4 +130,4 @@ class NestedServiceSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Service
-        fields = ['id', 'url', 'name', 'protocol', 'ports']
+        fields = ['id', 'url', 'display', 'name', 'protocol', 'ports']

--- a/netbox/ipam/api/serializers.py
+++ b/netbox/ipam/api/serializers.py
@@ -43,8 +43,9 @@ class VRFSerializer(PrimaryModelSerializer):
     class Meta:
         model = VRF
         fields = [
-            'id', 'url', 'name', 'rd', 'tenant', 'enforce_unique', 'description', 'import_targets', 'export_targets',
-            'tags', 'display_name', 'custom_fields', 'created', 'last_updated', 'ipaddress_count', 'prefix_count',
+            'id', 'url', 'display', 'name', 'rd', 'tenant', 'enforce_unique', 'description', 'import_targets',
+            'export_targets', 'tags', 'display_name', 'custom_fields', 'created', 'last_updated', 'ipaddress_count',
+            'prefix_count',
         ]
 
 
@@ -59,7 +60,7 @@ class RouteTargetSerializer(PrimaryModelSerializer):
     class Meta:
         model = RouteTarget
         fields = [
-            'id', 'url', 'name', 'tenant', 'description', 'tags', 'custom_fields', 'created', 'last_updated',
+            'id', 'url', 'display', 'name', 'tenant', 'description', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
 
 
@@ -74,8 +75,8 @@ class RIRSerializer(OrganizationalModelSerializer):
     class Meta:
         model = RIR
         fields = [
-            'id', 'url', 'name', 'slug', 'is_private', 'description', 'custom_fields', 'created', 'last_updated',
-            'aggregate_count',
+            'id', 'url', 'display', 'name', 'slug', 'is_private', 'description', 'custom_fields', 'created',
+            'last_updated', 'aggregate_count',
         ]
 
 
@@ -88,8 +89,8 @@ class AggregateSerializer(PrimaryModelSerializer):
     class Meta:
         model = Aggregate
         fields = [
-            'id', 'url', 'family', 'prefix', 'rir', 'tenant', 'date_added', 'description', 'tags', 'custom_fields',
-            'created', 'last_updated',
+            'id', 'url', 'display', 'family', 'prefix', 'rir', 'tenant', 'date_added', 'description', 'tags',
+            'custom_fields', 'created', 'last_updated',
         ]
         read_only_fields = ['family']
 
@@ -106,7 +107,7 @@ class RoleSerializer(OrganizationalModelSerializer):
     class Meta:
         model = Role
         fields = [
-            'id', 'url', 'name', 'slug', 'weight', 'description', 'custom_fields', 'created', 'last_updated',
+            'id', 'url', 'display', 'name', 'slug', 'weight', 'description', 'custom_fields', 'created', 'last_updated',
             'prefix_count', 'vlan_count',
         ]
 
@@ -126,8 +127,8 @@ class VLANGroupSerializer(OrganizationalModelSerializer):
     class Meta:
         model = VLANGroup
         fields = [
-            'id', 'url', 'name', 'slug', 'scope_type', 'scope_id', 'scope', 'description', 'custom_fields', 'created',
-            'last_updated', 'vlan_count',
+            'id', 'url', 'display', 'name', 'slug', 'scope_type', 'scope_id', 'scope', 'description', 'custom_fields',
+            'created', 'last_updated', 'vlan_count',
         ]
         validators = []
 
@@ -165,7 +166,7 @@ class VLANSerializer(PrimaryModelSerializer):
     class Meta:
         model = VLAN
         fields = [
-            'id', 'url', 'site', 'group', 'vid', 'name', 'tenant', 'status', 'role', 'description', 'tags',
+            'id', 'url', 'display', 'site', 'group', 'vid', 'name', 'tenant', 'status', 'role', 'description', 'tags',
             'display_name', 'custom_fields', 'created', 'last_updated', 'prefix_count',
         ]
         validators = []
@@ -201,7 +202,7 @@ class PrefixSerializer(PrimaryModelSerializer):
     class Meta:
         model = Prefix
         fields = [
-            'id', 'url', 'family', 'prefix', 'site', 'vrf', 'tenant', 'vlan', 'status', 'role', 'is_pool',
+            'id', 'url', 'display', 'family', 'prefix', 'site', 'vrf', 'tenant', 'vlan', 'status', 'role', 'is_pool',
             'description', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
         read_only_fields = ['family']
@@ -277,7 +278,7 @@ class IPAddressSerializer(PrimaryModelSerializer):
     class Meta:
         model = IPAddress
         fields = [
-            'id', 'url', 'family', 'address', 'vrf', 'tenant', 'status', 'role', 'assigned_object_type',
+            'id', 'url', 'display', 'family', 'address', 'vrf', 'tenant', 'status', 'role', 'assigned_object_type',
             'assigned_object_id', 'assigned_object', 'nat_inside', 'nat_outside', 'dns_name', 'description', 'tags',
             'custom_fields', 'created', 'last_updated',
         ]
@@ -331,6 +332,6 @@ class ServiceSerializer(PrimaryModelSerializer):
     class Meta:
         model = Service
         fields = [
-            'id', 'url', 'device', 'virtual_machine', 'name', 'ports', 'protocol', 'ipaddresses', 'description', 'tags',
-            'custom_fields', 'created', 'last_updated',
+            'id', 'url', 'display', 'device', 'virtual_machine', 'name', 'ports', 'protocol', 'ipaddresses',
+            'description', 'tags', 'custom_fields', 'created', 'last_updated',
         ]

--- a/netbox/ipam/forms.py
+++ b/netbox/ipam/forms.py
@@ -394,8 +394,7 @@ class PrefixForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
-        label='VRF',
-        display_field='display_name'
+        label='VRF'
     )
     region = DynamicModelChoiceField(
         queryset=Region.objects.all(),
@@ -436,7 +435,6 @@ class PrefixForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
         queryset=VLAN.objects.all(),
         required=False,
         label='VLAN',
-        display_field='display_name',
         query_params={
             'site_id': '$site',
             'group_id': '$vlan_group',
@@ -555,8 +553,7 @@ class PrefixBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditF
     vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
-        label='VRF',
-        display_field='display_name'
+        label='VRF'
     )
     prefix_length = forms.IntegerField(
         min_value=PREFIX_LENGTH_MIN,
@@ -685,7 +682,6 @@ class IPAddressForm(BootstrapMixin, TenancyForm, ReturnURLForm, CustomFieldModel
     device = DynamicModelChoiceField(
         queryset=Device.objects.all(),
         required=False,
-        display_field='display_name',
         initial_params={
             'interfaces': '$interface'
         }
@@ -715,8 +711,7 @@ class IPAddressForm(BootstrapMixin, TenancyForm, ReturnURLForm, CustomFieldModel
     vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
-        label='VRF',
-        display_field='display_name'
+        label='VRF'
     )
     nat_region = DynamicModelChoiceField(
         queryset=Region.objects.all(),
@@ -747,7 +742,6 @@ class IPAddressForm(BootstrapMixin, TenancyForm, ReturnURLForm, CustomFieldModel
         queryset=Rack.objects.all(),
         required=False,
         label='Rack',
-        display_field='display_name',
         null_option='None',
         query_params={
             'site_id': '$site'
@@ -757,7 +751,6 @@ class IPAddressForm(BootstrapMixin, TenancyForm, ReturnURLForm, CustomFieldModel
         queryset=Device.objects.all(),
         required=False,
         label='Device',
-        display_field='display_name',
         query_params={
             'site_id': '$site',
             'rack_id': '$nat_rack',
@@ -779,14 +772,12 @@ class IPAddressForm(BootstrapMixin, TenancyForm, ReturnURLForm, CustomFieldModel
     nat_vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
-        label='VRF',
-        display_field='display_name'
+        label='VRF'
     )
     nat_inside = DynamicModelChoiceField(
         queryset=IPAddress.objects.all(),
         required=False,
         label='IP Address',
-        display_field='address',
         query_params={
             'device_id': '$nat_device',
             'virtual_machine_id': '$nat_virtual_machine',
@@ -895,8 +886,7 @@ class IPAddressBulkAddForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
     vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
-        label='VRF',
-        display_field='display_name'
+        label='VRF'
     )
     tags = DynamicModelMultipleChoiceField(
         queryset=Tag.objects.all(),
@@ -1027,8 +1017,7 @@ class IPAddressBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEd
     vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
-        label='VRF',
-        display_field='display_name'
+        label='VRF'
     )
     mask_length = forms.IntegerField(
         min_value=IPADDRESS_MASK_LENGTH_MIN,

--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -22,7 +22,7 @@ class AppTest(APITestCase):
 
 class VRFTest(APIViewTestCases.APIViewTestCase):
     model = VRF
-    brief_fields = ['display_name', 'id', 'name', 'prefix_count', 'rd', 'url']
+    brief_fields = ['display', 'display_name', 'id', 'name', 'prefix_count', 'rd', 'url']
     create_data = [
         {
             'name': 'VRF 4',
@@ -54,7 +54,7 @@ class VRFTest(APIViewTestCases.APIViewTestCase):
 
 class RouteTargetTest(APIViewTestCases.APIViewTestCase):
     model = RouteTarget
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     create_data = [
         {
             'name': '65000:1004',
@@ -83,7 +83,7 @@ class RouteTargetTest(APIViewTestCases.APIViewTestCase):
 
 class RIRTest(APIViewTestCases.APIViewTestCase):
     model = RIR
-    brief_fields = ['aggregate_count', 'id', 'name', 'slug', 'url']
+    brief_fields = ['aggregate_count', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'RIR 4',
@@ -115,7 +115,7 @@ class RIRTest(APIViewTestCases.APIViewTestCase):
 
 class AggregateTest(APIViewTestCases.APIViewTestCase):
     model = Aggregate
-    brief_fields = ['family', 'id', 'prefix', 'url']
+    brief_fields = ['display', 'family', 'id', 'prefix', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -154,7 +154,7 @@ class AggregateTest(APIViewTestCases.APIViewTestCase):
 
 class RoleTest(APIViewTestCases.APIViewTestCase):
     model = Role
-    brief_fields = ['id', 'name', 'prefix_count', 'slug', 'url', 'vlan_count']
+    brief_fields = ['display', 'id', 'name', 'prefix_count', 'slug', 'url', 'vlan_count']
     create_data = [
         {
             'name': 'Role 4',
@@ -186,7 +186,7 @@ class RoleTest(APIViewTestCases.APIViewTestCase):
 
 class PrefixTest(APIViewTestCases.APIViewTestCase):
     model = Prefix
-    brief_fields = ['family', 'id', 'prefix', 'url']
+    brief_fields = ['display', 'family', 'id', 'prefix', 'url']
     create_data = [
         {
             'prefix': '192.168.4.0/24',
@@ -360,7 +360,7 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
 
 class IPAddressTest(APIViewTestCases.APIViewTestCase):
     model = IPAddress
-    brief_fields = ['address', 'family', 'id', 'url']
+    brief_fields = ['address', 'display', 'family', 'id', 'url']
     create_data = [
         {
             'address': '192.168.0.4/24',
@@ -389,7 +389,7 @@ class IPAddressTest(APIViewTestCases.APIViewTestCase):
 
 class VLANGroupTest(APIViewTestCases.APIViewTestCase):
     model = VLANGroup
-    brief_fields = ['id', 'name', 'slug', 'url', 'vlan_count']
+    brief_fields = ['display', 'id', 'name', 'slug', 'url', 'vlan_count']
     create_data = [
         {
             'name': 'VLAN Group 4',
@@ -421,7 +421,7 @@ class VLANGroupTest(APIViewTestCases.APIViewTestCase):
 
 class VLANTest(APIViewTestCases.APIViewTestCase):
     model = VLAN
-    brief_fields = ['display_name', 'id', 'name', 'url', 'vid']
+    brief_fields = ['display', 'display_name', 'id', 'name', 'url', 'vid']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -481,7 +481,7 @@ class VLANTest(APIViewTestCases.APIViewTestCase):
 
 class ServiceTest(APIViewTestCases.APIViewTestCase):
     model = Service
-    brief_fields = ['id', 'name', 'ports', 'protocol', 'url']
+    brief_fields = ['display', 'id', 'name', 'ports', 'protocol', 'url']
     bulk_update_data = {
         'description': 'New description',
     }

--- a/netbox/netbox/api/serializers.py
+++ b/netbox/netbox/api/serializers.py
@@ -10,7 +10,14 @@ from extras.models import CustomField, Tag
 from utilities.utils import dict_to_filter_params
 
 
-class ValidatedModelSerializer(serializers.ModelSerializer):
+class BaseModelSerializer(serializers.ModelSerializer):
+    display = serializers.SerializerMethodField(read_only=True)
+
+    def get_display(self, obj):
+        return str(obj)
+
+
+class ValidatedModelSerializer(BaseModelSerializer):
     """
     Extends the built-in ModelSerializer to enforce calling full_clean() on a copy of the associated instance during
     validation. (DRF does not do this by default; see https://github.com/encode/django-rest-framework/issues/3144)
@@ -74,7 +81,7 @@ class CustomFieldModelSerializer(ValidatedModelSerializer):
 # Nested serializers
 #
 
-class WritableNestedSerializer(serializers.ModelSerializer):
+class WritableNestedSerializer(BaseModelSerializer):
     """
     Returns a nested representation of an object on read, but accepts only a primary key on write.
     """
@@ -133,7 +140,7 @@ class NestedTagSerializer(WritableNestedSerializer):
 
     class Meta:
         model = Tag
-        fields = ['id', 'url', 'name', 'slug', 'color']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'color']
 
 
 #

--- a/netbox/secrets/api/nested_serializers.py
+++ b/netbox/secrets/api/nested_serializers.py
@@ -14,7 +14,7 @@ class NestedSecretSerializer(WritableNestedSerializer):
 
     class Meta:
         model = Secret
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedSecretRoleSerializer(WritableNestedSerializer):
@@ -23,4 +23,4 @@ class NestedSecretRoleSerializer(WritableNestedSerializer):
 
     class Meta:
         model = SecretRole
-        fields = ['id', 'url', 'name', 'slug', 'secret_count']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'secret_count']

--- a/netbox/secrets/api/serializers.py
+++ b/netbox/secrets/api/serializers.py
@@ -21,7 +21,8 @@ class SecretRoleSerializer(OrganizationalModelSerializer):
     class Meta:
         model = SecretRole
         fields = [
-            'id', 'url', 'name', 'slug', 'description', 'custom_fields', 'created', 'last_updated', 'secret_count',
+            'id', 'url', 'display', 'name', 'slug', 'description', 'custom_fields', 'created', 'last_updated',
+            'secret_count',
         ]
 
 
@@ -37,8 +38,8 @@ class SecretSerializer(PrimaryModelSerializer):
     class Meta:
         model = Secret
         fields = [
-            'id', 'url', 'assigned_object_type', 'assigned_object_id', 'assigned_object', 'role', 'name', 'plaintext',
-            'hash', 'tags', 'custom_fields', 'created', 'last_updated',
+            'id', 'url', 'display', 'assigned_object_type', 'assigned_object_id', 'assigned_object', 'role', 'name',
+            'plaintext', 'hash', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
         validators = []
 

--- a/netbox/secrets/forms.py
+++ b/netbox/secrets/forms.py
@@ -80,8 +80,7 @@ class SecretRoleBulkEditForm(BootstrapMixin, CustomFieldBulkEditForm):
 class SecretForm(BootstrapMixin, CustomFieldModelForm):
     device = DynamicModelChoiceField(
         queryset=Device.objects.all(),
-        required=False,
-        display_field='display_name'
+        required=False
     )
     virtual_machine = DynamicModelChoiceField(
         queryset=VirtualMachine.objects.all(),

--- a/netbox/secrets/tests/test_api.py
+++ b/netbox/secrets/tests/test_api.py
@@ -21,7 +21,7 @@ class AppTest(APITestCase):
 
 class SecretRoleTest(APIViewTestCases.APIViewTestCase):
     model = SecretRole
-    brief_fields = ['id', 'name', 'secret_count', 'slug', 'url']
+    brief_fields = ['display', 'id', 'name', 'secret_count', 'slug', 'url']
     create_data = [
         {
             'name': 'Secret Role 4',
@@ -53,7 +53,7 @@ class SecretRoleTest(APIViewTestCases.APIViewTestCase):
 
 class SecretTest(APIViewTestCases.APIViewTestCase):
     model = Secret
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
 
     def setUp(self):
         super().setUp()

--- a/netbox/tenancy/api/nested_serializers.py
+++ b/netbox/tenancy/api/nested_serializers.py
@@ -20,7 +20,7 @@ class NestedTenantGroupSerializer(WritableNestedSerializer):
 
     class Meta:
         model = TenantGroup
-        fields = ['id', 'url', 'name', 'slug', 'tenant_count', '_depth']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'tenant_count', '_depth']
 
 
 class NestedTenantSerializer(WritableNestedSerializer):
@@ -28,4 +28,4 @@ class NestedTenantSerializer(WritableNestedSerializer):
 
     class Meta:
         model = Tenant
-        fields = ['id', 'url', 'name', 'slug']
+        fields = ['id', 'url', 'display', 'name', 'slug']

--- a/netbox/tenancy/api/serializers.py
+++ b/netbox/tenancy/api/serializers.py
@@ -17,7 +17,7 @@ class TenantGroupSerializer(NestedGroupModelSerializer):
     class Meta:
         model = TenantGroup
         fields = [
-            'id', 'url', 'name', 'slug', 'parent', 'description', 'custom_fields', 'created', 'last_updated',
+            'id', 'url', 'display', 'name', 'slug', 'parent', 'description', 'custom_fields', 'created', 'last_updated',
             'tenant_count', '_depth',
         ]
 
@@ -39,7 +39,7 @@ class TenantSerializer(PrimaryModelSerializer):
     class Meta:
         model = Tenant
         fields = [
-            'id', 'url', 'name', 'slug', 'group', 'description', 'comments', 'tags', 'custom_fields', 'created',
-            'last_updated', 'circuit_count', 'device_count', 'ipaddress_count', 'prefix_count', 'rack_count',
+            'id', 'url', 'display', 'name', 'slug', 'group', 'description', 'comments', 'tags', 'custom_fields',
+            'created', 'last_updated', 'circuit_count', 'device_count', 'ipaddress_count', 'prefix_count', 'rack_count',
             'site_count', 'virtualmachine_count', 'vlan_count', 'vrf_count', 'cluster_count',
         ]

--- a/netbox/tenancy/tests/test_api.py
+++ b/netbox/tenancy/tests/test_api.py
@@ -16,7 +16,7 @@ class AppTest(APITestCase):
 
 class TenantGroupTest(APIViewTestCases.APIViewTestCase):
     model = TenantGroup
-    brief_fields = ['_depth', 'id', 'name', 'slug', 'tenant_count', 'url']
+    brief_fields = ['_depth', 'display', 'id', 'name', 'slug', 'tenant_count', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -54,7 +54,7 @@ class TenantGroupTest(APIViewTestCases.APIViewTestCase):
 
 class TenantTest(APIViewTestCases.APIViewTestCase):
     model = Tenant
-    brief_fields = ['id', 'name', 'slug', 'url']
+    brief_fields = ['display', 'id', 'name', 'slug', 'url']
     bulk_update_data = {
         'group': None,
         'description': 'New description',

--- a/netbox/users/api/nested_serializers.py
+++ b/netbox/users/api/nested_serializers.py
@@ -17,7 +17,7 @@ class NestedGroupSerializer(WritableNestedSerializer):
 
     class Meta:
         model = Group
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedUserSerializer(WritableNestedSerializer):
@@ -25,7 +25,7 @@ class NestedUserSerializer(WritableNestedSerializer):
 
     class Meta:
         model = User
-        fields = ['id', 'url', 'username']
+        fields = ['id', 'url', 'display', 'username']
 
 
 class NestedObjectPermissionSerializer(WritableNestedSerializer):
@@ -39,7 +39,7 @@ class NestedObjectPermissionSerializer(WritableNestedSerializer):
 
     class Meta:
         model = ObjectPermission
-        fields = ['id', 'url', 'name', 'enabled', 'object_types', 'groups', 'users', 'actions']
+        fields = ['id', 'url', 'display', 'name', 'enabled', 'object_types', 'groups', 'users', 'actions']
 
     def get_groups(self, obj):
         return [g.name for g in obj.groups.all()]

--- a/netbox/users/api/serializers.py
+++ b/netbox/users/api/serializers.py
@@ -19,7 +19,7 @@ class UserSerializer(ValidatedModelSerializer):
     class Meta:
         model = User
         fields = (
-            'id', 'url', 'username', 'password', 'first_name', 'last_name', 'email', 'is_staff', 'is_active',
+            'id', 'url', 'display', 'username', 'password', 'first_name', 'last_name', 'email', 'is_staff', 'is_active',
             'date_joined', 'groups',
         )
         extra_kwargs = {
@@ -44,7 +44,7 @@ class GroupSerializer(ValidatedModelSerializer):
 
     class Meta:
         model = Group
-        fields = ('id', 'url', 'name', 'user_count')
+        fields = ('id', 'url', 'display', 'name', 'user_count')
 
 
 class ObjectPermissionSerializer(ValidatedModelSerializer):
@@ -69,5 +69,6 @@ class ObjectPermissionSerializer(ValidatedModelSerializer):
     class Meta:
         model = ObjectPermission
         fields = (
-            'id', 'url', 'name', 'description', 'enabled', 'object_types', 'groups', 'users', 'actions', 'constraints',
+            'id', 'url', 'display', 'name', 'description', 'enabled', 'object_types', 'groups', 'users', 'actions',
+            'constraints',
         )

--- a/netbox/users/tests/test_api.py
+++ b/netbox/users/tests/test_api.py
@@ -20,7 +20,7 @@ class AppTest(APITestCase):
 class UserTest(APIViewTestCases.APIViewTestCase):
     model = User
     view_namespace = 'users'
-    brief_fields = ['id', 'url', 'username']
+    brief_fields = ['display', 'id', 'url', 'username']
     validation_excluded_fields = ['password']
     create_data = [
         {
@@ -51,7 +51,7 @@ class UserTest(APIViewTestCases.APIViewTestCase):
 class GroupTest(APIViewTestCases.APIViewTestCase):
     model = Group
     view_namespace = 'users'
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     create_data = [
         {
             'name': 'Group 4',
@@ -77,7 +77,7 @@ class GroupTest(APIViewTestCases.APIViewTestCase):
 
 class ObjectPermissionTest(APIViewTestCases.APIViewTestCase):
     model = ObjectPermission
-    brief_fields = ['actions', 'enabled', 'groups', 'id', 'name', 'object_types', 'url', 'users']
+    brief_fields = ['actions', 'display', 'enabled', 'groups', 'id', 'name', 'object_types', 'url', 'users']
 
     @classmethod
     def setUpTestData(cls):

--- a/netbox/utilities/forms/fields.py
+++ b/netbox/utilities/forms/fields.py
@@ -276,7 +276,7 @@ class DynamicModelChoiceMixin:
     filter = django_filters.ModelChoiceFilter
     widget = widgets.APISelect
 
-    def __init__(self, display_field='name', query_params=None, initial_params=None, null_option=None,
+    def __init__(self, display_field='display', query_params=None, initial_params=None, null_option=None,
                  disabled_indicator=None, brief_mode=True, *args, **kwargs):
         self.display_field = display_field
         self.query_params = query_params or {}

--- a/netbox/virtualization/api/nested_serializers.py
+++ b/netbox/virtualization/api/nested_serializers.py
@@ -23,7 +23,7 @@ class NestedClusterTypeSerializer(WritableNestedSerializer):
 
     class Meta:
         model = ClusterType
-        fields = ['id', 'url', 'name', 'slug', 'cluster_count']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'cluster_count']
 
 
 class NestedClusterGroupSerializer(WritableNestedSerializer):
@@ -32,7 +32,7 @@ class NestedClusterGroupSerializer(WritableNestedSerializer):
 
     class Meta:
         model = ClusterGroup
-        fields = ['id', 'url', 'name', 'slug', 'cluster_count']
+        fields = ['id', 'url', 'display', 'name', 'slug', 'cluster_count']
 
 
 class NestedClusterSerializer(WritableNestedSerializer):
@@ -41,7 +41,7 @@ class NestedClusterSerializer(WritableNestedSerializer):
 
     class Meta:
         model = Cluster
-        fields = ['id', 'url', 'name', 'virtualmachine_count']
+        fields = ['id', 'url', 'display', 'name', 'virtualmachine_count']
 
 
 #
@@ -53,7 +53,7 @@ class NestedVirtualMachineSerializer(WritableNestedSerializer):
 
     class Meta:
         model = VirtualMachine
-        fields = ['id', 'url', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedVMInterfaceSerializer(WritableNestedSerializer):
@@ -62,4 +62,4 @@ class NestedVMInterfaceSerializer(WritableNestedSerializer):
 
     class Meta:
         model = Interface
-        fields = ['id', 'url', 'virtual_machine', 'name']
+        fields = ['id', 'url', 'display', 'virtual_machine', 'name']

--- a/netbox/virtualization/api/serializers.py
+++ b/netbox/virtualization/api/serializers.py
@@ -24,7 +24,8 @@ class ClusterTypeSerializer(OrganizationalModelSerializer):
     class Meta:
         model = ClusterType
         fields = [
-            'id', 'url', 'name', 'slug', 'description', 'custom_fields', 'created', 'last_updated', 'cluster_count',
+            'id', 'url', 'display', 'name', 'slug', 'description', 'custom_fields', 'created', 'last_updated',
+            'cluster_count',
         ]
 
 
@@ -35,7 +36,8 @@ class ClusterGroupSerializer(OrganizationalModelSerializer):
     class Meta:
         model = ClusterGroup
         fields = [
-            'id', 'url', 'name', 'slug', 'description', 'custom_fields', 'created', 'last_updated', 'cluster_count',
+            'id', 'url', 'display', 'name', 'slug', 'description', 'custom_fields', 'created', 'last_updated',
+            'cluster_count',
         ]
 
 
@@ -51,8 +53,8 @@ class ClusterSerializer(PrimaryModelSerializer):
     class Meta:
         model = Cluster
         fields = [
-            'id', 'url', 'name', 'type', 'group', 'tenant', 'site', 'comments', 'tags', 'custom_fields', 'created',
-            'last_updated', 'device_count', 'virtualmachine_count',
+            'id', 'url', 'display', 'name', 'type', 'group', 'tenant', 'site', 'comments', 'tags', 'custom_fields',
+            'created', 'last_updated', 'device_count', 'virtualmachine_count',
         ]
 
 
@@ -75,9 +77,9 @@ class VirtualMachineSerializer(PrimaryModelSerializer):
     class Meta:
         model = VirtualMachine
         fields = [
-            'id', 'url', 'name', 'status', 'site', 'cluster', 'role', 'tenant', 'platform', 'primary_ip', 'primary_ip4',
-            'primary_ip6', 'vcpus', 'memory', 'disk', 'comments', 'local_context_data', 'tags', 'custom_fields',
-            'created', 'last_updated',
+            'id', 'url', 'display', 'name', 'status', 'site', 'cluster', 'role', 'tenant', 'platform', 'primary_ip',
+            'primary_ip4', 'primary_ip6', 'vcpus', 'memory', 'disk', 'comments', 'local_context_data', 'tags',
+            'custom_fields', 'created', 'last_updated',
         ]
         validators = []
 
@@ -87,9 +89,9 @@ class VirtualMachineWithConfigContextSerializer(VirtualMachineSerializer):
 
     class Meta(VirtualMachineSerializer.Meta):
         fields = [
-            'id', 'url', 'name', 'status', 'site', 'cluster', 'role', 'tenant', 'platform', 'primary_ip', 'primary_ip4',
-            'primary_ip6', 'vcpus', 'memory', 'disk', 'comments', 'local_context_data', 'tags', 'custom_fields',
-            'config_context', 'created', 'last_updated',
+            'id', 'url', 'display', 'name', 'status', 'site', 'cluster', 'role', 'tenant', 'platform', 'primary_ip',
+            'primary_ip4', 'primary_ip6', 'vcpus', 'memory', 'disk', 'comments', 'local_context_data', 'tags',
+            'custom_fields', 'config_context', 'created', 'last_updated',
         ]
 
     @swagger_serializer_method(serializer_or_field=serializers.DictField)
@@ -116,7 +118,7 @@ class VMInterfaceSerializer(PrimaryModelSerializer):
     class Meta:
         model = VMInterface
         fields = [
-            'id', 'url', 'virtual_machine', 'name', 'enabled', 'mtu', 'mac_address', 'description', 'mode',
+            'id', 'url', 'display', 'virtual_machine', 'name', 'enabled', 'mtu', 'mac_address', 'description', 'mode',
             'untagged_vlan', 'tagged_vlans', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
 

--- a/netbox/virtualization/forms.py
+++ b/netbox/virtualization/forms.py
@@ -281,14 +281,12 @@ class ClusterAddDevicesForm(BootstrapMixin, forms.Form):
         queryset=Rack.objects.all(),
         required=False,
         null_option='None',
-        display_field='display_name',
         query_params={
             'site_id': '$site'
         }
     )
     devices = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
-        display_field='display_name',
         query_params={
             'site_id': '$site',
             'rack_id': '$rack',
@@ -609,7 +607,6 @@ class VMInterfaceForm(BootstrapMixin, InterfaceCommonForm, CustomFieldModelForm)
         queryset=VLAN.objects.all(),
         required=False,
         label='Untagged VLAN',
-        display_field='display_name',
         brief_mode=False,
         query_params={
             'site_id': 'null',
@@ -619,7 +616,6 @@ class VMInterfaceForm(BootstrapMixin, InterfaceCommonForm, CustomFieldModelForm)
         queryset=VLAN.objects.all(),
         required=False,
         label='Tagged VLANs',
-        display_field='display_name',
         brief_mode=False,
         query_params={
             'site_id': 'null',
@@ -694,7 +690,6 @@ class VMInterfaceCreateForm(BootstrapMixin, InterfaceCommonForm):
     untagged_vlan = DynamicModelChoiceField(
         queryset=VLAN.objects.all(),
         required=False,
-        display_field='display_name',
         brief_mode=False,
         query_params={
             'site_id': 'null',
@@ -703,7 +698,6 @@ class VMInterfaceCreateForm(BootstrapMixin, InterfaceCommonForm):
     tagged_vlans = DynamicModelMultipleChoiceField(
         queryset=VLAN.objects.all(),
         required=False,
-        display_field='display_name',
         brief_mode=False,
         query_params={
             'site_id': 'null',
@@ -784,7 +778,6 @@ class VMInterfaceBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
     untagged_vlan = DynamicModelChoiceField(
         queryset=VLAN.objects.all(),
         required=False,
-        display_field='display_name',
         brief_mode=False,
         query_params={
             'site_id': 'null',
@@ -793,7 +786,6 @@ class VMInterfaceBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
     tagged_vlans = DynamicModelMultipleChoiceField(
         queryset=VLAN.objects.all(),
         required=False,
-        display_field='display_name',
         brief_mode=False,
         query_params={
             'site_id': 'null',

--- a/netbox/virtualization/tests/test_api.py
+++ b/netbox/virtualization/tests/test_api.py
@@ -19,7 +19,7 @@ class AppTest(APITestCase):
 
 class ClusterTypeTest(APIViewTestCases.APIViewTestCase):
     model = ClusterType
-    brief_fields = ['cluster_count', 'id', 'name', 'slug', 'url']
+    brief_fields = ['cluster_count', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'Cluster Type 4',
@@ -51,7 +51,7 @@ class ClusterTypeTest(APIViewTestCases.APIViewTestCase):
 
 class ClusterGroupTest(APIViewTestCases.APIViewTestCase):
     model = ClusterGroup
-    brief_fields = ['cluster_count', 'id', 'name', 'slug', 'url']
+    brief_fields = ['cluster_count', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'Cluster Group 4',
@@ -83,7 +83,7 @@ class ClusterGroupTest(APIViewTestCases.APIViewTestCase):
 
 class ClusterTest(APIViewTestCases.APIViewTestCase):
     model = Cluster
-    brief_fields = ['id', 'name', 'url', 'virtualmachine_count']
+    brief_fields = ['display', 'id', 'name', 'url', 'virtualmachine_count']
     bulk_update_data = {
         'comments': 'New comment',
     }
@@ -131,7 +131,7 @@ class ClusterTest(APIViewTestCases.APIViewTestCase):
 
 class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
     model = VirtualMachine
-    brief_fields = ['id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'staged',
     }
@@ -207,7 +207,7 @@ class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
 
 class VMInterfaceTest(APIViewTestCases.APIViewTestCase):
     model = VMInterface
-    brief_fields = ['id', 'name', 'url', 'virtual_machine']
+    brief_fields = ['display', 'id', 'name', 'url', 'virtual_machine']
     bulk_update_data = {
         'description': 'New description',
     }


### PR DESCRIPTION
### Closes: #5891

- Add a `display` field to every REST API serializer, conveying a human-friendly simple name for the serialized object
- Discontinue use of `display_field` by DynamicModelChoiceFields