### PR TITLE
Check for the extras.run_script permission when running scripts via. the API

### DIFF
--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -318,6 +318,10 @@ class ScriptViewSet(ViewSet):
         """
         Run a Script identified as "<module>.<script>" and return the pending JobResult as the result
         """
+
+        if not request.user.has_perm('extras.run_script'):
+            raise PermissionDenied("This user does not have permission to run scripts.")
+
         script = self._get_script(pk)()
         input_serializer = serializers.ScriptInputSerializer(data=request.data)
 

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -590,6 +590,7 @@ class ScriptTest(APITestCase):
 
     @skipIf(not rq_worker_running, "RQ worker not running")
     def test_run_script(self):
+        self.add_permissions('extras.run_script')
 
         script_data = {
             'var1': 'FooBar',


### PR DESCRIPTION
### Fixes: #11497

Check for the extras.run_script permission when running scripts via. the API