### PR TITLE
Fixes #8342

### DIFF
--- a/netbox/circuits/api/serializers.py
+++ b/netbox/circuits/api/serializers.py
@@ -100,5 +100,5 @@ class CircuitTerminationSerializer(ValidatedModelSerializer, LinkTerminationSeri
         fields = [
             'id', 'url', 'display', 'circuit', 'term_side', 'site', 'provider_network', 'port_speed', 'upstream_speed',
             'xconnect_id', 'pp_info', 'description', 'mark_connected', 'cable', 'link_peer', 'link_peer_type',
-            '_occupied',
+            '_occupied', 'created', 'last_updated',
         ]

--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -219,7 +219,7 @@ class RackReservationSerializer(PrimaryModelSerializer):
     class Meta:
         model = RackReservation
         fields = [
-            'id', 'url', 'display', 'rack', 'units', 'created', 'user', 'tenant', 'description', 'tags',
+            'id', 'url', 'display', 'rack', 'units', 'created', 'last_updated', 'user', 'tenant', 'description', 'tags',
             'custom_fields',
         ]
 
@@ -762,7 +762,7 @@ class CableSerializer(PrimaryModelSerializer):
         fields = [
             'id', 'url', 'display', 'termination_a_type', 'termination_a_id', 'termination_a', 'termination_b_type',
             'termination_b_id', 'termination_b', 'type', 'status', 'tenant', 'label', 'color', 'length', 'length_unit',
-            'tags', 'custom_fields',
+            'tags', 'custom_fields', 'created', 'last_updated',
         ]
 
     def _get_termination(self, obj, side):
@@ -856,7 +856,10 @@ class VirtualChassisSerializer(PrimaryModelSerializer):
 
     class Meta:
         model = VirtualChassis
-        fields = ['id', 'url', 'display', 'name', 'domain', 'master', 'tags', 'custom_fields', 'member_count']
+        fields = [
+            'id', 'url', 'display', 'name', 'domain', 'master', 'tags', 'custom_fields', 'member_count',
+            'created', 'last_updated',
+        ]
 
 
 #
@@ -875,7 +878,10 @@ class PowerPanelSerializer(PrimaryModelSerializer):
 
     class Meta:
         model = PowerPanel
-        fields = ['id', 'url', 'display', 'site', 'location', 'name', 'tags', 'custom_fields', 'powerfeed_count']
+        fields = [
+            'id', 'url', 'display', 'site', 'location', 'name', 'tags', 'custom_fields', 'powerfeed_count',
+            'created', 'last_updated',
+        ]
 
 
 class PowerFeedSerializer(PrimaryModelSerializer, LinkTerminationSerializer, ConnectedEndpointSerializer):

--- a/netbox/extras/api/serializers.py
+++ b/netbox/extras/api/serializers.py
@@ -61,7 +61,7 @@ class WebhookSerializer(ValidatedModelSerializer):
         fields = [
             'id', 'url', 'display', 'content_types', 'name', 'type_create', 'type_update', 'type_delete', 'payload_url',
             'enabled', 'http_method', 'http_content_type', 'additional_headers', 'body_template', 'secret',
-            'conditions', 'ssl_verification', 'ca_file_path',
+            'conditions', 'ssl_verification', 'ca_file_path', 'created', 'last_updated',
         ]
 
 
@@ -82,7 +82,8 @@ class CustomFieldSerializer(ValidatedModelSerializer):
         model = CustomField
         fields = [
             'id', 'url', 'display', 'content_types', 'type', 'name', 'label', 'description', 'required', 'filter_logic',
-            'default', 'weight', 'validation_minimum', 'validation_maximum', 'validation_regex', 'choices',
+            'default', 'weight', 'validation_minimum', 'validation_maximum', 'validation_regex', 'choices', 'created',
+            'last_updated',
         ]
 
 
@@ -100,7 +101,7 @@ class CustomLinkSerializer(ValidatedModelSerializer):
         model = CustomLink
         fields = [
             'id', 'url', 'display', 'content_type', 'name', 'link_text', 'link_url', 'weight', 'group_name',
-            'button_class', 'new_window',
+            'button_class', 'new_window', 'created', 'last_updated',
         ]
 
 
@@ -118,7 +119,7 @@ class ExportTemplateSerializer(ValidatedModelSerializer):
         model = ExportTemplate
         fields = [
             'id', 'url', 'display', 'content_type', 'name', 'description', 'template_code', 'mime_type',
-            'file_extension', 'as_attachment',
+            'file_extension', 'as_attachment', 'created', 'last_updated',
         ]
 
 
@@ -132,7 +133,9 @@ class TagSerializer(ValidatedModelSerializer):
 
     class Meta:
         model = Tag
-        fields = ['id', 'url', 'display', 'name', 'slug', 'color', 'description', 'tagged_items']
+        fields = [
+            'id', 'url', 'display', 'name', 'slug', 'color', 'description', 'tagged_items', 'created', 'last_updated',
+        ]
 
 
 #


### PR DESCRIPTION
### Fixes: #8342 

created & last_updated fields are missing from some REST API calls. Added missing fields to the following API calls

/api/dcim/virtual-chassis/
/api/dcim/cables/
/api/dcim/power-panels/
/api/dcim/rack-reservations/
/api/circuits/circuit-terminations/
/api/extras/webhooks/
/api/extras/custom-fields/
/api/extras/custom-links/
/api/extras/export-templates/
/api/extras/tags/