### PR TITLE
Fixes #10259: Fix NoReverseMatch exception when listing available prefixes with "flat" column displayed

### DIFF
--- a/docs/release-notes/version-3.3.md
+++ b/docs/release-notes/version-3.3.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 * [#9231](https://github.com/netbox-community/netbox/issues/9231) - Fix `empty` lookup expression for string filters
+* [#10259](https://github.com/netbox-community/netbox/issues/10259) - Fix `NoReverseMatch` exception when listing available prefixes with "flat" column displayed
 * [#10270](https://github.com/netbox-community/netbox/issues/10270) - Fix custom field validation when creating new services
 * [#10278](https://github.com/netbox-community/netbox/issues/10278) - Fix "create & add another" for image attachments
 

--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -21,6 +21,14 @@ __all__ = (
 AVAILABLE_LABEL = mark_safe('<span class="badge bg-success">Available</span>')
 
 PREFIX_LINK = """
+{% if record.pk %}
+  <a href="{{ record.get_absolute_url }}">{{ record.prefix }}</a>
+{% else %}
+  <a href="{% url 'ipam:prefix_add' %}?prefix={{ record }}{% if object.vrf %}&vrf={{ object.vrf.pk }}{% endif %}{% if object.site %}&site={{ object.site.pk }}{% endif %}{% if object.tenant %}&tenant_group={{ object.tenant.group.pk }}&tenant={{ object.tenant.pk }}{% endif %}">{{ record.prefix }}</a>
+{% endif %}
+"""
+
+PREFIX_LINK_WITH_DEPTH = """
 {% load helpers %}
 {% if record.depth %}
     <div class="record-depth">
@@ -29,8 +37,7 @@ PREFIX_LINK = """
         {% endfor %}
     </div>
 {% endif %}
-<a href="{% if record.pk %}{% url 'ipam:prefix' pk=record.pk %}{% else %}{% url 'ipam:prefix_add' %}?prefix={{ record }}{% if object.vrf %}&vrf={{ object.vrf.pk }}{% endif %}{% if object.site %}&site={{ object.site.pk }}{% endif %}{% if object.tenant %}&tenant_group={{ object.tenant.group.pk }}&tenant={{ object.tenant.pk }}{% endif %}{% endif %}">{{ record.prefix }}</a>
-"""
+""" + PREFIX_LINK
 
 IPADDRESS_LINK = """
 {% if record.pk %}
@@ -216,14 +223,15 @@ class PrefixUtilizationColumn(columns.UtilizationColumn):
 
 class PrefixTable(TenancyColumnsMixin, NetBoxTable):
     prefix = columns.TemplateColumn(
-        template_code=PREFIX_LINK,
+        template_code=PREFIX_LINK_WITH_DEPTH,
         export_raw=True,
         attrs={'td': {'class': 'text-nowrap'}}
     )
-    prefix_flat = tables.Column(
+    prefix_flat = columns.TemplateColumn(
         accessor=Accessor('prefix'),
-        linkify=True,
-        verbose_name='Prefix (Flat)',
+        template_code=PREFIX_LINK,
+        export_raw=True,
+        verbose_name='Prefix (Flat)'
     )
     depth = tables.Column(
         accessor=Accessor('_depth'),


### PR DESCRIPTION
### Fixes: #10259

- Change `prefix_flat` to a TemplateColumn
- Tweak `PREFIX_LINK` template code to avoid duplication