### PR TITLE
Closes #5429: Paginator on top of tables

### DIFF
--- a/netbox/project-static/css/base.css
+++ b/netbox/project-static/css/base.css
@@ -33,11 +33,6 @@ footer p {
 #navbar_search {
     padding: 0 8px;
 }
-.right-side-panel {
-    max-width: 400px;
-    min-width: 300px;
-    padding-right: 0;
-}
 
 /* Hide the username in the navigation menu on displays less than 1400px wide */
 @media (max-width: 1399px) {
@@ -168,7 +163,7 @@ td.min-width {
 
 /* Paginator */
 div.paginator {
-    margin-bottom: 20px;
+    margin-bottom: 1em;
 }
 div.paginator form {
     margin-bottom: 6px;

--- a/netbox/templates/circuits/provider.html
+++ b/netbox/templates/circuits/provider.html
@@ -129,7 +129,7 @@
                 </div>
             {% endif %}
         </div>
-    {% include 'inc/paginator.html' with paginator=circuits_table.paginator page=circuits_table.page %}
+    {% include 'inc/paginator.html' with paginator=circuits_table.paginator page=circuits_table.page show_count=True %}
     {% plugin_right_page object %}
     </div>
 </div>

--- a/netbox/templates/dcim/connections_list.html
+++ b/netbox/templates/dcim/connections_list.html
@@ -6,13 +6,13 @@
     {% export_button content_type %}
 </div>
 <h1>{% block title %}{{ title }}{% endblock %}</h1>
-<div class="row">
-	  <div class="col-md-12">
-        <div class="col-md-3 pull-right right-side-panel noprint">
-            {% include 'inc/search_panel.html' %}
-        </div>
+<div class="row">        
+    <div class="col-xs-12 col-sm-12 col-md-4 col-lg-3 pull-right noprint">
+        {% include 'inc/search_panel.html' %}
+    </div>
+	<div class="col-xs-12 col-sm-12 col-md-8 col-lg-9">
         {% include 'responsive_table.html' %}
-        {% include 'inc/paginator.html' with paginator=table.paginator page=table.page %}
+        {% include 'inc/paginator.html' with paginator=table.paginator page=table.page show_count=True %}
     </div>
 </div>
 {% endblock %}

--- a/netbox/templates/dcim/rack_elevation_list.html
+++ b/netbox/templates/dcim/rack_elevation_list.html
@@ -18,10 +18,10 @@
 </div>
 <h1>{% block title %}Rack Elevations{% endblock %}</h1>
 <div class="row">
-    <div class="col-md-12">
-        <div class="col-md-3 pull-right right-side-panel noprint">
-            {% include 'inc/search_panel.html' %}
-        </div>
+    <div class="col-xs-12 col-sm-12 col-md-4 col-lg-3 pull-right noprint">
+        {% include 'inc/search_panel.html' %}
+    </div>
+	<div class="col-xs-12 col-sm-12 col-md-8 col-lg-9">
         {% if page %}
             <div style="white-space: nowrap; overflow-x: scroll;">
                 {% for rack in page %}
@@ -49,7 +49,7 @@
                 {% endfor %}
             </div>
             <br />
-            {% include 'inc/paginator.html' %}
+            {% include 'inc/paginator.html' with show_count=True %}
         {% else %}
             <p>No racks found</p>
         {% endif %}

--- a/netbox/templates/extras/object_changelog.html
+++ b/netbox/templates/extras/object_changelog.html
@@ -4,7 +4,7 @@
 
 {% block content %}
     {% include 'panel_table.html' %}
-    {% include 'inc/paginator.html' with paginator=table.paginator page=table.page %}
+    {% include 'inc/paginator.html' with paginator=table.paginator page=table.page show_count=True %}
     <div class="text-muted">
         Change log retention: {% if settings.CHANGELOG_RETENTION %}{{ settings.CHANGELOG_RETENTION }} days{% else %}Indefinite{% endif %}
     </div>

--- a/netbox/templates/extras/tag.html
+++ b/netbox/templates/extras/tag.html
@@ -92,7 +92,7 @@
         </div>
         <div class="col-md-6">
             {% include 'panel_table.html' with table=items_table heading='Tagged Objects' %}
-            {% include 'inc/paginator.html' with paginator=items_table.paginator page=items_table.page %}
+            {% include 'inc/paginator.html' with paginator=items_table.paginator page=items_table.page show_count=True %}
         </div>
     </div>
 {% endblock %}

--- a/netbox/templates/generic/object_list.html
+++ b/netbox/templates/generic/object_list.html
@@ -4,30 +4,38 @@
 {% load static %}
 
 {% block content %}
-<div class="pull-right noprint">
-    {% block buttons %}{% endblock %}
-    {% if request.user.is_authenticated and table_config_form %}
-        <button type="button" class="btn btn-default" data-toggle="modal" data-target="#ObjectTable_config" title="Configure table"><i class="mdi mdi-cog"></i> Configure</button>
-    {% endif %}
-    {% if permissions.add and 'add' in action_buttons %}
-        {% add_button content_type.model_class|validated_viewname:"add" %}
-    {% endif %}
-    {% if permissions.add and 'import' in action_buttons %}
-        {% import_button content_type.model_class|validated_viewname:"import" %}
-    {% endif %}
-    {% if 'export' in action_buttons %}
-        {% export_button content_type %}
-    {% endif %}
-</div>
-<h1>{% block title %}{{ content_type.model_class|meta:"verbose_name_plural"|bettertitle }}{% endblock %}</h1>
 <div class="row">
-    <div class="col-md-12">
-        {% if filter_form %}
-            <div class="col-md-3 pull-right right-side-panel noprint">
-                {% include 'inc/search_panel.html' %}
-                {% block sidebar %}{% endblock %}
-            </div>
+    <div class="col-xs-12 col-sm-6 col-lg-6 col-md-2">
+        <h1>{% block title %}{{ content_type.model_class|meta:"verbose_name_plural"|bettertitle }}{% endblock %}</h1>
+    </div>
+    <div class="col-xs-12 col-sm-6 col-lg-3 col-md-4 pull-right text-right noprint" style="margin-bottom: 1em;">
+        {% block buttons %}{% endblock %}
+        {% if request.user.is_authenticated and table_config_form %}
+            <button type="button" class="btn btn-default" data-toggle="modal" data-target="#ObjectTable_config" title="Configure table"><i class="mdi mdi-cog"></i> Configure</button>
         {% endif %}
+        {% if permissions.add and 'add' in action_buttons %}
+            {% add_button content_type.model_class|validated_viewname:"add" %}
+        {% endif %}
+        {% if permissions.add and 'import' in action_buttons %}
+            {% import_button content_type.model_class|validated_viewname:"import" %}
+        {% endif %}
+        {% if 'export' in action_buttons %}
+            {% export_button content_type %}
+        {% endif %}
+    </div>
+    <div class="col-xs-12 col-sm-12 col-lg-3 col-md-6">
+        {% include 'inc/paginator.html' with paginator=table.paginator page=table.page show_count=False%}
+    </div>
+</div>
+
+<div class="row">
+    {% if filter_form %}
+        <div class="col-xs-12 col-sm-12 col-lg-3 col-md-4 pull-right noprint">
+            {% include 'inc/search_panel.html' %}
+            {% block sidebar %}{% endblock %}
+        </div>
+    {% endif %}
+    <div class="col-xs-12 col-sm-12 col-lg-9 col-md-8">
         {% with bulk_edit_url=content_type.model_class|validated_viewname:"bulk_edit" bulk_delete_url=content_type.model_class|validated_viewname:"bulk_delete" %}
         {% if permissions.change or permissions.delete %}
             <form method="post" class="form form-horizontal">
@@ -58,7 +66,7 @@
                     </div>
                 {% endif %}
                 {% include table_template|default:'responsive_table.html' %}
-                <div class="pull-left noprint">
+                <div class="pull-left noprint" style="margin-bottom: 1em;">
                     {% block bulk_buttons %}{% endblock %}
                     {% if bulk_edit_url and permissions.change %}
                         <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning btn-sm">
@@ -76,10 +84,11 @@
             {% include table_template|default:'responsive_table.html' %}
         {% endif %}
         {% endwith %}
-        {% include 'inc/paginator.html' with paginator=table.paginator page=table.page %}
+        {% include 'inc/paginator.html' with paginator=table.paginator page=table.page show_count=True %}
         <div class="clearfix"></div>
     </div>
 </div>
+
 {% table_config_form table table_name="ObjectTable" %}
 {% endblock %}
 

--- a/netbox/templates/inc/paginator.html
+++ b/netbox/templates/inc/paginator.html
@@ -1,6 +1,6 @@
 {% load helpers %}
 
-<div class="paginator pull-right text-right">
+<div class="paginator pull-right text-right noprint">
     {% if paginator.num_pages > 1 %}
         <nav>
             <ul class="pagination pull-right">
@@ -20,23 +20,25 @@
             </ul>
         </nav>
     {% endif %}
-    <form method="get">
-        {% for k, v_list in request.GET.lists %}
-            {% if k != 'per_page' %}
-                {% for v in v_list %}
-                    <input type="hidden" name="{{ k }}" value="{{ v }}" />
-                {% endfor %}
-            {% endif %}
-        {% endfor %}
-        <select name="per_page" id="per_page">
+    {% if show_count %}
+        <form method="get">
+            {% for k, v_list in request.GET.lists %}
+                {% if k != 'per_page' %}
+                    {% for v in v_list %}
+                        <input type="hidden" name="{{ k }}" value="{{ v }}" />
+                    {% endfor %}
+                {% endif %}
+            {% endfor %}
+            <select name="per_page" id="per_page">
             {% for n in settings.PER_PAGE_DEFAULTS %}
                 <option value="{{ n }}"{% if page.paginator.per_page == n %} selected="selected"{% endif %}>{{ n }}</option>
             {% endfor %}
-        </select> per page
-    </form>
-    {% if page %}
-        <div class="text-right text-muted">
-            Showing {{ page.start_index }}-{{ page.end_index }} of {{ page.paginator.count }}
-        </div>
+            </select> per page
+            {% if page %}
+                <div class="text-right text-muted">
+                    Showing {{ page.start_index }}-{{ page.end_index }} of {{ page.paginator.count }}
+                </div>
+            {% endif %}
+        </form>
     {% endif %}
 </div>

--- a/netbox/templates/utilities/obj_table.html
+++ b/netbox/templates/utilities/obj_table.html
@@ -45,5 +45,5 @@
 {% else %}
     {% include table_template|default:'responsive_table.html' %}
 {% endif %}
-    {% include 'inc/paginator.html' with paginator=table.paginator page=table.page %}
+{% include 'inc/paginator.html' with paginator=table.paginator page=table.page show_count=True %}
 <div class="clearfix"></div>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5429
<!--
    Please include a summary of the proposed changes below.
-->

* I've re-worked the structure of the top of the page to show the page buttons right aligned with the table.
* I've restructured the grids on the page such that the bottom paginator controls are always right aligned with the table. There are a few side effects to this.
  * The responsiveness of the application as a whole is, IMO, better - especially for small screens.
  * The select all n objects confirmation no longer pushes the table below the sidebar (an unreported bug?)
  * For some very wide (e.g. 4K) screen widths, the side bar now appears a bit large. This will be trivial to fix by using the col-xxl-* classes from Bootstrap 5 (when implemented in #5893) or could be back-ported to the NetBox CSS now. I stopped short of doing this as part of this change)

![Screenshot 2021-03-18 at 22 12 21](https://user-images.githubusercontent.com/1878544/111704729-891ead80-8837-11eb-970a-693f1d959eba.png)

![Screenshot 2021-03-18 at 22 12 43](https://user-images.githubusercontent.com/1878544/111704773-9471d900-8837-11eb-9754-8696426567fc.png)


![Screenshot 2021-03-18 at 22 15 10](https://user-images.githubusercontent.com/1878544/111704683-799f6480-8837-11eb-9048-16e747d56ac4.png)


![Screenshot 2021-03-18 at 22 13 11](https://user-images.githubusercontent.com/1878544/111704552-3b09aa00-8837-11eb-847f-a8d1527a91c4.png)
