### PR TITLE
Get_Environment from napalm should not need any decoding

### DIFF
--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -501,7 +501,7 @@ class DeviceViewSet(ConfigContextQuerySetMixin, CustomFieldModelViewSet):
                 response[method] = {'error': 'Only get_* NAPALM methods are supported'}
                 continue
             try:
-                response[method] = decode_dict(getattr(d, method)(), decode_keys=False)
+                response[method] = getattr(d, method)()
             except NotImplementedError:
                 response[method] = {'error': 'Method {} not implemented for NAPALM driver {}'.format(method, driver)}
             except Exception as e:

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -501,7 +501,7 @@ class DeviceViewSet(ConfigContextQuerySetMixin, CustomFieldModelViewSet):
                 response[method] = {'error': 'Only get_* NAPALM methods are supported'}
                 continue
             try:
-                response[method] = decode_dict(getattr(d, method)())
+                response[method] = decode_dict(getattr(d, method)(), decode_keys=False)
             except NotImplementedError:
                 response[method] = {'error': 'Method {} not implemented for NAPALM driver {}'.format(method, driver)}
             except Exception as e:


### PR DESCRIPTION
### Fixes: #7246

As stated already in the issue, napalm method `get_environment` is currently failing. Dictionary coming from napalm driver are already sanitized and therefore param decode_keys should be set to false before calling decode_dict.

https://github.com/napalm-automation/napalm/blob/develop/napalm/base/base.py#L465
https://github.com/napalm-automation/napalm/blob/develop/napalm/ios/ios.py#L2197

This was tested with ios driver.
