### PR TITLE
Fixes #10294 - Don't return empty string for empty wwn form field

### DIFF
--- a/netbox/dcim/forms/models.py
+++ b/netbox/dcim/forms/models.py
@@ -1331,6 +1331,12 @@ class InterfaceForm(InterfaceCommonForm, NetBoxModelForm):
         label='VRF'
     )
 
+    wwn = forms.CharField(
+        empty_value=None,
+        required=False,
+        label='WWN'
+    )
+
     fieldsets = (
         ('Interface', ('device', 'module', 'name', 'type', 'speed', 'duplex', 'label', 'description', 'tags')),
         ('Addressing', ('vrf', 'mac_address', 'wwn')),


### PR DESCRIPTION
### Fixes: #10294

Adds wwn as a CharField with empty_value set to None. This fixes the spurious changes in changelogs when the field is empty.

[This is equivalent with the mac address field](https://github.com/netbox-community/netbox/blob/b7028228578066b81e5f26d83cbba6c303401efe/netbox/dcim/forms/common.py#L12-L15) but wwn is only present on device interfaces and not vm interfaces which was probably why it was missed when it was added.