### PR TITLE
Fixes #9480 - Make the Service and ServiceTemplate tables sortable by ports

### DIFF
--- a/netbox/ipam/tables/services.py
+++ b/netbox/ipam/tables/services.py
@@ -14,7 +14,8 @@ class ServiceTemplateTable(NetBoxTable):
         linkify=True
     )
     ports = tables.Column(
-        accessor=tables.A('port_list')
+        accessor=tables.A('port_list'),
+        order_by=tables.A('ports'),
     )
     tags = columns.TagColumn(
         url_name='ipam:servicetemplate_list'
@@ -35,7 +36,8 @@ class ServiceTable(NetBoxTable):
         order_by=('device', 'virtual_machine')
     )
     ports = tables.Column(
-        accessor=tables.A('port_list')
+        accessor=tables.A('port_list'),
+        order_by=tables.A('ports'),
     )
     tags = columns.TagColumn(
         url_name='ipam:service_list'


### PR DESCRIPTION
### Fixes: #9480

Added the order_by argument to sort by the real db field instead of the computed list.