### PR TITLE
11077 use formatting for custom field date

### DIFF
--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -51,10 +51,12 @@ class DateColumn(tables.DateColumn):
     tables and null when exporting data. It is registered in the tables library to use this class instead of the
     default, making this behavior consistent in all fields of type DateField.
     """
-    def value(self, value):
+    def render(self, value):
         if value:
             return date_format(value, format="SHORT_DATE_FORMAT")
-        return None
+
+    def value(self, value):
+        return value
 
     @classmethod
     def from_field(cls, field, **kwargs):
@@ -444,7 +446,6 @@ class CustomFieldColumn(tables.Column):
         return escape(item)
 
     def render(self, value):
-        print("render CustomFieldColumn")
         if self.customfield.type == CustomFieldTypeChoices.TYPE_BOOLEAN and value is True:
             return mark_safe('<i class="mdi mdi-check-bold text-success"></i>')
         if self.customfield.type == CustomFieldTypeChoices.TYPE_BOOLEAN and value is False:

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -7,6 +7,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.db.models import DateField, DateTimeField
 from django.template import Context, Template
 from django.urls import reverse
+from django.utils.dateparse import parse_date
 from django.utils.encoding import escape_uri_path
 from django.utils.html import escape
 from django.utils.formats import date_format
@@ -51,7 +52,9 @@ class DateColumn(tables.DateColumn):
     default, making this behavior consistent in all fields of type DateField.
     """
     def value(self, value):
-        return value
+        if value:
+            return date_format(value, format="SHORT_DATE_FORMAT")
+        return None
 
     @classmethod
     def from_field(cls, field, **kwargs):
@@ -441,6 +444,7 @@ class CustomFieldColumn(tables.Column):
         return escape(item)
 
     def render(self, value):
+        print("render CustomFieldColumn")
         if self.customfield.type == CustomFieldTypeChoices.TYPE_BOOLEAN and value is True:
             return mark_safe('<i class="mdi mdi-check-bold text-success"></i>')
         if self.customfield.type == CustomFieldTypeChoices.TYPE_BOOLEAN and value is False:
@@ -455,6 +459,8 @@ class CustomFieldColumn(tables.Column):
             ))
         if self.customfield.type == CustomFieldTypeChoices.TYPE_LONGTEXT and value:
             return render_markdown(value)
+        if self.customfield.type == CustomFieldTypeChoices.TYPE_DATE and value:
+            return date_format(parse_date(value), format="SHORT_DATE_FORMAT")
         if value is not None:
             obj = self.customfield.deserialize(value)
             return mark_safe(self._linkify_item(obj))


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11077 

<!--
    Please include a summary of the proposed changes below.
-->
Updates custom field display in tables to use SHORT_DATE_FORMAT specifier, also updates the override for DateColumn to also use SHORT_DATE_FORMAT. Is assuming Custom field date will always be in the Y-m-d format, would need an extra date-format specifier if in another format.