### PR TITLE
Closes #7679: Add action button column to sites table

### DIFF
--- a/netbox/dcim/tables/sites.py
+++ b/netbox/dcim/tables/sites.py
@@ -80,15 +80,18 @@ class SiteTable(BaseTable):
     tags = TagColumn(
         url_name='dcim:site_list'
     )
+    actions = ButtonsColumn(
+        model=Site
+    )
 
     class Meta(BaseTable.Meta):
         model = Site
         fields = (
             'pk', 'name', 'slug', 'status', 'facility', 'region', 'group', 'tenant', 'asn', 'time_zone', 'description',
             'physical_address', 'shipping_address', 'latitude', 'longitude', 'contact_name', 'contact_phone',
-            'contact_email', 'comments', 'tags',
+            'contact_email', 'comments', 'tags', 'actions'
         )
-        default_columns = ('pk', 'name', 'status', 'facility', 'region', 'group', 'tenant', 'asn', 'description')
+        default_columns = ('pk', 'name', 'status', 'facility', 'region', 'group', 'tenant', 'asn', 'description', 'actions')
 
 
 #


### PR DESCRIPTION

### Closes: #7679 
Adds the action buttons column (edit, delete, changelog) to the sites table.

![image](https://user-images.githubusercontent.com/3577982/139335696-627b017d-583a-42a4-a2a7-3e80d43ae574.png)

