### PR TITLE
feat: add 6GHz & 60Ghz channels

### DIFF
--- a/netbox/wireless/choices.py
+++ b/netbox/wireless/choices.py
@@ -86,115 +86,115 @@ class WirelessChannelChoices(ChoiceSet):
     
     # 6 GHz
     CHANNEL_6G_1 = '6g-1-5955-20'
-    CHANNEL_6G_3 = '6g-3-5975-40'
+    CHANNEL_6G_3 = '6g-3-5965-40'
     CHANNEL_6G_5 = '6g-5-5975-20'
-    CHANNEL_6G_7 = '6g-7-6015-80'
+    CHANNEL_6G_7 = '6g-7-5985-80'
     CHANNEL_6G_9 = '6g-9-5995-20'
-    CHANNEL_6G_11 = '6g-11-6015-40'
+    CHANNEL_6G_11 = '6g-11-6005-40'
     CHANNEL_6G_13 = '6g-13-6015-20'
-    CHANNEL_6G_15 = '6g-15-6095-160'
+    CHANNEL_6G_15 = '6g-15-6025-160'
     CHANNEL_6G_17 = '6g-17-6035-20'
-    CHANNEL_6G_19 = '6g-19-6055-40'
+    CHANNEL_6G_19 = '6g-19-6045-40'
     CHANNEL_6G_21 = '6g-21-6055-20'
-    CHANNEL_6G_23 = '6g-23-6095-80'
+    CHANNEL_6G_23 = '6g-23-6065-80'
     CHANNEL_6G_25 = '6g-25-6075-20'
-    CHANNEL_6G_28 = '6g-28-6100-40'
+    CHANNEL_6G_27 = '6g-27-6085-40'
     CHANNEL_6G_29 = '6g-29-6095-20'
-    CHANNEL_6G_31 = '6g-31-6255-320'
+    CHANNEL_6G_31 = '6g-31-6105-320'
     CHANNEL_6G_33 = '6g-33-6115-20'
-    CHANNEL_6G_36 = '6g-36-6140-40'
+    CHANNEL_6G_35 = '6g-35-6125-40'
     CHANNEL_6G_37 = '6g-37-6135-20'
-    CHANNEL_6G_39 = '6g-39-6175-80'
+    CHANNEL_6G_39 = '6g-39-6145-80'
     CHANNEL_6G_41 = '6g-41-6155-20'
-    CHANNEL_6G_44 = '6g-44-6180-40'
+    CHANNEL_6G_43 = '6g-43-6165-40'
     CHANNEL_6G_45 = '6g-45-6175-20'
-    CHANNEL_6G_47 = '6g-47-6255-160'
+    CHANNEL_6G_47 = '6g-47-6185-160'
     CHANNEL_6G_49 = '6g-49-6195-20'
-    CHANNEL_6G_52 = '6g-52-6220-40'
+    CHANNEL_6G_51 = '6g-51-6205-40'
     CHANNEL_6G_53 = '6g-53-6215-20'
-    CHANNEL_6G_55 = '6g-55-6255-80'
+    CHANNEL_6G_55 = '6g-55-6225-80'
     CHANNEL_6G_57 = '6g-57-6235-20'
-    CHANNEL_6G_60 = '6g-60-6260-40'
+    CHANNEL_6G_59 = '6g-59-6245-40'
     CHANNEL_6G_61 = '6g-61-6255-20'
     CHANNEL_6G_65 = '6g-65-6275-20'
-    CHANNEL_6G_68 = '6g-68-6300-40'
+    CHANNEL_6G_67 = '6g-67-6285-40'
     CHANNEL_6G_69 = '6g-69-6295-20'
-    CHANNEL_6G_71 = '6g-71-6335-80'
+    CHANNEL_6G_71 = '6g-71-6305-80'
     CHANNEL_6G_73 = '6g-73-6315-20'
-    CHANNEL_6G_76 = '6g-76-6340-40'
+    CHANNEL_6G_75 = '6g-75-6325-40'
     CHANNEL_6G_77 = '6g-77-6335-20'
-    CHANNEL_6G_79 = '6g-79-6415-160'
+    CHANNEL_6G_79 = '6g-79-6345-160'
     CHANNEL_6G_81 = '6g-81-6355-20'
-    CHANNEL_6G_84 = '6g-84-6380-40'
+    CHANNEL_6G_83 = '6g-83-6365-40'
     CHANNEL_6G_85 = '6g-85-6375-20'
-    CHANNEL_6G_87 = '6g-87-6415-80'
+    CHANNEL_6G_87 = '6g-87-6385-80'
     CHANNEL_6G_89 = '6g-89-6395-20'
-    CHANNEL_6G_92 = '6g-92-6420-40'
+    CHANNEL_6G_91 = '6g-91-6405-40'
     CHANNEL_6G_93 = '6g-93-6415-20'
-    CHANNEL_6G_95 = '6g-95-6575-320'
+    CHANNEL_6G_95 = '6g-95-6425-320'
     CHANNEL_6G_97 = '6g-97-6435-20'
-    CHANNEL_6G_100 = '6g-100-6460-40'
+    CHANNEL_6G_99 = '6g-99-6445-40'
     CHANNEL_6G_101 = '6g-101-6455-20'
-    CHANNEL_6G_103 = '6g-103-6495-80'
+    CHANNEL_6G_103 = '6g-103-6465-80'
     CHANNEL_6G_105 = '6g-105-6475-20'
-    CHANNEL_6G_108 = '6g-108-6500-40'
+    CHANNEL_6G_107 = '6g-107-6485-40'
     CHANNEL_6G_109 = '6g-109-6495-20'
-    CHANNEL_6G_111 = '6g-111-6575-160'
+    CHANNEL_6G_111 = '6g-111-6505-160'
     CHANNEL_6G_113 = '6g-113-6515-20'
-    CHANNEL_6G_116 = '6g-116-6540-40'
+    CHANNEL_6G_115 = '6g-115-6525-40'
     CHANNEL_6G_117 = '6g-117-6535-20'
-    CHANNEL_6G_119 = '6g-119-6575-80'
+    CHANNEL_6G_119 = '6g-119-6545-80'
     CHANNEL_6G_121 = '6g-121-6555-20'
-    CHANNEL_6G_124 = '6g-124-6580-40'
+    CHANNEL_6G_123 = '6g-123-6565-40'
     CHANNEL_6G_125 = '6g-125-6575-20'
     CHANNEL_6G_129 = '6g-129-6595-20'
-    CHANNEL_6G_132 = '6g-132-6620-40'
+    CHANNEL_6G_131 = '6g-131-6605-40'
     CHANNEL_6G_133 = '6g-133-6615-20'
-    CHANNEL_6G_135 = '6g-135-6655-80'
+    CHANNEL_6G_135 = '6g-135-6625-80'
     CHANNEL_6G_137 = '6g-137-6635-20'
-    CHANNEL_6G_140 = '6g-140-6660-40'
+    CHANNEL_6G_139 = '6g-139-6645-40'
     CHANNEL_6G_141 = '6g-141-6655-20'
-    CHANNEL_6G_143 = '6g-143-6735-160'
+    CHANNEL_6G_143 = '6g-143-6665-160'
     CHANNEL_6G_145 = '6g-145-6675-20'
-    CHANNEL_6G_148 = '6g-148-6700-40'
+    CHANNEL_6G_147 = '6g-147-6685-40'
     CHANNEL_6G_149 = '6g-149-6695-20'
-    CHANNEL_6G_151 = '6g-151-6735-80'
+    CHANNEL_6G_151 = '6g-151-6705-80'
     CHANNEL_6G_153 = '6g-153-6715-20'
-    CHANNEL_6G_156 = '6g-156-6740-40'
+    CHANNEL_6G_155 = '6g-155-6725-40'
     CHANNEL_6G_157 = '6g-157-6735-20'
-    CHANNEL_6G_159 = '6g-159-6895-320'
+    CHANNEL_6G_159 = '6g-159-6745-320'
     CHANNEL_6G_161 = '6g-161-6755-20'
-    CHANNEL_6G_164 = '6g-164-6780-40'
+    CHANNEL_6G_163 = '6g-163-6765-40'
     CHANNEL_6G_165 = '6g-165-6775-20'
-    CHANNEL_6G_167 = '6g-167-6815-80'
+    CHANNEL_6G_167 = '6g-167-6785-80'
     CHANNEL_6G_169 = '6g-169-6795-20'
-    CHANNEL_6G_172 = '6g-172-6820-40'
+    CHANNEL_6G_171 = '6g-171-6805-40'
     CHANNEL_6G_173 = '6g-173-6815-20'
-    CHANNEL_6G_175 = '6g-175-6895-160'
+    CHANNEL_6G_175 = '6g-175-6825-160'
     CHANNEL_6G_177 = '6g-177-6835-20'
-    CHANNEL_6G_180 = '6g-180-6860-40'
+    CHANNEL_6G_179 = '6g-179-6845-40'
     CHANNEL_6G_181 = '6g-181-6855-20'
-    CHANNEL_6G_183 = '6g-183-6895-80'
+    CHANNEL_6G_183 = '6g-183-6865-80'
     CHANNEL_6G_185 = '6g-185-6875-20'
-    CHANNEL_6G_188 = '6g-188-6900-40'
+    CHANNEL_6G_187 = '6g-187-6885-40'
     CHANNEL_6G_189 = '6g-189-6895-20'
     CHANNEL_6G_193 = '6g-193-6915-20'
-    CHANNEL_6G_196 = '6g-196-6940-40'
+    CHANNEL_6G_195 = '6g-195-6925-40'
     CHANNEL_6G_197 = '6g-197-6935-20'
-    CHANNEL_6G_199 = '6g-199-6975-80'
+    CHANNEL_6G_199 = '6g-199-6945-80'
     CHANNEL_6G_201 = '6g-201-6955-20'
-    CHANNEL_6G_204 = '6g-204-6980-40'
+    CHANNEL_6G_203 = '6g-203-6965-40'
     CHANNEL_6G_205 = '6g-205-6975-20'
-    CHANNEL_6G_207 = '6g-207-7055-160'
+    CHANNEL_6G_207 = '6g-207-6985-160'
     CHANNEL_6G_209 = '6g-209-6995-20'
-    CHANNEL_6G_212 = '6g-212-7020-40'
+    CHANNEL_6G_211 = '6g-211-7005-40'
     CHANNEL_6G_213 = '6g-213-7015-20'
-    CHANNEL_6G_215 = '6g-215-7055-80'
+    CHANNEL_6G_215 = '6g-215-7025-80'
     CHANNEL_6G_217 = '6g-217-7035-20'
-    CHANNEL_6G_220 = '6g-220-7060-40'
+    CHANNEL_6G_219 = '6g-219-7045-40'
     CHANNEL_6G_221 = '6g-221-7055-20'
     CHANNEL_6G_225 = '6g-225-7075-20'
-    CHANNEL_6G_228 = '6g-228-7100-40'
+    CHANNEL_6G_227 = '6g-227-7085-40'
     CHANNEL_6G_229 = '6g-229-7095-20'
     CHANNEL_6G_233 = '6g-233-7115-20'
 
@@ -300,115 +300,115 @@ class WirelessChannelChoices(ChoiceSet):
             '6 GHz (802.11ax)',
             (
                 (CHANNEL_6G_1, '1 (5955/20 MHz)'),
-                (CHANNEL_6G_3, '3 (5975/40 MHz)'),
+                (CHANNEL_6G_3, '3 (5965/40 MHz)'),
                 (CHANNEL_6G_5, '5 (5975/20 MHz)'),
-                (CHANNEL_6G_7, '7 (6015/80 MHz)'),
+                (CHANNEL_6G_7, '7 (5985/80 MHz)'),
                 (CHANNEL_6G_9, '9 (5995/20 MHz)'),
-                (CHANNEL_6G_11, '11 (6015/40 MHz)'),
+                (CHANNEL_6G_11, '11 (6005/40 MHz)'),
                 (CHANNEL_6G_13, '13 (6015/20 MHz)'),
-                (CHANNEL_6G_15, '15 (6095/160 MHz)'),
+                (CHANNEL_6G_15, '15 (6025/160 MHz)'),
                 (CHANNEL_6G_17, '17 (6035/20 MHz)'),
-                (CHANNEL_6G_19, '19 (6055/40 MHz)'),
+                (CHANNEL_6G_19, '19 (6045/40 MHz)'),
                 (CHANNEL_6G_21, '21 (6055/20 MHz)'),
-                (CHANNEL_6G_23, '23 (6095/80 MHz)'),
+                (CHANNEL_6G_23, '23 (6065/80 MHz)'),
                 (CHANNEL_6G_25, '25 (6075/20 MHz)'),
-                (CHANNEL_6G_28, '28 (6100/40 MHz)'),
+                (CHANNEL_6G_27, '27 (6085/40 MHz)'),
                 (CHANNEL_6G_29, '29 (6095/20 MHz)'),
-                (CHANNEL_6G_31, '31 (6255/320 MHz)'),
+                (CHANNEL_6G_31, '31 (6105/320 MHz)'),
                 (CHANNEL_6G_33, '33 (6115/20 MHz)'),
-                (CHANNEL_6G_36, '36 (6140/40 MHz)'),
+                (CHANNEL_6G_35, '35 (6125/40 MHz)'),
                 (CHANNEL_6G_37, '37 (6135/20 MHz)'),
-                (CHANNEL_6G_39, '39 (6175/80 MHz)'),
+                (CHANNEL_6G_39, '39 (6145/80 MHz)'),
                 (CHANNEL_6G_41, '41 (6155/20 MHz)'),
-                (CHANNEL_6G_44, '44 (6180/40 MHz)'),
+                (CHANNEL_6G_43, '43 (6165/40 MHz)'),
                 (CHANNEL_6G_45, '45 (6175/20 MHz)'),
-                (CHANNEL_6G_47, '47 (6255/160 MHz)'),
+                (CHANNEL_6G_47, '47 (6185/160 MHz)'),
                 (CHANNEL_6G_49, '49 (6195/20 MHz)'),
-                (CHANNEL_6G_52, '52 (6220/40 MHz)'),
+                (CHANNEL_6G_51, '51 (6205/40 MHz)'),
                 (CHANNEL_6G_53, '53 (6215/20 MHz)'),
-                (CHANNEL_6G_55, '55 (6255/80 MHz)'),
+                (CHANNEL_6G_55, '55 (6225/80 MHz)'),
                 (CHANNEL_6G_57, '57 (6235/20 MHz)'),
-                (CHANNEL_6G_60, '60 (6260/40 MHz)'),
+                (CHANNEL_6G_59, '59 (6245/40 MHz)'),
                 (CHANNEL_6G_61, '61 (6255/20 MHz)'),
                 (CHANNEL_6G_65, '65 (6275/20 MHz)'),
-                (CHANNEL_6G_68, '68 (6300/40 MHz)'),
+                (CHANNEL_6G_67, '67 (6285/40 MHz)'),
                 (CHANNEL_6G_69, '69 (6295/20 MHz)'),
-                (CHANNEL_6G_71, '71 (6335/80 MHz)'),
+                (CHANNEL_6G_71, '71 (6305/80 MHz)'),
                 (CHANNEL_6G_73, '73 (6315/20 MHz)'),
-                (CHANNEL_6G_76, '76 (6340/40 MHz)'),
+                (CHANNEL_6G_75, '75 (6325/40 MHz)'),
                 (CHANNEL_6G_77, '77 (6335/20 MHz)'),
-                (CHANNEL_6G_79, '79 (6415/160 MHz)'),
+                (CHANNEL_6G_79, '79 (6345/160 MHz)'),
                 (CHANNEL_6G_81, '81 (6355/20 MHz)'),
-                (CHANNEL_6G_84, '84 (6380/40 MHz)'),
+                (CHANNEL_6G_83, '83 (6365/40 MHz)'),
                 (CHANNEL_6G_85, '85 (6375/20 MHz)'),
-                (CHANNEL_6G_87, '87 (6415/80 MHz)'),
+                (CHANNEL_6G_87, '87 (6385/80 MHz)'),
                 (CHANNEL_6G_89, '89 (6395/20 MHz)'),
-                (CHANNEL_6G_92, '92 (6420/40 MHz)'),
+                (CHANNEL_6G_91, '91 (6405/40 MHz)'),
                 (CHANNEL_6G_93, '93 (6415/20 MHz)'),
-                (CHANNEL_6G_95, '95 (6575/320 MHz)'),
+                (CHANNEL_6G_95, '95 (6425/320 MHz)'),
                 (CHANNEL_6G_97, '97 (6435/20 MHz)'),
-                (CHANNEL_6G_100, '100 (6460/40 MHz)'),
+                (CHANNEL_6G_99, '99 (6445/40 MHz)'),
                 (CHANNEL_6G_101, '101 (6455/20 MHz)'),
-                (CHANNEL_6G_103, '103 (6495/80 MHz)'),
+                (CHANNEL_6G_103, '103 (6465/80 MHz)'),
                 (CHANNEL_6G_105, '105 (6475/20 MHz)'),
-                (CHANNEL_6G_108, '108 (6500/40 MHz)'),
+                (CHANNEL_6G_107, '107 (6485/40 MHz)'),
                 (CHANNEL_6G_109, '109 (6495/20 MHz)'),
-                (CHANNEL_6G_111, '111 (6575/160 MHz)'),
+                (CHANNEL_6G_111, '111 (6505/160 MHz)'),
                 (CHANNEL_6G_113, '113 (6515/20 MHz)'),
-                (CHANNEL_6G_116, '116 (6540/40 MHz)'),
+                (CHANNEL_6G_115, '115 (6525/40 MHz)'),
                 (CHANNEL_6G_117, '117 (6535/20 MHz)'),
-                (CHANNEL_6G_119, '119 (6575/80 MHz)'),
+                (CHANNEL_6G_119, '119 (6545/80 MHz)'),
                 (CHANNEL_6G_121, '121 (6555/20 MHz)'),
-                (CHANNEL_6G_124, '124 (6580/40 MHz)'),
+                (CHANNEL_6G_123, '123 (6565/40 MHz)'),
                 (CHANNEL_6G_125, '125 (6575/20 MHz)'),
                 (CHANNEL_6G_129, '129 (6595/20 MHz)'),
-                (CHANNEL_6G_132, '132 (6620/40 MHz)'),
+                (CHANNEL_6G_131, '131 (6605/40 MHz)'),
                 (CHANNEL_6G_133, '133 (6615/20 MHz)'),
-                (CHANNEL_6G_135, '135 (6655/80 MHz)'),
+                (CHANNEL_6G_135, '135 (6625/80 MHz)'),
                 (CHANNEL_6G_137, '137 (6635/20 MHz)'),
-                (CHANNEL_6G_140, '140 (6660/40 MHz)'),
+                (CHANNEL_6G_139, '139 (6645/40 MHz)'),
                 (CHANNEL_6G_141, '141 (6655/20 MHz)'),
-                (CHANNEL_6G_143, '143 (6735/160 MHz)'),
+                (CHANNEL_6G_143, '143 (6665/160 MHz)'),
                 (CHANNEL_6G_145, '145 (6675/20 MHz)'),
-                (CHANNEL_6G_148, '148 (6700/40 MHz)'),
+                (CHANNEL_6G_147, '147 (6685/40 MHz)'),
                 (CHANNEL_6G_149, '149 (6695/20 MHz)'),
-                (CHANNEL_6G_151, '151 (6735/80 MHz)'),
+                (CHANNEL_6G_151, '151 (6705/80 MHz)'),
                 (CHANNEL_6G_153, '153 (6715/20 MHz)'),
-                (CHANNEL_6G_156, '156 (6740/40 MHz)'),
+                (CHANNEL_6G_155, '155 (6725/40 MHz)'),
                 (CHANNEL_6G_157, '157 (6735/20 MHz)'),
-                (CHANNEL_6G_159, '159 (6895/320 MHz)'),
+                (CHANNEL_6G_159, '159 (6745/320 MHz)'),
                 (CHANNEL_6G_161, '161 (6755/20 MHz)'),
-                (CHANNEL_6G_164, '164 (6780/40 MHz)'),
+                (CHANNEL_6G_163, '163 (6765/40 MHz)'),
                 (CHANNEL_6G_165, '165 (6775/20 MHz)'),
-                (CHANNEL_6G_167, '167 (6815/80 MHz)'),
+                (CHANNEL_6G_167, '167 (6785/80 MHz)'),
                 (CHANNEL_6G_169, '169 (6795/20 MHz)'),
-                (CHANNEL_6G_172, '172 (6820/40 MHz)'),
+                (CHANNEL_6G_171, '171 (6805/40 MHz)'),
                 (CHANNEL_6G_173, '173 (6815/20 MHz)'),
-                (CHANNEL_6G_175, '175 (6895/160 MHz)'),
+                (CHANNEL_6G_175, '175 (6825/160 MHz)'),
                 (CHANNEL_6G_177, '177 (6835/20 MHz)'),
-                (CHANNEL_6G_180, '180 (6860/40 MHz)'),
+                (CHANNEL_6G_179, '179 (6845/40 MHz)'),
                 (CHANNEL_6G_181, '181 (6855/20 MHz)'),
-                (CHANNEL_6G_183, '183 (6895/80 MHz)'),
+                (CHANNEL_6G_183, '183 (6865/80 MHz)'),
                 (CHANNEL_6G_185, '185 (6875/20 MHz)'),
-                (CHANNEL_6G_188, '188 (6900/40 MHz)'),
+                (CHANNEL_6G_187, '187 (6885/40 MHz)'),
                 (CHANNEL_6G_189, '189 (6895/20 MHz)'),
                 (CHANNEL_6G_193, '193 (6915/20 MHz)'),
-                (CHANNEL_6G_196, '196 (6940/40 MHz)'),
+                (CHANNEL_6G_195, '195 (6925/40 MHz)'),
                 (CHANNEL_6G_197, '197 (6935/20 MHz)'),
-                (CHANNEL_6G_199, '199 (6975/80 MHz)'),
+                (CHANNEL_6G_199, '199 (6945/80 MHz)'),
                 (CHANNEL_6G_201, '201 (6955/20 MHz)'),
-                (CHANNEL_6G_204, '204 (6980/40 MHz)'),
+                (CHANNEL_6G_203, '203 (6965/40 MHz)'),
                 (CHANNEL_6G_205, '205 (6975/20 MHz)'),
-                (CHANNEL_6G_207, '207 (7055/160 MHz)'),
+                (CHANNEL_6G_207, '207 (6985/160 MHz)'),
                 (CHANNEL_6G_209, '209 (6995/20 MHz)'),
-                (CHANNEL_6G_212, '212 (7020/40 MHz)'),
+                (CHANNEL_6G_211, '211 (7005/40 MHz)'),
                 (CHANNEL_6G_213, '213 (7015/20 MHz)'),
-                (CHANNEL_6G_215, '215 (7055/80 MHz)'),
+                (CHANNEL_6G_215, '215 (7025/80 MHz)'),
                 (CHANNEL_6G_217, '217 (7035/20 MHz)'),
-                (CHANNEL_6G_220, '220 (7060/40 MHz)'),
+                (CHANNEL_6G_219, '219 (7045/40 MHz)'),
                 (CHANNEL_6G_221, '221 (7055/20 MHz)'),
                 (CHANNEL_6G_225, '225 (7075/20 MHz)'),
-                (CHANNEL_6G_228, '228 (7100/40 MHz)'),
+                (CHANNEL_6G_227, '227 (7085/40 MHz)'),
                 (CHANNEL_6G_229, '229 (7095/20 MHz)'),
                 (CHANNEL_6G_233, '233 (7115/20 MHz)'),
             )

--- a/netbox/wireless/choices.py
+++ b/netbox/wireless/choices.py
@@ -83,6 +83,143 @@ class WirelessChannelChoices(ChoiceSet):
     CHANNEL_5G_173 = '5g-173-5865-20'
     CHANNEL_5G_175 = '5g-175-5875-40'
     CHANNEL_5G_177 = '5g-177-5885-20'
+    
+    # 6 GHz
+    CHANNEL_6G_1 = '6g-1-5955-20'
+    CHANNEL_6G_3 = '6g-3-5955-40'
+    CHANNEL_6G_5 = '6g-5-5965-20'
+    CHANNEL_6G_7 = '6g-7-5975-80'
+    CHANNEL_6G_9 = '6g-9-5985-20'
+    CHANNEL_6G_11 = '6g-11-5995-40'
+    CHANNEL_6G_13 = '6g-13-6005-20'
+    CHANNEL_6G_15 = '6g-15-6015-160'
+    CHANNEL_6G_17 = '6g-17-6025-20'
+    CHANNEL_6G_19 = '6g-19-6035-40'
+    CHANNEL_6G_21 = '6g-21-6045-20'
+    CHANNEL_6G_23 = '6g-23-6055-80'
+    CHANNEL_6G_25 = '6g-25-6065-20'
+    CHANNEL_6G_28 = '6g-28-6080-40'
+    CHANNEL_6G_29 = '6g-29-6085-20'
+    CHANNEL_6G_31 = '6g-31-6095-320'
+    CHANNEL_6G_33 = '6g-33-6105-20'
+    CHANNEL_6G_36 = '6g-36-6120-40'
+    CHANNEL_6G_37 = '6g-37-6125-20'
+    CHANNEL_6G_39 = '6g-39-6135-80'
+    CHANNEL_6G_41 = '6g-41-6145-20'
+    CHANNEL_6G_44 = '6g-44-6160-40'
+    CHANNEL_6G_45 = '6g-45-6165-20'
+    CHANNEL_6G_47 = '6g-47-6175-160'
+    CHANNEL_6G_49 = '6g-49-6185-20'
+    CHANNEL_6G_52 = '6g-52-6200-40'
+    CHANNEL_6G_53 = '6g-53-6205-20'
+    CHANNEL_6G_55 = '6g-55-6215-80'
+    CHANNEL_6G_57 = '6g-57-6225-20'
+    CHANNEL_6G_60 = '6g-60-6240-40'
+    CHANNEL_6G_61 = '6g-61-6245-20'
+    CHANNEL_6G_65 = '6g-65-6265-20'
+    CHANNEL_6G_68 = '6g-68-6280-40'
+    CHANNEL_6G_69 = '6g-69-6285-20'
+    CHANNEL_6G_71 = '6g-71-6295-80'
+    CHANNEL_6G_73 = '6g-73-6305-20'
+    CHANNEL_6G_76 = '6g-76-6320-40'
+    CHANNEL_6G_77 = '6g-77-6325-20'
+    CHANNEL_6G_79 = '6g-79-6335-160'
+    CHANNEL_6G_81 = '6g-81-6345-20'
+    CHANNEL_6G_84 = '6g-84-6360-40'
+    CHANNEL_6G_85 = '6g-85-6365-20'
+    CHANNEL_6G_87 = '6g-87-6375-80'
+    CHANNEL_6G_89 = '6g-89-6385-20'
+    CHANNEL_6G_92 = '6g-92-6400-40'
+    CHANNEL_6G_93 = '6g-93-6405-20'
+    CHANNEL_6G_95 = '6g-95-6415-320'
+    CHANNEL_6G_97 = '6g-97-6425-20'
+    CHANNEL_6G_100 = '6g-100-6440-40'
+    CHANNEL_6G_101 = '6g-101-6445-20'
+    CHANNEL_6G_103 = '6g-103-6455-80'
+    CHANNEL_6G_105 = '6g-105-6465-20'
+    CHANNEL_6G_108 = '6g-108-6480-40'
+    CHANNEL_6G_109 = '6g-109-6485-20'
+    CHANNEL_6G_111 = '6g-111-6495-160'
+    CHANNEL_6G_113 = '6g-113-6505-20'
+    CHANNEL_6G_116 = '6g-116-6520-40'
+    CHANNEL_6G_117 = '6g-117-6525-20'
+    CHANNEL_6G_119 = '6g-119-6535-80'
+    CHANNEL_6G_121 = '6g-121-6545-20'
+    CHANNEL_6G_124 = '6g-124-6560-40'
+    CHANNEL_6G_125 = '6g-125-6565-20'
+    CHANNEL_6G_129 = '6g-129-6585-20'
+    CHANNEL_6G_132 = '6g-132-6600-40'
+    CHANNEL_6G_133 = '6g-133-6605-20'
+    CHANNEL_6G_135 = '6g-135-6615-80'
+    CHANNEL_6G_137 = '6g-137-6625-20'
+    CHANNEL_6G_140 = '6g-140-6640-40'
+    CHANNEL_6G_141 = '6g-141-6645-20'
+    CHANNEL_6G_143 = '6g-143-6655-160'
+    CHANNEL_6G_145 = '6g-145-6665-20'
+    CHANNEL_6G_148 = '6g-148-6680-40'
+    CHANNEL_6G_149 = '6g-149-6685-20'
+    CHANNEL_6G_151 = '6g-151-6695-80'
+    CHANNEL_6G_153 = '6g-153-6705-20'
+    CHANNEL_6G_156 = '6g-156-6720-40'
+    CHANNEL_6G_157 = '6g-157-6725-20'
+    CHANNEL_6G_159 = '6g-159-6735-320'
+    CHANNEL_6G_161 = '6g-161-6745-20'
+    CHANNEL_6G_164 = '6g-164-6760-40'
+    CHANNEL_6G_165 = '6g-165-6765-20'
+    CHANNEL_6G_167 = '6g-167-6775-80'
+    CHANNEL_6G_169 = '6g-169-6785-20'
+    CHANNEL_6G_172 = '6g-172-6800-40'
+    CHANNEL_6G_173 = '6g-173-6805-20'
+    CHANNEL_6G_175 = '6g-175-6815-160'
+    CHANNEL_6G_177 = '6g-177-6825-20'
+    CHANNEL_6G_180 = '6g-180-6840-40'
+    CHANNEL_6G_181 = '6g-181-6845-20'
+    CHANNEL_6G_183 = '6g-183-6855-80'
+    CHANNEL_6G_185 = '6g-185-6865-20'
+    CHANNEL_6G_188 = '6g-188-6880-40'
+    CHANNEL_6G_189 = '6g-189-6885-20'
+    CHANNEL_6G_193 = '6g-193-6905-20'
+    CHANNEL_6G_196 = '6g-196-6920-40'
+    CHANNEL_6G_197 = '6g-197-6925-20'
+    CHANNEL_6G_199 = '6g-199-6935-80'
+    CHANNEL_6G_201 = '6g-201-6945-20'
+    CHANNEL_6G_204 = '6g-204-6960-40'
+    CHANNEL_6G_205 = '6g-205-6965-20'
+    CHANNEL_6G_207 = '6g-207-6975-160'
+    CHANNEL_6G_209 = '6g-209-6985-20'
+    CHANNEL_6G_212 = '6g-212-7000-40'
+    CHANNEL_6G_213 = '6g-213-7005-20'
+    CHANNEL_6G_215 = '6g-215-7015-80'
+    CHANNEL_6G_217 = '6g-217-7025-20'
+    CHANNEL_6G_220 = '6g-220-7040-40'
+    CHANNEL_6G_221 = '6g-221-7045-20'
+    CHANNEL_6G_225 = '6g-225-7065-20'
+    CHANNEL_6G_228 = '6g-228-7080-40'
+    CHANNEL_6G_229 = '6g-229-7085-20'
+    CHANNEL_6G_233 = '6g-233-7105-20'
+
+    
+    # 60 GHz
+    CHANNEL_60G_1 = '60g-1-58320-2160'
+    CHANNEL_60G_2 = '60g-2-60480-2160'
+    CHANNEL_60G_3 = '60g-3-62640-2160'
+    CHANNEL_60G_4 = '60g-4-64800-2160'
+    CHANNEL_60G_5 = '60g-5-66960-2160'
+    CHANNEL_60G_6 = '60g-6-69120-2160'
+    CHANNEL_60G_9 = '60g-9-59400-4320'
+    CHANNEL_60G_10 = '60g-10-61560-4320'
+    CHANNEL_60G_11 = '60g-11-63720-4320'
+    CHANNEL_60G_12 = '60g-12-65880-4320'
+    CHANNEL_60G_13 = '60g-13-68040-4320'
+    CHANNEL_60G_17 = '60g-17-60480-6480'
+    CHANNEL_60G_18 = '60g-18-62640-6480'
+    CHANNEL_60G_19 = '60g-19-64800-6480'
+    CHANNEL_60G_20 = '60g-20-66960-6480'
+    CHANNEL_60G_25 = '60g-25-61560-6480'
+    CHANNEL_60G_26 = '60g-26-63720-6480'
+    CHANNEL_60G_27 = '60g-27-65880-6480'
+    
+
 
     CHOICES = (
         (
@@ -160,6 +297,147 @@ class WirelessChannelChoices(ChoiceSet):
                 (CHANNEL_5G_173, '173 (5865/20 MHz)'),
                 (CHANNEL_5G_175, '175 (5875/40 MHz)'),
                 (CHANNEL_5G_177, '177 (5885/20 MHz)'),
+            )
+        ),
+        (
+            '6 GHz (802.11ax)',
+            (
+                (CHANNEL_6G_1, '1 (5945/20 MHz)'),
+                (CHANNEL_6G_3, '3 (5955/40 MHz)'),
+                (CHANNEL_6G_5, '5 (5965/20 MHz)'),
+                (CHANNEL_6G_7, '7 (5975/80 MHz)'),
+                (CHANNEL_6G_9, '9 (5985/20 MHz)'),
+                (CHANNEL_6G_11, '11 (5995/40 MHz)'),
+                (CHANNEL_6G_13, '13 (6005/20 MHz)'),
+                (CHANNEL_6G_15, '15 (6015/160 MHz)'),
+                (CHANNEL_6G_17, '17 (6025/20 MHz)'),
+                (CHANNEL_6G_19, '19 (6035/40 MHz)'),
+                (CHANNEL_6G_21, '21 (6045/20 MHz)'),
+                (CHANNEL_6G_23, '23 (6055/80 MHz)'),
+                (CHANNEL_6G_25, '25 (6065/20 MHz)'),
+                (CHANNEL_6G_28, '28 (6080/40 MHz)'),
+                (CHANNEL_6G_29, '29 (6085/20 MHz)'),
+                (CHANNEL_6G_31, '31 (6095/320 MHz)'),
+                (CHANNEL_6G_33, '33 (6105/20 MHz)'),
+                (CHANNEL_6G_36, '36 (6120/40 MHz)'),
+                (CHANNEL_6G_37, '37 (6125/20 MHz)'),
+                (CHANNEL_6G_39, '39 (6135/80 MHz)'),
+                (CHANNEL_6G_41, '41 (6145/20 MHz)'),
+                (CHANNEL_6G_44, '44 (6160/40 MHz)'),
+                (CHANNEL_6G_45, '45 (6165/20 MHz)'),
+                (CHANNEL_6G_47, '47 (6175/160 MHz)'),
+                (CHANNEL_6G_49, '49 (6185/20 MHz)'),
+                (CHANNEL_6G_52, '52 (6200/40 MHz)'),
+                (CHANNEL_6G_53, '53 (6205/20 MHz)'),
+                (CHANNEL_6G_55, '55 (6215/80 MHz)'),
+                (CHANNEL_6G_57, '57 (6225/20 MHz)'),
+                (CHANNEL_6G_60, '60 (6240/40 MHz)'),
+                (CHANNEL_6G_61, '61 (6245/20 MHz)'),
+                (CHANNEL_6G_65, '65 (6265/20 MHz)'),
+                (CHANNEL_6G_68, '68 (6280/40 MHz)'),
+                (CHANNEL_6G_69, '69 (6285/20 MHz)'),
+                (CHANNEL_6G_71, '71 (6295/80 MHz)'),
+                (CHANNEL_6G_73, '73 (6305/20 MHz)'),
+                (CHANNEL_6G_76, '76 (6320/40 MHz)'),
+                (CHANNEL_6G_77, '77 (6325/20 MHz)'),
+                (CHANNEL_6G_79, '79 (6335/160 MHz)'),
+                (CHANNEL_6G_81, '81 (6345/20 MHz)'),
+                (CHANNEL_6G_84, '84 (6360/40 MHz)'),
+                (CHANNEL_6G_85, '85 (6365/20 MHz)'),
+                (CHANNEL_6G_87, '87 (6375/80 MHz)'),
+                (CHANNEL_6G_89, '89 (6385/20 MHz)'),
+                (CHANNEL_6G_92, '92 (6400/40 MHz)'),
+                (CHANNEL_6G_93, '93 (6405/20 MHz)'),
+                (CHANNEL_6G_95, '95 (6415/320 MHz)'),
+                (CHANNEL_6G_97, '97 (6425/20 MHz)'),
+                (CHANNEL_6G_100, '100 (6440/40 MHz)'),
+                (CHANNEL_6G_101, '101 (6445/20 MHz)'),
+                (CHANNEL_6G_103, '103 (6455/80 MHz)'),
+                (CHANNEL_6G_105, '105 (6465/20 MHz)'),
+                (CHANNEL_6G_108, '108 (6480/40 MHz)'),
+                (CHANNEL_6G_109, '109 (6485/20 MHz)'),
+                (CHANNEL_6G_111, '111 (6495/160 MHz)'),
+                (CHANNEL_6G_113, '113 (6505/20 MHz)'),
+                (CHANNEL_6G_116, '116 (6520/40 MHz)'),
+                (CHANNEL_6G_117, '117 (6525/20 MHz)'),
+                (CHANNEL_6G_119, '119 (6535/80 MHz)'),
+                (CHANNEL_6G_121, '121 (6545/20 MHz)'),
+                (CHANNEL_6G_124, '124 (6560/40 MHz)'),
+                (CHANNEL_6G_125, '125 (6565/20 MHz)'),
+                (CHANNEL_6G_129, '129 (6585/20 MHz)'),
+                (CHANNEL_6G_132, '132 (6600/40 MHz)'),
+                (CHANNEL_6G_133, '133 (6605/20 MHz)'),
+                (CHANNEL_6G_135, '135 (6615/80 MHz)'),
+                (CHANNEL_6G_137, '137 (6625/20 MHz)'),
+                (CHANNEL_6G_140, '140 (6640/40 MHz)'),
+                (CHANNEL_6G_141, '141 (6645/20 MHz)'),
+                (CHANNEL_6G_143, '143 (6655/160 MHz)'),
+                (CHANNEL_6G_145, '145 (6665/20 MHz)'),
+                (CHANNEL_6G_148, '148 (6680/40 MHz)'),
+                (CHANNEL_6G_149, '149 (6685/20 MHz)'),
+                (CHANNEL_6G_151, '151 (6695/80 MHz)'),
+                (CHANNEL_6G_153, '153 (6705/20 MHz)'),
+                (CHANNEL_6G_156, '156 (6720/40 MHz)'),
+                (CHANNEL_6G_157, '157 (6725/20 MHz)'),
+                (CHANNEL_6G_159, '159 (6735/320 MHz)'),
+                (CHANNEL_6G_161, '161 (6745/20 MHz)'),
+                (CHANNEL_6G_164, '164 (6760/40 MHz)'),
+                (CHANNEL_6G_165, '165 (6765/20 MHz)'),
+                (CHANNEL_6G_167, '167 (6775/80 MHz)'),
+                (CHANNEL_6G_169, '169 (6785/20 MHz)'),
+                (CHANNEL_6G_172, '172 (6800/40 MHz)'),
+                (CHANNEL_6G_173, '173 (6805/20 MHz)'),
+                (CHANNEL_6G_175, '175 (6815/160 MHz)'),
+                (CHANNEL_6G_177, '177 (6825/20 MHz)'),
+                (CHANNEL_6G_180, '180 (6840/40 MHz)'),
+                (CHANNEL_6G_181, '181 (6845/20 MHz)'),
+                (CHANNEL_6G_183, '183 (6855/80 MHz)'),
+                (CHANNEL_6G_185, '185 (6865/20 MHz)'),
+                (CHANNEL_6G_188, '188 (6880/40 MHz)'),
+                (CHANNEL_6G_189, '189 (6885/20 MHz)'),
+                (CHANNEL_6G_193, '193 (6905/20 MHz)'),
+                (CHANNEL_6G_196, '196 (6920/40 MHz)'),
+                (CHANNEL_6G_197, '197 (6925/20 MHz)'),
+                (CHANNEL_6G_199, '199 (6935/80 MHz)'),
+                (CHANNEL_6G_201, '201 (6945/20 MHz)'),
+                (CHANNEL_6G_204, '204 (6960/40 MHz)'),
+                (CHANNEL_6G_205, '205 (6965/20 MHz)'),
+                (CHANNEL_6G_207, '207 (6975/160 MHz)'),
+                (CHANNEL_6G_209, '209 (6985/20 MHz)'),
+                (CHANNEL_6G_212, '212 (7000/40 MHz)'),
+                (CHANNEL_6G_213, '213 (7005/20 MHz)'),
+                (CHANNEL_6G_215, '215 (7015/80 MHz)'),
+                (CHANNEL_6G_217, '217 (7025/20 MHz)'),
+                (CHANNEL_6G_220, '220 (7040/40 MHz)'),
+                (CHANNEL_6G_221, '221 (7045/20 MHz)'),
+                (CHANNEL_6G_225, '225 (7065/20 MHz)'),
+                (CHANNEL_6G_228, '228 (7080/40 MHz)'),
+                (CHANNEL_6G_229, '229 (7085/20 MHz)'),
+                (CHANNEL_6G_233, '233 (7105/20 MHz)'),
+
+            )
+        ),
+        (
+            '60 GHz (802.11ad/ay)',
+            (
+                (CHANNEL_60G_1, '1 (58.32/2.16 GHz)'),
+                (CHANNEL_60G_2, '2 (60.48/2.16 GHz)'),
+                (CHANNEL_60G_3, '3 (62.64/2.16 GHz)'),
+                (CHANNEL_60G_4, '4 (64.80/2.16 GHz)'),
+                (CHANNEL_60G_5, '5 (66.96/2.16 GHz)'),
+                (CHANNEL_60G_6, '6 (69.12/2.16 GHz)'),
+                (CHANNEL_60G_9, '9 (59.40/4.32 GHz)'),
+                (CHANNEL_60G_10, '10 (61.56/4.32 GHz)'),
+                (CHANNEL_60G_11, '11 (63.72/4.32 GHz)'),
+                (CHANNEL_60G_12, '12 (65.88/4.32 GHz)'),
+                (CHANNEL_60G_13, '13 (68.04/4.32 GHz)'),
+                (CHANNEL_60G_17, '17 (60.48/6.48 GHz)'),
+                (CHANNEL_60G_18, '18 (62.64/6.48 GHz)'),
+                (CHANNEL_60G_19, '19 (64.80/6.48 GHz)'),
+                (CHANNEL_60G_20, '20 (66.96/6.48 GHz)'),
+                (CHANNEL_60G_25, '25 (61.56/8.64 GHz)'),
+                (CHANNEL_60G_26, '26 (63.72/8.64 GHz)'),
+                (CHANNEL_60G_27, '27 (65.88/8.64 GHz)'),
             )
         ),
     )

--- a/netbox/wireless/choices.py
+++ b/netbox/wireless/choices.py
@@ -86,119 +86,118 @@ class WirelessChannelChoices(ChoiceSet):
     
     # 6 GHz
     CHANNEL_6G_1 = '6g-1-5955-20'
-    CHANNEL_6G_3 = '6g-3-5955-40'
-    CHANNEL_6G_5 = '6g-5-5965-20'
-    CHANNEL_6G_7 = '6g-7-5975-80'
-    CHANNEL_6G_9 = '6g-9-5985-20'
-    CHANNEL_6G_11 = '6g-11-5995-40'
-    CHANNEL_6G_13 = '6g-13-6005-20'
-    CHANNEL_6G_15 = '6g-15-6015-160'
-    CHANNEL_6G_17 = '6g-17-6025-20'
-    CHANNEL_6G_19 = '6g-19-6035-40'
-    CHANNEL_6G_21 = '6g-21-6045-20'
-    CHANNEL_6G_23 = '6g-23-6055-80'
-    CHANNEL_6G_25 = '6g-25-6065-20'
-    CHANNEL_6G_28 = '6g-28-6080-40'
-    CHANNEL_6G_29 = '6g-29-6085-20'
-    CHANNEL_6G_31 = '6g-31-6095-320'
-    CHANNEL_6G_33 = '6g-33-6105-20'
-    CHANNEL_6G_36 = '6g-36-6120-40'
-    CHANNEL_6G_37 = '6g-37-6125-20'
-    CHANNEL_6G_39 = '6g-39-6135-80'
-    CHANNEL_6G_41 = '6g-41-6145-20'
-    CHANNEL_6G_44 = '6g-44-6160-40'
-    CHANNEL_6G_45 = '6g-45-6165-20'
-    CHANNEL_6G_47 = '6g-47-6175-160'
-    CHANNEL_6G_49 = '6g-49-6185-20'
-    CHANNEL_6G_52 = '6g-52-6200-40'
-    CHANNEL_6G_53 = '6g-53-6205-20'
-    CHANNEL_6G_55 = '6g-55-6215-80'
-    CHANNEL_6G_57 = '6g-57-6225-20'
-    CHANNEL_6G_60 = '6g-60-6240-40'
-    CHANNEL_6G_61 = '6g-61-6245-20'
-    CHANNEL_6G_65 = '6g-65-6265-20'
-    CHANNEL_6G_68 = '6g-68-6280-40'
-    CHANNEL_6G_69 = '6g-69-6285-20'
-    CHANNEL_6G_71 = '6g-71-6295-80'
-    CHANNEL_6G_73 = '6g-73-6305-20'
-    CHANNEL_6G_76 = '6g-76-6320-40'
-    CHANNEL_6G_77 = '6g-77-6325-20'
-    CHANNEL_6G_79 = '6g-79-6335-160'
-    CHANNEL_6G_81 = '6g-81-6345-20'
-    CHANNEL_6G_84 = '6g-84-6360-40'
-    CHANNEL_6G_85 = '6g-85-6365-20'
-    CHANNEL_6G_87 = '6g-87-6375-80'
-    CHANNEL_6G_89 = '6g-89-6385-20'
-    CHANNEL_6G_92 = '6g-92-6400-40'
-    CHANNEL_6G_93 = '6g-93-6405-20'
-    CHANNEL_6G_95 = '6g-95-6415-320'
-    CHANNEL_6G_97 = '6g-97-6425-20'
-    CHANNEL_6G_100 = '6g-100-6440-40'
-    CHANNEL_6G_101 = '6g-101-6445-20'
-    CHANNEL_6G_103 = '6g-103-6455-80'
-    CHANNEL_6G_105 = '6g-105-6465-20'
-    CHANNEL_6G_108 = '6g-108-6480-40'
-    CHANNEL_6G_109 = '6g-109-6485-20'
-    CHANNEL_6G_111 = '6g-111-6495-160'
-    CHANNEL_6G_113 = '6g-113-6505-20'
-    CHANNEL_6G_116 = '6g-116-6520-40'
-    CHANNEL_6G_117 = '6g-117-6525-20'
-    CHANNEL_6G_119 = '6g-119-6535-80'
-    CHANNEL_6G_121 = '6g-121-6545-20'
-    CHANNEL_6G_124 = '6g-124-6560-40'
-    CHANNEL_6G_125 = '6g-125-6565-20'
-    CHANNEL_6G_129 = '6g-129-6585-20'
-    CHANNEL_6G_132 = '6g-132-6600-40'
-    CHANNEL_6G_133 = '6g-133-6605-20'
-    CHANNEL_6G_135 = '6g-135-6615-80'
-    CHANNEL_6G_137 = '6g-137-6625-20'
-    CHANNEL_6G_140 = '6g-140-6640-40'
-    CHANNEL_6G_141 = '6g-141-6645-20'
-    CHANNEL_6G_143 = '6g-143-6655-160'
-    CHANNEL_6G_145 = '6g-145-6665-20'
-    CHANNEL_6G_148 = '6g-148-6680-40'
-    CHANNEL_6G_149 = '6g-149-6685-20'
-    CHANNEL_6G_151 = '6g-151-6695-80'
-    CHANNEL_6G_153 = '6g-153-6705-20'
-    CHANNEL_6G_156 = '6g-156-6720-40'
-    CHANNEL_6G_157 = '6g-157-6725-20'
-    CHANNEL_6G_159 = '6g-159-6735-320'
-    CHANNEL_6G_161 = '6g-161-6745-20'
-    CHANNEL_6G_164 = '6g-164-6760-40'
-    CHANNEL_6G_165 = '6g-165-6765-20'
-    CHANNEL_6G_167 = '6g-167-6775-80'
-    CHANNEL_6G_169 = '6g-169-6785-20'
-    CHANNEL_6G_172 = '6g-172-6800-40'
-    CHANNEL_6G_173 = '6g-173-6805-20'
-    CHANNEL_6G_175 = '6g-175-6815-160'
-    CHANNEL_6G_177 = '6g-177-6825-20'
-    CHANNEL_6G_180 = '6g-180-6840-40'
-    CHANNEL_6G_181 = '6g-181-6845-20'
-    CHANNEL_6G_183 = '6g-183-6855-80'
-    CHANNEL_6G_185 = '6g-185-6865-20'
-    CHANNEL_6G_188 = '6g-188-6880-40'
-    CHANNEL_6G_189 = '6g-189-6885-20'
-    CHANNEL_6G_193 = '6g-193-6905-20'
-    CHANNEL_6G_196 = '6g-196-6920-40'
-    CHANNEL_6G_197 = '6g-197-6925-20'
-    CHANNEL_6G_199 = '6g-199-6935-80'
-    CHANNEL_6G_201 = '6g-201-6945-20'
-    CHANNEL_6G_204 = '6g-204-6960-40'
-    CHANNEL_6G_205 = '6g-205-6965-20'
-    CHANNEL_6G_207 = '6g-207-6975-160'
-    CHANNEL_6G_209 = '6g-209-6985-20'
-    CHANNEL_6G_212 = '6g-212-7000-40'
-    CHANNEL_6G_213 = '6g-213-7005-20'
-    CHANNEL_6G_215 = '6g-215-7015-80'
-    CHANNEL_6G_217 = '6g-217-7025-20'
-    CHANNEL_6G_220 = '6g-220-7040-40'
-    CHANNEL_6G_221 = '6g-221-7045-20'
-    CHANNEL_6G_225 = '6g-225-7065-20'
-    CHANNEL_6G_228 = '6g-228-7080-40'
-    CHANNEL_6G_229 = '6g-229-7085-20'
-    CHANNEL_6G_233 = '6g-233-7105-20'
+    CHANNEL_6G_3 = '6g-3-5975-40'
+    CHANNEL_6G_5 = '6g-5-5975-20'
+    CHANNEL_6G_7 = '6g-7-6015-80'
+    CHANNEL_6G_9 = '6g-9-5995-20'
+    CHANNEL_6G_11 = '6g-11-6015-40'
+    CHANNEL_6G_13 = '6g-13-6015-20'
+    CHANNEL_6G_15 = '6g-15-6095-160'
+    CHANNEL_6G_17 = '6g-17-6035-20'
+    CHANNEL_6G_19 = '6g-19-6055-40'
+    CHANNEL_6G_21 = '6g-21-6055-20'
+    CHANNEL_6G_23 = '6g-23-6095-80'
+    CHANNEL_6G_25 = '6g-25-6075-20'
+    CHANNEL_6G_28 = '6g-28-6100-40'
+    CHANNEL_6G_29 = '6g-29-6095-20'
+    CHANNEL_6G_31 = '6g-31-6255-320'
+    CHANNEL_6G_33 = '6g-33-6115-20'
+    CHANNEL_6G_36 = '6g-36-6140-40'
+    CHANNEL_6G_37 = '6g-37-6135-20'
+    CHANNEL_6G_39 = '6g-39-6175-80'
+    CHANNEL_6G_41 = '6g-41-6155-20'
+    CHANNEL_6G_44 = '6g-44-6180-40'
+    CHANNEL_6G_45 = '6g-45-6175-20'
+    CHANNEL_6G_47 = '6g-47-6255-160'
+    CHANNEL_6G_49 = '6g-49-6195-20'
+    CHANNEL_6G_52 = '6g-52-6220-40'
+    CHANNEL_6G_53 = '6g-53-6215-20'
+    CHANNEL_6G_55 = '6g-55-6255-80'
+    CHANNEL_6G_57 = '6g-57-6235-20'
+    CHANNEL_6G_60 = '6g-60-6260-40'
+    CHANNEL_6G_61 = '6g-61-6255-20'
+    CHANNEL_6G_65 = '6g-65-6275-20'
+    CHANNEL_6G_68 = '6g-68-6300-40'
+    CHANNEL_6G_69 = '6g-69-6295-20'
+    CHANNEL_6G_71 = '6g-71-6335-80'
+    CHANNEL_6G_73 = '6g-73-6315-20'
+    CHANNEL_6G_76 = '6g-76-6340-40'
+    CHANNEL_6G_77 = '6g-77-6335-20'
+    CHANNEL_6G_79 = '6g-79-6415-160'
+    CHANNEL_6G_81 = '6g-81-6355-20'
+    CHANNEL_6G_84 = '6g-84-6380-40'
+    CHANNEL_6G_85 = '6g-85-6375-20'
+    CHANNEL_6G_87 = '6g-87-6415-80'
+    CHANNEL_6G_89 = '6g-89-6395-20'
+    CHANNEL_6G_92 = '6g-92-6420-40'
+    CHANNEL_6G_93 = '6g-93-6415-20'
+    CHANNEL_6G_95 = '6g-95-6575-320'
+    CHANNEL_6G_97 = '6g-97-6435-20'
+    CHANNEL_6G_100 = '6g-100-6460-40'
+    CHANNEL_6G_101 = '6g-101-6455-20'
+    CHANNEL_6G_103 = '6g-103-6495-80'
+    CHANNEL_6G_105 = '6g-105-6475-20'
+    CHANNEL_6G_108 = '6g-108-6500-40'
+    CHANNEL_6G_109 = '6g-109-6495-20'
+    CHANNEL_6G_111 = '6g-111-6575-160'
+    CHANNEL_6G_113 = '6g-113-6515-20'
+    CHANNEL_6G_116 = '6g-116-6540-40'
+    CHANNEL_6G_117 = '6g-117-6535-20'
+    CHANNEL_6G_119 = '6g-119-6575-80'
+    CHANNEL_6G_121 = '6g-121-6555-20'
+    CHANNEL_6G_124 = '6g-124-6580-40'
+    CHANNEL_6G_125 = '6g-125-6575-20'
+    CHANNEL_6G_129 = '6g-129-6595-20'
+    CHANNEL_6G_132 = '6g-132-6620-40'
+    CHANNEL_6G_133 = '6g-133-6615-20'
+    CHANNEL_6G_135 = '6g-135-6655-80'
+    CHANNEL_6G_137 = '6g-137-6635-20'
+    CHANNEL_6G_140 = '6g-140-6660-40'
+    CHANNEL_6G_141 = '6g-141-6655-20'
+    CHANNEL_6G_143 = '6g-143-6735-160'
+    CHANNEL_6G_145 = '6g-145-6675-20'
+    CHANNEL_6G_148 = '6g-148-6700-40'
+    CHANNEL_6G_149 = '6g-149-6695-20'
+    CHANNEL_6G_151 = '6g-151-6735-80'
+    CHANNEL_6G_153 = '6g-153-6715-20'
+    CHANNEL_6G_156 = '6g-156-6740-40'
+    CHANNEL_6G_157 = '6g-157-6735-20'
+    CHANNEL_6G_159 = '6g-159-6895-320'
+    CHANNEL_6G_161 = '6g-161-6755-20'
+    CHANNEL_6G_164 = '6g-164-6780-40'
+    CHANNEL_6G_165 = '6g-165-6775-20'
+    CHANNEL_6G_167 = '6g-167-6815-80'
+    CHANNEL_6G_169 = '6g-169-6795-20'
+    CHANNEL_6G_172 = '6g-172-6820-40'
+    CHANNEL_6G_173 = '6g-173-6815-20'
+    CHANNEL_6G_175 = '6g-175-6895-160'
+    CHANNEL_6G_177 = '6g-177-6835-20'
+    CHANNEL_6G_180 = '6g-180-6860-40'
+    CHANNEL_6G_181 = '6g-181-6855-20'
+    CHANNEL_6G_183 = '6g-183-6895-80'
+    CHANNEL_6G_185 = '6g-185-6875-20'
+    CHANNEL_6G_188 = '6g-188-6900-40'
+    CHANNEL_6G_189 = '6g-189-6895-20'
+    CHANNEL_6G_193 = '6g-193-6915-20'
+    CHANNEL_6G_196 = '6g-196-6940-40'
+    CHANNEL_6G_197 = '6g-197-6935-20'
+    CHANNEL_6G_199 = '6g-199-6975-80'
+    CHANNEL_6G_201 = '6g-201-6955-20'
+    CHANNEL_6G_204 = '6g-204-6980-40'
+    CHANNEL_6G_205 = '6g-205-6975-20'
+    CHANNEL_6G_207 = '6g-207-7055-160'
+    CHANNEL_6G_209 = '6g-209-6995-20'
+    CHANNEL_6G_212 = '6g-212-7020-40'
+    CHANNEL_6G_213 = '6g-213-7015-20'
+    CHANNEL_6G_215 = '6g-215-7055-80'
+    CHANNEL_6G_217 = '6g-217-7035-20'
+    CHANNEL_6G_220 = '6g-220-7060-40'
+    CHANNEL_6G_221 = '6g-221-7055-20'
+    CHANNEL_6G_225 = '6g-225-7075-20'
+    CHANNEL_6G_228 = '6g-228-7100-40'
+    CHANNEL_6G_229 = '6g-229-7095-20'
+    CHANNEL_6G_233 = '6g-233-7115-20'
 
-    
     # 60 GHz
     CHANNEL_60G_1 = '60g-1-58320-2160'
     CHANNEL_60G_2 = '60g-2-60480-2160'
@@ -219,8 +218,6 @@ class WirelessChannelChoices(ChoiceSet):
     CHANNEL_60G_26 = '60g-26-63720-6480'
     CHANNEL_60G_27 = '60g-27-65880-6480'
     
-
-
     CHOICES = (
         (
             '2.4 GHz (802.11b/g/n/ax)',
@@ -302,119 +299,118 @@ class WirelessChannelChoices(ChoiceSet):
         (
             '6 GHz (802.11ax)',
             (
-                (CHANNEL_6G_1, '1 (5945/20 MHz)'),
-                (CHANNEL_6G_3, '3 (5955/40 MHz)'),
-                (CHANNEL_6G_5, '5 (5965/20 MHz)'),
-                (CHANNEL_6G_7, '7 (5975/80 MHz)'),
-                (CHANNEL_6G_9, '9 (5985/20 MHz)'),
-                (CHANNEL_6G_11, '11 (5995/40 MHz)'),
-                (CHANNEL_6G_13, '13 (6005/20 MHz)'),
-                (CHANNEL_6G_15, '15 (6015/160 MHz)'),
-                (CHANNEL_6G_17, '17 (6025/20 MHz)'),
-                (CHANNEL_6G_19, '19 (6035/40 MHz)'),
-                (CHANNEL_6G_21, '21 (6045/20 MHz)'),
-                (CHANNEL_6G_23, '23 (6055/80 MHz)'),
-                (CHANNEL_6G_25, '25 (6065/20 MHz)'),
-                (CHANNEL_6G_28, '28 (6080/40 MHz)'),
-                (CHANNEL_6G_29, '29 (6085/20 MHz)'),
-                (CHANNEL_6G_31, '31 (6095/320 MHz)'),
-                (CHANNEL_6G_33, '33 (6105/20 MHz)'),
-                (CHANNEL_6G_36, '36 (6120/40 MHz)'),
-                (CHANNEL_6G_37, '37 (6125/20 MHz)'),
-                (CHANNEL_6G_39, '39 (6135/80 MHz)'),
-                (CHANNEL_6G_41, '41 (6145/20 MHz)'),
-                (CHANNEL_6G_44, '44 (6160/40 MHz)'),
-                (CHANNEL_6G_45, '45 (6165/20 MHz)'),
-                (CHANNEL_6G_47, '47 (6175/160 MHz)'),
-                (CHANNEL_6G_49, '49 (6185/20 MHz)'),
-                (CHANNEL_6G_52, '52 (6200/40 MHz)'),
-                (CHANNEL_6G_53, '53 (6205/20 MHz)'),
-                (CHANNEL_6G_55, '55 (6215/80 MHz)'),
-                (CHANNEL_6G_57, '57 (6225/20 MHz)'),
-                (CHANNEL_6G_60, '60 (6240/40 MHz)'),
-                (CHANNEL_6G_61, '61 (6245/20 MHz)'),
-                (CHANNEL_6G_65, '65 (6265/20 MHz)'),
-                (CHANNEL_6G_68, '68 (6280/40 MHz)'),
-                (CHANNEL_6G_69, '69 (6285/20 MHz)'),
-                (CHANNEL_6G_71, '71 (6295/80 MHz)'),
-                (CHANNEL_6G_73, '73 (6305/20 MHz)'),
-                (CHANNEL_6G_76, '76 (6320/40 MHz)'),
-                (CHANNEL_6G_77, '77 (6325/20 MHz)'),
-                (CHANNEL_6G_79, '79 (6335/160 MHz)'),
-                (CHANNEL_6G_81, '81 (6345/20 MHz)'),
-                (CHANNEL_6G_84, '84 (6360/40 MHz)'),
-                (CHANNEL_6G_85, '85 (6365/20 MHz)'),
-                (CHANNEL_6G_87, '87 (6375/80 MHz)'),
-                (CHANNEL_6G_89, '89 (6385/20 MHz)'),
-                (CHANNEL_6G_92, '92 (6400/40 MHz)'),
-                (CHANNEL_6G_93, '93 (6405/20 MHz)'),
-                (CHANNEL_6G_95, '95 (6415/320 MHz)'),
-                (CHANNEL_6G_97, '97 (6425/20 MHz)'),
-                (CHANNEL_6G_100, '100 (6440/40 MHz)'),
-                (CHANNEL_6G_101, '101 (6445/20 MHz)'),
-                (CHANNEL_6G_103, '103 (6455/80 MHz)'),
-                (CHANNEL_6G_105, '105 (6465/20 MHz)'),
-                (CHANNEL_6G_108, '108 (6480/40 MHz)'),
-                (CHANNEL_6G_109, '109 (6485/20 MHz)'),
-                (CHANNEL_6G_111, '111 (6495/160 MHz)'),
-                (CHANNEL_6G_113, '113 (6505/20 MHz)'),
-                (CHANNEL_6G_116, '116 (6520/40 MHz)'),
-                (CHANNEL_6G_117, '117 (6525/20 MHz)'),
-                (CHANNEL_6G_119, '119 (6535/80 MHz)'),
-                (CHANNEL_6G_121, '121 (6545/20 MHz)'),
-                (CHANNEL_6G_124, '124 (6560/40 MHz)'),
-                (CHANNEL_6G_125, '125 (6565/20 MHz)'),
-                (CHANNEL_6G_129, '129 (6585/20 MHz)'),
-                (CHANNEL_6G_132, '132 (6600/40 MHz)'),
-                (CHANNEL_6G_133, '133 (6605/20 MHz)'),
-                (CHANNEL_6G_135, '135 (6615/80 MHz)'),
-                (CHANNEL_6G_137, '137 (6625/20 MHz)'),
-                (CHANNEL_6G_140, '140 (6640/40 MHz)'),
-                (CHANNEL_6G_141, '141 (6645/20 MHz)'),
-                (CHANNEL_6G_143, '143 (6655/160 MHz)'),
-                (CHANNEL_6G_145, '145 (6665/20 MHz)'),
-                (CHANNEL_6G_148, '148 (6680/40 MHz)'),
-                (CHANNEL_6G_149, '149 (6685/20 MHz)'),
-                (CHANNEL_6G_151, '151 (6695/80 MHz)'),
-                (CHANNEL_6G_153, '153 (6705/20 MHz)'),
-                (CHANNEL_6G_156, '156 (6720/40 MHz)'),
-                (CHANNEL_6G_157, '157 (6725/20 MHz)'),
-                (CHANNEL_6G_159, '159 (6735/320 MHz)'),
-                (CHANNEL_6G_161, '161 (6745/20 MHz)'),
-                (CHANNEL_6G_164, '164 (6760/40 MHz)'),
-                (CHANNEL_6G_165, '165 (6765/20 MHz)'),
-                (CHANNEL_6G_167, '167 (6775/80 MHz)'),
-                (CHANNEL_6G_169, '169 (6785/20 MHz)'),
-                (CHANNEL_6G_172, '172 (6800/40 MHz)'),
-                (CHANNEL_6G_173, '173 (6805/20 MHz)'),
-                (CHANNEL_6G_175, '175 (6815/160 MHz)'),
-                (CHANNEL_6G_177, '177 (6825/20 MHz)'),
-                (CHANNEL_6G_180, '180 (6840/40 MHz)'),
-                (CHANNEL_6G_181, '181 (6845/20 MHz)'),
-                (CHANNEL_6G_183, '183 (6855/80 MHz)'),
-                (CHANNEL_6G_185, '185 (6865/20 MHz)'),
-                (CHANNEL_6G_188, '188 (6880/40 MHz)'),
-                (CHANNEL_6G_189, '189 (6885/20 MHz)'),
-                (CHANNEL_6G_193, '193 (6905/20 MHz)'),
-                (CHANNEL_6G_196, '196 (6920/40 MHz)'),
-                (CHANNEL_6G_197, '197 (6925/20 MHz)'),
-                (CHANNEL_6G_199, '199 (6935/80 MHz)'),
-                (CHANNEL_6G_201, '201 (6945/20 MHz)'),
-                (CHANNEL_6G_204, '204 (6960/40 MHz)'),
-                (CHANNEL_6G_205, '205 (6965/20 MHz)'),
-                (CHANNEL_6G_207, '207 (6975/160 MHz)'),
-                (CHANNEL_6G_209, '209 (6985/20 MHz)'),
-                (CHANNEL_6G_212, '212 (7000/40 MHz)'),
-                (CHANNEL_6G_213, '213 (7005/20 MHz)'),
-                (CHANNEL_6G_215, '215 (7015/80 MHz)'),
-                (CHANNEL_6G_217, '217 (7025/20 MHz)'),
-                (CHANNEL_6G_220, '220 (7040/40 MHz)'),
-                (CHANNEL_6G_221, '221 (7045/20 MHz)'),
-                (CHANNEL_6G_225, '225 (7065/20 MHz)'),
-                (CHANNEL_6G_228, '228 (7080/40 MHz)'),
-                (CHANNEL_6G_229, '229 (7085/20 MHz)'),
-                (CHANNEL_6G_233, '233 (7105/20 MHz)'),
-
+                (CHANNEL_6G_1, '1 (5955/20 MHz)'),
+                (CHANNEL_6G_3, '3 (5975/40 MHz)'),
+                (CHANNEL_6G_5, '5 (5975/20 MHz)'),
+                (CHANNEL_6G_7, '7 (6015/80 MHz)'),
+                (CHANNEL_6G_9, '9 (5995/20 MHz)'),
+                (CHANNEL_6G_11, '11 (6015/40 MHz)'),
+                (CHANNEL_6G_13, '13 (6015/20 MHz)'),
+                (CHANNEL_6G_15, '15 (6095/160 MHz)'),
+                (CHANNEL_6G_17, '17 (6035/20 MHz)'),
+                (CHANNEL_6G_19, '19 (6055/40 MHz)'),
+                (CHANNEL_6G_21, '21 (6055/20 MHz)'),
+                (CHANNEL_6G_23, '23 (6095/80 MHz)'),
+                (CHANNEL_6G_25, '25 (6075/20 MHz)'),
+                (CHANNEL_6G_28, '28 (6100/40 MHz)'),
+                (CHANNEL_6G_29, '29 (6095/20 MHz)'),
+                (CHANNEL_6G_31, '31 (6255/320 MHz)'),
+                (CHANNEL_6G_33, '33 (6115/20 MHz)'),
+                (CHANNEL_6G_36, '36 (6140/40 MHz)'),
+                (CHANNEL_6G_37, '37 (6135/20 MHz)'),
+                (CHANNEL_6G_39, '39 (6175/80 MHz)'),
+                (CHANNEL_6G_41, '41 (6155/20 MHz)'),
+                (CHANNEL_6G_44, '44 (6180/40 MHz)'),
+                (CHANNEL_6G_45, '45 (6175/20 MHz)'),
+                (CHANNEL_6G_47, '47 (6255/160 MHz)'),
+                (CHANNEL_6G_49, '49 (6195/20 MHz)'),
+                (CHANNEL_6G_52, '52 (6220/40 MHz)'),
+                (CHANNEL_6G_53, '53 (6215/20 MHz)'),
+                (CHANNEL_6G_55, '55 (6255/80 MHz)'),
+                (CHANNEL_6G_57, '57 (6235/20 MHz)'),
+                (CHANNEL_6G_60, '60 (6260/40 MHz)'),
+                (CHANNEL_6G_61, '61 (6255/20 MHz)'),
+                (CHANNEL_6G_65, '65 (6275/20 MHz)'),
+                (CHANNEL_6G_68, '68 (6300/40 MHz)'),
+                (CHANNEL_6G_69, '69 (6295/20 MHz)'),
+                (CHANNEL_6G_71, '71 (6335/80 MHz)'),
+                (CHANNEL_6G_73, '73 (6315/20 MHz)'),
+                (CHANNEL_6G_76, '76 (6340/40 MHz)'),
+                (CHANNEL_6G_77, '77 (6335/20 MHz)'),
+                (CHANNEL_6G_79, '79 (6415/160 MHz)'),
+                (CHANNEL_6G_81, '81 (6355/20 MHz)'),
+                (CHANNEL_6G_84, '84 (6380/40 MHz)'),
+                (CHANNEL_6G_85, '85 (6375/20 MHz)'),
+                (CHANNEL_6G_87, '87 (6415/80 MHz)'),
+                (CHANNEL_6G_89, '89 (6395/20 MHz)'),
+                (CHANNEL_6G_92, '92 (6420/40 MHz)'),
+                (CHANNEL_6G_93, '93 (6415/20 MHz)'),
+                (CHANNEL_6G_95, '95 (6575/320 MHz)'),
+                (CHANNEL_6G_97, '97 (6435/20 MHz)'),
+                (CHANNEL_6G_100, '100 (6460/40 MHz)'),
+                (CHANNEL_6G_101, '101 (6455/20 MHz)'),
+                (CHANNEL_6G_103, '103 (6495/80 MHz)'),
+                (CHANNEL_6G_105, '105 (6475/20 MHz)'),
+                (CHANNEL_6G_108, '108 (6500/40 MHz)'),
+                (CHANNEL_6G_109, '109 (6495/20 MHz)'),
+                (CHANNEL_6G_111, '111 (6575/160 MHz)'),
+                (CHANNEL_6G_113, '113 (6515/20 MHz)'),
+                (CHANNEL_6G_116, '116 (6540/40 MHz)'),
+                (CHANNEL_6G_117, '117 (6535/20 MHz)'),
+                (CHANNEL_6G_119, '119 (6575/80 MHz)'),
+                (CHANNEL_6G_121, '121 (6555/20 MHz)'),
+                (CHANNEL_6G_124, '124 (6580/40 MHz)'),
+                (CHANNEL_6G_125, '125 (6575/20 MHz)'),
+                (CHANNEL_6G_129, '129 (6595/20 MHz)'),
+                (CHANNEL_6G_132, '132 (6620/40 MHz)'),
+                (CHANNEL_6G_133, '133 (6615/20 MHz)'),
+                (CHANNEL_6G_135, '135 (6655/80 MHz)'),
+                (CHANNEL_6G_137, '137 (6635/20 MHz)'),
+                (CHANNEL_6G_140, '140 (6660/40 MHz)'),
+                (CHANNEL_6G_141, '141 (6655/20 MHz)'),
+                (CHANNEL_6G_143, '143 (6735/160 MHz)'),
+                (CHANNEL_6G_145, '145 (6675/20 MHz)'),
+                (CHANNEL_6G_148, '148 (6700/40 MHz)'),
+                (CHANNEL_6G_149, '149 (6695/20 MHz)'),
+                (CHANNEL_6G_151, '151 (6735/80 MHz)'),
+                (CHANNEL_6G_153, '153 (6715/20 MHz)'),
+                (CHANNEL_6G_156, '156 (6740/40 MHz)'),
+                (CHANNEL_6G_157, '157 (6735/20 MHz)'),
+                (CHANNEL_6G_159, '159 (6895/320 MHz)'),
+                (CHANNEL_6G_161, '161 (6755/20 MHz)'),
+                (CHANNEL_6G_164, '164 (6780/40 MHz)'),
+                (CHANNEL_6G_165, '165 (6775/20 MHz)'),
+                (CHANNEL_6G_167, '167 (6815/80 MHz)'),
+                (CHANNEL_6G_169, '169 (6795/20 MHz)'),
+                (CHANNEL_6G_172, '172 (6820/40 MHz)'),
+                (CHANNEL_6G_173, '173 (6815/20 MHz)'),
+                (CHANNEL_6G_175, '175 (6895/160 MHz)'),
+                (CHANNEL_6G_177, '177 (6835/20 MHz)'),
+                (CHANNEL_6G_180, '180 (6860/40 MHz)'),
+                (CHANNEL_6G_181, '181 (6855/20 MHz)'),
+                (CHANNEL_6G_183, '183 (6895/80 MHz)'),
+                (CHANNEL_6G_185, '185 (6875/20 MHz)'),
+                (CHANNEL_6G_188, '188 (6900/40 MHz)'),
+                (CHANNEL_6G_189, '189 (6895/20 MHz)'),
+                (CHANNEL_6G_193, '193 (6915/20 MHz)'),
+                (CHANNEL_6G_196, '196 (6940/40 MHz)'),
+                (CHANNEL_6G_197, '197 (6935/20 MHz)'),
+                (CHANNEL_6G_199, '199 (6975/80 MHz)'),
+                (CHANNEL_6G_201, '201 (6955/20 MHz)'),
+                (CHANNEL_6G_204, '204 (6980/40 MHz)'),
+                (CHANNEL_6G_205, '205 (6975/20 MHz)'),
+                (CHANNEL_6G_207, '207 (7055/160 MHz)'),
+                (CHANNEL_6G_209, '209 (6995/20 MHz)'),
+                (CHANNEL_6G_212, '212 (7020/40 MHz)'),
+                (CHANNEL_6G_213, '213 (7015/20 MHz)'),
+                (CHANNEL_6G_215, '215 (7055/80 MHz)'),
+                (CHANNEL_6G_217, '217 (7035/20 MHz)'),
+                (CHANNEL_6G_220, '220 (7060/40 MHz)'),
+                (CHANNEL_6G_221, '221 (7055/20 MHz)'),
+                (CHANNEL_6G_225, '225 (7075/20 MHz)'),
+                (CHANNEL_6G_228, '228 (7100/40 MHz)'),
+                (CHANNEL_6G_229, '229 (7095/20 MHz)'),
+                (CHANNEL_6G_233, '233 (7115/20 MHz)'),
             )
         ),
         (


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #7999
This PR includes support for 6GHz and 60GHz channels as per IEEE802.11ax and IEEE802.11ad/ay