### PR TITLE
Fixes #6887 Add Examples in the Lookup Expression Docs

### DIFF
--- a/docs/rest-api/filtering.md
+++ b/docs/rest-api/filtering.md
@@ -69,6 +69,12 @@ Numeric based fields (ASN, VLAN ID, etc) support these lookup expressions:
 | `gt` | Greater than |
 | `gte` | Greater than or equal to |
 
+Here is an example of a Numeric Field lookup expression that will return all VLANs with a VLAN ID greater than 9000:
+
+```no-highlight
+GET /api/ipam/vlans/?vid__gt=900
+```
+
 ### String Fields
 
 String based (char) fields (Name, Address, etc) support these lookup expressions:
@@ -86,7 +92,17 @@ String based (char) fields (Name, Address, etc) support these lookup expressions
 | `nie` | Inverse exact match (case-insensitive) |
 | `empty` | Is empty (boolean) |
 
+Here is an example of a lookup expression on a string field that will return all devices with 'switch' in the name:
+
+```no-highlight
+GET /api/dcim/devices/?name__ic=switch
+```
+
 ### Foreign Keys & Other Fields
 
 Certain other fields, namely foreign key relationships support just the negation
-expression: `n`.
+expression: `n`. Here is example of a lookup expression on a foreign key, it would return all the VLANs that don't have have VLAN Group ID of 3203:
+
+```no-highlight
+GET /api/ipam/vlans/?group_id__n=3203
+```

--- a/docs/rest-api/filtering.md
+++ b/docs/rest-api/filtering.md
@@ -101,7 +101,7 @@ GET /api/dcim/devices/?name__ic=switch
 ### Foreign Keys & Other Fields
 
 Certain other fields, namely foreign key relationships support just the negation
-expression: `n`. Here is example of a lookup expression on a foreign key, it would return all the VLANs that don't have a VLAN Group ID of 3203:
+expression: `n`. Here is an example of a lookup expression on a foreign key, it would return all the VLANs that don't have a VLAN Group ID of 3203:
 
 ```no-highlight
 GET /api/ipam/vlans/?group_id__n=3203

--- a/docs/rest-api/filtering.md
+++ b/docs/rest-api/filtering.md
@@ -69,7 +69,7 @@ Numeric based fields (ASN, VLAN ID, etc) support these lookup expressions:
 | `gt` | Greater than |
 | `gte` | Greater than or equal to |
 
-Here is an example of a Numeric Field lookup expression that will return all VLANs with a VLAN ID greater than 9000:
+Here is an example of a Numeric Field lookup expression that will return all VLANs with a VLAN ID greater than 900:
 
 ```no-highlight
 GET /api/ipam/vlans/?vid__gt=900

--- a/docs/rest-api/filtering.md
+++ b/docs/rest-api/filtering.md
@@ -69,7 +69,7 @@ Numeric based fields (ASN, VLAN ID, etc) support these lookup expressions:
 | `gt` | Greater than |
 | `gte` | Greater than or equal to |
 
-Here is an example of a Numeric Field lookup expression that will return all VLANs with a VLAN ID greater than 900:
+Here is an example of a numeric field lookup expression that will return all VLANs with a VLAN ID greater than 900:
 
 ```no-highlight
 GET /api/ipam/vlans/?vid__gt=900
@@ -92,7 +92,7 @@ String based (char) fields (Name, Address, etc) support these lookup expressions
 | `nie` | Inverse exact match (case-insensitive) |
 | `empty` | Is empty (boolean) |
 
-Here is an example of a lookup expression on a string field that will return all devices with 'switch' in the name:
+Here is an example of a lookup expression on a string field that will return all devices with `switch` in the name:
 
 ```no-highlight
 GET /api/dcim/devices/?name__ic=switch
@@ -101,7 +101,7 @@ GET /api/dcim/devices/?name__ic=switch
 ### Foreign Keys & Other Fields
 
 Certain other fields, namely foreign key relationships support just the negation
-expression: `n`. Here is example of a lookup expression on a foreign key, it would return all the VLANs that don't have have VLAN Group ID of 3203:
+expression: `n`. Here is example of a lookup expression on a foreign key, it would return all the VLANs that don't have a VLAN Group ID of 3203:
 
 ```no-highlight
 GET /api/ipam/vlans/?group_id__n=3203


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #6887 
<!--
    Please include a summary of the proposed changes below.
-->
This adds some examples in the lookup expressions sections of the docs. I added them in each subsection since that seemed fit in more with the rest of the docs. 

I can move this around if you would like. I'm not exactly sure how you want the docs to look. I could either make an new subsection with examples or add it to the bottom of the main section but then it's kind of wonky because the examples are before the reference tables. Let me know.
 