### PR TITLE
feat: Add search for tag

### DIFF
--- a/netbox/netbox/constants.py
+++ b/netbox/netbox/constants.py
@@ -22,6 +22,9 @@ from utilities.utils import count_related
 from virtualization.filtersets import ClusterFilterSet, VirtualMachineFilterSet
 from virtualization.models import Cluster, VirtualMachine
 from virtualization.tables import ClusterTable, VirtualMachineTable
+from extras.filtersets import TagFilterSet
+from extras.models import Tag
+from extras.tables import TagTable
 
 SEARCH_MAX_RESULTS = 15
 SEARCH_TYPES = OrderedDict((
@@ -176,5 +179,12 @@ SEARCH_TYPES = OrderedDict((
         'filterset': TenantFilterSet,
         'table': TenantTable,
         'url': 'tenancy:tenant_list',
+    }),
+    # Other
+    ('tag', {
+        'queryset': Tag.objects.prefetch_related('prefix'),
+        'filterset': TagFilterSet,
+        'table': TagTable,
+        'url': 'extras:tag_list',
     }),
 ))

--- a/netbox/netbox/constants.py
+++ b/netbox/netbox/constants.py
@@ -182,7 +182,7 @@ SEARCH_TYPES = OrderedDict((
     }),
     # Other
     ('tag', {
-        'queryset': Tag.objects.prefetch_related('prefix'),
+        'queryset': Tag.objects.prefetch_related('prefix', 'ipaddress', 'vlan', 'device', 'location', 'site'),
         'filterset': TagFilterSet,
         'table': TagTable,
         'url': 'extras:tag_list',

--- a/netbox/netbox/forms.py
+++ b/netbox/netbox/forms.py
@@ -33,6 +33,9 @@ OBJ_TYPE_CHOICES = (
         ('cluster', 'Clusters'),
         ('virtualmachine', 'Virtual Machines'),
     )),
+    ('Other', (
+        ('tag', 'Tags'),
+    )),
 )
 
 


### PR DESCRIPTION
The purpose of this PR is to be able to use global search for tags. And also make it more convenient to search for related tags in other netbox modules

