### PR TITLE
Fixed AttributeError: object of class Schema has no attribute fields

### DIFF
--- a/netbox/utilities/custom_inspectors.py
+++ b/netbox/utilities/custom_inspectors.py
@@ -27,7 +27,7 @@ class NetBoxSwaggerAutoSchema(SwaggerAutoSchema):
     def get_request_serializer(self):
         serializer = super().get_request_serializer()
 
-        if serializer is not None and self.method in self.implicit_body_methods:
+        if serializer is not None and not isinstance(serializer, openapi.Schema) and self.method in self.implicit_body_methods:
             if writable_class := self.get_writable_class(serializer):
                 if hasattr(serializer, 'child'):
                     child_serializer = self.get_writable_class(serializer.child)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11433 

<!--
    Please include a summary of the proposed changes below.
-->
The custom inspector assumes that `get_request_serializer()` always return a `serializer` but it can sometimes be `Schema`
