### PR TITLE
#11871 - Implement PoE choice for IEEE 802.3az

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1135,6 +1135,7 @@ class InterfacePoETypeChoices(ChoiceSet):
 
     TYPE_1_8023AF = 'type1-ieee802.3af'
     TYPE_2_8023AT = 'type2-ieee802.3at'
+    TYPE_2_8023AZ = 'type2-ieee802.3az'
     TYPE_3_8023BT = 'type3-ieee802.3bt'
     TYPE_4_8023BT = 'type4-ieee802.3bt'
 
@@ -1149,6 +1150,7 @@ class InterfacePoETypeChoices(ChoiceSet):
             (
                 (TYPE_1_8023AF, '802.3af (Type 1)'),
                 (TYPE_2_8023AT, '802.3at (Type 2)'),
+                (TYPE_2_8023AZ, '802.3az (Type 2)'),
                 (TYPE_3_8023BT, '802.3bt (Type 3)'),
                 (TYPE_4_8023BT, '802.3bt (Type 4)'),
             )


### PR DESCRIPTION
Fixes: #11871

Added PoE Choice for Type 2 IEEE 802.3az as per described in issue #11871 