### PR TITLE
Fixes #9823 - Make validation error from NumericArrayField more verbose.

### DIFF
--- a/netbox/utilities/forms/widgets.py
+++ b/netbox/utilities/forms/widgets.py
@@ -110,6 +110,13 @@ class SelectSpeedWidget(forms.NumberInput):
 
 class NumericArrayField(SimpleArrayField):
 
+    def clean(self, value):
+        if value and not self.to_python(value):
+            raise forms.ValidationError(f'Invalid list ({value}). '
+                                        f'Must be numeric and ranges must be in ascending order')
+        return super().clean(value)
+
+
     def to_python(self, value):
         if not value:
             return []

--- a/netbox/utilities/forms/widgets.py
+++ b/netbox/utilities/forms/widgets.py
@@ -116,7 +116,6 @@ class NumericArrayField(SimpleArrayField):
                                         f'Must be numeric and ranges must be in ascending order')
         return super().clean(value)
 
-
     def to_python(self, value):
         if not value:
             return []


### PR DESCRIPTION
### Fixes: #9823

Update clean() method to provide a more verbose error when ranges within the list are in descending order
