### PR TITLE
10999 fix power utilization on Device detail

### DIFF
--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -229,7 +229,7 @@
                                 <th>Utilization</th>
                             </tr>
                             {% for powerport in object.powerports.all %}
-                                {% with utilization=powerport.get_power_draw powerfeed=powerport.connected_endpoint %}
+                                {% with utilization=powerport.get_power_draw powerfeed=powerport.connected_endpoints.0 %}
                                     <tr>
                                         <td>{{ powerport }}</td>
                                         <td>{{ utilization.outlet_count }}</td>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #10999 

<!--
    Please include a summary of the proposed changes below.
-->
Fixes power utilization on device detail page with the repro given in the ticket screenshots show before (no info for available or utilization, after correct graphs are shown)
![Monosnap PowerRail | NetBox 2022-11-28 08-45-58](https://user-images.githubusercontent.com/99642/204334684-2efe08b4-c746-4f42-88c1-b42e59c4efd6.png)
![Monosnap PowerRail | NetBox 2022-11-28 08-46-24](https://user-images.githubusercontent.com/99642/204334685-b63437b6-e220-4c7d-9fc7-53352a36b8a5.png)
