### PR TITLE
Fixes: #10480 Fix link-target on cable-trace svg

### DIFF
--- a/netbox/dcim/svg/cables.py
+++ b/netbox/dcim/svg/cables.py
@@ -35,7 +35,7 @@ class Node(Hyperlink):
     """
 
     def __init__(self, position, width, url, color, labels, radius=10, **extra):
-        super(Node, self).__init__(href=url, target='_blank', **extra)
+        super(Node, self).__init__(href=url, target='_parent', **extra)
 
         x, y = position
 


### PR DESCRIPTION
### Fixes: #10480

Fix link-target on cable-trace svg to open link in the same window.
