### PR TITLE
Introduce pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+# See PEP 518 for the spec of this file
+# https://www.python.org/dev/peps/pep-0518/
+
+[tool.black]
+line-length = 120
+target_version = ['py38', 'py39', 'py310']
+skip-string-normalization = true
+
+[tool.isort]
+profile = "black"
+
+[tool.pylint]
+max-line-length = 120


### PR DESCRIPTION
### Fixes: #10298

Introduces a `pyproject.toml` (see [PEP 518](https://peps.python.org/pep-0518/)) file to define some of the linting rules used in the project such as line length and the usage of single-quote strings.

This PR provides a _basic_ `pyproject.toml` with simple rules for black, isort and pylint tweaked to not break the existing codebase... too much.

The current pre-commit hook which (among other things) runs pycodestyle with a few arguments to control the rules being applied does not format code but will prevent non PEP8 code submissions to be committed. This PR does not alter this behavior.
