### PR TITLE
Fixes #7149: Delete all changelog records referencing the old secrets app

### DIFF
--- a/netbox/extras/migrations/0062_clear_secrets_changelog.py
+++ b/netbox/extras/migrations/0062_clear_secrets_changelog.py
@@ -1,0 +1,26 @@
+from django.db import migrations
+
+
+def clear_secrets_changelog(apps, schema_editor):
+    """
+    Delete all ObjectChange records referencing a model within the old secrets app (pre-v3.0).
+    """
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    ObjectChange = apps.get_model('extras', 'ObjectChange')
+
+    content_type_ids = ContentType.objects.filter(app_label='secrets').values_list('id', flat=True)
+    ObjectChange.objects.filter(changed_object_type__in=content_type_ids).delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('extras', '0061_extras_change_logging'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=clear_secrets_changelog,
+            reverse_code=migrations.RunPython.noop
+        ),
+    ]


### PR DESCRIPTION
### Fixes: #7149

This PR introduces a new database migration that deletes all changelog records referencing a model from the old secrets app (which was removed in NetBox v3.0). This has been tested to ensure that only change records from the secrets app are removed.

I've submitted this for reference as one of the two potential solutions being discussed under #7149.