### PR TITLE
Replace None in templates with placeholder filter

### DIFF
--- a/netbox/templates/circuits/circuit_terminations_swap.html
+++ b/netbox/templates/circuits/circuit_terminations_swap.html
@@ -10,7 +10,7 @@
             {% if termination_a %}
                 {{ termination_a.site }} {% if termination_a.interface %}- {{ termination_a.interface.device }} {{ termination_a.interface }}{% endif %}
             {% else %}
-                <span class="text-muted">None</span>
+                {{ ''|placeholder }}
             {% endif %}
         </li>
         <li>
@@ -18,7 +18,7 @@
             {% if termination_z %}
                 {{ termination_z.site }} {% if termination_z.interface %}- {{ termination_z.interface.device }} {{ termination_z.interface }}{% endif %}
             {% else %}
-                <span class="text-muted">None</span>
+                {{ ''|placeholder }}
             {% endif %}
         </li>
     </ul>

--- a/netbox/templates/circuits/inc/circuit_termination.html
+++ b/netbox/templates/circuits/inc/circuit_termination.html
@@ -94,7 +94,7 @@
                 {% elif termination.port_speed %}
                     {{ termination.port_speed|humanize_speed }}
                 {% else %}
-                    <span class="text-muted">&mdash;</span>
+                    {{ ''|placeholder }}
                 {% endif %}
                 </td>
             </tr>

--- a/netbox/templates/circuits/provider.html
+++ b/netbox/templates/circuits/provider.html
@@ -50,7 +50,7 @@
                             {% if object.portal_url %}
                                 <a href="{{ object.portal_url }}">{{ object.portal_url }}</a>
                             {% else %}
-                                <span class="text-muted">&mdash;</span>
+                                {{ ''|placeholder }}
                             {% endif %}
                         </td>
                     </tr>

--- a/netbox/templates/dcim/cable.html
+++ b/netbox/templates/dcim/cable.html
@@ -40,7 +40,7 @@
                                 {% if object.color %}
                                     <span class="color-label" style="background-color: #{{ object.color }}">&nbsp;</span>
                                 {% else %}
-                                    <span class="text-muted">&mdash;</span>
+                                    {{ ''|placeholder }}
                                 {% endif %}
                             </td>
                         </tr>
@@ -50,7 +50,7 @@
                                 {% if object.length %}
                                     {{ object.length|floatformat }} {{ object.get_length_unit_display }}
                                 {% else %}
-                                    <span class="text-muted">&mdash;</span>
+                                    {{ ''|placeholder }}
                                 {% endif %}
                             </td>
                         </tr>

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -23,7 +23,7 @@
                                     {% endfor %}
                                     {{ object.site.region|linkify }}
                                 {% else %}
-                                    <span class="text-muted">None</span>
+                                    {{ ''|placeholder }}
                                 {% endif %}
                             </td>
                         </tr>
@@ -40,7 +40,7 @@
                                 {% endfor %}
                                 {{ object.location|linkify }}
                             {% else %}
-                                <span class="text-muted">None</span>
+                                {{ ''|placeholder }}
                             {% endif %}
                             </td>
                         </tr>
@@ -50,7 +50,7 @@
                                 {% if object.rack %}
                                     <a href="{% url 'dcim:rack' pk=object.rack.pk %}">{{ object.rack }}</a>
                                 {% else %}
-                                    <span class="text-muted">None</span>
+                                    {{ ''|placeholder }}
                                 {% endif %}
                             </td>
                         </tr>
@@ -69,7 +69,7 @@
                                 {% elif object.rack and object.device_type.u_height %}
                                     <span class="badge bg-warning">Not racked</span>
                                 {% else %}
-                                    <span class="text-muted">&mdash;</span>
+                                    {{ ''|placeholder }}
                                 {% endif %}
                             </td>
                         </tr>
@@ -180,7 +180,7 @@
                                   (NAT: {{ object.primary_ip4.nat_outside.address.ip|linkify }})
                                 {% endif %}
                               {% else %}
-                                <span class="text-muted">&mdash;</span>
+                                {{ ''|placeholder }}
                               {% endif %}
                             </td>
                         </tr>
@@ -195,7 +195,7 @@
                                   (NAT: {{ object.primary_ip6.nat_outside.address.ip|linkify }})
                                 {% endif %}
                               {% else %}
-                                <span class="text-muted">&mdash;</span>
+                                {{ ''|placeholder }}
                               {% endif %}
                             </td>
                         </tr>

--- a/netbox/templates/dcim/devicerole.html
+++ b/netbox/templates/dcim/devicerole.html
@@ -54,7 +54,7 @@
               {% if object.vm_role %}
                 <a href="{% url 'virtualization:virtualmachine_list' %}?role_id={{ object.pk }}">{{ virtualmachine_count }}</a>
               {% else %}
-                &mdash;
+                {{ ''|placeholder }}
               {% endif %}
             </td>
           </tr>

--- a/netbox/templates/dcim/devicetype.html
+++ b/netbox/templates/dcim/devicetype.html
@@ -55,7 +55,7 @@
                                         <img src="{{ object.front_image.url }}" alt="{{ object.front_image.name }}" class="img-fluid" />
                                     </a>
                                 {% else %}
-                                    <span class="text-muted">&mdash;</span>
+                                    {{ ''|placeholder }}
                                 {% endif %}
                             </td>
                         </tr>
@@ -67,7 +67,7 @@
                                         <img src="{{ object.rear_image.url }}" alt="{{ object.rear_image.name }}" class="img-fluid" />
                                     </a>
                                 {% else %}
-                                    <span class="text-muted">&mdash;</span>
+                                    {{ ''|placeholder }}
                                 {% endif %}
                             </td>
                         </tr>

--- a/netbox/templates/dcim/interface.html
+++ b/netbox/templates/dcim/interface.html
@@ -321,7 +321,7 @@
                     {% if object.rf_channel_frequency %}
                       {{ object.rf_channel_frequency|simplify_decimal }} MHz
                     {% else %}
-                      <span class="text-muted">&mdash;</span>
+                      {{ ''|placeholder }}
                     {% endif %}
                   </td>
                   {% if peer %}
@@ -329,7 +329,7 @@
                       {% if peer.rf_channel_frequency %}
                         {{ peer.rf_channel_frequency|simplify_decimal }} MHz
                       {% else %}
-                        <span class="text-muted">&mdash;</span>
+                        {{ ''|placeholder }}
                       {% endif %}
                     </td>
                   {% endif %}
@@ -340,7 +340,7 @@
                     {% if object.rf_channel_width %}
                       {{ object.rf_channel_width|simplify_decimal }} MHz
                     {% else %}
-                      <span class="text-muted">&mdash;</span>
+                      {{ ''|placeholder }}
                     {% endif %}
                   </td>
                   {% if peer %}
@@ -348,7 +348,7 @@
                       {% if peer.rf_channel_width %}
                         {{ peer.rf_channel_width|simplify_decimal }} MHz
                       {% else %}
-                        <span class="text-muted">&mdash;</span>
+                        {{ ''|placeholder }}
                       {% endif %}
                     </td>
                   {% endif %}

--- a/netbox/templates/dcim/powerfeed.html
+++ b/netbox/templates/dcim/powerfeed.html
@@ -44,7 +44,7 @@
                             {% if object.connected_endpoint %}
                                 {{ object.connected_endpoint.device|linkify }} ({{ object.connected_endpoint }})
                             {% else %}
-                                <span class="text-muted">None</span>
+                                {{ ''|placeholder }}
                             {% endif %}
                         </td>
                     </tr>

--- a/netbox/templates/dcim/rack.html
+++ b/netbox/templates/dcim/rack.html
@@ -53,7 +53,7 @@
                                 {% endfor %}
                                 {{ object.location|linkify }}
                             {% else %}
-                                <span class="text-muted">None</span>
+                                {{ ''|placeholder }}
                             {% endif %}
                         </td>
                     </tr>
@@ -115,7 +115,7 @@
                             {% if object.type %}
                                 {{ object.get_type_display }}
                             {% else %}
-                                <span class="text-muted">None</span>
+                                {{ ''|placeholder }}
                             {% endif %}
                         </td>
                     </tr>
@@ -133,7 +133,7 @@
                             {% if object.outer_width %}
                                 <span>{{ object.outer_width }} {{ object.get_outer_unit_display }}</span>
                             {% else %}
-                                <span class="text-muted">&mdash;</span>
+                                {{ ''|placeholder }}
                             {% endif %}
                         </td>
                     </tr>
@@ -143,7 +143,7 @@
                             {% if object.outer_depth %}
                                 <span>{{ object.outer_depth }} {{ object.get_outer_unit_display }}</span>
                             {% else %}
-                                <span class="text-muted">&mdash;</span>
+                                {{ ''|placeholder }}
                             {% endif %}
                         </td>
                     </tr>

--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -34,7 +34,7 @@
                 {% endfor %}
                 {{ object.region|linkify }}
               {% else %}
-                <span class="text-muted">None</span>
+                {{ ''|placeholder }}
               {% endif %}
             </td>
           </tr>
@@ -47,7 +47,7 @@
                 {% endfor %}
                 {{ object.group|linkify }}
               {% else %}
-                <span class="text-muted">None</span>
+                {{ ''|placeholder }}
               {% endif %}
             </td>
           </tr>
@@ -79,7 +79,7 @@
                 {{ object.time_zone }} (UTC {{ object.time_zone|tzoffset }})<br />
                 <small class="text-muted">Site time: {% timezone object.time_zone %}{% annotated_now %}{% endtimezone %}</small>
               {% else %}
-                <span class="text-muted">&mdash;</span>
+                {{ ''|placeholder }}
               {% endif %}
             </td>
           </tr>
@@ -94,7 +94,7 @@
                 </div>
                 <span>{{ object.physical_address|linebreaksbr }}</span>
               {% else %}
-                <span class="text-muted">&mdash;</span>
+                {{ ''|placeholder }}
               {% endif %}
             </td>
           </tr>
@@ -113,7 +113,7 @@
                 </div>
                 <span>{{ object.latitude }}, {{ object.longitude }}</span>
               {% else %}
-                <span class="text-muted">&mdash;</span>
+                {{ ''|placeholder }}
               {% endif %}
             </td>
           </tr>

--- a/netbox/templates/dcim/virtualchassis_edit.html
+++ b/netbox/templates/dcim/virtualchassis_edit.html
@@ -57,7 +57,7 @@
                                   {% if device.rack %}
                                       {{ device.rack }} / {{ device.position }}
                                   {% else %}
-                                      <span class="text-muted">&mdash;</span>
+                                      {{ ''|placeholder }}
                                   {% endif %}
                               </td>
                               <td>{{ device.serial|placeholder }}</td>

--- a/netbox/templates/extras/customfield.html
+++ b/netbox/templates/extras/customfield.html
@@ -57,7 +57,7 @@
               {% if object.choices %}
                 {{ object.choices|join:", " }}
               {% else %}
-                <span class="text-muted">&mdash;</span>
+                {{ ''|placeholder }}
               {% endif %}
             </td>
           </tr>
@@ -105,7 +105,7 @@
               {% if object.validation_regex %}
                 <code>{{ object.validation_regex }}</code>
               {% else %}
-                &mdash;
+                {{ ''|placeholder }}
               {% endif %}
             </td>
           </tr>

--- a/netbox/templates/extras/htmx/report_result.html
+++ b/netbox/templates/extras/htmx/report_result.html
@@ -57,7 +57,7 @@
                   {% elif obj %}
                     {{ obj }}
                   {% else %}
-                    <span class="muted">&mdash;</span>
+                    {{ ''|placeholder }}
                   {% endif %}
                 </td>
                 <td class="rendered-markdown">{{ message|markdown }}</td>

--- a/netbox/templates/generic/bulk_import.html
+++ b/netbox/templates/generic/bulk_import.html
@@ -76,14 +76,14 @@ Context:
                                                 {% if field.required %}
                                                     {% checkmark True true="Required" %}
                                                 {% else %}
-                                                    <span class="text-muted">&mdash;</span>
+                                                    {{ ''|placeholder }}
                                                 {% endif %}
                                             </td>
                                             <td>
                                                 {% if field.to_field_name %}
                                                     <code>{{ field.to_field_name }}</code>
                                                 {% else %}
-                                                    <span class="text-muted">&mdash;</span>
+                                                    {{ ''|placeholder }}
                                                 {% endif %}
                                             </td>
                                             <td>

--- a/netbox/templates/inc/panels/custom_fields.html
+++ b/netbox/templates/inc/panels/custom_fields.html
@@ -37,7 +37,7 @@
                                 {% elif field.required %}
                                     <span class="text-warning">Not defined</span>
                                 {% else %}
-                                    <span class="text-muted">&mdash;</span>
+                                    {{ ''|placeholder }}
                                 {% endif %}
                             </td>
                         </tr>

--- a/netbox/templates/ipam/ipaddress.html
+++ b/netbox/templates/ipam/ipaddress.html
@@ -52,7 +52,7 @@
                           {% if object.role %}
                               <a href="{% url 'ipam:ipaddress_list' %}?role={{ object.role }}">{{ object.get_role_display }}</a>
                           {% else %}
-                              <span class="text-muted">None</span>
+                              {{ ''|placeholder }}
                           {% endif %}
                       </td>
                   </tr>
@@ -73,7 +73,7 @@
                           {% endif %}
                           {{ object.assigned_object|linkify }}
                         {% else %}
-                          <span class="text-muted">&mdash;</span>
+                          {{ ''|placeholder }}
                         {% endif %}
                       </td>
                   </tr>
@@ -86,7 +86,7 @@
                                   ({{ object.nat_inside.assigned_object.parent_object|linkify }})
                               {% endif %}
                           {% else %}
-                              <span class="text-muted">None</span>
+                              {{ ''|placeholder }}
                           {% endif %}
                       </td>
                   </tr>

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -39,7 +39,7 @@
               {% if aggregate %}
                 <a href="{% url 'ipam:aggregate' pk=aggregate.pk %}">{{ aggregate.prefix }}</a> ({{ aggregate.rir }})
               {% else %}
-                <span class="text-warning">None</span>
+                {{ ''|placeholder }}
               {% endif %}
             </td>
           </tr>
@@ -52,7 +52,7 @@
                 {% endif %}
                 {{ object.site|linkify }}
               {% else %}
-                <span class="text-muted">None</span>
+                {{ ''|placeholder }}
               {% endif %}
             </td>
           </tr>
@@ -65,7 +65,7 @@
                 {% endif %}
                 {{ object.vlan|linkify }}
               {% else %}
-                <span class="text-muted">None</span>
+                {{ ''|placeholder }}
               {% endif %}
             </td>
           </tr>
@@ -138,7 +138,7 @@
                     {{ first_available_ip }}
                   {% endif %}
                 {% else %}
-                  <span class="text-muted">None</span>
+                  {{ ''|placeholder }}
                 {% endif %}
               {% endwith %}
             </td>

--- a/netbox/templates/ipam/role.html
+++ b/netbox/templates/ipam/role.html
@@ -45,7 +45,7 @@
                 {% if ipranges_count %}
                   <a href="{% url 'ipam:iprange_list' %}?role_id={{ object.pk }}">{{ ipranges_count }}</a>
                 {% else %}
-                  &mdash;
+                  {{ ''|placeholder }}
                 {% endif %}
               {% endwith %}
             </td>
@@ -57,7 +57,7 @@
                 {% if vlans_count %}
                   <a href="{% url 'ipam:vlan_list' %}?role_id={{ object.pk }}">{{ vlans_count }}</a>
                 {% else %}
-                  &mdash;
+                  {{ ''|placeholder }}
                 {% endif %}
               {% endwith %}
             </td>

--- a/netbox/templates/ipam/service.html
+++ b/netbox/templates/ipam/service.html
@@ -44,7 +44,7 @@
                             {% for ipaddress in object.ipaddresses.all %}
                                 {{ ipaddress|linkify }}<br />
                             {% empty %}
-                                <span class="text-muted">None</span>
+                                {{ ''|placeholder }}
                             {% endfor %}
                         </td>
                     </tr>

--- a/netbox/templates/ipam/vlan.html
+++ b/netbox/templates/ipam/vlan.html
@@ -21,7 +21,7 @@
                                     {% endif %}
                                     {{ object.site|linkify }}
                                 {% else %}
-                                    <span class="text-muted">None</span>
+                                    {{ ''|placeholder }}
                                 {% endif %}
                             </td>
                         </tr>
@@ -56,7 +56,7 @@
                                 {% if object.role %}
                                     <a href="{% url 'ipam:vlan_list' %}?role={{ object.role.slug }}">{{ object.role }}</a>
                                 {% else %}
-                                    <span class="text-muted">None</span>
+                                    {{ ''|placeholder }}
                                 {% endif %}
                             </td>
                         </tr>

--- a/netbox/templates/tenancy/contact.html
+++ b/netbox/templates/tenancy/contact.html
@@ -35,7 +35,7 @@
                 {% if object.phone %}
                   <a href="tel:{{ object.phone }}">{{ object.phone }}</a>
                 {% else %}
-                  <span class="text-muted">None</span>
+                  {{ ''|placeholder }}
                 {% endif %}
               </td>
             </tr>
@@ -45,7 +45,7 @@
                 {% if object.email %}
                   <a href="mailto:{{ object.email }}">{{ object.email }}</a>
                 {% else %}
-                  <span class="text-muted">None</span>
+                  {{ ''|placeholder }}
                 {% endif %}
               </td>
             </tr>

--- a/netbox/templates/users/profile.html
+++ b/netbox/templates/users/profile.html
@@ -21,7 +21,7 @@
                 {% if request.user.first_name or request.user.last_name %}
                   {{ request.user.first_name }} {{ request.user.last_name }}
                 {% else %}
-                  <span class="text-muted">&mdash;</span>
+                  {{ ''|placeholder }}
                 {% endif %}
               </td>
             </tr>

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -49,7 +49,7 @@
                               (NAT: <a href="{{ object.primary_ip4.nat_outside.get_absolute_url }}">{{ object.primary_ip4.nat_outside.address.ip }}</a>)
                             {% endif %}
                           {% else %}
-                            <span class="text-muted">&mdash;</span>
+                            {{ ''|placeholder }}
                           {% endif %}
                         </td>
                     </tr>
@@ -64,7 +64,7 @@
                               (NAT: <a href="{{ object.primary_ip6.nat_outside.get_absolute_url }}">{{ object.primary_ip6.nat_outside.address.ip }}</a>)
                             {% endif %}
                           {% else %}
-                            <span class="text-muted">&mdash;</span>
+                            {{ ''|placeholder }}
                           {% endif %}
                         </td>
                     </tr>
@@ -115,7 +115,7 @@
                             {% if object.memory %}
                                 {{ object.memory|humanize_megabytes }}
                             {% else %}
-                                <span class="text-muted">&mdash;</span>
+                                {{ ''|placeholder }}
                             {% endif %}
                         </td>
                     </tr>
@@ -125,7 +125,7 @@
                             {% if object.disk %}
                                 {{ object.disk }} GB
                             {% else %}
-                                <span class="text-muted">&mdash;</span>
+                                {{ ''|placeholder }}
                             {% endif %}
                         </td>
                     </tr>

--- a/netbox/templates/wireless/inc/wirelesslink_interface.html
+++ b/netbox/templates/wireless/inc/wirelesslink_interface.html
@@ -33,7 +33,7 @@
         {% if interface.rf_channel_frequency %}
           {{ interface.rf_channel_frequency|simplify_decimal }} MHz
         {% else %}
-          <span class="text-muted">&mdash;</span>
+          {{ ''|placeholder }}
         {% endif %}
       </td>
   </tr>
@@ -43,7 +43,7 @@
         {% if interface.rf_channel_width %}
           {{ interface.rf_channel_width|simplify_decimal }} MHz
         {% else %}
-          <span class="text-muted">&mdash;</span>
+          {{ ''|placeholder }}
         {% endif %}
       </td>
   </tr>


### PR DESCRIPTION
### Fixes: #9537

To be consistent, all uses of &mdash; or None is replaced with the
placeholder filter.
