### PR TITLE
11178 fix quick search press enter button

### DIFF
--- a/netbox/templates/generic/object_list.html
+++ b/netbox/templates/generic/object_list.html
@@ -67,6 +67,9 @@ Context:
         {% applied_filters filter_form request.GET %}
       {% endif %}
 
+      {# Object table controls #}
+      {% include 'inc/table_controls_htmx.html' with table_modal="ObjectTable_config" %}
+
       <form method="post" class="form form-horizontal">
         {% csrf_token %}
         {# "Select all" form #}
@@ -92,9 +95,6 @@ Context:
             </div>
           </div>
         {% endif %}
-
-        {# Object table controls #}
-        {% include 'inc/table_controls_htmx.html' with table_modal="ObjectTable_config" %}
 
         <div class="form form-horizontal">
           {% csrf_token %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11178 

<!--
    Please include a summary of the proposed changes below.
-->
Moves the quick search outside the form element so the enter key doesn't effect it (previous behavior before https://github.com/netbox-community/netbox/pull/10848) 

**Note:** this moves the position of the "Select all" box that appears, see screenshots:
![Monosnap Devices | NetBox 2022-12-14 12-29-01](https://user-images.githubusercontent.com/99642/207707906-bae18530-bb90-4a89-9472-8e610a18a341.png)
![Monosnap Devices | NetBox 2022-12-14 12-31-03](https://user-images.githubusercontent.com/99642/207707911-55b268e3-5949-4aac-b446-c4ebdb505c34.png)
