### PR TITLE
Fixes #10212 - Add padding to the bottom of the sidebar

### DIFF
--- a/netbox/templates/base/sidenav.html
+++ b/netbox/templates/base/sidenav.html
@@ -28,7 +28,7 @@
   <div class="sidenav-inner h-100 mb-auto">
 
     {# Collapse #}
-    <div class="collapse sidenav-collapse">
+    <div class="collapse sidenav-collapse pb-4">
 
       {# Nav Items #}
       {% nav %}


### PR DESCRIPTION
### Fixes: #10212

Adds padding to the bottom of the sidebar to prevent the link preview text in Chrome from covering the last link. Tested all kinds of window sizes and saw no obvious downsides, but feel free to verify.