### PR TITLE
Change big auto int to string in the API

### DIFF
--- a/netbox/netbox/api/serializers.py
+++ b/netbox/netbox/api/serializers.py
@@ -151,7 +151,7 @@ class OrganizationalModelSerializer(CustomFieldModelSerializer):
     """
     Adds support for custom fields.
     """
-    pass
+    id = serializers.CharField()
 
 
 class PrimaryModelSerializer(CustomFieldModelSerializer):


### PR DESCRIPTION
When dealing with large row IDs such as those generated by cockroachDB, the JS floating point implementation can alter IDs returned from the API when parsing JSON. This results in nonexistent rows being queried.

As can be seen below the ID in JSON and the ID in JS do not match up.
```javascript
let data = JSON.parse('{"count":1,"next":null,"previous":null,"results":[{"id":707372639259361282,"url":"http://nb.as207960.net/api/ipam/rirs/707372639259361282/","display":"RIPE","name":"RIPE","slug":"ripe","aggregate_count":1}]}');
undefined
// data.results[0].id
707372639259361300
```

This PR changes the return type of the API from an int to a string, so as to avoid this error.
