### PR TITLE
Closes #10231: Add missing serializer annotations

### DIFF
--- a/netbox/extras/api/serializers.py
+++ b/netbox/extras/api/serializers.py
@@ -403,6 +403,7 @@ class ScriptSerializer(serializers.Serializer):
     vars = serializers.SerializerMethodField(read_only=True)
     result = NestedJobResultSerializer()
 
+    @swagger_serializer_method(serializer_or_field=serializers.JSONField)
     def get_vars(self, instance):
         return {
             k: v.__class__.__name__ for k, v in instance._get_vars().items()

--- a/netbox/ipam/api/serializers.py
+++ b/netbox/ipam/api/serializers.py
@@ -190,6 +190,7 @@ class VLANGroupSerializer(NetBoxModelSerializer):
         ]
         validators = []
 
+    @swagger_serializer_method(serializer_or_field=serializers.JSONField)
     def get_scope(self, obj):
         if obj.scope_id is None:
             return None

--- a/netbox/users/api/nested_serializers.py
+++ b/netbox/users/api/nested_serializers.py
@@ -1,5 +1,6 @@
 from django.contrib.auth.models import Group, User
 from django.contrib.contenttypes.models import ContentType
+from drf_yasg.utils import swagger_serializer_method
 from rest_framework import serializers
 
 from netbox.api.fields import ContentTypeField
@@ -56,8 +57,10 @@ class NestedObjectPermissionSerializer(WritableNestedSerializer):
         model = ObjectPermission
         fields = ['id', 'url', 'display', 'name', 'enabled', 'object_types', 'groups', 'users', 'actions']
 
+    @swagger_serializer_method(serializer_or_field=serializers.ListField)
     def get_groups(self, obj):
         return [g.name for g in obj.groups.all()]
 
+    @swagger_serializer_method(serializer_or_field=serializers.ListField)
     def get_users(self, obj):
         return [u.username for u in obj.users.all()]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.

    Specify your assigned issue number on the line below.
-->
### Fixes: #10231

<!--
    Please include a summary of the proposed changes below.
-->

This PR adds missing annotations to all fields using serializers.SerializerMethodField, that do not return a string.

Only the annotation of VlanGroupSerializer.scope currently has an effect as the other objects are currently not exposed in the API.

Diff of swagger.json after merge:
```
*** swagger.orig.json   2022-09-01 17:15:26.325786061 +0200
--- swagger.new.json    2022-09-01 17:16:12.493466700 +0200
***************
*** 13184,13192 ****
                  },
                "scope" : { 
                    "readOnly" : true,
                    "title" : "Scope",
!                   "type" : "string"
                  },
                "scope_id" : { 
                    "title" : "Scope id",
                    "type" : "integer",
--- 13184,13192 ----
                  },
                "scope" : { 
                    "readOnly" : true,
                    "title" : "Scope",
!                   "type" : "object"
                  },
                "scope_id" : { 
                    "title" : "Scope id",
                    "type" : "integer",
```