### PR TITLE
Added the missing filterset on Cable Termination

### DIFF
--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -1727,6 +1727,7 @@ class CableFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
 
 
 class CableTerminationFilterSet(BaseFilterSet):
+    termination_type = ContentTypeFilter()
 
     class Meta:
         model = CableTermination


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11819

<!--
    Please include a summary of the proposed changes below.
-->

- I have the missing `ContentTypeFilter` for the `termination_type` to allow for sending queries like `termination_type=dcim.interface`