### PR TITLE
Update 6-ldap.md - AUTH_LDAP_USER_DN_TEMPLATE to none for windows 2012+

### DIFF
--- a/docs/installation/6-ldap.md
+++ b/docs/installation/6-ldap.md
@@ -74,7 +74,7 @@ STARTTLS can be configured by setting `AUTH_LDAP_START_TLS = True` and using the
 ### User Authentication
 
 !!! info
-    When using Windows Server 2012, `AUTH_LDAP_USER_DN_TEMPLATE` should be set to None.
+    When using Windows Server 2012+, `AUTH_LDAP_USER_DN_TEMPLATE` should be set to None.
 
 ```python
 from django_auth_ldap.config import LDAPSearch


### PR DESCRIPTION
changed     When using Windows Server 2012, `AUTH_LDAP_USER_DN_TEMPLATE` should be set to None.
to Windows Server 2012+

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: <ISSUE NUMBER GOES HERE>
<!--
    Please include a summary of the proposed changes below.
-->
