### PR TITLE
Fixes #10946 - Check that device has a platform set before rendering napalm tab

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -2072,6 +2072,7 @@ class NAPALMViewTab(ViewTab):
         if not (
             instance.status == 'active' and
             instance.primary_ip and
+            instance.platform and
             instance.platform.napalm_driver
         ):
             return None


### PR DESCRIPTION
### Fixes: #10946

Check for platform before rendering napalm tab