### PR TITLE
Fixes #11032 - Replication fields broken in custom validation

### DIFF
--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -258,7 +258,7 @@ class CustomValidationMixin(models.Model):
         super().clean()
 
         # If the instance is a base for replications, skip custom validation
-        if hasattr(self, '_replicated_base'):
+        if getattr(self, '_replicated_base', False):
             return
 
         # Send the post_clean signal

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -257,6 +257,10 @@ class CustomValidationMixin(models.Model):
     def clean(self):
         super().clean()
 
+        # If the instance is a base for replications, skip custom validation
+        if hasattr(self, '_replicated_base'):
+            return
+
         # Send the post_clean signal
         post_clean.send(sender=self.__class__, instance=self)
 

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -436,6 +436,10 @@ class ComponentCreateView(GetReturnURLMixin, BaseObjectView):
         form = self.initialize_form(request)
         instance = self.alter_object(self.queryset.model(), request)
 
+        # Note that the form instance is a replicated field base
+        # This is needed to avoid running custom validators multiple times
+        form.instance._replicated_base = hasattr(self.form, "replication_fields")
+
         if form.is_valid():
             new_components = []
             data = deepcopy(request.POST)


### PR DESCRIPTION
### Fixes: #11032

The issue here is that validation is triggered on the base instance when the form uses `replication_fields`. So if the user creates a vminterface with name test[1-2] validation is triggered for:

VMInterface with no name
VMInterface with name test1
VMInterface with name test2

For the normal validation this works okay, but for custom validation it results in the validator being triggered for the first VMInterface which is never actually saved. Not sure if there is a smarter way to fix this, my approach is to tag the instance that is never going to be saved with a private variable and make sure we don't run custom validators for these instances.