### PR TITLE
When handling an exception during an API query, send an error response containing structured information about the error rather than HTML

### DIFF
--- a/docs/release-notes/version-3.0.md
+++ b/docs/release-notes/version-3.0.md
@@ -23,6 +23,7 @@
 * [#7101](https://github.com/netbox-community/netbox/issues/7101) - Enforce `MAX_PAGE_SIZE` for table and REST API pagination
 * [#7106](https://github.com/netbox-community/netbox/issues/7106) - Fix incorrect "Map It" button URL on a site's Physical Address field
 * [#7107](https://github.com/netbox-community/netbox/issues/7107) - Fix missing search button and search results in IP Address assignment "Assign IP" tab
+* [#7109](https://github.com/netbox-community/netbox/issues/7109) - When handling an exception during an API query, send an error response containing structured information about the error rather than HTML.
 
 ---
 

--- a/netbox/netbox/api/views.py
+++ b/netbox/netbox/api/views.py
@@ -22,7 +22,7 @@ from extras.models import ExportTemplate
 from netbox.api import BulkOperationSerializer
 from netbox.api.authentication import IsAuthenticatedOrLoginNotRequired
 from netbox.api.exceptions import SerializerNotFound
-from utilities.api import get_serializer_for_model
+from utilities.api import get_serializer_for_model, rest_api_server_error
 
 HTTP_ACTIONS = {
     'GET': 'view',
@@ -210,6 +210,8 @@ class ModelViewSet(BulkUpdateModelMixin, BulkDestroyModelMixin, ModelViewSet_):
                 *args,
                 **kwargs
             )
+        except Exception as e:
+            return rest_api_server_error(request, *args, **kwargs)
 
     def _validate_objects(self, instance):
         """


### PR DESCRIPTION
### Fixes: #7109

See #7109 for more details. There seemed to be an already-written handler for such cases, this simply reuses it in the `ModelViewSet` view as a fallback.