### PR TITLE
Fix #7365: Optimize calculation of prefix utilization

### DIFF
--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -487,11 +487,9 @@ class Prefix(PrimaryModel):
             utilization = int(float(child_prefixes.size) / self.prefix.size * 100)
         else:
             # Compile an IPSet to avoid counting duplicate IPs
-            child_ips = netaddr.IPSet()
-            for iprange in self.get_child_ranges():
-                child_ips.add(iprange.range)
-            for ip in self.get_child_ips():
-                child_ips.add(ip.address.ip)
+            child_ips = netaddr.IPSet(
+                [_.range for _ in self.get_child_ranges()] + [_.address.ip for _ in self.get_child_ips()]
+            )
 
             prefix_size = self.prefix.size
             if self.prefix.version == 4 and self.prefix.prefixlen < 31 and not self.is_pool:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #7365 

By profiling the python interpreter, I found `Prefix.get_utilization()` in `ipam/models/ip.py` consumes a lot of time.
Especially, `IPSet.add()` in a loop is the biggest bottle-neck.
https://github.com/netbox-community/netbox/blob/develop/netbox/ipam/models/ip.py#L491

In my experiment, instead of `IPset.add()`, `IPSet()` constructor could reduces the execution time. `IPSet()` also can dedup IPs and IP ranges.

Five times quick experiments results (unit: second):

v3.0.3 | fixed
-------|-------
37.93 | 9.24
38.51 | 9.18
39.06 | 10.06
37.80 | 9.98
38.46 | 10.22
