### PR TITLE
Update nginx.conf

### DIFF
--- a/contrib/nginx.conf
+++ b/contrib/nginx.conf
@@ -1,6 +1,7 @@
 server {
     listen 443 ssl;
-
+    listen [::]:443 ssl;
+    
     # CHANGE THIS TO YOUR SERVER'S NAME
     server_name netbox.example.com;
 
@@ -24,6 +25,7 @@ server {
 server {
     # Redirect HTTP traffic to HTTPS
     listen 80;
+    listen [::]:80;
     server_name _;
     return 301 https://$host$request_uri;
 }


### PR DESCRIPTION
extend example nginx config to listen on IPv6 addresses as well as IPv4.

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #6702
<!--
    Please include a summary of the proposed changes below.
-->
update example nginx config to also listen on all ipv6 addresses since the current option results in only listening to ipv4 on nginx 1.18.0 (Ubuntu)