### PR TITLE
Fixes #9497 - Change non-racked filter for sites/locations

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -355,7 +355,7 @@ class SiteView(generic.ObjectView):
 
         nonracked_devices = Device.objects.filter(
             site=instance,
-            position__isnull=True,
+            rack__isnull=True,
             parent_bay__isnull=True
         ).prefetch_related('device_type__manufacturer', 'parent_bay', 'device_role')
 
@@ -450,7 +450,7 @@ class LocationView(generic.ObjectView):
 
         nonracked_devices = Device.objects.filter(
             location=instance,
-            position__isnull=True,
+            rack__isnull=True,
             parent_bay__isnull=True
         ).prefetch_related('device_type__manufacturer', 'parent_bay', 'device_role')
 


### PR DESCRIPTION
### Fixes: #9497

Change the filter for non-racked devices in sites/locations detailed view to only show devices not attached to a rack
