### PR TITLE
Closes: #9525 - Add split button functionality to table rows

### DIFF
--- a/netbox/netbox/tables/tables.py
+++ b/netbox/netbox/tables/tables.py
@@ -165,7 +165,14 @@ class NetBoxTable(BaseTable):
         linkify=True,
         verbose_name='ID'
     )
-    actions = columns.ActionsColumn()
+    actions = columns.ActionsColumn(
+        extra_buttons="""
+        <a class="btn btn-sm btn-warning" href="{{ record.get_absolute_url }}edit/" type="button">
+        <i class="mdi mdi-pencil">
+        </i>
+        </a>
+        """
+    )
 
     exempt_columns = ('pk', 'actions')
 

--- a/netbox/netbox/tables/tables.py
+++ b/netbox/netbox/tables/tables.py
@@ -167,10 +167,7 @@ class NetBoxTable(BaseTable):
     )
     actions = columns.ActionsColumn(
         extra_buttons="""
-        <a class="btn btn-sm btn-warning" href="{{ record.get_absolute_url }}edit/" type="button">
-        <i class="mdi mdi-pencil">
-        </i>
-        </a>
+        <a class="btn btn-sm btn-warning" href="{{ record.get_absolute_url }}edit/" type="button"><i class="mdi mdi-pencil"></i></a>
         """
     )
 

--- a/netbox/netbox/tables/tables.py
+++ b/netbox/netbox/tables/tables.py
@@ -165,11 +165,7 @@ class NetBoxTable(BaseTable):
         linkify=True,
         verbose_name='ID'
     )
-    actions = columns.ActionsColumn(
-        extra_buttons="""
-        <a class="btn btn-sm btn-warning" href="{{ record.get_absolute_url }}edit/" type="button"><i class="mdi mdi-pencil"></i></a>
-        """
-    )
+    actions = columns.ActionsColumn()
 
     exempt_columns = ('pk', 'actions')
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #9525 
<!--
    Please include a summary of the proposed changes below.
-->

Utilizing the _**extra_buttons**_ argument within the _**ActionsColumn**_ class, I added an additional button that takes the user directly to the edit page, removing a click from the workflow.

The edit button was added through the **_actions_** of the **_NetBoxTable_**. The existing **_Edit_** link inside the dropdown is retained but can be removed if requested by maintainers/users.

![netbox-1-click-edit-arrow](https://user-images.githubusercontent.com/64506580/174464585-e342d72c-174e-4456-b533-0db9e2f7d0ef.png)

