### PR TITLE
Add 802.1ad (QinQ) to Interface Mode Choices

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -940,11 +940,13 @@ class InterfaceModeChoices(ChoiceSet):
     MODE_ACCESS = 'access'
     MODE_TAGGED = 'tagged'
     MODE_TAGGED_ALL = 'tagged-all'
+    MODE_Q_IN_Q = 'q-in-q'
 
     CHOICES = (
         (MODE_ACCESS, 'Access'),
         (MODE_TAGGED, 'Tagged'),
         (MODE_TAGGED_ALL, 'Tagged (All)'),
+        (MODE_Q_IN_Q, '802.1ad (QinQ)'),
     )
 
 

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -940,13 +940,13 @@ class InterfaceModeChoices(ChoiceSet):
     MODE_ACCESS = 'access'
     MODE_TAGGED = 'tagged'
     MODE_TAGGED_ALL = 'tagged-all'
-    MODE_Q_IN_Q = 'q-in-q'
+    MODE_DOT1Q_TUNNEL = 'dot1q-tunnel'
 
     CHOICES = (
         (MODE_ACCESS, 'Access'),
         (MODE_TAGGED, 'Tagged'),
         (MODE_TAGGED_ALL, 'Tagged (All)'),
-        (MODE_Q_IN_Q, '802.1ad (QinQ)'),
+        (MODE_DOT1Q_TUNNEL, '802.1ad (QinQ)'),
     )
 
 

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -940,13 +940,13 @@ class InterfaceModeChoices(ChoiceSet):
     MODE_ACCESS = 'access'
     MODE_TAGGED = 'tagged'
     MODE_TAGGED_ALL = 'tagged-all'
-    MODE_DOT1Q_TUNNEL = 'dot1q-tunnel'
+    MODE_Q_IN_Q = 'q-in-q'
 
     CHOICES = (
         (MODE_ACCESS, 'Access'),
         (MODE_TAGGED, 'Tagged'),
         (MODE_TAGGED_ALL, 'Tagged (All)'),
-        (MODE_DOT1Q_TUNNEL, '802.1ad (QinQ)'),
+        (MODE_Q_IN_Q, 'Q-in-Q (802.1ad)'),
     )
 
 

--- a/netbox/dcim/forms/common.py
+++ b/netbox/dcim/forms/common.py
@@ -32,7 +32,13 @@ class InterfaceCommonForm(forms.Form):
             raise forms.ValidationError({
                 'mode': "An access interface cannot have tagged VLANs assigned."
             })
-
+            
+        # Q-in-Q interfaces cannot be assigned tagged VLANs
+        elif self.cleaned_data['mode'] == InterfaceModeChoices.MODE_Q_IN_Q and tagged_vlans:
+            raise forms.ValidationError({
+                'mode': "A Q-in-Q (802.1ad) interface cannot have tagged VLANs assigned."
+            })            
+ 
         # Remove all tagged VLAN assignments from "tagged all" interfaces
         elif self.cleaned_data['mode'] == InterfaceModeChoices.MODE_TAGGED_ALL:
             self.cleaned_data['tagged_vlans'] = []

--- a/netbox/dcim/forms/models.py
+++ b/netbox/dcim/forms/models.py
@@ -60,8 +60,8 @@ __all__ = (
 INTERFACE_MODE_HELP_TEXT = """
 Access: One untagged VLAN<br />
 Tagged: One untagged VLAN and/or one or more tagged VLANs<br />
-Tagged (All): Implies all VLANs are available (w/optional untagged VLAN)
-Dot1Q Tunnel: Implies 802.1q Tunneling (QinQ), Service VLAN/TAG is set as access VLAN
+Tagged (All): Implies all VLANs are available (w/optional untagged VLAN)<br />
+QinQ: Implies 802.1ad Tunneling (QinQ), Service VLAN/TAG is set as untagged VLAN
 """
 
 

--- a/netbox/dcim/forms/models.py
+++ b/netbox/dcim/forms/models.py
@@ -61,7 +61,7 @@ INTERFACE_MODE_HELP_TEXT = """
 Access: One untagged VLAN<br />
 Tagged: One untagged VLAN and/or one or more tagged VLANs<br />
 Tagged (All): Implies all VLANs are available (w/optional untagged VLAN)<br />
-QinQ: Implies 802.1ad Tunneling (QinQ), Service VLAN/TAG is set as untagged VLAN
+Q-in-Q: Implies 802.1ad Tunneling (QinQ), Service VLAN/TAG is set as untagged VLAN
 """
 
 

--- a/netbox/dcim/forms/models.py
+++ b/netbox/dcim/forms/models.py
@@ -61,6 +61,7 @@ INTERFACE_MODE_HELP_TEXT = """
 Access: One untagged VLAN<br />
 Tagged: One untagged VLAN and/or one or more tagged VLANs<br />
 Tagged (All): Implies all VLANs are available (w/optional untagged VLAN)
+Dot1Q Tunnel: Implies 802.1q Tunneling (QinQ), Service VLAN/TAG is set as access VLAN
 """
 
 

--- a/netbox/project-static/src/forms/vlanTags.ts
+++ b/netbox/project-static/src/forms/vlanTags.ts
@@ -125,6 +125,7 @@ function handleModeTaggedAll(): void {
 function handleModeChange(element: HTMLSelectElement): void {
   switch (element.value) {
     case 'access':
+    case 'dot1q-tunnel':
       handleModeAccess();
       break;
     case 'tagged':

--- a/netbox/project-static/src/forms/vlanTags.ts
+++ b/netbox/project-static/src/forms/vlanTags.ts
@@ -125,7 +125,7 @@ function handleModeTaggedAll(): void {
 function handleModeChange(element: HTMLSelectElement): void {
   switch (element.value) {
     case 'access':
-    case 'dot1q-tunnel':
+    case 'q-in-q':
       handleModeAccess();
       break;
     case 'tagged':


### PR DESCRIPTION
### Fixes: 116
Add 802.1ad [Q-in-Q] (https://en.wikipedia.org/wiki/IEEE_802.1ad) to Interface Types
  - The previous feature requests have greatly complicated this. Bare minimum needed is simply the option in InterfaceModeChoices. When an interface is in the q-in-q mode. As far as Netbox is concerned, it's a "special" access port. I'm looking for this field to use for automating switchport configuration. Yes, I can add a custom field, but this is a IEEE 802.x type, it should be an option.

Below is an example of the relevant portions of a port configured for q-in-q (Cisco Catalyst switch, I'm guessing others are similar):

interface GigabitEthernet1/0/11
 switchport access vlan 1000
 switchport mode **dot1q-tunnel**

As opposed to a "tagged" port:

interface TenGigabitEthernet1/1/3
 switchport trunk native vlan 1001
 switchport mode trunk
 switchport trunk allowed vlan 10,20,30,55-60

Or a "tagged-all" port:

interface TenGigabitEthernet1/1/3
 switchport trunk native vlan 1001
 switchport mode trunk
 switchport trunk allowed vlan all

Or an "access" port:
interface TenGigabitEthernet1/1/4
 switchport trunk native vlan 1002
 switchport mode **access**
