### PR TITLE
Add Cisco StackWise-n choices

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -816,6 +816,10 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_STACKWISE_PLUS = 'cisco-stackwise-plus'
     TYPE_FLEXSTACK = 'cisco-flexstack'
     TYPE_FLEXSTACK_PLUS = 'cisco-flexstack-plus'
+    TYPE_STACKWISE80 = 'cisco-stackwise-80'
+    TYPE_STACKWISE160 = 'cisco-stackwise-160'
+    TYPE_STACKWISE320 = 'cisco-stackwise-320'
+    TYPE_STACKWISE480 = 'cisco-stackwise-480'
     TYPE_JUNIPER_VCP = 'juniper-vcp'
     TYPE_SUMMITSTACK = 'extreme-summitstack'
     TYPE_SUMMITSTACK128 = 'extreme-summitstack-128'
@@ -950,6 +954,10 @@ class InterfaceTypeChoices(ChoiceSet):
                 (TYPE_STACKWISE_PLUS, 'Cisco StackWise Plus'),
                 (TYPE_FLEXSTACK, 'Cisco FlexStack'),
                 (TYPE_FLEXSTACK_PLUS, 'Cisco FlexStack Plus'),
+                (TYPE_STACKWISE80, 'Cisco StackWise-80'),
+                (TYPE_STACKWISE160, 'Cisco StackWise-160'),
+                (TYPE_STACKWISE320, 'Cisco StackWise-320'),
+                (TYPE_STACKWISE480, 'Cisco StackWise-480'),
                 (TYPE_JUNIPER_VCP, 'Juniper VCP'),
                 (TYPE_SUMMITSTACK, 'Extreme SummitStack'),
                 (TYPE_SUMMITSTACK128, 'Extreme SummitStack-128'),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #8265
<!--
    Please include a summary of the proposed changes below.
-->

Add the 4 new Catalyst 9xxx StackWise types.

I struggled to decide whether these should be listed above or below the FlexStack choices. But then I noticed how some other choices are grouped, for example: t1 > e1 > t3 > e3 and decided to put them below the FlexStack.