### PR TITLE
Closes #9517: Linkify Power Port on Power Outlet Object View

### DIFF
--- a/netbox/templates/dcim/poweroutlet.html
+++ b/netbox/templates/dcim/poweroutlet.html
@@ -44,7 +44,7 @@
                         </tr>
                         <tr>
                             <th scope="row">Power Port</th>
-                            <td>{{ object.power_port }}</td>
+                            <td>{{ object.power_port|linkify|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Feed Leg</th>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #9517 
<!--
    Please include a summary of the proposed changes below.
-->

Added links to the _Power Port_ on the _Power Outlet_ view page.
&nbsp;<br>

![Loom_WiKY6hKSnu](https://user-images.githubusercontent.com/64506580/174509921-02790669-a28c-4987-9d77-3c6320cd86cc.png)

To do so, I added linkify and placeholder to the respective table row:
```django
<tr>
  <th scope="row">Power Port</th>
  <td>{{ object.power_port|linkify|placeholder }}</td>
</tr>
```
