### PR TITLE
Corrected typo for description of 'snapshots'

### DIFF
--- a/docs/models/extras/webhook.md
+++ b/docs/models/extras/webhook.md
@@ -43,7 +43,7 @@ The following data is available as context for Jinja2 templates:
 * `username` - The name of the user account associated with the change.
 * `request_id` - The unique request ID. This may be used to correlate multiple changes associated with a single request.
 * `data` - A detailed representation of the object in its current state. This is typically equivalent to the model's representation in NetBox's REST API.
-* `snapshots` - Minimal "snapshots" of the object state both before and after the change was made; provided ass a dictionary with keys named `prechange` and `postchange`. These are not as extensive as the fully serialized representation, but contain enough information to convey what has changed.
+* `snapshots` - Minimal "snapshots" of the object state both before and after the change was made; provided as a dictionary with keys named `prechange` and `postchange`. These are not as extensive as the fully serialized representation, but contain enough information to convey what has changed.
 
 ### Default Request Body
 


### PR DESCRIPTION
Corrected a small typo for "snapshots" description under under docs/models/extras/webhook.md
