### PR TITLE
Fixes #10333: Show available values for ui_visibility field of CustomField for CSV import

### DIFF
--- a/netbox/extras/forms/bulk_import.py
+++ b/netbox/extras/forms/bulk_import.py
@@ -3,7 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.postgres.forms import SimpleArrayField
 from django.utils.safestring import mark_safe
 
-from extras.choices import CustomFieldTypeChoices
+from extras.choices import CustomFieldVisibilityChoices, CustomFieldTypeChoices
 from extras.models import *
 from extras.utils import FeatureQuery
 from utilities.forms import CSVChoiceField, CSVContentTypeField, CSVModelForm, CSVMultipleContentTypeField, SlugField
@@ -37,6 +37,10 @@ class CustomFieldCSVForm(CSVModelForm):
         base_field=forms.CharField(),
         required=False,
         help_text='Comma-separated list of field choices'
+    )
+    ui_visibility = CSVChoiceField(
+        choices=CustomFieldVisibilityChoices,
+        help_text='How the custom field is displayed in the user interface'
     )
 
     class Meta:


### PR DESCRIPTION
### Fixes: #10333

- Change `CustomFieldCSVForm.ui_visibility` to a CSVChoiceField to ensure the available choices are displayed in the CSV import form