### PR TITLE
Fixes #11223 & #11248 - Reindex app label

### DIFF
--- a/netbox/extras/migrations/0083_search.py
+++ b/netbox/extras/migrations/0083_search.py
@@ -10,7 +10,16 @@ from django.db import migrations, models
 def reindex(apps, schema_editor):
     # Build the search index (except during tests)
     if 'test' not in sys.argv:
-        management.call_command('reindex')
+        management.call_command(
+            'reindex',
+            'circuits',
+            'dcim',
+            'extras',
+            'ipam',
+            'tenancy',
+            'virtualization',
+            'wireless',
+        )
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11223 and #11248 

Add the possibility to reindex all the models of an app_label via the management command reindex.

The second commit modifies the reindex call in migration extras.0083_search to reindex only the models of core NetBox, to prevent plugins from blocking the migration as in #11248. Plugins should add their own reindex migration when they add a SearchIndex, such as:

```python
import sys

from django.core import management
from django.db import migrations

def reindex(apps, schema_editor):
    # Build the search index (except during tests)
    if "test" not in sys.argv:
        management.call_command("reindex", "<plugin_label>")

class Migration(migrations.Migration):
    dependencies = [
        ("<plugin_label>", "<NNNN_previous_migration>"),
    ]

    operations = [
        migrations.RunPython(
            code=reindex, reverse_code=migrations.RunPython.noop
        ),
    ]
```
