### PR TITLE
Fix #7685: Doc image links

### DIFF
--- a/docs/core-functionality/power.md
+++ b/docs/core-functionality/power.md
@@ -5,4 +5,4 @@
 
 # Example Power Topology
 
-![Power distribution model](/media/power_distribution.png)
+![Power distribution model](../media/power_distribution.png)

--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -240,7 +240,7 @@ An IPv4 or IPv6 network with a mask. Returns a `netaddr.IPNetwork` object. Two a
 !!! note
     To run a custom script, a user must be assigned the `extras.run_script` permission. This is achieved by assigning the user (or group) a permission on the Script object and specifying the `run` action in the admin UI as shown below.
 
-    ![Adding the run action to a permission](/media/admin_ui_run_permission.png)
+    ![Adding the run action to a permission](../media/admin_ui_run_permission.png)
 
 ### Via the Web UI
 

--- a/docs/models/dcim/cable.md
+++ b/docs/models/dcim/cable.md
@@ -25,7 +25,7 @@ A cable may be traced from either of its endpoints by clicking the "trace" butto
 
 In the example below, three individual cables comprise a path between devices A and D:
 
-![Cable path](/media/models/dcim_cable_trace.png)
+![Cable path](../media/models/dcim_cable_trace.png)
 
 Traced from Interface 1 on Device A, NetBox will show the following path:
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #7685
<!--
    Please include a summary of the proposed changes below.
-->

Several image links pointed to `/media/` and were broken. Add `../` in front of the link as other media URLs in the docs. Tried to catch all the broken images, hopefully I got them all.

The GitHub web was used to create this patch so I hope it is OK to squash on merge since the web UI cannot squash otherwise.