### PR TITLE
Fixes #11438 - Get the queue from QUEUE_MAPPINGS when deleting JobResults

### DIFF
--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -634,7 +634,8 @@ class JobResult(models.Model):
     def delete(self, *args, **kwargs):
         super().delete(*args, **kwargs)
 
-        queue = django_rq.get_queue("default")
+        rq_queue_name = get_config().QUEUE_MAPPINGS.get(self.obj_type.name, RQ_QUEUE_DEFAULT)
+        queue = django_rq.get_queue(rq_queue_name)
         job = queue.fetch_job(str(self.job_id))
 
         if job:


### PR DESCRIPTION
### Fixes: #11438

Seems like I missed one place where the queue is fetched.