### PR TITLE
Fixes #8477: The commands for running the tests in the development se…

### DIFF
--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -122,22 +122,22 @@ The demo data is provided in JSON format and loaded into an empty database using
 
 ## Running Tests
 
-Prior to committing any substantial changes to the code base, be sure to run NetBox's test suite to catch any potential errors. Tests are run using the `test` management command. Remember to ensure the Python virtual environment is active before running this command.
+Prior to committing any substantial changes to the code base, be sure to run NetBox's test suite to catch any potential errors. Tests are run using the `test` management command. Remember to ensure the Python virtual environment is active before running this command. Also keep in mind that these commands are executed in the `/netbox/` directory, not the root directory of the repository.
 
 ```no-highlight
-$ python netbox/manage.py test
+$ python manage.py test
 ```
 
 In cases where you haven't made any changes to the database (which is most of the time), you can append the `--keepdb` argument to this command to reuse the test database between runs. This cuts down on the time it takes to run the test suite since the database doesn't have to be rebuilt each time. (Note that this argument will cause errors if you've modified any model fields since the previous test run.)
 
 ```no-highlight
-$ python netbox/manage.py test --keepdb
+$ python manage.py test --keepdb
 ```
 
 You can also limit the command to running only a specific subset of tests. For example, to run only IPAM and DCIM view tests:
 
 ```no-highlight
-$ python netbox/manage.py test dcim.tests.test_views ipam.tests.test_views
+$ python manage.py test dcim.tests.test_views ipam.tests.test_views
 ```
 
 ## Submitting Pull Requests


### PR DESCRIPTION
…ction are not working

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #8477
<!--
    Please include a summary of the proposed changes below.
-->
Running `python3 netbox/manage.py test netbox` does work, but working with submodules does not work, because `netbox` is not a proper package. It will fail with an error saying that it can't load the submodules. Therefore running `python3 manage.py test` in the `netbox` directory is the way to go.