### PR TITLE
Fix #7564: virtual-chassis position zero

### DIFF
--- a/docs/release-notes/version-3.0.md
+++ b/docs/release-notes/version-3.0.md
@@ -10,6 +10,7 @@
 * [#7534](https://github.com/netbox-community/netbox/issues/7534) - Avoid exception when utilizing "create and add another" twice in succession
 * [#7544](https://github.com/netbox-community/netbox/issues/7544) - Fix multi-value filtering of custom field objects
 * [#7545](https://github.com/netbox-community/netbox/issues/7545) - Fix incorrect display of update/delete events for webhooks
+* [#7564](https://github.com/netbox-community/netbox/issues/7564) - Fix VC position zero at VC creation and VC position zero not being displayed
 
 ---
 

--- a/netbox/dcim/forms/object_create.py
+++ b/netbox/dcim/forms/object_create.py
@@ -122,7 +122,7 @@ class VirtualChassisCreateForm(BootstrapMixin, CustomFieldModelForm):
 
         # Assign VC members
         if instance.pk:
-            initial_position = self.cleaned_data.get('initial_position', 1)
+            initial_position = self.cleaned_data.get('initial_position') if self.cleaned_data.get('initial_position') is not None else 1
             for i, member in enumerate(self.cleaned_data['members'], start=initial_position):
                 member.virtual_chassis = instance
                 member.vc_position = i

--- a/netbox/dcim/forms/object_create.py
+++ b/netbox/dcim/forms/object_create.py
@@ -122,7 +122,7 @@ class VirtualChassisCreateForm(BootstrapMixin, CustomFieldModelForm):
 
         # Assign VC members
         if instance.pk:
-            initial_position = self.cleaned_data.get('initial_position',1)
+            initial_position = self.cleaned_data.get('initial_position', 1)
             for i, member in enumerate(self.cleaned_data['members'], start=initial_position):
                 member.virtual_chassis = instance
                 member.vc_position = i

--- a/netbox/dcim/forms/object_create.py
+++ b/netbox/dcim/forms/object_create.py
@@ -122,7 +122,7 @@ class VirtualChassisCreateForm(BootstrapMixin, CustomFieldModelForm):
 
         # Assign VC members
         if instance.pk:
-            initial_position = self.cleaned_data.get('initial_position') if self.cleaned_data.get('initial_position') != None else 1
+            initial_position = self.cleaned_data.get('initial_position',1)
             for i, member in enumerate(self.cleaned_data['members'], start=initial_position):
                 member.virtual_chassis = instance
                 member.vc_position = i

--- a/netbox/dcim/forms/object_create.py
+++ b/netbox/dcim/forms/object_create.py
@@ -122,7 +122,7 @@ class VirtualChassisCreateForm(BootstrapMixin, CustomFieldModelForm):
 
         # Assign VC members
         if instance.pk:
-            initial_position = self.cleaned_data.get('initial_position') or 1
+            initial_position = self.cleaned_data.get('initial_position') if self.cleaned_data.get('initial_position') != None else 1
             for i, member in enumerate(self.cleaned_data['members'], start=initial_position):
                 member.virtual_chassis = instance
                 member.vc_position = i

--- a/netbox/utilities/templatetags/helpers.py
+++ b/netbox/utilities/templatetags/helpers.py
@@ -375,7 +375,7 @@ def badge(value, bg_class='secondary', show_empty=False):
     Display the specified number as a badge.
     """
     return {
-        'value': value,
+        'value': str(value),
         'bg_class': bg_class,
         'show_empty': show_empty,
     }


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #7564 
<!--
    Please include a summary of the proposed changes below.
-->
When a new VC was created with a VC start position of zero, it was created with a start position of 1.
When a VC was displayed that had a position of zero, the label was not displayed in the VC overview.