### PR TITLE
Fixes #11850 - Fix loading of CSV files with BOM

### DIFF
--- a/netbox/utilities/forms/forms.py
+++ b/netbox/utilities/forms/forms.py
@@ -180,7 +180,7 @@ class ImportForm(BootstrapMixin, forms.Form):
         if 'data_file' in self.files:
             self.data_field = 'data_file'
             file = self.files.get('data_file')
-            data = file.read().decode('utf-8')
+            data = file.read().decode('utf-8-sig')
         else:
             data = self.cleaned_data['data']
 


### PR DESCRIPTION
### Fixes: #11850

What it says on the tin. Using utf-8-sig takes into account the BOM and prevent mangling of the first csv header.