### PR TITLE
10719 check ip permission on fhrpgroup form save

### DIFF
--- a/netbox/ipam/forms/models.py
+++ b/netbox/ipam/forms/models.py
@@ -550,26 +550,6 @@ class FHRPGroupForm(NetBoxModelForm):
             'protocol', 'group_id', 'auth_type', 'auth_key', 'description', 'ip_vrf', 'ip_address', 'ip_status', 'tags',
         )
 
-    def save(self, *args, **kwargs):
-        instance = super().save(*args, **kwargs)
-
-        # Check if we need to create a new IPAddress for the group
-        if self.cleaned_data.get('ip_address'):
-            ipaddress = IPAddress(
-                vrf=self.cleaned_data['ip_vrf'],
-                address=self.cleaned_data['ip_address'],
-                status=self.cleaned_data['ip_status'],
-                role=FHRP_PROTOCOL_ROLE_MAPPINGS.get(self.cleaned_data['protocol'], IPAddressRoleChoices.ROLE_VIP),
-                assigned_object=instance
-            )
-            ipaddress.save()
-
-            # Check that the new IPAddress conforms with any assigned object-level permissions
-            if not IPAddress.objects.filter(pk=ipaddress.pk).first():
-                raise PermissionsViolation()
-
-        return instance
-
     def clean(self):
         super().clean()
 

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -932,18 +932,19 @@ class FHRPGroupEditView(generic.ObjectEditView):
         return return_url
 
     def save_related_data(self, request, form, obj):
-        ipaddress = IPAddress(
-            vrf=form.cleaned_data['ip_vrf'],
-            address=form.cleaned_data['ip_address'],
-            status=form.cleaned_data['ip_status'],
-            role=FHRP_PROTOCOL_ROLE_MAPPINGS.get(form.cleaned_data['protocol'], IPAddressRoleChoices.ROLE_VIP),
-            assigned_object=obj
-        )
-        ipaddress.save()
+        if form.cleaned_data.get('ip_address'):
+            ipaddress = IPAddress(
+                vrf=form.cleaned_data['ip_vrf'],
+                address=form.cleaned_data['ip_address'],
+                status=form.cleaned_data['ip_status'],
+                role=FHRP_PROTOCOL_ROLE_MAPPINGS.get(form.cleaned_data['protocol'], IPAddressRoleChoices.ROLE_VIP),
+                assigned_object=obj
+            )
+            ipaddress.save()
 
-        # Check that the new IPAddress conforms with any assigned object-level permissions
-        if not IPAddress.objects.restrict(request.user, 'add').filter(pk=ipaddress.pk).first():
-            raise PermissionsViolation()
+            # Check that the new IPAddress conforms with any assigned object-level permissions
+            if not IPAddress.objects.restrict(request.user, 'add').filter(pk=ipaddress.pk).first():
+                raise PermissionsViolation()
 
 
 class FHRPGroupDeleteView(generic.ObjectDeleteView):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #10719 

<!--
    Please include a summary of the proposed changes below.
-->
Moved the save / permission check out of the ipam form and into the view.
Created a save_related_data to make it more generic when using the generic edit form, otherwise would need to copy-pasta the whole post function.
This also showed an existing issue (fixed) where if the form got a permission error it would switch to an edit view (noticeable on the fhrpgroup form) as the obj.pk would be set even though the transaction would be rolled-back.