### PR TITLE
Conflicting documentation on remote default group

### DIFF
--- a/docs/configuration/remote-authentication.md
+++ b/docs/configuration/remote-authentication.md
@@ -43,7 +43,7 @@ A mapping of permissions to assign a new user account when created using remote 
 
 Default: `False`
 
-NetBox can be configured to support remote user authentication by inferring user authentication from an HTTP header set by the HTTP reverse proxy (e.g. nginx or Apache). Set this to `True` to enable this functionality. (Local authentication will still take effect as a fallback.) (`REMOTE_AUTH_DEFAULT_GROUPS` will not function if `REMOTE_AUTH_ENABLED` is enabled)
+NetBox can be configured to support remote user authentication by inferring user authentication from an HTTP header set by the HTTP reverse proxy (e.g. nginx or Apache). Set this to `True` to enable this functionality. (Local authentication will still take effect as a fallback.) (`REMOTE_AUTH_DEFAULT_GROUPS` will not function if `REMOTE_AUTH_ENABLED` is disabled)
 
 ---
 


### PR DESCRIPTION
### Fixes: #8751
In the current [documentation](https://github.com/netbox-community/netbox/blob/develop/docs/configuration/remote-authentication.md) we have two seemingly conflicting sentences:

At [#remote_auth_enabled](https://github.com/netbox-community/netbox/blob/develop/docs/configuration/remote-authentication.md#remote_auth_enabled) we have

REMOTE_AUTH_ENABLED: (REMOTE_AUTH_DEFAULT_GROUPS will not function if REMOTE_AUTH_ENABLED is enabled)
At [#REMOTE_AUTH_DEFAULT_GROUPS](https://github.com/netbox-community/netbox/blob/develop/docs/configuration/remote-authentication.md#remote_auth_default_groups) we have

REMOTE_AUTH_DEFAULT_GROUPS: (Requires REMOTE_AUTH_ENABLED.)
Shouldn't it say REMOTE_AUTH_DEFAULT_GROUPS will not function if REMOTE_AUTH_ENABLED is disabled? Or explain better the situation if this is correct?