### PR TITLE
Closes #11152: Add support to abort custom script gracefully

### DIFF
--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -142,6 +142,19 @@ obj.full_clean()
 obj.save()
 ```
 
+## Error handling
+
+Sometimes things go wrong and a script will run into an `Exception`. If that happens and an uncaught exception is raised by the custom script, the execution is aborted and a full stack trace is reported.
+
+Although this is helpful for debugging, in some situations it might be required to cleanly abort the execution of a custom script (e.g. because of invalid input data) and thereby make sure no changes are performed on the database. In this case the script can throw an `AbortScript` exception, which will prevent the stack trace from being reported, but still terminating the script's execution and reporting a given error message.
+
+```python
+from utilities.exceptions import AbortScript
+
+if some_error:
+    raise AbortScript("Some meaningful error message")
+```
+
 ## Variable Reference
 
 ### Default Options

--- a/netbox/utilities/exceptions.py
+++ b/netbox/utilities/exceptions.py
@@ -24,6 +24,13 @@ class AbortRequest(Exception):
         self.message = message
 
 
+class AbortScript(Exception):
+    """
+    Raised to cleanly abort a script.
+    """
+    pass
+
+
 class PermissionsViolation(Exception):
     """
     Raised when an operation was prevented because it would violate the


### PR DESCRIPTION
### Fixes: #11152

This PR adds a new `AbortScript` exception which a custom script can throw in case the script should be terminated cleanly. It allows specifying an error message which will be reported to the user, but no stack trace is shown. Any other unhandled exception will still raise a stacktrace.

