### PR TITLE
Fixes #11565 - Populate custom field defaults when creating FHRP groups with VIP

### DIFF
--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -578,6 +578,7 @@ class FHRPGroupForm(NetBoxModelForm):
                 role=FHRP_PROTOCOL_ROLE_MAPPINGS.get(self.cleaned_data['protocol'], IPAddressRoleChoices.ROLE_VIP),
                 assigned_object=instance
             )
+            ipaddress.populate_custom_field_defaults()
             ipaddress.save()
 
             # Check that the new IPAddress conforms with any assigned object-level permissions

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -216,6 +216,13 @@ class CustomFieldsMixin(models.Model):
 
         return dict(groups)
 
+    def populate_custom_field_defaults(self):
+        """
+        Apply the default value for each custom field
+        """
+        for cf in self.custom_fields:
+            self.custom_field_data[cf.name] = cf.default
+
     def clean(self):
         super().clean()
         from extras.models import CustomField


### PR DESCRIPTION
### Fixes: #11565

Creates a new method in CustomFieldMixin for populating defaults. It is utilized when creating the IP during FHRP creation.

I created a method on the model because it seems likely there's other places where we manually create objects during the creation of other objects. We might look into just always applying the defaults whenever an object with CustomFieldMixin is instantiated.