### PR TITLE
Redirect users on error to the GitHub discussion forum

### DIFF
--- a/netbox/templates/500.html
+++ b/netbox/templates/500.html
@@ -32,7 +32,7 @@
 Python version: {{ python_version }}
 NetBox version: {{ netbox_version }}</pre>
                         <p>
-                            If further assistance is required, please post to the <a href="https://groups.google.com/g/netbox-discuss">NetBox mailing list</a>.
+                            If further assistance is required, please post to the <a href="https://github.com/netbox-community/netbox/discussions">NetBox discussion forum</a> on GitHub.
                         </p>
                         <div class="text-end">
                             <a href="{% url 'home' %}" class="btn btn-primary">Home Page</a>

--- a/netbox/utilities/management/commands/makemigrations.py
+++ b/netbox/utilities/management/commands/makemigrations.py
@@ -21,8 +21,8 @@ class Command(_Command):
             raise CommandError(
                 "This command is available for development purposes only. It will\n"
                 "NOT resolve any issues with missing or unapplied migrations. For assistance,\n"
-                "please post to the NetBox mailing list:\n"
-                "    https://groups.google.com/g/netbox-discuss"
+                "please post to the NetBox discussion forum on GitHub:\n"
+                "    https://github.com/netbox-community/netbox/discussions"
             )
 
         super().handle(*args, **kwargs)


### PR DESCRIPTION
### Fixes: #7102

In error messages, refer users to the GitHub discussion forum rather than the legacy mailing list on Google Groups.