### PR TITLE
Fixes #11280 - Fix exporting interfaces and FHRP group rows with multiple IP's assigned

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -506,6 +506,9 @@ class BaseInterfaceTable(NetBoxTable):
         verbose_name='Tagged VLANs'
     )
 
+    def value_ip_addresses(self, value):
+        return ",".join([str(obj.address) for obj in value.all()])
+
 
 class InterfaceTable(ModularDeviceComponentTable, BaseInterfaceTable, PathEndpointTable):
     device = tables.Column(

--- a/netbox/ipam/tables/fhrp.py
+++ b/netbox/ipam/tables/fhrp.py
@@ -36,7 +36,6 @@ class FHRPGroupTable(NetBoxTable):
     def value_ip_addresses(self, value):
         return ",".join([str(obj.address) for obj in value.all()])
 
-
     class Meta(NetBoxTable.Meta):
         model = FHRPGroup
         fields = (

--- a/netbox/ipam/tables/fhrp.py
+++ b/netbox/ipam/tables/fhrp.py
@@ -33,6 +33,10 @@ class FHRPGroupTable(NetBoxTable):
         url_name='ipam:fhrpgroup_list'
     )
 
+    def value_ip_addresses(self, value):
+        return ",".join([str(obj.address) for obj in value.all()])
+
+
     class Meta(NetBoxTable.Meta):
         model = FHRPGroup
         fields = (


### PR DESCRIPTION
### Fixes: #11280

Adds `value_ip_address` method to BaseInterfaceTable and FHRPGroupTable.

@jeremystretch - Let me know if we should create a new column extending TemplateColumn for IPAddresses instead. I felt like it might be overkill, but there is slight replication of code in the current fix.