### PR TITLE
Fixes #8279 - No virtual chassis name in rack view

### DIFF
--- a/netbox/dcim/svg.py
+++ b/netbox/dcim/svg.py
@@ -19,7 +19,12 @@ __all__ = (
 
 
 def get_device_name(device):
-    return device.name or str(device.device_type)
+    if device.virtual_chassis:
+        return f'{device.virtual_chassis.name}:{device.vc_position}'
+    elif device.name:
+        return device.name
+    else:
+        return str(device.device_type)
 
 
 class RackElevationSVG:


### PR DESCRIPTION
### Fixes: #8279
A device that is part of a VC that has no name should display [virtual-chassis name]:[virtual-chassis position] as opposed to [device_type] in the rack rendering.
