### PR TITLE
Fix #7729: Fix context of VLAN table in VLAN Group view

### DIFF
--- a/netbox/templates/ipam/vlangroup.html
+++ b/netbox/templates/ipam/vlangroup.html
@@ -1,6 +1,7 @@
 {% extends 'generic/object.html' %}
 {% load helpers %}
 {% load plugins %}
+{% load render_table from django_tables2 %}
 
 {% block breadcrumbs %}
   {{ block.super }}
@@ -68,7 +69,7 @@
         VLANs
       </h5>
       <div class="card-body">
-        {% include 'inc/table.html' with table=vlans_table %}
+        {% render_table vlans_table 'inc/table.html' %}
       </div>
       {% if perms.ipam.add_vlan %}
         <div class="card-footer text-end noprint">


### PR DESCRIPTION
### Fixes: #7729

Using the `render_table` tag attaches the calling template's context to the table object, thus allowing the `vid` `TemplateColumn` to properly evaluate the `perms.ipam.add_vlan` check. 

https://github.com/netbox-community/netbox/blob/98cc36c458e1dd6fbcf140dc271846ececb6e6f1/netbox/ipam/tables/vlans.py#L25-L33

See the note at https://django-tables2.readthedocs.io/en/latest/pages/template-tags.html#render-table