### PR TITLE
Update 5-http-server.md

### DIFF
--- a/docs/installation/5-http-server.md
+++ b/docs/installation/5-http-server.md
@@ -56,10 +56,12 @@ Begin by installing Apache:
 sudo apt install -y apache2
 ```
 
-Next, copy the default configuration file to `/etc/apache2/sites-available/`. Be sure to modify the `ServerName` parameter appropriately.
+Next, copy the default configuration file to `/etc/apache2/sites-available/`. Be sure to modify the `ServerName` parameter appropriately. 
+(ParameterName ServerName = Server-Name or IP-Adress)
 
 ```no-highlight
 sudo cp /opt/netbox/contrib/apache.conf /etc/apache2/sites-available/netbox.conf
+sudo nano /etc/apache2/sites-available/netbox.conf
 ```
 
 Finally, ensure that the required Apache modules are enabled, enable the `netbox` site, and reload Apache:
@@ -73,6 +75,8 @@ sudo systemctl restart apache2
 ## Confirm Connectivity
 
 At this point, you should be able to connect to the HTTPS service at the server name or IP address you provided.
+
+Open in the browser https://Servername/ or https://IP-Adress/ (depending on the netbox.conf entry) without the port 8000!
 
 !!! info
     Please keep in mind that the configurations provided here are bare minimums required to get NetBox up and running. You may want to make adjustments to better suit your production environment.


### PR DESCRIPTION
Add: "sudo nano /etc/apache2/sites-available/netbox.conf"  and Change description
Reason: To point out more strongly the necessary adjustment of the server name. I had overlooked it in the text.

Add: Open in the browser https://Servername/ or    ...     without the port 8000!
Add: I assumed that you still have to call it with port 8000. As in the pre-test. But it runs with 443

<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: <ISSUE NUMBER GOES HERE>
<!--
    Please include a summary of the proposed changes below.
-->
