### PR TITLE
Closes #9417: Pre-populate manufacturer when adding modules to devices

### DIFF
--- a/netbox/dcim/tables/template_code.py
+++ b/netbox/dcim/tables/template_code.py
@@ -385,7 +385,7 @@ MODULEBAY_BUTTONS = """
             <i class="mdi mdi-server-minus" aria-hidden="true" title="Remove module"></i>
         </a>
     {% else %}
-        <a href="{% url 'dcim:module_add' %}?device={{ record.device.pk }}&module_bay={{ record.pk }}&return_url={% url 'dcim:device_modulebays' pk=object.pk %}" class="btn btn-success btn-sm">
+        <a href="{% url 'dcim:module_add' %}?device={{ record.device.pk }}&module_bay={{ record.pk }}&manufacturer={{ object.device_type.manufacturer_id }}&return_url={% url 'dcim:device_modulebays' pk=object.pk %}" class="btn btn-success btn-sm">
             <i class="mdi mdi-server-plus" aria-hidden="true" title="Install module"></i>
         </a>
     {% endif %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #9417
<!--
    Please include a summary of the proposed changes below.
-->

When adding a module from a device, the functionality was added to auto-populate the module's manufacturer to that of the device it's being added to.
&nbsp;<br>

![module_manufacturer2](https://user-images.githubusercontent.com/64506580/174506236-fc1f880b-c94d-4008-bf39-33c1a3ad8340.gif)
&nbsp;<br>


This was accomplished by adding the following additional parameter to the device's "Add Module" button link:
```django
&manufacturer={{ object.device_type.manufacturer_id }}
```
&nbsp;<br>
