### PR TITLE
Fixes #9267 - Fix early terminated tuple in IPAddressRoleChoices

### DIFF
--- a/netbox/ipam/choices.py
+++ b/netbox/ipam/choices.py
@@ -91,7 +91,7 @@ class IPAddressRoleChoices(ChoiceSet):
         (ROLE_VRRP, 'VRRP', 'green'),
         (ROLE_HSRP, 'HSRP', 'green'),
         (ROLE_GLBP, 'GLBP', 'green'),
-        (ROLE_CARP, 'CARP'), 'green',
+        (ROLE_CARP, 'CARP', 'green'),
     )
 
 


### PR DESCRIPTION
### Fixes: #9267

Fix early terminated tuple in IPAddressRoleChoices