### PR TITLE
Fixes #9430 - Make sure initial data is passed as array for DynamicModelChoiceFields

### DIFF
--- a/netbox/utilities/forms/fields/dynamic.py
+++ b/netbox/utilities/forms/fields/dynamic.py
@@ -88,7 +88,12 @@ class DynamicModelChoiceMixin:
         # Modify the QuerySet of the field before we return it. Limit choices to any data already bound: Options
         # will be populated on-demand via the APISelect widget.
         data = bound_field.value()
+
         if data:
+            # When the field is multiple choice pass the data as a list if it's not already
+            if isinstance(bound_field.field, DynamicModelMultipleChoiceField) and not type(data) is list:
+                data = [data]
+
             field_name = getattr(self, 'to_field_name') or 'pk'
             filter = self.filter(field_name=field_name)
             try:


### PR DESCRIPTION
### Fixes: #9430

When pre-filling a MultiObjectVar for custom script execution passing a single pk above 9 would not work. Passing multiple values like: `?devices=1&device=99` works.

The error occurs in line 95 here:

https://github.com/netbox-community/netbox/blob/2e5a5f71ba4622b2989d892d4215e2aefe59b91c/netbox/utilities/forms/fields/dynamic.py#L88-L100

When passed a two or more digit number in a string, the value seems to get split into a string, so instead of looking up pk 123, it looks up pk 1, 2 and 3.

I'm not sure exactly what's going on here so there might be a better place to fix the issue, please let me know and I'll change it.