### PR TITLE
Fixes #11345 - Fix module validation

### DIFF
--- a/netbox/dcim/forms/common.py
+++ b/netbox/dcim/forms/common.py
@@ -54,23 +54,20 @@ class InterfaceCommonForm(forms.Form):
 class ModuleCommonForm(forms.Form):
 
     def clean(self):
-        cleaned_data = super().clean()
+        super().clean()
 
-        # Skip form validation if field validation already found errors.
-        if self.errors:
-            return cleaned_data
-
-        replicate_components = cleaned_data.get("replicate_components")
-        adopt_components = cleaned_data.get("adopt_components")
-        device = cleaned_data.get('device')
-        module_type = cleaned_data.get('module_type')
-        module_bay = cleaned_data.get('module_bay')
+        replicate_components = self.cleaned_data.get('replicate_components')
+        adopt_components = self.cleaned_data.get('adopt_components')
+        device = self.cleaned_data.get('device')
+        module_type = self.cleaned_data.get('module_type')
+        module_bay = self.cleaned_data.get('module_bay')
 
         if adopt_components:
             self.instance._adopt_components = True
 
-        # Bail out if we are not installing a new module or if we are not replicating components
-        if self.instance.pk or not replicate_components:
+        # Bail out if we are not installing a new module or if we are not replicating components (or if
+        # validation has already failed)
+        if self.errors or self.instance.pk or not replicate_components:
             self.instance._disable_replication = True
             return
 

--- a/netbox/dcim/forms/common.py
+++ b/netbox/dcim/forms/common.py
@@ -54,13 +54,17 @@ class InterfaceCommonForm(forms.Form):
 class ModuleCommonForm(forms.Form):
 
     def clean(self):
-        super().clean()
+        cleaned_data = super().clean()
 
-        replicate_components = self.cleaned_data.get("replicate_components")
-        adopt_components = self.cleaned_data.get("adopt_components")
-        device = self.cleaned_data.get('device')
-        module_type = self.cleaned_data.get('module_type')
-        module_bay = self.cleaned_data.get('module_bay')
+        # Skip form validation if field validation already found errors.
+        if self.errors:
+            return cleaned_data
+
+        replicate_components = cleaned_data.get("replicate_components")
+        adopt_components = cleaned_data.get("adopt_components")
+        device = cleaned_data.get('device')
+        module_type = cleaned_data.get('module_type')
+        module_bay = cleaned_data.get('module_bay')
 
         if adopt_components:
             self.instance._adopt_components = True

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -961,7 +961,7 @@ class Module(PrimaryModel, ConfigContextModel):
     def clean(self):
         super().clean()
 
-        if self.module_bay.device != self.device:
+        if hasattr(self, "module_bay") and (self.module_bay.device != self.device):
             raise ValidationError(
                 f"Module must be installed within a module bay belonging to the assigned device ({self.device})."
             )


### PR DESCRIPTION
### Fixes: #11345

The issue was that validation of module component replication/adoption was executed even if field validation failed. The model also had a validation step that would throw an exception when no module_bay was set (which was the case when trying to import to a non-existant module bay).

I'm not sure if this is actually the preferred way to do this:

```
cleaned_data = super().clean()

# Skip form validation if field validation already found errors.
if self.errors:
    return cleaned_data
```

Please let me know if there is a smarted way to bail out if field validation (non-existant device for example) has already failed.