### PR TITLE
Fix #7399: LDAP excessive CPU usage when AUTH_LDAP_FIND_GROUP_PERMS is enabled

### DIFF
--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -34,7 +34,7 @@ class ObjectPermissionMixin():
         object_permissions = ObjectPermission.objects.filter(
             self.get_permission_filter(user_obj),
             enabled=True
-        ).prefetch_related('object_types')
+        ).order_by('id').distinct('id').prefetch_related('object_types')
 
         # Create a dictionary mapping permissions to their constraints
         perms = defaultdict(list)


### PR DESCRIPTION
### Fixes: #7399

This should fix the excessive CPU usage when enabling AUTH_LDAP_FIND_GROUP_PERMS and having a combination of many object permissions and many users in the same group.

First, this is not an optimal fix, feel free to close the PR if a better fix is suggested. The reason for the bad performance is the filter added in 82300990ec79f8ce6b2fca953d5548028a14aaea:

https://github.com/netbox-community/netbox/blob/82300990ec79f8ce6b2fca953d5548028a14aaea/netbox/netbox/authentication.py#L174-L180

When added to the original query:

https://github.com/netbox-community/netbox/blob/82300990ec79f8ce6b2fca953d5548028a14aaea/netbox/netbox/authentication.py#L23-L34

The resulting SQL is essentially:

```sql
SELECT "users_objectpermission".*
FROM "users_objectpermission"
LEFT OUTER JOIN "users_objectpermission_users" ON ("users_objectpermission"."id" = "users_objectpermission_users"."objectpermission_id")
LEFT OUTER JOIN "users_objectpermission_groups" ON ("users_objectpermission"."id" = "users_objectpermission_groups"."objectpermission_id")
LEFT OUTER JOIN "auth_group" ON ("users_objectpermission_groups"."group_id" = "auth_group"."id")
LEFT OUTER JOIN "auth_user_groups" ON ("auth_group"."id" = "auth_user_groups"."group_id")
WHERE (("users_objectpermission_users"."user_id" = 1
        OR "auth_user_groups"."user_id" = 1
        OR "auth_group"."name" IN (
                                   'netbox-user',
                                   'group1',
                                   'group2'
                                   ))
       AND "users_objectpermission"."enabled")
ORDER BY "users_objectpermission"."name" ASC;
```

The outer join for auth_user_group essentially duplicates each users_objectpermission row once for each other user that is allocated to one of the groups not filtered out in the auth_group join.

In my test instance, with 327 objectpermissions in the netbox-user group, 30 other users has that same group, which makes the query return 30 duplicates per objectpermission totalling 9810 permissionobjects. The fix caused a load of the rack page with 50 objects per page to decrease from 1400 ms to 600 ms.

I'm not sure how to fix it in a smart way, as I have a hard time seing how the relationship is supposed to work. Even the original query is iffy I think, as I'm pretty sure it can return duplicate permissions as well if user bound objectpermissions are used.

The fix just makes the postgres remove the duplicates, which fixes the performance regression when using AUTH_LDAP_FIND_GROUP_PERMS. The query time increase should be negligible even in extreme cases.

Still someone should probably rework the queries.

Note: While the fix is pretty straightforward and I can't see how it could mess anything up, I would appreciate if someone else could test it before deciding to merge.