### PR TITLE
[Bugfix] Fix permissions to view VLANs, but don't have Prefix permission

### DIFF
--- a/netbox/ipam/tables.py
+++ b/netbox/ipam/tables.py
@@ -72,11 +72,15 @@ VLAN_LINK = """
 """
 
 VLAN_PREFIXES = """
+{% if perms.ipam.view_prefix %}
 {% for prefix in record.prefixes.all %}
     <a href="{% url 'ipam:prefix' pk=prefix.pk %}">{{ prefix }}</a>{% if not forloop.last %}<br />{% endif %}
 {% empty %}
     &mdash;
 {% endfor %}
+{% else %}
+    &mdash;
+{% endif }
 """
 
 VLAN_ROLE_LINK = """


### PR DESCRIPTION
Fixes the UI display when viewing the list of VLANs, but don't have permission to view IP Prefixes.

Summary:
Check if the user has `view_prefix` permission before displaying the Prefixes associated with the VLAN.