### PR TITLE
Fixes #9950 Open redirect fix after login

### DIFF
--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -91,7 +91,7 @@ class LoginView(View):
         data = request.POST if request.method == "POST" else request.GET
         redirect_url = data.get('next', settings.LOGIN_REDIRECT_URL)
 
-        if redirect_url and redirect_url.startswith('/'):
+        if redirect_url and redirect_url.startswith('/') and not redirect_url.startswith('//'):
             logger.debug(f"Redirecting user to {redirect_url}")
         else:
             if redirect_url:


### PR DESCRIPTION
### Fixes: #9950

This is just to make sure after login you are just redirecting to a path not another domain.
Otherwise if some one clicks on a link to Login, it could redirect them to malicious site without realizing it. 
