### PR TITLE
Fixes #10156: Avoid forcing SVG image links to open in a new window

### DIFF
--- a/docs/release-notes/version-3.3.md
+++ b/docs/release-notes/version-3.3.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 * [#10155](https://github.com/netbox-community/netbox/issues/10155) - Fix rear port display when editing front port template for module type 
+* [#10156](https://github.com/netbox-community/netbox/issues/10156) - Avoid forcing SVG image links to open in a new window
 
 ---
 

--- a/netbox/dcim/svg/cables.py
+++ b/netbox/dcim/svg/cables.py
@@ -94,7 +94,7 @@ class Connector(Group):
         self.add(cable)
 
         # Add link
-        link = Hyperlink(href=url, target='_blank')
+        link = Hyperlink(href=url, target='_parent')
 
         # Add text label(s)
         cursor = start[1]
@@ -281,7 +281,7 @@ class CableTraceSVG:
         self.cursor += PADDING * 2
 
         # Add link
-        link = Hyperlink(href=f'{self.base_url}{wirelesslink.get_absolute_url()}', target='_blank')
+        link = Hyperlink(href=f'{self.base_url}{wirelesslink.get_absolute_url()}', target='_parent')
 
         # Add text label(s)
         for i, label in enumerate(labels):

--- a/netbox/dcim/svg/racks.py
+++ b/netbox/dcim/svg/racks.py
@@ -151,7 +151,7 @@ class RackElevationSVG:
         css_extra = ' shaded' if is_shaded else ''
 
         # Create hyperlink element
-        link = Hyperlink(href=f'{self.base_url}{device.get_absolute_url()}', target='_blank')
+        link = Hyperlink(href=f'{self.base_url}{device.get_absolute_url()}', target="_parent")
         link.set_desc(description)
 
         # Add rect element to hyperlink
@@ -235,10 +235,7 @@ class RackElevationSVG:
                     self.margin_width,
                     u_height * self.unit_height
                 )
-                link = Hyperlink(
-                    href='{}{}'.format(self.base_url, reservation.get_absolute_url()),
-                    target='_blank'
-                )
+                link = Hyperlink(href=f'{self.base_url}{reservation.get_absolute_url()}', target='_parent')
                 link.set_desc(f'Reservation #{reservation.pk}: {reservation.description}')
                 link.add(
                     Rect(coords, size, class_='reservation')
@@ -268,7 +265,7 @@ class RackElevationSVG:
                 y_offset + self.unit_height / 2
             )
 
-            link = Hyperlink(href=url_string.format(unit), target='_blank')
+            link = Hyperlink(href=url_string.format(unit), target='_parent')
             link.add(Rect((x_offset, y_offset), (self.unit_width, self.unit_height), class_='slot'))
             link.add(Text('add device', insert=text_coords, class_='add-device'))
 


### PR DESCRIPTION
### Fixes: #10156

- Update all Hyperlink instances in SVG documents to specify `target="_parent"`