### PR TITLE
Fixes #10220: Validate IP version when assigning primary IPs to a VM

### DIFF
--- a/docs/release-notes/version-3.3.md
+++ b/docs/release-notes/version-3.3.md
@@ -24,6 +24,7 @@
 * [#10181](https://github.com/netbox-community/netbox/issues/10181) - Restore MultiPartParser (regression from #10031)
 * [#10208](https://github.com/netbox-community/netbox/issues/10208) - Fix permissions evaluation for interface actions dropdown menu
 * [#10217](https://github.com/netbox-community/netbox/issues/10217) - Handle exception when trace splits to multiple rear ports
+* [#10220](https://github.com/netbox-community/netbox/issues/10220) - Validate IP version when assigning primary IPs to a virtual machine
 
 ---
 

--- a/netbox/virtualization/models.py
+++ b/netbox/virtualization/models.py
@@ -368,9 +368,14 @@ class VirtualMachine(NetBoxModel, ConfigContextModel):
 
         # Validate primary IP addresses
         interfaces = self.interfaces.all()
-        for field in ['primary_ip4', 'primary_ip6']:
+        for family in (4, 6):
+            field = f'primary_ip{family}'
             ip = getattr(self, field)
             if ip is not None:
+                if ip.address.version != family:
+                    raise ValidationError({
+                        field: f"Must be an IPv{family} address. ({ip} is an IPv{ip.address.version} address.)",
+                    })
                 if ip.assigned_object in interfaces:
                     pass
                 elif ip.nat_inside is not None and ip.nat_inside.assigned_object in interfaces:


### PR DESCRIPTION
### Fixes: #10220

- Extend `clean()` on VirtualMachine to verify the IP version of `primary_ip4` and `primary_ip6` (if set)