### PR TITLE
CSV file import

### DIFF
--- a/netbox/netbox/views/generic.py
+++ b/netbox/netbox/views/generic.py
@@ -670,9 +670,10 @@ class BulkImportView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
                 from_form=self.model_form,
                 required=False
             )
-            def used_both_methods(self):
+
+            def used_both_csv_fields(self):
                 if self.cleaned_data['csv_file'][1] and self.cleaned_data['csv'][1]:
-                    raise ValidationError('')
+                    return True
                 return False
 
         return ImportForm(*args, **kwargs)
@@ -700,10 +701,13 @@ class BulkImportView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
         new_objs = []
         form = self._import_form(request.POST, request.FILES)
 
-        if form.is_valid() and not form.used_both_methods():
+        if form.is_valid():
             logger.debug("Form validation was successful")
 
             try:
+                if form.used_both_csv_fields():
+                    form.add_error('csv_file', "Choose one of two import methods")
+                    raise ValidationError("")
                 # Iterate through CSV data and bind each row to a new model form instance.
                 with transaction.atomic():
                     if request.FILES:

--- a/netbox/netbox/views/generic.py
+++ b/netbox/netbox/views/generic.py
@@ -7,7 +7,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist, ValidationError
 from django.db import transaction, IntegrityError
 from django.db.models import ManyToManyField, ProtectedError
-from django.forms import Form, ModelMultipleChoiceField, MultipleHiddenInput, Textarea
+from django.forms import Form, ModelMultipleChoiceField, MultipleHiddenInput, Textarea, FileField, CharField
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.html import escape
@@ -665,7 +665,10 @@ class BulkImportView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
                 from_form=self.model_form,
                 widget=Textarea(attrs=self.widget_attrs)
             )
-
+            Upload_CSV = FileField(
+                required=False
+            )
+        # this is where the import form is created -- add csv upload here or create new form?
         return ImportForm(*args, **kwargs)
 
     def _save_obj(self, obj_form, request):
@@ -690,6 +693,7 @@ class BulkImportView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
         logger = logging.getLogger('netbox.views.BulkImportView')
         new_objs = []
         form = self._import_form(request.POST)
+        # this is where the csv data is handled
 
         if form.is_valid():
             logger.debug("Form validation was successful")
@@ -697,6 +701,9 @@ class BulkImportView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
             try:
                 # Iterate through CSV data and bind each row to a new model form instance.
                 with transaction.atomic():
+                    # some prints trying to figure out how the form works
+                    print(type(form["Upload_CSV"]))
+                    print(form["Upload_CSV"].data)
                     headers, records = form.cleaned_data['csv']
                     for row, data in enumerate(records, start=1):
                         obj_form = self.model_form(data, headers=headers)

--- a/netbox/netbox/views/generic.py
+++ b/netbox/netbox/views/generic.py
@@ -672,9 +672,7 @@ class BulkImportView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
             )
 
             def used_both_csv_fields(self):
-                if self.cleaned_data['csv_file'][1] and self.cleaned_data['csv'][1]:
-                    return True
-                return False
+                return self.cleaned_data['csv_file'][1] and self.cleaned_data['csv'][1]
 
         return ImportForm(*args, **kwargs)
 

--- a/netbox/netbox/views/generic.py
+++ b/netbox/netbox/views/generic.py
@@ -666,7 +666,7 @@ class BulkImportView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
                 from_form=self.model_form,
                 widget=Textarea(attrs=self.widget_attrs)
             )
-            Upload_CSV = FileField(
+            upload_csv = FileField(
                 required=False
             )
         return ImportForm(*args, **kwargs)
@@ -692,7 +692,7 @@ class BulkImportView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
     def post(self, request):
         logger = logging.getLogger('netbox.views.BulkImportView')
         new_objs = []
-        form = self._import_form(request.POST)
+        form = self._import_form(request.POST, request.FILES)
 
         if form.is_valid():
             logger.debug("Form validation was successful")
@@ -700,8 +700,8 @@ class BulkImportView(GetReturnURLMixin, ObjectPermissionRequiredMixin, View):
             try:
                 # Iterate through CSV data and bind each row to a new model form instance.
                 with transaction.atomic():
-                    if len(request.FILES) != 0:
-                        csv_file = request.FILES["Upload_CSV"]
+                    if request.FILES:
+                        csv_file = request.FILES["upload_csv"]
                         csv_file.seek(0)
                         csv_str = csv_file.read().decode('utf-8')
                         reader = csv.reader(csv_str.splitlines())

--- a/netbox/templates/generic/object_bulk_import.html
+++ b/netbox/templates/generic/object_bulk_import.html
@@ -20,7 +20,7 @@
             </ul>
             <div class="tab-content">
                 <div role="tabpanel" class="tab-pane active" id="csv">
-                    <form action="" method="post" class="form">
+                    <form action="" method="post" class="form" enctype="multipart/form-data">
                         {% csrf_token %}
                         {% render_form form %}
                         <div class="form-group">

--- a/netbox/utilities/forms/fields.py
+++ b/netbox/utilities/forms/fields.py
@@ -224,9 +224,10 @@ class CSVDataField(forms.CharField):
 
 class CSVFileField(forms.FileField):
     """
-    A CharField (rendered as a Textarea) which accepts CSV-formatted data. It returns data as a two-tuple: The first
-    item is a dictionary of column headers, mapping field names to the attribute by which they match a related object
-    (where applicable). The second item is a list of dictionaries, each representing a discrete row of CSV data.
+    A FileField (rendered as a file input button) which accepts a file containing CSV-formatted data. It returns
+    data as a two-tuple: The first item is a dictionary of column headers, mapping field names to the attribute
+    by which they match a related object (where applicable). The second item is a list of dictionaries, each
+    representing a discrete row of CSV data.
 
     :param from_form: The form from which the field derives its validation rules.
     """

--- a/netbox/utilities/forms/fields.py
+++ b/netbox/utilities/forms/fields.py
@@ -246,7 +246,6 @@ class CSVFileField(forms.FileField):
     def to_python(self, file):
 
         records = []
-        file.seek(0)
         csv_str = file.read().decode('utf-8')
         reader = csv.reader(csv_str.splitlines())
 

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -14,6 +14,8 @@ __all__ = (
     'parse_alphanumeric_range',
     'parse_numeric_range',
     'restrict_form_fields',
+    'parse_csv',
+    'validate_csv',
 )
 
 
@@ -134,3 +136,54 @@ def restrict_form_fields(form, user, action='view'):
     for field in form.fields.values():
         if hasattr(field, 'queryset') and issubclass(field.queryset.__class__, RestrictedQuerySet):
             field.queryset = field.queryset.restrict(user, action)
+
+
+def parse_csv(reader):
+    """
+    Parse a csv_reader object into a headers dictionary and a list of records dictionaries. Raise an error
+    if the records are formatted incorrectly. Return headers and records as a tuple.
+    """
+    records = []
+    headers = {}
+
+    # Consume the first line of CSV data as column headers. Create a dictionary mapping each header to an optional
+    # "to" field specifying how the related object is being referenced. For example, importing a Device might use a
+    # `site.slug` header, to indicate the related site is being referenced by its slug.
+
+    for header in next(reader):
+        if '.' in header:
+            field, to_field = header.split('.', 1)
+            headers[field] = to_field
+        else:
+            headers[header] = None
+
+    # Parse CSV rows into a list of dictionaries mapped from the column headers.
+    for i, row in enumerate(reader, start=1):
+        if len(row) != len(headers):
+            raise forms.ValidationError(
+                f"Row {i}: Expected {len(headers)} columns but found {len(row)}"
+            )
+        row = [col.strip() for col in row]
+        record = dict(zip(headers.keys(), row))
+        records.append(record)
+    return headers, records
+
+
+def validate_csv(headers, fields, required_fields):
+    """
+    Validate that parsed csv data conforms to the object's available fields. Raise validation errors
+    if parsed csv data contains invalid headers or does not contain required headers.
+    """
+    # Validate provided column headers
+    for field, to_field in headers.items():
+        if field not in fields:
+            raise forms.ValidationError(f'Unexpected column header "{field}" found.')
+        if to_field and not hasattr(fields[field], 'to_field_name'):
+            raise forms.ValidationError(f'Column "{field}" is not a related object; cannot use dots')
+        if to_field and not hasattr(fields[field].queryset.model, to_field):
+            raise forms.ValidationError(f'Invalid related object attribute for column "{field}": {to_field}')
+
+    # Validate required fields
+    for f in required_fields:
+        if f not in headers:
+            raise forms.ValidationError(f'Required column header "{f}" not found.')


### PR DESCRIPTION
### Fixes: #6560

An example / first draft of a solution for #6560 .

In the current implementation, if users try to use both the `CSVFileField` and the `CSVDataField`, the `CSVDataField` will be ignored and only the objects in the file will be imported. It should be unusual that both fields are populated, but let me know if you prefer to handle that case differently, such as by raising a validation error. The csv file is checked for errors (incorrect formatting, objects already exist, invalid columns) before importing.

This solution involves some duplication between `CSVFileField` and `CSVDataField`. If you prefer, I could remove most of the duplication by refactoring them to both inherit from a single class - say, `CSVParsingField`.
