### PR TITLE
Closes #10945: Enable recurring execution of scheduled reports & scripts

### DIFF
--- a/netbox/dcim/tables/sites.py
+++ b/netbox/dcim/tables/sites.py
@@ -99,9 +99,9 @@ class SiteTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = Site
         fields = (
-            'pk', 'id', 'name', 'slug', 'status', 'facility', 'region', 'group', 'tenant', 'tenant_group', 'asns', 'asn_count',
-            'time_zone', 'description', 'physical_address', 'shipping_address', 'latitude', 'longitude', 'comments',
-            'contacts', 'tags', 'created', 'last_updated', 'actions',
+            'pk', 'id', 'name', 'slug', 'status', 'facility', 'region', 'group', 'tenant', 'tenant_group', 'asns',
+            'asn_count', 'time_zone', 'description', 'physical_address', 'shipping_address', 'latitude', 'longitude',
+            'comments', 'contacts', 'tags', 'created', 'last_updated', 'actions',
         )
         default_columns = ('pk', 'name', 'status', 'facility', 'region', 'group', 'tenant', 'description')
 

--- a/netbox/extras/api/serializers.py
+++ b/netbox/extras/api/serializers.py
@@ -385,8 +385,8 @@ class JobResultSerializer(BaseModelSerializer):
     class Meta:
         model = JobResult
         fields = [
-            'id', 'url', 'display', 'status', 'created', 'scheduled', 'started', 'completed', 'name', 'obj_type',
-            'user', 'data', 'job_id',
+            'id', 'url', 'display', 'status', 'created', 'scheduled', 'interval', 'started', 'completed', 'name',
+            'obj_type', 'user', 'data', 'job_id',
         ]
 
 

--- a/netbox/extras/api/serializers.py
+++ b/netbox/extras/api/serializers.py
@@ -414,6 +414,7 @@ class ReportDetailSerializer(ReportSerializer):
 
 class ReportInputSerializer(serializers.Serializer):
     schedule_at = serializers.DateTimeField(required=False, allow_null=True)
+    interval = serializers.IntegerField(required=False, allow_null=True)
 
 
 #
@@ -448,6 +449,7 @@ class ScriptInputSerializer(serializers.Serializer):
     data = serializers.JSONField()
     commit = serializers.BooleanField()
     schedule_at = serializers.DateTimeField(required=False, allow_null=True)
+    interval = serializers.IntegerField(required=False, allow_null=True)
 
 
 class ScriptLogMessageSerializer(serializers.Serializer):

--- a/netbox/extras/choices.py
+++ b/netbox/extras/choices.py
@@ -148,12 +148,12 @@ class JobResultStatusChoices(ChoiceSet):
     STATUS_FAILED = 'failed'
 
     CHOICES = (
-        (STATUS_PENDING, 'Pending'),
-        (STATUS_SCHEDULED, 'Scheduled'),
-        (STATUS_RUNNING, 'Running'),
-        (STATUS_COMPLETED, 'Completed'),
-        (STATUS_ERRORED, 'Errored'),
-        (STATUS_FAILED, 'Failed'),
+        (STATUS_PENDING, 'Pending', 'cyan'),
+        (STATUS_SCHEDULED, 'Scheduled', 'gray'),
+        (STATUS_RUNNING, 'Running', 'blue'),
+        (STATUS_COMPLETED, 'Completed', 'green'),
+        (STATUS_ERRORED, 'Errored', 'red'),
+        (STATUS_FAILED, 'Failed', 'red'),
     )
 
     TERMINAL_STATE_CHOICES = (

--- a/netbox/extras/filtersets.py
+++ b/netbox/extras/filtersets.py
@@ -17,10 +17,10 @@ __all__ = (
     'ConfigContextFilterSet',
     'ContentTypeFilterSet',
     'CustomFieldFilterSet',
-    'JobResultFilterSet',
     'CustomLinkFilterSet',
     'ExportTemplateFilterSet',
     'ImageAttachmentFilterSet',
+    'JobResultFilterSet',
     'JournalEntryFilterSet',
     'LocalConfigContextFilterSet',
     'ObjectChangeFilterSet',
@@ -537,7 +537,7 @@ class JobResultFilterSet(BaseFilterSet):
 
     class Meta:
         model = JobResult
-        fields = ('id', 'status', 'user', 'obj_type', 'name')
+        fields = ('id', 'interval', 'status', 'user', 'obj_type', 'name')
 
     def search(self, queryset, name, value):
         if not value.strip():

--- a/netbox/extras/forms/reports.py
+++ b/netbox/extras/forms/reports.py
@@ -15,3 +15,8 @@ class ReportForm(BootstrapMixin, forms.Form):
         label=_("Schedule at"),
         help_text=_("Schedule execution of report to a set time"),
     )
+    interval = forms.IntegerField(
+        required=False,
+        label=_("Recurs every"),
+        help_text=_("Interval at which this report is re-run (in minutes)")
+    )

--- a/netbox/extras/forms/reports.py
+++ b/netbox/extras/forms/reports.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils import timezone
 from django.utils.translation import gettext as _
 
 from utilities.forms import BootstrapMixin, DateTimePicker
@@ -17,6 +18,14 @@ class ReportForm(BootstrapMixin, forms.Form):
     )
     interval = forms.IntegerField(
         required=False,
+        min_value=1,
         label=_("Recurs every"),
         help_text=_("Interval at which this report is re-run (in minutes)")
     )
+
+    def clean_schedule_at(self):
+        scheduled_time = self.cleaned_data['schedule_at']
+        if scheduled_time and scheduled_time < timezone.now():
+            raise forms.ValidationError(_('Scheduled time must be in the future.'))
+
+        return scheduled_time

--- a/netbox/extras/forms/scripts.py
+++ b/netbox/extras/forms/scripts.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.utils import timezone
 from django.utils.translation import gettext as _
 
 from utilities.forms import BootstrapMixin, DateTimePicker
@@ -23,6 +24,7 @@ class ScriptForm(BootstrapMixin, forms.Form):
     )
     _interval = forms.IntegerField(
         required=False,
+        min_value=1,
         label=_("Recurs every"),
         help_text=_("Interval at which this script is re-run (in minutes)")
     )
@@ -37,6 +39,15 @@ class ScriptForm(BootstrapMixin, forms.Form):
         self.fields['_schedule_at'] = schedule_at
         self.fields['_interval'] = interval
         self.fields['_commit'] = commit
+
+    def clean__schedule_at(self):
+        scheduled_time = self.cleaned_data['_schedule_at']
+        if scheduled_time and scheduled_time < timezone.now():
+            raise forms.ValidationError({
+                '_schedule_at': _('Scheduled time must be in the future.')
+            })
+
+        return scheduled_time
 
     @property
     def requires_input(self):

--- a/netbox/extras/forms/scripts.py
+++ b/netbox/extras/forms/scripts.py
@@ -21,19 +21,26 @@ class ScriptForm(BootstrapMixin, forms.Form):
         label=_("Schedule at"),
         help_text=_("Schedule execution of script to a set time"),
     )
+    _interval = forms.IntegerField(
+        required=False,
+        label=_("Recurs every"),
+        help_text=_("Interval at which this script is re-run (in minutes)")
+    )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # Move _commit and _schedule_at to the end of the form
         schedule_at = self.fields.pop('_schedule_at')
+        interval = self.fields.pop('_interval')
         commit = self.fields.pop('_commit')
         self.fields['_schedule_at'] = schedule_at
+        self.fields['_interval'] = interval
         self.fields['_commit'] = commit
 
     @property
     def requires_input(self):
         """
-        A boolean indicating whether the form requires user input (ignore the _commit and _schedule_at fields).
+        A boolean indicating whether the form requires user input (ignore the built-in fields).
         """
-        return bool(len(self.fields) > 2)
+        return bool(len(self.fields) > 3)

--- a/netbox/extras/migrations/0079_scheduled_jobs.py
+++ b/netbox/extras/migrations/0079_scheduled_jobs.py
@@ -1,3 +1,4 @@
+import django.core.validators
 from django.db import migrations, models
 
 
@@ -16,7 +17,7 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='jobresult',
             name='interval',
-            field=models.PositiveIntegerField(blank=True, null=True),
+            field=models.PositiveIntegerField(blank=True, null=True, validators=[django.core.validators.MinValueValidator(1)]),
         ),
         migrations.AddField(
             model_name='jobresult',

--- a/netbox/extras/migrations/0079_scheduled_jobs.py
+++ b/netbox/extras/migrations/0079_scheduled_jobs.py
@@ -15,6 +15,11 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='jobresult',
+            name='interval',
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name='jobresult',
             name='started',
             field=models.DateTimeField(blank=True, null=True),
         ),

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -7,7 +7,7 @@ from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
-from django.core.validators import ValidationError
+from django.core.validators import MinValueValidator, ValidationError
 from django.db import models
 from django.http import HttpResponse, QueryDict
 from django.urls import reverse
@@ -590,6 +590,9 @@ class JobResult(models.Model):
     interval = models.PositiveIntegerField(
         blank=True,
         null=True,
+        validators=(
+            MinValueValidator(1),
+        ),
         help_text=_("Recurrence interval (in minutes)")
     )
     started = models.DateTimeField(

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -640,6 +640,9 @@ class JobResult(models.Model):
     def get_absolute_url(self):
         return reverse(f'extras:{self.obj_type.name}_result', args=[self.pk])
 
+    def get_status_color(self):
+        return JobResultStatusChoices.colors.get(self.status)
+
     @property
     def duration(self):
         if not self.completed:

--- a/netbox/extras/reports.py
+++ b/netbox/extras/reports.py
@@ -1,8 +1,8 @@
-import importlib
 import inspect
 import logging
 import pkgutil
 import traceback
+from datetime import timedelta
 
 from django.conf import settings
 from django.utils import timezone
@@ -10,7 +10,6 @@ from django_rq import job
 
 from .choices import JobResultStatusChoices, LogLevelChoices
 from .models import JobResult
-
 
 logger = logging.getLogger(__name__)
 
@@ -85,10 +84,23 @@ def run_report(job_result, *args, **kwargs):
     try:
         job_result.start()
         report.run(job_result)
-    except Exception as e:
+    except Exception:
         job_result.set_status(JobResultStatusChoices.STATUS_ERRORED)
         job_result.save()
         logging.error(f"Error during execution of report {job_result.name}")
+    finally:
+        # Schedule the next job if an interval has been set
+        if job_result.interval:
+            new_scheduled_time = job_result.scheduled + timedelta(minutes=job_result.interval)
+            JobResult.enqueue_job(
+                run_report,
+                name=job_result.name,
+                obj_type=job_result.obj_type,
+                user=job_result.user,
+                job_timeout=report.job_timeout,
+                schedule_at=new_scheduled_time,
+                interval=job_result.interval
+            )
 
 
 class Report(object):

--- a/netbox/extras/reports.py
+++ b/netbox/extras/reports.py
@@ -90,8 +90,9 @@ def run_report(job_result, *args, **kwargs):
         logging.error(f"Error during execution of report {job_result.name}")
     finally:
         # Schedule the next job if an interval has been set
-        if job_result.interval:
-            new_scheduled_time = job_result.scheduled + timedelta(minutes=job_result.interval)
+        start_time = job_result.scheduled or job_result.started
+        if start_time and job_result.interval:
+            new_scheduled_time = start_time + timedelta(minutes=job_result.interval)
             JobResult.enqueue_job(
                 run_report,
                 name=job_result.name,

--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -4,8 +4,9 @@ import logging
 import os
 import pkgutil
 import sys
-import traceback
 import threading
+import traceback
+from datetime import timedelta
 
 import yaml
 from django import forms
@@ -16,6 +17,7 @@ from django.utils.functional import classproperty
 
 from extras.api.serializers import ScriptOutputSerializer
 from extras.choices import JobResultStatusChoices, LogLevelChoices
+from extras.models import JobResult
 from extras.signals import clear_webhooks
 from ipam.formfields import IPAddressFormField, IPNetworkFormField
 from ipam.validators import MaxPrefixLengthValidator, MinPrefixLengthValidator, prefix_validator
@@ -490,6 +492,22 @@ def run_script(data, request, commit=True, *args, **kwargs):
             _run_script()
     else:
         _run_script()
+
+    # Schedule the next job if an interval has been set
+    if job_result.interval:
+        new_scheduled_time = job_result.scheduled + timedelta(minutes=job_result.interval)
+        JobResult.enqueue_job(
+            run_script,
+            name=job_result.name,
+            obj_type=job_result.obj_type,
+            user=job_result.user,
+            schedule_at=new_scheduled_time,
+            interval=job_result.interval,
+            job_timeout=script.job_timeout,
+            data=data,
+            request=request,
+            commit=commit
+        )
 
 
 def get_scripts(use_names=False):

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -8,9 +8,9 @@ from .template_code import *
 __all__ = (
     'ConfigContextTable',
     'CustomFieldTable',
-    'JobResultTable',
     'CustomLinkTable',
     'ExportTemplateTable',
+    'JobResultTable',
     'JournalEntryTable',
     'ObjectChangeTable',
     'SavedFilterTable',
@@ -41,7 +41,6 @@ class JobResultTable(NetBoxTable):
     name = tables.Column(
         linkify=True
     )
-
     actions = columns.ActionsColumn(
         actions=('delete',)
     )
@@ -49,10 +48,12 @@ class JobResultTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = JobResult
         fields = (
-            'pk', 'id', 'name', 'obj_type', 'status', 'created', 'scheduled', 'started', 'completed', 'user', 'job_id',
+            'pk', 'id', 'name', 'obj_type', 'status', 'created', 'scheduled', 'interval', 'started', 'completed',
+            'user', 'job_id',
         )
         default_columns = (
-            'pk', 'id', 'name', 'obj_type', 'status', 'created', 'scheduled', 'started', 'completed', 'user',
+            'pk', 'id', 'name', 'obj_type', 'status', 'created', 'scheduled', 'interval', 'started', 'completed',
+            'user',
         )
 
 

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -1,5 +1,6 @@
 import django_tables2 as tables
 from django.conf import settings
+from django.utils.translation import gettext as _
 
 from extras.models import *
 from netbox.tables import NetBoxTable, columns
@@ -41,6 +42,15 @@ class JobResultTable(NetBoxTable):
     name = tables.Column(
         linkify=True
     )
+    obj_type = columns.ContentTypeColumn(
+        verbose_name=_('Type')
+    )
+    status = columns.ChoiceFieldColumn()
+    created = columns.DateTimeColumn()
+    scheduled = columns.DateTimeColumn()
+    interval = columns.DurationColumn()
+    started = columns.DateTimeColumn()
+    completed = columns.DateTimeColumn()
     actions = columns.ActionsColumn(
         actions=('delete',)
     )
@@ -48,11 +58,11 @@ class JobResultTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = JobResult
         fields = (
-            'pk', 'id', 'name', 'obj_type', 'status', 'created', 'scheduled', 'interval', 'started', 'completed',
+            'pk', 'id', 'obj_type', 'name', 'status', 'created', 'scheduled', 'interval', 'started', 'completed',
             'user', 'job_id',
         )
         default_columns = (
-            'pk', 'id', 'name', 'obj_type', 'status', 'created', 'scheduled', 'interval', 'started', 'completed',
+            'pk', 'id', 'obj_type', 'name', 'status', 'created', 'scheduled', 'interval', 'started', 'completed',
             'user',
         )
 

--- a/netbox/netbox/navigation/menu.py
+++ b/netbox/netbox/navigation/menu.py
@@ -299,7 +299,7 @@ OTHER_MENU = Menu(
                 ),
                 MenuItem(
                     link='extras:jobresult_list',
-                    link_text=_('Job Results'),
+                    link_text=_('Jobs'),
                     permissions=['extras.view_jobresult'],
                 ),
             ),

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -28,6 +28,7 @@ __all__ = (
     'ContentTypesColumn',
     'CustomFieldColumn',
     'CustomLinkColumn',
+    'DurationColumn',
     'LinkedCountColumn',
     'MarkdownColumn',
     'ManyToManyColumn',
@@ -75,6 +76,24 @@ class DateTimeColumn(tables.DateTimeColumn):
     def from_field(cls, field, **kwargs):
         if isinstance(field, DateTimeField):
             return cls(**kwargs)
+
+
+class DurationColumn(tables.Column):
+    """
+    Express a duration of time (in minutes) in a human-friendly format. Example: 437 minutes becomes "7h 17m"
+    """
+    def render(self, value):
+        ret = ''
+        if days := value // 1440:
+            ret += f'{days}d '
+        if hours := value % 1440 // 60:
+            ret += f'{hours}h '
+        if minutes := value % 60:
+            ret += f'{minutes}m'
+        return ret.strip()
+
+    def value(self, value):
+        return value
 
 
 class ManyToManyColumn(tables.ManyToManyColumn):

--- a/netbox/templates/extras/htmx/report_result.html
+++ b/netbox/templates/extras/htmx/report_result.html
@@ -1,10 +1,11 @@
+{% load humanize %}
 {% load helpers %}
 
 <p>
   {% if result.started %}
     Started: <strong>{{ result.started|annotated_date }}</strong>
   {% elif result.scheduled %}
-    Scheduled for: <strong>{{ result.scheduled|annotated_date }}</strong>
+    Scheduled for: <strong>{{ result.scheduled|annotated_date }}</strong> ({{ result.scheduled|naturaltime }})
   {% else %}
     Created: <strong>{{ result.created|annotated_date }}</strong>
   {% endif %}

--- a/netbox/templates/extras/htmx/script_result.html
+++ b/netbox/templates/extras/htmx/script_result.html
@@ -5,7 +5,7 @@
   {% if result.started %}
     Started: <strong>{{ result.started|annotated_date }}</strong>
   {% elif result.scheduled %}
-    Scheduled for: <strong>{{ result.scheduled|annotated_date }}</strong>
+    Scheduled for: <strong>{{ result.scheduled|annotated_date }}</strong> ({{ result.scheduled|naturaltime }})
   {% else %}
     Created: <strong>{{ result.created|annotated_date }}</strong>
   {% endif %}


### PR DESCRIPTION
### Closes: #10945

- Add an `interval` field to the JobResult model
- Extend the UI & API views to record recurrence interval (in minutes) when scheduling jobs
- Extend workers to automatically reschedule jobs with an interval defined