### PR TITLE
10653 log failed login attempts on INFO

### DIFF
--- a/netbox/users/apps.py
+++ b/netbox/users/apps.py
@@ -1,7 +1,7 @@
 from django.apps import AppConfig
 
 
-class HomeConfig(AppConfig):
+class UsersConfig(AppConfig):
     name = 'users'
 
     def ready(self):

--- a/netbox/users/apps.py
+++ b/netbox/users/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class HomeConfig(AppConfig):
+    name = 'users'
+
+    def ready(self):
+        import users.signals

--- a/netbox/users/signals.py
+++ b/netbox/users/signals.py
@@ -6,5 +6,5 @@ from django.contrib.auth.signals import user_login_failed
 @receiver(user_login_failed)
 def log_user_login_failed(sender, credentials, request, **kwargs):
     logger = logging.getLogger('netbox.auth.login')
-    username = credentials.get("username", None)
+    username = credentials.get("username")
     logger.info(f"Failed login attempt for username: {username}")

--- a/netbox/users/signals.py
+++ b/netbox/users/signals.py
@@ -1,0 +1,10 @@
+import logging
+from django.dispatch import receiver
+from django.contrib.auth.signals import user_login_failed
+
+
+@receiver(user_login_failed)
+def log_user_login_failed(sender, credentials, request, **kwargs):
+    logger = logging.getLogger('netbox.auth.login')
+    username = credentials.get("username", None)
+    logger.info(f"Failed login attempt for username: {username}")

--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -106,7 +106,7 @@ class LoginView(View):
             return self.redirect_to_next(request, logger)
 
         else:
-            logger.info(f"Login form validation failed for username: {form['username'].value()}")
+            logger.debug(f"Login form validation failed for username: {form['username'].value()}")
 
         return render(request, self.template_name, {
             'form': form,

--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -106,7 +106,7 @@ class LoginView(View):
             return self.redirect_to_next(request, logger)
 
         else:
-            logger.debug("Login form validation failed")
+            logger.info(f"Login form validation failed for username: {form['username'].value()}")
 
         return render(request, self.template_name, {
             'form': form,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #10653 

<!--
    Please include a summary of the proposed changes below.
-->
@jeremystretch Not completely sure of what is the best way here.  The log was done for failed login attempts but at DEBUG level which would be fairly spammy to have on, changed to INFO level also included failed username - I don't think that would violate personal-identifiable-information security issues...  Probably up for discussion if this makes sense to change (from a logging standpoint if that is too much info for some people, and security if the username should be shown).