### PR TITLE
Add DEVELOPER setting to example config

### DIFF
--- a/netbox/netbox/configuration_example.py
+++ b/netbox/netbox/configuration_example.py
@@ -103,6 +103,9 @@ CORS_ORIGIN_REGEX_WHITELIST = [
 # on a production system.
 DEBUG = False
 
+# Set to True in addition to DEBUG above to enable the creation of new database migrations.
+DEVELOPER = False
+
 # Email settings
 EMAIL = {
     'SERVER': 'localhost',


### PR DESCRIPTION
### Fixes: #9806

As described, adds a default setting so people with similarly bad typing skills won't be as confused.