### PR TITLE
Update installation instructions for RHEL.

### DIFF
--- a/docs/installation/3-netbox.md
+++ b/docs/installation/3-netbox.md
@@ -15,13 +15,14 @@ Begin by installing all system packages required by NetBox and its dependencies.
     sudo apt install -y python3 python3-pip python3-venv python3-dev build-essential libxml2-dev libxslt1-dev libffi-dev libpq-dev libssl-dev zlib1g-dev
     ```
 
-=== "CentOS"
+=== "RHEL"
 
     ```no-highlight
-    sudo yum install -y gcc libxml2-devel libxslt-devel libffi-devel libpq-devel openssl-devel redhat-rpm-config
+    sudo yum install -y python39 gcc libxml2-devel libxslt-devel libffi-devel libpq-devel openssl-devel redhat-rpm-config
+    sudo alternatives --set python3 /usr/bin/python3.9
     ```
 
-Before continuing, check that your installed Python version is at least 3.8:
+Before continuing, check that your installed Python 3 version is at least 3.8:
 
 ```no-highlight
 python3 -V
@@ -61,7 +62,7 @@ If `git` is not already installed, install it:
     sudo apt install -y git
     ```
 
-=== "CentOS"
+=== "RHEL"
 
     ```no-highlight
     sudo yum install -y git
@@ -102,7 +103,7 @@ Create a system user account named `netbox`. We'll configure the WSGI and HTTP s
     sudo chown --recursive netbox /opt/netbox/netbox/media/
     ```
 
-=== "CentOS"
+=== "RHEL"
 
     ```
     sudo groupadd --system netbox


### PR DESCRIPTION
CentOS is RHEL based so the heading makes more sense to be RHEL rather than CentOS. Also I don't think anyone will install netbox on CentOS anymore. RHEL is more likely.

I have installed netbox on RHEL8. The default version of Python 3 is too old, but it's possible to install Python 3.9 from a package. The default python3 is not replaced, so you have to change the pointer to point at python3.9 for the upgrade script to work.

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #1234

<!--
    Please include a summary of the proposed changes below.
-->
