### PR TITLE
Release v2.11.9

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -17,7 +17,7 @@ body:
         What version of NetBox are you currently running? (If you don't have access to the most
         recent NetBox release, consider testing on our [demo instance](https://demo.netbox.dev/)
         before opening a bug report to see if your issue has already been addressed.)
-      placeholder: v2.11.8
+      placeholder: v2.11.9
     validations:
       required: true
   - type: dropdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: NetBox version
       description: What version of NetBox are you currently running?
-      placeholder: v2.11.8
+      placeholder: v2.11.9
     validations:
       required: true
   - type: dropdown

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * [#6710](https://github.com/netbox-community/netbox/issues/6710) - Fix assignment of VM interface parent via REST API
+* [#6714](https://github.com/netbox-community/netbox/issues/6714) - Fix rendering of device type component creation forms
 
 ---
 

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -4,6 +4,7 @@
 
 ### Bug Fixes
 
+* [#6456](https://github.com/netbox-community/netbox/issues/6456) - API schema type should be boolean for `_occupied` on cable termination models
 * [#6710](https://github.com/netbox-community/netbox/issues/6710) - Fix assignment of VM interface parent via REST API
 * [#6714](https://github.com/netbox-community/netbox/issues/6714) - Fix rendering of device type component creation forms
 

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -1,5 +1,13 @@
 # NetBox v2.11
 
+## v2.11.9 (FUTURE)
+
+### Bug Fixes
+
+* [#6710](https://github.com/netbox-community/netbox/issues/6710) - Fix assignment of VM interface parent via REST API
+
+---
+
 ## v2.11.8 (2021-07-06)
 
 ### Enhancements

--- a/docs/release-notes/version-2.11.md
+++ b/docs/release-notes/version-2.11.md
@@ -1,6 +1,6 @@
 # NetBox v2.11
 
-## v2.11.9 (FUTURE)
+## v2.11.9 (2021-07-08)
 
 ### Bug Fixes
 

--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -25,6 +25,7 @@ from .nested_serializers import *
 class CableTerminationSerializer(serializers.ModelSerializer):
     cable_peer_type = serializers.SerializerMethodField(read_only=True)
     cable_peer = serializers.SerializerMethodField(read_only=True)
+    _occupied = serializers.SerializerMethodField(read_only=True)
 
     def get_cable_peer_type(self, obj):
         if obj._cable_peer is not None:
@@ -41,6 +42,10 @@ class CableTerminationSerializer(serializers.ModelSerializer):
             context = {'request': self.context['request']}
             return serializer(obj._cable_peer, context=context).data
         return None
+
+    @swagger_serializer_method(serializer_or_field=serializers.BooleanField)
+    def get__occupied(self, obj):
+        return obj._occupied
 
 
 class ConnectedEndpointSerializer(serializers.ModelSerializer):

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -1211,8 +1211,9 @@ class InterfaceTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase
             {
                 'device': device.pk,
                 'name': 'Interface 6',
-                'type': '1000base-t',
+                'type': 'virtual',
                 'mode': InterfaceModeChoices.MODE_TAGGED,
+                'parent': interfaces[0].pk,
                 'tagged_vlans': [vlans[0].pk, vlans[1].pk],
                 'untagged_vlan': vlans[2].pk,
             },

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -16,7 +16,7 @@ from django.core.validators import URLValidator
 # Environment setup
 #
 
-VERSION = '2.11.9-dev'
+VERSION = '2.11.9'
 
 # Hostname
 HOSTNAME = platform.node()

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -16,7 +16,7 @@ from django.core.validators import URLValidator
 # Environment setup
 #
 
-VERSION = '2.11.8'
+VERSION = '2.11.9-dev'
 
 # Hostname
 HOSTNAME = platform.node()

--- a/netbox/templates/dcim/device_component_add.html
+++ b/netbox/templates/dcim/device_component_add.html
@@ -26,7 +26,7 @@
                         {{ field }}
                     {% endfor %}
                     {% for field in form.visible_fields %}
-                        {% if field.name not in form.custom_fields %}
+                        {% if not form.custom_fields or field.name not in form.custom_fields %}
                             {% render_field field %}
                         {% endif %}
                     {% endfor %}

--- a/netbox/virtualization/api/nested_serializers.py
+++ b/netbox/virtualization/api/nested_serializers.py
@@ -1,8 +1,7 @@
 from rest_framework import serializers
 
-from dcim.models import Interface
 from netbox.api import WritableNestedSerializer
-from virtualization.models import Cluster, ClusterGroup, ClusterType, VirtualMachine
+from virtualization.models import Cluster, ClusterGroup, ClusterType, VirtualMachine, VMInterface
 
 __all__ = [
     'NestedClusterGroupSerializer',
@@ -61,5 +60,5 @@ class NestedVMInterfaceSerializer(WritableNestedSerializer):
     virtual_machine = NestedVirtualMachineSerializer(read_only=True)
 
     class Meta:
-        model = Interface
+        model = VMInterface
         fields = ['id', 'url', 'display', 'virtual_machine', 'name']

--- a/netbox/virtualization/tests/test_api.py
+++ b/netbox/virtualization/tests/test_api.py
@@ -251,6 +251,7 @@ class VMInterfaceTest(APIViewTestCases.APIViewTestCase):
             {
                 'virtual_machine': virtualmachine.pk,
                 'name': 'Interface 6',
+                'parent': interfaces[0].pk,
                 'mode': InterfaceModeChoices.MODE_TAGGED,
                 'tagged_vlans': [vlans[0].pk, vlans[1].pk],
                 'untagged_vlan': vlans[2].pk,

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ gunicorn==20.1.0
 Jinja2==3.0.1
 Markdown==3.3.4
 netaddr==0.8.0
-Pillow==8.3.0
+Pillow==8.3.1
 psycopg2-binary==2.9.1
 pycryptodome==3.10.1
 PyYAML==5.4.1


### PR DESCRIPTION
### Bug Fixes

* [#6456](https://github.com/netbox-community/netbox/issues/6456) - API schema type should be boolean for `_occupied` on cable termination models
* [#6710](https://github.com/netbox-community/netbox/issues/6710) - Fix assignment of VM interface parent via REST API
* [#6714](https://github.com/netbox-community/netbox/issues/6714) - Fix rendering of device type component creation forms
