### PR TITLE
Partially fixes #9374 - Implement a custom paginator for DeviceViewSet to improve config_context load times

### DIFF
--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -19,6 +19,7 @@ from ipam.models import Prefix, VLAN
 from netbox.api.authentication import IsAuthenticatedOrLoginNotRequired
 from netbox.api.exceptions import ServiceUnavailable
 from netbox.api.metadata import ContentTypeMetadata
+from netbox.api.pagination import StripCountAnnotationsPaginator
 from netbox.api.viewsets import NetBoxModelViewSet
 from netbox.config import get_config
 from utilities.api import get_serializer_for_model
@@ -392,6 +393,7 @@ class DeviceViewSet(ConfigContextQuerySetMixin, NetBoxModelViewSet):
         'virtual_chassis__master', 'primary_ip4__nat_outside', 'primary_ip6__nat_outside', 'tags',
     )
     filterset_class = filtersets.DeviceFilterSet
+    pagination_class = StripCountAnnotationsPaginator
 
     def get_serializer_class(self):
         """


### PR DESCRIPTION
### Fixes: #9374

Running count on the annotated query for loading config_context is slow. The custom paginator removes the annotation before getting the count.

Testing with 35k devices loading the devices list via. the API improved load times from ~3200 ms to ~1600 ms.

This doesn't fix the underlying issue in that the query config_context annotation is slow in general and scales with the number of devices, regardless of number of records fetched.