### PR TITLE
Fixed #8952: rack rear faces link not clickable

### DIFF
--- a/netbox/dcim/svg.py
+++ b/netbox/dcim/svg.py
@@ -146,10 +146,10 @@ class RackElevationSVG:
                 class_='device-image'
             )
             image.fit(scale='slice')
-            drawing.add(image)
-            drawing.add(drawing.text(get_device_name(device), insert=text, stroke='black',
-                        stroke_width='0.2em', stroke_linejoin='round', class_='device-image-label'))
-            drawing.add(drawing.text(get_device_name(device), insert=text, fill='white', class_='device-image-label'))
+            link.add(image)
+            link.add(drawing.text(get_device_name(device), insert=text, stroke='black',
+                     stroke_width='0.2em', stroke_linejoin='round', class_='device-image-label'))
+            link.add(drawing.text(get_device_name(device), insert=text, fill='white', class_='device-image-label'))
 
     @staticmethod
     def _draw_empty(drawing, rack, start, end, text, id_, face_id, class_, reservation):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #8952
<!--
    Please include a summary of the proposed changes below.
-->
Makes the links in the SVG rack view on the rear clickable by adding the image/text as a child of the link.