### PR TITLE
Fixes: #10460 Fix view for connection details

### DIFF
--- a/netbox/templates/dcim/consoleport.html
+++ b/netbox/templates/dcim/consoleport.html
@@ -72,22 +72,22 @@
                                     </a>
                                 </td>
                             </tr>
-                            {% if object.connected_endpoint %}
+                            {% for endpoint in object.connected_endpoints %}
                                 <tr>
                                     <th scope="row">Device</th>
-                                    <td>{{ object.connected_endpoint.device|linkify }}</td>
+                                    <td>{{ endpoint.device|linkify }}</td>
                                 </tr>
                                 <tr>
                                     <th scope="row">Name</th>
-                                    <td>{{ object.connected_endpoint|linkify:"name" }}</td>
+                                    <td>{{ endpoint|linkify:"name" }}</td>
                                 </tr>
                                 <tr>
                                     <th scope="row">Type</th>
-                                    <td>{{ object.connected_endpoint.get_type_display|placeholder }}</td>
+                                    <td>{{ endpoint.get_type_display|placeholder }}</td>
                                 </tr>
                                 <tr>
                                     <th scope="row">Description</th>
-                                    <td>{{ object.connected_endpoint.description|placeholder }}</td>
+                                    <td>{{ endpoint.description|placeholder }}</td>
                                 </tr>
                                 <tr>
                                     <th scope="row">Path Status</th>
@@ -99,7 +99,7 @@
                                         {% endif %}
                                     </td>
                                 </tr>
-                            {% endif %}
+                            {% endfor %}
                         </table>
                     {% else %}
                         <div class="text-muted">

--- a/netbox/templates/dcim/consoleserverport.html
+++ b/netbox/templates/dcim/consoleserverport.html
@@ -72,24 +72,24 @@
                                 </a>
                             </td>
                         </tr>
-                        {% if object.connected_endpoint %}
+                        {% for endpoint in object.connected_endpoints %}
                             <tr>
                                 <th scope="row">Device</th>
                                 <td>
-                                    {{ object.connected_endpoint.device|linkify }}
+                                    {{ endpoint.device|linkify }}
                                 </td>
                             </tr>
                             <tr>
                                 <th scope="row">Name</th>
-                                <td>{{ object.connected_endpoint|linkify:"name" }}</td>
+                                <td>{{ endpoint|linkify:"name" }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Type</th>
-                                <td>{{ object.connected_endpoint.get_type_display|placeholder }}</td>
+                                <td>{{ endpoint.get_type_display|placeholder }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Description</th>
-                                <td>{{ object.connected_endpoint.description|placeholder }}</td>
+                                <td>{{ endpoint.description|placeholder }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Path Status</th>
@@ -101,7 +101,7 @@
                                     {% endif %}
                                 </td>
                             </tr>
-                        {% endif %}
+                        {% endfor %}
                     </table>
                 {% else %}
                     <div class="text-muted">

--- a/netbox/templates/dcim/interface.html
+++ b/netbox/templates/dcim/interface.html
@@ -165,57 +165,42 @@
                     </a>
                   </td>
                 </tr>
-                {% if object.connected_endpoint.device %}
-                  {% with iface=object.connected_endpoint %}
+                {% for endpoint in object.connected_endpoints %}
+                  {% if endpoint.device %}
                     <tr>
                       <th scope="row">Device</th>
-                      <td>{{ iface.device|linkify }}</td>
+                      <td>{{ endpoint.device|linkify }}</td>
                     </tr>
                     <tr>
                       <th scope="row">Name</th>
-                      <td>{{ iface|linkify:"name" }}</td>
+                      <td>{{ endpoint|linkify:"name" }}</td>
                     </tr>
                     <tr>
                       <th scope="row">Type</th>
-                      <td>{{ iface.get_type_display }}</td>
+                      <td>{{ endpoint.get_type_display }}</td>
                     </tr>
                     <tr>
                       <th scope="row">LAG</th>
-                      <td>{{ iface.lag|linkify|placeholder }}</td>
+                      <td>{{ endpoint.lag|linkify|placeholder }}</td>
                     </tr>
                     <tr>
                       <th scope="row">Description</th>
-                      <td>{{ iface.description|placeholder }}</td>
+                      <td>{{ endpoint.description|placeholder }}</td>
                     </tr>
                     <tr>
                       <th scope="row">MTU</th>
-                      <td>{{ iface.mtu|placeholder }}</td>
+                      <td>{{ endpoint.mtu|placeholder }}</td>
                     </tr>
                     <tr>
                       <th scope="row">MAC Address</th>
-                      <td>{{ iface.mac_address|placeholder }}</td>
+                      <td>{{ endpoint.mac_address|placeholder }}</td>
                     </tr>
                     <tr>
                       <th scope="row">802.1Q Mode</th>
-                      <td>{{ iface.get_mode_display }}</td>
+                      <td>{{ endpoint.get_mode_display }}</td>
                     </tr>
-                  {% endwith %}
-                {% elif object.connected_endpoint.circuit %}
-                  {% with ct=object.connected_endpoint %}
-                    <tr>
-                      <th scope="row">Provider</th>
-                      <td>{{ ct.circuit.provider|linkify }}</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">Circuit</th>
-                      <td>{{ ct.circuit|linkify }}</td>
-                    </tr>
-                    <tr>
-                      <th scope="row">Side</th>
-                      <td>{{ ct.term_side }}</td>
-                    </tr>
-                  {% endwith %}
-                {% endif %}
+                  {% endif %}
+                {% endfor %}
                 <tr>
                   <th scope="row">Path Status</th>
                   <td>

--- a/netbox/templates/dcim/powerfeed.html
+++ b/netbox/templates/dcim/powerfeed.html
@@ -41,8 +41,8 @@
                     <tr>
                         <th scope="row">Connected Device</th>
                         <td>
-                            {% if object.connected_endpoint %}
-                                {{ object.connected_endpoint.device|linkify }} ({{ object.connected_endpoint }})
+                            {% if object.connected_endpoints %}
+                                {{ object.connected_endpoints.0.device|linkify }} ({{ object.connected_endpoints.0|linkify:"name" }})
                             {% else %}
                                 {{ ''|placeholder }}
                             {% endif %}
@@ -50,7 +50,7 @@
                     </tr>
                     <tr>
                         <th scope="row">Utilization (Allocated)</th>
-                        {% with utilization=object.connected_endpoint.get_power_draw %}
+                        {% with utilization=object.connected_endpoints.0.get_power_draw %}
                             {% if utilization %}
                                 <td>
                                     {{ utilization.allocated }}VA / {{ object.available_power }}VA
@@ -120,22 +120,22 @@
                             </a>
                         </td>
                     </tr>
-                    {% if object.connected_endpoint %}
+                    {% for endpoint in object.connected_endpoints %}
                         <tr>
                             <th scope="row">Device</th>
-                            <td>{{ object.connected_endpoint.device|linkify }}</td>
+                            <td>{{ endpoint.device|linkify }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Name</th>
-                            <td>{{ object.connected_endpoint|linkify:"name" }}</td>
+                            <td>{{ endpoint|linkify:"name" }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Type</th>
-                            <td>{{ object.connected_endpoint.get_type_display|placeholder }}</td>
+                            <td>{{ endpoint.get_type_display|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Description</th>
-                            <td>{{ object.connected_endpoint.description|placeholder }}</td>
+                            <td>{{ endpoint.description|placeholder }}</td>
                         </tr>
                         <tr>
                             <th scope="row">Path Status</th>
@@ -147,7 +147,7 @@
                                 {% endif %}
                             </td>
                         </tr>
-                    {% endif %}
+                    {% endfor %}
                 </table>
             {% else %}
                 <div class="text-muted">

--- a/netbox/templates/dcim/poweroutlet.html
+++ b/netbox/templates/dcim/poweroutlet.html
@@ -78,22 +78,22 @@
                                 </a>
                             </td>
                         </tr>
-                        {% if object.connected_endpoint %}
+                        {% if object.connected_endpoints %}
                             <tr>
                                 <th scope="row">Device</th>
-                                <td>{{ object.connected_endpoint.device|linkify }}</td>
+                                <td>{{ object.connected_endpoints.0.device|linkify }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Name</th>
-                                <td>{{ object.connected_endpoint|linkify:"name" }}</td>
+                                <td>{{ object.connected_endpoints.0|linkify:"name" }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Type</th>
-                                <td>{{ object.connected_endpoint.get_type_display|placeholder }}</td>
+                                <td>{{ object.connected_endpoints.0.get_type_display|placeholder }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Description</th>
-                                <td>{{ object.connected_endpoint.description|placeholder }}</td>
+                                <td>{{ object.connected_endpoints.0.description|placeholder }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Path Status</th>

--- a/netbox/templates/dcim/powerport.html
+++ b/netbox/templates/dcim/powerport.html
@@ -78,22 +78,22 @@
                                 </a>
                             </td>
                         </tr>
-                        {% if object.connected_endpoint %}
+                        {% if object.connected_endpoints %}
                             <tr>
                                 <th scope="row">Device</th>
-                                <td>{{ object.connected_endpoint.device|linkify }}</td>
+                                <td>{{ object.connected_endpoints.0.device|linkify }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Name</th>
-                                <td>{{ object.connected_endpoint|linkify:"name" }}</td>
+                                <td>{{ object.connected_endpoints.0|linkify:"name" }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Type</th>
-                                <td>{{ object.connected_endpoint.get_type_display|placeholder }}</td>
+                                <td>{{ object.connected_endpoints.0.get_type_display|placeholder }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Description</th>
-                                <td>{{ object.connected_endpoint.description|placeholder }}</td>
+                                <td>{{ object.connected_endpoints.0.description|placeholder }}</td>
                             </tr>
                             <tr>
                                 <th scope="row">Path Status</th>
@@ -105,7 +105,7 @@
                                     {% endif %}
                                 </td>
                             </tr>
-                        {% endif %}
+                        {% endfor %}
                     </table>
                 {% else %}
                     <div class="text-muted">


### PR DESCRIPTION
### Fixes: #10460

* assumes only one connection for power related connections
* consoleport and consoleserver allow multiple connections on the view
* interface allows multiple connections and old circuit details removed (circuit is broken since at least 2.7 and this is probably a remnant of the first cable-model overhaul)
