### PR TITLE
Release v2.11.5

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -17,7 +17,7 @@ body:
         What version of NetBox are you currently running? (If you don't have access to the most
         recent NetBox release, consider testing on our [demo instance](https://demo.netbox.dev/)
         before opening a bug report to see if your issue has already been addressed.)
-      placeholder: v2.11.4
+      placeholder: v2.11.5
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,9 +1,12 @@
 # Reference: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
 blank_issues_enabled: false
 contact_links:
+  - name: ❓ Discussion
+    url: https://github.com/netbox-community/netbox/discussions
+    about: "If you're just looking for help, try starting a discussion instead"
   - name: 📖 Contributing Policy
     url: https://github.com/netbox-community/netbox/blob/develop/CONTRIBUTING.md
-    about: Please read through our contributing policy before opening an issue or pull request
-  - name: 💬 Discussion Group
-    url: https://groups.google.com/g/netbox-discuss
-    about: Join our discussion group for assistance with installation issues and other problems
+    about: "Please read through our contributing policy before opening an issue or pull request"
+  - name: 💬 Community Slack
+    url: https://netdev.chat/
+    about: "Join #netbox on the NetDev Community Slack for assistance with installation issues and other problems"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,12 +1,12 @@
 # Reference: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
 blank_issues_enabled: false
 contact_links:
-  - name: ❓ Discussion
-    url: https://github.com/netbox-community/netbox/discussions
-    about: "If you're just looking for help, try starting a discussion instead"
   - name: 📖 Contributing Policy
     url: https://github.com/netbox-community/netbox/blob/develop/CONTRIBUTING.md
     about: "Please read through our contributing policy before opening an issue or pull request"
+  - name: ❓ Discussion
+    url: https://github.com/netbox-community/netbox/discussions
+    about: "If you're just looking for help, try starting a discussion instead"
   - name: 💬 Community Slack
     url: https://netdev.chat/
     about: "Join #netbox on the NetDev Community Slack for assistance with installation issues and other problems"

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: NetBox version
       description: What version of NetBox are you currently running?
-      placeholder: v2.11.4
+      placeholder: v2.11.5
     validations:
       required: true
   - type: dropdown

--- a/docs/additional-features/custom-scripts.md
+++ b/docs/additional-features/custom-scripts.md
@@ -175,7 +175,7 @@ A particular object within NetBox. Each ObjectVar must specify a particular mode
 * `null_option` - A label representing a "null" or empty choice (optional)
 
 !!! warning
-    The `display_field` parameter is now deprecated, and will be removed in NetBox v2.12. All ObjectVar instances will
+    The `display_field` parameter is now deprecated, and will be removed in NetBox v3.0. All ObjectVar instances will
     instead use the new standard `display` field for all serializers (introduced in NetBox v2.11).
 
 To limit the selections available within the list, additional query parameters can be passed as the `query_params` dictionary. For example, to show only devices with an "active" status:

--- a/docs/additional-features/reports.md
+++ b/docs/additional-features/reports.md
@@ -80,13 +80,10 @@ class DeviceConnectionsReport(Report):
                 self.log_success(device)
 ```
 
-As you can see, reports are completely customizable. Validation logic can be as simple or as complex as needed.
+As you can see, reports are completely customizable. Validation logic can be as simple or as complex as needed. Also note that the `description` attribute support markdown syntax. It will be rendered in the report list page.
 
 !!! warning
     Reports should never alter data: If you find yourself using the `create()`, `save()`, `update()`, or `delete()` methods on objects within reports, stop and re-evaluate what you're trying to accomplish. Note that there are no safeguards against the accidental alteration or destruction of data.
-
-!!! note 
-    The `description`attribute support markdown syntax. You can use markdown to print fency description in the report list page.
 
 The following methods are available to log results within a report:
 
@@ -96,10 +93,7 @@ The following methods are available to log results within a report:
 * log_warning(object, message)
 * log_failure(object, message)
 
-The recording of one or more failure messages will automatically flag a report as failed. It is advised to log a success for each object that is evaluated so that the results will reflect how many objects are being reported on. (The inclusion of a log message is optional for successes.) Messages recorded with `log()` will appear in a report's results but are not associated with a particular object or status.
-
-!!! note 
-    Every `log_`methods support markdown syntax. Thus you can use markdown in the message and it will be printed as such in the report result.
+The recording of one or more failure messages will automatically flag a report as failed. It is advised to log a success for each object that is evaluated so that the results will reflect how many objects are being reported on. (The inclusion of a log message is optional for successes.) Messages recorded with `log()` will appear in a report's results but are not associated with a particular object or status. Log messages also support using markdown syntax and will be rendered on the report result page.
 
 To perform additional tasks, such as sending an email or calling a webhook, after a report has been run, extend the `post_run()` method. The status of the report is available as `self.failed` and the results object is `self.result`.
 

--- a/docs/additional-features/reports.md
+++ b/docs/additional-features/reports.md
@@ -85,6 +85,9 @@ As you can see, reports are completely customizable. Validation logic can be as 
 !!! warning
     Reports should never alter data: If you find yourself using the `create()`, `save()`, `update()`, or `delete()` methods on objects within reports, stop and re-evaluate what you're trying to accomplish. Note that there are no safeguards against the accidental alteration or destruction of data.
 
+!!! note 
+    The `description`attribute support markdown syntax. You can use markdown to print fency description in the report list page.
+
 The following methods are available to log results within a report:
 
 * log(message)
@@ -94,6 +97,9 @@ The following methods are available to log results within a report:
 * log_failure(object, message)
 
 The recording of one or more failure messages will automatically flag a report as failed. It is advised to log a success for each object that is evaluated so that the results will reflect how many objects are being reported on. (The inclusion of a log message is optional for successes.) Messages recorded with `log()` will appear in a report's results but are not associated with a particular object or status.
+
+!!! note 
+    Every `log_`methods support markdown syntax. Thus you can use markdown in the message and it will be printed as such in the report result.
 
 To perform additional tasks, such as sending an email or calling a webhook, after a report has been run, extend the `post_run()` method. The status of the report is available as `self.failed` and the results object is `self.result`.
 

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -24,7 +24,7 @@ The video below demonstrates the installation of NetBox v2.10.3 on Ubuntu 20.04 
 | Redis      | 4.0             |
 
 !!! note
-    Python 3.7 or later will be required in NetBox v2.12. Users are strongly encouraged to install NetBox using Python 3.7 or later for new deployments.
+    Python 3.7 or later will be required in NetBox v3.0. Users are strongly encouraged to install NetBox using Python 3.7 or later for new deployments.
 
 Below is a simplified overview of the NetBox application stack for reference:
 

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -7,6 +7,7 @@
 * [#6087](https://github.com/netbox-community/netbox/issues/6087) - Improved prefix hierarchy rendering
 * [#6487](https://github.com/netbox-community/netbox/issues/6487) - Add location filter to cable connection form
 * [#6501](https://github.com/netbox-community/netbox/issues/6501) - Expose prefix depth and children on REST API serializer
+* [#6527](https://github.com/netbox-community/netbox/issues/6527) - Support Markdown for report descriptions
 
 ### Bug Fixes
 

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -8,6 +8,7 @@
 * [#6487](https://github.com/netbox-community/netbox/issues/6487) - Add location filter to cable connection form
 * [#6501](https://github.com/netbox-community/netbox/issues/6501) - Expose prefix depth and children on REST API serializer
 * [#6527](https://github.com/netbox-community/netbox/issues/6527) - Support Markdown for report descriptions
+* [#6540](https://github.com/netbox-community/netbox/issues/6540) - Add a "flat" column to the prefix table
 
 ### Bug Fixes
 

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -14,6 +14,7 @@
 * [#6284](https://github.com/netbox-community/netbox/issues/6284) - Avoid sending redundant webhooks when adding/removing tags
 * [#6496](https://github.com/netbox-community/netbox/issues/6496) - Fix upgrade script when Python installed in nonstandard path
 * [#6502](https://github.com/netbox-community/netbox/issues/6502) - Correct permissions evaluation for running a report via the REST API
+* [#6525](https://github.com/netbox-community/netbox/issues/6525) - Paginate related IPs table under IP address view
 
 ---
 

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+* [#6064](https://github.com/netbox-community/netbox/issues/6064) - Fix object permission assignments for user and group models
 * [#6496](https://github.com/netbox-community/netbox/issues/6496) - Fix upgrade script when Python installed in nonstandard path
 * [#6502](https://github.com/netbox-community/netbox/issues/6502) - Correct permissions evaluation for running a report via the REST API
 

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 * [#6064](https://github.com/netbox-community/netbox/issues/6064) - Fix object permission assignments for user and group models
+* [#6217](https://github.com/netbox-community/netbox/issues/6217) - Disallow passing of string values for integer custom fields
 * [#6284](https://github.com/netbox-community/netbox/issues/6284) - Avoid sending redundant webhooks when adding/removing tags
 * [#6496](https://github.com/netbox-community/netbox/issues/6496) - Fix upgrade script when Python installed in nonstandard path
 * [#6502](https://github.com/netbox-community/netbox/issues/6502) - Correct permissions evaluation for running a report via the REST API

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -14,6 +14,7 @@
 * [#6284](https://github.com/netbox-community/netbox/issues/6284) - Avoid sending redundant webhooks when adding/removing tags
 * [#6496](https://github.com/netbox-community/netbox/issues/6496) - Fix upgrade script when Python installed in nonstandard path
 * [#6502](https://github.com/netbox-community/netbox/issues/6502) - Correct permissions evaluation for running a report via the REST API
+* [#6517](https://github.com/netbox-community/netbox/issues/6517) - Fix assignment of user when creating rack reservations via REST API
 * [#6525](https://github.com/netbox-community/netbox/issues/6525) - Paginate related IPs table under IP address view
 
 ---

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 
+* [#6496](https://github.com/netbox-community/netbox/issues/6496) - Fix upgrade script when Python installed in nonstandard path
 * [#6502](https://github.com/netbox-community/netbox/issues/6502) - Correct permissions evaluation for running a report via the REST API
 
 ---

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -5,6 +5,7 @@
 ### Enhancements
 
 * [#6087](https://github.com/netbox-community/netbox/issues/6087) - Improved prefix hierarchy rendering
+* [#6487](https://github.com/netbox-community/netbox/issues/6487) - Add location filter to cable connection form
 * [#6501](https://github.com/netbox-community/netbox/issues/6501) - Expose prefix depth and children on REST API serializer
 
 ---

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -8,6 +8,10 @@
 * [#6487](https://github.com/netbox-community/netbox/issues/6487) - Add location filter to cable connection form
 * [#6501](https://github.com/netbox-community/netbox/issues/6501) - Expose prefix depth and children on REST API serializer
 
+### Bug Fixes
+
+* [#6502](https://github.com/netbox-community/netbox/issues/6502) - Correct permissions evaluation for running a report via the REST API
+
 ---
 
 ## v2.11.4 (2021-05-25)

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -11,6 +11,7 @@
 ### Bug Fixes
 
 * [#6064](https://github.com/netbox-community/netbox/issues/6064) - Fix object permission assignments for user and group models
+* [#6284](https://github.com/netbox-community/netbox/issues/6284) - Avoid sending redundant webhooks when adding/removing tags
 * [#6496](https://github.com/netbox-community/netbox/issues/6496) - Fix upgrade script when Python installed in nonstandard path
 * [#6502](https://github.com/netbox-community/netbox/issues/6502) - Correct permissions evaluation for running a report via the REST API
 

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -1,5 +1,14 @@
 # NetBox v2.11
 
+## v2.11.5 (FUTURE)
+
+### Enhancements
+
+* [#6087](https://github.com/netbox-community/netbox/issues/6087) - Improved prefix hierarchy rendering
+* [#6501](https://github.com/netbox-community/netbox/issues/6501) - Expose prefix depth and children on REST API serializer
+
+---
+
 ## v2.11.4 (2021-05-25)
 
 ### Enhancements

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -1,6 +1,8 @@
 # NetBox v2.11
 
-## v2.11.5 (FUTURE)
+## v2.11.5 (2021-06-04)
+
+**NOTE:** This release includes a database migration that calculates and annotates prefix depth. It may impose a noticeable delay on the upgrade process: Users should anticipate roughly one minute of delay per 100 thousand prefixes being updated.
 
 ### Enhancements
 

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -93,7 +93,7 @@
 
 ## v2.11.0 (2021-04-16)
 
-**Note:** NetBox v2.11 is the last major release that will support Python 3.6. Beginning with NetBox v2.12, Python 3.7 or later will be required.
+**Note:** NetBox v2.11 is the last major release that will support Python 3.6. Beginning with NetBox v3.0, Python 3.7 or later will be required.
 
 ### Breaking Changes
 
@@ -151,7 +151,7 @@ Devices can now be assigned to locations (formerly known as rack groups) within 
 
 When exporting a list of objects in NetBox, users now have the option of selecting the "current view". This will render CSV output matching the current configuration of the table being viewed. For example, if you modify the sites list to display only the site name, tenant, and status, the rendered CSV will include only these columns, and they will appear in the order chosen.
 
-The legacy static export behavior has been retained to ensure backward compatibility for dependent integrations. However, users are strongly encouraged to adapt custom export templates where needed as this functionality will be removed in v2.12.
+The legacy static export behavior has been retained to ensure backward compatibility for dependent integrations. However, users are strongly encouraged to adapt custom export templates where needed as this functionality will be removed in v3.0.
 
 #### Variable Scope Support for VLAN Groups ([#5284](https://github.com/netbox-community/netbox/issues/5284))
 

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -13,6 +13,7 @@
 * [#6064](https://github.com/netbox-community/netbox/issues/6064) - Fix object permission assignments for user and group models
 * [#6217](https://github.com/netbox-community/netbox/issues/6217) - Disallow passing of string values for integer custom fields
 * [#6284](https://github.com/netbox-community/netbox/issues/6284) - Avoid sending redundant webhooks when adding/removing tags
+* [#6492](https://github.com/netbox-community/netbox/issues/6492) - Correct tag population in post-change data resulting from REST API changes
 * [#6496](https://github.com/netbox-community/netbox/issues/6496) - Fix upgrade script when Python installed in nonstandard path
 * [#6502](https://github.com/netbox-community/netbox/issues/6502) - Correct permissions evaluation for running a report via the REST API
 * [#6517](https://github.com/netbox-community/netbox/issues/6517) - Fix assignment of user when creating rack reservations via REST API

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -246,10 +246,6 @@ class RackReservationViewSet(ModelViewSet):
     serializer_class = serializers.RackReservationSerializer
     filterset_class = filtersets.RackReservationFilterSet
 
-    # Assign user from request
-    def perform_create(self, serializer):
-        serializer.save(user=self.request.user)
-
 
 #
 # Manufacturers

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -3923,13 +3923,23 @@ class ConnectCableToDeviceForm(BootstrapMixin, CustomFieldModelForm):
             'group_id': '$termination_b_site_group',
         }
     )
+    termination_b_location = DynamicModelChoiceField(
+        queryset=Location.objects.all(),
+        label='Location',
+        required=False,
+        null_option='None',
+        query_params={
+            'site_id': '$termination_b_site'
+        }
+    )
     termination_b_rack = DynamicModelChoiceField(
         queryset=Rack.objects.all(),
         label='Rack',
         required=False,
         null_option='None',
         query_params={
-            'site_id': '$termination_b_site'
+            'site_id': '$termination_b_site',
+            'location_id': '$termination_b_location',
         }
     )
     termination_b_device = DynamicModelChoiceField(

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -349,40 +349,36 @@ class RackReservationTest(APIViewTestCases.APIViewTestCase):
         user = User.objects.create(username='user1', is_active=True)
         site = Site.objects.create(name='Test Site 1', slug='test-site-1')
 
-        cls.racks = (
+        racks = (
             Rack(site=site, name='Rack 1'),
             Rack(site=site, name='Rack 2'),
         )
-        Rack.objects.bulk_create(cls.racks)
+        Rack.objects.bulk_create(racks)
 
         rack_reservations = (
-            RackReservation(rack=cls.racks[0], units=[1, 2, 3], user=user, description='Reservation #1'),
-            RackReservation(rack=cls.racks[0], units=[4, 5, 6], user=user, description='Reservation #2'),
-            RackReservation(rack=cls.racks[0], units=[7, 8, 9], user=user, description='Reservation #3'),
+            RackReservation(rack=racks[0], units=[1, 2, 3], user=user, description='Reservation #1'),
+            RackReservation(rack=racks[0], units=[4, 5, 6], user=user, description='Reservation #2'),
+            RackReservation(rack=racks[0], units=[7, 8, 9], user=user, description='Reservation #3'),
         )
         RackReservation.objects.bulk_create(rack_reservations)
 
-    def setUp(self):
-        super().setUp()
-
-        # We have to set creation data under setUp() because we need access to the test user.
-        self.create_data = [
+        cls.create_data = [
             {
-                'rack': self.racks[1].pk,
+                'rack': racks[1].pk,
                 'units': [10, 11, 12],
-                'user': self.user.pk,
+                'user': user.pk,
                 'description': 'Reservation #4',
             },
             {
-                'rack': self.racks[1].pk,
+                'rack': racks[1].pk,
                 'units': [13, 14, 15],
-                'user': self.user.pk,
+                'user': user.pk,
                 'description': 'Reservation #5',
             },
             {
-                'rack': self.racks[1].pk,
+                'rack': racks[1].pk,
                 'units': [16, 17, 18],
-                'user': self.user.pk,
+                'user': user.pk,
                 'description': 'Reservation #6',
             },
         ]

--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -239,7 +239,7 @@ class ReportViewSet(ViewSet):
         Run a Report identified as "<module>.<script>" and return the pending JobResult as the result
         """
         # Check that the user has permission to run reports.
-        if not request.user.has_perm('extras.run_script'):
+        if not request.user.has_perm('extras.run_report'):
             raise PermissionDenied("This user does not have permission to run reports.")
 
         # Check that at least one RQ worker is running

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -286,9 +286,7 @@ class CustomField(BigIDModel):
 
             # Validate integer
             if self.type == CustomFieldTypeChoices.TYPE_INTEGER:
-                try:
-                    int(value)
-                except ValueError:
+                if type(value) is not int:
                     raise ValidationError("Value must be an integer.")
                 if self.validation_minimum is not None and value < self.validation_minimum:
                     raise ValidationError(f"Value must be at least {self.validation_minimum}")

--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -188,10 +188,10 @@ class ObjectVar(ScriptVariable):
 
     def __init__(self, model, query_params=None, null_option=None, *args, **kwargs):
 
-        # TODO: Remove display_field in v2.12
+        # TODO: Remove display_field in v3.0
         if 'display_field' in kwargs:
             warnings.warn(
-                "The 'display_field' parameter has been deprecated, and will be removed in NetBox v2.12. Object "
+                "The 'display_field' parameter has been deprecated, and will be removed in NetBox v3.0. Object "
                 "variables will now reference the 'display' attribute available on all model serializers by default."
             )
         display_field = kwargs.pop('display_field', 'display')

--- a/netbox/extras/signals.py
+++ b/netbox/extras/signals.py
@@ -60,6 +60,7 @@ def _handle_changed_object(request, webhook_queue, sender, instance, **kwargs):
     if m2m_changed and webhook_queue:
         # TODO: Need more validation here
         # TODO: Need to account for snapshot changes
+        instance.refresh_from_db()  # Ensure that we're working with fresh M2M assignments
         webhook_queue[-1]['data'] = serialize_for_webhook(instance)
     else:
         enqueue_object(webhook_queue, instance, request.user, request.id, action)

--- a/netbox/extras/signals.py
+++ b/netbox/extras/signals.py
@@ -12,17 +12,20 @@ from prometheus_client import Counter
 
 from .choices import ObjectChangeActionChoices
 from .models import CustomField, ObjectChange
-from .webhooks import enqueue_webhooks
+from .webhooks import enqueue_object, serialize_for_webhook
 
 
 #
 # Change logging/webhooks
 #
 
-def _handle_changed_object(request, sender, instance, **kwargs):
+def _handle_changed_object(request, webhook_queue, sender, instance, **kwargs):
     """
     Fires when an object is created or updated.
     """
+    if not hasattr(instance, 'to_objectchange'):
+        return
+
     m2m_changed = False
 
     # Determine the type of change being made
@@ -53,8 +56,13 @@ def _handle_changed_object(request, sender, instance, **kwargs):
             objectchange.request_id = request.id
             objectchange.save()
 
-    # Enqueue webhooks
-    enqueue_webhooks(instance, request.user, request.id, action)
+    # If this is an M2M change, update the previously queued webhook (from post_save)
+    if m2m_changed and webhook_queue:
+        # TODO: Need more validation here
+        # TODO: Need to account for snapshot changes
+        webhook_queue[-1]['data'] = serialize_for_webhook(instance)
+    else:
+        enqueue_object(webhook_queue, instance, request.user, request.id, action)
 
     # Increment metric counters
     if action == ObjectChangeActionChoices.ACTION_CREATE:
@@ -68,10 +76,13 @@ def _handle_changed_object(request, sender, instance, **kwargs):
         ObjectChange.objects.filter(time__lt=cutoff)._raw_delete(using=DEFAULT_DB_ALIAS)
 
 
-def _handle_deleted_object(request, sender, instance, **kwargs):
+def _handle_deleted_object(request, webhook_queue, sender, instance, **kwargs):
     """
     Fires when an object is deleted.
     """
+    if not hasattr(instance, 'to_objectchange'):
+        return
+
     # Record an ObjectChange if applicable
     if hasattr(instance, 'to_objectchange'):
         objectchange = instance.to_objectchange(ObjectChangeActionChoices.ACTION_DELETE)
@@ -80,7 +91,7 @@ def _handle_deleted_object(request, sender, instance, **kwargs):
         objectchange.save()
 
     # Enqueue webhooks
-    enqueue_webhooks(instance, request.user, request.id, ObjectChangeActionChoices.ACTION_DELETE)
+    enqueue_object(webhook_queue, instance, request.user, request.id, ObjectChangeActionChoices.ACTION_DELETE)
 
     # Increment metric counters
     model_deletes.labels(instance._meta.model_name).inc()

--- a/netbox/extras/tests/test_webhooks.py
+++ b/netbox/extras/tests/test_webhooks.py
@@ -11,7 +11,7 @@ from rest_framework import status
 
 from dcim.models import Site
 from extras.choices import ObjectChangeActionChoices
-from extras.models import Webhook
+from extras.models import Tag, Webhook
 from extras.webhooks import enqueue_object, generate_signature
 from extras.webhooks_worker import process_webhook
 from utilities.testing import APITestCase
@@ -20,11 +20,10 @@ from utilities.testing import APITestCase
 class WebhookTest(APITestCase):
 
     def setUp(self):
-
         super().setUp()
 
         self.queue = django_rq.get_queue('default')
-        self.queue.empty()  # Begin each test with an empty queue
+        self.queue.empty()
 
     @classmethod
     def setUpTestData(cls):
@@ -34,38 +33,55 @@ class WebhookTest(APITestCase):
         DUMMY_SECRET = "LOOKATMEIMASECRETSTRING"
 
         webhooks = Webhook.objects.bulk_create((
-            Webhook(name='Site Create Webhook', type_create=True, payload_url=DUMMY_URL, secret=DUMMY_SECRET, additional_headers='X-Foo: Bar'),
-            Webhook(name='Site Update Webhook', type_update=True, payload_url=DUMMY_URL, secret=DUMMY_SECRET),
-            Webhook(name='Site Delete Webhook', type_delete=True, payload_url=DUMMY_URL, secret=DUMMY_SECRET),
+            Webhook(name='Webhook 1', type_create=True, payload_url=DUMMY_URL, secret=DUMMY_SECRET, additional_headers='X-Foo: Bar'),
+            Webhook(name='Webhook 2', type_update=True, payload_url=DUMMY_URL, secret=DUMMY_SECRET),
+            Webhook(name='Webhook 3', type_delete=True, payload_url=DUMMY_URL, secret=DUMMY_SECRET),
         ))
         for webhook in webhooks:
             webhook.content_types.set([site_ct])
 
+        Tag.objects.bulk_create((
+            Tag(name='Foo', slug='foo'),
+            Tag(name='Bar', slug='bar'),
+            Tag(name='Baz', slug='baz'),
+        ))
+
     def test_enqueue_webhook_create(self):
         # Create an object via the REST API
         data = {
-            'name': 'Test Site',
-            'slug': 'test-site',
+            'name': 'Site 1',
+            'slug': 'site-1',
+            'tags': [
+                {'name': 'Foo'},
+                {'name': 'Bar'},
+            ]
         }
         url = reverse('dcim-api:site-list')
         self.add_permissions('dcim.add_site')
         response = self.client.post(url, data, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_201_CREATED)
         self.assertEqual(Site.objects.count(), 1)
+        self.assertEqual(Site.objects.first().tags.count(), 2)
 
         # Verify that a job was queued for the object creation webhook
         self.assertEqual(self.queue.count, 1)
         job = self.queue.jobs[0]
         self.assertEqual(job.kwargs['webhook'], Webhook.objects.get(type_create=True))
         self.assertEqual(job.kwargs['data']['id'], response.data['id'])
+        self.assertEqual(len(job.kwargs['data']['tags']), len(response.data['tags']))
         self.assertEqual(job.kwargs['model_name'], 'site')
         self.assertEqual(job.kwargs['event'], ObjectChangeActionChoices.ACTION_CREATE)
 
     def test_enqueue_webhook_update(self):
-        # Update an object via the REST API
         site = Site.objects.create(name='Site 1', slug='site-1')
+        site.tags.set(*Tag.objects.filter(name__in=['Foo', 'Bar']))
+
+        # Update an object via the REST API
         data = {
             'comments': 'Updated the site',
+            'tags': [
+                {'name': 'Baz'}
+            ]
         }
         url = reverse('dcim-api:site-detail', kwargs={'pk': site.pk})
         self.add_permissions('dcim.change_site')
@@ -77,12 +93,15 @@ class WebhookTest(APITestCase):
         job = self.queue.jobs[0]
         self.assertEqual(job.kwargs['webhook'], Webhook.objects.get(type_update=True))
         self.assertEqual(job.kwargs['data']['id'], site.pk)
+        self.assertEqual(len(job.kwargs['data']['tags']), len(response.data['tags']))
         self.assertEqual(job.kwargs['model_name'], 'site')
         self.assertEqual(job.kwargs['event'], ObjectChangeActionChoices.ACTION_UPDATE)
 
     def test_enqueue_webhook_delete(self):
-        # Delete an object via the REST API
         site = Site.objects.create(name='Site 1', slug='site-1')
+        site.tags.set(*Tag.objects.filter(name__in=['Foo', 'Bar']))
+
+        # Delete an object via the REST API
         url = reverse('dcim-api:site-detail', kwargs={'pk': site.pk})
         self.add_permissions('dcim.delete_site')
         response = self.client.delete(url, **self.header)

--- a/netbox/extras/tests/test_webhooks.py
+++ b/netbox/extras/tests/test_webhooks.py
@@ -12,7 +12,7 @@ from rest_framework import status
 from dcim.models import Site
 from extras.choices import ObjectChangeActionChoices
 from extras.models import Tag, Webhook
-from extras.webhooks import enqueue_object, generate_signature
+from extras.webhooks import enqueue_object, flush_webhooks, generate_signature
 from extras.webhooks_worker import process_webhook
 from utilities.testing import APITestCase
 
@@ -251,48 +251,49 @@ class WebhookTest(APITestCase):
             self.assertEqual(job.kwargs['snapshots']['prechange']['name'], sites[i].name)
             self.assertEqual(job.kwargs['snapshots']['prechange']['tags'], ['Bar', 'Foo'])
 
-    # TODO: Replace webhook worker test
-    # def test_webhooks_worker(self):
-    #
-    #     request_id = uuid.uuid4()
-    #
-    #     def dummy_send(_, request, **kwargs):
-    #         """
-    #         A dummy implementation of Session.send() to be used for testing.
-    #         Always returns a 200 HTTP response.
-    #         """
-    #         webhook = Webhook.objects.get(type_create=True)
-    #         signature = generate_signature(request.body, webhook.secret)
-    #
-    #         # Validate the outgoing request headers
-    #         self.assertEqual(request.headers['Content-Type'], webhook.http_content_type)
-    #         self.assertEqual(request.headers['X-Hook-Signature'], signature)
-    #         self.assertEqual(request.headers['X-Foo'], 'Bar')
-    #
-    #         # Validate the outgoing request body
-    #         body = json.loads(request.body)
-    #         self.assertEqual(body['event'], 'created')
-    #         self.assertEqual(body['timestamp'], job.kwargs['timestamp'])
-    #         self.assertEqual(body['model'], 'site')
-    #         self.assertEqual(body['username'], 'testuser')
-    #         self.assertEqual(body['request_id'], str(request_id))
-    #         self.assertEqual(body['data']['name'], 'Site 1')
-    #
-    #         return HttpResponse()
-    #
-    #     # Enqueue a webhook for processing
-    #     site = Site.objects.create(name='Site 1', slug='site-1')
-    #     enqueue_webhooks(
-    #         queue=[],
-    #         instance=site,
-    #         user=self.user,
-    #         request_id=request_id,
-    #         action=ObjectChangeActionChoices.ACTION_CREATE
-    #     )
-    #
-    #     # Retrieve the job from queue
-    #     job = self.queue.jobs[0]
-    #
-    #     # Patch the Session object with our dummy_send() method, then process the webhook for sending
-    #     with patch.object(Session, 'send', dummy_send) as mock_send:
-    #         process_webhook(**job.kwargs)
+    def test_webhooks_worker(self):
+
+        request_id = uuid.uuid4()
+
+        def dummy_send(_, request, **kwargs):
+            """
+            A dummy implementation of Session.send() to be used for testing.
+            Always returns a 200 HTTP response.
+            """
+            webhook = Webhook.objects.get(type_create=True)
+            signature = generate_signature(request.body, webhook.secret)
+
+            # Validate the outgoing request headers
+            self.assertEqual(request.headers['Content-Type'], webhook.http_content_type)
+            self.assertEqual(request.headers['X-Hook-Signature'], signature)
+            self.assertEqual(request.headers['X-Foo'], 'Bar')
+
+            # Validate the outgoing request body
+            body = json.loads(request.body)
+            self.assertEqual(body['event'], 'created')
+            self.assertEqual(body['timestamp'], job.kwargs['timestamp'])
+            self.assertEqual(body['model'], 'site')
+            self.assertEqual(body['username'], 'testuser')
+            self.assertEqual(body['request_id'], str(request_id))
+            self.assertEqual(body['data']['name'], 'Site 1')
+
+            return HttpResponse()
+
+        # Enqueue a webhook for processing
+        webhooks_queue = []
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        enqueue_object(
+            webhooks_queue,
+            instance=site,
+            user=self.user,
+            request_id=request_id,
+            action=ObjectChangeActionChoices.ACTION_CREATE
+        )
+        flush_webhooks(webhooks_queue)
+
+        # Retrieve the job from queue
+        job = self.queue.jobs[0]
+
+        # Patch the Session object with our dummy_send() method, then process the webhook for sending
+        with patch.object(Session, 'send', dummy_send) as mock_send:
+            process_webhook(**job.kwargs)

--- a/netbox/extras/tests/test_webhooks.py
+++ b/netbox/extras/tests/test_webhooks.py
@@ -12,7 +12,7 @@ from rest_framework import status
 from dcim.models import Site
 from extras.choices import ObjectChangeActionChoices
 from extras.models import Webhook
-from extras.webhooks import enqueue_webhooks, generate_signature
+from extras.webhooks import enqueue_object, generate_signature
 from extras.webhooks_worker import process_webhook
 from utilities.testing import APITestCase
 
@@ -96,46 +96,48 @@ class WebhookTest(APITestCase):
         self.assertEqual(job.kwargs['model_name'], 'site')
         self.assertEqual(job.kwargs['event'], ObjectChangeActionChoices.ACTION_DELETE)
 
-    def test_webhooks_worker(self):
-
-        request_id = uuid.uuid4()
-
-        def dummy_send(_, request, **kwargs):
-            """
-            A dummy implementation of Session.send() to be used for testing.
-            Always returns a 200 HTTP response.
-            """
-            webhook = Webhook.objects.get(type_create=True)
-            signature = generate_signature(request.body, webhook.secret)
-
-            # Validate the outgoing request headers
-            self.assertEqual(request.headers['Content-Type'], webhook.http_content_type)
-            self.assertEqual(request.headers['X-Hook-Signature'], signature)
-            self.assertEqual(request.headers['X-Foo'], 'Bar')
-
-            # Validate the outgoing request body
-            body = json.loads(request.body)
-            self.assertEqual(body['event'], 'created')
-            self.assertEqual(body['timestamp'], job.kwargs['timestamp'])
-            self.assertEqual(body['model'], 'site')
-            self.assertEqual(body['username'], 'testuser')
-            self.assertEqual(body['request_id'], str(request_id))
-            self.assertEqual(body['data']['name'], 'Site 1')
-
-            return HttpResponse()
-
-        # Enqueue a webhook for processing
-        site = Site.objects.create(name='Site 1', slug='site-1')
-        enqueue_webhooks(
-            instance=site,
-            user=self.user,
-            request_id=request_id,
-            action=ObjectChangeActionChoices.ACTION_CREATE
-        )
-
-        # Retrieve the job from queue
-        job = self.queue.jobs[0]
-
-        # Patch the Session object with our dummy_send() method, then process the webhook for sending
-        with patch.object(Session, 'send', dummy_send) as mock_send:
-            process_webhook(**job.kwargs)
+    # TODO: Replace webhook worker test
+    # def test_webhooks_worker(self):
+    #
+    #     request_id = uuid.uuid4()
+    #
+    #     def dummy_send(_, request, **kwargs):
+    #         """
+    #         A dummy implementation of Session.send() to be used for testing.
+    #         Always returns a 200 HTTP response.
+    #         """
+    #         webhook = Webhook.objects.get(type_create=True)
+    #         signature = generate_signature(request.body, webhook.secret)
+    #
+    #         # Validate the outgoing request headers
+    #         self.assertEqual(request.headers['Content-Type'], webhook.http_content_type)
+    #         self.assertEqual(request.headers['X-Hook-Signature'], signature)
+    #         self.assertEqual(request.headers['X-Foo'], 'Bar')
+    #
+    #         # Validate the outgoing request body
+    #         body = json.loads(request.body)
+    #         self.assertEqual(body['event'], 'created')
+    #         self.assertEqual(body['timestamp'], job.kwargs['timestamp'])
+    #         self.assertEqual(body['model'], 'site')
+    #         self.assertEqual(body['username'], 'testuser')
+    #         self.assertEqual(body['request_id'], str(request_id))
+    #         self.assertEqual(body['data']['name'], 'Site 1')
+    #
+    #         return HttpResponse()
+    #
+    #     # Enqueue a webhook for processing
+    #     site = Site.objects.create(name='Site 1', slug='site-1')
+    #     enqueue_webhooks(
+    #         queue=[],
+    #         instance=site,
+    #         user=self.user,
+    #         request_id=request_id,
+    #         action=ObjectChangeActionChoices.ACTION_CREATE
+    #     )
+    #
+    #     # Retrieve the job from queue
+    #     job = self.queue.jobs[0]
+    #
+    #     # Patch the Session object with our dummy_send() method, then process the webhook for sending
+    #     with patch.object(Session, 'send', dummy_send) as mock_send:
+    #         process_webhook(**job.kwargs)

--- a/netbox/ipam/api/nested_serializers.py
+++ b/netbox/ipam/api/nested_serializers.py
@@ -102,10 +102,11 @@ class NestedVLANSerializer(WritableNestedSerializer):
 class NestedPrefixSerializer(WritableNestedSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='ipam-api:prefix-detail')
     family = serializers.IntegerField(read_only=True)
+    _depth = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = models.Prefix
-        fields = ['id', 'url', 'display', 'family', 'prefix']
+        fields = ['id', 'url', 'display', 'family', 'prefix', '_depth']
 
 
 #

--- a/netbox/ipam/api/serializers.py
+++ b/netbox/ipam/api/serializers.py
@@ -197,12 +197,14 @@ class PrefixSerializer(PrimaryModelSerializer):
     vlan = NestedVLANSerializer(required=False, allow_null=True)
     status = ChoiceField(choices=PrefixStatusChoices, required=False)
     role = NestedRoleSerializer(required=False, allow_null=True)
+    children = serializers.IntegerField(read_only=True)
+    _depth = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = Prefix
         fields = [
             'id', 'url', 'display', 'family', 'prefix', 'site', 'vrf', 'tenant', 'vlan', 'status', 'role', 'is_pool',
-            'description', 'tags', 'custom_fields', 'created', 'last_updated',
+            'description', 'tags', 'custom_fields', 'created', 'last_updated', 'children', '_depth',
         ]
         read_only_fields = ['family']
 

--- a/netbox/ipam/api/serializers.py
+++ b/netbox/ipam/api/serializers.py
@@ -274,7 +274,7 @@ class IPAddressSerializer(PrimaryModelSerializer):
     )
     assigned_object = serializers.SerializerMethodField(read_only=True)
     nat_inside = NestedIPAddressSerializer(required=False, allow_null=True)
-    nat_outside = NestedIPAddressSerializer(read_only=True)
+    nat_outside = NestedIPAddressSerializer(required=False, read_only=True)
 
     class Meta:
         model = IPAddress
@@ -283,7 +283,7 @@ class IPAddressSerializer(PrimaryModelSerializer):
             'assigned_object_id', 'assigned_object', 'nat_inside', 'nat_outside', 'dns_name', 'description', 'tags',
             'custom_fields', 'created', 'last_updated',
         ]
-        read_only_fields = ['family']
+        read_only_fields = ['family', 'nat_outside']
 
     @swagger_serializer_method(serializer_or_field=serializers.DictField)
     def get_assigned_object(self, obj):

--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -209,6 +209,12 @@ class PrefixFilterSet(PrimaryModelFilterSet, TenancyFilterSet):
         method='search_contains',
         label='Prefixes which contain this prefix or IP',
     )
+    depth = django_filters.NumberFilter(
+        field_name='_depth'
+    )
+    children = django_filters.NumberFilter(
+        field_name='_children'
+    )
     mask_length = django_filters.NumberFilter(
         field_name='prefix',
         lookup_expr='net_mask_length'

--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -209,10 +209,10 @@ class PrefixFilterSet(PrimaryModelFilterSet, TenancyFilterSet):
         method='search_contains',
         label='Prefixes which contain this prefix or IP',
     )
-    depth = django_filters.NumberFilter(
+    depth = MultiValueNumberFilter(
         field_name='_depth'
     )
-    children = django_filters.NumberFilter(
+    children = MultiValueNumberFilter(
         field_name='_children'
     )
     mask_length = django_filters.NumberFilter(

--- a/netbox/ipam/management/commands/rebuild_prefixes.py
+++ b/netbox/ipam/management/commands/rebuild_prefixes.py
@@ -1,0 +1,27 @@
+from django.core.management.base import BaseCommand
+
+from ipam.models import Prefix, VRF
+from ipam.utils import rebuild_prefixes
+
+
+class Command(BaseCommand):
+    help = "Rebuild the prefix hierarchy (depth and children counts)"
+
+    def handle(self, *model_names, **options):
+        self.stdout.write(f'Rebuilding {Prefix.objects.count()} prefixes...')
+
+        # Reset existing counts
+        Prefix.objects.update(_depth=0, _children=0)
+
+        # Rebuild the global table
+        global_count = Prefix.objects.filter(vrf__isnull=True).count()
+        self.stdout.write(f'Global: {global_count} prefixes...')
+        rebuild_prefixes(None)
+
+        # Rebuild each VRF
+        for vrf in VRF.objects.all():
+            vrf_count = Prefix.objects.filter(vrf=vrf).count()
+            self.stdout.write(f'VRF {vrf}: {vrf_count} prefixes...')
+            rebuild_prefixes(vrf)
+
+        self.stdout.write(self.style.SUCCESS('Finished.'))

--- a/netbox/ipam/migrations/0047_prefix_depth_children.py
+++ b/netbox/ipam/migrations/0047_prefix_depth_children.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ipam', '0046_set_vlangroup_scope_types'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='prefix',
+            name='_children',
+            field=models.PositiveBigIntegerField(default=0, editable=False),
+        ),
+        migrations.AddField(
+            model_name='prefix',
+            name='_depth',
+            field=models.PositiveSmallIntegerField(default=0, editable=False),
+        ),
+    ]

--- a/netbox/ipam/migrations/0048_prefix_populate_depth_children.py
+++ b/netbox/ipam/migrations/0048_prefix_populate_depth_children.py
@@ -4,17 +4,6 @@ from django.db import migrations
 from ipam.utils import rebuild_prefixes
 
 
-def push_to_stack(stack, prefix):
-    # Increment child count on parent nodes
-    for n in stack:
-        n['children'] += 1
-    stack.append({
-        'pk': prefix['pk'],
-        'prefix': prefix['prefix'],
-        'children': 0,
-    })
-
-
 def populate_prefix_hierarchy(apps, schema_editor):
     """
     Populate _depth and _children attrs for all Prefixes.

--- a/netbox/ipam/migrations/0048_prefix_populate_depth_children.py
+++ b/netbox/ipam/migrations/0048_prefix_populate_depth_children.py
@@ -1,5 +1,7 @@
 from django.db import migrations
 
+from ipam.utils import rebuild_prefixes
+
 
 def push_to_stack(stack, prefix):
     # Increment child count on parent nodes
@@ -22,54 +24,12 @@ def populate_prefix_hierarchy(apps, schema_editor):
     total_count = Prefix.objects.count()
     print(f'\nUpdating {total_count} prefixes...')
 
-    # Iterate through all VRFs and the global table
-    vrfs = [None] + list(VRF.objects.values_list('pk', flat=True))
-    for vrf in vrfs:
+    # Rebuild the global table
+    rebuild_prefixes(None)
 
-        stack = []
-        update_queue = []
-
-        # Iterate through all Prefixes in the VRF, growing and shrinking the stack as we go
-        prefixes = Prefix.objects.filter(vrf=vrf).values('pk', 'prefix')
-        for i, p in enumerate(prefixes):
-
-            # Grow the stack if this is a child of the most recent prefix
-            if not stack or p['prefix'] in stack[-1]['prefix']:
-                push_to_stack(stack, p)
-
-            # If this is a sibling or parent of the most recent prefix, pop nodes from the
-            # stack until we reach a parent prefix (or the root)
-            else:
-                while stack and p['prefix'] not in stack[-1]['prefix'] and p['prefix'] != stack[-1]['prefix']:
-                    node = stack.pop()
-                    update_queue.append(
-                        Prefix(
-                            pk=node['pk'],
-                            _depth=len(stack),
-                            _children=node['children']
-                        )
-                    )
-                push_to_stack(stack, p)
-
-                # Flush the update queue once it reaches 100 Prefixes
-                if len(update_queue) >= 100:
-                    Prefix.objects.bulk_update(update_queue, ['_depth', '_children'])
-                    update_queue = []
-                    print(f'  [{i}/{total_count}]')
-
-        # Clear out any prefixes remaining in the stack
-        while stack:
-            node = stack.pop()
-            update_queue.append(
-                Prefix(
-                    pk=node['pk'],
-                    _depth=len(stack),
-                    _children=node['children']
-                )
-            )
-
-        # Final flush of any remaining Prefixes
-        Prefix.objects.bulk_update(update_queue, ['_depth', '_children'])
+    # Iterate through all VRFs, rebuilding each
+    for vrf in VRF.objects.all():
+        rebuild_prefixes(vrf)
 
 
 class Migration(migrations.Migration):

--- a/netbox/ipam/migrations/0048_prefix_populate_depth_children.py
+++ b/netbox/ipam/migrations/0048_prefix_populate_depth_children.py
@@ -1,0 +1,86 @@
+from django.db import migrations
+
+
+def push_to_stack(stack, prefix):
+    # Increment child count on parent nodes
+    for n in stack:
+        n['children'] += 1
+    stack.append({
+        'pk': prefix['pk'],
+        'prefix': prefix['prefix'],
+        'children': 0,
+    })
+
+
+def populate_prefix_hierarchy(apps, schema_editor):
+    """
+    Populate _depth and _children attrs for all Prefixes.
+    """
+    Prefix = apps.get_model('ipam', 'Prefix')
+    VRF = apps.get_model('ipam', 'VRF')
+
+    total_count = Prefix.objects.count()
+    print(f'\nUpdating {total_count} prefixes...')
+
+    # Iterate through all VRFs and the global table
+    vrfs = [None] + list(VRF.objects.values_list('pk', flat=True))
+    for vrf in vrfs:
+
+        stack = []
+        update_queue = []
+
+        # Iterate through all Prefixes in the VRF, growing and shrinking the stack as we go
+        prefixes = Prefix.objects.filter(vrf=vrf).values('pk', 'prefix')
+        for i, p in enumerate(prefixes):
+
+            # Grow the stack if this is a child of the most recent prefix
+            if not stack or p['prefix'] in stack[-1]['prefix']:
+                push_to_stack(stack, p)
+
+            # If this is a sibling or parent of the most recent prefix, pop nodes from the
+            # stack until we reach a parent prefix (or the root)
+            else:
+                while stack and p['prefix'] not in stack[-1]['prefix'] and p['prefix'] != stack[-1]['prefix']:
+                    node = stack.pop()
+                    update_queue.append(
+                        Prefix(
+                            pk=node['pk'],
+                            _depth=len(stack),
+                            _children=node['children']
+                        )
+                    )
+                push_to_stack(stack, p)
+
+                # Flush the update queue once it reaches 100 Prefixes
+                if len(update_queue) >= 100:
+                    Prefix.objects.bulk_update(update_queue, ['_depth', '_children'])
+                    update_queue = []
+                    print(f'  [{i}/{total_count}]')
+
+        # Clear out any prefixes remaining in the stack
+        while stack:
+            node = stack.pop()
+            update_queue.append(
+                Prefix(
+                    pk=node['pk'],
+                    _depth=len(stack),
+                    _children=node['children']
+                )
+            )
+
+        # Final flush of any remaining Prefixes
+        Prefix.objects.bulk_update(update_queue, ['_depth', '_children'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ipam', '0047_prefix_depth_children'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=populate_prefix_hierarchy,
+            reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/netbox/ipam/migrations/0048_prefix_populate_depth_children.py
+++ b/netbox/ipam/migrations/0048_prefix_populate_depth_children.py
@@ -1,3 +1,4 @@
+import sys
 from django.db import migrations
 
 from ipam.utils import rebuild_prefixes
@@ -22,7 +23,8 @@ def populate_prefix_hierarchy(apps, schema_editor):
     VRF = apps.get_model('ipam', 'VRF')
 
     total_count = Prefix.objects.count()
-    print(f'\nUpdating {total_count} prefixes...')
+    if 'test' not in sys.argv:
+        print(f'\nUpdating {total_count} prefixes...')
 
     # Rebuild the global table
     rebuild_prefixes(None)

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -293,6 +293,16 @@ class Prefix(PrimaryModel):
         blank=True
     )
 
+    # Cached depth & child counts
+    _depth = models.PositiveSmallIntegerField(
+        default=0,
+        editable=False
+    )
+    _children = models.PositiveBigIntegerField(
+        default=0,
+        editable=False
+    )
+
     objects = PrefixQuerySet.as_manager()
 
     csv_headers = [
@@ -305,6 +315,13 @@ class Prefix(PrimaryModel):
     class Meta:
         ordering = (F('vrf').asc(nulls_first=True), 'prefix', 'pk')  # (vrf, prefix) may be non-unique
         verbose_name_plural = 'prefixes'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Cache the original prefix and VRF so we can check if they have changed on post_save
+        self._prefix = self.prefix
+        self._vrf = self.vrf
 
     def __str__(self):
         return str(self.prefix)
@@ -373,6 +390,14 @@ class Prefix(PrimaryModel):
             return self.prefix.version
         return None
 
+    @property
+    def depth(self):
+        return self._depth
+
+    @property
+    def children(self):
+        return self._children
+
     def _set_prefix_length(self, value):
         """
         Expose the IPNetwork object's prefixlen attribute on the parent model so that it can be manipulated directly,
@@ -384,6 +409,26 @@ class Prefix(PrimaryModel):
 
     def get_status_class(self):
         return PrefixStatusChoices.CSS_CLASSES.get(self.status)
+
+    def get_parents(self, include_self=False):
+        """
+        Return all containing Prefixes in the hierarchy.
+        """
+        lookup = 'net_contains_or_equals' if include_self else 'net_contains'
+        return Prefix.objects.filter(**{
+            'vrf': self.vrf,
+            f'prefix__{lookup}': self.prefix
+        })
+
+    def get_children(self, include_self=False):
+        """
+        Return all covered Prefixes in the hierarchy.
+        """
+        lookup = 'net_contained_or_equal' if include_self else 'net_contained'
+        return Prefix.objects.filter(**{
+            'vrf': self.vrf,
+            f'prefix__{lookup}': self.prefix
+        })
 
     def get_duplicates(self):
         return Prefix.objects.filter(vrf=self.vrf, prefix=str(self.prefix)).exclude(pk=self.pk)

--- a/netbox/ipam/signals.py
+++ b/netbox/ipam/signals.py
@@ -1,9 +1,52 @@
-from django.db.models.signals import pre_delete
+from django.db.models.signals import post_delete, post_save, pre_delete
 from django.dispatch import receiver
 
 from dcim.models import Device
 from virtualization.models import VirtualMachine
-from .models import IPAddress
+from .models import IPAddress, Prefix
+
+
+def update_parents_children(prefix):
+    """
+    Update depth on prefix & containing prefixes
+    """
+    parents = prefix.get_parents(include_self=True).annotate_hierarchy()
+    for parent in parents:
+        parent._children = parent.hierarchy_children
+    Prefix.objects.bulk_update(parents, ['_children'])
+
+
+def update_children_depth(prefix):
+    """
+    Update children count on prefix & contained prefixes
+    """
+    children = prefix.get_children(include_self=True).annotate_hierarchy()
+    for child in children:
+        child._depth = child.hierarchy_depth
+    Prefix.objects.bulk_update(children, ['_depth'])
+
+
+@receiver(post_save, sender=Prefix)
+def handle_prefix_saved(instance, created, **kwargs):
+
+    # Prefix has changed (or new instance has been created)
+    if created or instance.vrf != instance._vrf or instance.prefix != instance._prefix:
+
+        update_parents_children(instance)
+        update_children_depth(instance)
+
+        # If this is not a new prefix, clean up parent/children of previous prefix
+        if not created:
+            old_prefix = Prefix(vrf=instance._vrf, prefix=instance._prefix)
+            update_parents_children(old_prefix)
+            update_children_depth(old_prefix)
+
+
+@receiver(post_delete, sender=Prefix)
+def handle_prefix_deleted(instance, **kwargs):
+
+    update_parents_children(instance)
+    update_children_depth(instance)
 
 
 @receiver(pre_delete, sender=IPAddress)

--- a/netbox/ipam/signals.py
+++ b/netbox/ipam/signals.py
@@ -13,7 +13,7 @@ def update_parents_children(prefix):
     parents = prefix.get_parents(include_self=True).annotate_hierarchy()
     for parent in parents:
         parent._children = parent.hierarchy_children
-    Prefix.objects.bulk_update(parents, ['_children'])
+    Prefix.objects.bulk_update(parents, ['_children'], batch_size=100)
 
 
 def update_children_depth(prefix):
@@ -23,7 +23,7 @@ def update_children_depth(prefix):
     children = prefix.get_children(include_self=True).annotate_hierarchy()
     for child in children:
         child._depth = child.hierarchy_depth
-    Prefix.objects.bulk_update(children, ['_depth'])
+    Prefix.objects.bulk_update(children, ['_depth'], batch_size=100)
 
 
 @receiver(post_save, sender=Prefix)

--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -15,7 +15,7 @@ AVAILABLE_LABEL = mark_safe('<span class="label label-success">Available</span>'
 
 PREFIX_LINK = """
 {% load helpers %}
-{% for i in record.parents|as_range %}
+{% for i in record.depth|as_range %}
     <i class="mdi mdi-circle-small"></i>
 {% endfor %}
 <a href="{% if record.pk %}{% url 'ipam:prefix' pk=record.pk %}{% else %}{% url 'ipam:prefix_add' %}?prefix={{ record }}{% if object.vrf %}&vrf={{ object.vrf.pk }}{% endif %}{% if object.site %}&site={{ object.site.pk }}{% endif %}{% if object.tenant %}&tenant_group={{ object.tenant.group.pk }}&tenant={{ object.tenant.pk }}{% endif %}{% endif %}">{{ record.prefix }}</a>
@@ -262,6 +262,14 @@ class PrefixTable(BaseTable):
         template_code=PREFIX_LINK,
         attrs={'td': {'class': 'text-nowrap'}}
     )
+    depth = tables.Column(
+        accessor=Accessor('_depth'),
+        verbose_name='Depth'
+    )
+    children = tables.Column(
+        accessor=Accessor('_children'),
+        verbose_name='Children'
+    )
     status = ChoiceFieldColumn(
         default=AVAILABLE_LABEL
     )
@@ -287,7 +295,8 @@ class PrefixTable(BaseTable):
     class Meta(BaseTable.Meta):
         model = Prefix
         fields = (
-            'pk', 'prefix', 'status', 'children', 'vrf', 'tenant', 'site', 'vlan', 'role', 'is_pool', 'description',
+            'pk', 'prefix', 'status', 'depth', 'children', 'vrf', 'tenant', 'site', 'vlan', 'role', 'is_pool',
+            'description',
         )
         default_columns = ('pk', 'prefix', 'status', 'vrf', 'tenant', 'site', 'vlan', 'role', 'description')
         row_attrs = {

--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -262,6 +262,11 @@ class PrefixTable(BaseTable):
         template_code=PREFIX_LINK,
         attrs={'td': {'class': 'text-nowrap'}}
     )
+    prefix_flat = tables.Column(
+        accessor=Accessor('prefix'),
+        linkify=True,
+        verbose_name='Prefix (Flat)'
+    )
     depth = tables.Column(
         accessor=Accessor('_depth'),
         verbose_name='Depth'
@@ -300,8 +305,8 @@ class PrefixTable(BaseTable):
     class Meta(BaseTable.Meta):
         model = Prefix
         fields = (
-            'pk', 'prefix', 'status', 'depth', 'children', 'vrf', 'tenant', 'site', 'vlan', 'role', 'is_pool',
-            'description',
+            'pk', 'prefix', 'prefix_flat', 'status', 'depth', 'children', 'vrf', 'tenant', 'site', 'vlan', 'role',
+            'is_pool', 'description',
         )
         default_columns = ('pk', 'prefix', 'status', 'vrf', 'tenant', 'site', 'vlan', 'role', 'description')
         row_attrs = {
@@ -314,15 +319,14 @@ class PrefixDetailTable(PrefixTable):
         accessor='get_utilization',
         orderable=False
     )
-    tenant = TenantColumn()
     tags = TagColumn(
         url_name='ipam:prefix_list'
     )
 
     class Meta(PrefixTable.Meta):
         fields = (
-            'pk', 'prefix', 'status', 'children', 'vrf', 'utilization', 'tenant', 'site', 'vlan', 'role', 'is_pool',
-            'description', 'tags',
+            'pk', 'prefix', 'prefix_flat', 'status', 'children', 'vrf', 'utilization', 'tenant', 'site', 'vlan', 'role',
+            'is_pool', 'description', 'tags',
         )
         default_columns = (
             'pk', 'prefix', 'status', 'children', 'vrf', 'utilization', 'tenant', 'site', 'vlan', 'role', 'description',

--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -266,8 +266,13 @@ class PrefixTable(BaseTable):
         accessor=Accessor('_depth'),
         verbose_name='Depth'
     )
-    children = tables.Column(
+    children = LinkedCountColumn(
         accessor=Accessor('_children'),
+        viewname='ipam:prefix_list',
+        url_params={
+            'vrf_id': 'vrf_id',
+            'within': 'prefix',
+        },
         verbose_name='Children'
     )
     status = ChoiceFieldColumn(

--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -186,7 +186,7 @@ class RoleTest(APIViewTestCases.APIViewTestCase):
 
 class PrefixTest(APIViewTestCases.APIViewTestCase):
     model = Prefix
-    brief_fields = ['display', 'family', 'id', 'prefix', 'url']
+    brief_fields = ['_depth', 'display', 'family', 'id', 'prefix', 'url']
     create_data = [
         {
             'prefix': '192.168.4.0/24',

--- a/netbox/ipam/tests/test_filtersets.py
+++ b/netbox/ipam/tests/test_filtersets.py
@@ -400,7 +400,8 @@ class PrefixTestCase(TestCase, ChangeLoggedFilterSetTests):
             Prefix(prefix='10.0.0.0/16'),
             Prefix(prefix='2001:db8::/32'),
         )
-        Prefix.objects.bulk_create(prefixes)
+        for prefix in prefixes:
+            prefix.save()
 
     def test_family(self):
         params = {'family': '6'}
@@ -429,6 +430,18 @@ class PrefixTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {'contains': '10.0.1.0/24'}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'contains': '2001:db8:0:1::/64'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_depth(self):
+        params = {'depth': '0'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
+        params = {'depth__gt': '0'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_children(self):
+        params = {'children': '0'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
+        params = {'children__gt': '0'}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_mask_length(self):

--- a/netbox/ipam/tests/test_models.py
+++ b/netbox/ipam/tests/test_models.py
@@ -1,4 +1,4 @@
-import netaddr
+from netaddr import IPNetwork, IPSet
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 
@@ -10,27 +10,27 @@ class TestAggregate(TestCase):
 
     def test_get_utilization(self):
         rir = RIR.objects.create(name='RIR 1', slug='rir-1')
-        aggregate = Aggregate(prefix=netaddr.IPNetwork('10.0.0.0/8'), rir=rir)
+        aggregate = Aggregate(prefix=IPNetwork('10.0.0.0/8'), rir=rir)
         aggregate.save()
 
         # 25% utilization
         Prefix.objects.bulk_create((
-            Prefix(prefix=netaddr.IPNetwork('10.0.0.0/12')),
-            Prefix(prefix=netaddr.IPNetwork('10.16.0.0/12')),
-            Prefix(prefix=netaddr.IPNetwork('10.32.0.0/12')),
-            Prefix(prefix=netaddr.IPNetwork('10.48.0.0/12')),
+            Prefix(prefix=IPNetwork('10.0.0.0/12')),
+            Prefix(prefix=IPNetwork('10.16.0.0/12')),
+            Prefix(prefix=IPNetwork('10.32.0.0/12')),
+            Prefix(prefix=IPNetwork('10.48.0.0/12')),
         ))
         self.assertEqual(aggregate.get_utilization(), 25)
 
         # 50% utilization
         Prefix.objects.bulk_create((
-            Prefix(prefix=netaddr.IPNetwork('10.64.0.0/10')),
+            Prefix(prefix=IPNetwork('10.64.0.0/10')),
         ))
         self.assertEqual(aggregate.get_utilization(), 50)
 
         # 100% utilization
         Prefix.objects.bulk_create((
-            Prefix(prefix=netaddr.IPNetwork('10.128.0.0/9')),
+            Prefix(prefix=IPNetwork('10.128.0.0/9')),
         ))
         self.assertEqual(aggregate.get_utilization(), 100)
 
@@ -39,9 +39,9 @@ class TestPrefix(TestCase):
 
     def test_get_duplicates(self):
         prefixes = Prefix.objects.bulk_create((
-            Prefix(prefix=netaddr.IPNetwork('192.0.2.0/24')),
-            Prefix(prefix=netaddr.IPNetwork('192.0.2.0/24')),
-            Prefix(prefix=netaddr.IPNetwork('192.0.2.0/24')),
+            Prefix(prefix=IPNetwork('192.0.2.0/24')),
+            Prefix(prefix=IPNetwork('192.0.2.0/24')),
+            Prefix(prefix=IPNetwork('192.0.2.0/24')),
         ))
         duplicate_prefix_pks = [p.pk for p in prefixes[0].get_duplicates()]
 
@@ -54,11 +54,11 @@ class TestPrefix(TestCase):
             VRF(name='VRF 3'),
         ))
         prefixes = Prefix.objects.bulk_create((
-            Prefix(prefix=netaddr.IPNetwork('10.0.0.0/16'), status=PrefixStatusChoices.STATUS_CONTAINER),
-            Prefix(prefix=netaddr.IPNetwork('10.0.0.0/24'), vrf=None),
-            Prefix(prefix=netaddr.IPNetwork('10.0.1.0/24'), vrf=vrfs[0]),
-            Prefix(prefix=netaddr.IPNetwork('10.0.2.0/24'), vrf=vrfs[1]),
-            Prefix(prefix=netaddr.IPNetwork('10.0.3.0/24'), vrf=vrfs[2]),
+            Prefix(prefix=IPNetwork('10.0.0.0/16'), status=PrefixStatusChoices.STATUS_CONTAINER),
+            Prefix(prefix=IPNetwork('10.0.0.0/24'), vrf=None),
+            Prefix(prefix=IPNetwork('10.0.1.0/24'), vrf=vrfs[0]),
+            Prefix(prefix=IPNetwork('10.0.2.0/24'), vrf=vrfs[1]),
+            Prefix(prefix=IPNetwork('10.0.3.0/24'), vrf=vrfs[2]),
         ))
         child_prefix_pks = {p.pk for p in prefixes[0].get_child_prefixes()}
 
@@ -79,13 +79,13 @@ class TestPrefix(TestCase):
             VRF(name='VRF 3'),
         ))
         parent_prefix = Prefix.objects.create(
-            prefix=netaddr.IPNetwork('10.0.0.0/16'), status=PrefixStatusChoices.STATUS_CONTAINER
+            prefix=IPNetwork('10.0.0.0/16'), status=PrefixStatusChoices.STATUS_CONTAINER
         )
         ips = IPAddress.objects.bulk_create((
-            IPAddress(address=netaddr.IPNetwork('10.0.0.1/24'), vrf=None),
-            IPAddress(address=netaddr.IPNetwork('10.0.1.1/24'), vrf=vrfs[0]),
-            IPAddress(address=netaddr.IPNetwork('10.0.2.1/24'), vrf=vrfs[1]),
-            IPAddress(address=netaddr.IPNetwork('10.0.3.1/24'), vrf=vrfs[2]),
+            IPAddress(address=IPNetwork('10.0.0.1/24'), vrf=None),
+            IPAddress(address=IPNetwork('10.0.1.1/24'), vrf=vrfs[0]),
+            IPAddress(address=IPNetwork('10.0.2.1/24'), vrf=vrfs[1]),
+            IPAddress(address=IPNetwork('10.0.3.1/24'), vrf=vrfs[2]),
         ))
         child_ip_pks = {p.pk for p in parent_prefix.get_child_ips()}
 
@@ -102,16 +102,16 @@ class TestPrefix(TestCase):
     def test_get_available_prefixes(self):
 
         prefixes = Prefix.objects.bulk_create((
-            Prefix(prefix=netaddr.IPNetwork('10.0.0.0/16')),  # Parent prefix
-            Prefix(prefix=netaddr.IPNetwork('10.0.0.0/20')),
-            Prefix(prefix=netaddr.IPNetwork('10.0.32.0/20')),
-            Prefix(prefix=netaddr.IPNetwork('10.0.128.0/18')),
+            Prefix(prefix=IPNetwork('10.0.0.0/16')),  # Parent prefix
+            Prefix(prefix=IPNetwork('10.0.0.0/20')),
+            Prefix(prefix=IPNetwork('10.0.32.0/20')),
+            Prefix(prefix=IPNetwork('10.0.128.0/18')),
         ))
-        missing_prefixes = netaddr.IPSet([
-            netaddr.IPNetwork('10.0.16.0/20'),
-            netaddr.IPNetwork('10.0.48.0/20'),
-            netaddr.IPNetwork('10.0.64.0/18'),
-            netaddr.IPNetwork('10.0.192.0/18'),
+        missing_prefixes = IPSet([
+            IPNetwork('10.0.16.0/20'),
+            IPNetwork('10.0.48.0/20'),
+            IPNetwork('10.0.64.0/18'),
+            IPNetwork('10.0.192.0/18'),
         ])
         available_prefixes = prefixes[0].get_available_prefixes()
 
@@ -119,17 +119,17 @@ class TestPrefix(TestCase):
 
     def test_get_available_ips(self):
 
-        parent_prefix = Prefix.objects.create(prefix=netaddr.IPNetwork('10.0.0.0/28'))
+        parent_prefix = Prefix.objects.create(prefix=IPNetwork('10.0.0.0/28'))
         IPAddress.objects.bulk_create((
-            IPAddress(address=netaddr.IPNetwork('10.0.0.1/26')),
-            IPAddress(address=netaddr.IPNetwork('10.0.0.3/26')),
-            IPAddress(address=netaddr.IPNetwork('10.0.0.5/26')),
-            IPAddress(address=netaddr.IPNetwork('10.0.0.7/26')),
-            IPAddress(address=netaddr.IPNetwork('10.0.0.9/26')),
-            IPAddress(address=netaddr.IPNetwork('10.0.0.11/26')),
-            IPAddress(address=netaddr.IPNetwork('10.0.0.13/26')),
+            IPAddress(address=IPNetwork('10.0.0.1/26')),
+            IPAddress(address=IPNetwork('10.0.0.3/26')),
+            IPAddress(address=IPNetwork('10.0.0.5/26')),
+            IPAddress(address=IPNetwork('10.0.0.7/26')),
+            IPAddress(address=IPNetwork('10.0.0.9/26')),
+            IPAddress(address=IPNetwork('10.0.0.11/26')),
+            IPAddress(address=IPNetwork('10.0.0.13/26')),
         ))
-        missing_ips = netaddr.IPSet([
+        missing_ips = IPSet([
             '10.0.0.2/32',
             '10.0.0.4/32',
             '10.0.0.6/32',
@@ -145,39 +145,39 @@ class TestPrefix(TestCase):
     def test_get_first_available_prefix(self):
 
         prefixes = Prefix.objects.bulk_create((
-            Prefix(prefix=netaddr.IPNetwork('10.0.0.0/16')),  # Parent prefix
-            Prefix(prefix=netaddr.IPNetwork('10.0.0.0/24')),
-            Prefix(prefix=netaddr.IPNetwork('10.0.1.0/24')),
-            Prefix(prefix=netaddr.IPNetwork('10.0.2.0/24')),
+            Prefix(prefix=IPNetwork('10.0.0.0/16')),  # Parent prefix
+            Prefix(prefix=IPNetwork('10.0.0.0/24')),
+            Prefix(prefix=IPNetwork('10.0.1.0/24')),
+            Prefix(prefix=IPNetwork('10.0.2.0/24')),
         ))
-        self.assertEqual(prefixes[0].get_first_available_prefix(), netaddr.IPNetwork('10.0.3.0/24'))
+        self.assertEqual(prefixes[0].get_first_available_prefix(), IPNetwork('10.0.3.0/24'))
 
-        Prefix.objects.create(prefix=netaddr.IPNetwork('10.0.3.0/24'))
-        self.assertEqual(prefixes[0].get_first_available_prefix(), netaddr.IPNetwork('10.0.4.0/22'))
+        Prefix.objects.create(prefix=IPNetwork('10.0.3.0/24'))
+        self.assertEqual(prefixes[0].get_first_available_prefix(), IPNetwork('10.0.4.0/22'))
 
     def test_get_first_available_ip(self):
 
-        parent_prefix = Prefix.objects.create(prefix=netaddr.IPNetwork('10.0.0.0/24'))
+        parent_prefix = Prefix.objects.create(prefix=IPNetwork('10.0.0.0/24'))
         IPAddress.objects.bulk_create((
-            IPAddress(address=netaddr.IPNetwork('10.0.0.1/24')),
-            IPAddress(address=netaddr.IPNetwork('10.0.0.2/24')),
-            IPAddress(address=netaddr.IPNetwork('10.0.0.3/24')),
+            IPAddress(address=IPNetwork('10.0.0.1/24')),
+            IPAddress(address=IPNetwork('10.0.0.2/24')),
+            IPAddress(address=IPNetwork('10.0.0.3/24')),
         ))
         self.assertEqual(parent_prefix.get_first_available_ip(), '10.0.0.4/24')
 
-        IPAddress.objects.create(address=netaddr.IPNetwork('10.0.0.4/24'))
+        IPAddress.objects.create(address=IPNetwork('10.0.0.4/24'))
         self.assertEqual(parent_prefix.get_first_available_ip(), '10.0.0.5/24')
 
     def test_get_utilization(self):
 
         # Container Prefix
         prefix = Prefix.objects.create(
-            prefix=netaddr.IPNetwork('10.0.0.0/24'),
+            prefix=IPNetwork('10.0.0.0/24'),
             status=PrefixStatusChoices.STATUS_CONTAINER
         )
         Prefix.objects.bulk_create((
-            Prefix(prefix=netaddr.IPNetwork('10.0.0.0/26')),
-            Prefix(prefix=netaddr.IPNetwork('10.0.0.128/26')),
+            Prefix(prefix=IPNetwork('10.0.0.0/26')),
+            Prefix(prefix=IPNetwork('10.0.0.128/26')),
         ))
         self.assertEqual(prefix.get_utilization(), 50)
 
@@ -186,7 +186,7 @@ class TestPrefix(TestCase):
         prefix.save()
         IPAddress.objects.bulk_create(
             # Create 32 IPAddresses within the Prefix
-            [IPAddress(address=netaddr.IPNetwork('10.0.0.{}/24'.format(i))) for i in range(1, 33)]
+            [IPAddress(address=IPNetwork('10.0.0.{}/24'.format(i))) for i in range(1, 33)]
         )
         self.assertEqual(prefix.get_utilization(), 12)  # ~= 12%
 
@@ -196,36 +196,234 @@ class TestPrefix(TestCase):
 
     @override_settings(ENFORCE_GLOBAL_UNIQUE=False)
     def test_duplicate_global(self):
-        Prefix.objects.create(prefix=netaddr.IPNetwork('192.0.2.0/24'))
-        duplicate_prefix = Prefix(prefix=netaddr.IPNetwork('192.0.2.0/24'))
+        Prefix.objects.create(prefix=IPNetwork('192.0.2.0/24'))
+        duplicate_prefix = Prefix(prefix=IPNetwork('192.0.2.0/24'))
         self.assertIsNone(duplicate_prefix.clean())
 
     @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
     def test_duplicate_global_unique(self):
-        Prefix.objects.create(prefix=netaddr.IPNetwork('192.0.2.0/24'))
-        duplicate_prefix = Prefix(prefix=netaddr.IPNetwork('192.0.2.0/24'))
+        Prefix.objects.create(prefix=IPNetwork('192.0.2.0/24'))
+        duplicate_prefix = Prefix(prefix=IPNetwork('192.0.2.0/24'))
         self.assertRaises(ValidationError, duplicate_prefix.clean)
 
     def test_duplicate_vrf(self):
         vrf = VRF.objects.create(name='Test', rd='1:1', enforce_unique=False)
-        Prefix.objects.create(vrf=vrf, prefix=netaddr.IPNetwork('192.0.2.0/24'))
-        duplicate_prefix = Prefix(vrf=vrf, prefix=netaddr.IPNetwork('192.0.2.0/24'))
+        Prefix.objects.create(vrf=vrf, prefix=IPNetwork('192.0.2.0/24'))
+        duplicate_prefix = Prefix(vrf=vrf, prefix=IPNetwork('192.0.2.0/24'))
         self.assertIsNone(duplicate_prefix.clean())
 
     def test_duplicate_vrf_unique(self):
         vrf = VRF.objects.create(name='Test', rd='1:1', enforce_unique=True)
-        Prefix.objects.create(vrf=vrf, prefix=netaddr.IPNetwork('192.0.2.0/24'))
-        duplicate_prefix = Prefix(vrf=vrf, prefix=netaddr.IPNetwork('192.0.2.0/24'))
+        Prefix.objects.create(vrf=vrf, prefix=IPNetwork('192.0.2.0/24'))
+        duplicate_prefix = Prefix(vrf=vrf, prefix=IPNetwork('192.0.2.0/24'))
         self.assertRaises(ValidationError, duplicate_prefix.clean)
+
+
+class TestPrefixHierarchy(TestCase):
+    """
+    Test the automatic updating of depth and child count in response to changes made within
+    the prefix hierarchy.
+    """
+    @classmethod
+    def setUpTestData(cls):
+
+        prefixes = (
+
+            # IPv4
+            Prefix(prefix='10.0.0.0/8', _depth=0, _children=2),
+            Prefix(prefix='10.0.0.0/16', _depth=1, _children=1),
+            Prefix(prefix='10.0.0.0/24', _depth=2, _children=0),
+
+            # IPv6
+            Prefix(prefix='2001:db8::/32', _depth=0, _children=2),
+            Prefix(prefix='2001:db8::/40', _depth=1, _children=1),
+            Prefix(prefix='2001:db8::/48', _depth=2, _children=0),
+
+        )
+        Prefix.objects.bulk_create(prefixes)
+
+    def test_create_prefix4(self):
+        # Create 10.0.0.0/12
+        Prefix(prefix='10.0.0.0/12').save()
+
+        prefixes = Prefix.objects.filter(prefix__family=4)
+        self.assertEqual(prefixes[0].prefix, IPNetwork('10.0.0.0/8'))
+        self.assertEqual(prefixes[0]._depth, 0)
+        self.assertEqual(prefixes[0]._children, 3)
+        self.assertEqual(prefixes[1].prefix, IPNetwork('10.0.0.0/12'))
+        self.assertEqual(prefixes[1]._depth, 1)
+        self.assertEqual(prefixes[1]._children, 2)
+        self.assertEqual(prefixes[2].prefix, IPNetwork('10.0.0.0/16'))
+        self.assertEqual(prefixes[2]._depth, 2)
+        self.assertEqual(prefixes[2]._children, 1)
+        self.assertEqual(prefixes[3].prefix, IPNetwork('10.0.0.0/24'))
+        self.assertEqual(prefixes[3]._depth, 3)
+        self.assertEqual(prefixes[3]._children, 0)
+
+    def test_create_prefix6(self):
+        # Create 2001:db8::/36
+        Prefix(prefix='2001:db8::/36').save()
+
+        prefixes = Prefix.objects.filter(prefix__family=6)
+        self.assertEqual(prefixes[0].prefix, IPNetwork('2001:db8::/32'))
+        self.assertEqual(prefixes[0]._depth, 0)
+        self.assertEqual(prefixes[0]._children, 3)
+        self.assertEqual(prefixes[1].prefix, IPNetwork('2001:db8::/36'))
+        self.assertEqual(prefixes[1]._depth, 1)
+        self.assertEqual(prefixes[1]._children, 2)
+        self.assertEqual(prefixes[2].prefix, IPNetwork('2001:db8::/40'))
+        self.assertEqual(prefixes[2]._depth, 2)
+        self.assertEqual(prefixes[2]._children, 1)
+        self.assertEqual(prefixes[3].prefix, IPNetwork('2001:db8::/48'))
+        self.assertEqual(prefixes[3]._depth, 3)
+        self.assertEqual(prefixes[3]._children, 0)
+
+    def test_update_prefix4(self):
+        # Change 10.0.0.0/24 to 10.0.0.0/12
+        p = Prefix.objects.get(prefix='10.0.0.0/24')
+        p.prefix = '10.0.0.0/12'
+        p.save()
+
+        prefixes = Prefix.objects.filter(prefix__family=4)
+        self.assertEqual(prefixes[0].prefix, IPNetwork('10.0.0.0/8'))
+        self.assertEqual(prefixes[0]._depth, 0)
+        self.assertEqual(prefixes[0]._children, 2)
+        self.assertEqual(prefixes[1].prefix, IPNetwork('10.0.0.0/12'))
+        self.assertEqual(prefixes[1]._depth, 1)
+        self.assertEqual(prefixes[1]._children, 1)
+        self.assertEqual(prefixes[2].prefix, IPNetwork('10.0.0.0/16'))
+        self.assertEqual(prefixes[2]._depth, 2)
+        self.assertEqual(prefixes[2]._children, 0)
+
+    def test_update_prefix6(self):
+        # Change 2001:db8::/48 to 2001:db8::/36
+        p = Prefix.objects.get(prefix='2001:db8::/48')
+        p.prefix = '2001:db8::/36'
+        p.save()
+
+        prefixes = Prefix.objects.filter(prefix__family=6)
+        self.assertEqual(prefixes[0].prefix, IPNetwork('2001:db8::/32'))
+        self.assertEqual(prefixes[0]._depth, 0)
+        self.assertEqual(prefixes[0]._children, 2)
+        self.assertEqual(prefixes[1].prefix, IPNetwork('2001:db8::/36'))
+        self.assertEqual(prefixes[1]._depth, 1)
+        self.assertEqual(prefixes[1]._children, 1)
+        self.assertEqual(prefixes[2].prefix, IPNetwork('2001:db8::/40'))
+        self.assertEqual(prefixes[2]._depth, 2)
+        self.assertEqual(prefixes[2]._children, 0)
+
+    def test_update_prefix_vrf4(self):
+        vrf = VRF(name='VRF A')
+        vrf.save()
+
+        # Move 10.0.0.0/16 to a VRF
+        p = Prefix.objects.get(prefix='10.0.0.0/16')
+        p.vrf = vrf
+        p.save()
+
+        prefixes = Prefix.objects.filter(vrf__isnull=True, prefix__family=4)
+        self.assertEqual(prefixes[0].prefix, IPNetwork('10.0.0.0/8'))
+        self.assertEqual(prefixes[0]._depth, 0)
+        self.assertEqual(prefixes[0]._children, 1)
+        self.assertEqual(prefixes[1].prefix, IPNetwork('10.0.0.0/24'))
+        self.assertEqual(prefixes[1]._depth, 1)
+        self.assertEqual(prefixes[1]._children, 0)
+
+        prefixes = Prefix.objects.filter(vrf=vrf)
+        self.assertEqual(prefixes[0].prefix, IPNetwork('10.0.0.0/16'))
+        self.assertEqual(prefixes[0]._depth, 0)
+        self.assertEqual(prefixes[0]._children, 0)
+
+    def test_update_prefix_vrf6(self):
+        vrf = VRF(name='VRF A')
+        vrf.save()
+
+        # Move 2001:db8::/40 to a VRF
+        p = Prefix.objects.get(prefix='2001:db8::/40')
+        p.vrf = vrf
+        p.save()
+
+        prefixes = Prefix.objects.filter(vrf__isnull=True, prefix__family=6)
+        self.assertEqual(prefixes[0].prefix, IPNetwork('2001:db8::/32'))
+        self.assertEqual(prefixes[0]._depth, 0)
+        self.assertEqual(prefixes[0]._children, 1)
+        self.assertEqual(prefixes[1].prefix, IPNetwork('2001:db8::/48'))
+        self.assertEqual(prefixes[1]._depth, 1)
+        self.assertEqual(prefixes[1]._children, 0)
+
+        prefixes = Prefix.objects.filter(vrf=vrf)
+        self.assertEqual(prefixes[0].prefix, IPNetwork('2001:db8::/40'))
+        self.assertEqual(prefixes[0]._depth, 0)
+        self.assertEqual(prefixes[0]._children, 0)
+
+    def test_delete_prefix4(self):
+        # Delete 10.0.0.0/16
+        Prefix.objects.filter(prefix='10.0.0.0/16').delete()
+
+        prefixes = Prefix.objects.filter(prefix__family=4)
+        self.assertEqual(prefixes[0].prefix, IPNetwork('10.0.0.0/8'))
+        self.assertEqual(prefixes[0]._depth, 0)
+        self.assertEqual(prefixes[0]._children, 1)
+        self.assertEqual(prefixes[1].prefix, IPNetwork('10.0.0.0/24'))
+        self.assertEqual(prefixes[1]._depth, 1)
+        self.assertEqual(prefixes[1]._children, 0)
+
+    def test_delete_prefix6(self):
+        # Delete 2001:db8::/40
+        Prefix.objects.filter(prefix='2001:db8::/40').delete()
+
+        prefixes = Prefix.objects.filter(prefix__family=6)
+        self.assertEqual(prefixes[0].prefix, IPNetwork('2001:db8::/32'))
+        self.assertEqual(prefixes[0]._depth, 0)
+        self.assertEqual(prefixes[0]._children, 1)
+        self.assertEqual(prefixes[1].prefix, IPNetwork('2001:db8::/48'))
+        self.assertEqual(prefixes[1]._depth, 1)
+        self.assertEqual(prefixes[1]._children, 0)
+
+    def test_duplicate_prefix4(self):
+        # Duplicate 10.0.0.0/16
+        Prefix(prefix='10.0.0.0/16').save()
+
+        prefixes = Prefix.objects.filter(prefix__family=4)
+        self.assertEqual(prefixes[0].prefix, IPNetwork('10.0.0.0/8'))
+        self.assertEqual(prefixes[0]._depth, 0)
+        self.assertEqual(prefixes[0]._children, 3)
+        self.assertEqual(prefixes[1].prefix, IPNetwork('10.0.0.0/16'))
+        self.assertEqual(prefixes[1]._depth, 1)
+        self.assertEqual(prefixes[1]._children, 1)
+        self.assertEqual(prefixes[2].prefix, IPNetwork('10.0.0.0/16'))
+        self.assertEqual(prefixes[2]._depth, 1)
+        self.assertEqual(prefixes[2]._children, 1)
+        self.assertEqual(prefixes[3].prefix, IPNetwork('10.0.0.0/24'))
+        self.assertEqual(prefixes[3]._depth, 2)
+        self.assertEqual(prefixes[3]._children, 0)
+
+    def test_duplicate_prefix6(self):
+        # Duplicate 2001:db8::/40
+        Prefix(prefix='2001:db8::/40').save()
+
+        prefixes = Prefix.objects.filter(prefix__family=6)
+        self.assertEqual(prefixes[0].prefix, IPNetwork('2001:db8::/32'))
+        self.assertEqual(prefixes[0]._depth, 0)
+        self.assertEqual(prefixes[0]._children, 3)
+        self.assertEqual(prefixes[1].prefix, IPNetwork('2001:db8::/40'))
+        self.assertEqual(prefixes[1]._depth, 1)
+        self.assertEqual(prefixes[1]._children, 1)
+        self.assertEqual(prefixes[2].prefix, IPNetwork('2001:db8::/40'))
+        self.assertEqual(prefixes[2]._depth, 1)
+        self.assertEqual(prefixes[2]._children, 1)
+        self.assertEqual(prefixes[3].prefix, IPNetwork('2001:db8::/48'))
+        self.assertEqual(prefixes[3]._depth, 2)
+        self.assertEqual(prefixes[3]._children, 0)
 
 
 class TestIPAddress(TestCase):
 
     def test_get_duplicates(self):
         ips = IPAddress.objects.bulk_create((
-            IPAddress(address=netaddr.IPNetwork('192.0.2.1/24')),
-            IPAddress(address=netaddr.IPNetwork('192.0.2.1/24')),
-            IPAddress(address=netaddr.IPNetwork('192.0.2.1/24')),
+            IPAddress(address=IPNetwork('192.0.2.1/24')),
+            IPAddress(address=IPNetwork('192.0.2.1/24')),
+            IPAddress(address=IPNetwork('192.0.2.1/24')),
         ))
         duplicate_ip_pks = [p.pk for p in ips[0].get_duplicates()]
 
@@ -237,44 +435,44 @@ class TestIPAddress(TestCase):
 
     @override_settings(ENFORCE_GLOBAL_UNIQUE=False)
     def test_duplicate_global(self):
-        IPAddress.objects.create(address=netaddr.IPNetwork('192.0.2.1/24'))
-        duplicate_ip = IPAddress(address=netaddr.IPNetwork('192.0.2.1/24'))
+        IPAddress.objects.create(address=IPNetwork('192.0.2.1/24'))
+        duplicate_ip = IPAddress(address=IPNetwork('192.0.2.1/24'))
         self.assertIsNone(duplicate_ip.clean())
 
     @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
     def test_duplicate_global_unique(self):
-        IPAddress.objects.create(address=netaddr.IPNetwork('192.0.2.1/24'))
-        duplicate_ip = IPAddress(address=netaddr.IPNetwork('192.0.2.1/24'))
+        IPAddress.objects.create(address=IPNetwork('192.0.2.1/24'))
+        duplicate_ip = IPAddress(address=IPNetwork('192.0.2.1/24'))
         self.assertRaises(ValidationError, duplicate_ip.clean)
 
     def test_duplicate_vrf(self):
         vrf = VRF.objects.create(name='Test', rd='1:1', enforce_unique=False)
-        IPAddress.objects.create(vrf=vrf, address=netaddr.IPNetwork('192.0.2.1/24'))
-        duplicate_ip = IPAddress(vrf=vrf, address=netaddr.IPNetwork('192.0.2.1/24'))
+        IPAddress.objects.create(vrf=vrf, address=IPNetwork('192.0.2.1/24'))
+        duplicate_ip = IPAddress(vrf=vrf, address=IPNetwork('192.0.2.1/24'))
         self.assertIsNone(duplicate_ip.clean())
 
     def test_duplicate_vrf_unique(self):
         vrf = VRF.objects.create(name='Test', rd='1:1', enforce_unique=True)
-        IPAddress.objects.create(vrf=vrf, address=netaddr.IPNetwork('192.0.2.1/24'))
-        duplicate_ip = IPAddress(vrf=vrf, address=netaddr.IPNetwork('192.0.2.1/24'))
+        IPAddress.objects.create(vrf=vrf, address=IPNetwork('192.0.2.1/24'))
+        duplicate_ip = IPAddress(vrf=vrf, address=IPNetwork('192.0.2.1/24'))
         self.assertRaises(ValidationError, duplicate_ip.clean)
 
     @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
     def test_duplicate_nonunique_nonrole_role(self):
-        IPAddress.objects.create(address=netaddr.IPNetwork('192.0.2.1/24'))
-        duplicate_ip = IPAddress(address=netaddr.IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)
+        IPAddress.objects.create(address=IPNetwork('192.0.2.1/24'))
+        duplicate_ip = IPAddress(address=IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)
         self.assertRaises(ValidationError, duplicate_ip.clean)
 
     @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
     def test_duplicate_nonunique_role_nonrole(self):
-        IPAddress.objects.create(address=netaddr.IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)
-        duplicate_ip = IPAddress(address=netaddr.IPNetwork('192.0.2.1/24'))
+        IPAddress.objects.create(address=IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)
+        duplicate_ip = IPAddress(address=IPNetwork('192.0.2.1/24'))
         self.assertRaises(ValidationError, duplicate_ip.clean)
 
     @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
     def test_duplicate_nonunique_role(self):
-        IPAddress.objects.create(address=netaddr.IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)
-        IPAddress.objects.create(address=netaddr.IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)
+        IPAddress.objects.create(address=IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)
+        IPAddress.objects.create(address=IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)
 
 
 class TestVLANGroup(TestCase):

--- a/netbox/ipam/utils.py
+++ b/netbox/ipam/utils.py
@@ -91,3 +91,63 @@ def add_available_vlans(vlan_group, vlans):
     vlans.sort(key=lambda v: v.vid if type(v) == VLAN else v['vid'])
 
     return vlans
+
+
+def rebuild_prefixes(vrf):
+    """
+    Rebuild the prefix hierarchy for all prefixes in the specified VRF (or global table).
+    """
+    def contains(parent, child):
+        return child in parent and child != parent
+
+    def push_to_stack(prefix):
+        # Increment child count on parent nodes
+        for n in stack:
+            n['children'] += 1
+        stack.append({
+            'pk': prefix['pk'],
+            'prefix': prefix['prefix'],
+            'children': 0,
+        })
+
+    stack = []
+    update_queue = []
+    prefixes = Prefix.objects.filter(vrf=vrf).values('pk', 'prefix')
+
+    # Iterate through all Prefixes in the VRF, growing and shrinking the stack as we go
+    for i, p in enumerate(prefixes):
+
+        # Grow the stack if this is a child of the most recent prefix
+        if not stack or contains(stack[-1]['prefix'], p['prefix']):
+            push_to_stack(p)
+
+        # Handle duplicate prefixes
+        elif stack[-1]['prefix'] == p['prefix']:
+            update_queue.append(
+                Prefix(pk=p['pk'], _depth=len(stack) - 1, _children=stack[-1]['children'])
+            )
+
+        # If this is a sibling or parent of the most recent prefix, pop nodes from the
+        # stack until we reach a parent prefix (or the root)
+        else:
+            while stack and not contains(stack[-1]['prefix'], p['prefix']):
+                node = stack.pop()
+                update_queue.append(
+                    Prefix(pk=node['pk'], _depth=len(stack), _children=node['children'])
+                )
+            push_to_stack(p)
+
+        # Flush the update queue once it reaches 100 Prefixes
+        if len(update_queue) >= 100:
+            Prefix.objects.bulk_update(update_queue, ['_depth', '_children'])
+            update_queue = []
+
+    # Clear out any prefixes remaining in the stack
+    while stack:
+        node = stack.pop()
+        update_queue.append(
+            Prefix(pk=node['pk'], _depth=len(stack), _children=node['children'])
+        )
+
+    # Final flush of any remaining Prefixes
+    Prefix.objects.bulk_update(update_queue, ['_depth', '_children'])

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -551,6 +551,7 @@ class IPAddressView(generic.ObjectView):
             vrf=instance.vrf, address__net_contained_or_equal=str(instance.address)
         )
         related_ips_table = tables.IPAddressTable(related_ips, orderable=False)
+        paginate_table(related_ips_table, request)
 
         return {
             'parent_prefixes_table': parent_prefixes_table,

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -238,7 +238,7 @@ class AggregateView(generic.ObjectView):
             'site', 'role'
         ).order_by(
             'prefix'
-        ).annotate_tree()
+        )
 
         # Add available prefixes to the table if requested
         if request.GET.get('show_available', 'true') == 'true':
@@ -352,7 +352,7 @@ class RoleBulkDeleteView(generic.BulkDeleteView):
 #
 
 class PrefixListView(generic.ObjectListView):
-    queryset = Prefix.objects.annotate_tree()
+    queryset = Prefix.objects.all()
     filterset = filtersets.PrefixFilterSet
     filterset_form = forms.PrefixFilterForm
     table = tables.PrefixDetailTable
@@ -377,7 +377,7 @@ class PrefixView(generic.ObjectView):
             prefix__net_contains=str(instance.prefix)
         ).prefetch_related(
             'site', 'role'
-        ).annotate_tree()
+        )
         parent_prefix_table = tables.PrefixTable(list(parent_prefixes), orderable=False)
         parent_prefix_table.exclude = ('vrf',)
 
@@ -407,7 +407,7 @@ class PrefixPrefixesView(generic.ObjectView):
         # Child prefixes table
         child_prefixes = instance.get_child_prefixes().restrict(request.user, 'view').prefetch_related(
             'site', 'vlan', 'role',
-        ).annotate_tree()
+        )
 
         # Add available prefixes to the table if requested
         if child_prefixes and request.GET.get('show_available', 'true') == 'true':

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -16,7 +16,7 @@ from django.core.validators import URLValidator
 # Environment setup
 #
 
-VERSION = '2.11.5-dev'
+VERSION = '2.11.5'
 
 # Hostname
 HOSTNAME = platform.node()

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -29,10 +29,10 @@ if platform.python_version_tuple() < ('3', '6'):
     raise RuntimeError(
         "NetBox requires Python 3.6 or higher (current: Python {})".format(platform.python_version())
     )
-# TODO: Remove in NetBox v2.12
+# TODO: Remove in NetBox v3.0
 if platform.python_version_tuple() < ('3', '7'):
     warnings.warn(
-        "Support for Python 3.6 will be dropped in NetBox v2.12. Please upgrade to Python 3.7 or later at your "
+        "Support for Python 3.6 will be dropped in NetBox v3.0. Please upgrade to Python 3.7 or later at your "
         "earliest convenience."
     )
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -16,7 +16,7 @@ from django.core.validators import URLValidator
 # Environment setup
 #
 
-VERSION = '2.11.4'
+VERSION = '2.11.5-dev'
 
 # Hostname
 HOSTNAME = platform.node()

--- a/netbox/netbox/views/generic.py
+++ b/netbox/netbox/views/generic.py
@@ -774,9 +774,7 @@ class BulkEditView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
 
         # If we are editing *all* objects in the queryset, replace the PK list with all matched objects.
         if request.POST.get('_all') and self.filterset is not None:
-            pk_list = [
-                obj.pk for obj in self.filterset(request.GET, self.queryset.only('pk')).qs
-            ]
+            pk_list = self.filterset(request.GET, self.queryset.values_list('pk', flat=True)).qs
         else:
             pk_list = request.POST.getlist('pk')
 

--- a/netbox/secrets/views.py
+++ b/netbox/secrets/views.py
@@ -92,7 +92,7 @@ def inject_deprecation_warning(request):
     """
     messages.warning(
         request,
-        mark_safe('<i class="mdi mdi-alert"></i> The secrets functionality will be moved to a plugin in NetBox v2.12. '
+        mark_safe('<i class="mdi mdi-alert"></i> The secrets functionality will be moved to a plugin in NetBox v3.0. '
                   'Please see <a href="https://github.com/netbox-community/netbox/issues/5278">issue #5278</a> for '
                   'more information.')
     )

--- a/netbox/templates/base.html
+++ b/netbox/templates/base.html
@@ -74,7 +74,7 @@
                         <i class="mdi mdi-book-open-page-variant text-primary"></i> <a href="https://netbox.readthedocs.io/">Docs</a> &middot;
                         <i class="mdi mdi-cloud-braces text-primary"></i> <a href="{% url 'api_docs' %}">API</a> &middot;
                         <i class="mdi mdi-xml text-primary"></i> <a href="https://github.com/netbox-community/netbox">Code</a> &middot;
-                        <i class="mdi mdi-lifebuoy text-primary"></i> <a href="https://github.com/netbox-community/netbox/wiki">Help</a>
+                        <i class="mdi mdi-slack text-primary"></i> <a href="https://netdev.chat/">Community</a>
                     </p>
                 </div>
             </div>

--- a/netbox/templates/dcim/cable_connect.html
+++ b/netbox/templates/dcim/cable_connect.html
@@ -35,13 +35,13 @@
                             <div class="form-group">
                                 <label class="col-md-3 control-label required">Region</label>
                                 <div class="col-md-9">
-                                    <p class="form-control-static">{{ termination_a.device.site.region }}</p>
+                                    <p class="form-control-static">{{ termination_a.device.site.region|placeholder }}</p>
                                 </div>
                             </div>
                             <div class="form-group">
                                 <label class="col-md-3 control-label required">Site Group</label>
                                 <div class="col-md-9">
-                                    <p class="form-control-static">{{ termination_a.device.site.group }}</p>
+                                    <p class="form-control-static">{{ termination_a.device.site.group|placeholder }}</p>
                                 </div>
                             </div>
                             <div class="form-group">
@@ -51,9 +51,15 @@
                                 </div>
                             </div>
                             <div class="form-group">
+                                <label class="col-md-3 control-label required">Location</label>
+                                <div class="col-md-9">
+                                    <p class="form-control-static">{{ termination_a.device.location|placeholder }}</p>
+                                </div>
+                            </div>
+                            <div class="form-group">
                                 <label class="col-md-3 control-label required">Rack</label>
                                 <div class="col-md-9">
-                                    <p class="form-control-static">{{ termination_a.device.rack|default:"None" }}</p>
+                                    <p class="form-control-static">{{ termination_a.device.rack|placeholder }}</p>
                                 </div>
                             </div>
                             <div class="form-group">

--- a/netbox/templates/extras/report.html
+++ b/netbox/templates/extras/report.html
@@ -29,7 +29,7 @@
     {% endif %}
     <h1 class="title">{{ report.name }}</h1>
     {% if report.description %}
-        <p class="lead">{{ report.description }}</p>
+        <p class="lead">{{ report.description|render_markdown }}</p>
     {% endif %}
 {% endblock %}
 

--- a/netbox/templates/extras/report_list.html
+++ b/netbox/templates/extras/report_list.html
@@ -29,7 +29,7 @@
                                     <td>
                                         {% include 'extras/inc/job_label.html' with result=report.result %}
                                     </td>
-                                    <td>{{ report.description|placeholder }}</td>
+                                    <td class="rendered-markdown">{{ report.description|render_markdown|placeholder }}</td>
                                     <td class="text-right">
                                         {% if report.result %}
                                             <a href="{% url 'extras:report_result' job_result_pk=report.result.pk %}">{{ report.result.created }}</a>

--- a/netbox/templates/generic/object_list.html
+++ b/netbox/templates/generic/object_list.html
@@ -29,58 +29,58 @@
                 {% block sidebar %}{% endblock %}
             </div>
         {% endif %}
-        {% with bulk_edit_url=content_type.model_class|validated_viewname:"bulk_edit" bulk_delete_url=content_type.model_class|validated_viewname:"bulk_delete" %}
-            {% if permissions.change or permissions.delete %}
-                <form method="post" class="form form-horizontal">
-                    {% csrf_token %}
-                    <input type="hidden" name="return_url" value="{% if return_url %}{{ return_url }}{% else %}{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" />
-                    {% if table.paginator.num_pages > 1 %}
-                        <div id="select_all_box" class="hidden panel panel-default noprint">
-                            <div class="panel-body">
-                                <div class="checkbox-inline">
-                                    <label for="select_all">
-                                        <input type="checkbox" id="select_all" name="_all" />
-                                        Select <strong>all {{ table.rows|length }} {{ table.data.verbose_name_plural }}</strong> matching query
-                                    </label>
-                                </div>
-                                <div class="pull-right">
-                                    {% if bulk_edit_url and permissions.change %}
-                                        <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning btn-sm" disabled="disabled">
-                                            <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit All
-                                        </button>
-                                    {% endif %}
-                                    {% if bulk_delete_url and permissions.delete %}
-                                        <button type="submit" name="_delete" formaction="{% url bulk_delete_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-danger btn-sm" disabled="disabled">
-                                            <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete All
-                                        </button>
-                                    {% endif %}
+        <div class="table-responsive">
+            {% with bulk_edit_url=content_type.model_class|validated_viewname:"bulk_edit" bulk_delete_url=content_type.model_class|validated_viewname:"bulk_delete" %}
+                {% if permissions.change or permissions.delete %}
+                    <form method="post" class="form form-horizontal">
+                        {% csrf_token %}
+                        <input type="hidden" name="return_url" value="{% if return_url %}{{ return_url }}{% else %}{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" />
+                        {% if table.paginator.num_pages > 1 %}
+                            <div id="select_all_box" class="hidden panel panel-default noprint">
+                                <div class="panel-body">
+                                    <div class="checkbox-inline">
+                                        <label for="select_all">
+                                            <input type="checkbox" id="select_all" name="_all" />
+                                            Select <strong>all {{ table.rows|length }} {{ table.data.verbose_name_plural }}</strong> matching query
+                                        </label>
+                                    </div>
+                                    <div class="pull-right">
+                                        {% if bulk_edit_url and permissions.change %}
+                                            <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning btn-sm" disabled="disabled">
+                                                <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit All
+                                            </button>
+                                        {% endif %}
+                                        {% if bulk_delete_url and permissions.delete %}
+                                            <button type="submit" name="_delete" formaction="{% url bulk_delete_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-danger btn-sm" disabled="disabled">
+                                                <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete All
+                                            </button>
+                                        {% endif %}
+                                    </div>
                                 </div>
                             </div>
+                        {% endif %}
+                        {% render_table table 'inc/table.html' %}
+                        <div class="pull-left noprint">
+                            {% block bulk_buttons %}{% endblock %}
+                            {% if bulk_edit_url and permissions.change %}
+                                <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning btn-sm">
+                                    <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit Selected
+                                </button>
+                            {% endif %}
+                            {% if bulk_delete_url and permissions.delete %}
+                                <button type="submit" name="_delete" formaction="{% url bulk_delete_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-danger btn-sm">
+                                    <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete Selected
+                                </button>
+                            {% endif %}
                         </div>
-                    {% endif %}
+                    </form>
+                {% else %}
                     <div class="table-responsive">
                         {% render_table table 'inc/table.html' %}
                     </div>
-                    <div class="pull-left noprint">
-                        {% block bulk_buttons %}{% endblock %}
-                        {% if bulk_edit_url and permissions.change %}
-                            <button type="submit" name="_edit" formaction="{% url bulk_edit_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-warning btn-sm">
-                                <span class="mdi mdi-pencil" aria-hidden="true"></span> Edit Selected
-                            </button>
-                        {% endif %}
-                        {% if bulk_delete_url and permissions.delete %}
-                            <button type="submit" name="_delete" formaction="{% url bulk_delete_url %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-danger btn-sm">
-                                <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> Delete Selected
-                            </button>
-                        {% endif %}
-                    </div>
-                </form>
-            {% else %}
-                <div class="table-responsive">
-                    {% render_table table 'inc/table.html' %}
-                </div>
-            {% endif %}
-        {% endwith %}
+                {% endif %}
+            {% endwith %}
+        </div>
         {% include 'inc/paginator.html' with paginator=table.paginator page=table.page %}
         <div class="clearfix"></div>
     </div>

--- a/netbox/templates/ipam/prefix_list.html
+++ b/netbox/templates/ipam/prefix_list.html
@@ -5,6 +5,26 @@
     <div class="btn-group" role="group">
         <div class="dropdown">
             <button class="btn btn-default dropdown-toggle" type="button" id="max_length" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+                Max Depth{% if "depth__lte" in request.GET %}: {{ request.GET.depth__lte }}{% endif %}
+                <span class="caret"></span>
+            </button>
+            <ul class="dropdown-menu" aria-labelledby="max_length">
+                {% if request.GET.depth__lte %}
+                    <li>
+                        <a href="{% url 'ipam:prefix_list' %}{% querystring request depth__lte=None page=1 %}">Clear</a>
+                    </li>
+                {% endif %}
+                {% for i in 16|as_range %}
+                    <li><a href="{% url 'ipam:prefix_list' %}{% querystring request depth__lte=i page=1 %}">
+                        {{ i }} {% if request.GET.depth__lte == i %}<i class="mdi mdi-check-bold"></i>{% endif %}
+                    </a></li>
+                {% endfor %}
+            </ul>
+        </div>
+    </div>
+    <div class="btn-group" role="group">
+        <div class="dropdown">
+            <button class="btn btn-default dropdown-toggle" type="button" id="max_length" data-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
                 Max Length{% if "mask_length__lte" in request.GET %}: {{ request.GET.mask_length__lte }}{% endif %}
                 <span class="caret"></span>
             </button>

--- a/netbox/users/admin.py
+++ b/netbox/users/admin.py
@@ -7,7 +7,7 @@ from django.core.exceptions import FieldError, ValidationError
 
 from utilities.forms.fields import ContentTypeMultipleChoiceField
 from .constants import *
-from .models import AdminGroup, AdminUser, ObjectPermission, Token, UserConfig
+from .models import ObjectPermission, Token, UserConfig
 
 
 #
@@ -39,11 +39,11 @@ class ObjectPermissionInline(admin.TabularInline):
 
 
 class GroupObjectPermissionInline(ObjectPermissionInline):
-    model = AdminGroup.object_permissions.through
+    model = Group.object_permissions.through
 
 
 class UserObjectPermissionInline(ObjectPermissionInline):
-    model = AdminUser.object_permissions.through
+    model = User.object_permissions.through
 
 
 class UserConfigInline(admin.TabularInline):
@@ -62,7 +62,7 @@ admin.site.unregister(Group)
 admin.site.unregister(User)
 
 
-@admin.register(AdminGroup)
+@admin.register(Group)
 class GroupAdmin(admin.ModelAdmin):
     fields = ('name',)
     list_display = ('name', 'user_count')
@@ -75,7 +75,7 @@ class GroupAdmin(admin.ModelAdmin):
         return obj.user_set.count()
 
 
-@admin.register(AdminUser)
+@admin.register(User)
 class UserAdmin(UserAdmin_):
     list_display = [
         'username', 'email', 'first_name', 'last_name', 'is_superuser', 'is_staff', 'is_active'

--- a/netbox/users/models.py
+++ b/netbox/users/models.py
@@ -17,8 +17,6 @@ from .constants import *
 
 
 __all__ = (
-    'AdminGroup',
-    'AdminUser',
     'ObjectPermission',
     'Token',
     'UserConfig',
@@ -163,7 +161,6 @@ class UserConfig(models.Model):
 
 
 @receiver(post_save, sender=User)
-@receiver(post_save, sender=AdminUser)
 def create_userconfig(instance, created, **kwargs):
     """
     Automatically create a new UserConfig when a new User is created.

--- a/netbox/utilities/forms/fields.py
+++ b/netbox/utilities/forms/fields.py
@@ -338,7 +338,7 @@ class DynamicModelChoiceMixin:
     filter = django_filters.ModelChoiceFilter
     widget = widgets.APISelect
 
-    # TODO: Remove display_field in v2.12
+    # TODO: Remove display_field in v3.0
     def __init__(self, display_field='display', query_params=None, initial_params=None, null_option=None,
                  disabled_indicator=None, *args, **kwargs):
         self.display_field = display_field

--- a/netbox/utilities/tables.py
+++ b/netbox/utilities/tables.py
@@ -1,4 +1,5 @@
 import django_tables2 as tables
+from django.conf import settings
 from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
@@ -284,7 +285,10 @@ class LinkedCountColumn(tables.Column):
         if value:
             url = reverse(self.viewname, kwargs=self.view_kwargs)
             if self.url_params:
-                url += '?' + '&'.join([f'{k}={getattr(record, v)}' for k, v in self.url_params.items()])
+                url += '?' + '&'.join([
+                    f'{k}={getattr(record, v) or settings.FILTERS_NULL_CHOICE_VALUE}'
+                    for k, v in self.url_params.items()
+                ])
             return mark_safe(f'<a href="{url}">{value}</a>')
         return value
 

--- a/netbox/utilities/utils.py
+++ b/netbox/utilities/utils.py
@@ -105,7 +105,7 @@ def serialize_object(obj, extra=None):
 
     # Include any tags. Check for tags cached on the instance; fall back to using the manager.
     if is_taggable(obj):
-        tags = getattr(obj, '_tags', obj.tags.all())
+        tags = getattr(obj, '_tags', None) or obj.tags.all()
         data['tags'] = [tag.name for tag in tags]
 
     # Append any extra data

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.2.3
+Django==3.2.4
 django-cacheops==6.0
 django-cors-headers==3.7.0
 django-debug-toolbar==3.2.1

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -15,7 +15,7 @@ else
 fi
 
 # Create a new virtual environment
-COMMAND="/usr/bin/python3 -m venv ${VIRTUALENV}"
+COMMAND="python3 -m venv ${VIRTUALENV}"
 echo "Creating a new virtual environment at ${VIRTUALENV}..."
 eval $COMMAND || {
   echo "--------------------------------------------------------------------"


### PR DESCRIPTION
**NOTE:** This release includes a database migration that calculates and annotates prefix depth. It may impose a noticeable delay on the upgrade process: Users should anticipate roughly one minute of delay per 100 thousand prefixes being updated.

### Enhancements

* [#6087](https://github.com/netbox-community/netbox/issues/6087) - Improved prefix hierarchy rendering
* [#6487](https://github.com/netbox-community/netbox/issues/6487) - Add location filter to cable connection form
* [#6501](https://github.com/netbox-community/netbox/issues/6501) - Expose prefix depth and children on REST API serializer
* [#6527](https://github.com/netbox-community/netbox/issues/6527) - Support Markdown for report descriptions
* [#6540](https://github.com/netbox-community/netbox/issues/6540) - Add a "flat" column to the prefix table

### Bug Fixes

* [#6064](https://github.com/netbox-community/netbox/issues/6064) - Fix object permission assignments for user and group models
* [#6217](https://github.com/netbox-community/netbox/issues/6217) - Disallow passing of string values for integer custom fields
* [#6284](https://github.com/netbox-community/netbox/issues/6284) - Avoid sending redundant webhooks when adding/removing tags
* [#6492](https://github.com/netbox-community/netbox/issues/6492) - Correct tag population in post-change data resulting from REST API changes
* [#6496](https://github.com/netbox-community/netbox/issues/6496) - Fix upgrade script when Python installed in nonstandard path
* [#6502](https://github.com/netbox-community/netbox/issues/6502) - Correct permissions evaluation for running a report via the REST API
* [#6517](https://github.com/netbox-community/netbox/issues/6517) - Fix assignment of user when creating rack reservations via REST API
* [#6525](https://github.com/netbox-community/netbox/issues/6525) - Paginate related IPs table under IP address view
