### PR TITLE
Limit amount of nonracked devices displayed

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -342,17 +342,12 @@ class SiteView(generic.ObjectView):
             'device_count',
             cumulative=True
         ).restrict(request.user, 'view').filter(site=instance)
+
         nonracked_devices = Device.objects.filter(
             site=instance,
             position__isnull=True,
             parent_bay__isnull=True
-        ).prefetch_related('device_type__manufacturer').order_by('-pk')[:10]
-
-        total_nonracked_devices_count = Device.objects.filter(
-            site=instance,
-            position__isnull=True,
-            parent_bay__isnull=True
-        ).count()
+        ).prefetch_related('device_type__manufacturer')
 
         asns = ASN.objects.restrict(request.user, 'view').filter(sites=instance)
         asn_count = asns.count()
@@ -363,8 +358,8 @@ class SiteView(generic.ObjectView):
             'stats': stats,
             'locations': locations,
             'asns': asns,
-            'nonracked_devices': nonracked_devices,
-            'total_nonracked_devices_count': total_nonracked_devices_count,
+            'nonracked_devices': nonracked_devices.order_by('-pk')[:10],
+            'total_nonracked_devices_count': nonracked_devices.count(),
         }
 
 
@@ -442,24 +437,19 @@ class LocationView(generic.ObjectView):
         ).filter(pk__in=location_ids).exclude(pk=instance.pk)
         child_locations_table = tables.LocationTable(child_locations)
         child_locations_table.configure(request)
+
         nonracked_devices = Device.objects.filter(
             location=instance,
             position__isnull=True,
             parent_bay__isnull=True
-        ).prefetch_related('device_type__manufacturer').order_by('-pk')[:10]
-
-        total_nonracked_devices_count = Device.objects.filter(
-            location=instance,
-            position__isnull=True,
-            parent_bay__isnull=True
-        ).count()
+        ).prefetch_related('device_type__manufacturer')
 
         return {
             'rack_count': rack_count,
             'device_count': device_count,
             'child_locations_table': child_locations_table,
-            'nonracked_devices': nonracked_devices,
-            'total_nonracked_devices_count': total_nonracked_devices_count,
+            'nonracked_devices': nonracked_devices.order_by('-pk')[:10],
+            'total_nonracked_devices_count': nonracked_devices.count(),
         }
 
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -346,7 +346,13 @@ class SiteView(generic.ObjectView):
             site=instance,
             position__isnull=True,
             parent_bay__isnull=True
-        ).prefetch_related('device_type__manufacturer')
+        ).prefetch_related('device_type__manufacturer').order_by('-pk')[:10]
+
+        total_nonracked_devices_count = Device.objects.filter(
+            site=instance,
+            position__isnull=True,
+            parent_bay__isnull=True
+        ).count()
 
         asns = ASN.objects.restrict(request.user, 'view').filter(sites=instance)
         asn_count = asns.count()
@@ -358,6 +364,7 @@ class SiteView(generic.ObjectView):
             'locations': locations,
             'asns': asns,
             'nonracked_devices': nonracked_devices,
+            'total_nonracked_devices_count': total_nonracked_devices_count,
         }
 
 
@@ -439,13 +446,20 @@ class LocationView(generic.ObjectView):
             location=instance,
             position__isnull=True,
             parent_bay__isnull=True
-        ).prefetch_related('device_type__manufacturer')
+        ).prefetch_related('device_type__manufacturer').order_by('-pk')[:10]
+
+        total_nonracked_devices_count = Device.objects.filter(
+            location=instance,
+            position__isnull=True,
+            parent_bay__isnull=True
+        ).count()
 
         return {
             'rack_count': rack_count,
             'device_count': device_count,
             'child_locations_table': child_locations_table,
             'nonracked_devices': nonracked_devices,
+            'total_nonracked_devices_count': total_nonracked_devices_count,
         }
 
 

--- a/netbox/templates/dcim/inc/nonracked_devices.html
+++ b/netbox/templates/dcim/inc/nonracked_devices.html
@@ -1,40 +1,54 @@
 {% load helpers %}
 
 <div class="card">
-<h5 class="card-header">
-    Non-Racked Devices
-</h5>
-<div class="card-body">
-{% if nonracked_devices %}
-    <table class="table table-hover">
-        <tr>
-            <th>Name</th>
-            <th>Role</th>
-            <th>Type</th>
-            <th colspan="2">Parent Device</th>
-        </tr>
-        {% for device in nonracked_devices %}
-        <tr{% if device.device_type.u_height %} class="warning"{% endif %}>
-            <td>
-                <a href="{% url 'dcim:device' pk=device.pk %}">{{ device }}</a>
-            </td>
-            <td>{{ device.device_role }}</td>
-            <td>{{ device.device_type }}</td>
-            {% if device.parent_bay %}
-                <td>{{ device.parent_bay.device|linkify }}</td>
-                <td>{{ device.parent_bay }}</td>
-            {% else %}
-                <td colspan="2" class="text-muted">&mdash;</td>
+    <h5 class="card-header">
+        Non-Racked Devices
+    </h5>
+    <div class="card-body">
+    {% if nonracked_devices %}
+        <table class="table table-hover">
+            <tr>
+                <th>Name</th>
+                <th>Role</th>
+                <th>Type</th>
+                <th colspan="2">Parent Device</th>
+            </tr>
+            {% for device in nonracked_devices %}
+            <tr{% if device.device_type.u_height %} class="warning"{% endif %}>
+                <td>
+                    <a href="{% url 'dcim:device' pk=device.pk %}">{{ device }}</a>
+                </td>
+                <td>{{ device.device_role }}</td>
+                <td>{{ device.device_type }}</td>
+                {% if device.parent_bay %}
+                    <td>{{ device.parent_bay.device|linkify }}</td>
+                    <td>{{ device.parent_bay }}</td>
+                {% else %}
+                    <td colspan="2" class="text-muted">&mdash;</td>
+                {% endif %}
+            </tr>
+            {% endfor %}
+        </table>
+
+        {%  if nonracked_devices.count == 10 %}
+            {% if object|meta:'verbose_name' == 'site' %}
+                <div class="text-muted">
+                    Displaying 10 of {{ total_nonracked_devices_count }} devices (<a href="{% url 'dcim:device_list' %}?site_id={{ object.pk }}&rack_id=null">View full list</a>)
+                </div>
+            {% elif object|meta:'verbose_name' == 'location' %}
+                <div class="text-muted">
+                    Displaying 10 of {{ total_nonracked_devices_count }} devices (<a href="{% url 'dcim:device_list' %}?location_id={{ object.pk }}&rack_id=null">View full list</a>)
+                </div>
             {% endif %}
-        </tr>
-        {% endfor %}
-    </table>
+        {% endif %}
+
     {% else %}
         <div class="text-muted">
             None
         </div>
     {% endif %}
     </div>
+
     {% if perms.dcim.add_device %}
         {% if object|meta:'verbose_name' == 'rack' %}
         <div class="card-footer text-end noprint">

--- a/netbox/templates/dcim/inc/nonracked_devices.html
+++ b/netbox/templates/dcim/inc/nonracked_devices.html
@@ -30,14 +30,14 @@
             {% endfor %}
         </table>
 
-        {%  if nonracked_devices.count == 10 %}
+        {%  if total_nonracked_devices_count > nonracked_devices.count %}
             {% if object|meta:'verbose_name' == 'site' %}
                 <div class="text-muted">
-                    Displaying 10 of {{ total_nonracked_devices_count }} devices (<a href="{% url 'dcim:device_list' %}?site_id={{ object.pk }}&rack_id=null">View full list</a>)
+                    Displaying {{ nonracked_devices.count }} of {{ total_nonracked_devices_count }} devices (<a href="{% url 'dcim:device_list' %}?site_id={{ object.pk }}&rack_id=null">View full list</a>)
                 </div>
             {% elif object|meta:'verbose_name' == 'location' %}
                 <div class="text-muted">
-                    Displaying 10 of {{ total_nonracked_devices_count }} devices (<a href="{% url 'dcim:device_list' %}?location_id={{ object.pk }}&rack_id=null">View full list</a>)
+                    Displaying {{ nonracked_devices.count }} of {{ total_nonracked_devices_count }} devices (<a href="{% url 'dcim:device_list' %}?location_id={{ object.pk }}&rack_id=null">View full list</a>)
                 </div>
             {% endif %}
         {% endif %}


### PR DESCRIPTION
Fixes #8920

Limits the amount of non-racked devices on Site and Location view to 10 and provides a link to the device list this is pre-filtered to the relevant site or location.
