### PR TITLE
Fixes #7885: Linkify VLAN name in VLAN tables

### DIFF
--- a/netbox/ipam/tables/vlans.py
+++ b/netbox/ipam/tables/vlans.py
@@ -95,6 +95,9 @@ class VLANTable(BaseTable):
         template_code=VLAN_LINK,
         verbose_name='VID'
     )
+    name = tables.Column(
+        linkify=True
+    )
     site = tables.Column(
         linkify=True
     )


### PR DESCRIPTION
### Fixes: #7885

Makes the VLAN name clickable in VLAN tables, rather than just the VID.
