### PR TITLE
Fixes #10055: NAT Outside evaluations and links

### DIFF
--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -56,14 +56,6 @@ VRF_LINK = """
 {% endif %}
 """
 
-NAT_OUTSIDE_LINK = """
-{% if record.nat_outside.count > 0 %}
-    {% for nat in record.nat_outside.all %}<a href="{{ nat.get_absolute_url }}">{{ nat.address.ip }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
-{% else %}
-    &mdash;
-{% endif %}
-"""
-
 
 #
 # RIRs
@@ -368,8 +360,8 @@ class IPAddressTable(TenancyColumnsMixin, NetBoxTable):
         orderable=False,
         verbose_name='NAT (Inside)'
     )
-    nat_outside = tables.TemplateColumn(
-        template_code=NAT_OUTSIDE_LINK,
+    nat_outside = tables.ManyToManyColumn(
+        linkify_item=True,
         orderable=False,
         verbose_name='NAT (Outside)'
     )

--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -56,6 +56,12 @@ VRF_LINK = """
 {% endif %}
 """
 
+NAT_OUTSIDE_LINK = """
+{% if record.nat_outside.count > 0 %}
+    {% for nat in record.nat_outside.all %}<a href="{{ nat.get_absolute_url }}">{{ nat.address.ip }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
+{% endif %}
+"""
+
 
 #
 # RIRs
@@ -360,8 +366,8 @@ class IPAddressTable(TenancyColumnsMixin, NetBoxTable):
         orderable=False,
         verbose_name='NAT (Inside)'
     )
-    nat_outside = tables.Column(
-        linkify=True,
+    nat_outside = tables.TemplateColumn(
+        template_code=NAT_OUTSIDE_LINK,
         orderable=False,
         verbose_name='NAT (Outside)'
     )

--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -59,6 +59,8 @@ VRF_LINK = """
 NAT_OUTSIDE_LINK = """
 {% if record.nat_outside.count > 0 %}
     {% for nat in record.nat_outside.all %}<a href="{{ nat.get_absolute_url }}">{{ nat.address.ip }}</a>{% if not forloop.last %}, {% endif %}{% endfor %}
+{% else %}
+    &mdash;
 {% endif %}
 """
 

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -179,8 +179,8 @@
                                 <a href="{{ object.primary_ip4.get_absolute_url }}">{{ object.primary_ip4.address.ip }}</a>
                                 {% if object.primary_ip4.nat_inside %}
                                   (NAT for {{ object.primary_ip4.nat_inside.address.ip|linkify }})
-                                {% elif object.primary_ip4.nat_outside %}
-                                  (NAT: {{ object.primary_ip4.nat_outside.address.ip|linkify }})
+                                {% elif object.primary_ip4.nat_outside.count > 0 %}
+                                  (NAT for {% for nat in object.primary_ip4.nat_outside.all %}<a href="{{ nat.get_absolute_url }}">{{ nat.address.ip }}</a>{% if not forloop.last %}, {% endif %}{% endfor %})
                                 {% endif %}
                               {% else %}
                                 {{ ''|placeholder }}
@@ -194,8 +194,8 @@
                                 <a href="{{ object.primary_ip6.get_absolute_url }}">{{ object.primary_ip6.address.ip }}</a>
                                 {% if object.primary_ip6.nat_inside %}
                                   (NAT for {{ object.primary_ip6.nat_inside.address.ip|linkify }})
-                                {% elif object.primary_ip6.nat_outside %}
-                                  (NAT: {{ object.primary_ip6.nat_outside.address.ip|linkify }})
+                                {% elif object.primary_ip6.nat_outside.count > 0 %}
+                                  (NAT for {% for nat in object.primary_ip6.nat_outside.all %}<a href="{{ nat.get_absolute_url }}">{{ nat.address.ip }}</a>{% if not forloop.last %}, {% endif %}{% endfor %})
                                 {% endif %}
                               {% else %}
                                 {{ ''|placeholder }}

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -179,7 +179,7 @@
                                 <a href="{{ object.primary_ip4.get_absolute_url }}">{{ object.primary_ip4.address.ip }}</a>
                                 {% if object.primary_ip4.nat_inside %}
                                   (NAT for {{ object.primary_ip4.nat_inside.address.ip|linkify }})
-                                {% elif object.primary_ip4.nat_outside.count > 0 %}
+                                {% elif object.primary_ip4.nat_outside.exists %}
                                   (NAT for {% for nat in object.primary_ip4.nat_outside.all %}<a href="{{ nat.get_absolute_url }}">{{ nat.address.ip }}</a>{% if not forloop.last %}, {% endif %}{% endfor %})
                                 {% endif %}
                               {% else %}
@@ -194,7 +194,7 @@
                                 <a href="{{ object.primary_ip6.get_absolute_url }}">{{ object.primary_ip6.address.ip }}</a>
                                 {% if object.primary_ip6.nat_inside %}
                                   (NAT for {{ object.primary_ip6.nat_inside.address.ip|linkify }})
-                                {% elif object.primary_ip6.nat_outside.count > 0 %}
+                                {% elif object.primary_ip6.nat_outside.exists %}
                                   (NAT for {% for nat in object.primary_ip6.nat_outside.all %}<a href="{{ nat.get_absolute_url }}">{{ nat.address.ip }}</a>{% if not forloop.last %}, {% endif %}{% endfor %})
                                 {% endif %}
                               {% else %}

--- a/netbox/templates/ipam/ipaddress.html
+++ b/netbox/templates/ipam/ipaddress.html
@@ -91,10 +91,13 @@
                       </td>
                   </tr>
                   <tr>
-                      <th scope="row">Outside NAT IPs</th>
+                      <th scope="row">NAT (Outside)</th>
                       <td>
                         {% for ip in object.nat_outside.all %}
-                          {{ ip|linkify }}<br/>
+                          {{ ip|linkify }}
+                            {% if ip.assigned_object %}
+                              ({{ ip.assigned_object.parent_object|linkify }})
+                            {% endif %}<br/>
                         {% empty %}
                           {{ ''|placeholder }}
                         {% endfor %}

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -60,8 +60,8 @@
                             <a href="{% url 'ipam:ipaddress' pk=object.primary_ip6.pk %}">{{ object.primary_ip6.address.ip }}</a>
                             {% if object.primary_ip6.nat_inside %}
                               (NAT for <a href="{{ object.primary_ip6.nat_inside.get_absolute_url }}">{{ object.primary_ip6.nat_inside.address.ip }}</a>)
-                            {% elif object.primary_ip4.nat_outside.exists %}
-                              (NAT for {% for nat in object.primary_ip4.nat_outside.all %}<a href="{{ nat.get_absolute_url }}">{{ nat.address.ip }}</a>{% if not forloop.last %}, {% endif %}{% endfor %})
+                            {% elif object.primary_ip6.nat_outside.exists %}
+                              (NAT for {% for nat in object.primary_ip6.nat_outside.all %}<a href="{{ nat.get_absolute_url }}">{{ nat.address.ip }}</a>{% if not forloop.last %}, {% endif %}{% endfor %})
                             {% endif %}
                           {% else %}
                             {{ ''|placeholder }}

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -45,7 +45,7 @@
                             <a href="{% url 'ipam:ipaddress' pk=object.primary_ip4.pk %}">{{ object.primary_ip4.address.ip }}</a>
                             {% if object.primary_ip4.nat_inside %}
                               (NAT for <a href="{{ object.primary_ip4.nat_inside.get_absolute_url }}">{{ object.primary_ip4.nat_inside.address.ip }}</a>)
-                            {% elif object.primary_ip4.nat_outside.count > 0 %}
+                            {% elif object.primary_ip4.nat_outside.exists %}
                               (NAT for {% for nat in object.primary_ip4.nat_outside.all %}<a href="{{ nat.get_absolute_url }}">{{ nat.address.ip }}</a>{% if not forloop.last %}, {% endif %}{% endfor %})
                             {% endif %}
                           {% else %}
@@ -60,7 +60,7 @@
                             <a href="{% url 'ipam:ipaddress' pk=object.primary_ip6.pk %}">{{ object.primary_ip6.address.ip }}</a>
                             {% if object.primary_ip6.nat_inside %}
                               (NAT for <a href="{{ object.primary_ip6.nat_inside.get_absolute_url }}">{{ object.primary_ip6.nat_inside.address.ip }}</a>)
-                            {% elif object.primary_ip4.nat_outside.count > 0 %}
+                            {% elif object.primary_ip4.nat_outside.exists %}
                               (NAT for {% for nat in object.primary_ip4.nat_outside.all %}<a href="{{ nat.get_absolute_url }}">{{ nat.address.ip }}</a>{% if not forloop.last %}, {% endif %}{% endfor %})
                             {% endif %}
                           {% else %}

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -45,8 +45,8 @@
                             <a href="{% url 'ipam:ipaddress' pk=object.primary_ip4.pk %}">{{ object.primary_ip4.address.ip }}</a>
                             {% if object.primary_ip4.nat_inside %}
                               (NAT for <a href="{{ object.primary_ip4.nat_inside.get_absolute_url }}">{{ object.primary_ip4.nat_inside.address.ip }}</a>)
-                            {% elif object.primary_ip4.nat_outside %}
-                              (NAT: <a href="{{ object.primary_ip4.nat_outside.get_absolute_url }}">{{ object.primary_ip4.nat_outside.address.ip }}</a>)
+                            {% elif object.primary_ip4.nat_outside.count > 0 %}
+                              (NAT for {% for nat in object.primary_ip4.nat_outside.all %}<a href="{{ nat.get_absolute_url }}">{{ nat.address.ip }}</a>{% if not forloop.last %}, {% endif %}{% endfor %})
                             {% endif %}
                           {% else %}
                             {{ ''|placeholder }}
@@ -60,8 +60,8 @@
                             <a href="{% url 'ipam:ipaddress' pk=object.primary_ip6.pk %}">{{ object.primary_ip6.address.ip }}</a>
                             {% if object.primary_ip6.nat_inside %}
                               (NAT for <a href="{{ object.primary_ip6.nat_inside.get_absolute_url }}">{{ object.primary_ip6.nat_inside.address.ip }}</a>)
-                            {% elif object.primary_ip6.nat_outside %}
-                              (NAT: <a href="{{ object.primary_ip6.nat_outside.get_absolute_url }}">{{ object.primary_ip6.nat_outside.address.ip }}</a>)
+                            {% elif object.primary_ip4.nat_outside.count > 0 %}
+                              (NAT for {% for nat in object.primary_ip4.nat_outside.all %}<a href="{{ nat.get_absolute_url }}">{{ nat.address.ip }}</a>{% if not forloop.last %}, {% endif %}{% endfor %})
                             {% endif %}
                           {% else %}
                             {{ ''|placeholder }}


### PR DESCRIPTION
Fixes: #10055

Added loops for NAT Outside in IP Address (ipaddress.html), Device (device.html), and Virtual Machine (virtualmachine.html) templates, and fixed 'ipam.IPAddress.None' text in IP table (ip.py).