### PR TITLE
Closes #9278: Linkify device type in manufacturer table

### DIFF
--- a/netbox/dcim/tables/devicetypes.py
+++ b/netbox/dcim/tables/devicetypes.py
@@ -31,7 +31,9 @@ class ManufacturerTable(NetBoxTable):
     name = tables.Column(
         linkify=True
     )
-    devicetype_count = tables.Column(
+    devicetype_count = columns.LinkedCountColumn(
+        viewname='dcim:devicetype_list',
+        url_params={'manufacturer_id': 'pk'},
         verbose_name='Device Types'
     )
     inventoryitem_count = tables.Column(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #9278
<!--
    Please include a summary of the proposed changes below.
-->
Converted the devicetype_count field within the 'Manufacturer' table into a LinkedCountColumn type. This gives users the ability to click on the device count and be directed to a table of device types filtered by the manufacturer.
