### PR TITLE
Fixes #7267: Mark utilized not propagated to parent prefix

### DIFF
--- a/docs/release-notes/version-3.0.md
+++ b/docs/release-notes/version-3.0.md
@@ -15,6 +15,7 @@
 * [#7167](https://github.com/netbox-community/netbox/issues/7167) - Ensure consistent font size when using monospace formatting
 * [#7226](https://github.com/netbox-community/netbox/issues/7226) - Exempt GraphQL API requests from CSRF inspection
 * [#7248](https://github.com/netbox-community/netbox/issues/7248) - Fix global search results section links
+* [#7267](https://github.com/netbox-community/netbox/issues/7267) - Fix mark_utilized parent prefix utilization
 * [#7279](https://github.com/netbox-community/netbox/issues/7279) - Fix exception when tracing cable with no associated path
 
 ---


### PR DESCRIPTION
### Fixes: #7267 
Include mark utilized child prefixes in prefix get_utlization function

Signed-off-by: Misha Komarovskiy <zombah@gmail.com>
