### PR TITLE
12118 fix instantiting device template with parent-child relations

### DIFF
--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -777,10 +777,12 @@ class Device(PrimaryModel, ConfigContextModel):
                            to the newly created instances.
         """
         instance_map = None
+        kwargs = {'device': self}
         if from_template:
-            instance_map = {}
+            kwargs['instance_map'] = {}
 
-        components = [obj.instantiate(device=self, instance_map=instance_map) for obj in queryset]
+        components = [obj.instantiate(**kwargs) for obj in queryset]
+
         if components and bulk_create:
             model = components[0]._meta.model
             model.objects.bulk_create(components)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12118 

<!--
    Please include a summary of the proposed changes below.
-->
Fixes case of instantiating device with inventory items with parent-child relationships.  Previously the parent pointer in the template was referencing the template parent object when instantiating the new device, the parent object needs to be mapped to the previously created parent inventory item.