### PR TITLE
Fixes #11977: Multiple remote authentication backends

### DIFF
--- a/docs/configuration/remote-authentication.md
+++ b/docs/configuration/remote-authentication.md
@@ -16,7 +16,7 @@ If true, NetBox will automatically create local accounts for users authenticated
 
 Default: `'netbox.authentication.RemoteUserBackend'`
 
-This is the Python path to the custom [Django authentication backend](https://docs.djangoproject.com/en/stable/topics/auth/customizing/) to use for external user authentication. NetBox provides two built-in backends (listed below), though custom authentication backends may also be provided by other packages or plugins.
+This is the Python path to the custom [Django authentication backend](https://docs.djangoproject.com/en/stable/topics/auth/customizing/) to use for external user authentication. NetBox provides two built-in backends (listed below), though custom authentication backends may also be provided by other packages or plugins. Provide a string for a single backend, or an iterable for multiple backends, which will be attempted in the order given.
 
 * `netbox.authentication.RemoteUserBackend`
 * `netbox.authentication.LDAPBackend`

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -396,10 +396,11 @@ TEMPLATES = [
 ]
 
 # Set up authentication backends
-AUTHENTICATION_BACKENDS = [
-    REMOTE_AUTH_BACKEND,
-    'netbox.authentication.ObjectPermissionBackend',
-]
+if isinstance(REMOTE_AUTH_BACKEND, list) or isinstance(REMOTE_AUTH_BACKEND, tuple):
+    AUTHENTICATION_BACKENDS = [x for x in REMOTE_AUTH_BACKEND]
+else:
+    AUTHENTICATION_BACKENDS = [REMOTE_AUTH_BACKEND]
+AUTHENTICATION_BACKENDS.append('netbox.authentication.ObjectPermissionBackend')
 
 # Time zones
 USE_TZ = True

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -396,11 +396,12 @@ TEMPLATES = [
 ]
 
 # Set up authentication backends
-if isinstance(REMOTE_AUTH_BACKEND, list) or isinstance(REMOTE_AUTH_BACKEND, tuple):
-    AUTHENTICATION_BACKENDS = [x for x in REMOTE_AUTH_BACKEND]
-else:
-    AUTHENTICATION_BACKENDS = [REMOTE_AUTH_BACKEND]
-AUTHENTICATION_BACKENDS.append('netbox.authentication.ObjectPermissionBackend')
+if type(REMOTE_AUTH_BACKEND) not in (list, tuple):
+    REMOTE_AUTH_BACKEND = [REMOTE_AUTH_BACKEND]
+AUTHENTICATION_BACKENDS = [
+    *REMOTE_AUTH_BACKEND,
+    'netbox.authentication.ObjectPermissionBackend',
+]
 
 # Time zones
 USE_TZ = True


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11977 

Change the `REMOTE_AUTH_BACKEND` setting to accept an iterable, which will be merged with `AUTHENTICATION_BACKENDS` in `settings.py`, to allow multiple authentication backends that will be attempted in sequence when authentication a user.
