### PR TITLE
Closes #9340: Enable Sentry integration

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -102,6 +102,10 @@ psycopg2-binary
 # https://github.com/yaml/pyyaml
 PyYAML
 
+# Sentry SDK
+# https://github.com/getsentry/sentry-python
+sentry-sdk
+
 # Social authentication framework
 # https://github.com/python-social-auth/social-core
 social-auth-core

--- a/docs/administration/error-reporting.md
+++ b/docs/administration/error-reporting.md
@@ -1,0 +1,27 @@
+# Error Reporting
+
+## Sentry
+
+NetBox v3.2.3 and later support native integration with [Sentry](https://sentry.io/) for automatic error reporting. To enable this feature, begin by creating a new project in Sentry to represent your NetBox deployment and obtain its corresponding data source name (DSN). This looks like a URL similar to the example below:
+
+```
+https://examplePublicKey@o0.ingest.sentry.io/0
+```
+
+Once you have obtained a DSN, configure Sentry in NetBox's `configuration.py` file with the following parameters:
+
+```python
+SENTRY_ENABLED = True
+SENTRY_DSN = "https://YourDSNgoesHere@o0.ingest.sentry.io/0"
+```
+
+You can optionally attach one or more arbitrary tags to the outgoing error reports if desired by setting the `SENTRY_TAGS` parameter:
+
+```python
+SENTRY_TAGS = {
+    "custom.foo": "123",
+    "custom.bar": "abc",
+}
+```
+
+Once the configuration has been saved, restart the NetBox service.

--- a/docs/administration/error-reporting.md
+++ b/docs/administration/error-reporting.md
@@ -25,3 +25,5 @@ SENTRY_TAGS = {
 ```
 
 Once the configuration has been saved, restart the NetBox service.
+
+To test Sentry operation, try generating a 404 (page not found) error by navigating to an invalid URL, such as `https://netbox/404-error-testing`. After receiving a 404 response from the NetBox server, you should see the issue appear shortly in Sentry.

--- a/docs/configuration/optional-settings.md
+++ b/docs/configuration/optional-settings.md
@@ -404,6 +404,39 @@ The file path to the location where [custom scripts](../customization/custom-scr
 
 ---
 
+## SENTRY_DSN
+
+Default: None
+
+Defines a Sentry data source name (DSN) for automated error reporting. `SENTRY_ENABLED` must be True for this parameter to take effect. For example:
+
+```
+SENTRY_DSN = "https://examplePublicKey@o0.ingest.sentry.io/0"
+```
+
+---
+
+## SENTRY_ENABLED
+
+Default: False
+
+Set to True to enable automatic error reporting via [Sentry](https://sentry.io/). Requires `SENTRY_DSN` to be defined.
+
+---
+
+## SENTRY_TAGS
+
+An optional dictionary of tags to apply to Sentry error reports. `SENTRY_ENABLED` must be True for this parameter to take effect. For example:
+
+```
+SENTRY_TAGS = {
+    "custom.foo": "123",
+    "custom.bar": "abc",
+}
+```
+
+---
+
 ## SESSION_COOKIE_NAME
 
 Default: `sessionid`

--- a/docs/release-notes/version-3.2.md
+++ b/docs/release-notes/version-3.2.md
@@ -11,6 +11,7 @@
 * [#9278](https://github.com/netbox-community/netbox/issues/9278) - Linkify device types count under manufacturers list
 * [#9280](https://github.com/netbox-community/netbox/issues/9280) - Allow adopting existing components when installing a module
 * [#9314](https://github.com/netbox-community/netbox/issues/9314) - Add device and VM filters for FHRP group assignments
+* [#9340](https://github.com/netbox-community/netbox/issues/9340) - Introduce support for error reporting via Sentry
 
 ### Bug Fixes
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -123,6 +123,7 @@ nav:
             - Microsoft Azure AD: 'administration/authentication/microsoft-azure-ad.md'
             - Okta: 'administration/authentication/okta.md'
         - Permissions: 'administration/permissions.md'
+        - Error Reporting: 'administration/error-reporting.md'
         - Housekeeping: 'administration/housekeeping.md'
         - Replicating NetBox: 'administration/replicating-netbox.md'
         - NetBox Shell: 'administration/netbox-shell.md'

--- a/netbox/netbox/urls.py
+++ b/netbox/netbox/urls.py
@@ -100,4 +100,5 @@ urlpatterns = [
     path('{}'.format(settings.BASE_PATH), include(_patterns))
 ]
 
+handler404 = 'netbox.views.handler_404'
 handler500 = 'netbox.views.server_error'

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,6 +24,7 @@ netaddr==0.8.0
 Pillow==9.1.0
 psycopg2-binary==2.9.3
 PyYAML==6.0
+sentry-sdk==1.5.12
 social-auth-app-django==5.0.0
 social-auth-core==4.2.0
 svgwrite==1.4.2


### PR DESCRIPTION
### Closes: #9340

- Introduces `sentry-sdk` as a new dependency & enables Sentry integration
- Introduces three new configuration parameters for Sentry
- Adds an "error reporting" section under the administration docs