### PR TITLE
Fixes: #10356 backplane connections

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1178,7 +1178,6 @@ class PortTypeChoices(ChoiceSet):
     TYPE_OTHER = 'other'
     TYPE_BACKPLANE = 'backplane'
 
-
     CHOICES = (
         (
             'Copper',

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1176,7 +1176,7 @@ class PortTypeChoices(ChoiceSet):
     TYPE_URM_P4 = 'urm-p4'
     TYPE_URM_P8 = 'urm-p8'
     TYPE_OTHER = 'other'
-    TYPE_BACKPLAME = 'backplane'
+    TYPE_BACKPLANE = 'backplane'
 
 
     CHOICES = (
@@ -1271,7 +1271,7 @@ class CableTypeChoices(ChoiceSet):
     TYPE_SMF_OS2 = 'smf-os2'
     TYPE_AOC = 'aoc'
     TYPE_POWER = 'power'
-    TYPE_BACKPLAME = 'backplane'
+    TYPE_BACKPLANE = 'backplane'
 
     CHOICES = (
         (

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1268,7 +1268,6 @@ class CableTypeChoices(ChoiceSet):
     TYPE_SMF_OS2 = 'smf-os2'
     TYPE_AOC = 'aoc'
     TYPE_POWER = 'power'
-    TYPE_BACKPLANE = 'backplane'
 
     CHOICES = (
         (
@@ -1285,7 +1284,6 @@ class CableTypeChoices(ChoiceSet):
                 (TYPE_DAC_PASSIVE, 'Direct Attach Copper (Passive)'),
                 (TYPE_MRJ21_TRUNK, 'MRJ21 Trunk'),
                 (TYPE_COAXIAL, 'Coaxial'),
-                (TYPE_BACKPLANE, 'Directly connected (Backplane)'),
             ),
         ),
         (

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1176,6 +1176,8 @@ class PortTypeChoices(ChoiceSet):
     TYPE_URM_P4 = 'urm-p4'
     TYPE_URM_P8 = 'urm-p8'
     TYPE_OTHER = 'other'
+    TYPE_BACKPLAME = 'backplane'
+
 
     CHOICES = (
         (
@@ -1199,6 +1201,7 @@ class PortTypeChoices(ChoiceSet):
                 (TYPE_F, 'F Connector'),
                 (TYPE_N, 'N Connector'),
                 (TYPE_MRJ21, 'MRJ21'),
+                (TYPE_BACKPLANE, 'Backplane'),
             ),
         ),
         (

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -783,6 +783,17 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_400GE_QSFP_DD = '400gbase-x-qsfpdd'
     TYPE_400GE_OSFP = '400gbase-x-osfp'
 
+    # Ethernet Backplane
+    TYPE_1GE_KX = '1000base-kx'
+    TYPE_10GE_KR = '10gbase-kr'
+    TYPE_10GE_KX4 = '10gbase-kx4'
+    TYPE_25GE_KR = '25gbase-kr'
+    TYPE_40GE_KR4 = '40gbase-kr4'
+    TYPE_50GE_KR = '50gbase-kr'
+    TYPE_100GE_KP4 = '100gbase-kp4'
+    TYPE_100GE_KR2 = '100gbase-kr2'
+    TYPE_100GE_KR4 = '100gbase-kr4'
+
     # Wireless
     TYPE_80211A = 'ieee802.11a'
     TYPE_80211G = 'ieee802.11g'
@@ -909,6 +920,20 @@ class InterfaceTypeChoices(ChoiceSet):
                 (TYPE_200GE_QSFP56, 'QSFP56 (200GE)'),
                 (TYPE_400GE_QSFP_DD, 'QSFP-DD (400GE)'),
                 (TYPE_400GE_OSFP, 'OSFP (400GE)'),
+            )
+        ),
+        (
+            'Ethernet (backplane)',
+            (
+                (TYPE_1GE_KX, '1000BASE-KX (1GE)'),
+                (TYPE_10GE_KR, '10GBASE-KR (10GE)'),
+                (TYPE_10GE_KX4, '10GBASE-KX4 (10GE)'),
+                (TYPE_25GE_KR, '25GBASE-KR (25GE)'),
+                (TYPE_40GE_KR4, '40GBASE-KR4 (40GE)'),
+                (TYPE_50GE_KR, '50GBASE-KR (50GE)'),
+                (TYPE_100GE_KP4, '100GBASE-KP4 (100GE)'),
+                (TYPE_100GE_KR2, '100GBASE-KR2 (100GE)'),
+                (TYPE_100GE_KR4, '100GBASE-KR4 (100GE)'),
             )
         ),
         (
@@ -1243,6 +1268,7 @@ class CableTypeChoices(ChoiceSet):
     TYPE_SMF_OS2 = 'smf-os2'
     TYPE_AOC = 'aoc'
     TYPE_POWER = 'power'
+    TYPE_BACKPLAME = 'backplane'
 
     CHOICES = (
         (
@@ -1259,6 +1285,7 @@ class CableTypeChoices(ChoiceSet):
                 (TYPE_DAC_PASSIVE, 'Direct Attach Copper (Passive)'),
                 (TYPE_MRJ21_TRUNK, 'MRJ21 Trunk'),
                 (TYPE_COAXIAL, 'Coaxial'),
+                (TYPE_BACKPLANE, 'Backplane'),
             ),
         ),
         (

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1176,7 +1176,6 @@ class PortTypeChoices(ChoiceSet):
     TYPE_URM_P4 = 'urm-p4'
     TYPE_URM_P8 = 'urm-p8'
     TYPE_OTHER = 'other'
-    TYPE_BACKPLANE = 'backplane'
 
     CHOICES = (
         (
@@ -1200,7 +1199,6 @@ class PortTypeChoices(ChoiceSet):
                 (TYPE_F, 'F Connector'),
                 (TYPE_N, 'N Connector'),
                 (TYPE_MRJ21, 'MRJ21'),
-                (TYPE_BACKPLANE, 'Backplane'),
             ),
         ),
         (
@@ -1287,7 +1285,7 @@ class CableTypeChoices(ChoiceSet):
                 (TYPE_DAC_PASSIVE, 'Direct Attach Copper (Passive)'),
                 (TYPE_MRJ21_TRUNK, 'MRJ21 Trunk'),
                 (TYPE_COAXIAL, 'Coaxial'),
-                (TYPE_BACKPLANE, 'Backplane'),
+                (TYPE_BACKPLANE, 'Directly connected (Backplane)'),
             ),
         ),
         (


### PR DESCRIPTION
### Fixes: #10356

- Added new interface-types for backplane connections. The interface types are grouped as "Ethernet (backplane)'. This is inline with other Ethernet types. I refrained from using "IEE 802.3ap" in the group description as its not adequate.  the SIG 802.3ap only was involved for the 1G and 10G speeds, but the newer standards were developed in different SIG.

- Added new port-type backplane to enable modeling of bldecenter-passthru modules (e.g. SBM-25G-P10 which hast 10/25 backplane front ports and 40G/100G fiber rear-ports and acts like a passive media converter).

- Added new cable-type backplane to model the connection for backplane ports/interfaces.