### PR TITLE
Fixes #10109: Fix available prefixes calculation for container prefixes in the global table

### DIFF
--- a/docs/release-notes/version-3.3.md
+++ b/docs/release-notes/version-3.3.md
@@ -17,6 +17,7 @@
 * [#10059](https://github.com/netbox-community/netbox/issues/10059) - Add identifier column to L2VPN table
 * [#10089](https://github.com/netbox-community/netbox/issues/10089) - `linkify` template filter should escape object representation
 * [#10108](https://github.com/netbox-community/netbox/issues/10108) - Linkify inside NAT IPs for primary device IPs in UI
+* [#10109](https://github.com/netbox-community/netbox/issues/10109) - Fix available prefixes calculation for container prefixes in the global table
 * [#10111](https://github.com/netbox-community/netbox/issues/10111) - Wrap search QS to catch ValueError on identifier field
 
 ---

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -35,13 +35,16 @@ class GetAvailablePrefixesMixin:
 
     def get_available_prefixes(self):
         """
-        Return all available Prefixes within this aggregate as an IPSet.
+        Return all available prefixes within this Aggregate or Prefix as an IPSet.
         """
-        prefix = netaddr.IPSet(self.prefix)
-        child_prefixes = netaddr.IPSet([child.prefix for child in self.get_child_prefixes()])
-        available_prefixes = prefix - child_prefixes
+        params = {
+            'prefix__net_contained': str(self.prefix)
+        }
+        if hasattr(self, 'vrf'):
+            params['vrf'] = self.vrf
 
-        return available_prefixes
+        child_prefixes = Prefix.objects.filter(**params).values_list('prefix', flat=True)
+        return netaddr.IPSet(self.prefix) - netaddr.IPSet(child_prefixes)
 
     def get_first_available_prefix(self):
         """


### PR DESCRIPTION
### Fixes: #10109

- Rewrite `get_available_prefixes()` to find child prefixes without relying on `get_child_prefixes()` due to the conditional logic it employs