### PR TITLE
Fixes #6632  - Allow a /32 prefix to contain a /32 ipaddress

### DIFF
--- a/netbox/ipam/lookups.py
+++ b/netbox/ipam/lookups.py
@@ -151,7 +151,7 @@ class NetHostContained(Lookup):
         lhs, lhs_params = self.process_lhs(qn, connection)
         rhs, rhs_params = self.process_rhs(qn, connection)
         params = lhs_params + rhs_params
-        return 'CAST(HOST(%s) AS INET) << %s' % (lhs, rhs), params
+        return 'CAST(HOST(%s) AS INET) <<= %s' % (lhs, rhs), params
 
 
 class NetFamily(Transform):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #6632 
<!--

-->
Fix so that a /32 prefix can contain a /32 ipaddress
Creates consistent views and workflow to existing prefix / ip address relationship

fix proposed by **crafty-ua**