### PR TITLE
10903 add module type on manufacturer page

### DIFF
--- a/netbox/templates/dcim/manufacturer.html
+++ b/netbox/templates/dcim/manufacturer.html
@@ -4,10 +4,24 @@
 {% load render_table from django_tables2 %}
 
 {% block extra_controls %}
-  {% if perms.dcim.add_devicetype %}
-    <a href="{% url 'dcim:devicetype_add' %}?manufacturer={{ object.pk }}" class="btn btn-sm btn-primary">
-      <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add Device Type
-    </a>
+  {% if perms.dcim.add_devicetype or perms.dcim.add_moduletype %}
+    <div class="dropdown">
+      <button id="add-components" type="button" class="btn btn-sm btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+        <i class="mdi mdi-plus-thick" aria-hidden="true"></i> Add
+      </button>
+      <ul class="dropdown-menu" aria-labeled-by="add-components">
+        {% if perms.dcim.add_devicetype %}
+          <li><a class="dropdown-item" href="{% url 'dcim:devicetype_add' %}?manufacturer={{ object.pk }}">
+            Add Device Type
+          </a></li>
+        {% endif %}
+        {% if perms.dcim.add_moduletype %}
+          <li><a class="dropdown-item" href="{% url 'dcim:moduletype_add' %}?manufacturer={{ object.pk }}">
+            Add Module Type
+          </a></li>
+        {% endif %}
+      </ul>
+    </div>
   {% endif %}
 {% endblock extra_controls %}
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #10903 

<!--
    Please include a summary of the proposed changes below.
-->
Adds "Add Module Type" button to manufacturers detail page.  Converts existing "Add Device Type" button to an "Add" dropdown as it now has two buttons (see screenshot):
![Monosnap APC | NetBox 2022-11-14 10-21-24](https://user-images.githubusercontent.com/99642/201736644-7ee62e65-4553-401f-9333-180bf8a7c837.png)
