### PR TITLE
Fix #7090: cable bulk edit form - allow decimal input on length field

### DIFF
--- a/docs/release-notes/version-3.0.md
+++ b/docs/release-notes/version-3.0.md
@@ -17,7 +17,6 @@
 * [#7096](https://github.com/netbox-community/netbox/issues/7096) - Home links should honor `BASE_PATH` configuration
 * [#7101](https://github.com/netbox-community/netbox/issues/7101) - Enforce `MAX_PAGE_SIZE` for table and REST API pagination
 
-
 ---
 
 ## v3.0.0 (2021-08-30)

--- a/docs/release-notes/version-3.0.md
+++ b/docs/release-notes/version-3.0.md
@@ -12,9 +12,11 @@
 * [#7083](https://github.com/netbox-community/netbox/issues/7083) - Correct labeling for VM memory attribute
 * [#7084](https://github.com/netbox-community/netbox/issues/7084) - Fix KeyError exception when editing access VLAN on an interface
 * [#7089](https://github.com/netbox-community/netbox/issues/7089) - Fix ContentTypeFilterSet not filtering on q filter
+* [#7090](https://github.com/netbox-community/netbox/issues/7090) - Fix Cable Bulk Edit Form - allow decimal input on Length field
 * [#7093](https://github.com/netbox-community/netbox/issues/7093) - Multi-select custom field filters should employ exact match
 * [#7096](https://github.com/netbox-community/netbox/issues/7096) - Home links should honor `BASE_PATH` configuration
 * [#7101](https://github.com/netbox-community/netbox/issues/7101) - Enforce `MAX_PAGE_SIZE` for table and REST API pagination
+
 
 ---
 

--- a/netbox/dcim/forms.py
+++ b/netbox/dcim/forms.py
@@ -4586,8 +4586,8 @@ class CableBulkEditForm(BootstrapMixin, AddRemoveTagsForm, CustomFieldModelBulkE
     color = ColorField(
         required=False
     )
-    length = forms.IntegerField(
-        min_value=1,
+    length = forms.DecimalField(
+        min_value=0,
         required=False
     )
     length_unit = forms.ChoiceField(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #7090
<!--
    Please include a summary of the proposed changes below.
-->
#6154 changed the Length property of the Cable model from Integer to Decimal. This PR changes the bulk edit form for Cables to allow decimal input when editing multiple cables at once.

Note: I'm not sure why the properties for bulkeditform is not inherited from the model. The single edit page seems to follow this pattern. We should follow that pattern for bulk edit forms as well, to avoid code duplication.
 
