### PR TITLE
Fixes #11601 - Add partial lookup to IPRangeFilterSet

### DIFF
--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -441,9 +441,9 @@ class IPRangeFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
-        qs_filter = Q(description__icontains=value)
+        qs_filter = Q(description__icontains=value) | Q(start_address__contains=value) | Q(end_address__contains=value)
         try:
-            ipaddress = str(netaddr.IPNetwork(value.strip()).cidr)
+            ipaddress = str(netaddr.IPNetwork(value.strip()))
             qs_filter |= Q(start_address=ipaddress)
             qs_filter |= Q(end_address=ipaddress)
         except (AddrFormatError, ValueError):


### PR DESCRIPTION
### Fixes: #11601 

Allows partial lookup in the search method for IPRange. Also removes the `.cidr` from the parsed IP lookup as I really don't see how it makes sense.

The changes makes it so that the following matches (192.168.0.1/25-192.168.0.25/25, which didn't before:
192
192.16
192.168.0.1/25 <- even the full IP with mask didn't match before because of using the cidr.
192.168.0.25/25