### PR TITLE
12148 add swagger-sidecar for self-hosted swagger docs

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -70,6 +70,10 @@ djangorestframework
 # https://github.com/tfranzel/drf-spectacular
 drf-spectacular
 
+# Serve self-contained distribution builds of Swagger UI and Redoc with Django.
+# https://github.com/tfranzel/drf-spectacular-sidecar
+drf-spectacular-sidecar
+
 # RSS feed parser
 # https://github.com/kurtmckee/feedparser
 feedparser

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -345,6 +345,7 @@ INSTALLED_APPS = [
     'wireless',
     'django_rq',  # Must come after extras to allow overriding management commands
     'drf_spectacular',
+    'drf_spectacular_sidecar',
 ]
 
 # Middleware
@@ -584,6 +585,9 @@ SPECTACULAR_SETTINGS = {
     "LICENSE": {"name": "Apache v2 License"},
     "VERSION": VERSION,
     'COMPONENT_SPLIT_REQUEST': True,
+    'SWAGGER_UI_DIST': 'SIDECAR',
+    'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
+    'REDOC_DIST': 'SIDECAR',
 }
 
 #

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,8 @@ django-tables2==2.5.3
 django-taggit==3.1.0
 django-timezone-field==5.0
 djangorestframework==3.14.0
-drf-spectacular==0.25.1
+drf-spectacular==0.26.1
+drf-spectacular-sidecar==2023.4.1
 feedparser==6.0.10
 graphene-django==3.0.0
 gunicorn==20.1.0


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12148 

<!--
    Please include a summary of the proposed changes below.
-->
Adds drf-spectacular-sidecar to allow self-hosted swagger docs (see bug report).