### PR TITLE
Add dev server firewall configuration for EL distros

### DIFF
--- a/docs/installation/3-netbox.md
+++ b/docs/installation/3-netbox.md
@@ -270,9 +270,9 @@ Quit the server with CONTROL-C.
 !!! note
     By default RHEL based distros will likely block your testing attempts with firewalld. The development server port can be opened with `firewall-cmd` (add `--permanent` if you want the rule to survive server restarts):
 
-```no-highlight
-firewall-cmd --zone=public --add-port=8000/tcp
-```
+    ```no-highlight
+    firewall-cmd --zone=public --add-port=8000/tcp
+    ```
 
 Next, connect to the name or IP of the server (as defined in `ALLOWED_HOSTS`) on port 8000; for example, <http://127.0.0.1:8000/>. You should be greeted with the NetBox home page.
 

--- a/docs/installation/3-netbox.md
+++ b/docs/installation/3-netbox.md
@@ -267,6 +267,13 @@ Starting development server at http://0.0.0.0:8000/
 Quit the server with CONTROL-C.
 ```
 
+!!! note
+    By default RHEL based distros will likely block your testing attempts with firewalld. The development server port can be opened with `firewalld-cmd` (add `--permanent` if you want the rule to survive server restarts):
+
+```no-highlight
+firewall-cmd --zone=public --add-port=8000/tcp
+```
+
 Next, connect to the name or IP of the server (as defined in `ALLOWED_HOSTS`) on port 8000; for example, <http://127.0.0.1:8000/>. You should be greeted with the NetBox home page.
 
 !!! danger

--- a/docs/installation/3-netbox.md
+++ b/docs/installation/3-netbox.md
@@ -268,7 +268,7 @@ Quit the server with CONTROL-C.
 ```
 
 !!! note
-    By default RHEL based distros will likely block your testing attempts with firewalld. The development server port can be opened with `firewalld-cmd` (add `--permanent` if you want the rule to survive server restarts):
+    By default RHEL based distros will likely block your testing attempts with firewalld. The development server port can be opened with `firewall-cmd` (add `--permanent` if you want the rule to survive server restarts):
 
 ```no-highlight
 firewall-cmd --zone=public --add-port=8000/tcp


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #6612
<!--
    Please include a summary of the proposed changes below.
-->

The original PR #6631 suggested to completely stop the firewall. I think that is a very bad idea even for testing purposes. So here we only open the one needed TCP port.

Since the original PR was closed for no response to feedback, here's my attempt at it.