### PR TITLE
10874 remove link to contact roles

### DIFF
--- a/netbox/templates/tenancy/contactrole.html
+++ b/netbox/templates/tenancy/contactrole.html
@@ -25,7 +25,7 @@
             <tr>
               <th scope="row">Assignments</th>
               <td>
-                <a href="{% url 'tenancy:contact_list' %}?role={{ object.slug }}">{{ assignment_count }}</a>
+                {{ assignment_count }}
               </td>
             </tr>
           </table>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #10874 

<!--
    Please include a summary of the proposed changes below.
-->
Removes the incorrect link on the Contact Role detail page. The link currently goes to contact_list which is incorrect, it should go to contact_assignments_list, but there isn't any currently.  If needed this would need to be a new feature as needs a new list page, url, etc..