### PR TITLE
Closes #11592: Expose FILE_UPLOAD_MAX_MEMORY_SIZE as a setting

### DIFF
--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -69,6 +69,14 @@ By default, NetBox will permit users to create duplicate prefixes and IP address
 
 ---
 
+## FILE_UPLOAD_MAX_MEMORY_SIZE
+
+Default: 2621440 (i.e. 2.5 MB).
+
+The maximum size (in bytes) that an upload will be before it gets streamed to the file system. Changing this setting can be useful for example to be able to upload files bigger than 2.5MB to custom scripts for processing.
+
+---
+
 ## GRAPHQL_ENABLED
 
 !!! tip "Dynamic Configuration Parameter"

--- a/netbox/netbox/configuration_example.py
+++ b/netbox/netbox/configuration_example.py
@@ -217,6 +217,10 @@ RQ_DEFAULT_TIMEOUT = 300
 # this setting is derived from the installed location.
 # SCRIPTS_ROOT = '/opt/netbox/netbox/scripts'
 
+# The maximum size (in bytes) that an upload will be before it gets streamed to the file system.
+# Useful to be able to upload files bigger than 2.5Mbyte to custom scripts for processing.
+# FILE_UPLOAD_MAX_MEMORY_SIZE = 2621440
+
 # The name to use for the csrf token cookie.
 CSRF_COOKIE_NAME = 'csrftoken'
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -91,6 +91,7 @@ DOCS_ROOT = getattr(configuration, 'DOCS_ROOT', os.path.join(os.path.dirname(BAS
 EMAIL = getattr(configuration, 'EMAIL', {})
 EXEMPT_VIEW_PERMISSIONS = getattr(configuration, 'EXEMPT_VIEW_PERMISSIONS', [])
 FIELD_CHOICES = getattr(configuration, 'FIELD_CHOICES', {})
+FILE_UPLOAD_MAX_MEMORY_SIZE = getattr(configuration, 'FILE_UPLOAD_MAX_MEMORY_SIZE', 2621440)
 HTTP_PROXIES = getattr(configuration, 'HTTP_PROXIES', None)
 INTERNAL_IPS = getattr(configuration, 'INTERNAL_IPS', ('127.0.0.1', '::1'))
 JINJA2_FILTERS = getattr(configuration, 'JINJA2_FILTERS', {})
@@ -138,7 +139,6 @@ STORAGE_CONFIG = getattr(configuration, 'STORAGE_CONFIG', {})
 TIME_FORMAT = getattr(configuration, 'TIME_FORMAT', 'g:i a')
 TIME_ZONE = getattr(configuration, 'TIME_ZONE', 'UTC')
 ENABLE_LOCALIZATION = getattr(configuration, 'ENABLE_LOCALIZATION', False)
-FILE_UPLOAD_MAX_MEMORY_SIZE = getattr(configuration, 'FILE_UPLOAD_MAX_MEMORY_SIZE', 2621440)
 
 # Check for hard-coded dynamic config parameters
 for param in PARAMS:

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -138,6 +138,7 @@ STORAGE_CONFIG = getattr(configuration, 'STORAGE_CONFIG', {})
 TIME_FORMAT = getattr(configuration, 'TIME_FORMAT', 'g:i a')
 TIME_ZONE = getattr(configuration, 'TIME_ZONE', 'UTC')
 ENABLE_LOCALIZATION = getattr(configuration, 'ENABLE_LOCALIZATION', False)
+FILE_UPLOAD_MAX_MEMORY_SIZE = getattr(configuration, 'FILE_UPLOAD_MAX_MEMORY_SIZE', 2621440)
 
 # Check for hard-coded dynamic config parameters
 for param in PARAMS:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11592

<!--
    Please include a summary of the proposed changes below.
-->
Exposes FILE_UPLOAD_MAX_MEMORY_SIZE as a setting so that it can be changed in configuration.py.
This addresses an issue where file uploads fails if file size is greater than django default value. With these changes a user will be able to increase the max file upload size to fit there need. I tested this and can confirm that these changes fixes [ netbox docker issue 897](https://github.com/netbox-community/netbox-docker/issues/897) by allowing the user to increase the max size.