### PR TITLE
#10278 fix attaching an image to a rack "Create & Add Another"

### DIFF
--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -441,6 +441,12 @@ class ImageAttachmentEditView(generic.ObjectEditView):
     def get_return_url(self, request, obj=None):
         return obj.parent.get_absolute_url() if obj else super().get_return_url(request)
 
+    def get_extra_addanother_params(self, request):
+        return {
+            'content_type': request.GET.get('content_type'),
+            'object_id': request.GET.get('object_id'),
+        }
+
 
 class ImageAttachmentDeleteView(generic.ObjectDeleteView):
     queryset = ImageAttachment.objects.all()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.

    Specify your assigned issue number on the line below.
-->
### Fixes: #10278

<!--
    Please include a summary of the proposed changes below.
-->
Uses changes from #10094  adds the get_extra_addanother_params to put content_type and object_id into the add another button.