### PR TITLE
10709 add AzureAD Tenant Oauth2

### DIFF
--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -24,6 +24,7 @@ AUTH_BACKEND_ATTRS = {
     'azuread-oauth2': ('Microsoft Azure AD', 'microsoft'),
     'azuread-b2c-oauth2': ('Microsoft Azure AD', 'microsoft'),
     'azuread-tenant-oauth2': ('Microsoft Azure AD', 'microsoft'),
+    'azuread-v2-tenant-oauth2': ('Microsoft Azure AD', 'microsoft'),
     'bitbucket': ('BitBucket', 'bitbucket'),
     'bitbucket-oauth2': ('BitBucket', 'bitbucket'),
     'digitalocean': ('DigitalOcean', 'digital-ocean'),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #10709 

<!--
    Please include a summary of the proposed changes below.
-->
Adds AzureAD Tenant Oauth2, no way to test - taking from github issue, however did verify this exists in social auth.