### PR TITLE
Fixes: #7740 Add Mini-DIN 8 Console-Port-Type

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -185,6 +185,7 @@ class ConsolePortTypeChoices(ChoiceSet):
     TYPE_RJ11 = 'rj-11'
     TYPE_RJ12 = 'rj-12'
     TYPE_RJ45 = 'rj-45'
+    TYPE_MINI_DIN_8 = 'mini-din-8'
     TYPE_USB_A = 'usb-a'
     TYPE_USB_B = 'usb-b'
     TYPE_USB_C = 'usb-c'
@@ -202,6 +203,7 @@ class ConsolePortTypeChoices(ChoiceSet):
             (TYPE_RJ11, 'RJ-11'),
             (TYPE_RJ12, 'RJ-12'),
             (TYPE_RJ45, 'RJ-45'),
+            (TYPE_MINI_DIN_8, 'Mini-DIN 8'),
         )),
         ('USB', (
             (TYPE_USB_A, 'USB Type A'),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #7740 
<!--
    Please include a summary of the proposed changes below.
-->

Adds the Mini-DIN 8 Connector to the Console-Port-Types