### PR TITLE
11271 flag to disable localization

### DIFF
--- a/docs/configuration/system.md
+++ b/docs/configuration/system.md
@@ -69,7 +69,7 @@ Email is sent from NetBox only for critical events or if configured for [logging
 
 Default: False
 
-Determines if localization features are enabled or not.  This should only be enabled for development or testing purposes as the product is not fully localized and there can be issues in certain locales with turning this on (mostly in locales where commas are used as numeric separators instead of periods). Turning this on will localize numeric and date formats (overriding what is set for DATE_FORMAT) based on the browser settings as well as translate some strings within the product.
+Determines if localization features are enabled or not. This should only be enabled for development or testing purposes as netbox is not yet fully localized. Turning this on will localize numeric and date formats (overriding what is set for DATE_FORMAT) based on the browser locale as well as translate certain strings from third party modules.
 
 ---
 

--- a/docs/configuration/system.md
+++ b/docs/configuration/system.md
@@ -65,6 +65,14 @@ Email is sent from NetBox only for critical events or if configured for [logging
 
 ---
 
+## ENABLE_LOCALIZATION
+
+Default: False
+
+Determines if localization features are enabled or not.  This should only be enabled for development or testing purposes as the product is not fully localized and there can be issues in certain locales with turning this on (mostly in locales where commas are used as numeric separators instead of periods). Turning this on will localize numeric and date formats (overriding what is set for DATE_FORMAT) based on the browser settings as well as translate some strings within the product.
+
+---
+
 ## HTTP_PROXIES
 
 Default: None

--- a/netbox/netbox/configuration_example.py
+++ b/netbox/netbox/configuration_example.py
@@ -222,6 +222,9 @@ SESSION_COOKIE_NAME = 'sessionid'
 # database access.) Note that the user as which NetBox runs must have read and write permissions to this path.
 SESSION_FILE_PATH = None
 
+# Localization
+ENABLE_LOCALIZATION = False
+
 # Time zone (default: UTC)
 TIME_ZONE = 'UTC'
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -137,6 +137,7 @@ STORAGE_BACKEND = getattr(configuration, 'STORAGE_BACKEND', None)
 STORAGE_CONFIG = getattr(configuration, 'STORAGE_CONFIG', {})
 TIME_FORMAT = getattr(configuration, 'TIME_FORMAT', 'g:i a')
 TIME_ZONE = getattr(configuration, 'TIME_ZONE', 'UTC')
+ENABLE_LOCALIZATION = getattr(configuration, 'ENABLE_LOCALIZATION', False)
 
 # Check for hard-coded dynamic config parameters
 for param in PARAMS:
@@ -340,7 +341,14 @@ MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.locale.LocaleMiddleware',
+]
+
+if ENABLE_LOCALIZATION:
+    MIDDLEWARE.extend([
+        'django.middleware.locale.LocaleMiddleware',
+    ])
+
+MIDDLEWARE.extend([
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -354,7 +362,7 @@ MIDDLEWARE = [
     'netbox.middleware.APIVersionMiddleware',
     'netbox.middleware.ObjectChangeMiddleware',
     'django_prometheus.middleware.PrometheusAfterMiddleware',
-]
+])
 
 ROOT_URLCONF = 'netbox.urls'
 
@@ -651,6 +659,13 @@ RQ_QUEUES.update({
     queue: RQ_PARAMS for queue in set(QUEUE_MAPPINGS.values()) if queue not in RQ_QUEUES
 })
 
+#
+# Localization
+#
+
+if not ENABLE_LOCALIZATION:
+    USE_I18N = False
+    USE_L10N = False
 
 #
 # Plugins

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -341,14 +341,7 @@ MIDDLEWARE = [
     'django_prometheus.middleware.PrometheusBeforeMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-]
-
-if ENABLE_LOCALIZATION:
-    MIDDLEWARE.extend([
-        'django.middleware.locale.LocaleMiddleware',
-    ])
-
-MIDDLEWARE.extend([
+    'django.middleware.locale.LocaleMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -362,7 +355,10 @@ MIDDLEWARE.extend([
     'netbox.middleware.APIVersionMiddleware',
     'netbox.middleware.ObjectChangeMiddleware',
     'django_prometheus.middleware.PrometheusAfterMiddleware',
-])
+]
+
+if not ENABLE_LOCALIZATION:
+    MIDDLEWARE.remove("django.middleware.locale.LocaleMiddleware")
 
 ROOT_URLCONF = 'netbox.urls'
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11271 

<!--
    Please include a summary of the proposed changes below.
-->
Add configuration.py flag to ENABLE_LOCALIZATION (default False) so this will disable localization by default.  There are a couple issues with the localization that we will need to address in the future to enable this:

1. provide localization language files if we want to turn on USE_I18N
2. Fix a couple UI issues with localized commas in numbers breaking progress bars
3. Allow an override to DATE_FORMAT and such as USE_L10N will take the browser setting as precedence over DATE_FORMAT.  It sounds like users want to be able to control this directly so will probably need to be another setting (CUSTOM_DATE_FORMAT)