### PR TITLE
Fix #9122 - Clear the cache when running the upgrade script

### DIFF
--- a/netbox/extras/management/commands/clearcache.py
+++ b/netbox/extras/management/commands/clearcache.py
@@ -1,0 +1,11 @@
+from django.core.cache import cache
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    """Command to clear the entire cache."""
+    help = 'Clears the cache.'
+
+    def handle(self, *args, **kwargs):
+        cache.clear()
+        self.stdout.write('Cache has been cleared.', ending="\n")

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -108,6 +108,11 @@ COMMAND="python3 netbox/manage.py clearsessions"
 echo "Removing expired user sessions ($COMMAND)..."
 eval $COMMAND || exit 1
 
+# Clear the cache
+COMMAND="python3 netbox/manage.py clearcache"
+echo "Clearing the cache ($COMMAND)..."
+eval $COMMAND || exit 1
+
 if [ -v WARN_MISSING_VENV ]; then
   echo "--------------------------------------------------------------------"
   echo "WARNING: No existing virtual environment was detected. A new one has"


### PR DESCRIPTION
### Fixes: #9122

* Adds a clearcache management command.
* Runs the clearcache command when running upgrade.sh

Clearing the cache on upgrade prevents having a stale openapi definition.

I have an alternative version not adding a command and just calling `manage.py shell -i python .c <COMMAND>`, however the clearcache command can also be use to clear for example the "new update" notification, which has been mentioned as an issue a couple of times (https://github.com/netbox-community/netbox/discussions/8800).