### PR TITLE
Fix #10094 - Contact Assignments Create and Add Another

### DIFF
--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -327,7 +327,7 @@ class ObjectEditView(GetReturnURLMixin, BaseObjectView):
         """
         return obj
 
-    def get_extra_addanother_params(self, request, params):
+    def get_extra_addanother_params(self, request):
         """
         Return a dictionary of extra parameters to use on the Add Another button.
         """

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -327,7 +327,10 @@ class ObjectEditView(GetReturnURLMixin, BaseObjectView):
         """
         return obj
 
-    def get_extra_addanother_params(self, request, params: dict):
+    def get_extra_addanother_params(self, request, params):
+        """
+        Return a QueryDict of extra params to use on the Add Another button.
+        """
         return params
 
     #

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -327,6 +327,9 @@ class ObjectEditView(GetReturnURLMixin, BaseObjectView):
         """
         return obj
 
+    def get_extra_addanother_params(self, request, params: dict):
+        return params
+
     #
     # Request handlers
     #
@@ -399,6 +402,7 @@ class ObjectEditView(GetReturnURLMixin, BaseObjectView):
 
                     # If cloning is supported, pre-populate a new instance of the form
                     params = prepare_cloned_fields(obj)
+                    params = self.get_extra_addanother_params(request, params)
                     if params:
                         if 'return_url' in request.GET:
                             params['return_url'] = request.GET.get('return_url')

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -329,9 +329,9 @@ class ObjectEditView(GetReturnURLMixin, BaseObjectView):
 
     def get_extra_addanother_params(self, request, params):
         """
-        Return a QueryDict of extra params to use on the Add Another button.
+        Return a dictionary of extra parameters to use on the Add Another button.
         """
-        return params
+        return {}
 
     #
     # Request handlers
@@ -405,7 +405,7 @@ class ObjectEditView(GetReturnURLMixin, BaseObjectView):
 
                     # If cloning is supported, pre-populate a new instance of the form
                     params = prepare_cloned_fields(obj)
-                    params = self.get_extra_addanother_params(request, params)
+                    params.update(self.get_extra_addanother_params(request))
                     if params:
                         if 'return_url' in request.GET:
                             params['return_url'] = request.GET.get('return_url')

--- a/netbox/tenancy/views.py
+++ b/netbox/tenancy/views.py
@@ -1,4 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
+from django.http import QueryDict
 from django.shortcuts import get_object_or_404
 
 from circuits.models import Circuit
@@ -364,6 +365,15 @@ class ContactAssignmentEditView(generic.ObjectEditView):
             content_type = get_object_or_404(ContentType, pk=request.GET.get('content_type'))
             instance.object = get_object_or_404(content_type.model_class(), pk=request.GET.get('object_id'))
         return instance
+
+    def get_extra_addanother_params(self, request, params: dict):
+        if not params:
+            params = QueryDict(mutable=True)
+
+        params['content_type'] = request.GET.get('content_type')
+        params['object_id'] = request.GET.get('object_id')
+
+        return params
 
 
 class ContactAssignmentDeleteView(generic.ObjectDeleteView):

--- a/netbox/tenancy/views.py
+++ b/netbox/tenancy/views.py
@@ -366,14 +366,11 @@ class ContactAssignmentEditView(generic.ObjectEditView):
             instance.object = get_object_or_404(content_type.model_class(), pk=request.GET.get('object_id'))
         return instance
 
-    def get_extra_addanother_params(self, request, params: dict):
-        if not params:
-            params = QueryDict(mutable=True)
-
-        params['content_type'] = request.GET.get('content_type')
-        params['object_id'] = request.GET.get('object_id')
-
-        return params
+    def get_extra_addanother_params(self, request):
+        return {
+            'content_type': request.GET.get('content_type'),
+            'object_id': request.GET.get('object_id'),
+        }
 
 
 class ContactAssignmentDeleteView(generic.ObjectDeleteView):

--- a/netbox/utilities/utils.py
+++ b/netbox/utilities/utils.py
@@ -285,7 +285,7 @@ def prepare_cloned_fields(instance):
     """
     # Generate the clone attributes from the instance
     if not hasattr(instance, 'clone'):
-        return QueryDict()
+        return QueryDict(mutable=True)
     attrs = instance.clone()
 
     # Prepare querydict parameters


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #10094
<!--
    Please include a summary of the proposed changes below.
-->
Fixes for Contact Assignment create and Add Another (previously returning a 404 error:

Steps to Reproduce
Click 'Add a Contact' on a Device or Virtual Machine (possibly others) detail page.
Enter Contact and Role.
Click 'Create & Add Another'

adds a get_extra_addanother_params() to ObjectEditView that can be overridden to set extra query params for the button.