### PR TITLE
Allow racking of existing devices from rack view

### DIFF
--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -25,6 +25,7 @@ __all__ = (
     'ConsolePortTemplateForm',
     'ConsoleServerPortForm',
     'ConsoleServerPortTemplateForm',
+    'DeviceAssignForm',
     'DeviceBayForm',
     'DeviceBayTemplateForm',
     'DeviceForm',
@@ -40,9 +41,9 @@ __all__ = (
     'InventoryItemTemplateForm',
     'LocationForm',
     'ManufacturerForm',
-    'ModuleForm',
     'ModuleBayForm',
     'ModuleBayTemplateForm',
+    'ModuleForm',
     'ModuleTypeForm',
     'PlatformForm',
     'PopulateDeviceBayForm',
@@ -472,6 +473,18 @@ class PlatformForm(NetBoxModelForm):
         widgets = {
             'napalm_args': SmallTextarea(),
         }
+
+
+class DeviceAssignForm(BootstrapMixin, forms.Form):
+    q = forms.CharField(
+        required=False,
+        label=_('Search'),
+    )
+    show_racked_devices = forms.BooleanField(
+        required=False,
+        initial=False,
+        label=_('Show Racked Devices?'),
+    )
 
 
 class DeviceForm(TenancyForm, NetBoxModelForm):

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -12,6 +12,7 @@ __all__ = (
     'CableTerminationTable',
     'ConsolePortTable',
     'ConsoleServerPortTable',
+    'DeviceAssignTable',
     'DeviceBayTable',
     'DeviceConsolePortTable',
     'DeviceConsoleServerPortTable',
@@ -21,8 +22,8 @@ __all__ = (
     'DeviceInterfaceTable',
     'DeviceInventoryItemTable',
     'DeviceModuleBayTable',
-    'DevicePowerPortTable',
     'DevicePowerOutletTable',
+    'DevicePowerPortTable',
     'DeviceRearPortTable',
     'DeviceRoleTable',
     'DeviceTable',
@@ -217,6 +218,20 @@ class DeviceTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
             'pk', 'name', 'status', 'tenant', 'site', 'location', 'rack', 'device_role', 'manufacturer', 'device_type',
             'primary_ip',
         )
+
+
+class DeviceAssignTable(NetBoxTable):
+    device = tables.TemplateColumn(
+        template_code=DEVICE_ASSIGN_LINK,
+        verbose_name='Device'
+    )
+    status = columns.ChoiceFieldColumn()
+
+    class Meta(NetBoxTable.Meta):
+        model = models.Device
+        fields = ('device', 'status', 'device_role', 'site', 'location', 'rack', 'position')
+        exclude = ('id',)
+        orderable = False
 
 
 class DeviceImportTable(TenancyColumnsMixin, NetBoxTable):

--- a/netbox/dcim/tables/template_code.py
+++ b/netbox/dcim/tables/template_code.py
@@ -24,6 +24,10 @@ DEVICE_LINK = """
 {{ value|default:'<span class="badge bg-info">Unnamed device</span>' }}
 """
 
+DEVICE_ASSIGN_LINK = """
+<a href="{% url 'dcim:device_edit' pk=record.pk %}?{% if request.GET.rack %}rack={{ request.GET.rack }}&face={{ request.GET.face }}&position={{ request.GET.position }}{% endif %}&return_url={{ request.GET.return_url }}">{{ record }}</a>
+"""
+
 DEVICEBAY_STATUS = """
 {% if record.installed_device_id %}
     <span class="badge bg-{{ record.installed_device.get_status_color }}">

--- a/netbox/dcim/urls.py
+++ b/netbox/dcim/urls.py
@@ -176,6 +176,7 @@ urlpatterns = [
     # Devices
     path('devices/', views.DeviceListView.as_view(), name='device_list'),
     path('devices/add/', views.DeviceEditView.as_view(), name='device_add'),
+    path("devices/assign/", views.DeviceAssignView.as_view(), name="device_assign"),
     path('devices/import/', views.DeviceBulkImportView.as_view(), name='device_import'),
     path('devices/import/child-devices/', views.ChildDeviceBulkImportView.as_view(), name='device_import_child'),
     path('devices/edit/', views.DeviceBulkEditView.as_view(), name='device_bulk_edit'),

--- a/netbox/templates/dcim/device_assign.html
+++ b/netbox/templates/dcim/device_assign.html
@@ -1,0 +1,48 @@
+{% extends 'generic/object_edit.html' %}
+{% load static %}
+{% load form_helpers %}
+{% load helpers %}
+{% load render_table from django_tables2 %}
+
+{% block title %}Assign a Device{% endblock title %}
+
+{% block tabs %}
+  {% include 'dcim/inc/device_edit_header.html' with active_tab='assign' %}
+{% endblock %}
+
+{% block form %}
+    <form action="{% querystring request %}" method="post" class="form form-horizontal">
+        {% csrf_token %}
+        {% for field in form.hidden_fields %}
+            {{ field }}
+        {% endfor %}
+        <div class="row mb-3">
+            <div class="col col-md-8 offset-md-2">
+                <div class="field-group">
+                    <h6>Select Device</h6>
+                    {% render_field form.q %}
+                    {% render_field form.show_racked_devices %}
+                </div>
+            </div>
+        </div>
+        <div class="row mb-3">
+            <div class="col col-md-8 offset-md-2 text-end">
+                <a href="{{ return_url }}" class="btn btn-outline-danger">Cancel</a>
+                <button type="submit" class="btn btn-primary">Search</button>
+            </div>
+        </div>
+    </form>
+    {% if table %}
+        <div class="row mb-3">
+            <div class="col col-md-12">
+                <h3>Search Results</h3>
+                <div class="table-responsive">
+                  {% render_table table 'inc/table.html' %}
+                </div>
+            </div>
+        </div>
+    {% endif %}
+{% endblock form %}
+
+{% block buttons %}
+{% endblock buttons%}

--- a/netbox/templates/dcim/device_edit.html
+++ b/netbox/templates/dcim/device_edit.html
@@ -1,9 +1,13 @@
 {% extends 'generic/object_edit.html' %}
 {% load form_helpers %}
 
+{% block tabs %}
+  {% include 'dcim/inc/device_edit_header.html' with active_tab='add' %}
+{% endblock %}
+
 {% block form %}
     {% render_errors form %}
-    
+
     <div class="field-group my-5">
       <div class="row mb-2">
         <h5 class="offset-sm-3">Device</h5>
@@ -13,7 +17,7 @@
       {% render_field form.description %}
       {% render_field form.tags %}
     </div>
-    
+
     <div class="field-group my-5">
       <div class="row mb-2">
         <h5 class="offset-sm-3">Hardware</h5>
@@ -24,7 +28,7 @@
       {% render_field form.serial %}
       {% render_field form.asset_tag %}
     </div>
-    
+
     <div class="field-group my-5">
       <div class="row mb-2">
         <h5 class="offset-sm-3">Location</h5>
@@ -58,7 +62,7 @@
         {% render_field form.position %}
       {% endif %}
     </div>
-    
+
     <div class="field-group my-5">
       <div class="row mb-2">
         <h5 class="offset-sm-3">Management</h5>
@@ -70,7 +74,7 @@
         {% render_field form.primary_ip6 %}
       {% endif %}
     </div>
-    
+
     <div class="field-group my-5">
       <div class="row mb-2">
         <h5 class="offset-sm-3">Virtualization</h5>
@@ -78,7 +82,7 @@
       {% render_field form.cluster_group %}
       {% render_field form.cluster %}
     </div>
-    
+
     <div class="field-group my-5">
       <div class="row mb-2">
         <h5 class="offset-sm-3">Tenancy</h5>

--- a/netbox/templates/dcim/inc/device_edit_header.html
+++ b/netbox/templates/dcim/inc/device_edit_header.html
@@ -1,0 +1,22 @@
+{% load helpers %}
+
+<ul class="nav nav-tabs px-3">
+    <li class="nav-item">
+        <a
+            class="nav-link {% if active_tab == 'add' %}active{% endif %}"
+            href="{% url 'dcim:device_add' %}{% querystring request %}"
+        >
+            {% if obj.pk %}Edit{% else %}Create{% endif %}
+        </a>
+    </li>
+    {% if 'rack' in request.GET %}
+    <li class="nav-item">
+        <a
+            class="nav-link {% if active_tab == 'assign' %}active{% endif %}"
+            href="{% url 'dcim:device_assign' %}{% querystring request %}"
+        >
+            Assign Device
+        </a>
+    </li>
+    {% endif %}
+</ul>


### PR DESCRIPTION
### Fixes: #11216

<!--
    Please include a summary of the proposed changes below.
-->
When clicking on "Add Device" in the rack view, this now allows to select an already existing device.

Screenshots of the flow:

![image](https://user-images.githubusercontent.com/18670690/208171834-74939663-40fb-4da0-a444-f44463211df9.png)

![image](https://user-images.githubusercontent.com/18670690/208171864-4bc4a0a8-927a-4618-bba8-ad8fd4a79afa.png)

![image](https://user-images.githubusercontent.com/18670690/208171929-92381033-08e4-40f6-8030-d0a2c5816f9f.png)

This brings up the device edit form with the new rack info filled in:

![image](https://user-images.githubusercontent.com/18670690/208172002-3a9db922-67ba-466c-afc0-e35782535b3e.png)

After saving the device is successfully racked:

![image](https://user-images.githubusercontent.com/18670690/208172047-d39bb830-2fee-4ea8-a59e-3d897f3a4fca.png)

