### PR TITLE
Fixed #6438 Device Type Import does not import/export description/label fields for many components

### DIFF
--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -12,6 +12,7 @@
 * [#6376](https://github.com/netbox-community/netbox/issues/6376) - Fix assignment of VLAN groups to clusters, cluster groups via REST API
 * [#6398](https://github.com/netbox-community/netbox/issues/6398) - Avoid exception when deleting device connected to self via circuit
 * [#6426](https://github.com/netbox-community/netbox/issues/6426) - Allow assigning virtual chassis member interfaces to LAG on VC master
+* [#6438](https://github.com/netbox-community/netbox/issues/6438) - Fix missing descriptions and label for device type imports and exports
 
 ---
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -1825,7 +1825,7 @@ class ConsolePortTemplateImportForm(ComponentTemplateImportForm):
     class Meta:
         model = ConsolePortTemplate
         fields = [
-            'device_type', 'name', 'label', 'type',
+            'device_type', 'name', 'label', 'type', 'description',
         ]
 
 
@@ -1834,7 +1834,7 @@ class ConsoleServerPortTemplateImportForm(ComponentTemplateImportForm):
     class Meta:
         model = ConsoleServerPortTemplate
         fields = [
-            'device_type', 'name', 'label', 'type',
+            'device_type', 'name', 'label', 'type', 'description',
         ]
 
 
@@ -1843,7 +1843,7 @@ class PowerPortTemplateImportForm(ComponentTemplateImportForm):
     class Meta:
         model = PowerPortTemplate
         fields = [
-            'device_type', 'name', 'label', 'type', 'maximum_draw', 'allocated_draw',
+            'device_type', 'name', 'label', 'type', 'maximum_draw', 'allocated_draw', 'description',
         ]
 
 
@@ -1857,7 +1857,7 @@ class PowerOutletTemplateImportForm(ComponentTemplateImportForm):
     class Meta:
         model = PowerOutletTemplate
         fields = [
-            'device_type', 'name', 'label', 'type', 'power_port', 'feed_leg',
+            'device_type', 'name', 'label', 'type', 'power_port', 'feed_leg', 'description',
         ]
 
 
@@ -1869,7 +1869,7 @@ class InterfaceTemplateImportForm(ComponentTemplateImportForm):
     class Meta:
         model = InterfaceTemplate
         fields = [
-            'device_type', 'name', 'label', 'type', 'mgmt_only',
+            'device_type', 'name', 'label', 'type', 'mgmt_only', 'description',
         ]
 
 
@@ -1886,7 +1886,7 @@ class FrontPortTemplateImportForm(ComponentTemplateImportForm):
     class Meta:
         model = FrontPortTemplate
         fields = [
-            'device_type', 'name', 'type', 'rear_port', 'rear_port_position',
+            'device_type', 'name', 'type', 'rear_port', 'rear_port_position', 'label', 'description',
         ]
 
 
@@ -1898,7 +1898,7 @@ class RearPortTemplateImportForm(ComponentTemplateImportForm):
     class Meta:
         model = RearPortTemplate
         fields = [
-            'device_type', 'name', 'type', 'positions',
+            'device_type', 'name', 'type', 'positions', 'label', 'description',
         ]
 
 
@@ -1907,7 +1907,7 @@ class DeviceBayTemplateImportForm(ComponentTemplateImportForm):
     class Meta:
         model = DeviceBayTemplate
         fields = [
-            'device_type', 'name',
+            'device_type', 'name', 'label', 'description',
         ]
 
 

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -183,6 +183,8 @@ class DeviceType(PrimaryModel):
                 {
                     'name': c.name,
                     'type': c.type,
+                    'label': c.label,
+                    'description': c.description,
                 }
                 for c in self.consoleporttemplates.all()
             ]
@@ -191,6 +193,8 @@ class DeviceType(PrimaryModel):
                 {
                     'name': c.name,
                     'type': c.type,
+                    'label': c.label,
+                    'description': c.description,
                 }
                 for c in self.consoleserverporttemplates.all()
             ]
@@ -201,6 +205,8 @@ class DeviceType(PrimaryModel):
                     'type': c.type,
                     'maximum_draw': c.maximum_draw,
                     'allocated_draw': c.allocated_draw,
+                    'label': c.label,
+                    'description': c.description,
                 }
                 for c in self.powerporttemplates.all()
             ]
@@ -211,6 +217,8 @@ class DeviceType(PrimaryModel):
                     'type': c.type,
                     'power_port': c.power_port.name if c.power_port else None,
                     'feed_leg': c.feed_leg,
+                    'label': c.label,
+                    'description': c.description,
                 }
                 for c in self.poweroutlettemplates.all()
             ]
@@ -220,6 +228,8 @@ class DeviceType(PrimaryModel):
                     'name': c.name,
                     'type': c.type,
                     'mgmt_only': c.mgmt_only,
+                    'label': c.label,
+                    'description': c.description,
                 }
                 for c in self.interfacetemplates.all()
             ]
@@ -230,6 +240,8 @@ class DeviceType(PrimaryModel):
                     'type': c.type,
                     'rear_port': c.rear_port.name,
                     'rear_port_position': c.rear_port_position,
+                    'label': c.label,
+                    'description': c.description,
                 }
                 for c in self.frontporttemplates.all()
             ]
@@ -239,6 +251,8 @@ class DeviceType(PrimaryModel):
                     'name': c.name,
                     'type': c.type,
                     'positions': c.positions,
+                    'label': c.label,
+                    'description': c.description,
                 }
                 for c in self.rearporttemplates.all()
             ]
@@ -246,6 +260,8 @@ class DeviceType(PrimaryModel):
             data['device-bays'] = [
                 {
                     'name': c.name,
+                    'label': c.label,
+                    'description': c.description,
                 }
                 for c in self.devicebaytemplates.all()
             ]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #6438
<!--
    Please include a summary of the proposed changes below.
-->
Some Components of Device Types did not import and export their label and/or description fields.

I fixed it by adding the fields to the appropriate lists where needed.

A less redundant solution could be to only have the list of fields in the ImportForms and iterate over the Meta.fields attribute of the ImportForms in the export function.
