### PR TITLE
Fix #6905: Assign existing prefix to VLAN from VLAN view

### DIFF
--- a/netbox/ipam/forms/models.py
+++ b/netbox/ipam/forms/models.py
@@ -7,6 +7,7 @@ from extras.models import Tag
 from ipam.constants import *
 from ipam.models import *
 from tenancy.forms import TenancyForm
+from tenancy.models import Tenant
 from utilities.forms import (
     BootstrapMixin, ContentTypeChoiceField, DatePicker, DynamicModelChoiceField, DynamicModelMultipleChoiceField,
     NumericArrayField, SlugField, StaticSelect, StaticSelectMultiple,
@@ -208,7 +209,12 @@ class PrefixAssignForm(BootstrapMixin, forms.Form):
     site_id = DynamicModelChoiceField(
         queryset=Site.objects.all(),
         required=False,
-        label='Site'
+        label='Site',
+    )
+    tenant_id = DynamicModelChoiceField(
+        queryset=Tenant.objects.all(),
+        required=False,
+        label='Tenant',
     )
     vrf_id = DynamicModelChoiceField(
         queryset=VRF.objects.all(),

--- a/netbox/ipam/forms/models.py
+++ b/netbox/ipam/forms/models.py
@@ -20,6 +20,7 @@ __all__ = (
     'IPAddressForm',
     'IPRangeForm',
     'PrefixForm',
+    'PrefixAssignForm',
     'RIRForm',
     'RoleForm',
     'RouteTargetForm',
@@ -201,6 +202,23 @@ class PrefixForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):
         widgets = {
             'status': StaticSelect(),
         }
+
+
+class PrefixAssignForm(BootstrapMixin, forms.Form):
+    site_id = DynamicModelChoiceField(
+        queryset=Site.objects.all(),
+        required=False,
+        label='Site'
+    )
+    vrf_id = DynamicModelChoiceField(
+        queryset=VRF.objects.all(),
+        required=False,
+        label='VRF'
+    )
+    q = forms.CharField(
+        required=False,
+        label='Search',
+    )
 
 
 class IPRangeForm(BootstrapMixin, TenancyForm, CustomFieldModelForm):

--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -16,6 +16,7 @@ __all__ = (
     'IPAddressTable',
     'IPRangeTable',
     'PrefixTable',
+    'PrefixAssignTable',
     'RIRTable',
     'RoleTable',
 )
@@ -41,6 +42,10 @@ PREFIXFLAT_LINK = """
 {% else %}
     {{ record.prefix }}
 {% endif %}
+"""
+
+PREFIX_ASSIGN_LINK = """
+<a href="{% url 'ipam:prefix_edit' pk=record.pk %}?{% if request.GET.vlan %}vlan={{ request.GET.vlan }}{% endif %}&return_url={{ request.GET.return_url }}">{{ record }}</a>
 """
 
 IPADDRESS_LINK = """
@@ -244,6 +249,23 @@ class PrefixTable(BaseTable):
         row_attrs = {
             'class': lambda record: 'success' if not record.pk else '',
         }
+
+
+class PrefixAssignTable(BaseTable):
+    prefix = tables.TemplateColumn(
+        template_code=PREFIX_ASSIGN_LINK,
+        verbose_name='Prefix'
+    )
+    status = ChoiceFieldColumn()
+    is_pool = BooleanColumn(
+        verbose_name='Pool'
+    )
+
+    class Meta(BaseTable.Meta):
+        model = Prefix
+        fields = ('prefix', 'site', 'vrf', 'tenant', 'status', 'role', 'vlan', 'is_pool', 'description')
+        exclude = ('id', )
+        orderable = False
 
 
 #

--- a/netbox/ipam/urls.py
+++ b/netbox/ipam/urls.py
@@ -71,6 +71,7 @@ urlpatterns = [
     path('prefixes/import/', views.PrefixBulkImportView.as_view(), name='prefix_import'),
     path('prefixes/edit/', views.PrefixBulkEditView.as_view(), name='prefix_bulk_edit'),
     path('prefixes/delete/', views.PrefixBulkDeleteView.as_view(), name='prefix_bulk_delete'),
+    path('prefixes/assign/', views.PrefixAssignView.as_view(), name='prefix_assign'),
     path('prefixes/<int:pk>/', views.PrefixView.as_view(), name='prefix'),
     path('prefixes/<int:pk>/edit/', views.PrefixEditView.as_view(), name='prefix_edit'),
     path('prefixes/<int:pk>/delete/', views.PrefixDeleteView.as_view(), name='prefix_delete'),

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -6,7 +6,7 @@ from dcim.models import Device, Interface
 from netbox.views import generic
 from utilities.forms import TableConfigForm
 from utilities.tables import paginate_table
-from utilities.utils import count_related
+from utilities.utils import count_related, normalize_querydict
 from virtualization.models import VirtualMachine, VMInterface
 from . import filtersets, forms, tables
 from .constants import *
@@ -503,6 +503,7 @@ class PrefixAssignView(generic.ObjectView):
     Search for Prefixes to assign to a VLAN
     """
     queryset = Prefix.objects.all()
+    template_name = 'ipam/prefix_assign.html'
 
     def dispatch(self, request, *args, **kwargs):
 
@@ -513,9 +514,15 @@ class PrefixAssignView(generic.ObjectView):
         return super().dispatch(request, *args, **kwargs)
 
     def get(self, request):
-        form = forms.PrefixAssignForm()
+        url_params = normalize_querydict(request.GET)
+        initial_data = {}
+        if 'site' in url_params:
+            initial_data['site_id'] = url_params['site']
+        if 'tenant' in url_params:
+            initial_data['tenant_id'] = url_params['tenant']
+        form = forms.PrefixAssignForm(initial=initial_data)
 
-        return render(request, 'ipam/prefix_assign.html', {
+        return render(request, self.template_name, {
             'form': form,
             'return_url': request.GET.get('return_url', ''),
         })

--- a/netbox/templates/ipam/inc/prefix_edit_header.html
+++ b/netbox/templates/ipam/inc/prefix_edit_header.html
@@ -1,0 +1,22 @@
+{% load helpers %}
+
+<ul class="nav nav-tabs px-3">
+  <li class="nav-item">
+      <a
+          class="nav-link {% if active_tab == 'add' %}active{% endif %}"
+          href="{% url 'ipam:prefix_add' %}{% querystring request %}"
+      >
+          {% if obj.pk %}Edit{% else %}Create{% endif %}
+      </a>
+  </li>
+  {% if 'vlan' in request.GET %}
+  <li class="nav-item">
+      <a
+          class="nav-link {% if active_tab == 'assign' %}active{% endif %}"
+          href="{% url 'ipam:prefix_assign' %}{% querystring request %}"
+      >
+          Assign Prefix
+      </a>
+  </li>
+  {% endif %}
+</ul>

--- a/netbox/templates/ipam/prefix_assign.html
+++ b/netbox/templates/ipam/prefix_assign.html
@@ -20,6 +20,7 @@
                 <div class="field-group">
                     <h6>Select Prefix</h6>
                     {% render_field form.site_id %}
+                    {% render_field form.tenant_id %}
                     {% render_field form.vrf_id %}
                     {% render_field form.q %}
                 </div>

--- a/netbox/templates/ipam/prefix_assign.html
+++ b/netbox/templates/ipam/prefix_assign.html
@@ -1,0 +1,46 @@
+{% extends 'generic/object_edit.html' %}
+{% load static %}
+{% load form_helpers %}
+{% load helpers %}
+
+{% block title %}Assign a Prefix{% endblock title %}
+
+{% block tabs %}
+  {% include 'ipam/inc/prefix_edit_header.html' with active_tab='assign' %}
+{% endblock %}
+
+{% block form %}
+    <form action="{% querystring request %}" method="post" class="form form-horizontal">
+        {% csrf_token %}
+        {% for field in form.hidden_fields %}
+            {{ field }}
+        {% endfor %}
+        <div class="row mb-3">
+            <div class="col col-md-8 offset-md-2">
+                <div class="field-group">
+                    <h6>Select Prefix</h6>
+                    {% render_field form.site_id %}
+                    {% render_field form.vrf_id %}
+                    {% render_field form.q %}
+                </div>
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col col-md-8 offset-md-2 text-end">
+                <a href="{{ return_url }}" class="btn btn-outline-danger">Cancel</a>
+                <button type="submit" class="btn btn-primary">Search</button>
+            </div>
+        </div>
+    </form>
+    {% if table %}
+        <div class="row mb-3">
+            <div class="col col-md-12">
+                <h3>Search Results</h3>
+                {% include 'utilities/obj_table.html' %}
+            </div>
+        </div>
+    {% endif %}
+{% endblock form %}
+
+{% block buttons %}
+{% endblock buttons%}

--- a/netbox/templates/ipam/prefix_edit.html
+++ b/netbox/templates/ipam/prefix_edit.html
@@ -1,0 +1,8 @@
+{% extends 'generic/object_edit.html' %}
+{% load static %}
+{% load form_helpers %}
+{% load helpers %}
+
+{% block tabs %}
+  {% include 'ipam/inc/prefix_edit_header.html' with active_tab='add' %}
+{% endblock tabs %}


### PR DESCRIPTION
### Fixes: #6905

Adds a prefix assign form, mimicking the IP address assign form from the Interface view. This allows the end user to view a VLAN and assign an existing prefix, instead of only creating a new prefix.

Adds PrefixAssign form, table, view, url, and template.
Adds prefix_edit_header.html, used by prefix_assign.html and prefix_edit.html