### PR TITLE
Fix #7542: Add VLAN Group column to IP Prefix table

### DIFF
--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -206,6 +206,11 @@ class PrefixTable(BaseTable):
     site = tables.Column(
         linkify=True
     )
+    vlan_group = tables.Column(
+        accessor='vlan__group',
+        linkify=True,
+        verbose_name='VLAN Group'
+    )
     vlan = tables.Column(
         linkify=True,
         verbose_name='VLAN'
@@ -230,8 +235,8 @@ class PrefixTable(BaseTable):
     class Meta(BaseTable.Meta):
         model = Prefix
         fields = (
-            'pk', 'id', 'prefix', 'prefix_flat', 'status', 'children', 'vrf', 'utilization', 'tenant', 'site', 'vlan', 'role',
-            'is_pool', 'mark_utilized', 'description', 'tags',
+            'pk', 'id', 'prefix', 'prefix_flat', 'status', 'children', 'vrf', 'utilization', 'tenant', 'site', 'vlan_group',
+            'vlan', 'role', 'is_pool', 'mark_utilized', 'description', 'tags',
         )
         default_columns = (
             'pk', 'prefix', 'status', 'children', 'vrf', 'utilization', 'tenant', 'site', 'vlan', 'role', 'description',


### PR DESCRIPTION
### Fixes: #7542

Adds a non-default VLAN Group column to the IP Prefix table in order to disambiguate which VLAN instance the prefix is assigned to, particularly when the table is exported.

![image](https://user-images.githubusercontent.com/3577982/141667630-50e66571-31a0-4bd5-85fe-2a9269b940c3.png)
