### PR TITLE
Fixes #7657: Make request/webhook caching thread-safe

### DIFF
--- a/netbox/netbox/__init__.py
+++ b/netbox/netbox/__init__.py
@@ -1,0 +1,3 @@
+import threading
+
+thread_locals = threading.local()

--- a/netbox/netbox/middleware.py
+++ b/netbox/netbox/middleware.py
@@ -1,10 +1,10 @@
+import logging
 import uuid
 from urllib import parse
-import logging
 
 from django.conf import settings
-from django.contrib.auth.middleware import RemoteUserMiddleware as RemoteUserMiddleware_
 from django.contrib import auth
+from django.contrib.auth.middleware import RemoteUserMiddleware as RemoteUserMiddleware_
 from django.core.exceptions import ImproperlyConfigured
 from django.db import ProgrammingError
 from django.http import Http404, HttpResponseRedirect
@@ -114,7 +114,7 @@ class RemoteUserMiddleware(RemoteUserMiddleware_):
         return groups
 
 
-class ObjectChangeMiddleware(object):
+class ObjectChangeMiddleware:
     """
     This middleware performs three functions in response to an object being created, updated, or deleted:
 

--- a/netbox/netbox/request_context.py
+++ b/netbox/netbox/request_context.py
@@ -1,0 +1,9 @@
+from netbox import thread_locals
+
+
+def set_request(request):
+    thread_locals.request = request
+
+
+def get_request():
+    return getattr(thread_locals, 'request', None)

--- a/netbox/utilities/utils.py
+++ b/netbox/utilities/utils.py
@@ -327,13 +327,6 @@ def decode_dict(encoded_dict: Dict, *, decode_keys: bool = True) -> Dict:
     return {urllib.parse.unquote(k): decode_value(v, decode_keys) for k, v in encoded_dict.items()}
 
 
-# Taken from django.utils.functional (<3.0)
-def curry(_curried_func, *args, **kwargs):
-    def _curried(*moreargs, **morekwargs):
-        return _curried_func(*args, *moreargs, **{**kwargs, **morekwargs})
-    return _curried
-
-
 def array_to_string(array):
     """
     Generate an efficient, human-friendly string from a set of integers. Intended for use with ArrayField.


### PR DESCRIPTION
### Fixes: #7657

- Employ thread-local storage for capturing the request object and webhook queue
- Remove currying of these variables into the signal handlers

Initial testing seems to confirm that this resolves the bug without any negative effects, however further testing by other individuals would be greatly appreciated.