### PR TITLE
7503 do device validate-create in serial

### DIFF
--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -416,7 +416,9 @@ class DeviceViewSet(ConfigContextQuerySetMixin, ConfigTemplateRenderMixin, NetBo
 
     def create(self, request, *args, **kwargs):
         # do validate / create for each item in serial instead of validating all data at once
-        for data in request.data:
+        data_list = request.data if isinstance(request.data, list) else [request.data, ]
+
+        for data in data_list:
             serializer = self.get_serializer(data=data)
             serializer.is_valid(raise_exception=True)
             self.perform_create(serializer)

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 from drf_spectacular.types import OpenApiTypes
@@ -414,6 +415,7 @@ class DeviceViewSet(ConfigContextQuerySetMixin, ConfigTemplateRenderMixin, NetBo
 
         return serializers.DeviceWithConfigContextSerializer
 
+    @transaction.atomic
     def create(self, request, *args, **kwargs):
         # do validate / create for each item in serial instead of validating all data at once
         data_list = request.data if isinstance(request.data, list) else [request.data, ]

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -1115,7 +1115,7 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
 
         device_types = (
             DeviceType(manufacturer=manufacturer, model='Device Type 1', slug='device-type-1'),
-            DeviceType(manufacturer=manufacturer, model='Device Type 2', slug='device-type-2'),
+            DeviceType(manufacturer=manufacturer, model='Device Type 2', slug='device-type-2', u_height=2),
         )
         DeviceType.objects.bulk_create(device_types)
 
@@ -1222,6 +1222,39 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
             'site': device.site.pk,
             'name': device.name,
         }
+
+        self.add_permissions('dcim.add_device')
+        url = reverse('dcim-api:device-list')
+        response = self.client.post(url, data, format='json', **self.header)
+
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+
+    def test_rack_fit(self):
+        """
+        Check that creating multiple devices with overlapping position fails.
+        """
+        device = Device.objects.first()
+        device_type = DeviceType.objects.all()[1]
+        data = [
+            {
+                'device_type': device_type.pk,
+                'device_role': device.device_role.pk,
+                'site': device.site.pk,
+                'name': 'Test Device 7',
+                'rack': device.rack.pk,
+                'face': 'front',
+                'position': 1
+            },
+            {
+                'device_type': device_type.pk,
+                'device_role': device.device_role.pk,
+                'site': device.site.pk,
+                'name': 'Test Device 8',
+                'rack': device.rack.pk,
+                'face': 'front',
+                'position': 2
+            }
+        ]
 
         self.add_permissions('dcim.add_device')
         url = reverse('dcim-api:device-list')


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #7503 

<!--
    Please include a summary of the proposed changes below.
-->
Makes Device ViewSet to object validation and creation serial, instead of validating all at once then creating all at once - to catch conditions like overlapping rack locations.