### PR TITLE
Fixes #11473 graphql invalid tag filter returns all devices/interfaces

### DIFF
--- a/netbox/netbox/graphql/fields.py
+++ b/netbox/netbox/graphql/fields.py
@@ -61,7 +61,7 @@ class ObjectListField(DjangoListField):
         if filterset_class:
             filterset = filterset_class(data=args, queryset=queryset, request=info.context)
             if not filterset.is_valid():
-                return []
+                return queryset.none()
             return filterset.qs
 
         return queryset

--- a/netbox/netbox/graphql/fields.py
+++ b/netbox/netbox/graphql/fields.py
@@ -60,6 +60,8 @@ class ObjectListField(DjangoListField):
         filterset_class = django_object_type._meta.filterset_class
         if filterset_class:
             filterset = filterset_class(data=args, queryset=queryset, request=info.context)
+            if not filterset.is_valid():
+                return []
             return filterset.qs
 
         return queryset


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11473

<!--
    Please include a summary of the proposed changes below.
-->
Return an empty queryset if the filterset is invalid in the static method ObjectListField.list_resolver().