### PR TITLE
Remove deprecated usage of prefetch_related

### DIFF
--- a/netbox/circuits/views.py
+++ b/netbox/circuits/views.py
@@ -30,7 +30,8 @@ class ProviderView(generic.ObjectView):
         circuits = Circuit.objects.restrict(request.user, 'view').filter(
             provider=instance
         ).prefetch_related(
-            'type', 'tenant', 'tenant__group', 'terminations__site'
+            'tenant__group', 'termination_a__site', 'termination_z__site',
+            'termination_a__provider_network', 'termination_z__provider_network',
         )
         circuits_table = tables.CircuitTable(circuits, user=request.user, exclude=('provider',))
         circuits_table.configure(request)
@@ -91,7 +92,8 @@ class ProviderNetworkView(generic.ObjectView):
             Q(termination_a__provider_network=instance.pk) |
             Q(termination_z__provider_network=instance.pk)
         ).prefetch_related(
-            'type', 'tenant', 'tenant__group', 'terminations__site'
+            'tenant__group', 'termination_a__site', 'termination_z__site',
+            'termination_a__provider_network', 'termination_z__provider_network',
         )
         circuits_table = tables.CircuitTable(circuits, user=request.user)
         circuits_table.configure(request)
@@ -192,7 +194,8 @@ class CircuitTypeBulkDeleteView(generic.BulkDeleteView):
 
 class CircuitListView(generic.ObjectListView):
     queryset = Circuit.objects.prefetch_related(
-        'provider', 'type', 'tenant', 'tenant__group', 'termination_a', 'termination_z'
+        'tenant__group', 'termination_a__site', 'termination_z__site',
+        'termination_a__provider_network', 'termination_z__provider_network',
     )
     filterset = filtersets.CircuitFilterSet
     filterset_form = forms.CircuitFilterForm
@@ -220,7 +223,8 @@ class CircuitBulkImportView(generic.BulkImportView):
 
 class CircuitBulkEditView(generic.BulkEditView):
     queryset = Circuit.objects.prefetch_related(
-        'provider', 'type', 'tenant', 'terminations'
+        'termination_a__site', 'termination_z__site',
+        'termination_a__provider_network', 'termination_z__provider_network',
     )
     filterset = filtersets.CircuitFilterSet
     table = tables.CircuitTable
@@ -229,7 +233,8 @@ class CircuitBulkEditView(generic.BulkEditView):
 
 class CircuitBulkDeleteView(generic.BulkDeleteView):
     queryset = Circuit.objects.prefetch_related(
-        'provider', 'type', 'tenant', 'terminations'
+        'termination_a__site', 'termination_z__site',
+        'termination_a__provider_network', 'termination_z__provider_network',
     )
     filterset = filtersets.CircuitFilterSet
     table = tables.CircuitTable

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -324,7 +324,7 @@ class SiteListView(generic.ObjectListView):
 
 
 class SiteView(generic.ObjectView):
-    queryset = Site.objects.prefetch_related('region', 'tenant__group')
+    queryset = Site.objects.prefetch_related('tenant__group')
 
     def get_extra_context(self, request, instance):
         stats = {
@@ -359,7 +359,7 @@ class SiteView(generic.ObjectView):
             site=instance,
             position__isnull=True,
             parent_bay__isnull=True
-        ).prefetch_related('device_type__manufacturer')
+        ).prefetch_related('device_type__manufacturer', 'parent_bay', 'device_role')
 
         asns = ASN.objects.restrict(request.user, 'view').filter(sites=instance)
         asn_count = asns.count()
@@ -391,14 +391,14 @@ class SiteBulkImportView(generic.BulkImportView):
 
 
 class SiteBulkEditView(generic.BulkEditView):
-    queryset = Site.objects.prefetch_related('region', 'tenant')
+    queryset = Site.objects.all()
     filterset = filtersets.SiteFilterSet
     table = tables.SiteTable
     form = forms.SiteBulkEditForm
 
 
 class SiteBulkDeleteView(generic.BulkDeleteView):
-    queryset = Site.objects.prefetch_related('region', 'tenant')
+    queryset = Site.objects.all()
     filterset = filtersets.SiteFilterSet
     table = tables.SiteTable
 
@@ -454,7 +454,7 @@ class LocationView(generic.ObjectView):
             location=instance,
             position__isnull=True,
             parent_bay__isnull=True
-        ).prefetch_related('device_type__manufacturer')
+        ).prefetch_related('device_type__manufacturer', 'parent_bay', 'device_role')
 
         return {
             'rack_count': rack_count,
@@ -572,7 +572,7 @@ class RackRoleBulkDeleteView(generic.BulkDeleteView):
 #
 
 class RackListView(generic.ObjectListView):
-    queryset = Rack.objects.prefetch_related('devices__device_type').annotate(
+    queryset = Rack.objects.annotate(
         device_count=count_related(Device, 'rack')
     )
     filterset = filtersets.RackFilterSet
@@ -631,7 +631,7 @@ class RackView(generic.ObjectView):
             rack=instance,
             position__isnull=True,
             parent_bay__isnull=True
-        ).prefetch_related('device_type__manufacturer')
+        ).prefetch_related('device_type__manufacturer', 'parent_bay', 'device_role')
 
         peer_racks = Rack.objects.restrict(request.user, 'view').filter(site=instance.site)
 
@@ -682,14 +682,14 @@ class RackBulkImportView(generic.BulkImportView):
 
 
 class RackBulkEditView(generic.BulkEditView):
-    queryset = Rack.objects.prefetch_related('site', 'location', 'tenant', 'role')
+    queryset = Rack.objects.all()
     filterset = filtersets.RackFilterSet
     table = tables.RackTable
     form = forms.RackBulkEditForm
 
 
 class RackBulkDeleteView(generic.BulkDeleteView):
-    queryset = Rack.objects.prefetch_related('site', 'location', 'tenant', 'role')
+    queryset = Rack.objects.all()
     filterset = filtersets.RackFilterSet
     table = tables.RackTable
 
@@ -706,7 +706,7 @@ class RackReservationListView(generic.ObjectListView):
 
 
 class RackReservationView(generic.ObjectView):
-    queryset = RackReservation.objects.prefetch_related('rack')
+    queryset = RackReservation.objects.all()
 
 
 class RackReservationEditView(generic.ObjectEditView):
@@ -742,14 +742,14 @@ class RackReservationImportView(generic.BulkImportView):
 
 
 class RackReservationBulkEditView(generic.BulkEditView):
-    queryset = RackReservation.objects.prefetch_related('rack', 'user')
+    queryset = RackReservation.objects.all()
     filterset = filtersets.RackReservationFilterSet
     table = tables.RackReservationTable
     form = forms.RackReservationBulkEditForm
 
 
 class RackReservationBulkDeleteView(generic.BulkDeleteView):
-    queryset = RackReservation.objects.prefetch_related('rack', 'user')
+    queryset = RackReservation.objects.all()
     filterset = filtersets.RackReservationFilterSet
     table = tables.RackReservationTable
 
@@ -831,7 +831,7 @@ class ManufacturerBulkDeleteView(generic.BulkDeleteView):
 #
 
 class DeviceTypeListView(generic.ObjectListView):
-    queryset = DeviceType.objects.prefetch_related('manufacturer').annotate(
+    queryset = DeviceType.objects.annotate(
         instance_count=count_related(Device, 'device_type')
     )
     filterset = filtersets.DeviceTypeFilterSet
@@ -840,7 +840,7 @@ class DeviceTypeListView(generic.ObjectListView):
 
 
 class DeviceTypeView(generic.ObjectView):
-    queryset = DeviceType.objects.prefetch_related('manufacturer')
+    queryset = DeviceType.objects.all()
 
     def get_extra_context(self, request, instance):
         instance_count = Device.objects.restrict(request.user).filter(device_type=instance).count()
@@ -964,7 +964,7 @@ class DeviceTypeImportView(generic.ObjectImportView):
 
 
 class DeviceTypeBulkEditView(generic.BulkEditView):
-    queryset = DeviceType.objects.prefetch_related('manufacturer').annotate(
+    queryset = DeviceType.objects.annotate(
         instance_count=count_related(Device, 'device_type')
     )
     filterset = filtersets.DeviceTypeFilterSet
@@ -973,7 +973,7 @@ class DeviceTypeBulkEditView(generic.BulkEditView):
 
 
 class DeviceTypeBulkDeleteView(generic.BulkDeleteView):
-    queryset = DeviceType.objects.prefetch_related('manufacturer').annotate(
+    queryset = DeviceType.objects.annotate(
         instance_count=count_related(Device, 'device_type')
     )
     filterset = filtersets.DeviceTypeFilterSet
@@ -985,7 +985,7 @@ class DeviceTypeBulkDeleteView(generic.BulkDeleteView):
 #
 
 class ModuleTypeListView(generic.ObjectListView):
-    queryset = ModuleType.objects.prefetch_related('manufacturer').annotate(
+    queryset = ModuleType.objects.annotate(
         instance_count=count_related(Module, 'module_type')
     )
     filterset = filtersets.ModuleTypeFilterSet
@@ -994,7 +994,7 @@ class ModuleTypeListView(generic.ObjectListView):
 
 
 class ModuleTypeView(generic.ObjectView):
-    queryset = ModuleType.objects.prefetch_related('manufacturer')
+    queryset = ModuleType.objects.all()
 
     def get_extra_context(self, request, instance):
         instance_count = Module.objects.restrict(request.user).filter(module_type=instance).count()
@@ -1091,7 +1091,7 @@ class ModuleTypeImportView(generic.ObjectImportView):
 
 
 class ModuleTypeBulkEditView(generic.BulkEditView):
-    queryset = ModuleType.objects.prefetch_related('manufacturer').annotate(
+    queryset = ModuleType.objects.annotate(
         instance_count=count_related(Module, 'module_type')
     )
     filterset = filtersets.ModuleTypeFilterSet
@@ -1100,7 +1100,7 @@ class ModuleTypeBulkEditView(generic.BulkEditView):
 
 
 class ModuleTypeBulkDeleteView(generic.BulkDeleteView):
-    queryset = ModuleType.objects.prefetch_related('manufacturer').annotate(
+    queryset = ModuleType.objects.annotate(
         instance_count=count_related(Module, 'module_type')
     )
     filterset = filtersets.ModuleTypeFilterSet
@@ -1611,9 +1611,7 @@ class DeviceListView(generic.ObjectListView):
 
 
 class DeviceView(generic.ObjectView):
-    queryset = Device.objects.prefetch_related(
-        'site__region', 'location', 'rack', 'tenant__group', 'device_role', 'platform', 'primary_ip4', 'primary_ip6'
-    )
+    queryset = Device.objects.all()
 
     def get_extra_context(self, request, instance):
         # VirtualChassis members
@@ -1790,14 +1788,14 @@ class ChildDeviceBulkImportView(generic.BulkImportView):
 
 
 class DeviceBulkEditView(generic.BulkEditView):
-    queryset = Device.objects.prefetch_related('tenant', 'site', 'rack', 'device_role', 'device_type__manufacturer')
+    queryset = Device.objects.prefetch_related('device_type__manufacturer')
     filterset = filtersets.DeviceFilterSet
     table = tables.DeviceTable
     form = forms.DeviceBulkEditForm
 
 
 class DeviceBulkDeleteView(generic.BulkDeleteView):
-    queryset = Device.objects.prefetch_related('tenant', 'site', 'rack', 'device_role', 'device_type__manufacturer')
+    queryset = Device.objects.prefetch_related('device_type__manufacturer')
     filterset = filtersets.DeviceFilterSet
     table = tables.DeviceTable
 
@@ -1807,7 +1805,7 @@ class DeviceBulkDeleteView(generic.BulkDeleteView):
 #
 
 class ModuleListView(generic.ObjectListView):
-    queryset = Module.objects.prefetch_related('device', 'module_type__manufacturer')
+    queryset = Module.objects.prefetch_related('module_type__manufacturer')
     filterset = filtersets.ModuleFilterSet
     filterset_form = forms.ModuleFilterForm
     table = tables.ModuleTable
@@ -1833,14 +1831,14 @@ class ModuleBulkImportView(generic.BulkImportView):
 
 
 class ModuleBulkEditView(generic.BulkEditView):
-    queryset = Module.objects.prefetch_related('device', 'module_type__manufacturer')
+    queryset = Module.objects.prefetch_related('module_type__manufacturer')
     filterset = filtersets.ModuleFilterSet
     table = tables.ModuleTable
     form = forms.ModuleBulkEditForm
 
 
 class ModuleBulkDeleteView(generic.BulkDeleteView):
-    queryset = Module.objects.prefetch_related('device', 'module_type__manufacturer')
+    queryset = Module.objects.prefetch_related('module_type__manufacturer')
     filterset = filtersets.ModuleFilterSet
     table = tables.ModuleTable
 
@@ -2566,7 +2564,7 @@ class InventoryItemBulkImportView(generic.BulkImportView):
 
 
 class InventoryItemBulkEditView(generic.BulkEditView):
-    queryset = InventoryItem.objects.prefetch_related('device', 'manufacturer', 'role')
+    queryset = InventoryItem.objects.all()
     filterset = filtersets.InventoryItemFilterSet
     table = tables.InventoryItemTable
     form = forms.InventoryItemBulkEditForm
@@ -2577,7 +2575,7 @@ class InventoryItemBulkRenameView(generic.BulkRenameView):
 
 
 class InventoryItemBulkDeleteView(generic.BulkDeleteView):
-    queryset = InventoryItem.objects.prefetch_related('device', 'manufacturer', 'role')
+    queryset = InventoryItem.objects.all()
     table = tables.InventoryItemTable
     template_name = 'dcim/inventoryitem_bulk_delete.html'
 
@@ -2867,14 +2865,20 @@ class CableBulkImportView(generic.BulkImportView):
 
 
 class CableBulkEditView(generic.BulkEditView):
-    queryset = Cable.objects.prefetch_related('terminations')
+    queryset = Cable.objects.prefetch_related(
+        'terminations__termination', 'terminations___device', 'terminations___rack', 'terminations___location',
+        'terminations___site',
+    )
     filterset = filtersets.CableFilterSet
     table = tables.CableTable
     form = forms.CableBulkEditForm
 
 
 class CableBulkDeleteView(generic.BulkDeleteView):
-    queryset = Cable.objects.prefetch_related('terminations')
+    queryset = Cable.objects.prefetch_related(
+        'terminations__termination', 'terminations___device', 'terminations___rack', 'terminations___location',
+        'terminations___site',
+    )
     filterset = filtersets.CableFilterSet
     table = tables.CableTable
 
@@ -2930,7 +2934,7 @@ class InterfaceConnectionsListView(generic.ObjectListView):
 #
 
 class VirtualChassisListView(generic.ObjectListView):
-    queryset = VirtualChassis.objects.prefetch_related('master').annotate(
+    queryset = VirtualChassis.objects.annotate(
         member_count=count_related(Device, 'virtual_chassis')
     )
     table = tables.VirtualChassisTable
@@ -3158,9 +3162,7 @@ class VirtualChassisBulkDeleteView(generic.BulkDeleteView):
 #
 
 class PowerPanelListView(generic.ObjectListView):
-    queryset = PowerPanel.objects.prefetch_related(
-        'site', 'location'
-    ).annotate(
+    queryset = PowerPanel.objects.annotate(
         powerfeed_count=count_related(PowerFeed, 'power_panel')
     )
     filterset = filtersets.PowerPanelFilterSet
@@ -3169,10 +3171,10 @@ class PowerPanelListView(generic.ObjectListView):
 
 
 class PowerPanelView(generic.ObjectView):
-    queryset = PowerPanel.objects.prefetch_related('site', 'location')
+    queryset = PowerPanel.objects.all()
 
     def get_extra_context(self, request, instance):
-        power_feeds = PowerFeed.objects.restrict(request.user).filter(power_panel=instance).prefetch_related('rack')
+        power_feeds = PowerFeed.objects.restrict(request.user).filter(power_panel=instance)
         powerfeed_table = tables.PowerFeedTable(
             data=power_feeds,
             orderable=False
@@ -3202,16 +3204,14 @@ class PowerPanelBulkImportView(generic.BulkImportView):
 
 
 class PowerPanelBulkEditView(generic.BulkEditView):
-    queryset = PowerPanel.objects.prefetch_related('site', 'location')
+    queryset = PowerPanel.objects.all()
     filterset = filtersets.PowerPanelFilterSet
     table = tables.PowerPanelTable
     form = forms.PowerPanelBulkEditForm
 
 
 class PowerPanelBulkDeleteView(generic.BulkDeleteView):
-    queryset = PowerPanel.objects.prefetch_related(
-        'site', 'location'
-    ).annotate(
+    queryset = PowerPanel.objects.annotate(
         powerfeed_count=count_related(PowerFeed, 'power_panel')
     )
     filterset = filtersets.PowerPanelFilterSet
@@ -3230,7 +3230,7 @@ class PowerFeedListView(generic.ObjectListView):
 
 
 class PowerFeedView(generic.ObjectView):
-    queryset = PowerFeed.objects.prefetch_related('power_panel', 'rack')
+    queryset = PowerFeed.objects.all()
 
 
 class PowerFeedEditView(generic.ObjectEditView):
@@ -3249,7 +3249,7 @@ class PowerFeedBulkImportView(generic.BulkImportView):
 
 
 class PowerFeedBulkEditView(generic.BulkEditView):
-    queryset = PowerFeed.objects.prefetch_related('power_panel', 'rack')
+    queryset = PowerFeed.objects.all()
     filterset = filtersets.PowerFeedFilterSet
     table = tables.PowerFeedTable
     form = forms.PowerFeedBulkEditForm
@@ -3260,6 +3260,6 @@ class PowerFeedBulkDisconnectView(BulkDisconnectView):
 
 
 class PowerFeedBulkDeleteView(generic.BulkDeleteView):
-    queryset = PowerFeed.objects.prefetch_related('power_panel', 'rack')
+    queryset = PowerFeed.objects.all()
     filterset = filtersets.PowerFeedFilterSet
     table = tables.PowerFeedTable

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -492,14 +492,14 @@ class JournalEntryDeleteView(generic.ObjectDeleteView):
 
 
 class JournalEntryBulkEditView(generic.BulkEditView):
-    queryset = JournalEntry.objects.prefetch_related('created_by')
+    queryset = JournalEntry.objects.all()
     filterset = filtersets.JournalEntryFilterSet
     table = tables.JournalEntryTable
     form = forms.JournalEntryBulkEditForm
 
 
 class JournalEntryBulkDeleteView(generic.BulkDeleteView):
-    queryset = JournalEntry.objects.prefetch_related('created_by')
+    queryset = JournalEntry.objects.all()
     filterset = filtersets.JournalEntryFilterSet
     table = tables.JournalEntryTable
 

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -40,11 +40,11 @@ class VRFView(generic.ObjectView):
         ipaddress_count = IPAddress.objects.restrict(request.user, 'view').filter(vrf=instance).count()
 
         import_targets_table = tables.RouteTargetTable(
-            instance.import_targets.prefetch_related('tenant'),
+            instance.import_targets.all(),
             orderable=False
         )
         export_targets_table = tables.RouteTargetTable(
-            instance.export_targets.prefetch_related('tenant'),
+            instance.export_targets.all(),
             orderable=False
         )
 
@@ -72,14 +72,14 @@ class VRFBulkImportView(generic.BulkImportView):
 
 
 class VRFBulkEditView(generic.BulkEditView):
-    queryset = VRF.objects.prefetch_related('tenant')
+    queryset = VRF.objects.all()
     filterset = filtersets.VRFFilterSet
     table = tables.VRFTable
     form = forms.VRFBulkEditForm
 
 
 class VRFBulkDeleteView(generic.BulkDeleteView):
-    queryset = VRF.objects.prefetch_related('tenant')
+    queryset = VRF.objects.all()
     filterset = filtersets.VRFFilterSet
     table = tables.VRFTable
 
@@ -100,11 +100,11 @@ class RouteTargetView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         importing_vrfs_table = tables.VRFTable(
-            instance.importing_vrfs.prefetch_related('tenant'),
+            instance.importing_vrfs.all(),
             orderable=False
         )
         exporting_vrfs_table = tables.VRFTable(
-            instance.exporting_vrfs.prefetch_related('tenant'),
+            instance.exporting_vrfs.all(),
             orderable=False
         )
 
@@ -130,14 +130,14 @@ class RouteTargetBulkImportView(generic.BulkImportView):
 
 
 class RouteTargetBulkEditView(generic.BulkEditView):
-    queryset = RouteTarget.objects.prefetch_related('tenant')
+    queryset = RouteTarget.objects.all()
     filterset = filtersets.RouteTargetFilterSet
     table = tables.RouteTargetTable
     form = forms.RouteTargetBulkEditForm
 
 
 class RouteTargetBulkDeleteView(generic.BulkDeleteView):
-    queryset = RouteTarget.objects.prefetch_related('tenant')
+    queryset = RouteTarget.objects.all()
     filterset = filtersets.RouteTargetFilterSet
     table = tables.RouteTargetTable
 
@@ -334,14 +334,14 @@ class AggregateBulkImportView(generic.BulkImportView):
 
 
 class AggregateBulkEditView(generic.BulkEditView):
-    queryset = Aggregate.objects.prefetch_related('rir')
+    queryset = Aggregate.objects.all()
     filterset = filtersets.AggregateFilterSet
     table = tables.AggregateTable
     form = forms.AggregateBulkEditForm
 
 
 class AggregateBulkDeleteView(generic.BulkDeleteView):
-    queryset = Aggregate.objects.prefetch_related('rir')
+    queryset = Aggregate.objects.all()
     filterset = filtersets.AggregateFilterSet
     table = tables.AggregateTable
 
@@ -417,7 +417,7 @@ class PrefixListView(generic.ObjectListView):
 
 
 class PrefixView(generic.ObjectView):
-    queryset = Prefix.objects.prefetch_related('vrf', 'site__region', 'tenant__group', 'vlan__group', 'role')
+    queryset = Prefix.objects.all()
 
     def get_extra_context(self, request, instance):
         try:
@@ -433,7 +433,7 @@ class PrefixView(generic.ObjectView):
         ).filter(
             prefix__net_contains=str(instance.prefix)
         ).prefetch_related(
-            'site', 'role', 'tenant'
+            'site', 'role', 'tenant', 'vlan',
         )
         parent_prefix_table = tables.PrefixTable(
             list(parent_prefixes),
@@ -447,7 +447,7 @@ class PrefixView(generic.ObjectView):
         ).exclude(
             pk=instance.pk
         ).prefetch_related(
-            'site', 'role'
+            'site', 'role', 'tenant', 'vlan',
         )
         duplicate_prefix_table = tables.PrefixTable(
             list(duplicate_prefixes),
@@ -500,7 +500,7 @@ class PrefixIPRangesView(generic.ObjectChildrenView):
 
     def get_children(self, request, parent):
         return parent.get_child_ranges().restrict(request.user, 'view').prefetch_related(
-            'vrf', 'role', 'tenant', 'tenant__group',
+            'tenant__group',
         )
 
     def get_extra_context(self, request, instance):
@@ -519,7 +519,7 @@ class PrefixIPAddressesView(generic.ObjectChildrenView):
     template_name = 'ipam/prefix/ip_addresses.html'
 
     def get_children(self, request, parent):
-        return parent.get_child_ips().restrict(request.user, 'view').prefetch_related('vrf', 'tenant')
+        return parent.get_child_ips().restrict(request.user, 'view').prefetch_related('vrf', 'tenant', 'tenant__group')
 
     def prep_table_data(self, request, queryset, parent):
         show_available = bool(request.GET.get('show_available', 'true') == 'true')
@@ -552,14 +552,14 @@ class PrefixBulkImportView(generic.BulkImportView):
 
 
 class PrefixBulkEditView(generic.BulkEditView):
-    queryset = Prefix.objects.prefetch_related('site', 'vrf__tenant', 'tenant', 'vlan', 'role')
+    queryset = Prefix.objects.prefetch_related('vrf__tenant')
     filterset = filtersets.PrefixFilterSet
     table = tables.PrefixTable
     form = forms.PrefixBulkEditForm
 
 
 class PrefixBulkDeleteView(generic.BulkDeleteView):
-    queryset = Prefix.objects.prefetch_related('site', 'vrf__tenant', 'tenant', 'vlan', 'role')
+    queryset = Prefix.objects.prefetch_related('vrf__tenant')
     filterset = filtersets.PrefixFilterSet
     table = tables.PrefixTable
 
@@ -611,14 +611,14 @@ class IPRangeBulkImportView(generic.BulkImportView):
 
 
 class IPRangeBulkEditView(generic.BulkEditView):
-    queryset = IPRange.objects.prefetch_related('vrf', 'tenant')
+    queryset = IPRange.objects.all()
     filterset = filtersets.IPRangeFilterSet
     table = tables.IPRangeTable
     form = forms.IPRangeBulkEditForm
 
 
 class IPRangeBulkDeleteView(generic.BulkDeleteView):
-    queryset = IPRange.objects.prefetch_related('vrf', 'tenant')
+    queryset = IPRange.objects.all()
     filterset = filtersets.IPRangeFilterSet
     table = tables.IPRangeTable
 
@@ -789,14 +789,14 @@ class IPAddressBulkImportView(generic.BulkImportView):
 
 
 class IPAddressBulkEditView(generic.BulkEditView):
-    queryset = IPAddress.objects.prefetch_related('vrf__tenant', 'tenant')
+    queryset = IPAddress.objects.prefetch_related('vrf__tenant')
     filterset = filtersets.IPAddressFilterSet
     table = tables.IPAddressTable
     form = forms.IPAddressBulkEditForm
 
 
 class IPAddressBulkDeleteView(generic.BulkDeleteView):
-    queryset = IPAddress.objects.prefetch_related('vrf__tenant', 'tenant')
+    queryset = IPAddress.objects.prefetch_related('vrf__tenant')
     filterset = filtersets.IPAddressFilterSet
     table = tables.IPAddressTable
 
@@ -819,7 +819,8 @@ class VLANGroupView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         vlans = VLAN.objects.restrict(request.user, 'view').filter(group=instance).prefetch_related(
-            Prefetch('prefixes', queryset=Prefix.objects.restrict(request.user))
+            Prefetch('prefixes', queryset=Prefix.objects.restrict(request.user)),
+            'tenant', 'site', 'role',
         ).order_by('vid')
         vlans_count = vlans.count()
         vlans = add_available_vlans(vlans, vlan_group=instance)
@@ -894,7 +895,7 @@ class FHRPGroupView(generic.ObjectView):
     def get_extra_context(self, request, instance):
         # Get assigned IP addresses
         ipaddress_table = tables.AssignedIPAddressesTable(
-            data=instance.ip_addresses.restrict(request.user, 'view').prefetch_related('vrf', 'tenant'),
+            data=instance.ip_addresses.restrict(request.user, 'view'),
             orderable=False
         )
 
@@ -984,11 +985,11 @@ class VLANListView(generic.ObjectListView):
 
 
 class VLANView(generic.ObjectView):
-    queryset = VLAN.objects.prefetch_related('site__region', 'tenant__group', 'role')
+    queryset = VLAN.objects.all()
 
     def get_extra_context(self, request, instance):
         prefixes = Prefix.objects.restrict(request.user, 'view').filter(vlan=instance).prefetch_related(
-            'vrf', 'site', 'role'
+            'vrf', 'site', 'role', 'tenant'
         )
         prefix_table = tables.PrefixTable(list(prefixes), exclude=('vlan', 'utilization'), orderable=False)
 
@@ -1046,14 +1047,14 @@ class VLANBulkImportView(generic.BulkImportView):
 
 
 class VLANBulkEditView(generic.BulkEditView):
-    queryset = VLAN.objects.prefetch_related('site', 'group', 'tenant', 'role')
+    queryset = VLAN.objects.all()
     filterset = filtersets.VLANFilterSet
     table = tables.VLANTable
     form = forms.VLANBulkEditForm
 
 
 class VLANBulkDeleteView(generic.BulkDeleteView):
-    queryset = VLAN.objects.prefetch_related('site', 'group', 'tenant', 'role')
+    queryset = VLAN.objects.all()
     filterset = filtersets.VLANFilterSet
     table = tables.VLANTable
 
@@ -1106,14 +1107,14 @@ class ServiceTemplateBulkDeleteView(generic.BulkDeleteView):
 #
 
 class ServiceListView(generic.ObjectListView):
-    queryset = Service.objects.all()
+    queryset = Service.objects.prefetch_related('device', 'virtual_machine')
     filterset = filtersets.ServiceFilterSet
     filterset_form = forms.ServiceFilterForm
     table = tables.ServiceTable
 
 
 class ServiceView(generic.ObjectView):
-    queryset = Service.objects.prefetch_related('ipaddresses')
+    queryset = Service.objects.all()
 
 
 class ServiceCreateView(generic.ObjectEditView):
@@ -1123,7 +1124,7 @@ class ServiceCreateView(generic.ObjectEditView):
 
 
 class ServiceEditView(generic.ObjectEditView):
-    queryset = Service.objects.prefetch_related('ipaddresses')
+    queryset = Service.objects.all()
     form = forms.ServiceForm
     template_name = 'ipam/service_edit.html'
 

--- a/netbox/tenancy/views.py
+++ b/netbox/tenancy/views.py
@@ -95,7 +95,7 @@ class TenantListView(generic.ObjectListView):
 
 
 class TenantView(generic.ObjectView):
-    queryset = Tenant.objects.prefetch_related('group')
+    queryset = Tenant.objects.all()
 
     def get_extra_context(self, request, instance):
         stats = {
@@ -140,14 +140,14 @@ class TenantBulkImportView(generic.BulkImportView):
 
 
 class TenantBulkEditView(generic.BulkEditView):
-    queryset = Tenant.objects.prefetch_related('group')
+    queryset = Tenant.objects.all()
     filterset = filtersets.TenantFilterSet
     table = tables.TenantTable
     form = forms.TenantBulkEditForm
 
 
 class TenantBulkDeleteView(generic.BulkDeleteView):
-    queryset = Tenant.objects.prefetch_related('group')
+    queryset = Tenant.objects.all()
     filterset = filtersets.TenantFilterSet
     table = tables.TenantTable
 
@@ -337,14 +337,14 @@ class ContactBulkImportView(generic.BulkImportView):
 
 
 class ContactBulkEditView(generic.BulkEditView):
-    queryset = Contact.objects.prefetch_related('group')
+    queryset = Contact.objects.all()
     filterset = filtersets.ContactFilterSet
     table = tables.ContactTable
     form = forms.ContactBulkEditForm
 
 
 class ContactBulkDeleteView(generic.BulkDeleteView):
-    queryset = Contact.objects.prefetch_related('group')
+    queryset = Contact.objects.all()
     filterset = filtersets.ContactFilterSet
     table = tables.ContactTable
 

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -209,14 +209,14 @@ class ClusterBulkImportView(generic.BulkImportView):
 
 
 class ClusterBulkEditView(generic.BulkEditView):
-    queryset = Cluster.objects.prefetch_related('type', 'group', 'site')
+    queryset = Cluster.objects.all()
     filterset = filtersets.ClusterFilterSet
     table = tables.ClusterTable
     form = forms.ClusterBulkEditForm
 
 
 class ClusterBulkDeleteView(generic.BulkDeleteView):
-    queryset = Cluster.objects.prefetch_related('type', 'group', 'site')
+    queryset = Cluster.objects.all()
     filterset = filtersets.ClusterFilterSet
     table = tables.ClusterTable
 
@@ -308,7 +308,7 @@ class ClusterRemoveDevicesView(generic.ObjectEditView):
 #
 
 class VirtualMachineListView(generic.ObjectListView):
-    queryset = VirtualMachine.objects.all()
+    queryset = VirtualMachine.objects.prefetch_related('primary_ip4', 'primary_ip6')
     filterset = filtersets.VirtualMachineFilterSet
     filterset_form = forms.VirtualMachineFilterForm
     table = tables.VirtualMachineTable
@@ -334,7 +334,8 @@ class VirtualMachineView(generic.ObjectView):
         services = Service.objects.restrict(request.user, 'view').filter(
             virtual_machine=instance
         ).prefetch_related(
-            Prefetch('ipaddresses', queryset=IPAddress.objects.restrict(request.user))
+            Prefetch('ipaddresses', queryset=IPAddress.objects.restrict(request.user)),
+            'virtual_machine'
         )
 
         return {
@@ -383,14 +384,14 @@ class VirtualMachineBulkImportView(generic.BulkImportView):
 
 
 class VirtualMachineBulkEditView(generic.BulkEditView):
-    queryset = VirtualMachine.objects.prefetch_related('cluster', 'tenant', 'role')
+    queryset = VirtualMachine.objects.prefetch_related('primary_ip4', 'primary_ip6')
     filterset = filtersets.VirtualMachineFilterSet
     table = tables.VirtualMachineTable
     form = forms.VirtualMachineBulkEditForm
 
 
 class VirtualMachineBulkDeleteView(generic.BulkDeleteView):
-    queryset = VirtualMachine.objects.prefetch_related('cluster', 'tenant', 'role')
+    queryset = VirtualMachine.objects.prefetch_related('primary_ip4', 'primary_ip6')
     filterset = filtersets.VirtualMachineFilterSet
     table = tables.VirtualMachineTable
 
@@ -413,7 +414,7 @@ class VMInterfaceView(generic.ObjectView):
     def get_extra_context(self, request, instance):
         # Get assigned IP addresses
         ipaddress_table = AssignedIPAddressesTable(
-            data=instance.ip_addresses.restrict(request.user, 'view').prefetch_related('vrf', 'tenant'),
+            data=instance.ip_addresses.restrict(request.user, 'view'),
             orderable=False
         )
 


### PR DESCRIPTION
### Fixes: #9699

Removes deprecated usage of `prefetch_related` for views which are using a `NetBoxTable` to display its data.
