### PR TITLE
Fixes #9592: Remove member_count from NestedVirtualChassisSerializer

### DIFF
--- a/netbox/dcim/api/nested_serializers.py
+++ b/netbox/dcim/api/nested_serializers.py
@@ -432,11 +432,10 @@ class NestedCableSerializer(BaseModelSerializer):
 class NestedVirtualChassisSerializer(WritableNestedSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:virtualchassis-detail')
     master = NestedDeviceSerializer()
-    member_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = models.VirtualChassis
-        fields = ['id', 'url', 'display', 'name', 'master', 'member_count']
+        fields = ['id', 'url', 'display', 'name', 'master']
 
 
 #

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -1982,7 +1982,7 @@ class ConnectedDeviceTest(APITestCase):
 
 class VirtualChassisTest(APIViewTestCases.APIViewTestCase):
     model = VirtualChassis
-    brief_fields = ['display', 'id', 'master', 'member_count', 'name', 'url']
+    brief_fields = ['display', 'id', 'master', 'name', 'url']
 
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be approved and assigned prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the assigned feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY. For example:

    ### Fixes: #1234
-->
### Fixes: #9592
<!--
    Please include a summary of the proposed changes below.
-->

This removes the member_count field from the NestedVirtualChassisSerializer and the corresponding test.