### PR TITLE
Fixes #9133: Require Python 3.8+ to run upgrade.sh

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -3,23 +3,23 @@
 # its most recent release.
 
 # This script will invoke Python with the value of the PYTHON environment
-# variable (if set), or fall back to "python3". Note that NetBox v3.0+ requires
-# Python 3.7 or later.
+# variable (if set), or fall back to "python3". Note that NetBox v3.2+ requires
+# Python 3.8 or later.
 
 cd "$(dirname "$0")"
 VIRTUALENV="$(pwd -P)/venv"
 PYTHON="${PYTHON:-python3}"
 
 # Validate the minimum required Python version
-COMMAND="${PYTHON} -c 'import sys; exit(1 if sys.version_info < (3, 7) else 0)'"
+COMMAND="${PYTHON} -c 'import sys; exit(1 if sys.version_info < (3, 8) else 0)'"
 PYTHON_VERSION=$(eval "${PYTHON} -V")
 eval $COMMAND || {
   echo "--------------------------------------------------------------------"
   echo "ERROR: Unsupported Python version: ${PYTHON_VERSION}. NetBox requires"
-  echo "Python 3.7 or later. To specify an alternate Python executable, set"
+  echo "Python 3.8 or later. To specify an alternate Python executable, set"
   echo "the PYTHON environment variable. For example:"
   echo ""
-  echo "  sudo PYTHON=/usr/bin/python3.7 ./upgrade.sh"
+  echo "  sudo PYTHON=/usr/bin/python3.8 ./upgrade.sh"
   echo ""
   echo "To show your current Python version: ${PYTHON} -V"
   echo "--------------------------------------------------------------------"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #9133 
<!--
    Please include a summary of the proposed changes below.
-->

Updates the Python version checks in `upgrade.sh` to require 3.8+ (as required in NetBox 3.2).

```
# ./upgrade.sh
--------------------------------------------------------------------
ERROR: Unsupported Python version: Python 3.7.3. NetBox requires
Python 3.8 or later. To specify an alternate Python executable, set
the PYTHON environment variable. For example:

  sudo PYTHON=/usr/bin/python3.8 ./upgrade.sh

To show your current Python version: python3 -V
--------------------------------------------------------------------
#
```