### PR TITLE
Closes #8733: Add {% block pluginfooter %} to 'base/layout.html' template

### DIFF
--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -108,55 +108,54 @@
 
         {# Page footer #}
         <footer class="footer container-fluid">
-          {# Plugin Custom Footer #}
-          {% block pluginfooter %}{% endblock %}
-
-          <div class="row align-items-center justify-content-between mx-0">
-
-            {# Docs & Community Links #}
-            <div class="col-sm-12 col-md-auto fs-4 noprint">
-              <nav class="nav justify-content-center justify-content-lg-start">
-                {# Documentation #}
-                <a type="button" class="nav-link" href="{% static 'docs/' %}" target="_blank">
-                  <i title="Docs" class="mdi mdi-book-open-variant text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
-                </a>
-
-                {# REST API #}
-                <a type="button" class="nav-link" href="{% url 'api-root' %}" target="_blank">
-                  <i title="REST API" class="mdi mdi-cloud-braces text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
-                </a>
-
-                {# API docs #}
-                <a type="button" class="nav-link" href="{% url 'api_docs' %}" target="_blank">
-                  <i title="REST API documentation" class="mdi mdi-book text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
-                </a>
-
-                {# GraphQL API #}
-                {% if config.GRAPHQL_ENABLED %}
-                  <a type="button" class="nav-link" href="{% url 'graphql' %}" target="_blank">
-                    <i title="GraphQL API" class="mdi mdi-graphql text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
-                  </a>
-                {% endif %}
-
-                {# GitHub #}
-                <a type="button" class="nav-link" href="https://github.com/netbox-community/netbox" target="_blank">
-                  <i title="Source Code" class="mdi mdi-github text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
-                </a>
-
-                {# NetDev Slack #}
-                <a type="button" class="nav-link" href="https://netdev.chat/" target="_blank">
-                  <i title="Community" class="mdi mdi-slack text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
-                </a>
-              </nav>
+          {% block footer %}
+            <div class="row align-items-center justify-content-between mx-0">
+                  
+              <div class="col-sm-12 col-md-auto fs-4 noprint">
+                <nav class="nav justify-content-center justify-content-lg-start">
+                  {% block footer_links %}
+                    {# Documentation #}
+                    <a type="button" class="nav-link" href="{% static 'docs/' %}" target="_blank">
+                      <i title="Docs" class="mdi mdi-book-open-variant text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
+                    </a>
+    
+                    {# REST API #}
+                    <a type="button" class="nav-link" href="{% url 'api-root' %}" target="_blank">
+                      <i title="REST API" class="mdi mdi-cloud-braces text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
+                    </a>
+    
+                    {# API docs #}
+                    <a type="button" class="nav-link" href="{% url 'api_docs' %}" target="_blank">
+                      <i title="REST API documentation" class="mdi mdi-book text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
+                    </a>
+    
+                    {# GraphQL API #}
+                    {% if config.GRAPHQL_ENABLED %}
+                    <a type="button" class="nav-link" href="{% url 'graphql' %}" target="_blank">
+                      <i title="GraphQL API" class="mdi mdi-graphql text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
+                    </a>
+                    {% endif %}
+    
+                    {# GitHub #}
+                    <a type="button" class="nav-link" href="https://github.com/netbox-community/netbox" target="_blank">
+                      <i title="Source Code" class="mdi mdi-github text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
+                    </a>
+    
+                    {# NetDev Slack #}
+                    <a type="button" class="nav-link" href="https://netdev.chat/" target="_blank">
+                      <i title="Community" class="mdi mdi-slack text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
+                    </a>
+                  {% endblock footer_links %}
+                </nav>
+              </div>
+    
+              <div class="col-sm-12 col-md-auto text-center text-lg-end text-muted">
+                <span class="d-block d-md-inline">{% annotated_now %} {% now 'T' %}</span>
+                <span class="ms-md-3 d-block d-md-inline">{{ settings.HOSTNAME }} (v{{ settings.VERSION }})</span>
+              </div>
+                  
             </div>
-
-            {# System Info #}
-            <div class="col-sm-12 col-md-auto text-center text-lg-end text-muted">
-              <span class="d-block d-md-inline">{% annotated_now %} {% now 'T' %}</span>
-              <span class="ms-md-3 d-block d-md-inline">{{ settings.HOSTNAME }} (v{{ settings.VERSION }})</span>
-            </div>
-
-          </div>
+          {% endblock footer %}
         </footer>
 
       </div>

--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -108,6 +108,9 @@
 
         {# Page footer #}
         <footer class="footer container-fluid">
+          {# Plugin Custom Footer #}
+          {% block pluginfooter %}{% endblock %}
+
           <div class="row align-items-center justify-content-between mx-0">
 
             {# Docs & Community Links #}


### PR DESCRIPTION
Makes it easy to insert footer information into Netbox footer.

---

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #8733
Changed the **[base/layout.html](https://github.com/netbox-community/netbox/blob/develop/netbox/templates/base/layout.html)** template used by Netbox to accept plugin to insert its own useful links into the footer.

