### PR TITLE
Exception.message was deprecated in Python 2.6 and removed in Python 3

### DIFF
--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -153,7 +153,7 @@ class CustomField(BigIDModel):
                 self.validate(default_value)
             except ValidationError as err:
                 raise ValidationError({
-                    'default': f'Invalid default value "{self.default}": {err.message}'
+                    'default': f'Invalid default value "{self.default}": {err}'
                 })
 
         # Minimum/maximum values can be set only for numeric fields

--- a/netbox/netbox/models.py
+++ b/netbox/netbox/models.py
@@ -115,7 +115,7 @@ class CustomFieldsMixin(models.Model):
             try:
                 custom_fields[field_name].validate(value)
             except ValidationError as e:
-                raise ValidationError(f"Invalid value for custom field '{field_name}': {e.message}")
+                raise ValidationError(f"Invalid value for custom field '{field_name}': {e}")
 
         # Check for missing required values
         for cf in custom_fields.values():


### PR DESCRIPTION
`BaseException.message` was deprecated as of Python 2.6 and is removed in Python 3. Use `str(e)` to access the user-readable message. Use `e.args` to access arguments passed to the exception.

https://docs.python.org/3/whatsnew/2.6.html#deprecations-and-removals

$ `python3`
```

>>> dir(Exception('Hey'))
['__cause__', '__class__', '__context__', '__delattr__', '__dict__', '__dir__',
 '__doc__', '__eq__', '__format__', '__ge__', '__getattribute__', '__gt__',
 '__hash__', '__init__', '__init_subclass__', '__le__', '__lt__', '__ne__',
 '__new__', '__reduce__', '__reduce_ex__', '__repr__', '__setattr__',
 '__setstate__', '__sizeof__', '__str__', '__subclasshook__',
 '__suppress_context__', '__traceback__', 'args', 'with_traceback']
>>> try:
...     blah
... except Exception as e:
...     print(e)
...     print(e.args)
...     print(e.message)  # Will cause a second Exception
...     
name 'blah' is not defined
("name 'blah' is not defined",)
Traceback (most recent call last):
  File "<string>", line 2, in <module>
NameError: name 'blah' is not defined

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<string>", line 6, in <module>
AttributeError: 'NameError' object has no attribute 'message'
```

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: <ISSUE NUMBER GOES HERE>
<!--
    Please include a summary of the proposed changes below.
-->
