### PR TITLE
Fixes #11121 - Add summed resource card to cluster view

### DIFF
--- a/netbox/templates/virtualization/cluster.html
+++ b/netbox/templates/virtualization/cluster.html
@@ -55,6 +55,37 @@
     {% plugin_left_page object %}
   </div>
   <div class="col col-md-6">
+    <div class="card">
+      <h5 class="card-header">Allocated Resources</h5>
+      <div class="card-body">
+          <table class="table table-hover attr-table">
+              <tr>
+                  <th scope="row"><i class="mdi mdi-gauge"></i> Virtual CPUs</th>
+                  <td>{{ vcpus_sum|placeholder }}</td>
+              </tr>
+              <tr>
+                  <th scope="row"><i class="mdi mdi-chip"></i> Memory</th>
+                  <td>
+                      {% if memory_sum %}
+                          {{ memory_sum|humanize_megabytes }}
+                      {% else %}
+                          {{ ''|placeholder }}
+                      {% endif %}
+                  </td>
+              </tr>
+              <tr>
+                  <th scope="row"><i class="mdi mdi-harddisk"></i> Disk Space</th>
+                  <td>
+                      {% if disk_sum %}
+                          {{ disk_sum }} GB
+                      {% else %}
+                          {{ ''|placeholder }}
+                      {% endif %}
+                  </td>
+              </tr>
+          </table>
+      </div>
+  </div>
     {% include 'inc/panels/custom_fields.html' %}
     {% include 'inc/panels/tags.html' %}
     {% include 'inc/panels/contacts.html' %}

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -1,6 +1,6 @@
 from django.contrib import messages
 from django.db import transaction
-from django.db.models import Prefetch
+from django.db.models import Prefetch, Sum
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -168,6 +168,9 @@ class ClusterListView(generic.ObjectListView):
 @register_model_view(Cluster)
 class ClusterView(generic.ObjectView):
     queryset = Cluster.objects.all()
+
+    def get_extra_context(self, request, instance):
+        return instance.virtual_machines.aggregate(vcpus_sum=Sum('vcpus'), memory_sum=Sum('memory'), disk_sum=Sum('disk'))
 
 
 @register_model_view(Cluster, 'virtualmachines', path='virtual-machines')


### PR DESCRIPTION
### Fixes: #11121

Sums the allocated resources of a cluster and displays them on the cluster view.

![image](https://user-images.githubusercontent.com/400797/208442375-5e32f862-60eb-4247-a45a-d71d70f4621e.png)