### PR TITLE
Fixes #10447 - Allow re-assigning inventoryitems to other devices

### DIFF
--- a/netbox/dcim/forms/models.py
+++ b/netbox/dcim/forms/models.py
@@ -1610,6 +1610,13 @@ class InventoryItemForm(DeviceComponentForm):
         ('Hardware', ('manufacturer', 'part_id', 'serial', 'asset_tag')),
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Specifically allow editing the device of IntentoryItems
+        if self.instance.pk:
+            self.fields['device'].disabled = False
+
     class Meta:
         model = InventoryItem
         fields = [

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -1165,7 +1165,7 @@ class InventoryItem(MPTTModel, ComponentModel):
             # Prevent moving InventoryItems with children
             first_child = self.get_children().first()
             if first_child and first_child.device != self.device:
-                raise ValidationError("Cannot move an InventoryItem with dependent children")
+                raise ValidationError("Cannot move an inventory item with dependent children")
 
             # When moving an InventoryItem to another device, remove any associated component
             if self.component and self.component.device != self.device:


### PR DESCRIPTION
### Fixes: #10447

This is a suggested fix for allowing InventoryItems to be re-assigned to other devices. We had a discussion at one of the latest maintainers meetings about this, and my takeaway was that it would be fine to allow InventoryItems to move device. The alternative solution is to disallow it entirely, which requires disabling the device field for both the API and bulkedit.

There are two limitations to avoid inconsistant state:

* Validation prevents re-assigning the device if the InventoryItem has a parent or has children.
* When moving an InventoryItem the assigned component is removed.

An alternative to the second item would be to just deny the move, however it is currently not possible to de-couple an inventoryitem from a component (should also be fixed at some point), it seems like that would be too limiting.