### PR TITLE
Closes #10904: Added Colors to SVG for Front and Rear Ports

### DIFF
--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -902,6 +902,9 @@ class FrontPort(ModularComponentModel, CabledObjectModel):
             ('rear_port', 'rear_port_position'),
         )
 
+    def get_color(self):
+        return self.color
+
     def get_absolute_url(self):
         return reverse('dcim:frontport', kwargs={'pk': self.pk})
 
@@ -947,6 +950,9 @@ class RearPort(ModularComponentModel, CabledObjectModel):
     class Meta:
         ordering = ('device', '_name')
         unique_together = ('device', 'name')
+
+    def get_color(self):
+        return self.color
 
     def get_absolute_url(self):
         return reverse('dcim:rearport', kwargs={'pk': self.pk})

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -902,9 +902,6 @@ class FrontPort(ModularComponentModel, CabledObjectModel):
             ('rear_port', 'rear_port_position'),
         )
 
-    def get_color(self):
-        return self.color
-
     def get_absolute_url(self):
         return reverse('dcim:frontport', kwargs={'pk': self.pk})
 
@@ -950,9 +947,6 @@ class RearPort(ModularComponentModel, CabledObjectModel):
     class Meta:
         ordering = ('device', '_name')
         unique_together = ('device', 'name')
-
-    def get_color(self):
-        return self.color
 
     def get_absolute_url(self):
         return reverse('dcim:rearport', kwargs={'pk': self.pk})

--- a/netbox/dcim/svg/cables.py
+++ b/netbox/dcim/svg/cables.py
@@ -166,6 +166,8 @@ class CableTraceSVG:
         """
         if hasattr(instance, 'parent_object'):
             # Termination
+            if(hasattr(instance, 'get_color') and instance.get_color()):
+                return instance.get_color()
             return 'f0f0f0'
         if hasattr(instance, 'device_role'):
             # Device

--- a/netbox/dcim/svg/cables.py
+++ b/netbox/dcim/svg/cables.py
@@ -166,9 +166,7 @@ class CableTraceSVG:
         """
         if hasattr(instance, 'parent_object'):
             # Termination
-            if(hasattr(instance, 'get_color') and instance.get_color()):
-                return instance.get_color()
-            return 'f0f0f0'
+            return getattr(instance, 'color', 'f0f0f0') or 'f0f0f0'
         if hasattr(instance, 'device_role'):
             # Device
             return instance.device_role.color


### PR DESCRIPTION
Fix for feature request 10904 thanks to @TheZackCodec

### Fixes: #10904

When rendering the SVG, checks if a custom color is defined and renders that color on the termination.