### PR TITLE
 11933 saved filters clone of content-types and add m2m field cloning

### DIFF
--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -1,6 +1,7 @@
+import json
+
 from django import forms
 from django.contrib.contenttypes.models import ContentType
-from django.http import QueryDict
 from django.utils.translation import gettext as _
 
 from dcim.models import DeviceRole, DeviceType, Location, Platform, Region, Site, SiteGroup
@@ -128,11 +129,10 @@ class SavedFilterForm(BootstrapMixin, forms.ModelForm):
 
     def __init__(self, *args, initial=None, **kwargs):
 
-        # Convert any parameters delivered via initial data to a dictionary
+        # Convert any parameters delivered via initial data to JSON data
         if initial and 'parameters' in initial:
             if type(initial['parameters']) is str:
-                # TODO: Make a utility function for this
-                initial['parameters'] = dict(QueryDict(initial['parameters']).lists())
+                initial['parameters'] = json.loads(initial['parameters'])
 
         super().__init__(*args, initial=initial, **kwargs)
 

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -245,7 +245,7 @@ class CustomLink(CloningMixin, ExportTemplatesMixin, WebhooksMixin, ChangeLogged
     )
 
     clone_fields = (
-        'enabled', 'weight', 'group_name', 'button_class', 'new_window',
+        'content_types', 'enabled', 'weight', 'group_name', 'button_class', 'new_window',
     )
 
     class Meta:

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -406,7 +406,7 @@ class SavedFilter(CloningMixin, ExportTemplatesMixin, WebhooksMixin, ChangeLogge
     parameters = models.JSONField()
 
     clone_fields = (
-        'enabled', 'weight',
+        'content_types', 'weight', 'enabled', 'parameters',
     )
 
     class Meta:

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -110,9 +110,14 @@ class CloningMixin(models.Model):
 
         for field_name in getattr(self, 'clone_fields', []):
             field = self._meta.get_field(field_name)
-            field_value = field.value_from_object(self)
-            if field_value not in (None, ''):
-                attrs[field_name] = field_value
+            if isinstance(field, models.ManyToManyField):
+                m2m = getattr(self, field.name)
+                if m2m:
+                    attrs[field_name] = [f.pk for f in m2m.all()]
+            else:
+                field_value = field.value_from_object(self)
+                if field_value not in (None, ''):
+                    attrs[field_name] = field_value
 
         # Include tags (if applicable)
         if is_taggable(self):

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -1,3 +1,4 @@
+import json
 from collections import defaultdict
 from functools import cached_property
 
@@ -110,14 +111,13 @@ class CloningMixin(models.Model):
 
         for field_name in getattr(self, 'clone_fields', []):
             field = self._meta.get_field(field_name)
-            if isinstance(field, models.ManyToManyField):
-                m2m = getattr(self, field.name)
-                if m2m:
-                    attrs[field_name] = [f.pk for f in m2m.all()]
-            else:
-                field_value = field.value_from_object(self)
-                if field_value not in (None, ''):
-                    attrs[field_name] = field_value
+            field_value = field.value_from_object(self)
+            if field_value and isinstance(field, models.ManyToManyField):
+                attrs[field_name] = [v.pk for v in field_value]
+            elif field_value and isinstance(field, models.JSONField):
+                attrs[field_name] = json.dumps(field_value)
+            elif field_value not in (None, ''):
+                attrs[field_name] = field_value
 
         # Include tags (if applicable)
         if is_taggable(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11933 

<!--
    Please include a summary of the proposed changes below.
-->
Adds ability to clone M2M fields and also adds cloing of content_types and parameters to Saved Filters clone.