### PR TITLE
Closes #8163: Add bridge members panel to interface view

### DIFF
--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -763,6 +763,10 @@ class Interface(ComponentModel, BaseInterface, LinkTermination, PathEndpoint):
         return self.type == InterfaceTypeChoices.TYPE_LAG
 
     @property
+    def is_bridge(self):
+        return self.type == InterfaceTypeChoices.TYPE_BRIDGE
+
+    @property
     def link(self):
         return self.cable or self.wireless_link
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1776,6 +1776,14 @@ class InterfaceView(generic.ObjectView):
             orderable=False
         )
 
+        # Get bridge interfaces
+        bridge_interfaces = Interface.objects.restrict(request.user, 'view').filter(bridge=instance)
+        bridge_interfaces_tables = tables.InterfaceTable(
+            bridge_interfaces,
+            exclude=('device', 'parent'),
+            orderable=False
+        )
+
         # Get child interfaces
         child_interfaces = Interface.objects.restrict(request.user, 'view').filter(parent=instance)
         child_interfaces_tables = tables.InterfaceTable(
@@ -1800,6 +1808,7 @@ class InterfaceView(generic.ObjectView):
 
         return {
             'ipaddress_table': ipaddress_table,
+            'bridge_interfaces_table': bridge_interfaces_tables,
             'child_interfaces_table': child_interfaces_tables,
             'vlan_table': vlan_table,
         }

--- a/netbox/templates/dcim/interface.html
+++ b/netbox/templates/dcim/interface.html
@@ -467,6 +467,13 @@
             {% include 'inc/panel_table.html' with table=vlan_table heading="VLANs" %}
         </div>
     </div>
+    {% if object.is_bridge %}
+    <div class="row mb-3">
+        <div class="col col-md-12">
+            {% include 'inc/panel_table.html' with table=bridge_interfaces_table heading="Bridge Interfaces" %}
+        </div>
+    </div>
+    {% endif %}
     <div class="row mb-3">
         <div class="col col-md-12">
             {% include 'inc/panel_table.html' with table=child_interfaces_table heading="Child Interfaces" %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #8163
<!--
    Please include a summary of the proposed changes below.
-->
This PR adds a new bridge members panel to the interface view. It is only displayed, if the interface in question is of type bridge.