### PR TITLE
Update links to NAPALM

### DIFF
--- a/docs/additional-features/napalm.md
+++ b/docs/additional-features/napalm.md
@@ -1,6 +1,6 @@
 # NAPALM
 
-NetBox supports integration with the [NAPALM automation](https://napalm-automation.net/) library. NAPALM allows NetBox to serve a proxy for operational data, fetching live data from network devices and returning it to a requester via its REST API. Note that NetBox does not store any NAPALM data locally.
+NetBox supports integration with the [NAPALM automation](https://github.com/napalm-automation/napalm/) library. NAPALM allows NetBox to serve a proxy for operational data, fetching live data from network devices and returning it to a requester via its REST API. Note that NetBox does not store any NAPALM data locally.
 
 The NetBox UI will display tabs for status, LLDP neighbors, and configuration under the device view if the following conditions are met:
 

--- a/docs/configuration/optional-settings.md
+++ b/docs/configuration/optional-settings.md
@@ -327,7 +327,7 @@ Toggle the availability Prometheus-compatible metrics at `/metrics`. See the [Pr
 
 ## NAPALM_PASSWORD
 
-NetBox will use these credentials when authenticating to remote devices via the [NAPALM library](https://napalm-automation.net/), if installed. Both parameters are optional.
+NetBox will use these credentials when authenticating to remote devices via the [NAPALM library](https://github.com/napalm-automation/napalm/), if installed. Both parameters are optional.
 
 !!! note
     If SSH public key authentication has been set up on the remote device(s) for the system account under which NetBox runs, these parameters are not needed.

--- a/docs/installation/3-netbox.md
+++ b/docs/installation/3-netbox.md
@@ -200,7 +200,7 @@ All Python packages required by NetBox are listed in `requirements.txt` and will
 
 ### NAPALM
 
-The [NAPALM automation](https://napalm-automation.net/) library allows NetBox to fetch live data from devices and return it to a requester via its REST API. The `NAPALM_USERNAME` and `NAPALM_PASSWORD` configuration parameters define the credentials to be used when connecting to a device.
+The [NAPALM automation](https://github.com/napalm-automation/napalm/) library allows NetBox to fetch live data from devices and return it to a requester via its REST API. The `NAPALM_USERNAME` and `NAPALM_PASSWORD` configuration parameters define the credentials to be used when connecting to a device.
 
 ```no-highlight
 sudo sh -c "echo 'napalm' >> /opt/netbox/local_requirements.txt"

--- a/docs/models/dcim/platform.md
+++ b/docs/models/dcim/platform.md
@@ -4,6 +4,6 @@ A platform defines the type of software running on a device or virtual machine. 
 
 Platforms may optionally be limited by manufacturer: If a platform is assigned to a particular manufacturer, it can only be assigned to devices with a type belonging to that manufacturer.
 
-The platform model is also used to indicate which [NAPALM](https://napalm-automation.net/) driver and any associated arguments NetBox should use when connecting to a remote device. The name of the driver along with optional parameters are stored with the platform.
+The platform model is also used to indicate which [NAPALM](https://github.com/napalm-automation/napalm/) driver and any associated arguments NetBox should use when connecting to a remote device. The name of the driver along with optional parameters are stored with the platform.
 
 The assignment of platforms to devices is an optional feature, and may be disregarded if not desired.

--- a/docs/release-notes/version-2.1.md
+++ b/docs/release-notes/version-2.1.md
@@ -121,7 +121,7 @@ A new API endpoint has been added at `/api/ipam/prefixes/<pk>/available-ips/`. A
 
 #### NAPALM Integration ([#1348](https://github.com/netbox-community/netbox/issues/1348))
 
-The [NAPALM automation](https://napalm-automation.net/) library provides an abstracted interface for pulling live data (e.g. uptime, software version, running config, LLDP neighbors, etc.) from network devices. The NetBox API has been extended to support executing read-only NAPALM methods on devices defined in NetBox. To enable this functionality, ensure that NAPALM has been installed (`pip install napalm`) and the `NETBOX_USERNAME` and `NETBOX_PASSWORD` [configuration parameters](https://netbox.readthedocs.io/en/stable/configuration/optional-settings/#netbox_username) have been set in configuration.py.
+The [NAPALM automation](https://github.com/napalm-automation/napalm/) library provides an abstracted interface for pulling live data (e.g. uptime, software version, running config, LLDP neighbors, etc.) from network devices. The NetBox API has been extended to support executing read-only NAPALM methods on devices defined in NetBox. To enable this functionality, ensure that NAPALM has been installed (`pip install napalm`) and the `NETBOX_USERNAME` and `NETBOX_PASSWORD` [configuration parameters](https://netbox.readthedocs.io/en/stable/configuration/optional-settings/#netbox_username) have been set in configuration.py.
 
 ### Enhancements
 


### PR DESCRIPTION
Seems that the napalm website was taken over, switching links to maintainer preferred github

Per prior understanding, doc updates do not require an approved issue. 