### PR TITLE
Closes #4264: Do not allocate subnet router anycast for IPv6 prefixes

### DIFF
--- a/netbox/ipam/tests/test_models.py
+++ b/netbox/ipam/tests/test_models.py
@@ -185,6 +185,18 @@ class TestPrefix(TestCase):
         IPAddress.objects.create(address=IPNetwork('10.0.0.4/24'))
         self.assertEqual(parent_prefix.get_first_available_ip(), '10.0.0.5/24')
 
+    def test_get_first_available_ip_ipv6(self):
+        parent_prefix = Prefix.objects.create(prefix=IPNetwork('2001:db8:500::/64'))
+        self.assertEqual(parent_prefix.get_first_available_ip(), '2001:db8:500::1/64')
+
+    def test_get_first_available_ip_ipv6_rfc3627(self):
+        parent_prefix = Prefix.objects.create(prefix=IPNetwork('2001:db8:500:4::/126'))
+        self.assertEqual(parent_prefix.get_first_available_ip(), '2001:db8:500:4::1/126')
+
+    def test_get_first_available_ip_ipv6_rfc6164(self):
+        parent_prefix = Prefix.objects.create(prefix=IPNetwork('2001:db8:500:5::/127'))
+        self.assertEqual(parent_prefix.get_first_available_ip(), '2001:db8:500:5::/127')
+
     def test_get_utilization_container(self):
         prefixes = (
             Prefix(prefix=IPNetwork('10.0.0.0/24'), status=PrefixStatusChoices.STATUS_CONTAINER),


### PR DESCRIPTION
This fixes #4264 by removing the first IPv6 address from the available_ips that is returned, in cases where the RFCs prohibit it