### PR TITLE
#10033 disable Add a Termination button if 2 terminations on L2VPN P2P

### DIFF
--- a/netbox/ipam/models/l2vpn.py
+++ b/netbox/ipam/models/l2vpn.py
@@ -3,6 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
+from django.utils.functional import cached_property
 
 from ipam.choices import L2VPNTypeChoices
 from ipam.constants import L2VPN_ASSIGNMENT_MODELS
@@ -67,6 +68,7 @@ class L2VPN(NetBoxModel):
     def get_absolute_url(self):
         return reverse('ipam:l2vpn', args=[self.pk])
 
+    @cached_property
     def can_add_termination(self):
         if self.type in L2VPNTypeChoices.P2P and self.terminations.count() >= 2:
             return False

--- a/netbox/ipam/models/l2vpn.py
+++ b/netbox/ipam/models/l2vpn.py
@@ -67,6 +67,12 @@ class L2VPN(NetBoxModel):
     def get_absolute_url(self):
         return reverse('ipam:l2vpn', args=[self.pk])
 
+    def can_add_termination(self):
+        if self.type in L2VPNTypeChoices.P2P and self.terminations.count() >= 2:
+            return False
+        else:
+            return True
+
 
 class L2VPNTermination(NetBoxModel):
     l2vpn = models.ForeignKey(

--- a/netbox/templates/ipam/l2vpn.html
+++ b/netbox/templates/ipam/l2vpn.html
@@ -59,7 +59,7 @@
       </div>
       {% if perms.ipam.add_l2vpntermination %}
         <div class="card-footer text-end noprint">
-          <a href="{% url 'ipam:l2vpntermination_add' %}?l2vpn={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm">
+          <a href="{% url 'ipam:l2vpntermination_add' %}?l2vpn={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm{% if not object.can_add_termination %} disabled{% endif %}"{% if not object.can_add_termination %} aria-disabled="true"{% endif %}>
             <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add a Termination
           </a>
         </div>

--- a/netbox/templates/ipam/l2vpn.html
+++ b/netbox/templates/ipam/l2vpn.html
@@ -59,7 +59,7 @@
       </div>
       {% if perms.ipam.add_l2vpntermination %}
         <div class="card-footer text-end noprint">
-          <a href="{% url 'ipam:l2vpntermination_add' %}?l2vpn={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm{% if not object.can_add_termination %} disabled{% endif %}"{% if not object.can_add_termination %} aria-disabled="true"{% endif %}>
+          <a href="{% url 'ipam:l2vpntermination_add' %}?l2vpn={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary btn-sm{% if not object.can_add_termination %} disabled" aria-disabled="true{% endif %}">
             <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add a Termination
           </a>
         </div>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #10033 
<!--
    Please include a summary of the proposed changes below.
-->
Disables the "Add a Termination" button if there are already 2 terminations for an L2VPN P2P