### PR TITLE
Enable tab completion in nbshell

### DIFF
--- a/netbox/extras/management/commands/nbshell.py
+++ b/netbox/extras/management/commands/nbshell.py
@@ -70,10 +70,23 @@ class Command(BaseCommand):
         return namespace
 
     def handle(self, **options):
+        namespace = self.get_namespace()
+
         # If Python code has been passed, execute it and exit.
         if options['command']:
-            exec(options['command'], self.get_namespace())
+            exec(options['command'], namespace)
             return
 
-        shell = code.interact(banner=BANNER_TEXT, local=self.get_namespace())
+        # Try to enable tab-complete
+        try:
+            import readline
+            import rlcompleter
+        except ModuleNotFoundError:
+            pass
+        else:
+            readline.set_completer(rlcompleter.Completer(namespace).complete)
+            readline.parse_and_bind('tab: complete')
+
+        # Run interactive shell
+        shell = code.interact(banner=BANNER_TEXT, local=namespace)
         return shell


### PR DESCRIPTION
### Fixes: #8620

This uses the standard library [`readline`](https://docs.python.org/3/library/readline.html) and [`rlcompleter`](https://docs.python.org/3/library/rlcompleter.html) modules to add tab-completion to the NetBox Shell (`mange.py nbshell`).

If `readline` support isn't enabled in the Python installation, then this code does nothing.