### PR TITLE
Allow Plugins to register a list of Django apps to be appended to INSTALLED_APPS

### DIFF
--- a/docs/plugins/development/index.md
+++ b/docs/plugins/development/index.md
@@ -14,7 +14,7 @@ Plugins can do a lot, including:
 * Provide their own "pages" (views) in the web user interface
 * Inject template content and navigation links
 * Extend NetBox's REST and GraphQL APIs
-* Load additionnal Django Apps
+* Load additional Django apps
 * Add custom request/response middleware
 
 However, keep in mind that each piece of functionality is entirely optional. For example, if your plugin merely adds a piece of middleware or an API endpoint for existing data, there's no need to define any new models.
@@ -103,7 +103,7 @@ NetBox looks for the `config` variable within a plugin's `__init__.py` to load i
 | `base_url`            | Base path to use for plugin URLs (optional). If not specified, the project's `name` will be used.                        |
 | `required_settings`   | A list of any configuration parameters that **must** be defined by the user                                              |
 | `default_settings`    | A dictionary of configuration parameters and their default values                                                        |
-| `django_apps`         | A list of additionnal apps to load alongside the plugin                                                                  |
+| `django_apps`         | A list of additional Django apps to load alongside the plugin                                                            |
 | `min_version`         | Minimum version of NetBox with which the plugin is compatible                                                            |
 | `max_version`         | Maximum version of NetBox with which the plugin is compatible                                                            |
 | `middleware`          | A list of middleware classes to append after NetBox's build-in middleware                                                |
@@ -115,14 +115,13 @@ NetBox looks for the `config` variable within a plugin's `__init__.py` to load i
 
 All required settings must be configured by the user. If a configuration parameter is listed in both `required_settings` and `default_settings`, the default setting will be ignored.
 
-#### Important notes about `django_apps`
+#### Important Notes About `django_apps`
 
-Loading additional apps may cause more harm than good and could lead to make identifying problems within NetBox itself more difficult. The `django_apps` attribute is intented to be used only for advanced use-cases that require a deeper Django integration.
+Loading additional apps may cause more harm than good and could make identifying problems within NetBox itself more difficult. The `django_apps` attribute is intended only for advanced use cases that require a deeper Django integration.
 
-Apps from this list are inserted *before* the plugin's `PluginConfig` in the same order. Adding the plugin's `PluginConfig` module to this list changes this behavior and allows for apps to be loaded *after* the plugin.
+Apps from this list are inserted *before* the plugin's `PluginConfig` in the order defined. Adding the plugin's `PluginConfig` module to this list changes this behavior and allows for apps to be loaded *after* the plugin.
 
-Any additionnal app must be installed within the the same Python environment as NetBox or `ImproperlyConfigured` exceptions will be raised when loading the plugin.
-
+Any additional apps must be installed within the same Python environment as NetBox or `ImproperlyConfigured` exceptions will be raised when loading the plugin.
 
 ## Create setup.py
 

--- a/docs/plugins/development/index.md
+++ b/docs/plugins/development/index.md
@@ -14,6 +14,7 @@ Plugins can do a lot, including:
 * Provide their own "pages" (views) in the web user interface
 * Inject template content and navigation links
 * Extend NetBox's REST and GraphQL APIs
+* Load additionnal Django Apps
 * Add custom request/response middleware
 
 However, keep in mind that each piece of functionality is entirely optional. For example, if your plugin merely adds a piece of middleware or an API endpoint for existing data, there's no need to define any new models.
@@ -82,6 +83,7 @@ class FooBarConfig(PluginConfig):
     default_settings = {
         'baz': True
     }
+    django_apps = ["foo", "bar", "baz"]
 
 config = FooBarConfig
 ```
@@ -101,6 +103,7 @@ NetBox looks for the `config` variable within a plugin's `__init__.py` to load i
 | `base_url`            | Base path to use for plugin URLs (optional). If not specified, the project's `name` will be used.                        |
 | `required_settings`   | A list of any configuration parameters that **must** be defined by the user                                              |
 | `default_settings`    | A dictionary of configuration parameters and their default values                                                        |
+| `django_apps`         | A list of additionnal apps to load alongside the plugin                                                                  |
 | `min_version`         | Minimum version of NetBox with which the plugin is compatible                                                            |
 | `max_version`         | Maximum version of NetBox with which the plugin is compatible                                                            |
 | `middleware`          | A list of middleware classes to append after NetBox's build-in middleware                                                |
@@ -111,6 +114,15 @@ NetBox looks for the `config` variable within a plugin's `__init__.py` to load i
 | `user_preferences`    | The dotted path to the dictionary mapping of user preferences defined by the plugin (default: `preferences.preferences`) |
 
 All required settings must be configured by the user. If a configuration parameter is listed in both `required_settings` and `default_settings`, the default setting will be ignored.
+
+#### Important notes about `django_apps`
+
+Loading additional apps may cause more harm than good and could lead to make identifying problems within NetBox itself more difficult. The `django_apps` attribute is intented to be used only for advanced use-cases that require a deeper Django integration.
+
+Apps from this list are inserted *before* the plugin's `PluginConfig` in the same order. Adding the plugin's `PluginConfig` module to this list changes this behavior and allows for apps to be loaded *after* the plugin.
+
+Any additionnal app must be installed within the the same Python environment as NetBox or `ImproperlyConfigured` exceptions will be raised when loading the plugin.
+
 
 ## Create setup.py
 

--- a/netbox/dcim/tables/devicetypes.py
+++ b/netbox/dcim/tables/devicetypes.py
@@ -92,6 +92,9 @@ class DeviceTypeTable(NetBoxTable):
         template_code=DEVICE_WEIGHT,
         order_by=('_abs_weight', 'weight_unit')
     )
+    u_height = columns.TemplateColumn(
+        template_code='{{ value|floatformat }}'
+    )
 
     class Meta(NetBoxTable.Meta):
         model = DeviceType

--- a/netbox/extras/plugins/__init__.py
+++ b/netbox/extras/plugins/__init__.py
@@ -55,6 +55,9 @@ class PluginConfig(AppConfig):
     # Django-rq queues dedicated to the plugin
     queues = []
 
+    # Django apps to append to INSTALLED_APPS when plugin requires them.
+    django_apps = []
+
     # Default integration paths. Plugin authors can override these to customize the paths to
     # integrated components.
     graphql_schema = 'graphql.schema'

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -1,18 +1,17 @@
 import hashlib
 import importlib
-import logging
 import os
 import platform
-import re
-import socket
 import sys
 import warnings
 from urllib.parse import urlsplit
 
+import django
 import sentry_sdk
 from django.contrib.messages import constants as messages
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.validators import URLValidator
+from django.utils.encoding import force_str
 from sentry_sdk.integrations.django import DjangoIntegration
 
 from netbox.config import PARAMS
@@ -20,9 +19,7 @@ from netbox.config import PARAMS
 # Monkey patch to fix Django 4.0 support for graphene-django (see
 # https://github.com/graphql-python/graphene-django/issues/1284)
 # TODO: Remove this when graphene-django 2.16 becomes available
-import django
-from django.utils.encoding import force_str
-django.utils.encoding.force_text = force_str
+django.utils.encoding.force_text = force_str # type: ignore
 
 
 #
@@ -186,7 +183,7 @@ if STORAGE_BACKEND is not None:
     if STORAGE_BACKEND.startswith('storages.'):
 
         try:
-            import storages.utils
+            import storages.utils  # type: ignore
         except ModuleNotFoundError as e:
             if getattr(e, 'name') == 'storages':
                 raise ImproperlyConfigured(

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -21,7 +21,7 @@ from netbox.config import PARAMS
 # Monkey patch to fix Django 4.0 support for graphene-django (see
 # https://github.com/graphql-python/graphene-django/issues/1284)
 # TODO: Remove this when graphene-django 2.16 becomes available
-django.utils.encoding.force_text = force_str # type: ignore
+django.utils.encoding.force_text = force_str  # type: ignore
 
 
 #
@@ -669,7 +669,8 @@ for plugin_name in PLUGINS:
             "and point to the PluginConfig subclass.".format(plugin_name)
         )
 
-    plugin_module = "{}.{}".format(plugin_config.__module__, plugin_config.__name__) # type: ignore
+    plugin_module = "{}.{}".format(plugin_config.__module__, plugin_config.__name__)  # type: ignore
+
     # Gather additionnal apps to load alongside this plugin
     plugin_apps = plugin_config.django_apps
     if plugin_name in plugin_apps:
@@ -690,7 +691,6 @@ for plugin_name in PLUGINS:
                 f"The module {app}, from this list, cannot be imported. Check that the additionnal app has been "
                 "installed within the correct Python environment."
             )
-
 
     INSTALLED_APPS.extend(plugin_apps)
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -671,15 +671,15 @@ for plugin_name in PLUGINS:
 
     plugin_module = "{}.{}".format(plugin_config.__module__, plugin_config.__name__)  # type: ignore
 
-    # Gather additionnal apps to load alongside this plugin
-    plugin_apps = plugin_config.django_apps
-    if plugin_name in plugin_apps:
-        plugin_apps.pop(plugin_name)
-    if plugin_module not in plugin_apps:
-        plugin_apps.append(plugin_module)
+    # Gather additional apps to load alongside this plugin
+    django_apps = plugin_config.django_apps
+    if plugin_name in django_apps:
+        django_apps.pop(plugin_name)
+    if plugin_module not in django_apps:
+        django_apps.append(plugin_module)
 
     # Test if we can import all modules (or its parent, for PluginConfigs and AppConfigs)
-    for app in plugin_apps:
+    for app in django_apps:
         if "." in app:
             parts = app.split(".")
             spec = importlib.util.find_spec(".".join(parts[:-1]))
@@ -687,12 +687,12 @@ for plugin_name in PLUGINS:
             spec = importlib.util.find_spec(app)
         if spec is None:
             raise ImproperlyConfigured(
-                f"Plugin {plugin_name} provides a 'config' variable which contains invalid 'plugin_apps'. "
-                f"The module {app}, from this list, cannot be imported. Check that the additionnal app has been "
+                f"Failed to load django_apps specified by plugin {plugin_name}: {django_apps} "
+                f"The module {app} cannot be imported. Check that the necessary package has been "
                 "installed within the correct Python environment."
             )
 
-    INSTALLED_APPS.extend(plugin_apps)
+    INSTALLED_APPS.extend(django_apps)
 
     # Preserve uniqueness of the INSTALLED_APPS list, we keep the last occurence
     sorted_apps = reversed(list(dict.fromkeys(reversed(INSTALLED_APPS))))


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.

    Specify your assigned issue number on the line below.
-->
### Fixes: #9880

This PR extends the `PluginConfig` class to support a new `django_apps` attribute which would get appended to `INSTALLED_APPS`.

Like so:
```python
from extras.plugins import PluginConfig

class FooBarConfig(PluginConfig):
    name = 'foo_bar'
    verbose_name = 'Foo Bar'
    description = 'An example NetBox plugin'
    version = '0.1'
    author = 'Jeremy Stretch'
    author_email = 'author@example.com'
    base_url = 'foo-bar'
    required_settings = []
    default_settings = {
        'baz': True
    }
    django_apps = ["foo", "bar", "baz"] ### <<< HERE

config = FooBarConfig
```

These new apps should be inserted before the plugin that requires it, but after existing "core" apps in order to avoid conflicts. If the plugin's  `PluginConfig` is in the supplied list of modules, then the list is appended as-is to the INSTALLED_APPS. If, however, the plugin name is added in there, it will be silently removed and its `PluginConfig` will be added instead.
