### PR TITLE
Correct the endpoint for plugin API view names

### DIFF
--- a/netbox/utilities/utils.py
+++ b/netbox/utilities/utils.py
@@ -31,7 +31,7 @@ def get_viewname(model, action=None, rest_api=False):
 
     if rest_api:
         if is_plugin:
-            viewname = f'plugins-api:{app_label}:{model_name}'
+            viewname = f'plugins-api:{app_label}-api:{model_name}'
         else:
             viewname = f'{app_label}-api:{model_name}'
         # Append the action, if any


### PR DESCRIPTION
### Fixes: #8764

@jeremystretch: Yesterday's commit to issue #8764 does not actually insert the correct label for API endpoints. I had a look at the code and found the missing `-api` suffix for the application label to be the likely culprit.

Tested this with NetBox DNS, it works for me.