### PR TITLE
Fixes #11342 - Fix component traces all pointing to the interface trace URL

### DIFF
--- a/netbox/templates/dcim/consoleport.html
+++ b/netbox/templates/dcim/consoleport.html
@@ -60,7 +60,7 @@
               {% if object.mark_connected %}
                 <span class="text-success"><i class="mdi mdi-check-bold"></i></span> Marked as connected
               {% elif object.cable %}
-                {% include 'dcim/inc/connection_endpoints.html' %}
+                {% include 'dcim/inc/connection_endpoints.html' with trace_url='dcim:consoleport_trace' %}
               {% else %}
                 <div class="text-muted">
                   Not Connected

--- a/netbox/templates/dcim/consoleserverport.html
+++ b/netbox/templates/dcim/consoleserverport.html
@@ -60,7 +60,7 @@
               {% if object.mark_connected %}
                 <span class="text-success"><i class="mdi mdi-check-bold"></i></span> Marked as connected
               {% elif object.cable %}
-                {% include 'dcim/inc/connection_endpoints.html' %}
+                {% include 'dcim/inc/connection_endpoints.html' with trace_url='dcim:consoleserverport_trace' %}
               {% else %}
                 <div class="text-muted">
                   Not Connected

--- a/netbox/templates/dcim/inc/connection_endpoints.html
+++ b/netbox/templates/dcim/inc/connection_endpoints.html
@@ -3,7 +3,7 @@
     <th scope="row">Cable</th>
     <td>
       {{ object.cable|linkify }}
-      <a href="{% url 'dcim:interface_trace' pk=object.pk %}" class="btn btn-primary btn-sm lh-1" title="Trace">
+      <a href="{% url trace_url pk=object.pk %}" class="btn btn-primary btn-sm lh-1" title="Trace">
         <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
       </a>
     </td>

--- a/netbox/templates/dcim/interface.html
+++ b/netbox/templates/dcim/interface.html
@@ -145,7 +145,7 @@
                 <span class="text-success"><i class="mdi mdi-check-bold"></i></span> Marked as Connected
               </div>
             {% elif object.cable %}
-              {% include 'dcim/inc/connection_endpoints.html' %}
+              {% include 'dcim/inc/connection_endpoints.html' with trace_url='dcim:interface_trace' %}
             {% elif object.wireless_link %}
               <table class="table table-hover">
                 <tr>

--- a/netbox/templates/dcim/powerfeed.html
+++ b/netbox/templates/dcim/powerfeed.html
@@ -112,7 +112,7 @@
               <span class="text-success"><i class="mdi mdi-check-bold"></i></span> Marked as connected
             </div>
           {% elif object.cable %}
-            {% include 'dcim/inc/connection_endpoints.html' %}
+            {% include 'dcim/inc/connection_endpoints.html' with trace_url='dcim:powerfeed_trace' %}
           {% else %}
             <div class="text-muted">
               Not connected

--- a/netbox/templates/dcim/poweroutlet.html
+++ b/netbox/templates/dcim/poweroutlet.html
@@ -66,7 +66,7 @@
                   <span class="text-success"><i class="mdi mdi-check-bold"></i></span> Marked as Connected
                 </div>
               {% elif object.cable %}
-                {% include 'dcim/inc/connection_endpoints.html' %}
+                {% include 'dcim/inc/connection_endpoints.html' with trace_url='dcim:poweroutlet_trace' %}
               {% else %}
                 <div class="text-muted">
                   Not Connected

--- a/netbox/templates/dcim/powerport.html
+++ b/netbox/templates/dcim/powerport.html
@@ -66,7 +66,7 @@
                   <span class="text-success"><i class="mdi mdi-check-bold"></i></span> Marked as Connected
                 </div>
               {% elif object.cable %}
-                {% include 'dcim/inc/connection_endpoints.html' %}
+                {% include 'dcim/inc/connection_endpoints.html' with trace_url='dcim:powerport_trace' %}
               {% else %}
                 <div class="text-muted">
                   Not Connected


### PR DESCRIPTION
### Fixes: #11342

Alternatively we could add a property to the PathEndpoint abstract model called `trace_url` or something of that effect. Not sure if it's worth it, but let me know and I'll change it.