### PR TITLE
Fixes #10948 - Linkify primary IP for VDC

### DIFF
--- a/netbox/templates/dcim/virtualdevicecontext.html
+++ b/netbox/templates/dcim/virtualdevicecontext.html
@@ -31,13 +31,13 @@
           <tr>
             <th scope="row">Primary IPv4</th>
             <td>
-              {{ object.primary_ip4|placeholder }}
+              {{ object.primary_ip4|linkify|placeholder }}
             </td>
           </tr>
           <tr>
             <th scope="row">Primary IPv6</th>
             <td>
-              {{ object.primary_ip6|placeholder }}
+              {{ object.primary_ip6|linkify|placeholder }}
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
### Fixes: #10948 

Linkify primary IP for VDC