### PR TITLE
Fixes #7113: iprange bulk options under prefix view

### DIFF
--- a/docs/release-notes/version-3.0.md
+++ b/docs/release-notes/version-3.0.md
@@ -23,6 +23,7 @@
 * [#7101](https://github.com/netbox-community/netbox/issues/7101) - Enforce `MAX_PAGE_SIZE` for table and REST API pagination
 * [#7106](https://github.com/netbox-community/netbox/issues/7106) - Fix incorrect "Map It" button URL on a site's Physical Address field
 * [#7107](https://github.com/netbox-community/netbox/issues/7107) - Fix missing search button and search results in IP Address assignment "Assign IP" tab
+* [#7113](https://github.com/netbox-community/netbox/issues/7113) - Fix IPRange bulk options within Prefix view
 
 ---
 

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -427,8 +427,16 @@ class PrefixIPRangesView(generic.ObjectView):
 
         bulk_querystring = 'vrf_id={}&parent={}'.format(instance.vrf.pk if instance.vrf else '0', instance.prefix)
 
+        # Compile permissions list for rendering the object table
+        permissions = {
+            'add': request.user.has_perm('ipam.add_iprange'),
+            'change': request.user.has_perm('ipam.change_iprange'),
+            'delete': request.user.has_perm('ipam.delete_iprange'),
+        }
+
         return {
             'table': table,
+            'permissions': permissions,
             'bulk_querystring': bulk_querystring,
             'active_tab': 'ip-ranges',
         }

--- a/netbox/templates/ipam/prefix/ip_ranges.html
+++ b/netbox/templates/ipam/prefix/ip_ranges.html
@@ -6,7 +6,7 @@
   <div class="row">
     <div class="col col-md-12">
       {% include 'inc/table_controls.html' with table_modal="IPRangeTable_config" %}
-      {% include 'utilities/obj_table.html' with heading='Child IP Ranges' bulk_edit_url='ipam:prefix_bulk_edit' bulk_delete_url='ipam:prefix_bulk_delete' parent=prefix %}
+      {% include 'utilities/obj_table.html' with heading='Child IP Ranges' bulk_edit_url='ipam:iprange_bulk_edit' bulk_delete_url='ipam:iprange_bulk_delete' parent=prefix %}
     </div>
   </div>
   {% table_config_form table table_name="IPRangeTable" %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: 7113
<!--
    Please include a summary of the proposed changes below.
-->
Two small fixes in this PR:
- Add permissions to the Prefix view, so bulk option buttons are allowed to show
- Correct the links behind these buttons to IPRange bulk pages