### PR TITLE
Fixes #11046: Restrict length of indexed search values

### DIFF
--- a/netbox/extras/migrations/0083_search.py
+++ b/netbox/extras/migrations/0083_search.py
@@ -2,7 +2,6 @@ import sys
 import uuid
 
 import django.db.models.deletion
-import django.db.models.functions.text
 import django.db.models.lookups
 from django.core import management
 from django.db import migrations, models
@@ -47,10 +46,6 @@ class Migration(migrations.Migration):
             ],
             options={
                 'ordering': ('weight', 'object_type', 'object_id'),
-                'indexes': (
-                    models.Index(condition=models.Q(django.db.models.lookups.LessThan(django.db.models.functions.text.Length('value'), 1024)), fields=['value'], name='extras_cachedvalue_value'),
-                    models.Index(condition=models.Q(django.db.models.lookups.LessThan(django.db.models.functions.text.Length('value'), 1024)), fields=['value'], name='extras_cachedvalue_value_like', opclasses=['text_pattern_ops']),
-                )
             },
         ),
         migrations.RunPython(

--- a/netbox/extras/migrations/0083_search.py
+++ b/netbox/extras/migrations/0083_search.py
@@ -2,6 +2,8 @@ import sys
 import uuid
 
 import django.db.models.deletion
+import django.db.models.functions.text
+import django.db.models.lookups
 from django.core import management
 from django.db import migrations, models
 
@@ -39,12 +41,16 @@ class Migration(migrations.Migration):
                 ('object_id', models.PositiveBigIntegerField()),
                 ('field', models.CharField(max_length=200)),
                 ('type', models.CharField(max_length=30)),
-                ('value', models.TextField(db_index=True)),
+                ('value', models.TextField()),
                 ('weight', models.PositiveSmallIntegerField(default=1000)),
                 ('object_type', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='+', to='contenttypes.contenttype')),
             ],
             options={
                 'ordering': ('weight', 'object_type', 'object_id'),
+                'indexes': (
+                    models.Index(condition=models.Q(django.db.models.lookups.LessThan(django.db.models.functions.text.Length('value'), 1024)), fields=['value'], name='extras_cachedvalue_value'),
+                    models.Index(condition=models.Q(django.db.models.lookups.LessThan(django.db.models.functions.text.Length('value'), 1024)), fields=['value'], name='extras_cachedvalue_value_like', opclasses=['text_pattern_ops']),
+                )
             },
         ),
         migrations.RunPython(

--- a/netbox/extras/models/search.py
+++ b/netbox/extras/models/search.py
@@ -53,13 +53,13 @@ class CachedValue(models.Model):
             Index(
                 fields=['value'],
                 name='extras_cachedvalue_value',
-                condition=Q(LessThan(Length('value'), 1024))
+                condition=Q(LessThan(Length('value'), INDEX_MAX))
             ),
             Index(
                 fields=['value'],
                 name='extras_cachedvalue_value_like',
                 opclasses=['text_pattern_ops'],
-                condition=Q(LessThan(Length('value'), 1024))
+                condition=Q(LessThan(Length('value'), INDEX_MAX))
             ),
         )
 

--- a/netbox/extras/models/search.py
+++ b/netbox/extras/models/search.py
@@ -2,18 +2,12 @@ import uuid
 
 from django.contrib.contenttypes.models import ContentType
 from django.db import models
-from django.db.models import Index, Q
-from django.db.models.functions import Length
-from django.db.models.lookups import LessThan
 
 from utilities.fields import RestrictedGenericForeignKey
 
 __all__ = (
     'CachedValue',
 )
-
-# Maximum cached value length to index (see #11046)
-INDEX_MAX = 1024
 
 
 class CachedValue(models.Model):
@@ -49,19 +43,6 @@ class CachedValue(models.Model):
 
     class Meta:
         ordering = ('weight', 'object_type', 'object_id')
-        indexes = (
-            Index(
-                fields=['value'],
-                name='extras_cachedvalue_value',
-                condition=Q(LessThan(Length('value'), INDEX_MAX))
-            ),
-            Index(
-                fields=['value'],
-                name='extras_cachedvalue_value_like',
-                opclasses=['text_pattern_ops'],
-                condition=Q(LessThan(Length('value'), INDEX_MAX))
-            ),
-        )
 
     def __str__(self):
         return f'{self.object_type} {self.object_id}: {self.field}={self.value}'


### PR DESCRIPTION
### Fixes: #11046


This adjusts the indexes on `CachedValue.value` to index only values less than 1024 bytes in length. This may need further experimentation but it seemed like a reasonable cut-off.