### PR TITLE
Fixes #11775: Skip clearing cache when handling new objects

### DIFF
--- a/netbox/netbox/search/backends.py
+++ b/netbox/netbox/search/backends.py
@@ -52,11 +52,11 @@ class SearchBackend:
         """
         raise NotImplementedError
 
-    def caching_handler(self, sender, instance, **kwargs):
+    def caching_handler(self, sender, instance, created, **kwargs):
         """
         Receiver for the post_save signal, responsible for caching object creation/changes.
         """
-        self.cache(instance)
+        self.cache(instance, remove_existing=not created)
 
     def removal_handler(self, sender, instance, **kwargs):
         """


### PR DESCRIPTION
### Fixes: #11775

When receiving `post_save`, check whether the object is newly created. If so, skip deleting any pre-existing cache records.