### PR TITLE
Fixes #10161 - Render "Set Null" button for custom fields

### DIFF
--- a/netbox/utilities/templates/form_helpers/render_custom_fields.html
+++ b/netbox/utilities/templates/form_helpers/render_custom_fields.html
@@ -7,6 +7,10 @@
   </div>
   {% endif %}
   {% for name in fields %}
-    {% render_field form|getfield:name %}
+    {% if name in form.nullable_fields %}
+      {% render_field form|getfield:name bulk_nullable=True %}
+    {% else %}
+      {% render_field form|getfield:name %}
+    {% endif %}
   {% endfor %}
 {% endfor %}


### PR DESCRIPTION
### Fixes: #10161

For some reason the Set Null button was not rendered for custom fields. Not sure when it was broken, but the PR should fix it.