### PR TITLE
style(sidebar): fix sidebar dual scroll contexts

### DIFF
--- a/netbox/project-static/styles/netbox.scss
+++ b/netbox/project-static/styles/netbox.scss
@@ -535,8 +535,7 @@ div.content-container {
   }
 
   .accordion-body {
-    max-height: calc(100vh - 24rem);
-    overflow-y: auto;
+    overflow-y: visible;
     .nav-item {
       .nav-link {
         padding: 0.25rem 0.6rem;


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: <ISSUE NUMBER GOES HERE>
<!--
    Please include a summary of the proposed changes below.
-->

Currently large sections, like IPAM, create new scroll contexts inside themselves.

![image](https://user-images.githubusercontent.com/7415984/126805914-10ad9da5-a0c1-4edc-aa8a-25cc4dae7b03.png)

I think its more standard to fully open the dropdown and just scroll it with the master list of categories, i.e. extending the original scroll context.

Sorry, wasn't sure if you were going against `feature` or `develop` at the moment..