### PR TITLE
10491 improve error message for ProtectedError on contact assignment

### DIFF
--- a/netbox/tenancy/models/contacts.py
+++ b/netbox/tenancy/models/contacts.py
@@ -163,8 +163,8 @@ class ContactAssignment(WebhooksMixin, ChangeLoggedModel):
 
     def __str__(self):
         if self.priority:
-            return f"{self.contact} ({self.get_priority_display()})"
-        return str(self.contact)
+            return f"{self.contact} ({self.get_priority_display()}) -> {self.object}"
+        return str(f"{self.contact} -> {self.object}")
 
     def get_absolute_url(self):
         return reverse('tenancy:contact', args=[self.contact.pk])


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.

    Specify your assigned issue number on the line below.
-->
### Fixes: #10491 

<!--
    Please include a summary of the proposed changes below.
-->
@jeremystretch I wasn't sure if there were any side-effects from this str change.  The error handler is at https://github.com/netbox-community/netbox/blob/develop/netbox/utilities/error_handlers.py#L12 For contacts since this is the side the error happens on the protected_objects str is showing the wrong end of the link.  I think changing str to show self.object would break it in other places so showing both sides of the connection in the str seemed like the best approach?