### PR TITLE
11487 remove set null from read-only custom fields bulk edit

### DIFF
--- a/netbox/netbox/forms/base.py
+++ b/netbox/netbox/forms/base.py
@@ -131,7 +131,7 @@ class NetBoxModelBulkEditForm(BootstrapMixin, CustomFieldsMixin, forms.Form):
 
     def _extend_nullable_fields(self):
         nullable_custom_fields = [
-            name for name, customfield in self.custom_fields.items() if not customfield.required
+            name for name, customfield in self.custom_fields.items() if (not customfield.required and customfield.ui_visibility == CustomFieldVisibilityChoices.VISIBILITY_READ_WRITE)
         ]
         self.nullable_fields = (*self.nullable_fields, *nullable_custom_fields)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ netaddr==0.8.0
 Pillow==9.4.0
 psycopg2-binary==2.9.5
 PyYAML==6.0
-sentry-sdk==1.13.1
+sentry-sdk==1.13.0
 social-auth-app-django==5.0.0
 social-auth-core[openidconnect]==4.3.0
 svgwrite==1.4.3


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11487 

<!--
    Please include a summary of the proposed changes below.
-->
Removes the "Set Null" when bulk editing items that have custom fields when the custom fields UI visibility is not set to read-write (the other choices are read-only and hidden). 

Also downgrades sentry-sdk to 1.13.0 as tests were complaining that 1.13.1 is not available? Which is strange, but maybe pypi issue or the removed it.