### PR TITLE
Fixes #9280 - Add option to adopt existing DeviceComponents

### DIFF
--- a/netbox/dcim/forms/models.py
+++ b/netbox/dcim/forms/models.py
@@ -633,12 +633,18 @@ class ModuleForm(NetBoxModelForm):
         help_text="Automatically populate components associated with this module type"
     )
 
+    adopt_components = forms.BooleanField(
+        required=False,
+        initial=False,
+        help_text="Adopt already existing components"
+    )
+
     fieldsets = (
         ('Module', (
             'device', 'module_bay', 'manufacturer', 'module_type', 'tags',
         )),
         ('Hardware', (
-            'serial', 'asset_tag', 'replicate_components',
+            'serial', 'asset_tag', 'replicate_components', 'adopt_components',
         )),
     )
 
@@ -646,7 +652,7 @@ class ModuleForm(NetBoxModelForm):
         model = Module
         fields = [
             'device', 'module_bay', 'manufacturer', 'module_type', 'serial', 'asset_tag', 'tags',
-            'replicate_components', 'comments',
+            'replicate_components', 'adopt_components', 'comments',
         ]
 
     def __init__(self, *args, **kwargs):
@@ -655,12 +661,17 @@ class ModuleForm(NetBoxModelForm):
         if self.instance.pk:
             self.fields['replicate_components'].initial = False
             self.fields['replicate_components'].disabled = True
+            self.fields['adopt_components'].initial = False
+            self.fields['adopt_components'].disabled = True
 
     def save(self, *args, **kwargs):
 
         # If replicate_components is False, disable automatic component replication on the instance
         if self.instance.pk or not self.cleaned_data['replicate_components']:
             self.instance._disable_replication = True
+
+        if self.cleaned_data['adopt_components']:
+            self.instance._adopt_components = True
 
         return super().save(*args, **kwargs)
 

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -1086,13 +1086,17 @@ class Module(NetBoxModel, ConfigContextModel):
             create_instances = []
             update_instances = []
 
+            # Prefetch installed components
+            installed_components = {
+                component.name: component for component in getattr(self.device, component_attribute).filter(module__isnull=True)
+            }
+
             # Get the template for the module type.
             for template in getattr(self.module_type, templates).all():
                 template_instance = template.instantiate(device=self.device, module=self)
 
                 if adopt_components:
-                    existing_item = getattr(self.device, component_attribute).filter(
-                        module__isnull=True, name=template_instance.name).first()
+                    existing_item = installed_components.get(template_instance.name)
 
                     # Check if there's a component with the same name already
                     if existing_item:

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -1091,7 +1091,8 @@ class Module(NetBoxModel, ConfigContextModel):
                 template_instance = template.instantiate(device=self.device, module=self)
 
                 if adopt_components:
-                    existing_item = getattr(self.device, component_attribute).filter(name=template_instance.name).first()
+                    existing_item = getattr(self.device, component_attribute).filter(
+                        module__isnull=True, name=template_instance.name).first()
 
                     # Check if there's a component with the same name already
                     if existing_item:

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -1097,10 +1097,10 @@ class Module(NetBoxModel, ConfigContextModel):
                             existing_item.module = self
                             update_instances.append(existing_item)
                             continue
-                        
+
                     # If we are not adopting components or the component doesn't already exist
                     create_instances.append(template_instance)
-                
+
                 component_model.objects.bulk_create(create_instances)
                 component_model.objects.bulk_update(update_instances, ['module'])
 

--- a/netbox/dcim/tests/test_views.py
+++ b/netbox/dcim/tests/test_views.py
@@ -1894,7 +1894,7 @@ class ModuleTestCase(
         # Check that the interface was created
         initial_interface = Interface.objects.filter(device=device, name=interface_name).first()
         self.assertIsNotNone(initial_interface)
-        
+
         # Save the module id associated with the interface
         initial_module_id = initial_interface.module.id
 


### PR DESCRIPTION
### Fixes: #9280

This PR adds a new boolean field (adopt_components) to the Module form. The creation logic has been changed to check for and change the module field on any existing components.

~~This is still a draft. I need to verify that the API works, and I haven't checked a few cases.~~ Looking for input for the implementation also.