### PR TITLE
Fix #8785 - allow wildcard dns records

### DIFF
--- a/netbox/ipam/validators.py
+++ b/netbox/ipam/validators.py
@@ -24,7 +24,7 @@ class MinPrefixLengthValidator(BaseValidator):
 
 
 DNSValidator = RegexValidator(
-    regex='^[0-9A-Za-z*._-]+$',
+    regex=r'^([0-9A-Za-z_-]+|\*)(\.[0-9A-Za-z_-]+)*\.?$',
     message='Only alphanumeric characters, asterisks, hyphens, periods, and underscores are allowed in DNS names',
     code='invalid'
 )

--- a/netbox/ipam/validators.py
+++ b/netbox/ipam/validators.py
@@ -24,7 +24,7 @@ class MinPrefixLengthValidator(BaseValidator):
 
 
 DNSValidator = RegexValidator(
-    regex='^[0-9A-Za-z._-]+$',
-    message='Only alphanumeric characters, hyphens, periods, and underscores are allowed in DNS names',
+    regex='^[0-9A-Za-z*._-]+$',
+    message='Only alphanumeric characters, asterisks, hyphens, periods, and underscores are allowed in DNS names',
     code='invalid'
 )


### PR DESCRIPTION
### Fixes: #8785
Added * to the DNSValidator regex to allow wildcard domains like *.example.com