### PR TITLE
9231 fix empty search

### DIFF
--- a/netbox/netbox/filtersets.py
+++ b/netbox/netbox/filtersets.py
@@ -81,7 +81,7 @@ class BaseFilterSet(django_filters.FilterSet):
     })
 
     def __init__(self, *args, **kwargs):
-        self.base_filters = self.get_filters()
+        self.base_filters = self.__class__.get_filters()
         super().__init__(*args, **kwargs)
 
     @staticmethod

--- a/netbox/netbox/filtersets.py
+++ b/netbox/netbox/filtersets.py
@@ -80,6 +80,10 @@ class BaseFilterSet(django_filters.FilterSet):
         },
     })
 
+    def __init__(self, *args, **kwargs):
+        self.base_filters = self.get_filters()
+        super().__init__(*args, **kwargs)
+
     @staticmethod
     def _get_filter_lookup_dict(existing_filter):
         # Choose the lookup expression map based on the filter type

--- a/netbox/netbox/filtersets.py
+++ b/netbox/netbox/filtersets.py
@@ -81,6 +81,9 @@ class BaseFilterSet(django_filters.FilterSet):
     })
 
     def __init__(self, *args, **kwargs):
+        # bit of a hack for #9231 - extras.lookup.Empty is registered in apps.ready
+        # however FilterSet Factory is setup before this which creates the
+        # initial filters.  This recreates the filters so Empty is picked up correctly.
         self.base_filters = self.__class__.get_filters()
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.

    Specify your assigned issue number on the line below.
-->
### Fixes: #9231

<!--
    Please include a summary of the proposed changes below.
-->
See comment in code - The root issue I'm assuming is a change in Django initialization potentially.  What is happening is the register_lookup for the CharField gets run in App.ready(), however this is being called after the FilterSet class constructer is being  defined which is what sets up the filters ([in self.base_filters](https://github.com/carltongibson/django-filter/blob/main/django_filters/filterset.py#L62)) - so it is never getting setup.

This change re-inits the base_filters when the class is instantiated (after Empty has been registered) so it gets picked up correctly.