### PR TITLE
Fixed #5611 Script log message should be serialized as 'str' instance.

### DIFF
--- a/netbox/extras/api/serializers.py
+++ b/netbox/extras/api/serializers.py
@@ -392,7 +392,7 @@ class ScriptLogMessageSerializer(serializers.Serializer):
         return instance[0]
 
     def get_message(self, instance):
-        return instance[1]
+        return str(instance[1])
 
 
 class ScriptOutputSerializer(serializers.Serializer):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #5611
<!--
    Please include a summary of the proposed changes below.
-->
The script execution never finishes when the model instance is passed to Script.log_info().
The cause is that the serialized data cannot be saved at JobResult model.
So I fixed script log message will be serialized as 'str' instance for can be saved.
