### PR TITLE
fix for #10086 - change capitalization on wireless link table for Interface A, B and Auth Type

### DIFF
--- a/netbox/wireless/models.py
+++ b/netbox/wireless/models.py
@@ -23,7 +23,8 @@ class WirelessAuthenticationBase(models.Model):
     auth_type = models.CharField(
         max_length=50,
         choices=WirelessAuthTypeChoices,
-        blank=True
+        blank=True,
+        verbose_name="Auth Type",
     )
     auth_cipher = models.CharField(
         max_length=50,
@@ -134,13 +135,15 @@ class WirelessLink(WirelessAuthenticationBase, NetBoxModel):
         to='dcim.Interface',
         limit_choices_to={'type__in': WIRELESS_IFACE_TYPES},
         on_delete=models.PROTECT,
-        related_name='+'
+        related_name='+',
+        verbose_name="Interface A",
     )
     interface_b = models.ForeignKey(
         to='dcim.Interface',
         limit_choices_to={'type__in': WIRELESS_IFACE_TYPES},
         on_delete=models.PROTECT,
-        related_name='+'
+        related_name='+',
+        verbose_name="Interface B",
     )
     ssid = models.CharField(
         max_length=SSID_MAX_LENGTH,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #10086
<!--
    Please include a summary of the proposed changes below.
-->
Adds capitalization for some display names in wireless links table.