### PR TITLE
Fixes #11128 - Disable sorting by object_repr on ObjectChangeTable

### DIFF
--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -195,7 +195,8 @@ class ObjectChangeTable(NetBoxTable):
     object_repr = tables.TemplateColumn(
         accessor=tables.A('changed_object'),
         template_code=OBJECTCHANGE_OBJECT,
-        verbose_name='Object'
+        verbose_name='Object',
+        orderable=False
     )
     request_id = tables.TemplateColumn(
         template_code=OBJECTCHANGE_REQUEST_ID,


### PR DESCRIPTION
### Fixes: #11128

Sorting by object_repr causes an exception. Fix is to disable ordering for that field.