### PR TITLE
#9481 update child location whem move parent

### DIFF
--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -868,6 +868,7 @@ class Device(NetBoxModel, ConfigContextModel):
         for device in devices:
             device.site = self.site
             device.rack = self.rack
+            device.location = self.location
             device.save()
 
     @property


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.

    Specify your assigned issue number on the line below.
-->
### Fixes: #9481

<!--
    Please include a summary of the proposed changes below.
-->
See bug report - when parent device is moved to a new rack the child device location wasn't getting updated.  @jeremystretch you had mentioned "This may be a use case for https://github.com/netbox-community/netbox/issues/9903 (available in v3.3)." in the bug report, am I missing something for this - this seems to fix the issue?