### PR TITLE
#7503 API Bulk-Create of Devices does not check Rack-Space

### DIFF
--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -626,7 +626,7 @@ class CustomDeviceListSerializer(serializers.ListSerializer):
         # break these up into racks for space validation
         racks = {}
         for device in devices:
-            if device.rack:
+            if device.rack and device.position is not None:
                 if device.rack not in racks:
                     racks[device.rack] = []
                 racks[device.rack].append(device)

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -758,7 +758,7 @@ class Device(NetBoxModel, ConfigContextModel):
                     })
 
                 # Validate rack space
-                rack.check_for_space([self, ])
+                self.rack.check_for_space([self, ])
 
             except DeviceType.DoesNotExist:
                 pass

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -758,16 +758,7 @@ class Device(NetBoxModel, ConfigContextModel):
                     })
 
                 # Validate rack space
-                rack_face = self.face if not self.device_type.is_full_depth else None
-                exclude_list = [self.pk] if self.pk else []
-                available_units = self.rack.get_available_units(
-                    u_height=self.device_type.u_height, rack_face=rack_face, exclude=exclude_list
-                )
-                if self.position and self.position not in available_units:
-                    raise ValidationError({
-                        'position': f"U{self.position} is already occupied or does not have sufficient space to "
-                                    f"accommodate this device type: {self.device_type} ({self.device_type.u_height}U)"
-                    })
+                rack.check_for_space([self, ])
 
             except DeviceType.DoesNotExist:
                 pass

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -1115,7 +1115,7 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
 
         device_types = (
             DeviceType(manufacturer=manufacturer, model='Device Type 1', slug='device-type-1'),
-            DeviceType(manufacturer=manufacturer, model='Device Type 2', slug='device-type-2'),
+            DeviceType(manufacturer=manufacturer, model='Device Type 2', slug='device-type-2', u_height=2),
         )
         DeviceType.objects.bulk_create(device_types)
 
@@ -1222,6 +1222,39 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
             'site': device.site.pk,
             'name': device.name,
         }
+
+        self.add_permissions('dcim.add_device')
+        url = reverse('dcim-api:device-list')
+        response = self.client.post(url, data, format='json', **self.header)
+
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_rack_fit(self):
+        """
+        Check that creating multiple devices with overlapping position fails.
+        """
+        device = Device.objects.first()
+        device_type = DeviceType.objects.all()[1]
+        data = [
+            {
+                'device_type': device_type.pk,
+                'device_role': device.device_role.pk,
+                'site': device.site.pk,
+                'name': 'Test Device 7',
+                'rack': device.rack.pk,
+                'face': 'front',
+                'position': 1
+            },
+            {
+                'device_type': device_type.pk,
+                'device_role': device.device_role.pk,
+                'site': device.site.pk,
+                'name': 'Test Device 8',
+                'rack': device.rack.pk,
+                'face': 'front',
+                'position': 2
+            }
+        ]
 
         self.add_permissions('dcim.add_device')
         url = reverse('dcim-api:device-list')


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.
-->
### Fixes: #7503

<!--
    Please include a summary of the proposed changes below.
-->
If you bulk add devices and have overlapping positions it will return a validation error.    Bit bigger change but wanted to get the method down for validating cross objects in a bulk operation which will probably come up again (use ListSerializer).  @jeremystretch I spot checked the existing logic for adding devices but would probably be good for you to re-validate it as such a central piece.