### PR TITLE
Closes #10659: Import signals.py from Plugin

### DIFF
--- a/netbox/extras/plugins/__init__.py
+++ b/netbox/extras/plugins/__init__.py
@@ -2,6 +2,8 @@ import collections
 import inspect
 from packaging import version
 
+from importlib import import_module
+
 from django.apps import AppConfig
 from django.core.exceptions import ImproperlyConfigured
 from django.template.loader import get_template
@@ -60,9 +62,13 @@ class PluginConfig(AppConfig):
     menu_items = 'navigation.menu_items'
     template_extensions = 'template_content.template_extensions'
     user_preferences = 'preferences.preferences'
+    signals = 'signals'
 
     def ready(self):
         plugin_name = self.name.rsplit('.', 1)[-1]
+        
+        # import signals module (if existing)
+        import_module(f"{self.__module__}.{self.signals}")
 
         # Register template content (if defined)
         template_extensions = import_object(f"{self.__module__}.{self.template_extensions}")


### PR DESCRIPTION
This pull request uses the importlib.import_module function from Python to import the signals module from a plugin. This registers the receiver functions to receive signals from django. Maybe someone should add a small documentation page for signal development within plugins. 

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.

    Specify your assigned issue number on the line below.
-->
### Fixes: #10659

<!--
    Please include a summary of the proposed changes below.
-->

- [X]  Implement changes in `extras.plugins.__init__.py`
- [ ] Update documentation