### PR TITLE
Document that lookup expressions don't work on custom fields

### DIFF
--- a/docs/rest-api/filtering.md
+++ b/docs/rest-api/filtering.md
@@ -52,7 +52,7 @@ Custom fields can be mixed with built-in fields to further narrow results. When 
 
 ## Lookup Expressions
 
-Certain model fields also support filtering using additional lookup expressions. This allows
+Certain model fields (not custom fields) also support filtering using additional lookup expressions. This allows
 for negation and other context-specific filtering.
 
 These lookup expressions can be applied by adding a suffix to the desired field's name, e.g. `mac_address__n`. In this case, the filter expression is for negation and it is separated by two underscores. Below are the lookup expressions that are supported across different field types.


### PR DESCRIPTION
I tried using a lookup expression on a custom field and it didn't work.  Ie I used this URL:
https://netbox.xxxx.cloud/dcim/devices/?q=&cf_import_group__n=rumble_nov_2021
it returned all devices including those where import_group=rumble_nov_2021

I googled it and found this post which indicates that you can't do what I was trying to do:
https://groups.google.com/g/netbox-discuss/c/_6_zdVrKo8U

The documentation (https://netbox.readthedocs.io/en/stable/rest-api/filtering/) is a bit ambiguous about this so I want to clarify it.

### Fixes: 8093