### PR TITLE
Fixes #8854: Remote auth default groups added to new remote auth users

### DIFF
--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -1,5 +1,7 @@
 import logging
 from collections import defaultdict
+import requests
+from rich import print
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -348,3 +350,26 @@ class LDAPBackend:
             ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
 
         return obj
+
+
+# Custom Social Auth Pipeline Handlers
+def user_default_groups_handler(backend, user, response, *args, **kwargs):
+    """
+    Custom pipeline handler which adds remote auth users to the default group specified in the
+    configuration file.
+    """
+    logger = logging.getLogger('netbox.auth.user_default_groups_handler')
+    if settings.REMOTE_AUTH_DEFAULT_GROUPS:
+        # Assign default groups to the user
+        group_list = []
+        for name in settings.REMOTE_AUTH_DEFAULT_GROUPS:
+            try:
+                group_list.append(Group.objects.get(name=name))
+            except Group.DoesNotExist:
+                logging.error(
+                    f"Could not assign group {name} to remotely-authenticated user {user}: Group not found")
+        if group_list:
+            user.groups.add(*group_list)
+        else:
+            user.groups.clear()
+            logger.debug(f"Stripping user {user} from Groups")

--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -1,7 +1,5 @@
 import logging
 from collections import defaultdict
-import requests
-from rich import print
 
 from django.conf import settings
 from django.contrib.auth import get_user_model

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -483,6 +483,19 @@ for param in dir(configuration):
 
 SOCIAL_AUTH_JSONFIELD_ENABLED = True
 
+SOCIAL_AUTH_PIPELINE = (
+    'social_core.pipeline.social_auth.social_details',
+    'social_core.pipeline.social_auth.social_uid',
+    'social_core.pipeline.social_auth.social_user',
+    'social_core.pipeline.user.get_username',
+    'social_core.pipeline.social_auth.associate_by_email',
+    'social_core.pipeline.user.create_user',
+    'social_core.pipeline.social_auth.associate_user',
+    'netbox.authentication.user_default_groups_handler',
+    'social_core.pipeline.social_auth.load_extra_data',
+    'social_core.pipeline.user.user_details',
+)
+
 
 #
 # Django Prometheus


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #8854 
<!--
    Please include a summary of the proposed changes below.
-->

Added a custom pipeline handler function per python-social-auth [docs](https://python-social-auth.readthedocs.io/en/latest/configuration/django.html)

This pipeline handler assigns the default group(s) to remote auth users. Successfully tested with Microsoft Azure AD, however, there is nothing particular related to Azure AD in this configuration.


