### PR TITLE
Fixes #7783 - Site location visual changes

### DIFF
--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -219,8 +219,8 @@
                     </tr>
                     {% for location in locations %}
                         <tr>
-                            <td style="padding-left: {{ location.level }}8px">
-                                <i class="mdi mdi-folder-open"></i>
+                            <td>
+                                {% for i in location.level|as_range %}<i class="mdi mdi-circle-small"></i>{% endfor %}
                                 <a href="{{ location.get_absolute_url }}">{{ location }}</a>
                             </td>
                             <td>


### PR DESCRIPTION
### Fixes: #7783 
Updating site location list to visually match the /dcim/locations list where child locations are "indented" with mdi-circle-small.

Also removes the padding-left attribute on each row as it is no longer functional.