### PR TITLE
Fixes #9138 - Prevent searching when pressing enter in Quick Search

### DIFF
--- a/netbox/templates/dcim/device/consoleports.html
+++ b/netbox/templates/dcim/device/consoleports.html
@@ -4,9 +4,10 @@
 {% load static %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="DeviceConsolePortTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="DeviceConsolePortTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/dcim/device/consoleserverports.html
+++ b/netbox/templates/dcim/device/consoleserverports.html
@@ -4,9 +4,10 @@
 {% load static %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="DeviceConsoleServerPortTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="DeviceConsoleServerPortTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/dcim/device/devicebays.html
+++ b/netbox/templates/dcim/device/devicebays.html
@@ -4,9 +4,10 @@
 {% load static %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="DeviceDeviceBayTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="DeviceDeviceBayTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/dcim/device/frontports.html
+++ b/netbox/templates/dcim/device/frontports.html
@@ -4,9 +4,10 @@
 {% load static %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="DeviceFrontPortTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="DeviceFrontPortTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/dcim/device/interfaces.html
+++ b/netbox/templates/dcim/device/interfaces.html
@@ -4,44 +4,46 @@
 {% load static %}
 
 {% block content %}
-  <form method="post">
-    {% csrf_token %}
-    <div class="row mb-3 justify-content-between">
-      <div class="col col-12 col-lg-4 my-3 my-lg-0 d-flex noprint table-controls">
-        <div class="input-group input-group-sm">
-          <input
-              type="text"
-              name="q"
-              class="form-control"
-              placeholder="Quick search"
-              hx-get="{{ request.full_path }}"
-              hx-target="#object_list"
-              hx-trigger="keyup changed delay:500ms"
-          />
-        </div>
-      </div>
-      <div class="col col-md-3 mb-0 d-flex noprint table-controls">
-        <div class="input-group input-group-sm justify-content-end">
-          {% if request.user.is_authenticated %}
-            <button
-                type="button"
-                class="btn btn-sm btn-outline-dark"
-                data-bs-toggle="modal"
-                data-bs-target="#DeviceInterfaceTable_config"
-                title="Configure Table">
-                <i class="mdi mdi-cog"></i> Configure Table
-            </button>
-          {% endif %}
-          <button class="btn btn-sm btn-outline-dark dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-            <i class="mdi mdi-eye"></i>
-          </button>
-          <ul class="dropdown-menu">
-            <button type="button" class="dropdown-item toggle-enabled" data-state="show">Hide Enabled</button>
-            <button type="button" class="dropdown-item toggle-disabled" data-state="show">Hide Disabled</button>
-          </ul>
-        </div>
+  <div class="row mb-3 justify-content-between">
+    <div class="col col-12 col-lg-4 my-3 my-lg-0 d-flex noprint table-controls">
+      <div class="input-group input-group-sm">
+        <input
+            type="text"
+            name="q"
+            class="form-control"
+            placeholder="Quick search"
+            hx-get="{{ request.full_path }}"
+            hx-target="#object_list"
+            hx-trigger="keyup changed delay:500ms"
+        />
       </div>
     </div>
+    <div class="col col-md-3 mb-0 d-flex noprint table-controls">
+      <div class="input-group input-group-sm justify-content-end">
+        {% if request.user.is_authenticated %}
+          <button
+              type="button"
+              class="btn btn-sm btn-outline-dark"
+              data-bs-toggle="modal"
+              data-bs-target="#DeviceInterfaceTable_config"
+              title="Configure Table">
+              <i class="mdi mdi-cog"></i> Configure Table
+          </button>
+        {% endif %}
+        <button class="btn btn-sm btn-outline-dark dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+          <i class="mdi mdi-eye"></i>
+        </button>
+        <ul class="dropdown-menu">
+          <button type="button" class="dropdown-item toggle-enabled" data-state="show">Hide Enabled</button>
+          <button type="button" class="dropdown-item toggle-disabled" data-state="show">Hide Disabled</button>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <form method="post">
+    {% csrf_token %}
+
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/dcim/device/inventory.html
+++ b/netbox/templates/dcim/device/inventory.html
@@ -4,9 +4,10 @@
 {% load static %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="DeviceInventoryItemTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="DeviceInventoryItemTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/dcim/device/modulebays.html
+++ b/netbox/templates/dcim/device/modulebays.html
@@ -4,9 +4,10 @@
 {% load static %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="DeviceModuleBayTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="DeviceModuleBayTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/dcim/device/poweroutlets.html
+++ b/netbox/templates/dcim/device/poweroutlets.html
@@ -4,9 +4,10 @@
 {% load static %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="DevicePowerOutletTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="DevicePowerOutletTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/dcim/device/powerports.html
+++ b/netbox/templates/dcim/device/powerports.html
@@ -4,9 +4,10 @@
 {% load static %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="DevicePowerPortTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="DevicePowerPortTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/dcim/device/rearports.html
+++ b/netbox/templates/dcim/device/rearports.html
@@ -4,9 +4,10 @@
 {% load helpers %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="DeviceRearPortTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="DeviceRearPortTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/ipam/aggregate/prefixes.html
+++ b/netbox/templates/ipam/aggregate/prefixes.html
@@ -12,9 +12,10 @@
 {% endblock %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="PrefixTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="PrefixTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/ipam/iprange/ip_addresses.html
+++ b/netbox/templates/ipam/iprange/ip_addresses.html
@@ -10,9 +10,10 @@
 {% endblock %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="IPAddressTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="IPAddressTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/ipam/prefix/ip_addresses.html
+++ b/netbox/templates/ipam/prefix/ip_addresses.html
@@ -10,9 +10,10 @@
 {% endblock %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="IPAddressTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="IPAddressTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/ipam/prefix/ip_ranges.html
+++ b/netbox/templates/ipam/prefix/ip_ranges.html
@@ -10,9 +10,10 @@
 {% endblock %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="IPRangeTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="IPRangeTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/ipam/prefix/prefixes.html
+++ b/netbox/templates/ipam/prefix/prefixes.html
@@ -12,9 +12,10 @@
 {% endblock %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="PrefixTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="PrefixTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">

--- a/netbox/templates/ipam/vlan/interfaces.html
+++ b/netbox/templates/ipam/vlan/interfaces.html
@@ -2,9 +2,10 @@
 {% load helpers %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="VLANDevicesTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="VLANDevicesTable_config" %}
     <div class="card">
       <div class="card-body" id="object_list">
         {% include 'htmx/table.html' %}

--- a/netbox/templates/ipam/vlan/vminterfaces.html
+++ b/netbox/templates/ipam/vlan/vminterfaces.html
@@ -2,9 +2,10 @@
 {% load helpers %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="VLANVirtualMachinesTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="VLANVirtualMachinesTable_config" %}
     <div class="card">
       <div class="card-body" id="object_list">
         {% include 'htmx/table.html' %}

--- a/netbox/templates/virtualization/cluster/devices.html
+++ b/netbox/templates/virtualization/cluster/devices.html
@@ -3,9 +3,10 @@
 {% load render_table from django_tables2 %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="DeviceTable_config" %}
+  
   <form action="{% url 'virtualization:cluster_remove_devices' pk=object.pk %}" method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="DeviceTable_config" %}
     <div class="card">
       <div class="card-body" id="object_list">
         {% include 'htmx/table.html' %}

--- a/netbox/templates/virtualization/cluster/virtual_machines.html
+++ b/netbox/templates/virtualization/cluster/virtual_machines.html
@@ -3,9 +3,10 @@
 {% load render_table from django_tables2 %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="VirtualMachineTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="VirtualMachineTable_config" %}
     <div class="card">
       <div class="card-body" id="object_list">
         {% include 'htmx/table.html' %}

--- a/netbox/templates/virtualization/virtualmachine/interfaces.html
+++ b/netbox/templates/virtualization/virtualmachine/interfaces.html
@@ -3,9 +3,10 @@
 {% load helpers %}
 
 {% block content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="VirtualMachineVMInterfaceTable_config" %}
+  
   <form method="post">
     {% csrf_token %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="VirtualMachineVMInterfaceTable_config" %}
 
     <div class="card">
       <div class="card-body" id="object_list">


### PR DESCRIPTION
### Fixes: #9138

Move all includes of `inc/table_controls_htmx.html` out of the table forms. This matches the existing setup in `object_list.hml`, which is why the bug only occurred in some cases.

I tested quick search in all the tables I changed, and there seem to be no ill effects of the change, however there could be cases I haven't thought about (I wish UI testing was easier to setup).