### PR TITLE
Fixes GenericForeignKey validation

### DIFF
--- a/netbox/netbox/models/__init__.py
+++ b/netbox/netbox/models/__init__.py
@@ -67,6 +67,15 @@ class NetBoxModel(CloningMixin, NetBoxFeatureSet, models.Model):
 
         for field in self._meta.get_fields():
             if isinstance(field, GenericForeignKey):
+                if getattr(self, field.ct_field) is None and getattr(self, field.fk_field) is not None:
+                    raise ValidationError({
+                        field.ct_field: "This field cannot be null.",
+                    })
+                if getattr(self, field.fk_field) is None and getattr(self, field.ct_field) is not None:
+                    raise ValidationError({
+                        field.fk_field: "This field cannot be null.",
+                    })
+
                 if getattr(self, field.ct_field) and getattr(self, field.fk_field):
                     klass = getattr(self, field.ct_field).model_class()
                     try:

--- a/netbox/netbox/models/__init__.py
+++ b/netbox/netbox/models/__init__.py
@@ -67,22 +67,23 @@ class NetBoxModel(CloningMixin, NetBoxFeatureSet, models.Model):
 
         for field in self._meta.get_fields():
             if isinstance(field, GenericForeignKey):
-                if getattr(self, field.ct_field) is None and getattr(self, field.fk_field) is not None:
+                ct_field = getattr(self, field.ct_field)
+                fk_field = getattr(self, field.fk_field)
+
+                if ct_field is None and fk_field is not None:
                     raise ValidationError({
                         field.ct_field: "This field cannot be null.",
                     })
-                if getattr(self, field.fk_field) is None and getattr(self, field.ct_field) is not None:
+                if fk_field is None and ct_field is not None:
                     raise ValidationError({
                         field.fk_field: "This field cannot be null.",
                     })
 
-                if getattr(self, field.ct_field) and getattr(self, field.fk_field):
+                if ct_field and fk_field:
                     klass = getattr(self, field.ct_field).model_class()
-                    try:
-                        klass.objects.get(pk=getattr(self, field.fk_field))
-                    except klass.DoesNotExist:
+                    if not klass.objects.filter(pk=fk_field).exists():
                         raise ValidationError({
-                            field.fk_field: f"Invalid {getattr(self, field.fk_field)}: object does not exist on {getattr(self, field.ct_field)}."
+                            field.fk_field: f"Invalid {fk_field}: object does not exist on {ct_field}."
                         })
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #10221, #11454

<!--
    Please include a summary of the proposed changes below.
-->
Added a validation on `NetBoxModel` `clean()` method for GenericForeignKey fields to ensure that the content type and object ID exist.