### PR TITLE
10439 Add widget for Airflow field in DeviceTypeForm

### DIFF
--- a/netbox/dcim/forms/models.py
+++ b/netbox/dcim/forms/models.py
@@ -373,6 +373,7 @@ class DeviceTypeForm(NetBoxModelForm):
             'front_image', 'rear_image', 'comments', 'tags',
         ]
         widgets = {
+            'airflow': StaticSelect(),
             'subdevice_role': StaticSelect(),
             'front_image': ClearableFileInput(attrs={
                 'accept': DEVICETYPE_IMAGE_FORMATS


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.

    Specify your assigned issue number on the line below.
-->
### Fixes: #10439 Add widget `StaticSelect` for Airflow field in DeviceTypeForm

![image](https://user-images.githubusercontent.com/28296817/192096794-bd4ff092-d641-40b5-af7d-57575f457180.png)
