### PR TITLE
Fixes #8391: Install date should appear empty when exported

### DIFF
--- a/netbox/circuits/tables.py
+++ b/netbox/circuits/tables.py
@@ -140,9 +140,6 @@ class CircuitTable(BaseTable):
         template_code=CIRCUITTERMINATION_LINK,
         verbose_name='Side Z'
     )
-    install_date = tables.DateColumn(
-        default=''
-    )
     commit_rate = CommitRateColumn()
     comments = MarkdownColumn()
     tags = TagColumn(

--- a/netbox/circuits/tables.py
+++ b/netbox/circuits/tables.py
@@ -140,6 +140,9 @@ class CircuitTable(BaseTable):
         template_code=CIRCUITTERMINATION_LINK,
         verbose_name='Side Z'
     )
+    install_date = tables.DateColumn(
+        default=''
+    )
     commit_rate = CommitRateColumn()
     comments = MarkdownColumn()
     tags = TagColumn(

--- a/netbox/utilities/tables.py
+++ b/netbox/utilities/tables.py
@@ -4,10 +4,11 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist
-from django.db.models import DateField
+from django.db.models import DateField, DateTimeField
 from django.db.models.fields.related import RelatedField
 from django.urls import reverse
 from django.utils.safestring import mark_safe
+from django.utils.formats import date_format
 from django_tables2 import RequestConfig
 from django_tables2.columns import library
 from django_tables2.data import TableQuerysetData
@@ -221,6 +222,25 @@ class DateColumn(tables.DateColumn):
     @classmethod
     def from_field(cls, field, **kwargs):
         if isinstance(field, DateField):
+            return cls(**kwargs)
+
+
+@library.register
+class DateTimeColumn(tables.DateTimeColumn):
+    """
+    Overrides the default implementation of DateTimeColumn to better handle null values, returning a default value for
+    tables and null when exporting data. It is registered in the tables library to use this class instead of the
+    default, making this behavior consistent in all fields of type DateTimeField.
+    """
+
+    def value(self, value):
+        if value:
+            return date_format(value, format="SHORT_DATETIME_FORMAT")
+        return None
+
+    @classmethod
+    def from_field(cls, field, **kwargs):
+        if isinstance(field, DateTimeField):
             return cls(**kwargs)
 
 

--- a/netbox/utilities/tables.py
+++ b/netbox/utilities/tables.py
@@ -7,8 +7,8 @@ from django.core.exceptions import FieldDoesNotExist
 from django.db.models import DateField, DateTimeField
 from django.db.models.fields.related import RelatedField
 from django.urls import reverse
-from django.utils.safestring import mark_safe
 from django.utils.formats import date_format
+from django.utils.safestring import mark_safe
 from django_tables2 import RequestConfig
 from django_tables2.columns import library
 from django_tables2.data import TableQuerysetData

--- a/netbox/utilities/tables.py
+++ b/netbox/utilities/tables.py
@@ -4,10 +4,12 @@ from django.contrib.auth.models import AnonymousUser
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist
+from django.db.models import DateField
 from django.db.models.fields.related import RelatedField
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django_tables2 import RequestConfig
+from django_tables2.columns import library
 from django_tables2.data import TableQuerysetData
 from django_tables2.utils import Accessor
 
@@ -203,6 +205,23 @@ class TemplateColumn(tables.TemplateColumn):
         if ret == self.PLACEHOLDER:
             return ''
         return ret
+
+
+@library.register
+class DateColumn(tables.DateColumn):
+    """
+    Overrides the default implementation of DateColumn to better handle null values, returning a default value for
+    tables and null when exporting data. It is registered in the tables library to use this class instead of the
+    default, making this behavior consistent in all fields of type DateField.
+    """
+
+    def value(self, value):
+        return value
+
+    @classmethod
+    def from_field(cls, field, **kwargs):
+        if isinstance(field, DateField):
+            return cls(**kwargs)
 
 
 class ButtonsColumn(tables.TemplateColumn):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #8391
<!--
    Please include a summary of the proposed changes below.
-->
Set the default value to export installed_date values as empty when they are null
