### PR TITLE
feat: plugins can extend the GraphQL schema

### DIFF
--- a/netbox/netbox/graphql/schema.py
+++ b/netbox/netbox/graphql/schema.py
@@ -3,14 +3,14 @@ import graphene
 from circuits.graphql.schema import CircuitsQuery
 from dcim.graphql.schema import DCIMQuery
 from extras.graphql.schema import ExtrasQuery
+from extras.plugins import registry
 from ipam.graphql.schema import IPAMQuery
 from tenancy.graphql.schema import TenancyQuery
 from users.graphql.schema import UsersQuery
 from virtualization.graphql.schema import VirtualizationQuery
 from wireless.graphql.schema import WirelessQuery
 
-
-class Query(
+query_types = [
     CircuitsQuery,
     DCIMQuery,
     ExtrasQuery,
@@ -19,9 +19,45 @@ class Query(
     UsersQuery,
     VirtualizationQuery,
     WirelessQuery,
+    *registry['graphql_queries'],
+]
+
+mutation_types = [
+    *registry['graphql_mutations'],
+]
+
+subscription_types = [
+    *registry['graphql_subscriptions'],
+]
+
+extra_types = [
+    *registry['graphql_types'],
+]
+
+
+class Query(
+    *query_types,
     graphene.ObjectType
 ):
     pass
 
 
-schema = graphene.Schema(query=Query, auto_camelcase=False)
+class Mutation(
+    *mutation_types,
+    graphene.ObjectType
+):
+    pass
+
+
+class Subscription(
+    *subscription_types,
+    graphene.ObjectType
+):
+    pass
+
+
+schema = graphene.Schema(query=Query,
+                         mutation=Mutation if len(mutation_types) > 0 else None,
+                         subscription=Subscription if len(subscription_types) > 0 else None,
+                         types=extra_types if len(extra_types) > 0 else None,
+                         auto_camelcase=False)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #8405
<!--
    Please include a summary of the proposed changes below.
-->

This change allows plugin to extend the GraphQL schema with queries, mutations, subscriptions and custom types. This allows full flexibility in extending the API for Plugins.



Remaining Tasks:

 - [x] Plugin endpoint for amending the schema
 - [ ] Tests
 - [ ] Plugin Documentation updates
