### PR TITLE
Fixes #7003: Order image attachments by newest uploaded

### DIFF
--- a/netbox/templates/inc/image_attachments_panel.html
+++ b/netbox/templates/inc/image_attachments_panel.html
@@ -14,7 +14,7 @@
             <th>Created</th>
             <th></th>
           </tr>
-          {% for attachment in images %}
+          {% for attachment in images|dictsortreversed:"created" %}
             <tr{% if not attachment.size %} class="table-danger"{% endif %}>
               <td>
                 <i class="mdi mdi-file-image-outline"></i>


### PR DESCRIPTION
### Fixes: #7003 

Sorts images by date added, so that the most recent images are displayed first.
This might be better implemented by changing the models Meta ordering from `ordering = ('name', 'pk')`  to `ordering = ('created', 'name', 'pk')`, but that triggers a database migration.