### PR TITLE
Fixes #9765 - Fix "Total segment" count on trace view

### DIFF
--- a/netbox/templates/dcim/cable_trace.html
+++ b/netbox/templates/dcim/cable_trace.html
@@ -18,43 +18,41 @@
               </div>
             </div>
             <div class="trace-end">
-                {% with traced_path=path.origin.trace %}
-                    {% if path.is_split %}
-                        <h3 class="text-danger">Path split!</h3>
-                        <p>Select a node below to continue:</p>
-                        <ul class="text-start">
-                            {% for next_node in path.get_split_nodes %}
-                                {% if next_node.cable %}
-                                    <li>
-                                        <a href="{% url 'dcim:frontport_trace' pk=next_node.pk %}">{{ next_node }}</a>
-                                        (Cable {{ next_node.cable|linkify }})
-                                    </li>
-                                {% else %}
-                                    <li class="text-muted">{{ next_node }}</li>
-                                {% endif %}
-                            {% endfor %}
-                        </ul>
-                    {% else %}
-                        <h3 class="text-center text-success">Trace Completed</h3>
-                        <table class="table">
-                          <tr>
-                            <th scope="row">Total segments</th>
-                            <td>{{ traced_path|length }}</td>
-                          </tr>
-                          <tr>
-                            <th scope="row">Total length</th>
-                            <td>
-                              {% if total_length %}
-                                {{ total_length|floatformat:"-2" }}{% if not is_definitive %}+{% endif %} Meters /
-                                {{ total_length|meters_to_feet|floatformat:"-2" }} Feet
-                              {% else %}
-                                <span class="text-muted">N/A</span>
-                              {% endif %}
-                            </td>
-                          </tr>
-                        </table>
-                    {% endif %}
-                {% endwith %}
+                {% if path.is_split %}
+                    <h3 class="text-danger">Path split!</h3>
+                    <p>Select a node below to continue:</p>
+                    <ul class="text-start">
+                        {% for next_node in path.get_split_nodes %}
+                            {% if next_node.cable %}
+                                <li>
+                                    <a href="{% url 'dcim:frontport_trace' pk=next_node.pk %}">{{ next_node }}</a>
+                                    (Cable {{ next_node.cable|linkify }})
+                                </li>
+                            {% else %}
+                                <li class="text-muted">{{ next_node }}</li>
+                            {% endif %}
+                        {% endfor %}
+                    </ul>
+                {% else %}
+                    <h3 class="text-center text-success">Trace Completed</h3>
+                    <table class="table">
+                        <tr>
+                        <th scope="row">Total segments</th>
+                        <td>{{ path.segment_count }}</td>
+                        </tr>
+                        <tr>
+                        <th scope="row">Total length</th>
+                        <td>
+                            {% if total_length %}
+                            {{ total_length|floatformat:"-2" }}{% if not is_definitive %}+{% endif %} Meters /
+                            {{ total_length|meters_to_feet|floatformat:"-2" }} Feet
+                            {% else %}
+                            <span class="text-muted">N/A</span>
+                            {% endif %}
+                        </td>
+                        </tr>
+                    </table>
+                {% endif %}
             </div>
           {% else %}
             <h3 class="text-center text-muted my-3">


### PR DESCRIPTION
### Fixes: #9765

Removes unused traced_path context. `path.origin` does not exist anymore, so segment count cannot be accessed that way. Use segment_count directly on the path instead.