### PR TITLE
Closes #6358: Add search to VLAN group overview.

### DIFF
--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -536,6 +536,10 @@ class IPAddressFilterSet(PrimaryModelFilterSet, TenancyFilterSet):
 
 
 class VLANGroupFilterSet(OrganizationalModelFilterSet):
+    q = django_filters.CharFilter(
+        method='search',
+        label='Search',
+    )
     scope_type = ContentTypeFilter()
     region = django_filters.NumberFilter(
         method='filter_scope'
@@ -562,6 +566,15 @@ class VLANGroupFilterSet(OrganizationalModelFilterSet):
     class Meta:
         model = VLANGroup
         fields = ['id', 'name', 'slug', 'description', 'scope_id']
+
+    def search(self, queryset, name, value):
+        if not value.strip():
+            return queryset
+        qs_filter = (
+            Q(name__icontains=value) |
+            Q(description__icontains=value)
+        )
+        return queryset.filter(qs_filter)
 
     def filter_scope(self, queryset, name, value):
         return queryset.filter(

--- a/netbox/ipam/forms.py
+++ b/netbox/ipam/forms.py
@@ -1270,6 +1270,10 @@ class VLANGroupBulkEditForm(BootstrapMixin, CustomFieldBulkEditForm):
 
 
 class VLANGroupFilterForm(BootstrapMixin, forms.Form):
+    q = forms.CharField(
+        required=False,
+        label=_('Search')
+    )
     region = DynamicModelMultipleChoiceField(
         queryset=Region.objects.all(),
         required=False,


### PR DESCRIPTION
### Fixes: #6358
Add a q filter on VLANGroupFilterSet, searching the VLAN Group name and VLAN Group description. Added a search box on the VLAN Group overview.
