### PR TITLE
DCIM: Added sorting by Display Name to Rack Elevations (missed in #9665)

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -592,6 +592,8 @@ class RackElevationListView(generic.ObjectListView):
         ORDERING_CHOICES = {
             'name': 'Name (A-Z)',
             '-name': 'Name (Z-A)',
+            'display': 'Display Name (A-Z)',
+            '-display': 'Display Name (Z-A)',
             'facility_id': 'Facility ID (A-Z)',
             '-facility_id': 'Facility ID (Z-A)',
         }


### PR DESCRIPTION
#9665 introduced Rack Elevations sorting. We don't use facility_id, and sort by 'name' field works also wrong:

Look at this: 7 < 14, but not for this kind of sorting!
```json
{
    "count": 43,
    "next": "https://netbox.example.com/api/dcim/racks/?brief=1&limit=10&offset=10&ordering=name&tag=vpc-ru-7a",
    "previous": null,
    "results": [
        {
            "id": 1729,
            "url": "https://netbox.example.com/api/dcim/racks/1729/",
            "display": "3.14.18",
            "name": "3.14.18",
            "device_count": 19
        },
        {
            "id": 1730,
            "url": "https://netbox.example.com/api/dcim/racks/1730/",
            "display": "3.14.19",
            "name": "3.14.19",
            "device_count": 16
        },
        {
            "id": 1731,
            "url": "https://netbox.example.com/api/dcim/racks/1731/",
            "display": "3.14.20",
            "name": "3.14.20",
            "device_count": 18
        },
        {
            "id": 1732,
            "url": "https://netbox.example.com/api/dcim/racks/1732/",
            "display": "3.14.21",
            "name": "3.14.21",
            "device_count": 18
        },
        {
            "id": 1733,
            "url": "https://netbox.example.com/api/dcim/racks/1733/",
            "display": "3.14.22",
            "name": "3.14.22",
            "device_count": 18
        },
        {
            "id": 1734,
            "url": "https://netbox.example.com/api/dcim/racks/1734/",
            "display": "3.14.23",
            "name": "3.14.23",
            "device_count": 17
        },
        {
            "id": 1735,
            "url": "https://netbox.example.com/api/dcim/racks/1735/",
            "display": "3.14.24",
            "name": "3.14.24",
            "device_count": 18
        },
        {
            "id": 1736,
            "url": "https://netbox.example.com/api/dcim/racks/1736/",
            "display": "3.14.25",
            "name": "3.14.25",
            "device_count": 17
        },
        {
            "id": 2723,
            "url": "https://netbox.example.com/api/dcim/racks/2723/",
            "display": "3.7.10",
            "name": "3.7.10",
            "device_count": 22
        },
        {
            "id": 2724,
            "url": "https://netbox.example.com/api/dcim/racks/2724/",
            "display": "3.7.11",
            "name": "3.7.11",
            "device_count": 23
        }
    ]
}
```

Then we try to sort by Display Name:

```
{
    "count": 43,
    "next": "https://netbox.example.com/api/dcim/racks/?brief=1&limit=10&offset=10&ordering=display&tag=vpc-ru-7a",
    "previous": null,
    "results": [
        {
            "id": 2716,
            "url": "https://netbox.example.com/api/dcim/racks/2716/",
            "display": "3.7.3",
            "name": "3.7.3",
            "device_count": 19
        },
        {
            "id": 2717,
            "url": "https://netbox.example.com/api/dcim/racks/2717/",
            "display": "3.7.4",
            "name": "3.7.4",
            "device_count": 19
        },
        {
            "id": 2718,
            "url": "https://netbox.example.com/api/dcim/racks/2718/",
            "display": "3.7.5",
            "name": "3.7.5",
            "device_count": 20
        },
        {
            "id": 2719,
            "url": "https://netbox.example.com/api/dcim/racks/2719/",
            "display": "3.7.6",
            "name": "3.7.6",
            "device_count": 21
        },
        {
            "id": 2720,
            "url": "https://netbox.example.com/api/dcim/racks/2720/",
            "display": "3.7.7",
            "name": "3.7.7",
            "device_count": 20
        },
        {
            "id": 2721,
            "url": "https://netbox.example.com/api/dcim/racks/2721/",
            "display": "3.7.8",
            "name": "3.7.8",
            "device_count": 23
        },
        {
            "id": 2722,
            "url": "https://netbox.example.com/api/dcim/racks/2722/",
            "display": "3.7.9",
            "name": "3.7.9",
            "device_count": 23
        },
        {
            "id": 2723,
            "url": "https://netbox.example.com/api/dcim/racks/2723/",
            "display": "3.7.10",
            "name": "3.7.10",
            "device_count": 22
        },
        {
            "id": 2724,
            "url": "https://netbox.example.com/api/dcim/racks/2724/",
            "display": "3.7.11",
            "name": "3.7.11",
            "device_count": 23
        },
        {
            "id": 2725,
            "url": "https://netbox.example.com/api/dcim/racks/2725/",
            "display": "3.7.12",
            "name": "3.7.12",
            "device_count": 22
        }
    ]
}
```

And this ordering as expected by human: all 3.7.x racks, then 3.8.x racks...