### PR TITLE
10646 fix cable power feed filter

### DIFF
--- a/netbox/dcim/forms/connections.py
+++ b/netbox/dcim/forms/connections.py
@@ -108,7 +108,7 @@ def get_cable_form(a_type, b_type):
                         label='Power Feed',
                         disabled_indicator='_occupied',
                         query_params={
-                            'powerpanel_id': f'$termination_{cable_end}_powerpanel',
+                            'power_panel_id': f'$termination_{cable_end}_powerpanel',
                         }
                     )
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to filing a pull request. This helps avoid
    wasting time and effort on something that we might not be able to accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WE BE CLOSED AUTOMATICALLY.

    Specify your assigned issue number on the line below.
-->
### Fixes: #10646 

<!--
    Please include a summary of the proposed changes below.
-->
Power feeds were not correctly getting filtered to the selected power panel in the Add New Cable page due to a mis-spelling.