### PR TITLE
convert customfield multiobject to ids at save()

### DIFF
--- a/netbox/extras/api/customfields.py
+++ b/netbox/extras/api/customfields.py
@@ -69,6 +69,12 @@ class CustomFieldsDataField(Field):
                 "values."
             )
 
+        for cf in self._get_custom_fields():
+            if cf.name in data.keys():
+                # Convert the mixed array of dict and id's into id's only
+                if cf.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+                    data[cf.name] = [obj['id'] if isinstance(obj, dict) else obj for obj in data[cf.name]] or None
+
         # If updating an existing instance, start with existing custom_field_data
         if self.parent.instance:
             data = {**self.parent.instance.custom_field_data, **data}

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -293,8 +293,9 @@ class CustomField(CloningMixin, ExportTemplatesMixin, WebhooksMixin, ChangeLogge
             model = self.object_type.model_class()
             return model.objects.filter(pk=value).first()
         if self.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+            valueids = [obj['id'] if isinstance(obj, dict) else obj for obj in value] or None
             model = self.object_type.model_class()
-            return model.objects.filter(pk__in=value)
+            return model.objects.filter(pk__in=valueids)
         return value
 
     def to_form_field(self, set_initial=True, enforce_required=True, for_csv_import=False):

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -293,9 +293,8 @@ class CustomField(CloningMixin, ExportTemplatesMixin, WebhooksMixin, ChangeLogge
             model = self.object_type.model_class()
             return model.objects.filter(pk=value).first()
         if self.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
-            valueids = [obj['id'] if isinstance(obj, dict) else obj for obj in value] or None
             model = self.object_type.model_class()
-            return model.objects.filter(pk__in=valueids)
+            return model.objects.filter(pk__in=value)
         return value
 
     def to_form_field(self, set_initial=True, enforce_required=True, for_csv_import=False):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.

    Specify your assigned issue number on the line below.
-->
### Fixes: #10241 CustomField MultiObject API returns dict at read but expects id's at save
<!--
    Please include a summary of the proposed changes below.
-->
This change will convert the mixed array of dict and id's into id's only at deserialize