### PR TITLE
Refactor navigation menu to support plugin items

### DIFF
--- a/netbox/netbox/navigation_menu.py
+++ b/netbox/netbox/navigation_menu.py
@@ -236,7 +236,7 @@ IPAM_MENU = Menu(
     ),
 )
 
-VIRUTALIZATION_MENU = Menu(
+VIRTUALIZATION_MENU = Menu(
     label='Virtualization',
     icon_class='mdi mdi-monitor',
     groups=(
@@ -344,7 +344,7 @@ MENUS = [
     DEVICES_MENU,
     CONNECTIONS_MENU,
     IPAM_MENU,
-    VIRUTALIZATION_MENU,
+    VIRTUALIZATION_MENU,
     CIRCUITS_MENU,
     POWER_MENU,
     OTHER_MENU,

--- a/netbox/netbox/navigation_menu.py
+++ b/netbox/netbox/navigation_menu.py
@@ -95,8 +95,8 @@ ORGANIZATION_MENU = Menu(
             label='Sites',
             items=(
                 get_model_item('dcim', 'site', 'Sites'),
-                get_model_item('dcim', 'sitegroup', 'Site Groups'),
                 get_model_item('dcim', 'region', 'Regions'),
+                get_model_item('dcim', 'sitegroup', 'Site Groups'),
                 get_model_item('dcim', 'location', 'Locations'),
             ),
         ),
@@ -195,14 +195,14 @@ IPAM_MENU = Menu(
         MenuGroup(
             label='IP Addresses',
             items=(
+                get_model_item('ipam', 'ipaddress', 'IP Addresses'),
                 get_model_item('ipam', 'iprange', 'IP Ranges'),
-                get_model_item('ipam', 'ipaddress', 'IP Address'),
             ),
         ),
         MenuGroup(
             label='Prefixes',
             items=(
-                get_model_item('ipam', 'prefix', 'Prefix'),
+                get_model_item('ipam', 'prefix', 'Prefixes'),
                 get_model_item('ipam', 'role', 'Prefix & VLAN Roles'),
             ),
         ),
@@ -300,8 +300,8 @@ OTHER_MENU = Menu(
         MenuGroup(
             label='Logging',
             items=(
-                get_model_item('extras', 'objectchange', 'Change Log', actions=[]),
                 get_model_item('extras', 'journalentry', 'Journal Entries', actions=[]),
+                get_model_item('extras', 'objectchange', 'Change Log', actions=[]),
             ),
         ),
         MenuGroup(

--- a/netbox/utilities/templates/navigation/nav_items.html
+++ b/netbox/utilities/templates/navigation/nav_items.html
@@ -1,3 +1,5 @@
+{% load helpers %}
+
 <div id="sidenav-accordion" class="accordion accordion-flush nav-item">
   {% for menu in nav_items %}
 
@@ -11,7 +13,7 @@
         data-bs-target="#{{ menu.label|lower }}"
         class="d-flex justify-content-between align-items-center accordion-button nav-link collapsed">
           <span class="fw-bold sidebar-nav-link">
-            <i class="mdi mdi-{{ menu.icon }} me-1 opacity-50"></i>
+            <i class="{{ menu.icon_class }} me-1 opacity-50"></i>
             {{ menu.label }}
           </span>
         </a>
@@ -23,33 +25,57 @@
             {# Within each main menu, there are groups of menu items #}
             <div class="flex-column nav">
               
-              {% if menu.groups|length > 1 %}
-                <h6 class="accordion-item-title">{{ group.label }}</h6>
-              {% endif %}
+              <h6 class="accordion-item-title">{{ group.label }}</h6>
               
               {% for item in group.items %}
                 {# Each Menu Item #}
                 <div class="nav-item d-flex justify-content-between align-items-center">
                   
                   {# Menu Link with Text #}
-                  <a class="nav-link flex-grow-1" href="{% url item.url %}">
-                    {{ item.label }}
-                  </a>
-                  
-                  {# Add & Import Buttons #}
-                  {% if item.has_add or item.has_import %}
-                    <div class="btn-group ps-1">
-                      {% if item.has_add %}
-                          <a class="btn btn-sm btn-success lh-1" href="{% url item.add_url %}" title="Add {{ item.label }}">
-                            <i class="mdi mdi-plus-thick"></i>
-                          </a>
-                      {% endif %}
-                      {% if item.has_import %}
-                          <a class="btn btn-sm btn-outline-success lh-1" href="{% url item.import_url %}" title="Import {{ item.label }}">
-                            <i class="mdi mdi-upload"></i>
-                          </a>
-                      {% endif %}
-                    </div>
+                  {% if request.user|has_perms:item.permissions %}
+
+                    <a class="nav-link flex-grow-1" href="{% url item.link %}">
+                      {{ item.link_text }}
+                    </a>
+
+                    {% if item.buttons %}
+                      <div class="btn-group ps-1">
+
+                        {% for button in item.buttons %}
+
+                          {% if request.user|has_perms:button.permissions %}
+                            <a class="btn btn-sm btn-{{ button.color }} lh-1" href="{% url button.link %}" title="{{ button.title }}">
+                              <i class="{{ button.icon_class }}"></i>
+                            </a>
+                          {% endif %}
+
+                        {% endfor %}
+
+                      </div>
+                    {% endif %}
+
+                    {# Add & Import Buttons #}
+                    {% if item.has_add or item.has_import %}
+                      <div class="btn-group ps-1">
+                        {% if item.has_add %}
+                            <a class="btn btn-sm btn-success lh-1" href="{% url item.add_url %}" title="Add {{ item.label }}">
+                              <i class="mdi mdi-plus-thick"></i>
+                            </a>
+                        {% endif %}
+                        {% if item.has_import %}
+                            <a class="btn btn-sm btn-outline-success lh-1" href="{% url item.import_url %}" title="Import {{ item.label }}">
+                              <i class="mdi mdi-upload"></i>
+                            </a>
+                        {% endif %}
+                      </div>
+                    {% endif %}
+
+                  {% else %}
+
+                    <a class="nav-link flex-grow-1 disabled">
+                      {{ item.link_text }}
+                    </a>
+
                   {% endif %}
 
                 </div>

--- a/netbox/utilities/templates/navigation/nav_items.html
+++ b/netbox/utilities/templates/navigation/nav_items.html
@@ -38,40 +38,22 @@
                       {{ item.link_text }}
                     </a>
 
+                    {# Menu item buttons (if any) #}
                     {% if item.buttons %}
                       <div class="btn-group ps-1">
-
                         {% for button in item.buttons %}
-
                           {% if request.user|has_perms:button.permissions %}
                             <a class="btn btn-sm btn-{{ button.color }} lh-1" href="{% url button.link %}" title="{{ button.title }}">
                               <i class="{{ button.icon_class }}"></i>
                             </a>
                           {% endif %}
-
                         {% endfor %}
-
-                      </div>
-                    {% endif %}
-
-                    {# Add & Import Buttons #}
-                    {% if item.has_add or item.has_import %}
-                      <div class="btn-group ps-1">
-                        {% if item.has_add %}
-                            <a class="btn btn-sm btn-success lh-1" href="{% url item.add_url %}" title="Add {{ item.label }}">
-                              <i class="mdi mdi-plus-thick"></i>
-                            </a>
-                        {% endif %}
-                        {% if item.has_import %}
-                            <a class="btn btn-sm btn-outline-success lh-1" href="{% url item.import_url %}" title="Import {{ item.label }}">
-                              <i class="mdi mdi-upload"></i>
-                            </a>
-                        {% endif %}
                       </div>
                     {% endif %}
 
                   {% else %}
 
+                    {# Display a disabled link (no permission) #}
                     <a class="nav-link flex-grow-1 disabled">
                       {{ item.link_text }}
                     </a>

--- a/netbox/utilities/templatetags/nav.py
+++ b/netbox/utilities/templatetags/nav.py
@@ -1,43 +1,19 @@
 from typing import Dict
 from django import template
 from django.template import Context
-from django.contrib.auth.context_processors import PermWrapper
 
-from netbox.navigation_menu import Menu, MenuGroup, MENUS
+from netbox.navigation_menu import MENUS
 
 
 register = template.Library()
 
 
-def process_menu(menu: Menu, perms: PermWrapper) -> MenuGroup:
-    """Enable a menu item if view permissions exist for the user."""
-    for group in menu.groups:
-        for item in group.items:
-            # Parse the URL template tag to a permission string.
-            app, scope = item.url.split(":")
-            object_name = scope.replace("_list", "")
-
-            view_perm = f"{app}.view_{scope}"
-            add_perm = f"{app}.add_object_name"
-
-            if view_perm in perms:
-                # If the view permission for each item exists, toggle
-                # the `disabled` field, which will be used in the UI.
-                item.disabled = False
-
-            if add_perm in perms:
-                if item.add_url is not None:
-                    item.has_add = True
-                if item.import_url is not None:
-                    item.has_import = True
-
-    return menu
-
-
 @register.inclusion_tag("navigation/nav_items.html", takes_context=True)
 def nav(context: Context) -> Dict:
-    """Provide navigation items to template."""
-    perms: PermWrapper = context["perms"]
-    groups = [process_menu(g, perms) for g in MENUS]
-
-    return {"nav_items": groups, "request": context["request"]}
+    """
+    Render the navigation menu.
+    """
+    return {
+        "nav_items": MENUS,
+        "request": context["request"]
+    }


### PR DESCRIPTION
This builds on @thatmattlove's earlier work on the navigation menu refactor to add support for plugin items and view permissions awareness. Compatibility is maintained with the PluginMenuItem and PluginMenuButton classes for now, though we may re-evaluate these in the future.