### PR TITLE
Fixes #10181: Restore MultiPartParser (regression from #10031)

### DIFF
--- a/docs/release-notes/version-3.3.md
+++ b/docs/release-notes/version-3.3.md
@@ -7,6 +7,7 @@
 * [#10155](https://github.com/netbox-community/netbox/issues/10155) - Fix rear port display when editing front port template for module type 
 * [#10156](https://github.com/netbox-community/netbox/issues/10156) - Avoid forcing SVG image links to open in a new window
 * [#10161](https://github.com/netbox-community/netbox/issues/10161) - Restore "set null" option for custom fields during bulk edit
+* [#10181](https://github.com/netbox-community/netbox/issues/10181) - Restore MultiPartParser (regression from #10031)
 
 ---
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -535,6 +535,7 @@ REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'netbox.api.pagination.OptionalLimitOffsetPagination',
     'DEFAULT_PARSER_CLASSES': (
         'rest_framework.parsers.JSONParser',
+        'rest_framework.parsers.MultiPartParser',
     ),
     'DEFAULT_PERMISSION_CLASSES': (
         'netbox.api.authentication.TokenPermissions',


### PR DESCRIPTION
### Fixes: #10181

- Restore MultiPartParser as a default REST API parser