### PR TITLE
Removal of type2-ieee802.3az

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1137,7 +1137,6 @@ class InterfacePoETypeChoices(ChoiceSet):
 
     TYPE_1_8023AF = 'type1-ieee802.3af'
     TYPE_2_8023AT = 'type2-ieee802.3at'
-    TYPE_2_8023AZ = 'type2-ieee802.3az'
     TYPE_3_8023BT = 'type3-ieee802.3bt'
     TYPE_4_8023BT = 'type4-ieee802.3bt'
 
@@ -1152,7 +1151,6 @@ class InterfacePoETypeChoices(ChoiceSet):
             (
                 (TYPE_1_8023AF, '802.3af (Type 1)'),
                 (TYPE_2_8023AT, '802.3at (Type 2)'),
-                (TYPE_2_8023AZ, '802.3az (Type 2)'),
                 (TYPE_3_8023BT, '802.3bt (Type 3)'),
                 (TYPE_4_8023BT, '802.3bt (Type 4)'),
             )


### PR DESCRIPTION
### Fixes: #11984

As per my conversation with Braden McGrath, IEEE 802.3az is not a PoE standard but rather an Energy Efficient Ethernet standard and this does not belong here. The devices referenced in #11871 are actually `type2-ieee802.3at` based upon the PoE output rating