### PR TITLE
Closes #8231: Use HTMX for object deletion confirmations

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -529,7 +529,6 @@ class PrefixEditView(generic.ObjectEditView):
 
 class PrefixDeleteView(generic.ObjectDeleteView):
     queryset = Prefix.objects.all()
-    template_name = 'ipam/prefix_delete.html'
 
 
 class PrefixBulkImportView(generic.BulkImportView):

--- a/netbox/templates/generic/object.html
+++ b/netbox/templates/generic/object.html
@@ -100,4 +100,8 @@
   <div class="tab-content">
     {% block content %}{% endblock %}
   </div>
-{% endblock %}
+{% endblock content-wrapper %}
+
+{% block modals %}
+  {% include 'inc/htmx_modal.html' %}
+{% endblock modals %}

--- a/netbox/templates/generic/object_delete.html
+++ b/netbox/templates/generic/object_delete.html
@@ -1,9 +1,16 @@
-{% extends 'generic/confirmation_form.html' %}
+{% extends 'base/layout.html' %}
 {% load form_helpers %}
 
-{% block title %}Delete {{ obj_type }}?{% endblock %}
+{% block title %}Delete {{ object_type }}?{% endblock %}
 
-{% block message %}
-  <p>Are you sure you want to <strong class="text-danger">delete</strong> {{ obj_type }} <strong>{{ obj }}</strong>?</p>
-  {% block message_extra %}{% endblock %}
-{% endblock message %}
+{% block header %}{% endblock %}
+
+{% block content %}
+  <div class="modal" tabindex="-1" style="display: block; position: static">
+    <div class="modal-dialog">
+      <div class="modal-content" >
+        {% include 'htmx/delete_form.html' %}
+      </div>
+    </div>
+  </div>
+{% endblock %}

--- a/netbox/templates/htmx/delete_form.html
+++ b/netbox/templates/htmx/delete_form.html
@@ -1,0 +1,20 @@
+{% load form_helpers %}
+
+<form action="{{ form_url }}" method="post">
+  {% csrf_token %}
+  <div class="modal-header">
+    <h5 class="modal-title">Confirm Deletion</h5>
+  </div>
+  <div class="modal-body">
+    <p>Are you sure you want to <strong class="text-danger">delete</strong> {{ object_type }} <strong>{{ object }}</strong>?</p>
+    {% render_form form %}
+  </div>
+  <div class="modal-footer">
+    {% if return_url %}
+      <a href="{{ return_url }}" class="btn btn-outline-secondary">Cancel</a>
+    {% else %}
+      <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancel</button>
+    {% endif %}
+    <button type="submit" class="btn btn-danger">Delete</button>
+  </div>
+</form>

--- a/netbox/templates/inc/htmx_modal.html
+++ b/netbox/templates/inc/htmx_modal.html
@@ -1,0 +1,7 @@
+<div class="modal fade" id="htmx-modal" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content" id="htmx-modal-content">
+      {# Dynamic content goes here #}
+    </div>
+  </div>
+</div>

--- a/netbox/templates/inc/htmx_modal.html
+++ b/netbox/templates/inc/htmx_modal.html
@@ -1,5 +1,5 @@
 <div class="modal fade" id="htmx-modal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
+  <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content" id="htmx-modal-content">
       {# Dynamic content goes here #}
     </div>

--- a/netbox/templates/ipam/prefix_delete.html
+++ b/netbox/templates/ipam/prefix_delete.html
@@ -1,5 +1,0 @@
-{% extends 'generic/object_delete.html' %}
-
-{% block message_extra %}
-    <p>Note: This will <strong>not</strong> delete any child prefixes or IP addresses.</p>
-{% endblock %}

--- a/netbox/utilities/templates/buttons/delete.html
+++ b/netbox/utilities/templates/buttons/delete.html
@@ -1,3 +1,9 @@
-<a href="{{ url }}" class="btn btn-sm btn-danger" role="button">
-    <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span>&nbsp;Delete
+<a href="#"
+  hx-get="{{ url }}"
+  hx-target="#htmx-modal-content"
+  class="btn btn-sm btn-danger"
+  data-bs-toggle="modal"
+  data-bs-target="#htmx-modal"
+>
+  <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span>&nbsp;Delete
 </a>


### PR DESCRIPTION
### Closes: #8231

- Extend ObjectDeleteView to support HTMX responses
- Refactor the `object_delete.html` template
- Include an HTMX-backed modal component on all object views
- Update the "delete" object button to use the HTMX-backed modal to render the confirmation form