### PR TITLE
Closes #8912: Add linkify template filter

### DIFF
--- a/docs/plugins/development/templates.md
+++ b/docs/plugins/development/templates.md
@@ -230,6 +230,8 @@ The following custom template filters are available in NetBox.
 
 ::: utilities.templatetags.builtins.filters.content_type_id
 
+::: utilities.templatetags.builtins.filters.linkify
+
 ::: utilities.templatetags.builtins.filters.meta
 
 ::: utilities.templatetags.builtins.filters.placeholder

--- a/netbox/templates/circuits/circuit.html
+++ b/netbox/templates/circuits/circuit.html
@@ -18,9 +18,7 @@
                 <table class="table table-hover attr-table">
                     <tr>
                         <th scope="row">Provider</th>
-                        <td>
-                            <a href="{{ object.provider.get_absolute_url }}">{{ object.provider }}</a>
-                        </td>
+                        <td>{{ object.provider|linkify }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Circuit ID</th>
@@ -28,7 +26,7 @@
                     </tr>
                     <tr>
                         <th scope="row">Type</th>
-                        <td><a href="{{ object.type.get_absolute_url }}">{{ object.type }}</a></td>
+                        <td>{{ object.type|linkify }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Status</th>
@@ -39,9 +37,9 @@
                         <td>
                             {% if object.tenant %}
                                 {% if object.tenant.group %}
-                                    <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                                    {{ object.tenant.group|linkify }} /
                                 {% endif %}
-                                <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                                {{ object.tenant|linkify }}
                             {% else %}
                                 <span class="text-muted">None</span>
                             {% endif %}

--- a/netbox/templates/circuits/circuit.html
+++ b/netbox/templates/circuits/circuit.html
@@ -35,14 +35,10 @@
                     <tr>
                         <th scope="row">Tenant</th>
                         <td>
-                            {% if object.tenant %}
-                                {% if object.tenant.group %}
-                                    {{ object.tenant.group|linkify }} /
-                                {% endif %}
-                                {{ object.tenant|linkify }}
-                            {% else %}
-                                <span class="text-muted">None</span>
+                            {% if object.tenant.group %}
+                                {{ object.tenant.group|linkify }} /
                             {% endif %}
+                            {{ object.tenant|linkify|placeholder }}
                         </td>
                     </tr>
                     <tr>

--- a/netbox/templates/circuits/inc/circuit_termination.html
+++ b/netbox/templates/circuits/inc/circuit_termination.html
@@ -32,9 +32,9 @@
               <td>Site</td>
               <td>
                 {% if termination.site.region %}
-                  <a href="{{ termination.site.region.get_absolute_url }}">{{ termination.site.region }}</a> /
+                  {{ termination.site.region|linkify }} /
                 {% endif %}
-                <a href="{{ termination.site.get_absolute_url }}">{{ termination.site }}</a>
+                {{ termination.site|linkify }}
               </td>
             </tr>
             <tr>
@@ -48,11 +48,11 @@
                   {% with peer=termination.get_link_peer %}
                     to
                     {% if peer.device %}
-                      <a href="{{ peer.device.get_absolute_url }}">{{ peer.device }}</a><br/>
+                      {{ peer.device|linkify }}<br/>
                     {% elif peer.circuit %}
-                      <a href="{{ peer.circuit.get_absolute_url }}">{{ peer.circuit }}</a><br/>
+                      {{ peer.circuit|linkify }}<br/>
                     {% endif %}
-                    <a href="{{ peer.get_absolute_url }}">{{ peer }}</a>
+                    {{ peer|linkify }}
                   {% endwith %}
                   <div class="mt-1">
                     <a href="{% url 'circuits:circuittermination_trace' pk=termination.pk %}" class="btn btn-primary btn-sm lh-1" title="Trace">
@@ -82,9 +82,7 @@
           {% else %}
             <tr>
               <td>Provider Network</td>
-              <td>
-                <a href="{{ termination.provider_network.get_absolute_url }}">{{ termination.provider_network }}</a>
-              </td>
+              <td>{{ termination.provider_network|linkify }}</td>
             </tr>
           {% endif %}
             <tr>

--- a/netbox/templates/circuits/providernetwork.html
+++ b/netbox/templates/circuits/providernetwork.html
@@ -20,9 +20,7 @@
                 <table class="table table-hover attr-table">
                     <tr>
                         <th scope="row">Provider</th>
-                        <td>
-                            <a href="{{ object.provider.get_absolute_url }}">{{ object.provider }}</a>
-                        </td>
+                        <td>{{ object.provider|linkify }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Name</th>

--- a/netbox/templates/dcim/cable.html
+++ b/netbox/templates/dcim/cable.html
@@ -26,9 +26,9 @@
                             <td>
                                 {% if object.tenant %}
                                     {% if object.tenant.group %}
-                                        <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                                        {{ object.tenant.group|linkify }} /
                                     {% endif %}
-                                    <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                                    {{ object.tenant|linkify }}
                                 {% else %}
                                     <span class="text-muted">None</span>
                                 {% endif %}

--- a/netbox/templates/dcim/cable.html
+++ b/netbox/templates/dcim/cable.html
@@ -24,14 +24,10 @@
                         <tr>
                             <th scope="row">Tenant</th>
                             <td>
-                                {% if object.tenant %}
-                                    {% if object.tenant.group %}
-                                        {{ object.tenant.group|linkify }} /
-                                    {% endif %}
-                                    {{ object.tenant|linkify }}
-                                {% else %}
-                                    <span class="text-muted">None</span>
+                                {% if object.tenant.group %}
+                                    {{ object.tenant.group|linkify }} /
                                 {% endif %}
+                                {{ object.tenant|linkify|placeholder }}
                             </td>
                         </tr>
                         <tr>

--- a/netbox/templates/dcim/cable_trace.html
+++ b/netbox/templates/dcim/cable_trace.html
@@ -25,7 +25,7 @@
                                 {% if next_node.cable %}
                                     <li>
                                         <a href="{% url 'dcim:frontport_trace' pk=next_node.pk %}">{{ next_node }}</a>
-                                        (Cable <a href="{{ next_node.cable.get_absolute_url }}">{{ next_node.cable }}</a>)
+                                        (Cable {{ next_node.cable|linkify }})
                                     </li>
                                 {% else %}
                                     <li class="text-muted">{{ next_node }}</li>

--- a/netbox/templates/dcim/consoleport.html
+++ b/netbox/templates/dcim/consoleport.html
@@ -20,19 +20,11 @@
                     <table class="table table-hover attr-table">
                         <tr>
                             <th scope="row">Device</th>
-                            <td>
-                                <a href="{{ object.device.get_absolute_url }}">{{ object.device }}</a>
-                            </td>
+                            <td>{{ object.device|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Module</th>
-                            <td>
-                              {% if object.module %}
-                                <a href="{{ object.module.get_absolute_url }}">{{ object.module }}</a>
-                              {% else %}
-                                {{ None|placeholder }}
-                              {% endif %}
-                            </td>
+                            <td>{{ object.module|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Name</th>
@@ -74,7 +66,7 @@
                             <tr>
                                 <th scope="row">Cable</th>
                                 <td>
-                                    <a href="{{ object.cable.get_absolute_url }}">{{ object.cable }}</a>
+                                    {{ object.cable|linkify }}
                                     <a href="{% url 'dcim:consoleport_trace' pk=object.pk %}" class="btn btn-primary btn-sm lh-1" title="Trace">
                                         <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
                                     </a>
@@ -83,9 +75,7 @@
                             {% if object.connected_endpoint %}
                                 <tr>
                                     <th scope="row">Device</th>
-                                    <td>
-                                        <a href="{{ object.connected_endpoint.device.get_absolute_url }}">{{ object.connected_endpoint.device }}</a>
-                                    </td>
+                                    <td>{{ object.connected_endpoint.device|linkify }}</td>
                                 </tr>
                                 <tr>
                                     <th scope="row">Name</th>

--- a/netbox/templates/dcim/consoleport.html
+++ b/netbox/templates/dcim/consoleport.html
@@ -79,9 +79,7 @@
                                 </tr>
                                 <tr>
                                     <th scope="row">Name</th>
-                                    <td>
-                                        <a href="{{ object.connected_endpoint.get_absolute_url }}">{{ object.connected_endpoint.name }}</a>
-                                    </td>
+                                    <td>{{ object.connected_endpoint|linkify:"name" }}</td>
                                 </tr>
                                 <tr>
                                     <th scope="row">Type</th>

--- a/netbox/templates/dcim/consoleserverport.html
+++ b/netbox/templates/dcim/consoleserverport.html
@@ -20,19 +20,11 @@
                     <table class="table table-hover attr-table">
                         <tr>
                             <th scope="row">Device</th>
-                            <td>
-                                <a href="{{ object.device.get_absolute_url }}">{{ object.device }}</a>
-                            </td>
+                            <td>{{ object.device|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Module</th>
-                            <td>
-                              {% if object.module %}
-                                <a href="{{ object.module.get_absolute_url }}">{{ object.module }}</a>
-                              {% else %}
-                                {{ None|placeholder }}
-                              {% endif %}
-                            </td>
+                            <td>{{ object.module|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Name</th>
@@ -74,7 +66,7 @@
                         <tr>
                             <th scope="row">Cable</th>
                             <td>
-                                <a href="{{ object.cable.get_absolute_url }}">{{ object.cable }}</a>
+                                {{ object.cable|linkify }}
                                 <a href="{% url 'dcim:consoleserverport_trace' pk=object.pk %}" class="btn btn-primary btn-sm lh-1" title="Trace">
                                     <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
                                 </a>
@@ -84,7 +76,7 @@
                             <tr>
                                 <th scope="row">Device</th>
                                 <td>
-                                    <a href="{{ object.connected_endpoint.device.get_absolute_url }}">{{ object.connected_endpoint.device }}</a>
+                                    {{ object.connected_endpoint.device|linkify }}
                                 </td>
                             </tr>
                             <tr>

--- a/netbox/templates/dcim/consoleserverport.html
+++ b/netbox/templates/dcim/consoleserverport.html
@@ -81,9 +81,7 @@
                             </tr>
                             <tr>
                                 <th scope="row">Name</th>
-                                <td>
-                                    <a href="{{ object.connected_endpoint.get_absolute_url }}">{{ object.connected_endpoint.name }}</a>
-                                </td>
+                                <td>{{ object.connected_endpoint|linkify:"name" }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Type</th>

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -76,14 +76,10 @@
                         <tr>
                             <th scope="row">Tenant</th>
                             <td>
-                                {% if object.tenant %}
-                                    {% if object.tenant.group %}
-                                        {{ object.tenant.group|linkify }} /
-                                    {% endif %}
-                                    {{ object.tenant|linkify }}
-                                {% else %}
-                                    <span class="text-muted">None</span>
+                                {% if object.tenant.group %}
+                                    {{ object.tenant.group|linkify }} /
                                 {% endif %}
+                                {{ object.tenant|linkify|placeholder }}
                             </td>
                         </tr>
                         <tr>

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -19,28 +19,26 @@
                             <td>
                                 {% if object.site.region %}
                                     {% for region in object.site.region.get_ancestors %}
-                                    <a href="{{ region.get_absolute_url }}">{{ region }}</a> /
+                                        {{ region|linkify }} /
                                     {% endfor %}
-                                    <a href="{{ object.site.region.get_absolute_url }}">{{ object.site.region }}</a>
+                                    {{ object.site.region|linkify }}
                                 {% else %}
-                                <span class="text-muted">None</span>
+                                    <span class="text-muted">None</span>
                                 {% endif %}
                             </td>
                         </tr>
                         <tr>
                             <th scope="row">Site</th>
-                            <td>
-                                <a href="{{ object.site.get_absolute_url }}">{{ object.site }}</a>
-                            </td>
+                            <td>{{ object.site|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Location</th>
                             <td>
                             {% if object.location %}
                                 {% for location in object.location.get_ancestors %}
-                                    <a href="{{ location.get_absolute_url }}">{{ location }}</a> /
+                                    {{ location|linkify }} /
                                 {% endfor %}
-                                <a href="{{ object.location.get_absolute_url }}">{{ object.location }}</a>
+                                {{ object.location|linkify }}
                             {% else %}
                                 <span class="text-muted">None</span>
                             {% endif %}
@@ -61,7 +59,7 @@
                             <td>
                                 {% if object.parent_bay %}
                                     {% with object.parent_bay.device as parent %}
-                                        <a href="{{ parent.get_absolute_url }}">{{ parent }}</a> / {{ object.parent_bay }}
+                                        {{ parent|linkify }} / {{ object.parent_bay }}
                                         {% if parent.position %}
                                             (U{{ parent.position }} / {{ parent.get_face_display }})
                                         {% endif %}
@@ -80,9 +78,9 @@
                             <td>
                                 {% if object.tenant %}
                                     {% if object.tenant.group %}
-                                        <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                                        {{ object.tenant.group|linkify }} /
                                     {% endif %}
-                                    <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                                    {{ object.tenant|linkify }}
                                 {% else %}
                                     <span class="text-muted">None</span>
                                 {% endif %}
@@ -91,7 +89,7 @@
                         <tr>
                             <th scope="row">Device Type</th>
                             <td>
-                                <span><a href="{{ object.device_type.get_absolute_url }}">{{ object.device_type }}</a> ({{ object.device_type.u_height }}U)</span>
+                                {{ object.device_type|linkify }} ({{ object.device_type.u_height }}U)
                             </td>
                         </tr>
                         <tr>
@@ -127,7 +125,7 @@
                             {% for vc_member in vc_members %}
                                 <tr{% if vc_member == object %} class="info"{% endif %}>
                                     <td>
-                                        <a href="{{ vc_member.get_absolute_url }}">{{ vc_member }}</a>
+                                        {{ vc_member|linkify }}
                                     </td>
                                     <td>
                                       {% badge vc_member.vc_position show_empty=True %}
@@ -173,13 +171,7 @@
                         </tr>
                         <tr>
                             <th scope="row">Platform</th>
-                            <td>
-                                {% if object.platform %}
-                                <a href="{{ object.platform.get_absolute_url }}">{{ object.platform }}</a>
-                                {% else %}
-                                    <span class="text-muted">None</span>
-                                {% endif %}
-                            </td>
+                            <td>{{ object.platform|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Primary IPv4</th>
@@ -187,9 +179,9 @@
                               {% if object.primary_ip4 %}
                                 <a href="{% url 'ipam:ipaddress' pk=object.primary_ip4.pk %}">{{ object.primary_ip4.address.ip }}</a>
                                 {% if object.primary_ip4.nat_inside %}
-                                  (NAT for <a href="{{ object.primary_ip4.nat_inside.get_absolute_url }}">{{ object.primary_ip4.nat_inside.address.ip }}</a>)
+                                  (NAT for {{ object.primary_ip4.nat_inside.address.ip|linkify }})
                                 {% elif object.primary_ip4.nat_outside %}
-                                  (NAT: <a href="{{ object.primary_ip4.nat_outside.get_absolute_url }}">{{ object.primary_ip4.nat_outside.address.ip }}</a>)
+                                  (NAT: {{ object.primary_ip4.nat_outside.address.ip|linkify }})
                                 {% endif %}
                               {% else %}
                                 <span class="text-muted">&mdash;</span>
@@ -202,9 +194,9 @@
                               {% if object.primary_ip6 %}
                                 <a href="{% url 'ipam:ipaddress' pk=object.primary_ip6.pk %}">{{ object.primary_ip6.address.ip }}</a>
                                 {% if object.primary_ip6.nat_inside %}
-                                  (NAT for <a href="{{ object.primary_ip6.nat_inside.get_absolute_url }}">{{ object.primary_ip6.nat_inside.address.ip }}</a>)
+                                  (NAT for {{ object.primary_ip6.nat_inside.address.ip|linkify }})
                                 {% elif object.primary_ip6.nat_outside %}
-                                  (NAT: <a href="{{ object.primary_ip6.nat_outside.get_absolute_url }}">{{ object.primary_ip6.nat_outside.address.ip }}</a>)
+                                  (NAT: {{ object.primary_ip6.nat_outside.address.ip|linkify }})
                                 {% endif %}
                               {% else %}
                                 <span class="text-muted">&mdash;</span>
@@ -216,9 +208,9 @@
                                 <th>Cluster</th>
                                 <td>
                                     {% if object.cluster.group %}
-                                        <a href="{{ object.cluster.group.get_absolute_url }}">{{ object.cluster.group }}</a> /
+                                        {{ object.cluster.group|linkify }} /
                                     {% endif %}
-                                    <a href="{{ object.cluster.get_absolute_url }}">{{ object.cluster }}</a>
+                                    {{ object.cluster|linkify }}
                                 </td>
                             </tr>
                         {% endif %}

--- a/netbox/templates/dcim/devicebay.html
+++ b/netbox/templates/dcim/devicebay.html
@@ -20,9 +20,7 @@
                     <table class="table table-hover attr-table">
                         <tr>
                             <th scope="row">Device</th>
-                            <td>
-                                <a href="{{ object.device.get_absolute_url }}">{{ object.device }}</a>
-                            </td>
+                            <td>{{ object.device|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Name</th>
@@ -54,9 +52,7 @@
                         <table class="table table-hover attr-table">
                             <tr>
                                 <th scope="row">Device</th>
-                                <td>
-                                    <a href="{{ device.get_absolute_url }}">{{ device }}</a>
-                                </td>
+                                <td>{{ device|linkify }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Device Type</th>

--- a/netbox/templates/dcim/devicetype.html
+++ b/netbox/templates/dcim/devicetype.html
@@ -14,7 +14,7 @@
                     <table class="table table-hover attr-table">
                         <tr>
                             <td>Manufacturer</td>
-                            <td><a href="{{ object.manufacturer.get_absolute_url }}">{{ object.manufacturer }}</a></td>
+                            <td>{{ object.manufacturer|linkify }}</td>
                         </tr>
                         <tr>
                             <td>Model Name</td>

--- a/netbox/templates/dcim/frontport.html
+++ b/netbox/templates/dcim/frontport.html
@@ -20,19 +20,11 @@
                     <table class="table table-hover attr-table">
                         <tr>
                             <th scope="row">Device</th>
-                            <td>
-                                <a href="{{ object.device.get_absolute_url }}">{{ object.device }}</a>
-                            </td>
+                            <td>{{ object.device|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Module</th>
-                            <td>
-                              {% if object.module %}
-                                <a href="{{ object.module.get_absolute_url }}">{{ object.module }}</a>
-                              {% else %}
-                                {{ None|placeholder }}
-                              {% endif %}
-                            </td>
+                            <td>{{ object.module|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Name</th>
@@ -54,9 +46,7 @@
                         </tr>
                         <tr>
                             <th scope="row">Rear Port</th>
-                            <td>
-                                <a href="{{ object.rear_port.get_absolute_url }}">{{ object.rear_port }}</a>
-                            </td>
+                            <td>{{ object.rear_port|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Rear Port Position</th>
@@ -88,7 +78,7 @@
                         <tr>
                             <th scope="row">Cable</th>
                             <td>
-                                <a href="{{ object.cable.get_absolute_url }}">{{ object.cable }}</a>
+                                {{ object.cable|linkify }}
                                 <a href="{% url 'dcim:frontport_trace' pk=object.pk %}" class="btn btn-primary btn-sm lh-1" title="Trace">
                                     <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
                                 </a>

--- a/netbox/templates/dcim/inc/cable_termination.html
+++ b/netbox/templates/dcim/inc/cable_termination.html
@@ -4,51 +4,35 @@
         {# Device component #}
         <tr>
             <td>Device</td>
-            <td>
-                <a href="{{ termination.device.get_absolute_url }}">{{ termination.device }}</a>
-            </td>
+            <td>{{ termination.device|linkify }}</td>
         </tr>
-        {% if termination.device.site %}
         <tr>
             <td>Site</td>
-            <td>
-                <a href="{{ termination.device.site.get_absolute_url }}">{{ termination.device.site }}</a>
-            </td>
+            <td>{{ termination.device.site|linkify }}</td>
         </tr>
-        {% endif %}
         {% if termination.device.rack %}
-        <tr>
-            <td>Rack</td>
-            <td>
-                <a href="{{ termination.device.rack.get_absolute_url }}">{{ termination.device.rack }}</a>
-            </td>
-        </tr>
+            <tr>
+                <td>Rack</td>
+                <td>{{ termination.device.rack|linkify }}</td>
+            </tr>
         {% endif %}
         <tr>
             <td>Type</td>
-            <td>
-                {{ termination|meta:"verbose_name"|capfirst }}
-            </td>
+            <td>{{ termination|meta:"verbose_name"|capfirst }}</td>
         </tr>
         <tr>
             <td>Component</td>
-            <td>
-                <a href="{{ termination.get_absolute_url }}">{{ termination }}</a>
-            </td>
+            <td>{{ termination|linkify }}</td>
         </tr>
     {% else %}
         {# Circuit termination #}
         <tr>
             <td>Provider</td>
-            <td>
-                <a href="{{ termination.circuit.provider.get_absolute_url }}">{{ termination.circuit.provider }}</a>
-            </td>
+            <td>{{ termination.circuit.provider|linkify }}</td>
         </tr>
         <tr>
             <td>Circuit</td>
-            <td>
-                <a href="{{ termination.circuit.get_absolute_url }}">{{ termination.circuit }}</a> ({{ termination }})
-            </td>
+            <td>{{ termination.|linkify }} ({{ termination }})</td>
         </tr>
     {% endif %}
 </table>

--- a/netbox/templates/dcim/inc/cabletermination.html
+++ b/netbox/templates/dcim/inc/cabletermination.html
@@ -6,9 +6,9 @@
             {{ termination.parent_object }}
         </a>
     {% else %}
-        <a href="{{ termination.parent_object.get_absolute_url }}">{{ termination.parent_object }}</a>
+        {{ termination.parent_object|linkify }}
     {% endif %}
 </td>
 <td>
-    <a href="{{ termination.get_absolute_url }}">{{ termination }}</a>
+    {{ termination|linkify }}
 </td>

--- a/netbox/templates/dcim/inc/endpoint_connection.html
+++ b/netbox/templates/dcim/inc/endpoint_connection.html
@@ -1,7 +1,7 @@
 {% if path.destination_id %}
     {% with endpoint=path.destination %}
-        <td><a href="{{ endpoint.parent_object.get_absolute_url }}">{{ endpoint.parent_object }}</a></td>
-        <td><a href="{{ endpoint.get_absolute_url }}">{{ endpoint }}</a></td>
+        <td>{{ endpoint.parent_object|linkify }}</td>
+        <td>{{ endpoint|linkify }}</td>
     {% endwith %}
 {% else %}
     <td colspan="2" class="text-muted">Not connected</td>

--- a/netbox/templates/dcim/inc/interface_vlans_table.html
+++ b/netbox/templates/dcim/inc/interface_vlans_table.html
@@ -8,9 +8,7 @@
     {% with tagged_vlans=obj.tagged_vlans.all %}
         {% if obj.untagged_vlan and obj.untagged_vlan not in tagged_vlans %}
             <tr>
-                <td>
-                    <a href="{{ obj.untagged_vlan.get_absolute_url }}">{{ obj.untagged_vlan.vid }}</a>
-                </td>
+                <td>{{ obj.untagged_vlan|linkify:"vid" }}</td>
                 <td>{{ obj.untagged_vlan.name }}</td>
                 <td>
                     <input type="radio" name="untagged_vlan" value="{{ obj.untagged_vlan.pk }}" checked="checked" />
@@ -22,9 +20,7 @@
         {% endif %}
         {% for vlan in tagged_vlans %}
             <tr>
-                <td>
-                    <a href="{{ vlan.get_absolute_url }}">{{ vlan.vid }}</a>
-                </td>
+                <td>{{ vlan|linkify:"vid" }}</td>
                 <td>{{ vlan.name }}</td>
                 <td>
                     <input type="radio" name="untagged_vlan" value="{{ vlan.pk }}"{% if vlan == obj.untagged_vlan %} checked="checked"{% endif %} />

--- a/netbox/templates/dcim/inc/nonracked_devices.html
+++ b/netbox/templates/dcim/inc/nonracked_devices.html
@@ -21,7 +21,7 @@
             <td>{{ device.device_role }}</td>
             <td>{{ device.device_type }}</td>
             {% if device.parent_bay %}
-                <td><a href="{{ device.parent_bay.device.get_absolute_url }}">{{ device.parent_bay.device }}</a></td>
+                <td>{{ device.parent_bay.device|linkify }}</td>
                 <td>{{ device.parent_bay }}</td>
             {% else %}
                 <td colspan="2" class="text-muted">&mdash;</td>

--- a/netbox/templates/dcim/inc/panels/inventory_items.html
+++ b/netbox/templates/dcim/inc/panels/inventory_items.html
@@ -15,19 +15,9 @@
       <tbody>
         {% for item in object.inventory_items.all %}
           <tr>
-            <td>
-              <a href="{{ item.get_absolute_url }}">{{ item.name }}</a>
-            </td>
-            <td>
-              {{ item.label|placeholder }}
-            </td>
-            <td>
-              {% if item.role %}
-                <a href="{{ item.role.get_absolute_url }}">{{ item.role }}</a>
-              {% else %}
-                <span class="text-muted">&mdash;</span>
-              {% endif %}
-            </td>
+            <td><a href="{{ item.get_absolute_url }}">{{ item.name }}</a></td>
+            <td>{{ item.label|placeholder }}</td>
+            <td>{{ item.role|linkify|placeholder }}</td>
             <td class="text-end noprint">
               {% if perms.dcim.change_inventoryitem %}
                 <a href="{% url 'dcim:inventoryitem_edit' pk=item.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-warning btn-sm lh-1" title="Edit">

--- a/netbox/templates/dcim/inc/panels/inventory_items.html
+++ b/netbox/templates/dcim/inc/panels/inventory_items.html
@@ -15,7 +15,7 @@
       <tbody>
         {% for item in object.inventory_items.all %}
           <tr>
-            <td><a href="{{ item.get_absolute_url }}">{{ item.name }}</a></td>
+            <td>{{ item|linkify:"name" }}</td>
             <td>{{ item.label|placeholder }}</td>
             <td>{{ item.role|linkify|placeholder }}</td>
             <td class="text-end noprint">

--- a/netbox/templates/dcim/interface.html
+++ b/netbox/templates/dcim/interface.html
@@ -30,19 +30,11 @@
                     <table class="table table-hover">
                         <tr>
                             <th scope="row">Device</th>
-                            <td>
-                                <a href="{{ object.device.get_absolute_url }}">{{ object.device }}</a>
-                            </td>
+                            <td>{{ object.device|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Module</th>
-                            <td>
-                              {% if object.module %}
-                                <a href="{{ object.module.get_absolute_url }}">{{ object.module }}</a>
-                              {% else %}
-                                {{ None|placeholder }}
-                              {% endif %}
-                            </td>
+                            <td>{{ object.module|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Name</th>
@@ -74,33 +66,15 @@
                         </tr>
                         <tr>
                             <th scope="row">Parent</th>
-                            <td>
-                                {% if object.parent %}
-                                    <a href="{{ object.parent.get_absolute_url }}">{{ object.parent }}</a>
-                                {% else %}
-                                    <span class="text-muted">None</span>
-                                {% endif %}
-                            </td>
+                            <td>{{ object.parent|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Bridge</th>
-                            <td>
-                                {% if object.bridge %}
-                                    <a href="{{ object.bridge.get_absolute_url }}">{{ object.bridge }}</a>
-                                {% else %}
-                                    <span class="text-muted">None</span>
-                                {% endif %}
-                            </td>
+                            <td>{{ object.bridge|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">LAG</th>
-                            <td>
-                                {% if object.lag%}
-                                    <a href="{{ object.lag.get_absolute_url }}">{{ object.lag }}</a>
-                                {% else %}
-                                    <span class="text-muted">None</span>
-                                {% endif %}
-                            </td>
+                            <td>{{ object.lag|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Description</th>
@@ -128,13 +102,7 @@
                         </tr>
                         <tr>
                             <th scope="row">VRF</th>
-                            <td>
-                                {% if object.vrf %}
-                                    <a href="{{ object.vrf.get_absolute_url }}">{{ object.vrf }}</a>
-                                {% else %}
-                                    <span class="text-muted">None</span>
-                                {% endif %}
-                            </td>
+                            <td>{{ object.vrf|linkify|placeholder }}</td>
                         </tr>
                     </table>
                 </div>
@@ -170,7 +138,7 @@
                             <tr>
                                 <th scope="row">Cable</th>
                                 <td>
-                                    <a href="{{ object.cable.get_absolute_url }}">{{ object.cable }}</a>
+                                    {{ object.cable|linkify }}
                                     <a href="{% url 'dcim:interface_trace' pk=object.pk %}" class="btn btn-primary btn-sm lh-1" title="Trace">
                                         <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
                                     </a>
@@ -180,9 +148,7 @@
                                 {% with iface=object.connected_endpoint %}
                                     <tr>
                                         <th scope="row">Device</th>
-                                        <td>
-                                            <a href="{{ iface.device.get_absolute_url }}">{{ iface.device }}</a>
-                                        </td>
+                                        <td>{{ iface.device|linkify }}</td>
                                     </tr>
                                     <tr>
                                         <th scope="row">Name</th>
@@ -196,13 +162,7 @@
                                     </tr>
                                     <tr>
                                         <th scope="row">LAG</th>
-                                        <td>
-                                            {% if iface.lag%}
-                                                <a href="{{ iface.lag.get_absolute_url }}">{{ iface.lag }}</a>
-                                            {% else %}
-                                                <span class="text-muted">None</span>
-                                            {% endif %}
-                                        </td>
+                                        <td>{{ iface.lag|linkify|placeholder }}</td>
                                     </tr>
                                     <tr>
                                         <th scope="row">Description</th>
@@ -225,11 +185,11 @@
                                 {% with ct=object.connected_endpoint %}
                                     <tr>
                                         <th scope="row">Provider</th>
-                                        <td><a href="{{ ct.circuit.provider.get_absolute_url }}">{{ ct.circuit.provider }}</a></td>
+                                        <td>{{ ct.circuit.provider|linkify }}</td>
                                     </tr>
                                     <tr>
                                         <th scope="row">Circuit</th>
-                                        <td><a href="{{ ct.circuit.get_absolute_url }}">{{ ct.circuit }}</a></td>
+                                        <td>{{ ct.circuit|linkify }}</td>
                                     </tr>
                                     <tr>
                                         <th scope="row">Side</th>
@@ -253,7 +213,7 @@
                             <tr>
                                 <th scope="row">Wireless Link</th>
                                 <td>
-                                    <a href="{{ object.wireless_link.get_absolute_url }}">{{ object.wireless_link }}</a>
+                                    {{ object.wireless_link|linkify }}
                                     <a href="{% url 'dcim:interface_trace' pk=object.pk %}" class="btn btn-primary btn-sm lh-1" title="Trace">
                                         <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
                                     </a>
@@ -262,15 +222,11 @@
                             {% with peer_interface=object.connected_endpoint %}
                                 <tr>
                                     <th scope="row">Device</th>
-                                    <td>
-                                        <a href="{{ peer_interface.device.get_absolute_url }}">{{ peer_interface.device }}</a>
-                                    </td>
+                                    <td>{{ peer_interface.device|linkify }}</td>
                                 </tr>
                                 <tr>
                                     <th scope="row">Name</th>
-                                    <td>
-                                        <a href="{{ peer_interface.get_absolute_url }}">{{ peer_interface }}</a>
-                                    </td>
+                                    <td>{{ peer_interface|linkify }}</td>
                                 </tr>
                                 <tr>
                                     <th scope="row">Type</th>
@@ -409,7 +365,7 @@
                                     <tr>
                                         <td>
                                             {% if wlan.group %}
-                                              <a href="{{ wlan.group.get_absolute_url }}">{{ wlan.group }}</a>
+                                              {{ wlan.group|linkify }}
                                             {% else %}
                                               &mdash;
                                             {% endif %}
@@ -443,15 +399,9 @@
                             <tbody>
                                 {% for member in object.member_interfaces.all %}
                                     <tr>
-                                        <td>
-                                            <a href="{{ member.device.get_absolute_url }}">{{ member.device }}</a>
-                                        </td>
-                                        <td>
-                                            <a href="{{ member.get_absolute_url }}">{{ member }}</a>
-                                        </td>
-                                        <td>
-                                            {{ member.get_type_display }}
-                                        </td>
+                                        <td>{{ member.device|linkify }}</td>
+                                        <td>{{ member|linkify }}</td>
+                                        <td>{{ member.get_type_display }}</td>
                                     </tr>
                                 {% empty %}
                                     <tr>

--- a/netbox/templates/dcim/interface.html
+++ b/netbox/templates/dcim/interface.html
@@ -152,9 +152,7 @@
                                     </tr>
                                     <tr>
                                         <th scope="row">Name</th>
-                                        <td>
-                                            <a href="{{ iface.get_absolute_url }}">{{ iface.name }}</a>
-                                        </td>
+                                        <td>{{ iface|linkify:"name" }}</td>
                                     </tr>
                                     <tr>
                                         <th scope="row">Type</th>
@@ -370,9 +368,7 @@
                                               &mdash;
                                             {% endif %}
                                         </td>
-                                        <td>
-                                            <a href="{{ wlan.get_absolute_url }}">{{ wlan.ssid }}</a>
-                                        </td>
+                                        <td>{{ wlan|linkify:"ssid" }}</td>
                                     </tr>
                                 {% empty %}
                                     <tr>

--- a/netbox/templates/dcim/inventoryitem.html
+++ b/netbox/templates/dcim/inventoryitem.html
@@ -18,19 +18,11 @@
                     <table class="table table-hover attr-table">
                         <tr>
                             <th scope="row">Device</th>
-                            <td>
-                                <a href="{{ object.device.get_absolute_url }}">{{ object.device }}</a>
-                            </td>
+                            <td>{{ object.device|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Parent Item</th>
-                            <td>
-                                {% if object.parent %}
-                                    <a href="{{ object.parent.get_absolute_url }}">{{ object.parent }}</a>
-                                {% else %}
-                                    <span class="text-muted">&mdash;</span>
-                                {% endif %}
-                            </td>
+                            <td>{{ object.parent|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Name</th>
@@ -42,33 +34,15 @@
                         </tr>
                         <tr>
                             <th scope="row">Role</th>
-                            <td>
-                                {% if object.role %}
-                                    <a href="{{ object.role.get_absolute_url }}">{{ object.role }}</a>
-                                {% else %}
-                                    <span class="text-muted">&mdash;</span>
-                                {% endif %}
-                            </td>
+                            <td>{{ object.role|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Component</th>
-                            <td>
-                                {% if object.component %}
-                                    <a href="{{ object.component.get_absolute_url }}">{{ object.component }}</a>
-                                {% else %}
-                                    <span class="text-muted">&mdash;</span>
-                                {% endif %}
-                            </td>
+                            <td>{{ object.component|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Manufacturer</th>
-                            <td>
-                                {% if object.manufacturer %}
-                                    <a href="{{ object.manufacturer.get_absolute_url }}">{{ object.manufacturer }}</a>
-                                {% else %}
-                                    <span class="text-muted">&mdash;</span>
-                                {% endif %}
-                            </td>
+                            <td>{{ object.manufacturer|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Part ID</th>

--- a/netbox/templates/dcim/location.html
+++ b/netbox/templates/dcim/location.html
@@ -44,17 +44,13 @@
             <td>{{ object.parent|linkify|placeholder }}</td>
           </tr>
           <tr>
-              <th scope="row">Tenant</th>
-              <td>
-                  {% if object.tenant %}
-                      {% if object.tenant.group %}
-                          {{ object.tenant.group|linkify }} /
-                      {% endif %}
-                      {{ object.tenant|linkify }}
-                  {% else %}
-                      <span class="text-muted">None</span>
-                  {% endif %}
-              </td>
+            <th scope="row">Tenant</th>
+            <td>
+              {% if object.tenant.group %}
+                {{ object.tenant.group|linkify }} /
+              {% endif %}
+              {{ object.tenant|linkify|placeholder }}
+            </td>
           </tr>
           <tr>
             <th scope="row">Racks</th>

--- a/netbox/templates/dcim/location.html
+++ b/netbox/templates/dcim/location.html
@@ -6,7 +6,7 @@
 {% block breadcrumbs %}
   {{ block.super }}
   {% for location in object.get_ancestors %}
-    <li class="breadcrumb-item"><a href="{{ location.get_absolute_url }}">{{ location }}</a></li>
+    <li class="breadcrumb-item">{{ location|linkify }}</li>
   {% endfor %}
 {% endblock %}
 
@@ -37,26 +37,20 @@
           </tr>
           <tr>
             <th scope="row">Site</th>
-            <td><a href="{{ object.site.get_absolute_url }}">{{ object.site }}</a></td>
+            <td>{{ object.site|linkify }}</td>
           </tr>
           <tr>
             <th scope="row">Parent</th>
-            <td>
-              {% if object.parent %}
-                <a href="{{ object.parent.get_absolute_url }}">{{ object.parent }}</a>
-              {% else %}
-                <span class="text-muted">&mdash;</span>
-              {% endif %}
-            </td>
+            <td>{{ object.parent|linkify|placeholder }}</td>
           </tr>
           <tr>
               <th scope="row">Tenant</th>
               <td>
                   {% if object.tenant %}
                       {% if object.tenant.group %}
-                          <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                          {{ object.tenant.group|linkify }} /
                       {% endif %}
-                      <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                      {{ object.tenant|linkify }}
                   {% else %}
                       <span class="text-muted">None</span>
                   {% endif %}

--- a/netbox/templates/dcim/module.html
+++ b/netbox/templates/dcim/module.html
@@ -19,21 +19,15 @@
         <table class="table table-hover attr-table">
           <tr>
             <th scope="row">Device</th>
-            <td>
-              <a href="{{ object.device.get_absolute_url }}">{{ object.device }}</a>
-            </td>
+            <td>{{ object.device|linkify }}</td>
           </tr>
           <tr>
             <th scope="row">Device Type</th>
-            <td>
-              <a href="{{ object.device.device_type.get_absolute_url }}">{{ object.device.device_type }}</a>
-            </td>
+            <td>{{ object.device.device_type|linkify }}</td>
           </tr>
           <tr>
             <th scope="row">Module Type</th>
-            <td>
-              <a href="{{ object.module_type.get_absolute_url }}">{{ object.module_type }}</a>
-            </td>
+            <td>{{ object.module_type|linkify }}</td>
           </tr>
           <tr>
             <th scope="row">Serial Number</th>

--- a/netbox/templates/dcim/modulebay.html
+++ b/netbox/templates/dcim/modulebay.html
@@ -54,15 +54,11 @@
             <table class="table table-hover attr-table">
               <tr>
                 <th scope="row">Manufacturer</th>
-                <td>
-                  <a href="{{ module.module_type.manufacturer.get_absolute_url }}">{{ module.module_type.manufacturer }}</a>
-                </td>
+                <td>{{ module.module_type.manufacturer|linkify }}</td>
               </tr>
               <tr>
                 <th scope="row">Module Type</th>
-                <td>
-                  <a href="{{ module.get_absolute_url }}">{{ module.module_type }}</a>
-                </td>
+                <td>{{ module.module_type|linkify }}</td>
               </tr>
             </table>
           {% endwith %}

--- a/netbox/templates/dcim/moduletype.html
+++ b/netbox/templates/dcim/moduletype.html
@@ -12,7 +12,7 @@
           <table class="table table-hover attr-table">
             <tr>
               <td>Manufacturer</td>
-              <td><a href="{{ object.manufacturer.get_absolute_url }}">{{ object.manufacturer }}</a></td>
+              <td>{{ object.manufacturer|linkify }}</td>
             </tr>
             <tr>
               <td>Model Name</td>

--- a/netbox/templates/dcim/platform.html
+++ b/netbox/templates/dcim/platform.html
@@ -37,13 +37,7 @@
           </tr>
           <tr>
             <th scope="row">Manufacturer</th>
-            <td>
-              {% if object.manufacturer %}
-                <a href="{{ object.manufacturer.get_absolute_url }}">{{ object.manufacturer }}</a>
-              {% else %}
-                <span class="text-muted">None</span>
-              {% endif %}
-            </td>
+            <td>{{ object.manufacturer|linkify|placeholder }}</td>
           </tr>
           <tr>
             <th scope="row">NAPALM Driver</th>

--- a/netbox/templates/dcim/powerfeed.html
+++ b/netbox/templates/dcim/powerfeed.html
@@ -127,9 +127,7 @@
                         </tr>
                         <tr>
                             <th scope="row">Name</th>
-                            <td>
-                                <a href="{{ object.connected_endpoint.get_absolute_url }}">{{ object.connected_endpoint.name }}</a>
-                            </td>
+                            <td>{{ object.connected_endpoint|linkify:"name" }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Type</th>

--- a/netbox/templates/dcim/powerfeed.html
+++ b/netbox/templates/dcim/powerfeed.html
@@ -24,19 +24,11 @@
                 <table class="table table-hover attr-table">
                     <tr>
                         <th scope="row">Power Panel</th>
-                        <td>
-                            <a href="{{ object.power_panel.get_absolute_url }}">{{ object.power_panel }}</a>
-                        </td>
+                        <td>{{ object.power_panel|linkify }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Rack</th>
-                        <td>
-                            {% if object.rack %}
-                                <a href="{{ object.rack.get_absolute_url }}">{{ object.rack }}</a>
-                            {% else %}
-                                <span class="text-muted">None</span>
-                            {% endif %}
-                        </td>
+                        <td>{{ object.rack|linkify|placeholder }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Type</th>
@@ -50,7 +42,7 @@
                         <th scope="row">Connected Device</th>
                         <td>
                             {% if object.connected_endpoint %}
-                                <a href="{{ object.connected_endpoint.device.get_absolute_url }}">{{ object.connected_endpoint.device }}</a> ({{ object.connected_endpoint }})
+                                {{ object.connected_endpoint.device|linkify }} ({{ object.connected_endpoint }})
                             {% else %}
                                 <span class="text-muted">None</span>
                             {% endif %}
@@ -122,7 +114,7 @@
                     <tr>
                         <th scope="row">Cable</th>
                         <td>
-                            <a href="{{ object.cable.get_absolute_url }}">{{ object.cable }}</a>
+                            {{ object.cable|linkify }}
                             <a href="{% url 'dcim:powerfeed_trace' pk=object.pk %}" class="btn btn-primary btn-sm lh-1" title="Trace">
                                 <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
                             </a>
@@ -131,9 +123,7 @@
                     {% if object.connected_endpoint %}
                         <tr>
                             <th scope="row">Device</th>
-                            <td>
-                                <a href="{{ object.connected_endpoint.device.get_absolute_url }}">{{ object.connected_endpoint.device }}</a>
-                            </td>
+                            <td>{{ object.connected_endpoint.device|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Name</th>

--- a/netbox/templates/dcim/poweroutlet.html
+++ b/netbox/templates/dcim/poweroutlet.html
@@ -20,19 +20,11 @@
                     <table class="table table-hover attr-table">
                         <tr>
                             <th scope="row">Device</th>
-                            <td>
-                                <a href="{{ object.device.get_absolute_url }}">{{ object.device }}</a>
-                            </td>
+                            <td>{{ object.device|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Module</th>
-                            <td>
-                              {% if object.module %}
-                                <a href="{{ object.module.get_absolute_url }}">{{ object.module }}</a>
-                              {% else %}
-                                {{ None|placeholder }}
-                              {% endif %}
-                            </td>
+                            <td>{{ object.module|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Name</th>
@@ -80,7 +72,7 @@
                         <tr>
                             <th scope="row">Cable</th>
                             <td>
-                                <a href="{{ object.cable.get_absolute_url }}">{{ object.cable }}</a>
+                                {{ object.cable|linkify }}
                                 <a href="{% url 'dcim:poweroutlet_trace' pk=object.pk %}" class="btn btn-primary btn-sm lh-1" title="Trace">
                                     <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
                                 </a>
@@ -89,9 +81,7 @@
                         {% if object.connected_endpoint %}
                             <tr>
                                 <th scope="row">Device</th>
-                                <td>
-                                    <a href="{{ object.connected_endpoint.device.get_absolute_url }}">{{ object.connected_endpoint.device }}</a>
-                                </td>
+                                <td>{{ object.connected_endpoint.device|linkify }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Name</th>

--- a/netbox/templates/dcim/poweroutlet.html
+++ b/netbox/templates/dcim/poweroutlet.html
@@ -85,9 +85,7 @@
                             </tr>
                             <tr>
                                 <th scope="row">Name</th>
-                                <td>
-                                    <a href="{{ object.connected_endpoint.get_absolute_url }}">{{ object.connected_endpoint.name }}</a>
-                                </td>
+                                <td>{{ object.connected_endpoint|linkify:"name" }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Type</th>

--- a/netbox/templates/dcim/powerpanel.html
+++ b/netbox/templates/dcim/powerpanel.html
@@ -7,7 +7,7 @@
   {{ block.super }}
   <li class="breadcrumb-item"><a href="{% url 'dcim:powerpanel_list' %}?site_id={{ object.site.pk }}">{{ object.site }}</a></li>
   {% if object.location %}
-    <li class="breadcrumb-item"><a href="{{ object.location.get_absolute_url }}">{{ object.location }}</a></li>
+    <li class="breadcrumb-item">{{ object.location|linkify }}</li>
   {% endif %}
 {% endblock %}
 
@@ -22,19 +22,11 @@
                 <table class="table table-hover attr-table">
                     <tr>
                         <th scope="row">Site</th>
-                        <td>
-                            <a href="{{ object.site.get_absolute_url }}">{{ object.site }}</a>
-                        </td>
+                        <td>{{ object.site|linkify }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Location</th>
-                        <td>
-                            {% if object.location %}
-                                <a href="{{ object.location.get_absolute_url }}">{{ object.location }}</a>
-                            {% else %}
-                                <span class="text-muted">None</span>
-                            {% endif %}
-                        </td>
+                        <td>{{ object.location|linkify|placeholder }}</td>
                     </tr>
                 </table>
             </div>

--- a/netbox/templates/dcim/powerport.html
+++ b/netbox/templates/dcim/powerport.html
@@ -20,19 +20,11 @@
                     <table class="table table-hover attr-table">
                         <tr>
                             <th scope="row">Device</th>
-                            <td>
-                                <a href="{{ object.device.get_absolute_url }}">{{ object.device }}</a>
-                            </td>
+                            <td>{{ object.device|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Module</th>
-                            <td>
-                              {% if object.module %}
-                                <a href="{{ object.module.get_absolute_url }}">{{ object.module }}</a>
-                              {% else %}
-                                {{ None|placeholder }}
-                              {% endif %}
-                            </td>
+                            <td>{{ object.module|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Name</th>
@@ -80,7 +72,7 @@
                         <tr>
                             <th scope="row">Cable</th>
                             <td>
-                                <a href="{{ object.cable.get_absolute_url }}">{{ object.cable }}</a>
+                                {{ object.cable|linkify }}
                                 <a href="{% url 'dcim:powerport_trace' pk=object.pk %}" class="btn btn-primary btn-sm lh-1" title="Trace">
                                     <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
                                 </a>
@@ -89,9 +81,7 @@
                         {% if object.connected_endpoint %}
                             <tr>
                                 <th scope="row">Device</th>
-                                <td>
-                                    <a href="{{ object.connected_endpoint.device.get_absolute_url }}">{{ object.connected_endpoint.device }}</a>
-                                </td>
+                                <td>{{ object.connected_endpoint.device|linkify }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Name</th>

--- a/netbox/templates/dcim/powerport.html
+++ b/netbox/templates/dcim/powerport.html
@@ -85,9 +85,7 @@
                             </tr>
                             <tr>
                                 <th scope="row">Name</th>
-                                <td>
-                                    <a href="{{ object.connected_endpoint.get_absolute_url }}">{{ object.connected_endpoint.name }}</a>
-                                </td>
+                                <td>{{ object.connected_endpoint|linkify:"name" }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Type</th>

--- a/netbox/templates/dcim/rack.html
+++ b/netbox/templates/dcim/rack.html
@@ -66,7 +66,7 @@
                         <td>
                             {% if object.tenant %}
                                 {% if object.tenant.group %}
-                                    {{ object.tenant.group|linkify }}/
+                                    {{ object.tenant.group|linkify }} /
                                 {% endif %}
                                 {{ object|linkify }}
                             {% else %}
@@ -206,9 +206,7 @@
                     </tr>
                     {% for resv in reservations %}
                         <tr>
-                            <td>
-                                <a href="{{ resv.get_absolute_url }}">{{ resv.unit_list }}</a>
-                            </td>
+                            <td>{{ resv|linkify:"unit_list" }}</td>
                             <td>{{ resv.tenant|linkify|placeholder }}</td>
                             <td>
                                 {{ resv.description }}<br />

--- a/netbox/templates/dcim/rack.html
+++ b/netbox/templates/dcim/rack.html
@@ -64,14 +64,10 @@
                     <tr>
                         <th scope="row">Tenant</th>
                         <td>
-                            {% if object.tenant %}
-                                {% if object.tenant.group %}
-                                    {{ object.tenant.group|linkify }} /
-                                {% endif %}
-                                {{ object|linkify }}
-                            {% else %}
-                                <span class="text-muted">None</span>
+                            {% if object.tenant.group %}
+                                {{ object.tenant.group|linkify }} /
                             {% endif %}
+                            {{ object.tenant|linkify|placeholder }}
                         </td>
                     </tr>
                      <tr>

--- a/netbox/templates/dcim/rack.html
+++ b/netbox/templates/dcim/rack.html
@@ -39,9 +39,9 @@
                         <th scope="row">Site</th>
                         <td>
                             {% if object.site.region %}
-                                <a href="{{ object.site.region.get_absolute_url }}">{{ object.site.region }}</a> /
+                                {{ object.site.region|linkify }} /
                             {% endif %}
-                            <a href="{{ object.site.get_absolute_url }}">{{ object.site }}</a>
+                            {{ object.site|linkify }}
                         </td>
                     </tr>
                     <tr>
@@ -49,9 +49,9 @@
                         <td>
                             {% if object.location %}
                                 {% for location in object.location.get_ancestors %}
-                                    <a href="{{ location.get_absolute_url }}">{{ location }}</a> /
+                                    {{ location|linkify }} /
                                 {% endfor %}
-                                <a href="{{ object.location.get_absolute_url }}">{{ object.location }}</a>
+                                {{ object.location|linkify }}
                             {% else %}
                                 <span class="text-muted">None</span>
                             {% endif %}
@@ -66,9 +66,9 @@
                         <td>
                             {% if object.tenant %}
                                 {% if object.tenant.group %}
-                                    <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                                    {{ object.tenant.group|linkify }}/
                                 {% endif %}
-                                <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                                {{ object|linkify }}
                             {% else %}
                                 <span class="text-muted">None</span>
                             {% endif %}
@@ -80,13 +80,7 @@
                     </tr>
                     <tr>
                         <th scope="row">Role</th>
-                        <td>
-                            {% if object.role %}
-                                <a href="{{ object.role.get_absolute_url }}">{{ object.role }}</a>
-                            {% else %}
-                                <span class="text-muted">None</span>
-                            {% endif %}
-                        </td>
+                        <td>{{ object.role|linkify|placeholder }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Serial Number</th>
@@ -179,18 +173,10 @@
                         </tr>
                         {% for powerfeed in power_feeds %}
                             <tr>
-                                <td>
-                                    <a href="{{ powerfeed.power_panel.get_absolute_url }}">{{ powerfeed.power_panel.name }}</a>
-
-                                <td>
-                                    <a href="{{ powerfeed.get_absolute_url }}">{{ powerfeed.name }}</a>
-                                </td>
-                                <td>
-                                    {% badge powerfeed.get_status_display bg_color=powerfeed.get_status_color %}
-                                </td>
-                                <td>
-                                    {% badge powerfeed.get_type_display bg_color=powerfeed.get_type_color %}
-                                </td>
+                                <td>{{ powerfeed.power_panel|linkify }}</td>
+                                <td>{{ powerfeed|linkify }}</td>
+                                <td>{% badge powerfeed.get_status_display bg_color=powerfeed.get_status_color %}</td>
+                                <td>{% badge powerfeed.get_type_display bg_color=powerfeed.get_type_color %}</td>
                                 {% with power_port=powerfeed.connected_endpoint %}
                                     {% if power_port %}
                                         <td>{% utilization_graph power_port.get_power_draw.allocated|percentage:powerfeed.available_power %}</td>
@@ -223,13 +209,7 @@
                             <td>
                                 <a href="{{ resv.get_absolute_url }}">{{ resv.unit_list }}</a>
                             </td>
-                            <td>
-                                {% if resv.tenant %}
-                                    <a href="{{ resv.tenant.get_absolute_url }}">{{ resv.tenant }}</a>
-                                {% else %}
-                                    <span class="text-muted">None</span>
-                                {% endif %}
-                            </td>
+                            <td>{{ resv.tenant|linkify|placeholder }}</td>
                             <td>
                                 {{ resv.description }}<br />
                                 <small>{{ resv.user }} &middot; {{ resv.created|annotated_date }}</small>

--- a/netbox/templates/dcim/rackreservation.html
+++ b/netbox/templates/dcim/rackreservation.html
@@ -54,14 +54,10 @@
                     <tr>
                         <th scope="row">Tenant</th>
                         <td>
-                            {% if object.tenant %}
-                                {% if object.tenant.group %}
-                                    {{ object.tenant.group|linkify }} /
-                                {% endif %}
-                                {{ object.tenant|linkify }}
-                            {% else %}
-                                <span class="text-muted">None</span>
+                            {% if object.tenant.group %}
+                                {{ object.tenant.group|linkify }} /
                             {% endif %}
+                            {{ object.tenant|linkify|placeholder }}
                         </td>
                     </tr>
                     <tr>

--- a/netbox/templates/dcim/rackreservation.html
+++ b/netbox/templates/dcim/rackreservation.html
@@ -24,26 +24,18 @@
                             <th scope="row">Site</th>
                             <td>
                                 {% if rack.site.region %}
-                                    <a href="{{ rack.site.region.get_absolute_url }}">{{ rack.site.region }}</a> /
+                                    {{ rack.site.region|linkify }} /
                                 {% endif %}
-                                <a href="{{ rack.site.get_absolute_url }}">{{ rack.site }}</a>
+                                {{ rack.site|linkify }}
                             </td>
                         </tr>
                         <tr>
                             <th scope="row">Location</th>
-                            <td>
-                                {% if rack.location %}
-                                    <a href="{{ rack.location.get_absolute_url }}">{{ rack.location }}</a>
-                                {% else %}
-                                    <span class="text-muted">None</span>
-                                {% endif %}
-                            </td>
+                            <td>{{ rack.location|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Rack</th>
-                            <td>
-                                <a href="{{ rack.get_absolute_url }}">{{ rack }}</a>
-                            </td>
+                            <td>{{ rack|linkify }}</td>
                         </tr>
                     {% endwith %}
                 </table>
@@ -64,9 +56,9 @@
                         <td>
                             {% if object.tenant %}
                                 {% if object.tenant.group %}
-                                    <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                                    {{ object.tenant.group|linkify }} /
                                 {% endif %}
-                                <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                                {{ object.tenant|linkify }}
                             {% else %}
                                 <span class="text-muted">None</span>
                             {% endif %}

--- a/netbox/templates/dcim/rearport.html
+++ b/netbox/templates/dcim/rearport.html
@@ -20,19 +20,11 @@
                     <table class="table table-hover attr-table">
                         <tr>
                             <th scope="row">Device</th>
-                            <td>
-                                <a href="{{ object.device.get_absolute_url }}">{{ object.device }}</a>
-                            </td>
+                            <td>{{ object.device|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Module</th>
-                            <td>
-                              {% if object.module %}
-                                <a href="{{ object.module.get_absolute_url }}">{{ object.module }}</a>
-                              {% else %}
-                                {{ None|placeholder }}
-                              {% endif %}
-                            </td>
+                            <td>{{ object.module|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Name</th>
@@ -82,7 +74,7 @@
                         <tr>
                             <th scope="row">Cable</th>
                             <td>
-                                <a href="{{ object.cable.get_absolute_url }}">{{ object.cable }}</a>
+                                {{ object.cable|linkify }}
                                 <a href="{% url 'dcim:rearport_trace' pk=object.pk %}" class="btn btn-primary btn-sm lh-1" title="Trace">
                                     <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
                                 </a>

--- a/netbox/templates/dcim/region.html
+++ b/netbox/templates/dcim/region.html
@@ -37,13 +37,7 @@
           </tr>
           <tr>
             <th scope="row">Parent</th>
-            <td>
-              {% if object.parent %}
-                <a href="{{ object.parent.get_absolute_url }}">{{ object.parent }}</a>
-              {% else %}
-                <span class="text-muted">&mdash;</span>
-              {% endif %}
-            </td>
+            <td>{{ object.parent|linkify|placeholder }}</td>
           </tr>
           <tr>
             <th scope="row">Sites</th>

--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -30,9 +30,9 @@
             <td>
               {% if object.region %}
                 {% for region in object.region.get_ancestors %}
-                  <a href="{{ region.get_absolute_url }}">{{ region }}</a> /
+                  {{ region|linkify }} /
                 {% endfor %}
-                <a href="{{ object.region.get_absolute_url }}">{{ object.region }}</a>
+                {{ object.region|linkify }}
               {% else %}
                 <span class="text-muted">None</span>
               {% endif %}
@@ -43,9 +43,9 @@
             <td>
               {% if object.group %}
                 {% for group in object.group.get_ancestors %}
-                  <a href="{{ group.get_absolute_url }}">{{ group }}</a> /
+                  {{ group|linkify }} /
                 {% endfor %}
-                <a href="{{ object.group.get_absolute_url }}">{{ object.group }}</a>
+                {{ object.group|linkify }}
               {% else %}
                 <span class="text-muted">None</span>
               {% endif %}
@@ -60,9 +60,9 @@
             <td>
               {% if object.tenant %}
                 {% if object.tenant.group %}
-                  <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                  {{ object.tenant.group|linkify }} /
                 {% endif %}
-                <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                {{ object.tenant|linkify }}
               {% else %}
                 <span class="text-muted">None</span>
               {% endif %}
@@ -242,7 +242,7 @@
                 <tr>
                   <td>
                     {% for i in location.level|as_range %}<i class="mdi mdi-circle-small"></i>{% endfor %}
-                    <a href="{{ location.get_absolute_url }}">{{ location }}</a>
+                    {{ location|linkify }}
                   </td>
                   <td>
                     <a href="{% url 'dcim:rack_list' %}?location_id={{ location.pk }}">{{ location.rack_count }}</a>
@@ -281,7 +281,7 @@
               </tr>
             {% for asn in asns %}
               <tr>
-                <td><a href="{{ asn.get_absolute_url }}">{{ asn }}</a></td>
+                <td>{{ asn|linkify }}</td>
                 <td>{{ asn.description|placeholder }}</td>
               </tr>
             {% endfor %}

--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -58,14 +58,10 @@
           <tr>
             <th scope="row">Tenant</th>
             <td>
-              {% if object.tenant %}
-                {% if object.tenant.group %}
-                  {{ object.tenant.group|linkify }} /
-                {% endif %}
-                {{ object.tenant|linkify }}
-              {% else %}
-                <span class="text-muted">None</span>
+              {% if object.tenant.group %}
+                {{ object.tenant.group|linkify }} /
               {% endif %}
+              {{ object.tenant|linkify|placeholder }}
             </td>
           </tr>
           <tr>

--- a/netbox/templates/dcim/sitegroup.html
+++ b/netbox/templates/dcim/sitegroup.html
@@ -37,13 +37,7 @@
           </tr>
           <tr>
             <th scope="row">Parent</th>
-            <td>
-              {% if object.parent %}
-                <a href="{{ object.parent.get_absolute_url }}">{{ object.parent }}</a>
-              {% else %}
-                <span class="text-muted">&mdash;</span>
-              {% endif %}
-            </td>
+            <td>{{ object.parent|linkify|placeholder }}</td>
           </tr>
           <tr>
             <th scope="row">Sites</th>

--- a/netbox/templates/dcim/trace/circuit.html
+++ b/netbox/templates/dcim/trace/circuit.html
@@ -1,5 +1,5 @@
 <div class="node">
-    <strong><a href="{{ circuit.get_absolute_url }}">{{ circuit }}</a></strong><br />
+    <strong>{{ circuit|linkify }}</strong><br />
     Circuit<br />
-    <a href="{{ circuit.provider.get_absolute_url }}">{{ circuit.provider }}</a>
+    {{ circuit.provider|linkify }}
 </div>

--- a/netbox/templates/dcim/trace/device.html
+++ b/netbox/templates/dcim/trace/device.html
@@ -1,11 +1,11 @@
 <div class="node">
-    <strong><a href="{{ device.get_absolute_url }}">{{ device }}</a></strong><br />
+    <strong>{{ device|linkify }}</strong><br />
     {{ device.device_type.manufacturer }} {{ device.device_type }}<br />
-    <a href="{{ device.site.get_absolute_url }}">{{ device.site }}</a>
+    {{ device.site|linkify }}
     {% if device.location %}
-        / <a href="{{ device.location.get_absolute_url }}">{{ device.location }}</a>
+        / {{ device.location|linkify }}
     {% endif %}
     {% if device.rack %}
-        / <a href="{{ device.rack.get_absolute_url }}">{{ device.rack }}</a>
+        / {{ device.rack|linkify }}
     {% endif %}
 </div>

--- a/netbox/templates/dcim/trace/object.html
+++ b/netbox/templates/dcim/trace/object.html
@@ -1,3 +1,3 @@
 <div class="node">
-    <strong><a href="{{ object.get_absolute_url }}">{{ object }}</a></strong>
+    <strong>{{ object|linkify }}</strong>
 </div>

--- a/netbox/templates/dcim/trace/powerpanel.html
+++ b/netbox/templates/dcim/trace/powerpanel.html
@@ -1,5 +1,5 @@
 <div class="node">
-    <strong><a href="{{ powerpanel.get_absolute_url }}">{{ powerpanel }}</a></strong><br />
+    <strong>{{ powerpanel|linkify }}</strong><br />
     Power Panel<br />
-    <a href="{{ powerpanel.site.get_absolute_url }}">{{ powerpanel.site }}</a>
+    {{ powerpanel.site|linkify }}
 </div>

--- a/netbox/templates/dcim/trace/termination.html
+++ b/netbox/templates/dcim/trace/termination.html
@@ -1,6 +1,6 @@
 {% load helpers %}
 <div class="termination{% if obj == termination %} active{% endif %}">
-    <strong><a href="{{ termination.get_absolute_url }}">{{ termination }}</a></strong><br />
+    <strong>{{ termination|linkify }}</strong><br />
     {{ termination|meta:"verbose_name"|bettertitle }}
     {% if termination.type %}
         <small class="text-muted">{{ termination.get_type_display }}</small>

--- a/netbox/templates/dcim/virtualchassis.html
+++ b/netbox/templates/dcim/virtualchassis.html
@@ -27,13 +27,7 @@
                     </tr>
                     <tr>
                         <th scope="row">Master</th>
-                        <td>
-                            {% if object.master %}
-                                <a href="{{ object.master.get_absolute_url }}">{{ object.master }}</a>
-                            {% else %}
-                                <span class="text-muted">&mdash;</span>
-                            {% endif %}
-                        </td>
+                        <td>{{ object.master|linkify }}</td>
                     </tr>
                 </table>
             </div>
@@ -58,7 +52,7 @@
                     {% for vc_member in members %}
                         <tr{% if vc_member == device %} class="info"{% endif %}>
                             <td>
-                                <a href="{{ vc_member.get_absolute_url }}">{{ vc_member }}</a>
+                                {{ vc_member|linkify }}
                             </td>
                             <td>
                               {% badge vc_member.vc_position show_empty=True %}

--- a/netbox/templates/dcim/virtualchassis_edit.html
+++ b/netbox/templates/dcim/virtualchassis_edit.html
@@ -51,9 +51,7 @@
                       {% endfor %}
                       {% with device=form.instance virtual_chassis=vc_form.instance %}
                           <tr>
-                              <td>
-                                  <a href="{{ device.get_absolute_url }}">{{ device }}</a>
-                              </td>
+                              <td>{{ device|linkify }}</td>
                               <td>{{ device.pk }}</td>
                               <td>
                                   {% if device.rack %}

--- a/netbox/templates/extras/configcontext.html
+++ b/netbox/templates/extras/configcontext.html
@@ -56,7 +56,7 @@
                           <td>
                             <ul class="list-unstyled mb-0">
                               {% for object in objects %}
-                                <li><a href="{{ object.get_absolute_url }}">{{ object }}</a></li>
+                                <li>{{ object|linkify }}</li>
                               {% empty %}
                                 <li class="text-muted">None</li>
                               {% endfor %}

--- a/netbox/templates/extras/imageattachment_edit.html
+++ b/netbox/templates/extras/imageattachment_edit.html
@@ -10,7 +10,7 @@
       </label>
       <div class="col-sm-9">
         <div class="form-control-plaintext">
-          <a href="{{ object.parent.get_absolute_url }}" class="">{{ object.parent }}</a>
+          {{ object.parent|linkify }}
         </div>
       </div>
     </div>

--- a/netbox/templates/extras/journalentry.html
+++ b/netbox/templates/extras/journalentry.html
@@ -18,21 +18,15 @@
                     <table class="table table-hover attr-table">
                         <tr>
                             <th scope="row">Object</th>
-                            <td>
-                                <a href="{{ object.assigned_object.get_absolute_url }}">{{ object.assigned_object }}</a>
-                            </td>
+                            <td>{{ object.assigned_object|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Created</th>
-                            <td>
-                                {{ object.created|annotated_date }}
-                            </td>
+                            <td>{{ object.created|annotated_date }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Created By</th>
-                            <td>
-                                {{ object.created_by }}
-                            </td>
+                            <td>{{ object.created_by }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Kind</th>

--- a/netbox/templates/extras/object_configcontext.html
+++ b/netbox/templates/extras/object_configcontext.html
@@ -43,7 +43,7 @@
                         <div class="float-end">
                             <span class="text-muted">{{ context.weight }}</span>
                         </div>
-                        <a href="{{ context.get_absolute_url }}"><strong>{{ context.name }}</strong></a>
+                        <strong>{{ context|linkify:"name" }}"></strong>
                         {% if context.description %}
                             <br /><small>{{ context.description }}</small>
                         {% endif %}

--- a/netbox/templates/extras/objectchange.html
+++ b/netbox/templates/extras/objectchange.html
@@ -61,7 +61,7 @@
                         <th scope="row">Object</th>
                         <td>
                             {% if object.changed_object and object.changed_object.get_absolute_url %}
-                                <a href="{{ object.changed_object.get_absolute_url }}">{{ object.changed_object }}</a>
+                                {{ object.changed_object|linkify }}
                             {% else %}
                                 {{ object.object_repr }}
                             {% endif %}

--- a/netbox/templates/inc/panels/contacts.html
+++ b/netbox/templates/inc/panels/contacts.html
@@ -14,9 +14,7 @@
           </tr>
           {% for contact in contacts %}
             <tr>
-              <td>
-                <a href="{{ contact.contact.get_absolute_url }}">{{ contact.contact }}</a>
-              </td>
+              <td>{{ contact.contact|linkify }}</td>
               <td>{{ contact.role|placeholder }}</td>
               <td>{{ contact.get_priority_display|placeholder }}</td>
               <td class="text-end noprint">

--- a/netbox/templates/inc/panels/custom_fields.html
+++ b/netbox/templates/inc/panels/custom_fields.html
@@ -27,11 +27,11 @@
                                 {% elif field.type == 'multiselect' and value %}
                                     {{ value|join:", " }}
                                 {% elif field.type == 'object' and value %}
-                                    <a href="{{ value.get_absolute_url }}">{{ value }}</a>
+                                    {{ value|linkify }}
                                 {% elif field.type == 'multiobject' and value %}
                                     <ul>
                                       {% for obj in value %}
-                                        <li><a href="{{ obj.get_absolute_url }}">{{ obj }}</a></li>
+                                        <li>{{ obj|linkify }}</li>
                                       {% endfor %}
                                     </ul>
                                 {% elif value %}

--- a/netbox/templates/ipam/aggregate.html
+++ b/netbox/templates/ipam/aggregate.html
@@ -31,9 +31,9 @@
               <td>
                 {% if object.tenant %}
                   {% if prefix.object.group %}
-                    <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                    {{ object.tenant.group|linkify }} /
                   {% endif %}
-                  <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                  {{ object.tenant|linkify }}
                 {% else %}
                   <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/ipam/aggregate.html
+++ b/netbox/templates/ipam/aggregate.html
@@ -29,14 +29,10 @@
             <tr>
               <td>Tenant</td>
               <td>
-                {% if object.tenant %}
-                  {% if prefix.object.group %}
-                    {{ object.tenant.group|linkify }} /
-                  {% endif %}
-                  {{ object.tenant|linkify }}
-                {% else %}
-                  <span class="text-muted">None</span>
+                {% if object.tenant.group %}
+                  {{ object.tenant.group|linkify }} /
                 {% endif %}
+                {{ object.tenant|linkify|placeholder }}
               </td>
             </tr>
             <tr>

--- a/netbox/templates/ipam/asn.html
+++ b/netbox/templates/ipam/asn.html
@@ -30,10 +30,10 @@
               <td>Tenant</td>
               <td>
                 {% if object.tenant %}
-                  {% if prefix.object.group %}
-                    <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                  {% if object.tenant.group %}
+                    {{ object.tenant.group|linkify }} /
                   {% endif %}
-                  <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                  {{ object.tenant|linkify }}
                 {% else %}
                   <span class="text-muted">None</span>
                 {% endif %}

--- a/netbox/templates/ipam/asn.html
+++ b/netbox/templates/ipam/asn.html
@@ -29,14 +29,10 @@
             <tr>
               <td>Tenant</td>
               <td>
-                {% if object.tenant %}
-                  {% if object.tenant.group %}
-                    {{ object.tenant.group|linkify }} /
-                  {% endif %}
-                  {{ object.tenant|linkify }}
-                {% else %}
-                  <span class="text-muted">None</span>
+                {% if object.tenant.group %}
+                  {{ object.tenant.group|linkify }} /
                 {% endif %}
+                {{ object.tenant|linkify|placeholder }}
               </td>
             </tr>
             <tr>

--- a/netbox/templates/ipam/inc/panels/fhrp_groups.html
+++ b/netbox/templates/ipam/inc/panels/fhrp_groups.html
@@ -16,21 +16,14 @@
       <tbody>
         {% for assignment in object.fhrp_group_assignments.all %}
           <tr>
-            <td>
-              <a href="{{ assignment.group.get_absolute_url }}">{{ assignment.group.group_id }}</a>
-            </td>
-            <td>
-              {{ assignment.group.get_protocol_display }}
-            </td>
+            <td>{{ assignment.group|linkify:"group_id" }}</td>
+            <td>{{ assignment.group.get_protocol_display }}</td>
             <td>
               {% for ipaddress in assignment.group.ip_addresses.all %}
-                {{ ipaddress|linkify }}
-                {% if not forloop.last %}<br />{% endif %}
+                {{ ipaddress|linkify }}{% if not forloop.last %}<br />{% endif %}
               {% endfor %}
             </td>
-            <td>
-              {{ assignment.priority }}
-            </td>
+            <td>{{ assignment.priority }}</td>
             <td class="text-end noprint">
               {% if perms.ipam.change_fhrpgroupassignment %}
                 <a href="{% url 'ipam:fhrpgroupassignment_edit' pk=assignment.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-warning btn-sm lh-1" title="Edit">

--- a/netbox/templates/ipam/inc/panels/fhrp_groups.html
+++ b/netbox/templates/ipam/inc/panels/fhrp_groups.html
@@ -24,7 +24,7 @@
             </td>
             <td>
               {% for ipaddress in assignment.group.ip_addresses.all %}
-                <a href="{{ ipaddress.get_absolute_url }}">{{ ipaddress }}</a>
+                {{ ipaddress|linkify }}
                 {% if not forloop.last %}<br />{% endif %}
               {% endfor %}
             </td>

--- a/netbox/templates/ipam/inc/service.html
+++ b/netbox/templates/ipam/inc/service.html
@@ -1,5 +1,5 @@
 <tr>
-    <td><a href="{{ service.get_absolute_url }}">{{ service.name }}</a></td>
+    <td>{{ service|linkify:"name" }}</td>
     <td>{{ service.get_protocol_display }}</td>
     <td>{{ service.port_list }}</td>
     <td>

--- a/netbox/templates/ipam/ipaddress.html
+++ b/netbox/templates/ipam/ipaddress.html
@@ -36,14 +36,10 @@
                   <tr>
                       <th scope="row">Tenant</th>
                       <td>
-                          {% if object.tenant %}
-                              {% if object.tenant.group %}
-                                  {{ object.tenant.group|linkify }} /
-                              {% endif %}
-                              {{ object.tenant|linkify }}
-                          {% else %}
-                              <span class="text-muted">None</span>
+                          {% if object.tenant.group %}
+                              {{ object.tenant.group|linkify }} /
                           {% endif %}
+                          {{ object.tenant|linkify|placeholder }}
                       </td>
                   </tr>
                   <tr>

--- a/netbox/templates/ipam/ipaddress.html
+++ b/netbox/templates/ipam/ipaddress.html
@@ -38,9 +38,9 @@
                       <td>
                           {% if object.tenant %}
                               {% if object.tenant.group %}
-                                  <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                                  {{ object.tenant.group|linkify }} /
                               {% endif %}
-                              <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                              {{ object.tenant|linkify }}
                           {% else %}
                               <span class="text-muted">None</span>
                           {% endif %}
@@ -73,9 +73,9 @@
                       <td>
                         {% if object.assigned_object %}
                           {% if object.assigned_object.parent_object %}
-                            <a href="{{ object.assigned_object.parent_object.get_absolute_url }}">{{ object.assigned_object.parent_object }}</a> /
+                            {{ object.assigned_object.parent_object|linkify }} /
                           {% endif %}
-                          <a href="{{ object.assigned_object.get_absolute_url }}">{{ object.assigned_object }}
+                          {{ object.assigned_object|linkify }}
                         {% else %}
                           <span class="text-muted">&mdash;</span>
                         {% endif %}
@@ -85,9 +85,9 @@
                       <th scope="row">NAT (inside)</th>
                       <td>
                           {% if object.nat_inside %}
-                              <a href="{{ object.nat_inside.get_absolute_url }}">{{ object.nat_inside }}</a>
+                              {{ object.nat_inside|linkify }}
                               {% if object.nat_inside.assigned_object %}
-                                  (<a href="{{ object.nat_inside.assigned_object.parent_object.get_absolute_url }}">{{ object.nat_inside.assigned_object.parent_object }}</a>)
+                                  ({{ object.nat_inside.assigned_object.parent_object|linkify }})
                               {% endif %}
                           {% else %}
                               <span class="text-muted">None</span>
@@ -96,13 +96,7 @@
                   </tr>
                   <tr>
                       <th scope="row">NAT (outside)</th>
-                      <td>
-                          {% if object.nat_outside %}
-                              <a href="{{ object.nat_outside.get_absolute_url }}">{{ object.nat_outside }}</a>
-                          {% else %}
-                              <span class="text-muted">None</span>
-                          {% endif %}
-                      </td>
+                      <td>{{ object.nat_outside|linkify|placeholder }}</td>
                   </tr>
               </table>
           </div>

--- a/netbox/templates/ipam/iprange.html
+++ b/netbox/templates/ipam/iprange.html
@@ -54,14 +54,10 @@
                 <tr>
                     <th scope="row">Tenant</th>
                     <td>
-                        {% if object.tenant %}
-                            {% if object.tenant.group %}
-                                {{ object.tenant.group|linkify }} /
-                            {% endif %}
-                            {{ object.tenant|linkify }}
-                        {% else %}
-                            <span class="text-muted">None</span>
+                        {% if object.tenant.group %}
+                            {{ object.tenant.group|linkify }} /
                         {% endif %}
+                        {{ object.tenant|linkify|placeholder }}
                     </td>
                 </tr>
                 <tr>

--- a/netbox/templates/ipam/iprange.html
+++ b/netbox/templates/ipam/iprange.html
@@ -37,7 +37,7 @@
                     <th scope="row">VRF</th>
                     <td>
                         {% if object.vrf %}
-                            <a href="{{ object.vrf.get_absolute_url }}">{{ object.vrf }}</a> ({{ object.vrf.rd }})
+                            {{ object.vrf|linkify }} ({{ object.vrf.rd }})
                         {% else %}
                             <span>Global</span>
                         {% endif %}
@@ -45,13 +45,7 @@
                 </tr>
                 <tr>
                     <th scope="row">Role</th>
-                    <td>
-                        {% if object.role %}
-                            <a href="{{ object.role.get_absolute_url }}">{{ object.role }}</a>
-                        {% else %}
-                            <span class="text-muted">None</span>
-                        {% endif %}
-                    </td>
+                    <td>{{ object.role|linkify|placeholder }}</td>
                 </tr>
                 <tr>
                     <th scope="row">Status</th>
@@ -62,9 +56,9 @@
                     <td>
                         {% if object.tenant %}
                             {% if object.tenant.group %}
-                                <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                                {{ object.tenant.group|linkify }} /
                             {% endif %}
-                            <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                            {{ object.tenant|linkify }}
                         {% else %}
                             <span class="text-muted">None</span>
                         {% endif %}

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -29,9 +29,9 @@
             <td>
               {% if object.tenant %}
                 {% if object.tenant.group %}
-                  <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                  {{ object.tenant.group|linkify }} /
                 {% endif %}
-                <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                {{ object.tenant|linkify }}
               {% else %}
                 <span class="text-muted">None</span>
               {% endif %}
@@ -52,9 +52,9 @@
             <td>
               {% if object.site %}
                 {% if object.site.region %}
-                  <a href="{{ object.site.region.get_absolute_url }}">{{ object.site.region }}</a> /
+                  {{ object.site.region|linkify }} /
                 {% endif %}
-                <a href="{{ object.site.get_absolute_url }}">{{ object.site }}</a>
+                {{ object.site|linkify }}
               {% else %}
                 <span class="text-muted">None</span>
               {% endif %}
@@ -65,9 +65,9 @@
             <td>
               {% if object.vlan %}
                 {% if object.vlan.group %}
-                  <a href="{{ object.vlan.group.get_absolute_url }}">{{ object.vlan.group }}</a> /
+                  {{ object.vlan.group|linkify }} /
                 {% endif %}
-                <a href="{% url 'ipam:vlan' pk=object.vlan.pk %}">{{ object.vlan }}</a>
+                {{ object.vlan|linkify }}
               {% else %}
                 <span class="text-muted">None</span>
               {% endif %}
@@ -79,13 +79,7 @@
           </tr>
           <tr>
             <th scope="row">Role</th>
-            <td>
-              {% if object.role %}
-                <a href="{{ object.role.get_absolute_url }}">{{ object.role }}</a>
-              {% else %}
-                <span class="text-muted">None</span>
-              {% endif %}
-            </td>
+            <td>{{ object.role|linkify|placeholder }}</td>
           </tr>
           <tr>
             <th scope="row">Description</th>

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -26,16 +26,12 @@
           </tr>
           <tr>
             <th scope="row">Tenant</th>
-            <td>
-              {% if object.tenant %}
+              <td>
                 {% if object.tenant.group %}
                   {{ object.tenant.group|linkify }} /
                 {% endif %}
-                {{ object.tenant|linkify }}
-              {% else %}
-                <span class="text-muted">None</span>
-              {% endif %}
-            </td>
+                {{ object.tenant|linkify|placeholder }}
+              </td>
           </tr>
           <tr>
             <th scope="row">Aggregate</th>

--- a/netbox/templates/ipam/routetarget.html
+++ b/netbox/templates/ipam/routetarget.html
@@ -15,13 +15,7 @@
             </tr>
             <tr>
               <th  scope="row">Tenant</th>
-              <td>
-                {% if object.tenant %}
-                  <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
-                {% else %}
-                  <span class="text-muted">None</span>
-                {% endif %}
-              </td>
+              <td>{{ object.tenant|linkify|placeholder }}</td>
             </tr>
             <tr>
               <th scope="row">Description</th>

--- a/netbox/templates/ipam/service.html
+++ b/netbox/templates/ipam/service.html
@@ -28,9 +28,7 @@
                     </tr>
                     <tr>
                         <th scope="row">Parent</th>
-                        <td>
-                            <a href="{{ object.parent.get_absolute_url }}">{{ object.parent }}</a>
-                        </td>
+                        <td>{{ object.parent|linkify }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Protocol</th>
@@ -44,7 +42,7 @@
                         <th scope="row">IP Addresses</th>
                         <td>
                             {% for ipaddress in object.ipaddresses.all %}
-                                <a href="{{ ipaddress.get_absolute_url }}">{{ ipaddress }}</a><br />
+                                {{ ipaddress|linkify }}<br />
                             {% empty %}
                                 <span class="text-muted">None</span>
                             {% endfor %}

--- a/netbox/templates/ipam/vlan.html
+++ b/netbox/templates/ipam/vlan.html
@@ -17,9 +17,9 @@
                             <td>
                                 {% if object.site %}
                                     {% if object.site.region %}
-                                        <a href="{{ object.site.region.get_absolute_url }}">{{ object.site.region }}</a> /
+                                        {{ object.site.region|linkify }} /
                                     {% endif %}
-                                    <a href="{{ object.site.get_absolute_url }}">{{ object.site }}</a>
+                                    {{ object.site|linkify }}
                                 {% else %}
                                     <span class="text-muted">None</span>
                                 {% endif %}
@@ -27,13 +27,7 @@
                         </tr>
                         <tr>
                             <th scope="row">Group</th>
-                            <td>
-                                {% if object.group %}
-                                    <a href="{{ object.group.get_absolute_url }}">{{ object.group }}</a>
-                                {% else %}
-                                    <span class="text-muted">None</span>
-                                {% endif %}
-                            </td>
+                            <td>{{ object.group|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">VLAN ID</th>
@@ -48,9 +42,9 @@
                             <td>
                                 {% if object.tenant %}
                                     {% if object.tenant.group %}
-                                        <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                                        {{ object.tenant.group|linkify }} /
                                     {% endif %}
-                                    <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                                    {{ object.tenant|linkify }}
                                 {% else %}
                                     <span class="text-muted">None</span>
                                 {% endif %}

--- a/netbox/templates/ipam/vlan.html
+++ b/netbox/templates/ipam/vlan.html
@@ -40,14 +40,10 @@
                         <tr>
                             <th scope="row">Tenant</th>
                             <td>
-                                {% if object.tenant %}
-                                    {% if object.tenant.group %}
-                                        {{ object.tenant.group|linkify }} /
-                                    {% endif %}
-                                    {{ object.tenant|linkify }}
-                                {% else %}
-                                    <span class="text-muted">None</span>
+                                {% if object.tenant.group %}
+                                    {{ object.tenant.group|linkify }} /
                                 {% endif %}
+                                {{ object.tenant|linkify|placeholder }}
                             </td>
                         </tr>
                         <tr>

--- a/netbox/templates/ipam/vlangroup.html
+++ b/netbox/templates/ipam/vlangroup.html
@@ -7,7 +7,7 @@
   {{ block.super }}
   {% if object.scope %}
     {# TODO: This should link to a filtered list of VLANGroups #}
-    <li class="breadcrumb-item"><a href="{{ object.scope.get_absolute_url }}">{{ object.scope }}</a></li>
+    <li class="breadcrumb-item">{{ object.scope|linkify }}</li>
   {% endif %}
 {% endblock %}
 
@@ -36,12 +36,7 @@
           </tr>
           <tr>
             <th scope="row">Scope</th>
-            <td>
-            {% if object.scope %}
-              <a href="{{ object.scope.get_absolute_url }}">{{ object.scope }}</a>
-            {% else %}
-              <span class="text-muted">&mdash;</span>
-            {% endif %}
+            <td>{{ object.scope|linkify|placeholder }}</td>
           </tr>
           <tr>
             <th scope="row">Permitted VIDs</th>

--- a/netbox/templates/ipam/vrf.html
+++ b/netbox/templates/ipam/vrf.html
@@ -20,7 +20,12 @@
                   </tr>
                   <tr>
                       <th scope="row">Tenant</th>
-                      <td>{{ object.tenant|linkify|placeholder }}</td>
+                      <td>
+                          {% if object.tenant.group %}
+                              {{ object.tenant.group|linkify }} /
+                          {% endif %}
+                          {{ object.tenant|linkify|placeholder }}
+                      </td>
                   </tr>
                   <tr>
                       <th scope="row">Unique IP Space</th>

--- a/netbox/templates/ipam/vrf.html
+++ b/netbox/templates/ipam/vrf.html
@@ -20,13 +20,7 @@
                   </tr>
                   <tr>
                       <th scope="row">Tenant</th>
-                      <td>
-                          {% if object.tenant %}
-                              <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
-                          {% else %}
-                              <span class="text-muted">None</span>
-                          {% endif %}
-                      </td>
+                      <td>{{ object.tenant|linkify|placeholder }}</td>
                   </tr>
                   <tr>
                       <th scope="row">Unique IP Space</th>

--- a/netbox/templates/tenancy/contact.html
+++ b/netbox/templates/tenancy/contact.html
@@ -19,13 +19,7 @@
           <table class="table table-hover attr-table">
             <tr>
               <td>Group</td>
-              <td>
-                {% if object.group %}
-                  <a href="{{ object.group.get_absolute_url }}">{{ object.group }}</a>
-                {% else %}
-                  <span class="text-muted">None</span>
-                {% endif %}
-              </td>
+              <td>{{ object.group|linkify|placeholder }}</td>
             </tr>
             <tr>
               <td>Name</td>

--- a/netbox/templates/tenancy/contactgroup.html
+++ b/netbox/templates/tenancy/contactgroup.html
@@ -29,13 +29,7 @@
             </tr>
             <tr>
               <th scope="row">Parent</th>
-              <td>
-                {% if object.parent %}
-                  <a href="{{ object.parent.get_absolute_url }}">{{ object.parent }}</a>
-                {% else %}
-                  <span class="text-muted">&mdash;</span>
-                {% endif %}
-              </td>
+              <td>{{ object.parent|linkify|placeholder }}</td>
             </tr>
             <tr>
               <th scope="row">Contacts</th>

--- a/netbox/templates/tenancy/tenant.html
+++ b/netbox/templates/tenancy/tenant.html
@@ -20,13 +20,7 @@
                 <table class="table table-hover attr-table">
                     <tr>
                         <td>Group</td>
-                        <td>
-                            {% if object.group %}
-                                <a href="{{ object.group.get_absolute_url }}">{{ object.group }}</a>
-                            {% else %}
-                                <span class="text-muted">None</span>
-                            {% endif %}
-                        </td>
+                        <td>{{ object.group|linkify|placeholder }}</td>
                     </tr>
                     <tr>
                         <td>Description</td>

--- a/netbox/templates/tenancy/tenantgroup.html
+++ b/netbox/templates/tenancy/tenantgroup.html
@@ -37,13 +37,7 @@
           </tr>
           <tr>
             <th scope="row">Parent</th>
-            <td>
-              {% if object.parent %}
-                <a href="{{ object.parent.get_absolute_url }}">{{ object.parent }}</a>
-              {% else %}
-                <span class="text-muted">&mdash;</span>
-              {% endif %}
-            </td>
+            <td>{{ object.parent|linkify|placeholder }}</td>
           </tr>
           <tr>
             <th scope="row">Tenants</th>

--- a/netbox/templates/virtualization/cluster.html
+++ b/netbox/templates/virtualization/cluster.html
@@ -25,7 +25,12 @@
                 </tr>
                 <tr>
                     <th scope="row">Tenant</th>
-                    <td>{{ object.tenant|linkify }}</td>
+                    <td>
+                        {% if object.tenant.group %}
+                            {{ object.tenant.group|linkify }} /
+                        {% endif %}
+                        {{ object.tenant|linkify|placeholder }}
+                    </td>
                 </tr>
                 <tr>
                     <th scope="row">Site</th>

--- a/netbox/templates/virtualization/cluster.html
+++ b/netbox/templates/virtualization/cluster.html
@@ -17,37 +17,19 @@
                 </tr>
                 <tr>
                     <th scope="row">Type</th>
-                    <td><a href="{{ object.type.get_absolute_url }}">{{ object.type }}</a></td>
+                    <td>{{ object.type|linkify }}</td>
                 </tr>
                 <tr>
                     <th scope="row">Group</th>
-                    <td>
-                        {% if object.group %}
-                            <a href="{{ object.group.get_absolute_url }}">{{ object.group }}</a>
-                        {% else %}
-                            <span class="text-muted">None</span>
-                        {% endif %}
-                    </td>
+                    <td>{{ object.group|linkify }}</td>
                 </tr>
                 <tr>
                     <th scope="row">Tenant</th>
-                    <td>
-                        {% if object.tenant %}
-                            <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
-                        {% else %}
-                            <span class="text-muted">None</span>
-                        {% endif %}
-                    </td>
+                    <td>{{ object.tenant|linkify }}</td>
                 </tr>
                 <tr>
                     <th scope="row">Site</th>
-                    <td>
-                        {% if object.site %}
-                            <a href="{{ object.site.get_absolute_url }}">{{ object.site }}</a>
-                        {% else %}
-                            <span class="text-muted">None</span>
-                        {% endif %}
-                    </td>
+                    <td>{{ object.site|linkify }}</td>
                 </tr>
                 <tr>
                     <th scope="row">Virtual Machines</th>

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -23,32 +23,20 @@
                     </tr>
                     <tr>
                         <th scope="row">Role</th>
-                        <td>
-                            {% if object.role %}
-                                <a href="{{ object.role.get_absolute_url }}">{{ object.role }}</a>
-                            {% else %}
-                                <span class="text-muted">None</span>
-                            {% endif %}
-                        </td>
+                        <td>{{ object.role|linkify|placeholder }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Platform</th>
-                        <td>
-                            {% if object.platform %}
-                                <a href="{{ object.platform.get_absolute_url }}">{{ object.platform }}</a>
-                            {% else %}
-                                <span class="text-muted">None</span>
-                            {% endif %}
-                        </td>
+                        <td>{{ object.platform|linkify|placeholder }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Tenant</th>
                         <td>
                             {% if object.tenant %}
                                 {% if object.tenant.group %}
-                                    <a href="{{ object.tenant.group.get_absolute_url }}">{{ object.tenant.group }}</a> /
+                                    {{ object.tenant.group|linkify }} /
                                 {% endif %}
-                                <a href="{{ object.tenant.get_absolute_url }}">{{ object.tenant }}</a>
+                                {{ object.tenant|linkify }}
                             {% else %}
                                 <span class="text-muted">None</span>
                             {% endif %}
@@ -103,9 +91,9 @@
                         <th scope="row">Cluster</th>
                         <td>
                             {% if object.cluster.group %}
-                                <a href="{{ object.cluster.group.get_absolute_url }}">{{ object.cluster.group }}</a> /
+                                {{ object.cluster.group|linkify }} /
                             {% endif %}
-                            <a href="{{ object.cluster.get_absolute_url }}">{{ object.cluster }}</a>
+                            {{ object.cluster|linkify }}
                         </td>
                     </tr>
                     <tr>

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -32,14 +32,10 @@
                     <tr>
                         <th scope="row">Tenant</th>
                         <td>
-                            {% if object.tenant %}
-                                {% if object.tenant.group %}
-                                    {{ object.tenant.group|linkify }} /
-                                {% endif %}
-                                {{ object.tenant|linkify }}
-                            {% else %}
-                                <span class="text-muted">None</span>
+                            {% if object.tenant.group %}
+                                {{ object.tenant.group|linkify }} /
                             {% endif %}
+                            {{ object.tenant|linkify|placeholder }}
                         </td>
                     </tr>
                     <tr>

--- a/netbox/templates/virtualization/vminterface.html
+++ b/netbox/templates/virtualization/vminterface.html
@@ -21,9 +21,7 @@
                 <table class="table table-hover attr-table">
                     <tr>
                         <th scope="row">Virtual Machine</th>
-                        <td>
-                            <a href="{{ object.virtual_machine.get_absolute_url }}">{{ object.virtual_machine }}</a>
-                        </td>
+                        <td>{{ object.virtual_machine|linkify }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Name</th>
@@ -41,33 +39,15 @@
                     </tr>
                     <tr>
                         <th scope="row">Parent</th>
-                        <td>
-                            {% if object.parent %}
-                                <a href="{{ object.parent.get_absolute_url }}">{{ object.parent }}</a>
-                            {% else %}
-                                <span class="text-muted">None</span>
-                            {% endif %}
-                        </td>
+                        <td>{{ object.parent|linkify|placeholder }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Bridge</th>
-                        <td>
-                            {% if object.bridge %}
-                                <a href="{{ object.bridge.get_absolute_url }}">{{ object.bridge }}</a>
-                            {% else %}
-                                <span class="text-muted">None</span>
-                            {% endif %}
-                        </td>
+                        <td>{{ object.bridge|linkify|placeholder }}</td>
                     </tr>
                     <tr>
                         <th scope="row">VRF</th>
-                        <td>
-                            {% if object.vrf %}
-                                  <a href="{{ object.vrf.get_absolute_url }}">{{ object.vrf }}</a>
-                              {% else %}
-                                  <span class="text-muted">None</span>
-                              {% endif %}
-                        </td>
+                        <td>{{ object.vrf|linkify|placeholder }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Description</th>

--- a/netbox/templates/wireless/inc/wirelesslink_interface.html
+++ b/netbox/templates/wireless/inc/wirelesslink_interface.html
@@ -3,15 +3,11 @@
 <table class="table table-hover panel-body attr-table">
   <tr>
     <td>Device</td>
-    <td>
-      <a href="{{ interface.device.get_absolute_url }}">{{ interface.device }}</a>
-    </td>
+    <td>{{ interface.device|linkify }}</td>
   </tr>
   <tr>
     <td>Interface</td>
-    <td>
-      <a href="{{ interface.get_absolute_url }}">{{ interface }}</a>
-    </td>
+    <td>{{ interface|linkify }}</td>
   </tr>
   <tr>
     <td>Type</td>

--- a/netbox/templates/wireless/wirelesslan.html
+++ b/netbox/templates/wireless/wirelesslan.html
@@ -16,13 +16,7 @@
                     </tr>
                     <tr>
                         <td>Group</td>
-                        <td>
-                            {% if object.group %}
-                                <a href="{{ object.group.get_absolute_url }}">{{ object.group }}</a>
-                            {% else %}
-                                <span class="text-muted">None</span>
-                            {% endif %}
-                        </td>
+                        <td>{{ object.group|linkify|placeholder }}</td>
                     </tr>
                     <tr>
                         <th scope="row">Description</th>
@@ -30,13 +24,7 @@
                     </tr>
                     <tr>
                         <th scope="row">VLAN</th>
-                        <td>
-                            {% if object.vlan %}
-                                <a href="{{ object.vlan.get_absolute_url }}">{{ object.vlan }}</a>
-                            {% else %}
-                                <span class="text-muted">None</span>
-                            {% endif %}
-                        </td>
+                        <td>{{ object.vlan|linkify|placeholder }}</td>
                     </tr>
                 </table>
             </div>

--- a/netbox/templates/wireless/wirelesslangroup.html
+++ b/netbox/templates/wireless/wirelesslangroup.html
@@ -35,13 +35,7 @@
           </tr>
           <tr>
             <th scope="row">Parent</th>
-            <td>
-              {% if object.parent %}
-                <a href="{{ object.parent.get_absolute_url }}">{{ object.parent }}</a>
-              {% else %}
-                <span class="text-muted">&mdash;</span>
-              {% endif %}
-            </td>
+            <td>{{ object.parent|linkify|placeholder }}</td>
           </tr>
           <tr>
             <th scope="row">Wireless LANs</th>

--- a/netbox/utilities/templatetags/builtins/filters.py
+++ b/netbox/utilities/templatetags/builtins/filters.py
@@ -21,15 +21,23 @@ register = template.Library()
 #
 
 @register.filter()
-def linkify(instance):
+def linkify(instance, attr=None):
     """
-    Render a hyperlink for object's with a `get_absolute_url()` method, using the object's string representation
-    as the link's text. If the object has no `get_absolute_url()` method, return an empty string.
+    Render a hyperlink for an object with a `get_absolute_url()` method, optionally specifying the name of an
+    attribute to use for the link text. If no attribute is given, the object's string representation will be
+    used.
+
+    If the object has no `get_absolute_url()` method, return the text without a hyperlink element.
     """
-    try:
-        return mark_safe(f'<a href="{instance.get_absolute_url()}">{instance}</a>')
-    except (AttributeError, TypeError):
+    if instance is None:
         return ''
+
+    text = getattr(instance, attr) if attr is not None else str(instance)
+    try:
+        url = instance.get_absolute_url()
+        return mark_safe(f'<a href="{url}">{text}</a>')
+    except (AttributeError, TypeError):
+        return text
 
 
 @register.filter()

--- a/netbox/utilities/templatetags/builtins/filters.py
+++ b/netbox/utilities/templatetags/builtins/filters.py
@@ -21,6 +21,18 @@ register = template.Library()
 #
 
 @register.filter()
+def linkify(instance):
+    """
+    Render a hyperlink for object's with a `get_absolute_url()` method, using the object's string representation
+    as the link's text. If the object has no `get_absolute_url()` method, return an empty string.
+    """
+    try:
+        return mark_safe(f'<a href="{instance.get_absolute_url()}">{instance}</a>')
+    except (AttributeError, TypeError):
+        return ''
+
+
+@register.filter()
 def bettertitle(value):
     """
     Alternative to the builtin title(). Ensures that the first letter of each word is uppercase but retains the


### PR DESCRIPTION
### Closes: #8912

- Introduce a `linkify` template filter for generating hyperlink using an object's `get_absolute_url()` method
- Replace hard-coded hyperlink elements with `|linkify` where appropriate
- General cleanup