### PR TITLE
Fixes: #8295 Render the payload_url of a Webhook with Jinja2

### DIFF
--- a/docs/models/extras/webhook.md
+++ b/docs/models/extras/webhook.md
@@ -3,7 +3,7 @@
 A webhook is a mechanism for conveying to some external system a change that took place in NetBox. For example, you may want to notify a monitoring system whenever the status of a device is updated in NetBox. This can be done by creating a webhook for the device model in NetBox and identifying the webhook receiver. When NetBox detects a change to a device, an HTTP request containing the details of the change and who made it be sent to the specified receiver. Webhooks are managed under Logging > Webhooks.
 
 !!! warning
-    Webhooks support the inclusion of user-submitted code to generate custom headers and payloads, which may pose security risks under certain conditions. Only grant permission to create or modify webhooks to trusted users.
+    Webhooks support the inclusion of user-submitted code to generate URL, custom headers and payloads, which may pose security risks under certain conditions. Only grant permission to create or modify webhooks to trusted users.
 
 ## Configuration
 
@@ -12,7 +12,7 @@ A webhook is a mechanism for conveying to some external system a change that too
 * **Enabled** - If unchecked, the webhook will be inactive.
 * **Events** - A webhook may trigger on any combination of create, update, and delete events. At least one event type must be selected.
 * **HTTP method** - The type of HTTP request to send. Options include `GET`, `POST`, `PUT`, `PATCH`, and `DELETE`.
-* **URL** - The fuly-qualified URL of the request to be sent. This may specify a destination port number if needed.
+* **URL** - The fully-qualified URL of the request to be sent. This may specify a destination port number if needed. Jinja2 templating is supported for this field.
 * **HTTP content type** - The value of the request's `Content-Type` header. (Defaults to `application/json`)
 * **Additional headers** - Any additional headers to include with the request (optional). Add one header per line in the format `Name: Value`. Jinja2 templating is supported for this field (see below).
 * **Body template** - The content of the request being sent (optional). Jinja2 templating is supported for this field (see below). If blank, NetBox will populate the request body with a raw dump of the webhook context. (If the HTTP cotent type is set to `application/json`, this will be formatted as a JSON object.)
@@ -23,7 +23,7 @@ A webhook is a mechanism for conveying to some external system a change that too
 
 ## Jinja2 Template Support
 
-[Jinja2 templating](https://jinja.palletsprojects.com/) is supported for the `additional_headers` and `body_template` fields. This enables the user to convey object data in the request headers as well as to craft a customized request body. Request content can be crafted to enable the direct interaction with external systems by ensuring the outgoing message is in a format the receiver expects and understands.
+[Jinja2 templating](https://jinja.palletsprojects.com/) is supported for the `URL`, `additional_headers` and `body_template` fields. This enables the user to convey object data in the request headers as well as to craft a customized request body. Request content can be crafted to enable the direct interaction with external systems by ensuring the outgoing message is in a format the receiver expects and understands.
 
 For example, you might create a NetBox webhook to [trigger a Slack message](https://api.slack.com/messaging/webhooks) any time an IP address is created. You can accomplish this using the following configuration:
 

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -68,7 +68,8 @@ class Webhook(ChangeLoggedModel):
     payload_url = models.CharField(
         max_length=500,
         verbose_name='URL',
-        help_text="A POST will be sent to this URL when the webhook is called."
+        help_text='This URL will be called using the HTTP method defined when the webhook is called. '
+                  'Jinja2 template processing is supported with the same context as the request body.'
     )
     enabled = models.BooleanField(
         default=True
@@ -175,6 +176,12 @@ class Webhook(ChangeLoggedModel):
             return render_jinja2(self.body_template, context)
         else:
             return json.dumps(context, cls=JSONEncoder)
+
+    def render_payload_url(self, context):
+        """
+        Render the payload URL.
+        """
+        return render_jinja2(self.payload_url, context)
 
 
 @extras_features('webhooks', 'export_templates')

--- a/netbox/extras/webhooks_worker.py
+++ b/netbox/extras/webhooks_worker.py
@@ -67,7 +67,7 @@ def process_webhook(webhook, model_name, event, data, snapshots, timestamp, user
     # Prepare the HTTP request
     params = {
         'method': webhook.http_method,
-        'url': webhook.payload_url,
+        'url': webhook.render_payload_url(context),
         'headers': headers,
         'data': body.encode('utf8'),
     }


### PR DESCRIPTION
### Fixes: #8295 
Render the payload_url with Jinja2 when triggering a webhook.

- Update markdown documentation
- Expand on the help text for the Webhook model to reference support of Jinja2 templating