### PR TITLE
Closes #6010: Avoid duplicate entries when searching for VC

### DIFF
--- a/netbox/dcim/filters.py
+++ b/netbox/dcim/filters.py
@@ -1075,7 +1075,7 @@ class VirtualChassisFilterSet(BaseFilterSet):
             Q(members__name__icontains=value) |
             Q(domain__icontains=value)
         )
-        return queryset.filter(qs_filter)
+        return queryset.filter(qs_filter).distinct()
 
 
 class CableFilterSet(BaseFilterSet):


### PR DESCRIPTION
Closes issue #6010.

**Searching for Virtual Chassis or any of their member now returns only distinct Virtual Chassis**. Before this fix, we get duplicated VC when searching for its name of its member name.
