### PR TITLE
Fixes #8398: Add ConfigParam.size to enlarge specific config fields

### DIFF
--- a/netbox/extras/forms/config.py
+++ b/netbox/extras/forms/config.py
@@ -25,8 +25,6 @@ class FormMetaclass(forms.models.ModelFormMetaclass):
             }
             field_kwargs.update(**param.field_kwargs)
             param_fields[param.name] = param.field(**field_kwargs)
-            if param.size:
-                param_fields[param.name].widget.attrs["size"] = param.size
         attrs.update(param_fields)
 
         return super().__new__(mcs, name, bases, attrs)

--- a/netbox/extras/forms/config.py
+++ b/netbox/extras/forms/config.py
@@ -25,6 +25,8 @@ class FormMetaclass(forms.models.ModelFormMetaclass):
             }
             field_kwargs.update(**param.field_kwargs)
             param_fields[param.name] = param.field(**field_kwargs)
+            if param.size:
+                param_fields[param.name].widget.attrs["size"] = param.size
         attrs.update(param_fields)
 
         return super().__new__(mcs, name, bases, attrs)

--- a/netbox/netbox/config/parameters.py
+++ b/netbox/netbox/config/parameters.py
@@ -4,14 +4,13 @@ from django.contrib.postgres.forms import SimpleArrayField
 
 class ConfigParam:
 
-    def __init__(self, name, label, default, description='', field=None, field_kwargs=None, size=None):
+    def __init__(self, name, label, default, description='', field=None, field_kwargs=None):
         self.name = name
         self.label = label
         self.default = default
         self.field = field or forms.CharField
         self.description = description
         self.field_kwargs = field_kwargs or {}
-        self.size = size
 
 
 PARAMS = (
@@ -21,22 +20,19 @@ PARAMS = (
         name='BANNER_LOGIN',
         label='Login banner',
         default='',
-        description="Additional content to display on the login page",
-        size="80",
+        description="Additional content to display on the login page"
     ),
     ConfigParam(
         name='BANNER_TOP',
         label='Top banner',
         default='',
-        description="Additional content to display at the top of every page",
-        size="80",
+        description="Additional content to display at the top of every page"
     ),
     ConfigParam(
         name='BANNER_BOTTOM',
         label='Bottom banner',
         default='',
-        description="Additional content to display at the bottom of every page",
-        size="80",
+        description="Additional content to display at the bottom of every page"
     ),
 
     # IPAM
@@ -81,8 +77,7 @@ PARAMS = (
         ),
         description="Permitted schemes for URLs in user-provided content",
         field=SimpleArrayField,
-        field_kwargs={'base_field': forms.CharField()},
-        size="80",
+        field_kwargs={'base_field': forms.CharField()}
     ),
 
     # Pagination
@@ -162,8 +157,7 @@ PARAMS = (
         name='MAPS_URL',
         label='Maps URL',
         default='https://maps.google.com/?q=',
-        description="Base URL for mapping geographic locations",
-        size="80",
+        description="Base URL for mapping geographic locations"
     ),
 
 )

--- a/netbox/netbox/config/parameters.py
+++ b/netbox/netbox/config/parameters.py
@@ -20,19 +20,28 @@ PARAMS = (
         name='BANNER_LOGIN',
         label='Login banner',
         default='',
-        description="Additional content to display on the login page"
+        description="Additional content to display on the login page",
+        field_kwargs={
+            'widget': forms.Textarea(),
+        },
     ),
     ConfigParam(
         name='BANNER_TOP',
         label='Top banner',
         default='',
-        description="Additional content to display at the top of every page"
+        description="Additional content to display at the top of every page",
+        field_kwargs={
+            'widget': forms.Textarea(),
+        },
     ),
     ConfigParam(
         name='BANNER_BOTTOM',
         label='Bottom banner',
         default='',
-        description="Additional content to display at the bottom of every page"
+        description="Additional content to display at the bottom of every page",
+        field_kwargs={
+            'widget': forms.Textarea(),
+        },
     ),
 
     # IPAM

--- a/netbox/netbox/config/parameters.py
+++ b/netbox/netbox/config/parameters.py
@@ -4,13 +4,14 @@ from django.contrib.postgres.forms import SimpleArrayField
 
 class ConfigParam:
 
-    def __init__(self, name, label, default, description='', field=None, field_kwargs=None):
+    def __init__(self, name, label, default, description='', field=None, field_kwargs=None, size=None):
         self.name = name
         self.label = label
         self.default = default
         self.field = field or forms.CharField
         self.description = description
         self.field_kwargs = field_kwargs or {}
+        self.size = size
 
 
 PARAMS = (
@@ -20,19 +21,22 @@ PARAMS = (
         name='BANNER_LOGIN',
         label='Login banner',
         default='',
-        description="Additional content to display on the login page"
+        description="Additional content to display on the login page",
+        size="80",
     ),
     ConfigParam(
         name='BANNER_TOP',
         label='Top banner',
         default='',
-        description="Additional content to display at the top of every page"
+        description="Additional content to display at the top of every page",
+        size="80",
     ),
     ConfigParam(
         name='BANNER_BOTTOM',
         label='Bottom banner',
         default='',
-        description="Additional content to display at the bottom of every page"
+        description="Additional content to display at the bottom of every page",
+        size="80",
     ),
 
     # IPAM
@@ -77,7 +81,8 @@ PARAMS = (
         ),
         description="Permitted schemes for URLs in user-provided content",
         field=SimpleArrayField,
-        field_kwargs={'base_field': forms.CharField()}
+        field_kwargs={'base_field': forms.CharField()},
+        size="80",
     ),
 
     # Pagination
@@ -157,7 +162,8 @@ PARAMS = (
         name='MAPS_URL',
         label='Maps URL',
         default='https://maps.google.com/?q=',
-        description="Base URL for mapping geographic locations"
+        description="Base URL for mapping geographic locations",
+        size="80",
     ),
 
 )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #8398 
<!--
    Please include a summary of the proposed changes below.
-->

Adds `ConfigParam.size` attribute that can be used for enlarging the text input field for specific configuration parameters.

Also adds `size="80"` for those parameters that seems to benefit from longer input field.

Unfortunately my Django skills did not allow for using textareas for the banner fields, it was not a simple `field=forms.Textarea` change as it resulted as `TypeError: __init__() got an unexpected keyword argument 'required'` in https://github.com/netbox-community/netbox/blob/aff55881df21e0edeef589dbaf4204c1be6a0d42/netbox/extras/forms/config.py#L27
 🤔