### PR TITLE
Fixes #11516 - Prevent error when regex special characters are used in global search

### DIFF
--- a/netbox/utilities/utils.py
+++ b/netbox/utilities/utils.py
@@ -517,7 +517,7 @@ def highlight_string(value, highlight, trim_pre=None, trim_post=None, trim_place
     """
     # Split value on highlight string
     try:
-        pre, match, post = re.split(fr'({highlight})', value, maxsplit=1, flags=re.IGNORECASE)
+        pre, match, post = re.split(fr'({re.escape(highlight)})', value, maxsplit=1, flags=re.IGNORECASE)
     except ValueError:
         # Match not found
         return escape(value)


### PR DESCRIPTION
### Fixes: #11516

Prevent error when regex special characters are used in global search