### PR TITLE
10919 add location to cable termination panels

### DIFF
--- a/netbox/templates/dcim/inc/cable_termination.html
+++ b/netbox/templates/dcim/inc/cable_termination.html
@@ -8,6 +8,10 @@
         <td>{{ terminations.0.device.site|linkify }}</td>
       </tr>
       <tr>
+        <td>Location</td>
+        <td>{{ terminations.0.device.location|linkify|placeholder }}</td>
+      </tr>
+      <tr>
         <td>Rack</td>
         <td>{{ terminations.0.device.rack|linkify|placeholder }}</td>
       </tr>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #10919 

<!--
    Please include a summary of the proposed changes below.
-->
Adds Location to cable termination panels - see screenshot:
![Monosnap #107 | NetBox 2022-11-15 08-10-53](https://user-images.githubusercontent.com/99642/201969417-efa09141-f9b4-4d92-86d1-8ef0f05bc87b.png)
