### PR TITLE
Fixes #11431 - Disallow changing customfield type after creation

### DIFF
--- a/netbox/extras/api/serializers.py
+++ b/netbox/extras/api/serializers.py
@@ -97,6 +97,12 @@ class CustomFieldSerializer(ValidatedModelSerializer):
             'validation_minimum', 'validation_maximum', 'validation_regex', 'choices', 'created', 'last_updated',
         ]
 
+    def validate_type(self, value):
+        if self.instance and self.instance.type != value:
+            raise serializers.ValidationError('Changing the type of custom fields is not supported.')
+
+        return value
+
     def get_data_type(self, obj):
         types = CustomFieldTypeChoices
         if obj.type == types.TYPE_INTEGER:

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -63,6 +63,13 @@ class CustomFieldForm(BootstrapMixin, forms.ModelForm):
             'ui_visibility': StaticSelect(),
         }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Disable changing the type of a CustomField as it almost universally causes errors if custom field data is already present.
+        if self.instance.pk:
+            self.fields['type'].disabled = True
+
 
 class CustomLinkForm(BootstrapMixin, forms.ModelForm):
     content_types = ContentTypeMultipleChoiceField(

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -106,6 +106,11 @@ class CustomFieldTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    update_data = {
+        'content_types': ['dcim.device'],
+        'name': 'New_Name',
+        'description': 'New description',
+    }
 
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
### Fixes: #11431

For the API this is the simplest fix. I played around with dynamically choosing another serializer based on the action, but I couldn't get it working properly. Not sure if there's any good solution for omitting the type field in the put/patch in the swagger definition?