### PR TITLE
Fixes #10305: Allows null master in VirtualChassis APIs

### DIFF
--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -1076,7 +1076,7 @@ class CablePathSerializer(serializers.ModelSerializer):
 
 class VirtualChassisSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:virtualchassis-detail')
-    master = NestedDeviceSerializer(required=False)
+    master = NestedDeviceSerializer(required=False, allow_null=True, default=None)
     member_count = serializers.IntegerField(read_only=True)
 
     class Meta:

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -2057,6 +2057,7 @@ class VirtualChassisTest(APIViewTestCases.APIViewTestCase):
 
         cls.bulk_update_data = {
             'domain': 'newdomain',
+            'master': None
         }
 
 


### PR DESCRIPTION
### Fixes: #10305 

VirtualChassis API calls were not allowing the `master` field to be `null`. This PR allows the field to be null and adds a test to verify that the field can be set to `null`.
