### PR TITLE
Fix #8924 - Speed up rendering of the script list

### DIFF
--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -259,6 +259,10 @@ class BaseScript:
     Base model for custom scripts. User classes should inherit from this model if they want to extend Script
     functionality for use in other subclasses.
     """
+
+    # Prevent django from instantiating the class on all accesses
+    do_not_call_in_templates = True
+
     class Meta:
         pass
 
@@ -280,7 +284,7 @@ class BaseScript:
 
     @classproperty
     def name(self):
-        return getattr(self.Meta, 'name', self.__class__.__name__)
+        return getattr(self.Meta, 'name', self.__name__)
 
     @classproperty
     def full_name(self):

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -753,6 +753,8 @@ class ScriptListView(ContentTypePermissionRequiredMixin, View):
 
         for _scripts in scripts.values():
             for script in _scripts.values():
+                # Prevent django from instantiating the class on all accesses
+                script.do_not_call_in_templates = True
                 script.result = results.get(script.full_name)
 
         return render(request, 'extras/script_list.html', {

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -753,8 +753,6 @@ class ScriptListView(ContentTypePermissionRequiredMixin, View):
 
         for _scripts in scripts.values():
             for script in _scripts.values():
-                # Prevent django from instantiating the class on all accesses
-                script.do_not_call_in_templates = True
                 script.result = results.get(script.full_name)
 
         return render(request, 'extras/script_list.html', {

--- a/netbox/templates/extras/script_list.html
+++ b/netbox/templates/extras/script_list.html
@@ -34,7 +34,7 @@
                 {% for class_name, script in module_scripts.items %}
                   <tr>
                     <td>
-                      <a href="{% url 'extras:script' module=script.module name=class_name %}" name="script.{{ class_name }}">{{ script.Meta.name }}</a>
+                      <a href="{% url 'extras:script' module=script.module name=class_name %}" name="script.{{ class_name }}">{{ script.name }}</a>
                     </td>
                     <td>
                       {% include 'extras/inc/job_label.html' with result=script.result %}

--- a/netbox/templates/extras/script_list.html
+++ b/netbox/templates/extras/script_list.html
@@ -34,7 +34,7 @@
                 {% for class_name, script in module_scripts.items %}
                   <tr>
                     <td>
-                      <a href="{% url 'extras:script' module=script.module name=class_name %}" name="script.{{ class_name }}">{{ script }}</a>
+                      <a href="{% url 'extras:script' module=script.module name=class_name %}" name="script.{{ class_name }}">{{ script.Meta.name }}</a>
                     </td>
                     <td>
                       {% include 'extras/inc/job_label.html' with result=script.result %}


### PR DESCRIPTION
### Fixes: #8924

Loading the script list can become slow when having multiple large scripts. The reason is that django instantiates the Script class for each access in the template. This can be very slow in some cases.

The fix is simply to set `do_not_call_in_templates` = True on the callable before passing them to the template. Please let me know if there is a better option.

The template was changed slightly, as the script variable did not return the name when not instantiated. Name is now taken from Meta instead.