### PR TITLE
Closes #5991: Remove display_name

### DIFF
--- a/docs/release-notes/version-2.12.md
+++ b/docs/release-notes/version-2.12.md
@@ -6,3 +6,18 @@
 
 * [#5532](https://github.com/netbox-community/netbox/issues/5532) - Drop support for Python 3.6
 * [#5994](https://github.com/netbox-community/netbox/issues/5994) - Drop support for `display_field` argument on ObjectVar
+
+### REST API Changes
+
+* dcim.Device
+    * Removed the `display_name` attribute (use `display` instead)
+* dcim.DeviceType
+    * Removed the `display_name` attribute (use `display` instead)
+* dcim.Rack
+    * Removed the `display_name` attribute (use `display` instead)
+* extras.ContentType
+    * Removed the `display_name` attribute (use `display` instead)
+* ipam.VLAN
+    * Removed the `display_name` attribute (use `display` instead)
+* ipam.VRF
+    * Removed the `display_name` attribute (use `display` instead)

--- a/netbox/dcim/api/nested_serializers.py
+++ b/netbox/dcim/api/nested_serializers.py
@@ -101,7 +101,7 @@ class NestedRackSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Rack
-        fields = ['id', 'url', 'display', 'name', 'display_name', 'device_count']
+        fields = ['id', 'url', 'display', 'name', 'device_count']
 
 
 class NestedRackReservationSerializer(WritableNestedSerializer):
@@ -136,7 +136,7 @@ class NestedDeviceTypeSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.DeviceType
-        fields = ['id', 'url', 'display', 'manufacturer', 'model', 'slug', 'display_name', 'device_count']
+        fields = ['id', 'url', 'display', 'manufacturer', 'model', 'slug', 'device_count']
 
 
 class NestedConsolePortTemplateSerializer(WritableNestedSerializer):
@@ -232,7 +232,7 @@ class NestedDeviceSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.Device
-        fields = ['id', 'url', 'display', 'name', 'display_name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedConsoleServerPortSerializer(WritableNestedSerializer):

--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -172,10 +172,9 @@ class RackSerializer(PrimaryModelSerializer):
     class Meta:
         model = Rack
         fields = [
-            'id', 'url', 'display', 'name', 'facility_id', 'display_name', 'site', 'location', 'tenant', 'status',
-            'role', 'serial', 'asset_tag', 'type', 'width', 'u_height', 'desc_units', 'outer_width', 'outer_depth',
-            'outer_unit', 'comments', 'tags', 'custom_fields', 'created', 'last_updated', 'device_count',
-            'powerfeed_count',
+            'id', 'url', 'display', 'name', 'facility_id', 'site', 'location', 'tenant', 'status', 'role', 'serial',
+            'asset_tag', 'type', 'width', 'u_height', 'desc_units', 'outer_width', 'outer_depth', 'outer_unit',
+            'comments', 'tags', 'custom_fields', 'created', 'last_updated', 'device_count', 'powerfeed_count',
         ]
         # Omit the UniqueTogetherValidator that would be automatically added to validate (location, facility_id). This
         # prevents facility_id from being interpreted as a required field.
@@ -284,9 +283,9 @@ class DeviceTypeSerializer(PrimaryModelSerializer):
     class Meta:
         model = DeviceType
         fields = [
-            'id', 'url', 'display', 'manufacturer', 'model', 'slug', 'display_name', 'part_number', 'u_height',
-            'is_full_depth', 'subdevice_role', 'front_image', 'rear_image', 'comments', 'tags', 'custom_fields',
-            'created', 'last_updated', 'device_count',
+            'id', 'url', 'display', 'manufacturer', 'model', 'slug', 'part_number', 'u_height', 'is_full_depth',
+            'subdevice_role', 'front_image', 'rear_image', 'comments', 'tags', 'custom_fields', 'created',
+            'last_updated', 'device_count',
         ]
 
 
@@ -465,10 +464,10 @@ class DeviceSerializer(PrimaryModelSerializer):
     class Meta:
         model = Device
         fields = [
-            'id', 'url', 'display', 'name', 'display_name', 'device_type', 'device_role', 'tenant', 'platform',
-            'serial', 'asset_tag', 'site', 'location', 'rack', 'position', 'face', 'parent_device', 'status',
-            'primary_ip', 'primary_ip4', 'primary_ip6', 'cluster', 'virtual_chassis', 'vc_position', 'vc_priority',
-            'comments', 'local_context_data', 'tags', 'custom_fields', 'created', 'last_updated',
+            'id', 'url', 'display', 'name', 'device_type', 'device_role', 'tenant', 'platform', 'serial', 'asset_tag',
+            'site', 'location', 'rack', 'position', 'face', 'parent_device', 'status', 'primary_ip', 'primary_ip4',
+            'primary_ip6', 'cluster', 'virtual_chassis', 'vc_position', 'vc_priority', 'comments', 'local_context_data',
+            'tags', 'custom_fields', 'created', 'last_updated',
         ]
         validators = []
 
@@ -501,10 +500,10 @@ class DeviceWithConfigContextSerializer(DeviceSerializer):
 
     class Meta(DeviceSerializer.Meta):
         fields = [
-            'id', 'url', 'display', 'name', 'display_name', 'device_type', 'device_role', 'tenant', 'platform',
-            'serial', 'asset_tag', 'site', 'location', 'rack', 'position', 'face', 'parent_device', 'status',
-            'primary_ip', 'primary_ip4', 'primary_ip6', 'cluster', 'virtual_chassis', 'vc_position', 'vc_priority',
-            'comments', 'local_context_data', 'tags', 'custom_fields', 'config_context', 'created', 'last_updated',
+            'id', 'url', 'display', 'name', 'device_type', 'device_role', 'tenant', 'platform', 'serial', 'asset_tag',
+            'site', 'location', 'rack', 'position', 'face', 'parent_device', 'status', 'primary_ip', 'primary_ip4',
+            'primary_ip6', 'cluster', 'virtual_chassis', 'vc_position', 'vc_priority', 'comments', 'local_context_data',
+            'tags', 'custom_fields', 'config_context', 'created', 'last_updated',
         ]
 
     @swagger_serializer_method(serializer_or_field=serializers.DictField)

--- a/netbox/dcim/elevations.py
+++ b/netbox/dcim/elevations.py
@@ -34,10 +34,11 @@ class RackElevationSVG:
 
     @staticmethod
     def _get_device_description(device):
-        return '{} ({}) — {} ({}U) {} {}'.format(
+        return '{} ({}) — {} {} ({}U) {} {}'.format(
             device.name,
             device.device_role,
-            device.device_type.display_name,
+            device.device_type.manufacturer.name,
+            device.device_type.model,
             device.device_type.u_height,
             device.asset_tag or '',
             device.serial or ''

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -321,10 +321,6 @@ class DeviceType(PrimaryModel):
             self.rear_image.delete(save=False)
 
     @property
-    def display_name(self):
-        return f'{self.manufacturer.name} {self.model}'
-
-    @property
     def is_parent_device(self):
         return self.subdevice_role == SubdeviceRoleChoices.ROLE_PARENT
 
@@ -622,7 +618,13 @@ class Device(PrimaryModel, ConfigContextModel):
         )
 
     def __str__(self):
-        return self.display_name or super().__str__()
+        if self.name:
+            return self.name
+        elif self.virtual_chassis:
+            return f'{self.virtual_chassis.name}:{self.vc_position} ({self.pk})'
+        elif self.device_type:
+            return f'{self.device_type.manufacturer} {self.device_type.model} ({self.pk})'
+        return super().__str__()
 
     def get_absolute_url(self):
         return reverse('dcim:device', args=[self.pk])
@@ -822,17 +824,6 @@ class Device(PrimaryModel, ConfigContextModel):
             self.get_face_display(),
             self.comments,
         )
-
-    @property
-    def display_name(self):
-        if self.name:
-            return self.name
-        elif self.virtual_chassis:
-            return f'{self.virtual_chassis.name}:{self.vc_position} ({self.pk})'
-        elif self.device_type:
-            return f'{self.device_type.manufacturer} {self.device_type.model} ({self.pk})'
-        else:
-            return ''  # Device has not yet been created
 
     @property
     def identifier(self):

--- a/netbox/dcim/models/racks.py
+++ b/netbox/dcim/models/racks.py
@@ -209,7 +209,9 @@ class Rack(PrimaryModel):
         )
 
     def __str__(self):
-        return self.display_name or super().__str__()
+        if self.facility_id:
+            return f'{self.name} ({self.facility_id})'
+        return self.name
 
     def get_absolute_url(self):
         return reverse('dcim:rack', args=[self.pk])
@@ -276,12 +278,6 @@ class Rack(PrimaryModel):
             return range(1, self.u_height + 1)
         else:
             return reversed(range(1, self.u_height + 1))
-
-    @property
-    def display_name(self):
-        if self.facility_id:
-            return f'{self.name} ({self.facility_id})'
-        return self.name
 
     def get_status_class(self):
         return RackStatusChoices.CSS_CLASSES.get(self.status)

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -251,7 +251,7 @@ class RackRoleTest(APIViewTestCases.APIViewTestCase):
 
 class RackTest(APIViewTestCases.APIViewTestCase):
     model = Rack
-    brief_fields = ['device_count', 'display', 'display_name', 'id', 'name', 'url']
+    brief_fields = ['device_count', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'planned',
     }
@@ -422,7 +422,7 @@ class ManufacturerTest(APIViewTestCases.APIViewTestCase):
 
 class DeviceTypeTest(APIViewTestCases.APIViewTestCase):
     model = DeviceType
-    brief_fields = ['device_count', 'display', 'display_name', 'id', 'manufacturer', 'model', 'slug', 'url']
+    brief_fields = ['device_count', 'display', 'id', 'manufacturer', 'model', 'slug', 'url']
     bulk_update_data = {
         'part_number': 'ABC123',
     }
@@ -870,7 +870,7 @@ class PlatformTest(APIViewTestCases.APIViewTestCase):
 
 class DeviceTest(APIViewTestCases.APIViewTestCase):
     model = Device
-    brief_fields = ['display', 'display_name', 'id', 'name', 'url']
+    brief_fields = ['display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'failed',
     }

--- a/netbox/extras/api/serializers.py
+++ b/netbox/extras/api/serializers.py
@@ -453,12 +453,7 @@ class ObjectChangeSerializer(BaseModelSerializer):
 
 class ContentTypeSerializer(BaseModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='extras-api:contenttype-detail')
-    display_name = serializers.SerializerMethodField()
 
     class Meta:
         model = ContentType
-        fields = ['id', 'url', 'display', 'app_label', 'model', 'display_name']
-
-    @swagger_serializer_method(serializer_or_field=serializers.CharField)
-    def get_display_name(self, obj):
-        return obj.app_labeled_name
+        fields = ['id', 'url', 'display', 'app_label', 'model']

--- a/netbox/ipam/api/nested_serializers.py
+++ b/netbox/ipam/api/nested_serializers.py
@@ -27,7 +27,7 @@ class NestedVRFSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.VRF
-        fields = ['id', 'url', 'display', 'name', 'rd', 'display_name', 'prefix_count']
+        fields = ['id', 'url', 'display', 'name', 'rd', 'prefix_count']
 
 
 #
@@ -92,7 +92,7 @@ class NestedVLANSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.VLAN
-        fields = ['id', 'url', 'display', 'vid', 'name', 'display_name']
+        fields = ['id', 'url', 'display', 'vid', 'name']
 
 
 #

--- a/netbox/ipam/api/serializers.py
+++ b/netbox/ipam/api/serializers.py
@@ -44,8 +44,7 @@ class VRFSerializer(PrimaryModelSerializer):
         model = VRF
         fields = [
             'id', 'url', 'display', 'name', 'rd', 'tenant', 'enforce_unique', 'description', 'import_targets',
-            'export_targets', 'tags', 'display_name', 'custom_fields', 'created', 'last_updated', 'ipaddress_count',
-            'prefix_count',
+            'export_targets', 'tags', 'custom_fields', 'created', 'last_updated', 'ipaddress_count', 'prefix_count',
         ]
 
 
@@ -167,7 +166,7 @@ class VLANSerializer(PrimaryModelSerializer):
         model = VLAN
         fields = [
             'id', 'url', 'display', 'site', 'group', 'vid', 'name', 'tenant', 'status', 'role', 'description', 'tags',
-            'display_name', 'custom_fields', 'created', 'last_updated', 'prefix_count',
+            'custom_fields', 'created', 'last_updated', 'prefix_count',
         ]
         validators = []
 

--- a/netbox/ipam/models/vlans.py
+++ b/netbox/ipam/models/vlans.py
@@ -172,7 +172,7 @@ class VLAN(PrimaryModel):
         verbose_name_plural = 'VLANs'
 
     def __str__(self):
-        return self.display_name or super().__str__()
+        return f'{self.name} ({self.vid})'
 
     def get_absolute_url(self):
         return reverse('ipam:vlan', args=[self.pk])
@@ -198,10 +198,6 @@ class VLAN(PrimaryModel):
             self.role.name if self.role else None,
             self.description,
         )
-
-    @property
-    def display_name(self):
-        return f'{self.name} ({self.vid})'
 
     def get_status_class(self):
         return VLANStatusChoices.CSS_CLASSES.get(self.status)

--- a/netbox/ipam/models/vrfs.py
+++ b/netbox/ipam/models/vrfs.py
@@ -71,7 +71,9 @@ class VRF(PrimaryModel):
         verbose_name_plural = 'VRFs'
 
     def __str__(self):
-        return self.display_name or super().__str__()
+        if self.rd:
+            return f'{self.name} ({self.rd})'
+        return self.name
 
     def get_absolute_url(self):
         return reverse('ipam:vrf', args=[self.pk])
@@ -84,12 +86,6 @@ class VRF(PrimaryModel):
             self.enforce_unique,
             self.description,
         )
-
-    @property
-    def display_name(self):
-        if self.rd:
-            return f'{self.name} ({self.rd})'
-        return self.name
 
 
 @extras_features('custom_fields', 'custom_links', 'export_templates', 'webhooks')

--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -22,7 +22,7 @@ class AppTest(APITestCase):
 
 class VRFTest(APIViewTestCases.APIViewTestCase):
     model = VRF
-    brief_fields = ['display', 'display_name', 'id', 'name', 'prefix_count', 'rd', 'url']
+    brief_fields = ['display', 'id', 'name', 'prefix_count', 'rd', 'url']
     create_data = [
         {
             'name': 'VRF 4',
@@ -421,7 +421,7 @@ class VLANGroupTest(APIViewTestCases.APIViewTestCase):
 
 class VLANTest(APIViewTestCases.APIViewTestCase):
     model = VLAN
-    brief_fields = ['display', 'display_name', 'id', 'name', 'url', 'vid']
+    brief_fields = ['display', 'id', 'name', 'url', 'vid']
     bulk_update_data = {
         'description': 'New description',
     }

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -94,7 +94,7 @@
                                     <tr>
                                         <th scope="row">Device Type</th>
                                         <td>
-                                            <span><a href="{{ object.device_type.get_absolute_url }}">{{ object.device_type.display_name }}</a> ({{ object.device_type.u_height }}U)</span>
+                                            <span><a href="{{ object.device_type.get_absolute_url }}">{{ object.device_type }}</a> ({{ object.device_type.u_height }}U)</span>
                                         </td>
                                     </tr>
                                     <tr>
@@ -356,7 +356,7 @@
                                                 <span class="text-muted">&mdash;</span>
                                             {% endif %}
                                         </td>
-                                        <td>{{ rd.device_type.display_name }}</td>
+                                        <td>{{ rd.device_type }}</td>
                                     </tr>
                                     {% endfor %}
                                 </table>

--- a/netbox/templates/dcim/rack.html
+++ b/netbox/templates/dcim/rack.html
@@ -344,7 +344,7 @@
                             <a href="{% url 'dcim:device' pk=device.pk %}">{{ device }}</a>
                         </td>
                         <td>{{ device.device_role }}</td>
-                        <td>{{ device.device_type.display_name }}</td>
+                        <td>{{ device.device_type }}</td>
                         {% if device.parent_bay %}
                             <td><a href="{{ device.parent_bay.device.get_absolute_url }}">{{ device.parent_bay.device }}</a></td>
                             <td>{{ device.parent_bay }}</td>

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -79,7 +79,7 @@
                             {% if object.vlan.group %}
                                 <a href="{{ object.vlan.group.get_absolute_url }}">{{ object.vlan.group }}</a> /
                             {% endif %}
-                            <a href="{% url 'ipam:vlan' pk=object.vlan.pk %}">{{ object.vlan.display_name }}</a>
+                            <a href="{% url 'ipam:vlan' pk=object.vlan.pk %}">{{ object.vlan }}</a>
                         {% else %}
                             <span class="text-muted">None</span>
                         {% endif %}

--- a/netbox/templates/ipam/vlan/base.html
+++ b/netbox/templates/ipam/vlan/base.html
@@ -2,7 +2,7 @@
 {% load helpers %}
 {% load plugins %}
 
-{% block title %}VLAN {{ object.display_name }}{% endblock %}
+{% block title %}VLAN {{ object }}{% endblock %}
 
 {% block breadcrumbs %}
 <li class="breadcrumb-item">


### PR DESCRIPTION
### Closes: #5991

- Remove `display_name` from all serializers
- Remove `display_name()` method from all models