### PR TITLE
Add [tool.pyright] to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,12 @@ profile = "black"
 
 [tool.pylint]
 max-line-length = 120
+
+[tool.pyright]
+include = ["netbox"]
+exclude = [
+    "**/node_modules",
+    "**/__pycache__",
+]
+reportMissingImports = true
+reportMissingTypeStubs = false


### PR DESCRIPTION
### Fixes: #10431

The language server features in VSCode broke after the merge of #10338 but should work out of the box as they did before the change.

This fixes this issue by defining how `pyright` should find python files within the project.
