### PR TITLE
Fixes #9758: Fix path end device and provider network information on CableTable and DeviceInterfaceTable

### DIFF
--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -576,6 +576,7 @@ class CablePath(models.Model):
                         [object_to_path_node(circuit_termination)],
                         [object_to_path_node(circuit_termination.provider_network)],
                     ])
+                    is_complete = True
                     break
                 elif circuit_termination.site and not circuit_termination.cable:
                     # Circuit terminates to a Site

--- a/netbox/dcim/tables/cables.py
+++ b/netbox/dcim/tables/cables.py
@@ -123,5 +123,5 @@ class CableTable(TenancyColumnsMixin, NetBoxTable):
             'length', 'tags', 'created', 'last_updated',
         )
         default_columns = (
-            'pk', 'id', 'label', 'a_terminations', 'b_terminations', 'status', 'type',
+            'pk', 'id', 'label', 'device_a', 'a_terminations', 'device_b', 'b_terminations', 'status', 'type',
         )

--- a/netbox/dcim/tables/template_code.py
+++ b/netbox/dcim/tables/template_code.py
@@ -1,5 +1,9 @@
 LINKTERMINATION = """
 {% for termination in value %}
+  {% if termination.parent_object %}
+    <a href="{{ termination.parent_object.get_absolute_url }}">{{ termination.parent_object }}</a>
+    <i class="mdi mdi-chevron-right"></i>
+  {% endif %}
   <a href="{{ termination.get_absolute_url }}">{{ termination }}</a>{% if not forloop.last %},{% endif %}
 {% empty %}
   {{ ''|placeholder }}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #9758 
<!--
    Please include a summary of the proposed changes below.
-->
Please note that this won't fix existing CablePath objects that are marked with is_complete = False when path is initially connected