### PR TITLE
Fixes: #6925 Interfaces Table - bring back the visual aids from v2.9

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -53,6 +53,16 @@ def get_cabletermination_row_class(record):
     return ''
 
 
+def get_interface_row_class(record):
+    if not record.enabled:
+        return 'danger'
+    elif not record.is_connectable:
+        return 'primary'
+    else:
+        return get_cabletermination_row_class(record)
+    return ''
+
+
 def get_interface_state_attribute(record):
     """
     Get interface enabled state as string to attach to <tr/> DOM element.
@@ -534,7 +544,7 @@ class DeviceInterfaceTable(InterfaceTable):
             'cable', 'connection', 'actions',
         )
         row_attrs = {
-            'class': get_cabletermination_row_class,
+            'class': get_interface_row_class,
             'data-name': lambda record: record.name,
             'data-enabled': get_interface_state_attribute,
         }

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -501,8 +501,8 @@ class InterfaceTable(DeviceComponentTable, BaseInterfaceTable, PathEndpointTable
 
 class DeviceInterfaceTable(InterfaceTable):
     name = tables.TemplateColumn(
-        template_code='<i class="mdi mdi-{% if iface.mgmt_only %}wrench{% elif iface.is_lag %}drag-horizontal-variant'
-                      '{% elif iface.is_virtual %}circle{% elif iface.is_wireless %}wifi{% else %}ethernet'
+        template_code='<i class="mdi mdi-{% if record.mgmt_only %}wrench{% elif record.is_lag %}reorder-horizontal'
+                      '{% elif record.is_virtual %}circle{% elif record.is_wireless %}wifi{% else %}ethernet'
                       '{% endif %}"></i> <a href="{{ record.get_absolute_url }}">{{ value }}</a>',
         order_by=Accessor('_name'),
         attrs={'td': {'class': 'text-nowrap'}}

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -56,11 +56,9 @@ def get_cabletermination_row_class(record):
 def get_interface_row_class(record):
     if not record.enabled:
         return 'danger'
-    elif not record.is_connectable:
+    elif record.is_virtual:
         return 'primary'
-    else:
-        return get_cabletermination_row_class(record)
-    return ''
+    return get_cabletermination_row_class(record)
 
 
 def get_interface_state_attribute(record):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #6925 Interfaces Table - bring back the visual aids from v2.9
<!--
    Please include a summary of the proposed changes below.
-->
Reduce the need of the columns "Management Only", "Enabled" and "Type" on the Interfaces table by adding some visual aids that were used on past versions (v2.9).

1. Virtual Interfaces are distinguished by row color "primary ".
2. Disabled Interfaces are distinguished by row color "danger".
3. Keep Connected Interfaces distinguished by row color "success".
4. Interface type distinguished by different icons before the interface name:
   - Management Only: wrench
   - LAG: reorder-horizontal
   - Virtual: circle
   - Wireless: wifi
   - Others: ethernet