### PR TITLE
Fix LDAP auth: user never updated if inactive

### DIFF
--- a/netbox/netbox/api/authentication.py
+++ b/netbox/netbox/api/authentication.py
@@ -22,22 +22,24 @@ class TokenAuthentication(authentication.TokenAuthentication):
         if token.is_expired:
             raise exceptions.AuthenticationFailed("Token expired")
 
-        if not token.user.is_active:
-            raise exceptions.AuthenticationFailed("User inactive")
-
+        user = token.user
         # When LDAP authentication is active try to load user data from LDAP directory
         if settings.REMOTE_AUTH_BACKEND == 'netbox.authentication.LDAPBackend':
             from netbox.authentication import LDAPBackend
             ldap_backend = LDAPBackend()
 
             # Load from LDAP if FIND_GROUP_PERMS is active
-            if ldap_backend.settings.FIND_GROUP_PERMS:
-                user = ldap_backend.populate_user(token.user.username)
+            # Always query LDAP when user is not active, otherwise it is never activated again
+            if ldap_backend.settings.FIND_GROUP_PERMS or not token.user.is_active:
+                ldap_user = ldap_backend.populate_user(token.user.username)
                 # If the user is found in the LDAP directory use it, if not fallback to the local user
-                if user:
-                    return user, token
+                if ldap_user:
+                    user = ldap_user
 
-        return token.user, token
+        if not user.is_active:
+            raise exceptions.AuthenticationFailed("User inactive")
+
+        return user, token
 
 
 class TokenPermissions(DjangoObjectPermissions):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.

    Specify your assigned issue number on the line below.
-->
### Fixes: #10666

<!--
    Please include a summary of the proposed changes below.
-->

Before this PR, a disabled LDAP user were never enabled again when using API endpoints (DRF or GraphQL).

A LDAP user can be disabled when:
- the LDAP returns an empty 200 when `populate_user() `is called
- someone disables the user in the admin

`populate_user()` were never called for a disabled user.

With this commit, it is always called for a disabled user.