### PR TITLE
Add "Assign FHRP Group" to device-interfaces context menu

### DIFF
--- a/netbox/dcim/tables/template_code.py
+++ b/netbox/dcim/tables/template_code.py
@@ -241,6 +241,9 @@ INTERFACE_BUTTONS = """
       {% if perms.dcim.add_interface %}
         <li><a class="dropdown-item" href="{% url 'dcim:interface_add' %}?device={{ record.device_id }}&parent={{ record.pk }}&name_pattern={{ record.name }}.&type=virtual&return_url={% url 'dcim:device_interfaces' pk=object.pk %}">Child Interface</a></li>
       {% endif %}
+      {% if perms.ipam.add_l2vpntermination %}
+        <li><a class="dropdown-item" href="{% url 'ipam:l2vpntermination_add' %}?device={{ object.pk }}&interface={{ record.pk }}&return_url={% url 'dcim:device_interfaces' pk=object.pk %}">L2VPN Termination</a></li>
+      {% endif %}
     </ul>
   </span>
 {% endif %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be opened for approval prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the relevant feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ACCEPTED BUG REPORT OR
    FEATURE REQUEST, IT WILL BE MARKED AS INVALID AND CLOSED.
-->
### Fixes: #10038
<!--
    Please include a summary of the proposed changes below.
-->
Adds an "Assign FHRP Group" to the context menu of devices-interfaces (see screenshot).  Couple potential changes/questions:

1. This is an add button, so I'm not sure of putting an "assignment" in here if there is a convention?  Potentially rename it to "FHRP Group - Assign"
2. The feature request also had "Add FHRP Group" going to a separate page that had tabs for each of add and assign.  I didn't see any existing convention for this type of page currently?  Would require refactoring of the code to avoid code-duplication.
3. could add "Add FHRP Group" as a separate menu item - but that isn't tied at all to the particular interface so seems like an over-loading of the context menu?

![assign-fhrp](https://user-images.githubusercontent.com/99642/186532716-24f8f3f3-ca69-4246-85a6-77ef9c0bfd82.png)
