### PR TITLE
Fixes #9108 & #8944 - Sanitize HTML after rendering markdown

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -125,3 +125,7 @@ tablib
 # Timezone data (required by django-timezone-field on Python 3.9+)
 # https://github.com/python/tzdata
 tzdata
+
+# HTML sanitizer
+# https://github.com/mozilla/bleach
+bleach

--- a/netbox/utilities/templatetags/builtins/filters.py
+++ b/netbox/utilities/templatetags/builtins/filters.py
@@ -11,7 +11,7 @@ from markdown import markdown
 
 from netbox.config import get_config
 from utilities.markdown import StrikethroughExtension
-from utilities.utils import foreground_color
+from utilities.utils import clean_html, foreground_color
 
 register = template.Library()
 
@@ -144,18 +144,6 @@ def render_markdown(value):
 
         {{ md_source_text|markdown }}
     """
-    schemes = '|'.join(get_config().ALLOWED_URL_SCHEMES)
-
-    # Strip HTML tags
-    value = strip_tags(value)
-
-    # Sanitize Markdown links
-    pattern = fr'\[([^\]]+)\]\(\s*(?!({schemes})).*:(.+)\)'
-    value = re.sub(pattern, '[\\1](\\3)', value, flags=re.IGNORECASE)
-
-    # Sanitize Markdown reference links
-    pattern = fr'\[([^\]]+)\]:\s*(?!({schemes}))\w*:(.+)'
-    value = re.sub(pattern, '[\\1]: \\3', value, flags=re.IGNORECASE)
 
     # Render Markdown
     html = markdown(value, extensions=['def_list', 'fenced_code', 'tables', StrikethroughExtension()])
@@ -163,6 +151,11 @@ def render_markdown(value):
     # If the string is not empty wrap it in rendered-markdown to style tables
     if html:
         html = f'<div class="rendered-markdown">{html}</div>'
+
+    schemes = get_config().ALLOWED_URL_SCHEMES
+
+    # Sanitize HTML
+    html = clean_html(html, schemes)
 
     return mark_safe(html)
 

--- a/netbox/utilities/utils.py
+++ b/netbox/utilities/utils.py
@@ -4,6 +4,7 @@ from collections import OrderedDict
 from decimal import Decimal
 from itertools import count, groupby
 
+import bleach
 from django.core.serializers import serialize
 from django.db.models import Count, OuterRef, Subquery
 from django.db.models.functions import Coalesce
@@ -385,3 +386,33 @@ def copy_safe_request(request):
         'path': request.path,
         'id': getattr(request, 'id', None),  # UUID assigned by middleware
     })
+
+
+def clean_html(html, schemes):
+    """
+    Sanitizes HTML based on a whitelist of allowed tags and attributes.
+    Also takes a list of allowed URI schemes.
+    """
+
+    ALLOWED_TAGS = [
+        "div", "pre", "code", "blockquote", "del",
+        "hr", "h1", "h2", "h3", "h4", "h5", "h6",
+        "ul", "ol", "li", "p", "br",
+        "strong", "em", "a", "b", "i", "img",
+        "table", "thead", "tbody", "tr", "th", "td",
+        "dl", "dt", "dd",
+    ]
+
+    ALLOWED_ATTRIBUTES = {
+        "div": ['class'],
+        "h1": ["id"], "h2": ["id"], "h3": ["id"], "h4": ["id"], "h5": ["id"], "h6": ["id"],
+        "a": ["href", "title"],
+        "img": ["src", "title", "alt"],
+    }
+
+    return bleach.clean(
+        html,
+        tags=ALLOWED_TAGS,
+        attributes=ALLOWED_ATTRIBUTES,
+        protocols=schemes
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+bleach==5.0.0
 Django==4.0.4
 django-cors-headers==3.12.0
 django-debug-toolbar==3.2.4


### PR DESCRIPTION
### Fixes: #9108 and #8944

This PR removes the stripping of all HTML tags and the workarounds for sanitizing markdown links. Instead the HTML output of python-markdown is sanitized using [bleach](https://github.com/mozilla/bleach). The result is a more correct handling of markdown (HTML is explicitly allowed in the markdown spec) while still preventing user defined HTML that might result in XSS, by sanitizing with a whitelist approach.

From a little unscientific testing of a journal page with extreme markdown usage, the performance penalty is very slight (2-5% of total page load time).

I targeted this at the feature branch as a new dependency is added, not sure if that is correct. If it's not I'll change the target branch.