### PR TITLE
Closes #9396: Query modules by module bay & display installed_modules for module_bay REST API endpoint 

### DIFF
--- a/netbox/dcim/api/nested_serializers.py
+++ b/netbox/dcim/api/nested_serializers.py
@@ -281,6 +281,7 @@ class ModuleNestedModuleBaySerializer(WritableNestedSerializer):
         model = models.ModuleBay
         fields = ['id', 'url', 'display', 'name']
 
+
 class ModuleBayNestedModuleSerializer(WritableNestedSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:module-detail')
 

--- a/netbox/dcim/api/nested_serializers.py
+++ b/netbox/dcim/api/nested_serializers.py
@@ -5,6 +5,7 @@ from netbox.api.serializers import BaseModelSerializer, WritableNestedSerializer
 
 __all__ = [
     'ComponentNestedModuleSerializer',
+    'ModuleBayNestedModuleSerializer',
     'NestedCableSerializer',
     'NestedConsolePortSerializer',
     'NestedConsolePortTemplateSerializer',
@@ -279,6 +280,13 @@ class ModuleNestedModuleBaySerializer(WritableNestedSerializer):
     class Meta:
         model = models.ModuleBay
         fields = ['id', 'url', 'display', 'name']
+
+class ModuleBayNestedModuleSerializer(WritableNestedSerializer):
+    url = serializers.HyperlinkedIdentityField(view_name='dcim-api:module-detail')
+
+    class Meta:
+        model = models.Module
+        fields = ['id', 'url', 'display', 'serial']
 
 
 class ComponentNestedModuleSerializer(WritableNestedSerializer):

--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -886,7 +886,7 @@ class FrontPortSerializer(NetBoxModelSerializer, LinkTerminationSerializer):
 class ModuleBaySerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:modulebay-detail')
     device = NestedDeviceSerializer()
-    installed_module = ModuleBayNestedModuleSerializer()
+    installed_module = ModuleBayNestedModuleSerializer(required=False, allow_null=True)
 
     class Meta:
         model = ModuleBay

--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -886,12 +886,12 @@ class FrontPortSerializer(NetBoxModelSerializer, LinkTerminationSerializer):
 class ModuleBaySerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:modulebay-detail')
     device = NestedDeviceSerializer()
-    # installed_module = NestedModuleSerializer(required=False, allow_null=True)
+    installed_module = ModuleBayNestedModuleSerializer()
 
     class Meta:
         model = ModuleBay
         fields = [
-            'id', 'url', 'display', 'device', 'name', 'label', 'position', 'description', 'tags', 'custom_fields',
+            'id', 'url', 'display', 'device', 'name', 'installed_module', 'label', 'position', 'description', 'tags', 'custom_fields',
             'created', 'last_updated',
         ]
 

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -611,7 +611,7 @@ class RearPortViewSet(PassThroughPortMixin, NetBoxModelViewSet):
 
 
 class ModuleBayViewSet(NetBoxModelViewSet):
-    queryset = ModuleBay.objects.prefetch_related('tags')
+    queryset = ModuleBay.objects.prefetch_related('tags', 'installed_module')
     serializer_class = serializers.ModuleBaySerializer
     filterset_class = filtersets.ModuleBayFilterSet
     brief_prefetch_fields = ['device']

--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -992,6 +992,12 @@ class ModuleFilterSet(NetBoxModelFilterSet):
         to_field_name='model',
         label='Module type (model)',
     )
+    module_bay_id = django_filters.ModelMultipleChoiceFilter(
+        field_name='module_bay',
+        queryset=ModuleBay.objects.all(),
+        to_field_name='id',
+        label='Module Bay (ID)'
+    )
     device_id = django_filters.ModelMultipleChoiceFilter(
         queryset=Device.objects.all(),
         label='Device (ID)',

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -1852,7 +1852,7 @@ class ModuleTestCase(TestCase, ChangeLoggedFilterSetTests):
     def test_module_bay(self):
         module_bays = ModuleBay.objects.all()[:2]
         params = {'module_bay_id': [module_bays[0].pk, module_bays[1].pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_device(self):
         device_types = Device.objects.all()[:2]

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -1848,7 +1848,7 @@ class ModuleTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
         params = {'module_type': [module_types[0].model, module_types[1].model]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
-    
+
     def test_module_bay(self):
         module_bays = ModuleBay.objects.all()[:2]
         params = {'module_bay_id': [module_bays[0].pk, module_bays[1].pk]}

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -1848,6 +1848,11 @@ class ModuleTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
         params = {'module_type': [module_types[0].model, module_types[1].model]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+    
+    def test_module_bay(self):
+        module_bays = ModuleBay.objects.all()[:2]
+        params = {'module_bay_id': [module_bays[0].pk, module_bays[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_device(self):
         device_types = Device.objects.all()[:2]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #9396, #9597
<!--
    Please include a summary of the proposed changes below.
-->

Users can now query modules based on a given module bay id.

```
GET /api/dcim/modules/?module_bay_id=2
```
<details><summary>Example Response</summary>
&nbsp;<br>

```json
{
    "count": 1,
    "next": null,
    "previous": null,
    "results": [
        {
            "id": 2,
            "url": "http://127.0.0.1:8000/api/dcim/modules/2/",
            "display": "Slot 1: EX9200-32XS (2)",
            "device": {
                "id": 96,
                "url": "http://127.0.0.1:8000/api/dcim/devices/96/",
                "display": "ncsu-coreswitch1",
                "name": "ncsu-coreswitch1"
            },
            "module_bay": {
                "id": 2,
                "url": "http://127.0.0.1:8000/api/dcim/module-bays/2/",
                "display": "Slot 1",
                "name": "Slot 1"
            },
            "module_type": {
                "id": 1,
                "url": "http://127.0.0.1:8000/api/dcim/module-types/1/",
                "display": "EX9200-32XS",
                "manufacturer": {
                    "id": 7,
                    "url": "http://127.0.0.1:8000/api/dcim/manufacturers/7/",
                    "display": "Juniper",
                    "name": "Juniper",
                    "slug": "juniper"
                },
                "model": "EX9200-32XS"
            },
            "serial": "",
            "asset_tag": null,
            "comments": "",
            "tags": [],
            "custom_fields": {},
            "created": "2022-04-08T00:59:29.103000Z",
            "last_updated": "2022-04-08T00:59:29.103000Z"
        }
    ]
}
```

</details>

----
The installed module is now returned when calling the module bay REST API endpoint.

```
GET /api/dcim/module_bays/1/
```
<details><summary>Example Response</summary>
&nbsp;<br>

```json
{
    "id": 1,
    "url": "http://127.0.0.1:8000/api/dcim/module-bays/1/",
    "display": "Slot 0",
    "device": {
        "id": 96,
        "url": "http://127.0.0.1:8000/api/dcim/devices/96/",
        "display": "ncsu-coreswitch1",
        "name": "ncsu-coreswitch1"
    },
    "name": "Slot 0",
    "installed_module": {
        "id": 1,
        "url": "http://127.0.0.1:8000/api/dcim/modules/1/",
        "display": "Slot 0: EX9200-32XS (1)",
        "serial": ""
    },
    "label": "",
    "position": "0",
    "description": "",
    "tags": [],
    "custom_fields": {},
    "created": "2022-04-08T00:58:12.864000Z",
    "last_updated": "2022-04-08T00:58:12.864000Z"
}
```
</details>
&nbsp;<br>

```
GET /api/dcim/module_bays/
```
<details><summary>Example Response</summary>
&nbsp;<br>

```json
{
    "count": 49,
    "next": null,
    "previous": null,
    "results": [
        {
            "id": 29,
            "url": "http://127.0.0.1:8000/api/dcim/module-bays/29/",
            "display": "ge-0/0/0",
            "device": {
                "id": 1,
                "url": "http://127.0.0.1:8000/api/dcim/devices/1/",
                "display": "dmi01-akron-rtr01",
                "name": "dmi01-akron-rtr01"
            },
            "name": "ge-0/0/0",
            "installed_module": null,
            "label": "",
            "position": "",
            "description": "",
            "tags": [],
            "custom_fields": {},
            "created": "2022-06-19T23:51:17.460166Z",
            "last_updated": "2022-06-19T23:51:17.460180Z"
        },
        {
            "id": 1,
            "url": "http://127.0.0.1:8000/api/dcim/module-bays/1/",
            "display": "Slot 0",
            "device": {
                "id": 96,
                "url": "http://127.0.0.1:8000/api/dcim/devices/96/",
                "display": "ncsu-coreswitch1",
                "name": "ncsu-coreswitch1"
            },
            "name": "Slot 0",
            "installed_module": {
                "id": 1,
                "url": "http://127.0.0.1:8000/api/dcim/modules/1/",
                "display": "Slot 0: EX9200-32XS (1)",
                "serial": ""
            },
            "label": "",
            "position": "0",
            "description": "",
            "tags": [],
            "custom_fields": {},
            "created": "2022-04-08T00:58:12.864000Z",
            "last_updated": "2022-04-08T00:58:12.864000Z"
        },
        {
            "id": 2,
            "url": "http://127.0.0.1:8000/api/dcim/module-bays/2/",
            "display": "Slot 1",
            "device": {
                "id": 96,
                "url": "http://127.0.0.1:8000/api/dcim/devices/96/",
                "display": "ncsu-coreswitch1",
                "name": "ncsu-coreswitch1"
            },
            "name": "Slot 1",
            "installed_module": {
                "id": 2,
                "url": "http://127.0.0.1:8000/api/dcim/modules/2/",
                "display": "Slot 1: EX9200-32XS (2)",
                "serial": ""
            },
            "label": "",
            "position": "1",
            "description": "",
            "tags": [],
            "custom_fields": {},
            "created": "2022-04-08T00:58:12.988000Z",
            "last_updated": "2022-04-08T00:58:12.988000Z"
        },
...
```
</details>

