### PR TITLE
Change Interpreter in shebang to python3

### DIFF
--- a/netbox/generate_secret_key.py
+++ b/netbox/generate_secret_key.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # This script will generate a random 50-character string suitable for use as a SECRET_KEY.
 import secrets
 


### PR DESCRIPTION
Dear netbox community, thank you soo much for this great software :heart_eyes: 
While installing I noticed the interpreter in the shebang of this file varies from the interpreter which is suggested in your documentation. And indeed a ./generate_secret_key.py told me that python3 is required to run this file. 

Since this is no big deal I decided not to open a dedicated issue for this, I hope you allow this change anyway.