### PR TITLE
Fix 5952

### DIFF
--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -59,6 +59,17 @@ POWERFEED_MAX_UTILIZATION_DEFAULT = 80  # Percentage
 # Cabling and connections
 #
 
+# Cable endpoint parent types
+CABLE_TERMINATION_PARENT_MODELS = Q(
+    Q(app_label='circuits', model__in=(
+        'circuit',
+    )) |
+    Q(app_label='dcim', model__in=(
+        'device',
+        'powerpanel',
+    ))
+)
+
 # Cable endpoint types
 CABLE_TERMINATION_MODELS = Q(
     Q(app_label='circuits', model__in=(

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -3826,7 +3826,7 @@ class CableCSVForm(CustomFieldModelCSVForm):
         help_text='Side A parent type'
     )
     side_a_parent = DeferredCSVModelChoiceField(
-        queryset=Device.objects.none(), # this is a standin
+        queryset=Device.objects.none(),  # this is a standin
         to_field_name='name',
         help_text='Side A parent name'
     )
@@ -3836,7 +3836,7 @@ class CableCSVForm(CustomFieldModelCSVForm):
         help_text='Side A type'
     )
     side_a = DeferredCSVModelChoiceField(
-        queryset=Interface.objects.none(), # this is a standin
+        queryset=Interface.objects.none(),  # this is a standin
         to_field_name='name',
         help_text='Side A component name'
     )
@@ -3848,7 +3848,7 @@ class CableCSVForm(CustomFieldModelCSVForm):
         help_text='Side B parent type'
     )
     side_b_parent = DeferredCSVModelChoiceField(
-        queryset=Device.objects.none(), # this is a standin
+        queryset=Device.objects.none(),  # this is a standin
         to_field_name='name',
         help_text='Side B parent name'
     )
@@ -3858,7 +3858,7 @@ class CableCSVForm(CustomFieldModelCSVForm):
         help_text='Side B type'
     )
     side_b = DeferredCSVModelChoiceField(
-        queryset=Interface.objects.none(), # this is a standin
+        queryset=Interface.objects.none(),  # this is a standin
         to_field_name='name',
         help_text='Side B component name'
     )

--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -112,8 +112,9 @@ class Cable(ChangeLoggedModel, CustomFieldModel):
     objects = RestrictedQuerySet.as_manager()
 
     csv_headers = [
-        'termination_a_type', 'termination_a_id', 'termination_b_type', 'termination_b_id', 'type', 'status', 'label',
-        'color', 'length', 'length_unit',
+        'side_a_parent_type', 'side_a_parent_id', 'side_a_type', 'side_a_name',
+        'side_b_parent_type', 'side_b_parent_id', 'side_b_type', 'side_b_name',
+        'type', 'status', 'label', 'color', 'length', 'length_unit',
     ]
 
     class Meta:
@@ -281,12 +282,16 @@ class Cable(ChangeLoggedModel, CustomFieldModel):
 
     def to_csv(self):
         return (
+            '{}.{}'.format(self.termination_a.parent._meta.app_label, self.termination_a.parent._meta.model_name),
+            self.termination_a.parent.id,
             '{}.{}'.format(self.termination_a_type.app_label, self.termination_a_type.model),
-            self.termination_a_id,
+            self.termination_a.name if hasattr(self.termination_a, "name") else self.termination_a_id,
+            '{}.{}'.format(self.termination_b.parent._meta.app_label, self.termination_b.parent._meta.model_name),
+            self.termination_b.parent.id,
             '{}.{}'.format(self.termination_b_type.app_label, self.termination_b_type.model),
-            self.termination_b_id,
-            self.get_type_display(),
-            self.get_status_display(),
+            self.termination_b.name if hasattr(self.termination_b, "name") else self.termination_b_id,
+            self.type,
+            self.status,
             self.label,
             self.color,
             self.length,

--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -112,8 +112,8 @@ class Cable(ChangeLoggedModel, CustomFieldModel):
     objects = RestrictedQuerySet.as_manager()
 
     csv_headers = [
-        'side_a_parent_type', 'side_a_parent_id', 'side_a_type', 'side_a_name',
-        'side_b_parent_type', 'side_b_parent_id', 'side_b_type', 'side_b_name',
+        'side_a_parent_type', 'side_a_parent.id', 'side_a_type', 'side_a.id',
+        'side_b_parent_type', 'side_b_parent.id', 'side_b_type', 'side_b.id',
         'type', 'status', 'label', 'color', 'length', 'length_unit',
     ]
 
@@ -285,11 +285,11 @@ class Cable(ChangeLoggedModel, CustomFieldModel):
             '{}.{}'.format(self.termination_a.parent._meta.app_label, self.termination_a.parent._meta.model_name),
             self.termination_a.parent.id,
             '{}.{}'.format(self.termination_a_type.app_label, self.termination_a_type.model),
-            self.termination_a.name if hasattr(self.termination_a, "name") else self.termination_a_id,
+            self.termination_a_id,
             '{}.{}'.format(self.termination_b.parent._meta.app_label, self.termination_b.parent._meta.model_name),
             self.termination_b.parent.id,
             '{}.{}'.format(self.termination_b_type.app_label, self.termination_b_type.model),
-            self.termination_b.name if hasattr(self.termination_b, "name") else self.termination_b_id,
+            self.termination_b_id,
             self.type,
             self.status,
             self.label,

--- a/netbox/dcim/tests/test_views.py
+++ b/netbox/dcim/tests/test_views.py
@@ -1676,10 +1676,10 @@ class CableTestCase(
         }
 
         cls.csv_data = (
-            "side_a_device,side_a_type,side_a_name,side_b_device,side_b_type,side_b_name",
-            "Device 3,dcim.interface,Interface 1,Device 4,dcim.interface,Interface 1",
-            "Device 3,dcim.interface,Interface 2,Device 4,dcim.interface,Interface 2",
-            "Device 3,dcim.interface,Interface 3,Device 4,dcim.interface,Interface 3",
+            "side_a_parent_type,side_a_parent_id,side_a_type,side_a_name,side_b_parent_type,side_b_parent_id,side_b_type,side_b_name",
+            f"dcim.device,{devices[2].pk},dcim.interface,Interface 1,dcim.device,{devices[3].pk},dcim.interface,Interface 1",
+            f"dcim.device,{devices[2].pk},dcim.interface,Interface 2,dcim.device,{devices[3].pk},dcim.interface,Interface 2",
+            f"dcim.device,{devices[2].pk},dcim.interface,Interface 3,dcim.device,{devices[3].pk},dcim.interface,Interface 3",
         )
 
         cls.bulk_edit_data = {

--- a/netbox/dcim/tests/test_views.py
+++ b/netbox/dcim/tests/test_views.py
@@ -1676,10 +1676,10 @@ class CableTestCase(
         }
 
         cls.csv_data = (
-            "side_a_parent_type,side_a_parent_id,side_a_type,side_a_name,side_b_parent_type,side_b_parent_id,side_b_type,side_b_name",
-            f"dcim.device,{devices[2].pk},dcim.interface,Interface 1,dcim.device,{devices[3].pk},dcim.interface,Interface 1",
-            f"dcim.device,{devices[2].pk},dcim.interface,Interface 2,dcim.device,{devices[3].pk},dcim.interface,Interface 2",
-            f"dcim.device,{devices[2].pk},dcim.interface,Interface 3,dcim.device,{devices[3].pk},dcim.interface,Interface 3",
+            "side_a_parent_type,side_a_parent,side_a_type,side_a,side_b_parent_type,side_b_parent.id,side_b_type,side_b",
+            f"dcim.device,Device 3,dcim.interface,Interface 1,dcim.device,{devices[3].pk},dcim.interface,Interface 1",
+            f"dcim.device,Device 3,dcim.interface,Interface 2,dcim.device,{devices[3].pk},dcim.interface,Interface 2",
+            f"dcim.device,Device 3,dcim.interface,Interface 3,dcim.device,{devices[3].pk},dcim.interface,Interface 3",
         )
 
         cls.bulk_edit_data = {

--- a/netbox/utilities/forms/fields.py
+++ b/netbox/utilities/forms/fields.py
@@ -24,6 +24,7 @@ __all__ = (
     'CSVContentTypeField',
     'CSVDataField',
     'CSVModelChoiceField',
+    'DeferredCSVModelChoiceField',
     'DynamicModelChoiceField',
     'DynamicModelMultipleChoiceField',
     'ExpandableIPAddressField',
@@ -139,6 +140,29 @@ class CSVModelChoiceField(forms.ModelChoiceField):
         except MultipleObjectsReturned:
             raise forms.ValidationError(
                 f'"{value}" is not a unique value for this field; multiple objects were found'
+            )
+
+
+class DeferredCSVModelChoiceField(CSVModelChoiceField):
+    """
+    Allows to defer querying from to_python
+    """
+    default_error_messages = {
+        'invalid_choice': 'Object not found.',
+    }
+
+    def to_python(self, value):
+        self.value = value
+
+        return value
+
+    def get_value(self, qs):
+        self.queryset = qs
+        try:
+            return super().to_python(self.value)
+        except MultipleObjectsReturned:
+            raise forms.ValidationError(
+                f'"{self.value}" is not a unique value for this field; multiple objects were found'
             )
 
 


### PR DESCRIPTION
### Fixes: #5952

This PR unifies the import and export CSV formats for cables. As of now it is a mix of both. The new headers are:

```
side_a_parent_type
side_a_parent_id
side_b_parent_type
side_b_parent_id
```

They replace the headers `side_a_device` and `side_b_device`. An ID instead of a name was chosen for two reasons:
- Circuits do not have names, just IDs.
- Device names are not necessarily unique across sites.

The value for `side_a_name` and `side_b_name` also underwent a semantic change: if the component type does not have a name (such as for circuit terminations), the value of `side_<side>_name` will be assumed to be a PK instead. This is also exported like this.

I tried testing this with a good amount of cables (I dumped about ~1500 cables and reimported them), but I cannot guarantee that this code was tested with all possible combinations of types and values.

I’d be happy to rework this a bit if the approach used is not quite as intended.

Cheers