### PR TITLE
Fix #7589: Rename 128gfc-sfp28 to 128gfc-qsfp28

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -760,7 +760,7 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_16GFC_SFP_PLUS = '16gfc-sfpp'
     TYPE_32GFC_SFP28 = '32gfc-sfp28'
     TYPE_64GFC_QSFP_PLUS = '64gfc-qsfpp'
-    TYPE_128GFC_QSFP28 = '128gfc-sfp28'
+    TYPE_128GFC_QSFP28 = '128gfc-qsfp28'
 
     # InfiniBand
     TYPE_INFINIBAND_SDR = 'infiniband-sdr'


### PR DESCRIPTION
### Fixes: #7589
Renames 128gfc-sfp28 to 128gfc-qsfp28, this because QSFP28 is the right name for the optic type. 