### PR TITLE
feat: add cable reconnection

### DIFF
--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -4269,6 +4269,574 @@ class CableCSVForm(CustomFieldModelCSVForm):
         return length_unit if length_unit is not None else ''
 
 
+class ReconnectCableToDeviceForm(BootstrapMixin, forms.ModelForm):
+    """
+    Base form for connecting a Cable to a Device component
+    """
+    termination_a_site = DynamicModelChoiceField(
+        queryset=Site.objects.all(),
+        label='Site',
+        required=False,
+    )
+    termination_a_rack = DynamicModelChoiceField(
+        queryset=Rack.objects.all(),
+        label='Rack',
+        required=False,
+        display_field='display_name',
+        null_option='None',
+        query_params={
+            'site_id': '$termination_a_site'
+        }
+    )
+    termination_a_device = DynamicModelChoiceField(
+        queryset=Device.objects.all(),
+        label='Device',
+        required=False,
+        display_field='display_name',
+        query_params={
+            'site_id': '$termination_a_site',
+            'rack_id': '$termination_a_rack',
+        }
+    )
+    termination_b_site = DynamicModelChoiceField(
+        queryset=Site.objects.all(),
+        label='Site',
+        required=False
+    )
+    termination_b_rack = DynamicModelChoiceField(
+        queryset=Rack.objects.all(),
+        label='Rack',
+        required=False,
+        display_field='display_name',
+        null_option='None',
+        query_params={
+            'site_id': '$termination_b_site'
+        }
+    )
+    termination_b_device = DynamicModelChoiceField(
+        queryset=Device.objects.all(),
+        label='Device',
+        required=False,
+        display_field='display_name',
+        query_params={
+            'site_id': '$termination_b_site',
+            'rack_id': '$termination_b_rack',
+        }
+    )
+
+    class Meta:
+        model = Cable
+        fields = [
+            'termination_a_site', 'termination_a_rack', 'termination_a_device', 'termination_a_id',
+            'termination_b_site', 'termination_b_rack', 'termination_b_device', 'termination_b_id'
+        ]
+
+    def clean_termination_a_id(self):
+        # Return the PK rather than the object
+        return getattr(self.cleaned_data['termination_a_id'], 'pk', None)
+
+    def clean_termination_b_id(self):
+        # Return the PK rather than the object
+        return getattr(self.cleaned_data['termination_b_id'], 'pk', None)
+
+
+class ReconnectConsolePortToConsoleServerPortForm(ReconnectCableToDeviceForm):
+    termination_a_id = DynamicModelChoiceField(
+        queryset=ConsolePort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_a_device'
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=ConsoleServerPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device'
+        }
+    )
+
+
+class ReconnectConsolePortToFrontPortForm(ReconnectCableToDeviceForm):
+    termination_a_id = DynamicModelChoiceField(
+        queryset=ConsolePort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_a_device'
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=FrontPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device'
+        }
+    )
+
+
+class ReconnectConsolePortToRearPortForm(ReconnectCableToDeviceForm):
+    termination_a_id = DynamicModelChoiceField(
+        queryset=ConsolePort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_a_device'
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=RearPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device'
+        }
+    )
+
+
+class ReconnectConsoleServerPortToFrontPortForm(ReconnectCableToDeviceForm):
+    termination_a_id = DynamicModelChoiceField(
+        queryset=ConsoleServerPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_a_device'
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=FrontPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device'
+        }
+    )
+
+
+class ReconnectConsoleServerPortToRearPortForm(ReconnectCableToDeviceForm):
+    termination_a_id = DynamicModelChoiceField(
+        queryset=ConsoleServerPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_a_device'
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=RearPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device'
+        }
+    )
+
+
+class ReconnectPowerfeedToPowerPortForm(ReconnectCableToDeviceForm):
+    termination_a_site = DynamicModelChoiceField(
+        queryset=Site.objects.all(),
+        label='Site',
+        required=False,
+        display_field='cid'
+    )
+    termination_a_rackgroup = DynamicModelChoiceField(
+        queryset=Location.objects.all(),
+        label='Location',
+        required=False,
+        display_field='cid',
+        query_params={
+            'site_id': '$termination_a_site'
+        }
+    )
+    termination_a_powerpanel = DynamicModelChoiceField(
+        queryset=PowerPanel.objects.all(),
+        label='Power Panel',
+        required=False,
+        query_params={
+            'site_id': '$termination_a_site',
+            'rack_group_id': '$termination_a_rackgroup',
+        }
+    )
+    termination_a_id = DynamicModelChoiceField(
+        queryset=PowerFeed.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'power_panel_id': '$termination_a_powerpanel'
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=PowerPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device'
+        }
+    )
+
+    class Meta:
+        model = Cable
+        fields = [
+            'termination_a_site', 'termination_a_rackgroup', 'termination_a_powerpanel', 'termination_a_id',
+            'termination_b_site', 'termination_b_rack', 'termination_b_device', 'termination_b_id'
+        ]
+
+
+class ReconnectPowerOutletToPowerPortForm(ReconnectCableToDeviceForm):
+    termination_a_id = DynamicModelChoiceField(
+        queryset=PowerOutlet.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_a_device'
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=PowerPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device'
+        }
+    )
+
+
+class ReconnectInterfaceForm(ReconnectCableToDeviceForm):
+    termination_a_id = DynamicModelChoiceField(
+        queryset=Interface.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_a_device',
+            'kind': 'physical',
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=Interface.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device',
+            'kind': 'physical',
+        }
+    )
+
+
+class ReconnectFrontPortToInterfaceForm(ReconnectCableToDeviceForm):
+    termination_a_id = DynamicModelChoiceField(
+        queryset=FrontPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_a_device'
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=Interface.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device',
+            'kind': 'physical',
+        }
+    )
+
+
+class ReconnectInterfaceToRearPortForm(ReconnectCableToDeviceForm):
+    termination_a_id = DynamicModelChoiceField(
+        queryset=Interface.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_a_device',
+            'kind': 'physical',
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=RearPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device'
+        }
+    )
+
+
+class ReconnectCircuitTerminationToInterfaceForm(ReconnectCableToDeviceForm):
+    termination_a_provider = DynamicModelChoiceField(
+        queryset=Provider.objects.all(),
+        label='Provider',
+        required=False
+    )
+    termination_a_site = DynamicModelChoiceField(
+        queryset=Site.objects.all(),
+        label='Site',
+        required=False
+    )
+    termination_a_circuit = DynamicModelChoiceField(
+        queryset=Circuit.objects.all(),
+        label='Circuit',
+        display_field='cid',
+        query_params={
+            'provider_id': '$termination_a_provider',
+            'site_id': '$termination_a_site',
+        }
+    )
+    termination_a_id = DynamicModelChoiceField(
+        queryset=CircuitTermination.objects.all(),
+        label='Side',
+        display_field='term_side',
+        disabled_indicator='cable',
+        query_params={
+            'circuit_id': '$termination_a_circuit'
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=Interface.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device',
+            'kind': 'physical',
+        }
+    )
+
+    class Meta:
+        model = Cable
+        fields = [
+            'termination_a_provider', 'termination_a_site', 'termination_a_circuit', 'termination_a_id',
+            'termination_b_site', 'termination_b_rack', 'termination_b_device', 'termination_b_id'
+        ]
+
+
+class ReconnectCircuitTerminationForm(BootstrapMixin, forms.ModelForm):
+    termination_a_provider = DynamicModelChoiceField(
+        queryset=Provider.objects.all(),
+        label='Provider',
+        required=False
+    )
+    termination_a_site = DynamicModelChoiceField(
+        queryset=Site.objects.all(),
+        label='Site',
+        required=False
+    )
+    termination_a_circuit = DynamicModelChoiceField(
+        queryset=Circuit.objects.all(),
+        label='Circuit',
+        display_field='cid',
+        query_params={
+            'provider_id': '$termination_a_provider',
+            'site_id': '$termination_a_site',
+        }
+    )
+    termination_a_id = DynamicModelChoiceField(
+        queryset=CircuitTermination.objects.all(),
+        label='Side',
+        display_field='term_side',
+        disabled_indicator='cable',
+        query_params={
+            'circuit_id': '$termination_a_circuit'
+        }
+    )
+    termination_b_provider = DynamicModelChoiceField(
+        queryset=Provider.objects.all(),
+        label='Provider',
+        required=False
+    )
+    termination_b_site = DynamicModelChoiceField(
+        queryset=Site.objects.all(),
+        label='Site',
+        required=False
+    )
+    termination_b_circuit = DynamicModelChoiceField(
+        queryset=Circuit.objects.all(),
+        label='Circuit',
+        display_field='cid',
+        query_params={
+            'provider_id': '$termination_b_provider',
+            'site_id': '$termination_b_site',
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=CircuitTermination.objects.all(),
+        label='Side',
+        display_field='term_side',
+        disabled_indicator='cable',
+        query_params={
+            'circuit_id': '$termination_b_circuit'
+        }
+    )
+
+    class Meta:
+        model = Cable
+        fields = [
+            'termination_a_provider', 'termination_a_site', 'termination_a_circuit', 'termination_a_id',
+            'termination_b_provider', 'termination_b_site', 'termination_b_circuit', 'termination_b_id', 'type',
+            'status', 'label', 'color', 'length', 'length_unit',
+        ]
+
+    def clean_termination_a_id(self):
+        # Return the PK rather than the object
+        return getattr(self.cleaned_data['termination_a_id'], 'pk', None)
+
+    def clean_termination_b_id(self):
+        # Return the PK rather than the object
+        return getattr(self.cleaned_data['termination_b_id'], 'pk', None)
+
+
+class ReconnectFrontPortForm(ReconnectCableToDeviceForm):
+    termination_a_id = DynamicModelChoiceField(
+        queryset=FrontPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_a_device'
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=FrontPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device'
+        }
+    )
+
+
+class ReconnectFrontPortToRearPortForm(ReconnectCableToDeviceForm):
+    termination_a_id = DynamicModelChoiceField(
+        queryset=FrontPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_a_device'
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=RearPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device'
+        }
+    )
+
+
+class ReconnectRearPortForm(ReconnectCableToDeviceForm):
+    termination_a_id = DynamicModelChoiceField(
+        queryset=RearPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_a_device'
+        }
+    )
+    termination_b_id = DynamicModelChoiceField(
+        queryset=RearPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device'
+        }
+    )
+
+
+class ReconnectCircuitTerminationToForm(BootstrapMixin, forms.ModelForm):
+    termination_a_provider = DynamicModelChoiceField(
+        queryset=Provider.objects.all(),
+        label='Provider',
+        required=False
+    )
+    termination_a_site = DynamicModelChoiceField(
+        queryset=Site.objects.all(),
+        label='Site',
+        required=False
+    )
+    termination_a_circuit = DynamicModelChoiceField(
+        queryset=Circuit.objects.all(),
+        label='Circuit',
+        display_field='cid',
+        query_params={
+            'provider_id': '$termination_a_provider',
+            'site_id': '$termination_a_site',
+        }
+    )
+    termination_a_id = DynamicModelChoiceField(
+        queryset=CircuitTermination.objects.all(),
+        label='Side',
+        display_field='term_side',
+        disabled_indicator='cable',
+        query_params={
+            'circuit_id': '$termination_a_circuit'
+        }
+    )
+    termination_b_site = DynamicModelChoiceField(
+        queryset=Site.objects.all(),
+        label='Site',
+        required=False
+    )
+    termination_b_rack = DynamicModelChoiceField(
+        queryset=Rack.objects.all(),
+        label='Rack',
+        required=False,
+        display_field='display_name',
+        null_option='None',
+        query_params={
+            'site_id': '$termination_b_site'
+        }
+    )
+    termination_b_device = DynamicModelChoiceField(
+        queryset=Device.objects.all(),
+        label='Device',
+        required=False,
+        display_field='display_name',
+        query_params={
+            'site_id': '$termination_b_site',
+            'rack_id': '$termination_b_rack',
+        }
+    )
+
+    class Meta:
+        model = Cable
+        fields = [
+            'termination_a_provider', 'termination_a_site', 'termination_a_circuit', 'termination_a_id',
+            'termination_b_site', 'termination_b_rack', 'termination_b_device', 'termination_b_id'
+        ]
+
+    def clean_termination_a_id(self):
+        # Return the PK rather than the object
+        return getattr(self.cleaned_data['termination_a_id'], 'pk', None)
+
+    def clean_termination_b_id(self):
+        # Return the PK rather than the object
+        return getattr(self.cleaned_data['termination_b_id'], 'pk', None)
+
+
+class ReconnectCircuitTerminationToFrontPortForm(ReconnectCircuitTerminationToForm):
+    termination_b_id = DynamicModelChoiceField(
+        queryset=FrontPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device'
+        }
+    )
+
+
+class ReconnectCircuitTerminationToRearPortForm(ReconnectCircuitTerminationToForm):
+    termination_b_id = DynamicModelChoiceField(
+        queryset=RearPort.objects.all(),
+        label='Name',
+        disabled_indicator='cable',
+        query_params={
+            'device_id': '$termination_b_device'
+        }
+    )
+
+
 class CableBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldBulkEditForm):
     pk = forms.ModelMultipleChoiceField(
         queryset=Cable.objects.all(),

--- a/netbox/dcim/urls.py
+++ b/netbox/dcim/urls.py
@@ -378,6 +378,7 @@ urlpatterns = [
     path('cables/<int:pk>/delete/', views.CableDeleteView.as_view(), name='cable_delete'),
     path('cables/<int:pk>/changelog/', ObjectChangeLogView.as_view(), name='cable_changelog', kwargs={'model': Cable}),
     path('cables/<int:pk>/journal/', ObjectJournalView.as_view(), name='cable_journal', kwargs={'model': Cable}),
+    path(r'cables/<int:pk>/reconnect/', views.CableReconnectView.as_view(), name='cable_reconnect'),
 
     # Console/power/interface connections (read-only)
     path('console-connections/', views.ConsoleConnectionsListView.as_view(), name='console_connections_list'),

--- a/netbox/templates/dcim/cable.html
+++ b/netbox/templates/dcim/cable.html
@@ -11,6 +11,10 @@
 
 {% block buttons %}
   {% if request.user|can_change:object %}
+    <a href="{% url 'dcim:cable_reconnect' pk=object.pk %}" class="btn btn-primary">
+        <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span> Reconnect    </a>
+  {% endif %}
+  {% if request.user|can_change:object %}
     {% edit_button object %}
   {% endif %}
   {% if request.user|can_delete:object %}

--- a/netbox/templates/dcim/cable_reconnect.html
+++ b/netbox/templates/dcim/cable_reconnect.html
@@ -1,0 +1,140 @@
+{% extends 'base.html' %}
+{% load static %}
+{% load helpers %}
+{% load form_helpers %}
+
+{% block content %}
+<form method="post" class="form form-horizontal">
+    {% csrf_token %}
+    {% for field in form.hidden_fields %}
+        {{ field }}
+    {% endfor %}
+    {% if form.non_field_errors %}
+        <div class="row">
+            <div class="col-md-6 col-md-offset-3">
+                <div class="panel panel-danger">
+                    <div class="panel-heading"><strong>Errors</strong></div>
+                    <div class="panel-body">
+                        {{ form.non_field_errors }}
+                    </div>
+                </div>
+            </div>
+        </div>
+    {% endif %}
+    {% with termination_a=form.instance.termination_a %}
+        <h3>{% block title %}Reconnect {{ form.instance.termination_a_type.name|bettertitle }}<->{{ form.instance.termination_b_type.name|bettertitle }} cable{% endblock %}</h3>
+        <div class="row">
+            <div class="col-md-5">
+                <div class="panel panel-default">
+                    <div class="panel-heading text-center">
+                        <strong>A Side</strong>
+                    </div>
+                    <div class="panel-body">
+                        {% if tabs %}
+                            <ul class="nav nav-tabs">
+                                {% for url, link in tabs %}
+                                    <li role="presentation"><a href="{{ url }}">{{ link }}</a></li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                        {% if 'termination_a_provider' in form.fields %}
+                            {% render_field form.termination_a_provider %}
+                        {% endif %}
+                        {% if 'termination_a_site' in form.fields %}
+                            {% render_field form.termination_a_site %}
+                        {% endif %}
+                        {% if 'termination_a_rackgroup' in form.fields %}
+                            {% render_field form.termination_a_rackgroup %}
+                        {% endif %}
+                        {% if 'termination_a_rack' in form.fields %}
+                            {% render_field form.termination_a_rack %}
+                        {% endif %}
+                        {% if 'termination_a_device' in form.fields %}
+                            {% render_field form.termination_a_device %}
+                        {% endif %}
+                        {% if 'termination_a_type' in form.fields %}
+                            {% render_field form.termination_a_type %}
+                        {% endif %}
+                        {% if 'termination_a_powerpanel' in form.fields %}
+                            {% render_field form.termination_a_powerpanel %}
+                        {% endif %}
+                        {% if 'termination_a_circuit' in form.fields %}
+                            {% render_field form.termination_a_circuit %}
+                        {% endif %}
+                        <div class="form-group">
+                            <label class="col-md-3 control-label required">Type</label>
+                            <div class="col-md-9">
+                                <p class="form-control-static">{{ form.instance.termination_a_type.name|capfirst }}</p>
+                            </div>
+                        </div>
+                        {% render_field form.termination_a_id %}
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-2 text-center" style="padding-top: 90px;">
+                <i class="fa fa-exchange fa-4x"></i>
+            </div>
+            <div class="col-md-5">
+                <div class="panel panel-default">
+                    <div class="panel-heading text-center">
+                        <strong>B Side</strong>
+                    </div>
+                    <div class="panel-body">
+                        {% if tabs %}
+                            <ul class="nav nav-tabs">
+                                {% for url, link in tabs %}
+                                    <li role="presentation"><a href="{{ url }}">{{ link }}</a></li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                        {% if 'termination_b_provider' in form.fields %}
+                            {% render_field form.termination_b_provider %}
+                        {% endif %}
+                        {% if 'termination_b_site' in form.fields %}
+                            {% render_field form.termination_b_site %}
+                        {% endif %}
+                        {% if 'termination_b_rackgroup' in form.fields %}
+                            {% render_field form.termination_b_rackgroup %}
+                        {% endif %}
+                        {% if 'termination_b_rack' in form.fields %}
+                            {% render_field form.termination_b_rack %}
+                        {% endif %}
+                        {% if 'termination_b_device' in form.fields %}
+                            {% render_field form.termination_b_device %}
+                        {% endif %}
+                        {% if 'termination_b_type' in form.fields %}
+                            {% render_field form.termination_b_type %}
+                        {% endif %}
+                        {% if 'termination_b_powerpanel' in form.fields %}
+                            {% render_field form.termination_b_powerpanel %}
+                        {% endif %}
+                        {% if 'termination_b_circuit' in form.fields %}
+                            {% render_field form.termination_b_circuit %}
+                        {% endif %}
+                        <div class="form-group">
+                            <label class="col-md-3 control-label required">Type</label>
+                            <div class="col-md-9">
+                                <p class="form-control-static">{{ form.instance.termination_b_type.name|capfirst }}</p>
+                            </div>
+                        </div>
+                        {% render_field form.termination_b_id %}
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div style="display: none">
+          {% include 'dcim/inc/cable_form.html' %}
+        </div>
+        <div class="form-group">
+            <div class="col-md-12 text-center">
+                <button type="submit" name="_update" class="btn btn-primary">Reconnect</button>
+                <a href="{{ return_url }}" class="btn btn-default">Cancel</a>
+            </div>
+        </div>
+    {% endwith %}
+</form>
+{% endblock %}
+
+{% block javascript %}
+<script src="{% static 'js/livesearch.js' %}?v{{ settings.VERSION }}"></script>
+{% endblock %}


### PR DESCRIPTION
### Fixes: #4881

**Note:** This is marked as a draft PR, since it is rather big and makes some tradeoffs that we might have to talk about and reconsider. It also has no automated tests, since there are no cable form test cases. Should I try to add them anyway? My guess is “yes”, but I’d like to verify before doing that work :)


This PR adds, on the face of it, a button labelled `Reconnect` to a cable detail. The form that it leads to allows for both sides of the cable to move. As such, we needed to implement all the missing forms—18 in total. Another option would be to be able to edit just one side at a time, and do that from the device component table. This would possibly allow us to reuse the forms we already have. Since this is the implementation I had at hand (in a plugin, I can’t really edit the table), I stuck with this solution for now. Happy to change it.

It also, under the hood, deletes the cable and recreates it. This means that the PK changes on reconnection, which should be a non-issue in most cases. Otherwise we’d have to touch the cable model, which I refrained from doing for now. Again, happy to change that.

The use case of moving ends of a cable seems to work, though, so that’s good :)

Cheers