### PR TITLE
Fixes #10250: Fix exception when CableTermination validation fails during bulk import of cables

### DIFF
--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -281,15 +281,11 @@ class CableTermination(models.Model):
 
         # Validate interface type (if applicable)
         if self.termination_type.model == 'interface' and self.termination.type in NONCONNECTABLE_IFACE_TYPES:
-            raise ValidationError({
-                'termination': f'Cables cannot be terminated to {self.termination.get_type_display()} interfaces'
-            })
+            raise ValidationError(f"Cables cannot be terminated to {self.termination.get_type_display()} interfaces")
 
         # A CircuitTermination attached to a ProviderNetwork cannot have a Cable
         if self.termination_type.model == 'circuittermination' and self.termination.provider_network is not None:
-            raise ValidationError({
-                'termination': "Circuit terminations attached to a provider network may not be cabled."
-            })
+            raise ValidationError("Circuit terminations attached to a provider network may not be cabled.")
 
     def save(self, *args, **kwargs):
 


### PR DESCRIPTION
### Fixes: #10250

Decouple the ValidationError exceptions raised by `CableTermination.clean()` from the `termination` field so they're suitable for general purpose use.