### PR TITLE
10575 add requirements for openid connect packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ psycopg2-binary==2.9.3
 PyYAML==6.0
 sentry-sdk==1.9.10
 social-auth-app-django==5.0.0
-social-auth-core==4.3.0
+social-auth-core[openidconnect]==4.3.0
 svgwrite==1.4.3
 tablib==3.2.1
 tzdata==2022.4


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.

    Specify your assigned issue number on the line below.
-->
### Fixes: #10575 

<!--
    Please include a summary of the proposed changes below.
-->
Adds openid requirements to allow SSO configs to work.  This could be done as a documentation change, but I don't think there is an issue with the could extra installed packages, below are the extra ones that get installed (all dependencies of python-jose).  If needed can remove and just add to the documentation for setting up okta.

ecdsa==0.18.0
pyasn1==0.4.8
python-jose==3.3.0
rsa==4.9
six==1.16.0
