### PR TITLE
Closes #10739: Introduce get_queryset() method on generic views

### DIFF
--- a/docs/plugins/development/views.md
+++ b/docs/plugins/development/views.md
@@ -82,23 +82,25 @@ class ThingEditView(ObjectEditView):
 Below are the class definitions for NetBox's object views. These views handle CRUD actions for individual objects. The view, add/edit, and delete views each inherit from `BaseObjectView`, which is not intended to be used directly.
 
 ::: netbox.views.generic.base.BaseObjectView
+    options:
+      members:
+        - get_queryset
+        - get_object
+        - get_extra_context
 
 ::: netbox.views.generic.ObjectView
     options:
       members:
-        - get_object
         - get_template_name
 
 ::: netbox.views.generic.ObjectEditView
     options:
       members:
-        - get_object
         - alter_object
 
 ::: netbox.views.generic.ObjectDeleteView
     options:
-      members:
-        - get_object
+      members: false
 
 ::: netbox.views.generic.ObjectChildrenView
     options:
@@ -111,6 +113,10 @@ Below are the class definitions for NetBox's object views. These views handle CR
 Below are the class definitions for NetBox's multi-object views. These views handle simultaneous actions for sets objects. The list, import, edit, and delete views each inherit from `BaseMultiObjectView`, which is not intended to be used directly.
 
 ::: netbox.views.generic.base.BaseMultiObjectView
+    options:
+      members:
+        - get_queryset
+        - get_extra_context
 
 ::: netbox.views.generic.ObjectListView
     options:

--- a/docs/release-notes/version-3.4.md
+++ b/docs/release-notes/version-3.4.md
@@ -38,6 +38,7 @@ A new `PluginMenu` class has been introduced, which enables a plugin to inject a
 * [#9072](https://github.com/netbox-community/netbox/issues/9072) - Enable registration of tabbed plugin views for core NetBox models
 * [#9880](https://github.com/netbox-community/netbox/issues/9880) - Introduce `django_apps` plugin configuration parameter
 * [#10314](https://github.com/netbox-community/netbox/issues/10314) - Move `clone()` method from NetBoxModel to CloningMixin
+* [#10739](https://github.com/netbox-community/netbox/issues/10739) - Introduce `get_queryset()` method on generic views
 
 ### Other Changes
 


### PR DESCRIPTION
### Fixes: #10739

- Introduce new `BaseView` base class for all generic views
- Add a `get_queryset()` method which accepts the current request as its only argument
- Call `get_queryset()` within `dispatch()` for each request
- Update plugin development documentation