### PR TITLE
fix(docs): Render referenced image

### DIFF
--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -276,7 +276,7 @@ An IPv4 or IPv6 network with a mask. Returns a `netaddr.IPNetwork` object. Two a
 !!! note
     To run a custom script, a user must be assigned the `extras.run_script` permission. This is achieved by assigning the user (or group) a permission on the Script object and specifying the `run` action in the admin UI as shown below.
 
-    ![Adding the run action to a permission](../media/admin_ui_run_permission.png)
+![Adding the run action to a permission](../media/admin_ui_run_permission.png)
 
 ### Via the Web UI
 


### PR DESCRIPTION
Instead of showing it as a code block.

### Fixes: #11907 

See the rich diff or [this file](https://github.com/netbox-community/netbox/blob/cb37577ff617bf0386f56d9512edb481817a7007/docs/customization/custom-scripts.md#running-custom-scripts) to see the rendered changes :-)