### PR TITLE
Fixes #9189:  Correct custom validators docs

### DIFF
--- a/docs/customization/custom-validation.md
+++ b/docs/customization/custom-validation.md
@@ -105,11 +105,11 @@ from my_validators import Validator1, Validator2, Validator3
 
 CUSTOM_VALIDATORS = {
     'dcim.site': (
-        Validator1,
-        Validator2,
+        Validator1(),
+        Validator2(),
     ),
     'dcim.device': (
-        Validator3,
+        Validator3(),
     )
 }
 ```


### PR DESCRIPTION
### Fixes: #9189

Custom validators must be passed as instantiated when passed as direct references.