### PR TITLE
Fixes #12118: Refactor bulk creation logic under _instantiate_components()

### DIFF
--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -774,8 +774,10 @@ class Device(PrimaryModel, ConfigContextModel):
             bulk_create: If True, bulk_create() will be called to create all components in a single query
                          (default). Otherwise, save() will be called on each instance individually.
         """
-        components = [obj.instantiate(device=self) for obj in queryset]
-        if components and bulk_create:
+        if bulk_create:
+            components = [obj.instantiate(device=self) for obj in queryset]
+            if not components:
+                return
             model = components[0]._meta.model
             model.objects.bulk_create(components)
             # Manually send the post_save signal for each of the newly created components
@@ -788,8 +790,9 @@ class Device(PrimaryModel, ConfigContextModel):
                     using='default',
                     update_fields=None
                 )
-        elif components:
-            for component in components:
+        else:
+            for obj in queryset:
+                component = obj.instantiate(device=self)
                 component.save()
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
### Fixes: #12118

Simplify bulk creation logic to better accommodate the instantiation of inventory items.