### PR TITLE
Fixes #9001 & #9190 - Add form validation to model installation

### DIFF
--- a/netbox/dcim/forms/models.py
+++ b/netbox/dcim/forms/models.py
@@ -718,7 +718,7 @@ class ModuleForm(NetBoxModelForm):
                     raise forms.ValidationError(
                         f"Cannot adopt {template.component_model.__name__} '{resolved_name}' as it already belongs to a module"
                     )
-                
+
                 # If we are not adopting components we error if the component exists
                 if not adopt_components and resolved_name in installed_components:
                     raise forms.ValidationError(


### PR DESCRIPTION
### Fixes: #9190

Raises a ValidationError whenever installation would cause a foreign key violation. I tested all combinations I could think of. It short circuits on the first error. Batching all errors would cause a huge error message in most cases.