### PR TITLE
Fixes #11539: Use BooleanFilter for 'empty' lookups

### DIFF
--- a/netbox/extras/lookups.py
+++ b/netbox/extras/lookups.py
@@ -6,12 +6,14 @@ class Empty(Lookup):
     Filter on whether a string is empty.
     """
     lookup_name = 'empty'
+    prepare_rhs = False
 
-    def as_sql(self, qn, connection):
-        lhs, lhs_params = self.process_lhs(qn, connection)
-        rhs, rhs_params = self.process_rhs(qn, connection)
-        params = lhs_params + rhs_params
-        return 'CAST(LENGTH(%s) AS BOOLEAN) != %s' % (lhs, rhs), params
+    def as_sql(self, compiler, connection):
+        sql, params = compiler.compile(self.lhs)
+        if self.rhs:
+            return f"CAST(LENGTH({sql}) AS BOOLEAN) IS NOT TRUE", params
+        else:
+            return f"CAST(LENGTH({sql}) AS BOOLEAN) IS TRUE", params
 
 
 CharField.register_lookup(Empty)

--- a/netbox/extras/lookups.py
+++ b/netbox/extras/lookups.py
@@ -6,16 +6,12 @@ class Empty(Lookup):
     Filter on whether a string is empty.
     """
     lookup_name = 'empty'
-    prepare_rhs = False
 
-    def as_sql(self, compiler, connection):
-        if not isinstance(self.rhs, bool):
-            raise ValueError("The QuerySet value for an empty lookup must be True or False.")
-        sql, params = compiler.compile(self.lhs)
-        if self.rhs:
-            return f"CAST(LENGTH({sql}) AS BOOLEAN) IS NOT TRUE", params
-        else:
-            return f"CAST(LENGTH({sql}) AS BOOLEAN) IS TRUE", params
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return 'CAST(LENGTH(%s) AS BOOLEAN) != %s' % (lhs, rhs), params
 
 
 CharField.register_lookup(Empty)

--- a/netbox/extras/lookups.py
+++ b/netbox/extras/lookups.py
@@ -6,12 +6,16 @@ class Empty(Lookup):
     Filter on whether a string is empty.
     """
     lookup_name = 'empty'
+    prepare_rhs = False
 
-    def as_sql(self, qn, connection):
-        lhs, lhs_params = self.process_lhs(qn, connection)
-        rhs, rhs_params = self.process_rhs(qn, connection)
-        params = lhs_params + rhs_params
-        return 'CAST(LENGTH(%s) AS BOOLEAN) != %s' % (lhs, rhs), params
+    def as_sql(self, compiler, connection):
+        if not isinstance(self.rhs, bool):
+            raise ValueError("The QuerySet value for an empty lookup must be True or False.")
+        sql, params = compiler.compile(self.lhs)
+        if self.rhs:
+            return f"CAST(LENGTH({sql}) AS BOOLEAN) IS NOT TRUE", params
+        else:
+            return f"CAST(LENGTH({sql}) AS BOOLEAN) IS TRUE", params
 
 
 CharField.register_lookup(Empty)

--- a/netbox/netbox/filtersets.py
+++ b/netbox/netbox/filtersets.py
@@ -177,7 +177,8 @@ class BaseFilterSet(django_filters.FilterSet):
                     # create the new filter with the same type because there is no guarantee the defined type
                     # is the same as the default type for the field
                     resolve_field(field, lookup_expr)  # Will raise FieldLookupError if the lookup is invalid
-                    new_filter = type(existing_filter)(
+                    filter_cls = django_filters.BooleanFilter if lookup_expr == 'empty' else type(existing_filter)
+                    new_filter = filter_cls(
                         field_name=field_name,
                         lookup_expr=lookup_expr,
                         label=existing_filter.label,

--- a/netbox/netbox/filtersets.py
+++ b/netbox/netbox/filtersets.py
@@ -224,6 +224,14 @@ class BaseFilterSet(django_filters.FilterSet):
 
         return filters
 
+    @classmethod
+    def filter_for_lookup(cls, field, lookup_type):
+
+        if lookup_type == 'empty':
+            return django_filters.BooleanFilter, {}
+
+        return super().filter_for_lookup(field, lookup_type)
+
 
 class ChangeLoggedModelFilterSet(BaseFilterSet):
     """


### PR DESCRIPTION
### Fixes: #11539

- Clean up our custom `Empty` lookup to more accurately evaluate true/false conditions
- Force the use of BooleanFilter for `empty` lookups in requests

While this seems to address the bug for _most_ fields, I still need to figure out how to correct the filter class for declared filters, such `DeviceFilterSet.name` (which is the actual target of the bug report).