### PR TITLE
Fixes #11973 - Use ssid for the string representation of WirelessLinks if available

### DIFF
--- a/netbox/wireless/models.py
+++ b/netbox/wireless/models.py
@@ -190,7 +190,7 @@ class WirelessLink(WirelessAuthenticationBase, PrimaryModel):
         )
 
     def __str__(self):
-        return f'#{self.pk}'
+        return self.ssid or f'#{self.pk}'
 
     def get_absolute_url(self):
         return reverse('wireless:wirelesslink', args=[self.pk])


### PR DESCRIPTION
### Fixes: #11973

Implementation is the same as the Cable model which uses label as the `__str__` value if set.