### PR TITLE
11206 dont remove user groups if no valid REMOTE_AUTH_DEFAULT_GROUPS

### DIFF
--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -382,4 +382,4 @@ def user_default_groups_handler(backend, user, response, *args, **kwargs):
         if group_list:
             user.groups.add(*group_list)
         else:
-            logger.debug(f"No valid group assignments for {user}")
+            logger.info(f"No valid group assignments for {user} - REMOTE_AUTH_DEFAULT_GROUPS may be incorrectly set?")

--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -382,5 +382,4 @@ def user_default_groups_handler(backend, user, response, *args, **kwargs):
         if group_list:
             user.groups.add(*group_list)
         else:
-            user.groups.clear()
-            logger.debug(f"Stripping user {user} from Groups")
+            logger.debug(f"No valid group assignments for {user}")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11206 

<!--
    Please include a summary of the proposed changes below.
-->
Don't see any reason to remove any group assignments if REMOTE_AUTH_DEFAULT_GROUPS incorrectly set.