### PR TITLE
Handle `null_option` in `applied_filters` template tag

### DIFF
--- a/docs/release-notes/version-3.0.md
+++ b/docs/release-notes/version-3.0.md
@@ -10,6 +10,7 @@
 * [#7176](https://github.com/netbox-community/netbox/issues/7176) - Fix issue where query parameters were duplicated across different forms of the same type
 * [#7188](https://github.com/netbox-community/netbox/issues/7188) - Fix issue where select fields with `null_option` did not render or send the null option
 * [#7193](https://github.com/netbox-community/netbox/issues/7193) - Fix prefix (flat) template issue when viewing child prefixes with prefixes available
+* [#7205](https://github.com/netbox-community/netbox/issues/7205) - Fix issue where selected fields with `null_option` set were not added to applied filters
 
 ---
 

--- a/netbox/utilities/forms/fields.py
+++ b/netbox/utilities/forms/fields.py
@@ -485,5 +485,5 @@ class DynamicModelMultipleChoiceField(DynamicModelChoiceMixin, forms.ModelMultip
         """
         if self.null_option is not None and settings.FILTERS_NULL_CHOICE_VALUE in value:
             value = [v for v in value if v != settings.FILTERS_NULL_CHOICE_VALUE]
-            return [self.null_option, *value]
+            return [None, *value]
         return super().clean(value)

--- a/netbox/utilities/forms/fields.py
+++ b/netbox/utilities/forms/fields.py
@@ -478,7 +478,7 @@ class DynamicModelMultipleChoiceField(DynamicModelChoiceMixin, forms.ModelMultip
     filter = django_filters.ModelMultipleChoiceFilter
     widget = widgets.APISelectMultiple
 
-    def clean(self, value: list[str]):
+    def clean(self, value):
         """
         When null option is enabled and "None" is sent as part of a form to be submitted, it is sent as the
         string 'null'.  This will check for that condition and gracefully handle the conversion to a NoneType.

--- a/netbox/utilities/forms/fields.py
+++ b/netbox/utilities/forms/fields.py
@@ -477,3 +477,13 @@ class DynamicModelMultipleChoiceField(DynamicModelChoiceMixin, forms.ModelMultip
     """
     filter = django_filters.ModelMultipleChoiceFilter
     widget = widgets.APISelectMultiple
+
+    def clean(self, value: list[str]):
+        """
+        When null option is enabled and "None" is sent as part of a form to be submitted, it is sent as the
+        string 'null'.  This will check for that condition and gracefully handle the conversion to a NoneType.
+        """
+        if self.null_option is not None and settings.FILTERS_NULL_CHOICE_VALUE in value:
+            value = [v for v in value if v != settings.FILTERS_NULL_CHOICE_VALUE]
+            return [self.null_option, *value]
+        return super().clean(value)

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -1,6 +1,7 @@
 import re
 
 from django import forms
+from django.conf import settings
 from django.forms.models import fields_for_model
 
 from utilities.choices import unpack_grouped_choices
@@ -124,17 +125,16 @@ def get_selected_values(form, field_name):
     # Selection field
     if hasattr(field, 'choices'):
         try:
-            grouped_choices = [(k, v) for k, v in field.choices]
+            choices = unpack_grouped_choices(field.choices)
 
             if hasattr(field, 'null_option'):
                 # If the field has a `null_option` attribute set and it is selected,
                 # add it to the field's grouped choices.
                 if field.null_option is not None and None in filter_data:
-                    grouped_choices.append((field.null_option, field.null_option))
+                    choices.append((settings.FILTERS_NULL_CHOICE_VALUE, field.null_option))
 
-            choices = dict(unpack_grouped_choices(grouped_choices))
             return [
-                label for value, label in choices.items() if str(value) in filter_data or None in filter_data
+                label for value, label in choices if str(value) in filter_data or None in filter_data
             ]
         except TypeError:
             # Field uses dynamic choices. Show all that have been populated.

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -120,11 +120,20 @@ def get_selected_values(form, field_name):
     if not hasattr(form, 'cleaned_data'):
         form.is_valid()
     filter_data = form.cleaned_data.get(field_name)
+    field = form.fields[field_name]
 
     # Selection field
-    if hasattr(form.fields[field_name], 'choices'):
+    if hasattr(field, 'choices'):
         try:
-            choices = dict(unpack_grouped_choices(form.fields[field_name].choices))
+            grouped_choices = [(k, v) for k, v in field.choices]
+
+            if hasattr(field, 'null_option'):
+                # If the field has a `null_option` attribute set and it is selected,
+                # add it to the field's grouped choices.
+                if field.null_option is not None and field.null_option in filter_data:
+                    grouped_choices.append((field.null_option, field.null_option))
+
+            choices = dict(unpack_grouped_choices(grouped_choices))
             return [
                 label for value, label in choices.items() if str(value) in filter_data
             ]

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -121,7 +121,6 @@ def get_selected_values(form, field_name):
         form.is_valid()
     filter_data = form.cleaned_data.get(field_name)
     field = form.fields[field_name]
-
     # Selection field
     if hasattr(field, 'choices'):
         try:
@@ -130,12 +129,12 @@ def get_selected_values(form, field_name):
             if hasattr(field, 'null_option'):
                 # If the field has a `null_option` attribute set and it is selected,
                 # add it to the field's grouped choices.
-                if field.null_option is not None and field.null_option in filter_data:
+                if field.null_option is not None and None in filter_data:
                     grouped_choices.append((field.null_option, field.null_option))
 
             choices = dict(unpack_grouped_choices(grouped_choices))
             return [
-                label for value, label in choices.items() if str(value) in filter_data
+                label for value, label in choices.items() if str(value) in filter_data or None in filter_data
             ]
         except TypeError:
             # Field uses dynamic choices. Show all that have been populated.


### PR DESCRIPTION
### Fixes: #7205

- Apply same logic from `DynamicModelChoiceField.clean()` to `DynamicModelMultipleChoiceField` field so that `None` is added to cleaned form data
- More importantly, use a field's `null_option` for `applied_filters` template tag when selected. For example, if 'Global' is selected, the filter should show 'Global'. After my fix from 2a293d5 in APISelect, `applied_filters` is now broken when a field with a `null_option` is selected.