### PR TITLE
Fixes #11022 - Allow redefining internally used background queues 

### DIFF
--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -141,6 +141,22 @@ When determining the primary IP address for a device, IPv6 is preferred over IPv
 
 ---
 
+## QUEUE_MAPPINGS
+
+Allows changing which queues are used internally for background tasks.
+
+```python
+QUEUE_MAPPINGS = {
+    'webhook': 'low',
+    'report': 'high',
+    'script': 'high',
+}
+```
+
+If no queue is defined the queue named `default` will be used.
+
+---
+
 ## RELEASE_CHECK_URL
 
 Default: None (disabled)

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -21,6 +21,7 @@ from extras.choices import *
 from extras.constants import *
 from extras.conditions import ConditionSet
 from extras.utils import FeatureQuery, image_upload
+from netbox.config import get_config
 from netbox.models import ChangeLoggedModel
 from netbox.models.features import (
     CloningMixin, CustomFieldsMixin, CustomLinksMixin, ExportTemplatesMixin, JobResultsMixin, TagsMixin, WebhooksMixin,
@@ -681,7 +682,8 @@ class JobResult(models.Model):
             job_id=uuid.uuid4()
         )
 
-        queue = django_rq.get_queue("default")
+        rq_queue_name = get_config().QUEUE_MAPPINGS.get(obj_type.name, 'default')
+        queue = django_rq.get_queue(rq_queue_name)
 
         if schedule_at:
             job_result.status = JobResultStatusChoices.STATUS_SCHEDULED

--- a/netbox/extras/webhooks.py
+++ b/netbox/extras/webhooks.py
@@ -5,6 +5,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.utils import timezone
 from django_rq import get_queue
 
+from netbox.config import get_config
 from netbox.registry import registry
 from utilities.api import get_serializer_for_model
 from utilities.utils import serialize_object
@@ -78,7 +79,8 @@ def flush_webhooks(queue):
     """
     Flush a list of object representation to RQ for webhook processing.
     """
-    rq_queue = get_queue('default')
+    rq_queue_name = get_config().QUEUE_MAPPINGS.get('webhook', 'default')
+    rq_queue = get_queue(rq_queue_name)
     webhooks_cache = {
         'type_create': {},
         'type_update': {},

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -645,6 +645,11 @@ RQ_QUEUES = {
     'low': RQ_PARAMS,
 }
 
+# Add any queues defined in QUEUE_MAPPINGS
+RQ_QUEUES.update({
+    queue: RQ_PARAMS for queue in set(QUEUE_MAPPINGS.values()) if queue not in RQ_QUEUES
+})
+
 
 #
 # Plugins

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -101,6 +101,7 @@ MEDIA_ROOT = getattr(configuration, 'MEDIA_ROOT', os.path.join(BASE_DIR, 'media'
 METRICS_ENABLED = getattr(configuration, 'METRICS_ENABLED', False)
 PLUGINS = getattr(configuration, 'PLUGINS', [])
 PLUGINS_CONFIG = getattr(configuration, 'PLUGINS_CONFIG', {})
+QUEUE_MAPPINGS = getattr(configuration, 'QUEUE_MAPPINGS', {})
 RELEASE_CHECK_URL = getattr(configuration, 'RELEASE_CHECK_URL', None)
 REMOTE_AUTH_AUTO_CREATE_USER = getattr(configuration, 'REMOTE_AUTH_AUTO_CREATE_USER', False)
 REMOTE_AUTH_BACKEND = getattr(configuration, 'REMOTE_AUTH_BACKEND', 'netbox.authentication.RemoteUserBackend')


### PR DESCRIPTION
### Fixes: #11022

Adds the optional setting `QUEUE_MAPPINGS`.

Usage:

```
QUEUE_MAPPINGS = {
    'webhook': 'low',
    'report': 'high',
    'script': 'custom-script-queue',
}
```

I also added a change so that RQ_QUEUES gets updated if the queue defined in QUEUE_MAPPINGS is not defined already.