### PR TITLE
#10178 add manufacturer to device detail view devicetype

### DIFF
--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -168,6 +168,10 @@ class DeviceType(NetBoxModel):
     def get_absolute_url(self):
         return reverse('dcim:devicetype', args=[self.pk])
 
+    @property
+    def get_full_name(self):
+        return f"{ self.manufacturer } { self.model }"
+
     def to_yaml(self):
         data = {
             'manufacturer': self.manufacturer.name,

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -90,7 +90,7 @@
                         <tr>
                             <th scope="row">Device Type</th>
                             <td>
-                                {{ object.device_type|linkify }} ({{ object.device_type.u_height }}U)
+                                {{ object.device_type|linkify:"get_full_name" }} ({{ object.device_type.u_height }}U)
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note
    that our contribution policy requires that a feature request or bug
    report be approved and assigned prior to filing a pull request. This
    helps avoid wasting time and effort on something that we might not
    be able to accept.

    Please indicate the assigned feature request or bug report below.
    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY. For example:

    ### Fixes: #1234
-->
### Fixes: #10178 
<!--
    Please include a summary of the proposed changes below.
-->
Adds manufacturer to the device Type display and Device detail page:

![devicetype](https://user-images.githubusercontent.com/99642/187309971-f55f3510-26c4-4382-b3af-38b9206a7352.png)
