### PR TITLE
Fixes #11459 - Allow using null in conditions

### DIFF
--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -97,7 +97,7 @@ Multiple conditions can be combined into nested sets using AND or OR logic. This
 
 ### Examples
 
-`status` is "active" and `primary_ip` is defined _or_ the "exempt" tag is applied.
+`status` is "active" and `primary_ip4` is defined _or_ the "exempt" tag is applied.
 
 ```json
 {
@@ -109,8 +109,8 @@ Multiple conditions can be combined into nested sets using AND or OR logic. This
           "value": "active"
         },
         {
-          "attr": "primary_ip",
-          "value": "",
+          "attr": "primary_ip4",
+          "value": null,
           "negate": true
         }
       ]

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -44,7 +44,8 @@ class Condition:
         bool: (EQ, CONTAINS),
         int: (EQ, GT, GTE, LT, LTE, CONTAINS),
         float: (EQ, GT, GTE, LT, LTE, CONTAINS),
-        list: (EQ, IN, CONTAINS)
+        list: (EQ, IN, CONTAINS),
+        type(None): (EQ)
     }
 
     def __init__(self, attr, value, op=EQ, negate=False):

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -45,7 +45,7 @@ class Condition:
         int: (EQ, GT, GTE, LT, LTE, CONTAINS),
         float: (EQ, GT, GTE, LT, LTE, CONTAINS),
         list: (EQ, IN, CONTAINS),
-        type(None): (EQ)
+        type(None): (EQ,)
     }
 
     def __init__(self, attr, value, op=EQ, negate=False):

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -126,6 +126,16 @@ class ConditionSetTest(TestCase):
         with self.assertRaises(ValueError):
             ConditionSet({'foo': []})
 
+    def test_null_value(self):
+        cs = ConditionSet({
+            'and': [
+                {'attr': 'a', 'value': None, 'op': 'eq', 'negate': True},
+            ]
+        })
+        self.assertFalse(cs.eval({'a': None}))
+        self.assertTrue(cs.eval({'a': "string"}))
+        self.assertTrue(cs.eval({'a': {"key": "value"}}))
+
     def test_and_single_depth(self):
         cs = ConditionSet({
             'and': [


### PR DESCRIPTION
### Fixes: #11459

Issue here was two-fold I believe. First issue is that primary_ip is always None when evaluating the conditions as computed properties are not serialized when queuing webhooks.

The other issue is that comparing "" with None is False. Allowing conditions to contain `null`/`None` allows to compare against None instead of empty string which was not functional.