### PR TITLE
Fixes #9730 - Fix CableForm Validation for #9102

### DIFF
--- a/netbox/dcim/forms/connections.py
+++ b/netbox/dcim/forms/connections.py
@@ -160,12 +160,11 @@ def get_cable_form(a_type, b_type):
                 self.initial['a_terminations'] = self.instance.a_terminations
                 self.initial['b_terminations'] = self.instance.b_terminations
 
-        def save(self, *args, **kwargs):
+        def clean(self):
+            super().clean()
 
             # Set the A/B terminations on the Cable instance
             self.instance.a_terminations = self.cleaned_data['a_terminations']
             self.instance.b_terminations = self.cleaned_data['b_terminations']
-
-            return super().save(*args, **kwargs)
 
     return _CableForm


### PR DESCRIPTION
### Fixes: #9730

Moving assignment of Cable A/B terminations inside a CableForm from `save` to `clean` method.

Having them in `.save()` method of form resulted in raising `ValidationError("Must define A and B terminations when creating a new cable.")` in a `Cable` model validation.