### PR TITLE
11537 remove connection from power feed table

### DIFF
--- a/netbox/dcim/tables/power.py
+++ b/netbox/dcim/tables/power.py
@@ -78,7 +78,7 @@ class PowerFeedTable(CableTerminationTable):
         model = PowerFeed
         fields = (
             'pk', 'id', 'name', 'power_panel', 'rack', 'status', 'type', 'supply', 'voltage', 'amperage', 'phase',
-            'max_utilization', 'mark_connected', 'cable', 'cable_color', 'link_peer', 'connection', 'available_power',
+            'max_utilization', 'mark_connected', 'cable', 'cable_color', 'link_peer', 'available_power',
             'description', 'comments', 'tags', 'created', 'last_updated',
         )
         default_columns = (


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11537 

<!--
    Please include a summary of the proposed changes below.
-->
removes connection from PowerFeedTable, this doesn't look like a valid field as PowerFeedTable has the comments:

> We're not using PathEndpointTable for PowerFeed because power connections cannot traverse pass-through ports.

The fields from CableTerminationTable are already included in the fields.