### PR TITLE
Fixes #5442: Use LDAP groups to find permissions

### DIFF
--- a/netbox/netbox/api/authentication.py
+++ b/netbox/netbox/api/authentication.py
@@ -25,6 +25,16 @@ class TokenAuthentication(authentication.TokenAuthentication):
         if not token.user.is_active:
             raise exceptions.AuthenticationFailed("User inactive")
 
+        # When LDAP authentication is active try to load user data from LDAP directory
+        if (settings.REMOTE_AUTH_ENABLED and
+                settings.REMOTE_AUTH_BACKEND == 'netbox.authentication.LDAPBackend'):
+            from netbox.authentication import LDAPBackend
+            ldap_backend = LDAPBackend()
+            user = ldap_backend.populate_user(token.user.username)
+            # If the user is found in the LDAP directory use it, if not fallback to the local user
+            if user:
+                return user, token
+
         return token.user, token
 
 

--- a/netbox/netbox/api/authentication.py
+++ b/netbox/netbox/api/authentication.py
@@ -26,8 +26,7 @@ class TokenAuthentication(authentication.TokenAuthentication):
             raise exceptions.AuthenticationFailed("User inactive")
 
         # When LDAP authentication is active try to load user data from LDAP directory
-        if (settings.REMOTE_AUTH_ENABLED and
-                settings.REMOTE_AUTH_BACKEND == 'netbox.authentication.LDAPBackend'):
+        if settings.REMOTE_AUTH_BACKEND == 'netbox.authentication.LDAPBackend':
             from netbox.authentication import LDAPBackend
             ldap_backend = LDAPBackend()
             user = ldap_backend.populate_user(token.user.username)

--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -173,7 +173,7 @@ class LDAPBackend:
         # Create a new instance of django-auth-ldap's LDAPBackend with our own ObjectPermissions
         class NBLDAPBackend(ObjectPermissionMixin, LDAPBackend_):
             def get_permission_filter(self, user_obj):
-                permission_filter = Q(users=user_obj) | Q(groups__user=user_obj)
+                permission_filter = super().get_permission_filter(user_obj)
                 if self.settings.FIND_GROUP_PERMS:
                     permission_filter = permission_filter | Q(groups__name__in=user_obj.ldap_user.group_names)
                 return permission_filter

--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -147,7 +147,9 @@ try:
     class NBLDAPBackend(ObjectPermissionMixin, LDAPBackend_):
         def get_permission_filter(self, user_obj):
             permission_filter = super().get_permission_filter(user_obj)
-            if self.settings.FIND_GROUP_PERMS:
+            if (self.settings.FIND_GROUP_PERMS and
+                    hasattr(user_obj, "ldap_user") and
+                    hasattr(user_obj.ldap_user, "group_names")):
                 permission_filter = permission_filter | Q(groups__name__in=user_obj.ldap_user.group_names)
             return permission_filter
 except ModuleNotFoundError:


### PR DESCRIPTION
### Fixes: #5442

When AUTH_LDAP_FIND_GROUP_PERMS is set to true the filter to find the
users permissions is extended to search for all permissions assigned to
groups in which the LDAP user is.