### PR TITLE
11041 return power percentage with 1 decimal place

### DIFF
--- a/netbox/utilities/templatetags/helpers.py
+++ b/netbox/utilities/templatetags/helpers.py
@@ -138,7 +138,8 @@ def percentage(x, y):
     """
     if x is None or y is None:
         return None
-    return round(x / y * 100)
+
+    return round(x / y * 100, 1)
 
 
 @register.filter()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11041 

<!--
    Please include a summary of the proposed changes below.
-->
See bug report - power feed utilization is shown as percentage with 1 decimal place, but the function returns with 0 decimal places, this fixes it to return one decimal place.  Code search shows percentage template tag only used for showing power graphs so should have no side-effects.

![Monosnap TestFeed1 | NetBox 2022-12-01 08-52-48](https://user-images.githubusercontent.com/99642/205112578-61002821-f9c2-4be1-996d-48a401f534d1.png)
