### PR TITLE
12256 remove read-only fields from OpenAPI writable serializers

### DIFF
--- a/netbox/core/api/schema.py
+++ b/netbox/core/api/schema.py
@@ -150,8 +150,12 @@ class NetBoxAutoSchema(AutoSchema):
     def get_writable_class(self, serializer):
         properties = {}
         fields = {} if hasattr(serializer, 'child') else serializer.fields
+        remove_fields = []
 
         for child_name, child in fields.items():
+            # read_only fields don't need to be in writable (write only) serializers
+            if 'read_only' in dir(child) and child.read_only:
+                remove_fields.append(child_name)
             if isinstance(child, (ChoiceField, WritableNestedSerializer)):
                 properties[child_name] = None
             elif isinstance(child, ManyRelatedField) and isinstance(child.child_relation, SerializedPKRelatedField):
@@ -165,7 +169,12 @@ class NetBoxAutoSchema(AutoSchema):
             meta_class = getattr(type(serializer), 'Meta', None)
             if meta_class:
                 ref_name = 'Writable' + self.get_serializer_ref_name(serializer)
-                writable_meta = type('Meta', (meta_class,), {'ref_name': ref_name})
+                # remove read_only fields from write-only serializers
+                fields = list(meta_class.fields)
+                for field in remove_fields:
+                    fields.remove(field)
+                writable_meta = type('Meta', (meta_class,), {'ref_name': ref_name, 'fields': fields})
+
                 properties['Meta'] = writable_meta
 
             self.writable_serializers[type(serializer)] = type(writable_name, (type(serializer),), properties)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12256 

<!--
    Please include a summary of the proposed changes below.
-->
Removes read-only fields from Writable (write-only) serializers for drf-spectacular to silence warnings (removes 20 warnings).