### PR TITLE
Fix #7751: LDAP: Only get API user from ldap when FIND_GROUP_PERMS is on

### DIFF
--- a/netbox/netbox/api/authentication.py
+++ b/netbox/netbox/api/authentication.py
@@ -29,10 +29,13 @@ class TokenAuthentication(authentication.TokenAuthentication):
         if settings.REMOTE_AUTH_BACKEND == 'netbox.authentication.LDAPBackend':
             from netbox.authentication import LDAPBackend
             ldap_backend = LDAPBackend()
-            user = ldap_backend.populate_user(token.user.username)
-            # If the user is found in the LDAP directory use it, if not fallback to the local user
-            if user:
-                return user, token
+
+            # Load from LDAP if FIND_GROUP_PERMS is active
+            if ldap_backend.settings.FIND_GROUP_PERMS:
+                user = ldap_backend.populate_user(token.user.username)
+                # If the user is found in the LDAP directory use it, if not fallback to the local user
+                if user:
+                    return user, token
 
         return token.user, token
 


### PR DESCRIPTION
### Fixes: #7751

When using the LDAP backend for auth, all API requests would refresh the user (local or LDAP created) from the LDAP server, causing performance issues. With this fix, the user is only refreshed when FIND_GROUP_PERMS is enabled.

I tested all combinations I could think of. Not sure if this change in logic warrants a warning in the release notes. The changes for different combinations of settings can be seen in the issue: #7751 