### PR TITLE
Updated _schedule_at to use local time when _interval is set

### DIFF
--- a/netbox/extras/forms/reports.py
+++ b/netbox/extras/forms/reports.py
@@ -25,12 +25,16 @@ class ReportForm(BootstrapMixin, forms.Form):
         help_text=_("Interval at which this report is re-run (in minutes)")
     )
 
-    def clean_schedule_at(self):
+    def clean(self):
         scheduled_time = self.cleaned_data['schedule_at']
-        if scheduled_time and scheduled_time < timezone.now():
+        if scheduled_time and scheduled_time < local_now():
             raise forms.ValidationError(_('Scheduled time must be in the future.'))
 
-        return scheduled_time
+        # When interval is used without schedule at, raise an exception
+        if self.cleaned_data['interval'] and not scheduled_time:
+            self.cleaned_data['schedule_at'] = local_now()
+
+        return self.cleaned_data
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/netbox/extras/forms/scripts.py
+++ b/netbox/extras/forms/scripts.py
@@ -52,7 +52,7 @@ class ScriptForm(BootstrapMixin, forms.Form):
 
         # When interval is used without schedule at, raise an exception
         if self.cleaned_data['_interval'] and not scheduled_time:
-            raise forms.ValidationError(_('Scheduled time must be set when recurs is used.'))
+            self.cleaned_data['_schedule_at'] = local_now()
 
         return self.cleaned_data
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Closes: #11645 

<!--
    Please include a summary of the proposed changes below.
-->

When recurs every is set but schedule at is left empty, local time displayed on the form will be used instead.