### PR TITLE
Closes #6321: Re-add missing 'Add an IP Address' button in prefix view

### DIFF
--- a/netbox/templates/ipam/prefix/base.html
+++ b/netbox/templates/ipam/prefix/base.html
@@ -11,16 +11,6 @@
   <li>{{ object }}</li>
 {% endblock %}
 
-{% block buttons %}
-  {% if perms.ipam.add_ipaddress and active_tab == 'ip-addresses' and first_available_ip %}
-    <a href="{% url 'ipam:ipaddress_add' %}?address={{ first_available_ip }}&vrf={{ object.vrf.pk }}&tenant_group={{ object.tenant.group.pk }}&tenant={{ object.tenant.pk }}" class="btn btn-success">
-        <i class="mdi mdi-plus-thick" aria-hidden="true"></i>
-        Add an IP Address
-    </a>
-  {% endif %}
-  {{ block.super }}
-{% endblock %}
-
 {% block tabs %}
   <ul class="nav nav-tabs" style="margin-bottom: 20px">
     <li role="presentation"{% if not active_tab %} class="active"{% endif %}>

--- a/netbox/templates/ipam/prefix/base.html
+++ b/netbox/templates/ipam/prefix/base.html
@@ -11,6 +11,16 @@
   <li>{{ object }}</li>
 {% endblock %}
 
+{% block buttons %}
+  {% if perms.ipam.add_ipaddress and active_tab == 'ip-addresses' and first_available_ip %}
+    <a href="{% url 'ipam:ipaddress_add' %}?address={{ first_available_ip }}&vrf={{ object.vrf.pk }}&tenant_group={{ object.tenant.group.pk }}&tenant={{ object.tenant.pk }}" class="btn btn-success">
+        <i class="mdi mdi-plus-thick" aria-hidden="true"></i>
+        Add an IP Address
+    </a>
+  {% endif %}
+  {{ block.super }}
+{% endblock %}
+
 {% block tabs %}
   <ul class="nav nav-tabs" style="margin-bottom: 20px">
     <li role="presentation"{% if not active_tab %} class="active"{% endif %}>

--- a/netbox/templates/ipam/prefix/ip_addresses.html
+++ b/netbox/templates/ipam/prefix/ip_addresses.html
@@ -1,5 +1,15 @@
 {% extends 'ipam/prefix/base.html' %}
 
+{% block buttons %}
+  {% if perms.ipam.add_ipaddress and first_available_ip %}
+    <a href="{% url 'ipam:ipaddress_add' %}?address={{ first_available_ip }}&vrf={{ object.vrf.pk }}&tenant_group={{ object.tenant.group.pk }}&tenant={{ object.tenant.pk }}" class="btn btn-success">
+        <i class="mdi mdi-plus-thick" aria-hidden="true"></i>
+        Add an IP Address
+    </a>
+  {% endif %}
+  {{ block.super }}
+{% endblock %}
+
 {% block content %}
   <div class="row">
     <div class="col-md-12">


### PR DESCRIPTION
### Fixes: #6321

#### Template Changes
- Add 'Add an IP Address' button in prefix view which was removed in eac53a7