### PR TITLE
Fixes #10217: Handle exception when trace splits to multiple rear ports

### DIFF
--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -677,6 +677,12 @@ class CablePath(models.Model):
         """
         Return all available next segments in a split cable path.
         """
-        rearports = self.path_objects[-1]
+        nodes = self.path_objects[-1]
 
-        return FrontPort.objects.filter(rear_port__in=rearports)
+        # RearPort splitting to multiple FrontPorts with no stack position
+        if type(nodes[0]) is RearPort:
+            return FrontPort.objects.filter(rear_port__in=nodes)
+        # Cable terminating to multiple FrontPorts mapped to different
+        # RearPorts connected to different cables
+        elif type(nodes[0]) is FrontPort:
+            return RearPort.objects.filter(pk__in=[fp.rear_port_id for fp in nodes])

--- a/netbox/templates/dcim/cable_trace.html
+++ b/netbox/templates/dcim/cable_trace.html
@@ -22,16 +22,18 @@
                     <h3 class="text-danger">Path split!</h3>
                     <p>Select a node below to continue:</p>
                     <ul class="text-start">
-                        {% for next_node in path.get_split_nodes %}
-                            {% if next_node.cable %}
-                                <li>
-                                    <a href="{% url 'dcim:frontport_trace' pk=next_node.pk %}">{{ next_node }}</a>
-                                    (Cable {{ next_node.cable|linkify }})
-                                </li>
-                            {% else %}
-                                <li class="text-muted">{{ next_node }}</li>
-                            {% endif %}
-                        {% endfor %}
+                      {% for next_node in path.get_split_nodes %}
+                        {% if next_node.cable %}
+                          {% with viewname=next_node|viewname:"trace" %}
+                            <li>
+                              <a href="{% url viewname pk=next_node.pk %}">{{ next_node|meta:"verbose_name"|bettertitle }} {{ next_node }}</a>
+                              (Cable {{ next_node.cable|linkify }})
+                            </li>
+                          {% endwith %}
+                        {% else %}
+                          <li class="text-muted">{{ next_node }}</li>
+                        {% endif %}
+                      {% endfor %}
                     </ul>
                 {% else %}
                     <h3 class="text-center text-success">Trace Completed</h3>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.
-->
### Fixes: #10217
- Extend `get_split_nodes()` to handle splits occurring at multiple RearPorts
- Improve the cable trace HTML template