### PR TITLE
pin pytz version to 2022.7 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ social-auth-core[openidconnect]==4.3.0
 svgwrite==1.4.3
 tablib==3.3.0
 tzdata==2022.7
+pytz==2022.7
 
 # Workaround for #7401
 jsonschema==3.2.0


### PR DESCRIPTION
### Fixes: #11277


When pytz/tzdata release a new version together, if both are not pinned together, we end up with a mixed, non compatible versions. It happens this month with netbox version 3.3.8, because a fresh install would get ``tzdata==2022.6``, as pinned in requirements.txt, and ``pytz==2022.7``.

Which may lead to following error:

``zoneinfo._common.ZoneInfoNotFoundError: 'No time zone found with key America/Ciudad_Juarez'``

I suggest to pin both versions in the requirements.txt file.