### PR TITLE
Hide pk column in tables if it is not required

### DIFF
--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -70,8 +70,11 @@ class ObjectListView(BaseMultiObjectView):
             bulk_actions: Show checkboxes for object selection
         """
         table = self.table(self.queryset, user=request.user)
-        if 'pk' in table.base_columns and bulk_actions:
-            table.columns.show('pk')
+        if 'pk' in table.base_columns:
+            if bulk_actions:
+                table.columns.show('pk')
+            else:
+                table.columns.hide('pk')
 
         return table
 


### PR DESCRIPTION
### Fixes: #8787

When a table object is created, the pk column may be shown by default.

While the original code shows a previously hidden column if it is needed, it does not hide the pk column if it is not required. This PR fixes that behaviour.