### PR TITLE
Updating mkdocs to automatically adjust theme

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,11 +8,13 @@ theme:
   icon:
     repo: fontawesome/brands/github
   palette:
-    - scheme: default
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
       toggle:
         icon: material/lightbulb-outline
         name: Switch to Dark Mode
-    - scheme: slate
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
       toggle:
         icon: material/lightbulb
         name: Switch to Light Mode


### PR DESCRIPTION
### Fixes: #8770

Automatically adjusts documentation theme between default/slate based on users preference for dark mode. Tested in Chrome, Firefox & Safari on macOS 12.2 successfully. 
