### PR TITLE
Closes #6284: Fix redundant webhooks

### DIFF
--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 * [#6064](https://github.com/netbox-community/netbox/issues/6064) - Fix object permission assignments for user and group models
+* [#6284](https://github.com/netbox-community/netbox/issues/6284) - Avoid sending redundant webhooks when adding/removing tags
 * [#6496](https://github.com/netbox-community/netbox/issues/6496) - Fix upgrade script when Python installed in nonstandard path
 * [#6502](https://github.com/netbox-community/netbox/issues/6502) - Correct permissions evaluation for running a report via the REST API
 

--- a/netbox/extras/signals.py
+++ b/netbox/extras/signals.py
@@ -60,6 +60,7 @@ def _handle_changed_object(request, webhook_queue, sender, instance, **kwargs):
     if m2m_changed and webhook_queue:
         # TODO: Need more validation here
         # TODO: Need to account for snapshot changes
+        instance.refresh_from_db()  # Ensure that we're working with fresh M2M assignments
         webhook_queue[-1]['data'] = serialize_for_webhook(instance)
     else:
         enqueue_object(webhook_queue, instance, request.user, request.id, action)

--- a/netbox/extras/signals.py
+++ b/netbox/extras/signals.py
@@ -12,17 +12,20 @@ from prometheus_client import Counter
 
 from .choices import ObjectChangeActionChoices
 from .models import CustomField, ObjectChange
-from .webhooks import enqueue_webhooks
+from .webhooks import enqueue_object, serialize_for_webhook
 
 
 #
 # Change logging/webhooks
 #
 
-def _handle_changed_object(request, sender, instance, **kwargs):
+def _handle_changed_object(request, webhook_queue, sender, instance, **kwargs):
     """
     Fires when an object is created or updated.
     """
+    if not hasattr(instance, 'to_objectchange'):
+        return
+
     m2m_changed = False
 
     # Determine the type of change being made
@@ -53,8 +56,13 @@ def _handle_changed_object(request, sender, instance, **kwargs):
             objectchange.request_id = request.id
             objectchange.save()
 
-    # Enqueue webhooks
-    enqueue_webhooks(instance, request.user, request.id, action)
+    # If this is an M2M change, update the previously queued webhook (from post_save)
+    if m2m_changed and webhook_queue:
+        # TODO: Need more validation here
+        # TODO: Need to account for snapshot changes
+        webhook_queue[-1]['data'] = serialize_for_webhook(instance)
+    else:
+        enqueue_object(webhook_queue, instance, request.user, request.id, action)
 
     # Increment metric counters
     if action == ObjectChangeActionChoices.ACTION_CREATE:
@@ -68,10 +76,13 @@ def _handle_changed_object(request, sender, instance, **kwargs):
         ObjectChange.objects.filter(time__lt=cutoff)._raw_delete(using=DEFAULT_DB_ALIAS)
 
 
-def _handle_deleted_object(request, sender, instance, **kwargs):
+def _handle_deleted_object(request, webhook_queue, sender, instance, **kwargs):
     """
     Fires when an object is deleted.
     """
+    if not hasattr(instance, 'to_objectchange'):
+        return
+
     # Record an ObjectChange if applicable
     if hasattr(instance, 'to_objectchange'):
         objectchange = instance.to_objectchange(ObjectChangeActionChoices.ACTION_DELETE)
@@ -80,7 +91,7 @@ def _handle_deleted_object(request, sender, instance, **kwargs):
         objectchange.save()
 
     # Enqueue webhooks
-    enqueue_webhooks(instance, request.user, request.id, ObjectChangeActionChoices.ACTION_DELETE)
+    enqueue_object(webhook_queue, instance, request.user, request.id, ObjectChangeActionChoices.ACTION_DELETE)
 
     # Increment metric counters
     model_deletes.labels(instance._meta.model_name).inc()

--- a/netbox/extras/tests/test_webhooks.py
+++ b/netbox/extras/tests/test_webhooks.py
@@ -11,7 +11,7 @@ from rest_framework import status
 
 from dcim.models import Site
 from extras.choices import ObjectChangeActionChoices
-from extras.models import Webhook
+from extras.models import Tag, Webhook
 from extras.webhooks import enqueue_object, generate_signature
 from extras.webhooks_worker import process_webhook
 from utilities.testing import APITestCase
@@ -20,11 +20,10 @@ from utilities.testing import APITestCase
 class WebhookTest(APITestCase):
 
     def setUp(self):
-
         super().setUp()
 
         self.queue = django_rq.get_queue('default')
-        self.queue.empty()  # Begin each test with an empty queue
+        self.queue.empty()
 
     @classmethod
     def setUpTestData(cls):
@@ -34,38 +33,55 @@ class WebhookTest(APITestCase):
         DUMMY_SECRET = "LOOKATMEIMASECRETSTRING"
 
         webhooks = Webhook.objects.bulk_create((
-            Webhook(name='Site Create Webhook', type_create=True, payload_url=DUMMY_URL, secret=DUMMY_SECRET, additional_headers='X-Foo: Bar'),
-            Webhook(name='Site Update Webhook', type_update=True, payload_url=DUMMY_URL, secret=DUMMY_SECRET),
-            Webhook(name='Site Delete Webhook', type_delete=True, payload_url=DUMMY_URL, secret=DUMMY_SECRET),
+            Webhook(name='Webhook 1', type_create=True, payload_url=DUMMY_URL, secret=DUMMY_SECRET, additional_headers='X-Foo: Bar'),
+            Webhook(name='Webhook 2', type_update=True, payload_url=DUMMY_URL, secret=DUMMY_SECRET),
+            Webhook(name='Webhook 3', type_delete=True, payload_url=DUMMY_URL, secret=DUMMY_SECRET),
         ))
         for webhook in webhooks:
             webhook.content_types.set([site_ct])
 
+        Tag.objects.bulk_create((
+            Tag(name='Foo', slug='foo'),
+            Tag(name='Bar', slug='bar'),
+            Tag(name='Baz', slug='baz'),
+        ))
+
     def test_enqueue_webhook_create(self):
         # Create an object via the REST API
         data = {
-            'name': 'Test Site',
-            'slug': 'test-site',
+            'name': 'Site 1',
+            'slug': 'site-1',
+            'tags': [
+                {'name': 'Foo'},
+                {'name': 'Bar'},
+            ]
         }
         url = reverse('dcim-api:site-list')
         self.add_permissions('dcim.add_site')
         response = self.client.post(url, data, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
         self.assertEqual(Site.objects.count(), 1)
+        self.assertEqual(Site.objects.first().tags.count(), 2)
 
         # Verify that a job was queued for the object creation webhook
         self.assertEqual(self.queue.count, 1)
         job = self.queue.jobs[0]
         self.assertEqual(job.kwargs['webhook'], Webhook.objects.get(type_create=True))
         self.assertEqual(job.kwargs['data']['id'], response.data['id'])
+        self.assertEqual(len(job.kwargs['data']['tags']), len(response.data['tags']))
         self.assertEqual(job.kwargs['model_name'], 'site')
         self.assertEqual(job.kwargs['event'], ObjectChangeActionChoices.ACTION_CREATE)
 
     def test_enqueue_webhook_update(self):
-        # Update an object via the REST API
         site = Site.objects.create(name='Site 1', slug='site-1')
+        site.tags.set(*Tag.objects.filter(name__in=['Foo', 'Bar']))
+
+        # Update an object via the REST API
         data = {
             'comments': 'Updated the site',
+            'tags': [
+                {'name': 'Baz'}
+            ]
         }
         url = reverse('dcim-api:site-detail', kwargs={'pk': site.pk})
         self.add_permissions('dcim.change_site')
@@ -77,12 +93,15 @@ class WebhookTest(APITestCase):
         job = self.queue.jobs[0]
         self.assertEqual(job.kwargs['webhook'], Webhook.objects.get(type_update=True))
         self.assertEqual(job.kwargs['data']['id'], site.pk)
+        self.assertEqual(len(job.kwargs['data']['tags']), len(response.data['tags']))
         self.assertEqual(job.kwargs['model_name'], 'site')
         self.assertEqual(job.kwargs['event'], ObjectChangeActionChoices.ACTION_UPDATE)
 
     def test_enqueue_webhook_delete(self):
-        # Delete an object via the REST API
         site = Site.objects.create(name='Site 1', slug='site-1')
+        site.tags.set(*Tag.objects.filter(name__in=['Foo', 'Bar']))
+
+        # Delete an object via the REST API
         url = reverse('dcim-api:site-detail', kwargs={'pk': site.pk})
         self.add_permissions('dcim.delete_site')
         response = self.client.delete(url, **self.header)

--- a/netbox/extras/tests/test_webhooks.py
+++ b/netbox/extras/tests/test_webhooks.py
@@ -12,7 +12,7 @@ from rest_framework import status
 from dcim.models import Site
 from extras.choices import ObjectChangeActionChoices
 from extras.models import Tag, Webhook
-from extras.webhooks import enqueue_object, generate_signature
+from extras.webhooks import enqueue_object, flush_webhooks, generate_signature
 from extras.webhooks_worker import process_webhook
 from utilities.testing import APITestCase
 
@@ -251,48 +251,49 @@ class WebhookTest(APITestCase):
             self.assertEqual(job.kwargs['snapshots']['prechange']['name'], sites[i].name)
             self.assertEqual(job.kwargs['snapshots']['prechange']['tags'], ['Bar', 'Foo'])
 
-    # TODO: Replace webhook worker test
-    # def test_webhooks_worker(self):
-    #
-    #     request_id = uuid.uuid4()
-    #
-    #     def dummy_send(_, request, **kwargs):
-    #         """
-    #         A dummy implementation of Session.send() to be used for testing.
-    #         Always returns a 200 HTTP response.
-    #         """
-    #         webhook = Webhook.objects.get(type_create=True)
-    #         signature = generate_signature(request.body, webhook.secret)
-    #
-    #         # Validate the outgoing request headers
-    #         self.assertEqual(request.headers['Content-Type'], webhook.http_content_type)
-    #         self.assertEqual(request.headers['X-Hook-Signature'], signature)
-    #         self.assertEqual(request.headers['X-Foo'], 'Bar')
-    #
-    #         # Validate the outgoing request body
-    #         body = json.loads(request.body)
-    #         self.assertEqual(body['event'], 'created')
-    #         self.assertEqual(body['timestamp'], job.kwargs['timestamp'])
-    #         self.assertEqual(body['model'], 'site')
-    #         self.assertEqual(body['username'], 'testuser')
-    #         self.assertEqual(body['request_id'], str(request_id))
-    #         self.assertEqual(body['data']['name'], 'Site 1')
-    #
-    #         return HttpResponse()
-    #
-    #     # Enqueue a webhook for processing
-    #     site = Site.objects.create(name='Site 1', slug='site-1')
-    #     enqueue_webhooks(
-    #         queue=[],
-    #         instance=site,
-    #         user=self.user,
-    #         request_id=request_id,
-    #         action=ObjectChangeActionChoices.ACTION_CREATE
-    #     )
-    #
-    #     # Retrieve the job from queue
-    #     job = self.queue.jobs[0]
-    #
-    #     # Patch the Session object with our dummy_send() method, then process the webhook for sending
-    #     with patch.object(Session, 'send', dummy_send) as mock_send:
-    #         process_webhook(**job.kwargs)
+    def test_webhooks_worker(self):
+
+        request_id = uuid.uuid4()
+
+        def dummy_send(_, request, **kwargs):
+            """
+            A dummy implementation of Session.send() to be used for testing.
+            Always returns a 200 HTTP response.
+            """
+            webhook = Webhook.objects.get(type_create=True)
+            signature = generate_signature(request.body, webhook.secret)
+
+            # Validate the outgoing request headers
+            self.assertEqual(request.headers['Content-Type'], webhook.http_content_type)
+            self.assertEqual(request.headers['X-Hook-Signature'], signature)
+            self.assertEqual(request.headers['X-Foo'], 'Bar')
+
+            # Validate the outgoing request body
+            body = json.loads(request.body)
+            self.assertEqual(body['event'], 'created')
+            self.assertEqual(body['timestamp'], job.kwargs['timestamp'])
+            self.assertEqual(body['model'], 'site')
+            self.assertEqual(body['username'], 'testuser')
+            self.assertEqual(body['request_id'], str(request_id))
+            self.assertEqual(body['data']['name'], 'Site 1')
+
+            return HttpResponse()
+
+        # Enqueue a webhook for processing
+        webhooks_queue = []
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        enqueue_object(
+            webhooks_queue,
+            instance=site,
+            user=self.user,
+            request_id=request_id,
+            action=ObjectChangeActionChoices.ACTION_CREATE
+        )
+        flush_webhooks(webhooks_queue)
+
+        # Retrieve the job from queue
+        job = self.queue.jobs[0]
+
+        # Patch the Session object with our dummy_send() method, then process the webhook for sending
+        with patch.object(Session, 'send', dummy_send) as mock_send:
+            process_webhook(**job.kwargs)

--- a/netbox/extras/tests/test_webhooks.py
+++ b/netbox/extras/tests/test_webhooks.py
@@ -12,7 +12,7 @@ from rest_framework import status
 from dcim.models import Site
 from extras.choices import ObjectChangeActionChoices
 from extras.models import Webhook
-from extras.webhooks import enqueue_webhooks, generate_signature
+from extras.webhooks import enqueue_object, generate_signature
 from extras.webhooks_worker import process_webhook
 from utilities.testing import APITestCase
 
@@ -96,46 +96,48 @@ class WebhookTest(APITestCase):
         self.assertEqual(job.kwargs['model_name'], 'site')
         self.assertEqual(job.kwargs['event'], ObjectChangeActionChoices.ACTION_DELETE)
 
-    def test_webhooks_worker(self):
-
-        request_id = uuid.uuid4()
-
-        def dummy_send(_, request, **kwargs):
-            """
-            A dummy implementation of Session.send() to be used for testing.
-            Always returns a 200 HTTP response.
-            """
-            webhook = Webhook.objects.get(type_create=True)
-            signature = generate_signature(request.body, webhook.secret)
-
-            # Validate the outgoing request headers
-            self.assertEqual(request.headers['Content-Type'], webhook.http_content_type)
-            self.assertEqual(request.headers['X-Hook-Signature'], signature)
-            self.assertEqual(request.headers['X-Foo'], 'Bar')
-
-            # Validate the outgoing request body
-            body = json.loads(request.body)
-            self.assertEqual(body['event'], 'created')
-            self.assertEqual(body['timestamp'], job.kwargs['timestamp'])
-            self.assertEqual(body['model'], 'site')
-            self.assertEqual(body['username'], 'testuser')
-            self.assertEqual(body['request_id'], str(request_id))
-            self.assertEqual(body['data']['name'], 'Site 1')
-
-            return HttpResponse()
-
-        # Enqueue a webhook for processing
-        site = Site.objects.create(name='Site 1', slug='site-1')
-        enqueue_webhooks(
-            instance=site,
-            user=self.user,
-            request_id=request_id,
-            action=ObjectChangeActionChoices.ACTION_CREATE
-        )
-
-        # Retrieve the job from queue
-        job = self.queue.jobs[0]
-
-        # Patch the Session object with our dummy_send() method, then process the webhook for sending
-        with patch.object(Session, 'send', dummy_send) as mock_send:
-            process_webhook(**job.kwargs)
+    # TODO: Replace webhook worker test
+    # def test_webhooks_worker(self):
+    #
+    #     request_id = uuid.uuid4()
+    #
+    #     def dummy_send(_, request, **kwargs):
+    #         """
+    #         A dummy implementation of Session.send() to be used for testing.
+    #         Always returns a 200 HTTP response.
+    #         """
+    #         webhook = Webhook.objects.get(type_create=True)
+    #         signature = generate_signature(request.body, webhook.secret)
+    #
+    #         # Validate the outgoing request headers
+    #         self.assertEqual(request.headers['Content-Type'], webhook.http_content_type)
+    #         self.assertEqual(request.headers['X-Hook-Signature'], signature)
+    #         self.assertEqual(request.headers['X-Foo'], 'Bar')
+    #
+    #         # Validate the outgoing request body
+    #         body = json.loads(request.body)
+    #         self.assertEqual(body['event'], 'created')
+    #         self.assertEqual(body['timestamp'], job.kwargs['timestamp'])
+    #         self.assertEqual(body['model'], 'site')
+    #         self.assertEqual(body['username'], 'testuser')
+    #         self.assertEqual(body['request_id'], str(request_id))
+    #         self.assertEqual(body['data']['name'], 'Site 1')
+    #
+    #         return HttpResponse()
+    #
+    #     # Enqueue a webhook for processing
+    #     site = Site.objects.create(name='Site 1', slug='site-1')
+    #     enqueue_webhooks(
+    #         queue=[],
+    #         instance=site,
+    #         user=self.user,
+    #         request_id=request_id,
+    #         action=ObjectChangeActionChoices.ACTION_CREATE
+    #     )
+    #
+    #     # Retrieve the job from queue
+    #     job = self.queue.jobs[0]
+    #
+    #     # Patch the Session object with our dummy_send() method, then process the webhook for sending
+    #     with patch.object(Session, 'send', dummy_send) as mock_send:
+    #         process_webhook(**job.kwargs)


### PR DESCRIPTION
### Fixes: #6284

Queue webhooks in memory until the request completes, updating the most recent M2M changes as necessary, then flush to RQ once all webhooks have been updated.