### PR TITLE
Update GitHub link for Netaddr

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -83,7 +83,7 @@ markdown-include
 mkdocs-material
 
 # Library for manipulating IP prefixes and addresses
-# https://github.com/drkjam/netaddr
+# https://github.com/netaddr/netaddr
 netaddr
 
 # Fork of PIL (Python Imaging Library) for image processing


### PR DESCRIPTION
The project was renamed/moved to a new location in GitHub and we should update the link
in case the redirect stops functioning