### PR TITLE
Fix #7803: Clear sys.modules cache when reloading scripts

### DIFF
--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import pkgutil
+import sys
 import traceback
 from collections import OrderedDict
 
@@ -477,6 +478,10 @@ def get_scripts(use_names=False):
     # Iterate through all modules within the reports path. These are the user-created files in which reports are
     # defined.
     for importer, module_name, _ in pkgutil.iter_modules([settings.SCRIPTS_ROOT]):
+        # Remove cached module to ensure consistency with filesystem
+        if module_name in sys.modules:
+            del sys.modules[module_name]
+
         module = importer.find_module(module_name).load_module(module_name)
         if use_names and hasattr(module, 'name'):
             module_name = module.name


### PR DESCRIPTION
### Fixes: #7803

The PR clears the sys.modules entry for the script classes we are trying to load, allowing modification and removal of class names without restarting the application server.

I tested all scenarios I could think of and calling scripts from both the web ui and the API. There might be a slight performance penalty, but it should be very minor.