### PR TITLE
Fixes #11210 - Exception is thrown when trying to CSV import a cable in with occupied terminations

### DIFF
--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -112,6 +112,10 @@ class Cable(PrimaryModel):
     def a_terminations(self):
         if hasattr(self, '_a_terminations'):
             return self._a_terminations
+
+        if not self.pk:
+            return []
+
         # Query self.terminations.all() to leverage cached results
         return [
             ct.termination for ct in self.terminations.all() if ct.cable_end == CableEndChoices.SIDE_A
@@ -126,6 +130,10 @@ class Cable(PrimaryModel):
     def b_terminations(self):
         if hasattr(self, '_b_terminations'):
             return self._b_terminations
+
+        if not self.pk:
+            return []
+
         # Query self.terminations.all() to leverage cached results
         return [
             ct.termination for ct in self.terminations.all() if ct.cable_end == CableEndChoices.SIDE_B


### PR DESCRIPTION
### Fixes: #11210

I believe this is caused by the following django change:

https://docs.djangoproject.com/en/4.1/releases/4.1/#reverse-foreign-key-changes-for-unsaved-model-instances

This is the validation logic that is called for new cables that are bulk imported:
https://github.com/netbox-community/netbox/blob/3675ad2539400038af6797140ddca3679b8bca30/netbox/dcim/models/cables.py#L148-L149

In the case of occupied terminations, when the following code is reached the self.terminations queryset is called without the cable being saved yet:

https://github.com/netbox-community/netbox/blob/3675ad2539400038af6797140ddca3679b8bca30/netbox/dcim/models/cables.py#L111-L118

I'm not sure this is the correct fix. After the fix the following validation errors are provided:

![image](https://user-images.githubusercontent.com/400797/208376391-686a7a0b-f87a-4eb7-9de3-e72abbbcf8e1.png)

Tests passes, but please give this a good look before merging.

Bonus question: Why does the validation failing in CableImportForm not "cancel" the request? Why are the clean methods of the cable still called afterwards (or before)?