### PR TITLE
10694 remove bulk calls

### DIFF
--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -198,7 +198,7 @@ class CustomField(CloningMixin, ExportTemplatesMixin, WebhooksMixin, ChangeLogge
             instances = model.objects.exclude(**{f'custom_field_data__contains': self.name})
             for instance in instances:
                 instance.custom_field_data[self.name] = self.default
-            model.objects.bulk_update(instances, ['custom_field_data'], batch_size=100)
+                instance.save()
 
     def remove_stale_data(self, content_types):
         """
@@ -210,7 +210,7 @@ class CustomField(CloningMixin, ExportTemplatesMixin, WebhooksMixin, ChangeLogge
             instances = model.objects.filter(**{f'custom_field_data__{self.name}__isnull': False})
             for instance in instances:
                 del instance.custom_field_data[self.name]
-            model.objects.bulk_update(instances, ['custom_field_data'], batch_size=100)
+                instance.save()
 
     def rename_object_data(self, old_name, new_name):
         """
@@ -222,7 +222,7 @@ class CustomField(CloningMixin, ExportTemplatesMixin, WebhooksMixin, ChangeLogge
             instances = model.objects.filter(**params)
             for instance in instances:
                 instance.custom_field_data[new_name] = instance.custom_field_data.pop(old_name)
-            model.objects.bulk_update(instances, ['custom_field_data'], batch_size=100)
+                instance.save()
 
     def clean(self):
         super().clean()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #10694 

<!--
    Please include a summary of the proposed changes below.
-->
Figured we would want this in 3.4 as it will effect new search backend and should be in a .x release for thorough testing.

### bulk_create used in:

**netbox/dcim/models/devices.py** - removed
**netbox/search/backends.py** - this is for the search cache, I think this is okay and doesn't need to be update.

### bulk_update used in:

**netbox/dcim/models/devices.py** - removed
**netbox/extras/models/customfields.py** - removed: Note - this is possibly the largest performance penalty area depending on usage of custom fields...
**netbox/ipam/signals.py** - used to update tree nodes so I think it is okay to leave as bulk operations as nothing outside of MPTT should care about theses.
**netbox/ipam/utils.py** - used to change the ordering of the Prefix objects in the MPTT tree so I think is okay to leave as bulk operations.
**netbox/api/viewsets/mixins.py** - Just internal named function bulk_update, doesn't actually use bulk update operations.
