### PR TITLE
Fixes #7195 update base template in plugin dev doc

### DIFF
--- a/docs/plugins/development.md
+++ b/docs/plugins/development.md
@@ -218,7 +218,7 @@ NetBox provides a base template to ensure a consistent user experience, which pl
 For more information on how template blocks work, consult the [Django documentation](https://docs.djangoproject.com/en/stable/ref/templates/builtins/#block).
 
 ```jinja2
-{% extends 'base.html' %}
+{% extends 'base/layout.html' %}
 
 {% block content %}
     {% with config=settings.PLUGINS_CONFIG.netbox_animal_sounds %}


### PR DESCRIPTION
### Fixes: #7195 
- Correct the base template used by the example in the plugin development docs so it points to `'base/layout.html'` 
