### PR TITLE
Adding asdot notation to ASN views

### DIFF
--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -130,6 +130,14 @@ class ASN(PrimaryModel):
     def get_absolute_url(self):
         return reverse('ipam:asn', args=[self.pk])
 
+    @property
+    def asdot_notation(self):
+        # Return asdot notation for an ASN larger than 65535
+        if self.asn > 65535:
+            return '{}.{}'.format(self.asn // 65536, self.asn % 65536)
+        else:
+            return None
+
 
 @extras_features('custom_fields', 'custom_links', 'export_templates', 'tags', 'webhooks')
 class Aggregate(GetAvailablePrefixesMixin, PrimaryModel):

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -125,21 +125,18 @@ class ASN(PrimaryModel):
         verbose_name_plural = 'ASNs'
 
     def __str__(self):
-        if self.asn > 65535:
-            return 'AS{} ({}.{})'.format(self.asn, self.asn // 65536, self.asn % 65536)
-        else:
-            return f'AS{self.asn}'
+        return f'AS{self.asn_with_asdot}'
 
     def get_absolute_url(self):
         return reverse('ipam:asn', args=[self.pk])
 
     @property
-    def asdot_notation(self):
-        # Return asdot notation for an ASN larger than 65535
+    def asn_with_asdot(self):
+        # Return asn with asdot notation for an ASN larger than 65535 otherwise return the plain ASN
         if self.asn > 65535:
-            return '{}.{}'.format(self.asn // 65536, self.asn % 65536)
+            return f'{self.asn} ({self.asn // 65536}.{self.asn % 65536})'
         else:
-            return None
+            return self.asn
 
 
 @extras_features('custom_fields', 'custom_links', 'export_templates', 'tags', 'webhooks')

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -125,7 +125,10 @@ class ASN(PrimaryModel):
         verbose_name_plural = 'ASNs'
 
     def __str__(self):
-        return f'AS{self.asn}'
+        if self.asn > 65535:
+            return 'AS{} ({}.{})'.format(self.asn, self.asn // 65536, self.asn % 65536)
+        else:
+            return f'AS{self.asn}'
 
     def get_absolute_url(self):
         return reverse('ipam:asn', args=[self.pk])

--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -106,6 +106,13 @@ class ASNTable(BaseTable):
     asn = tables.Column(
         linkify=True
     )
+
+    def render_asn(self, value, record):
+        if record.asdot_notation:
+            return f'{value} ({record.asdot_notation})'
+        else:
+            return value
+
     site_count = LinkedCountColumn(
         viewname='dcim:site_list',
         url_params={'asn_id': 'pk'},

--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -108,10 +108,7 @@ class ASNTable(BaseTable):
     )
 
     def render_asn(self, value, record):
-        if record.asdot_notation:
-            return f'{value} ({record.asdot_notation})'
-        else:
-            return value
+        return record.asn_with_asdot
 
     site_count = LinkedCountColumn(
         viewname='dcim:site_list',

--- a/netbox/templates/ipam/asn.html
+++ b/netbox/templates/ipam/asn.html
@@ -18,7 +18,7 @@
           <table class="table table-hover attr-table">
             <tr>
               <td>AS Number</td>
-              <td>{{ object.asn }}</td>
+              <td>{{ object.asn }} {% if object.asdot_notation %}({{ object.asdot_notation }}){% endif %}</td>
             </tr>
             <tr>
               <td>RIR</td>

--- a/netbox/templates/ipam/asn.html
+++ b/netbox/templates/ipam/asn.html
@@ -18,7 +18,7 @@
           <table class="table table-hover attr-table">
             <tr>
               <td>AS Number</td>
-              <td>{{ object.asn }} {% if object.asdot_notation %}({{ object.asdot_notation }}){% endif %}</td>
+              <td>{{ object.asn_with_asdot }}</td>
             </tr>
             <tr>
               <td>RIR</td>


### PR DESCRIPTION
### Fixes: #8293 
Adds custom property to asn model to compute asdot notation if required.
Updates asn view to show asdot notation if one exists in the format xxxxx (yyy.yyy)
Adds a custom column renderer to asn table to display asdot notation if one exists
