### PR TITLE
12255 inventory item device change

### DIFF
--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -82,6 +82,12 @@ class ComponentTemplateModel(WebhooksMixin, ChangeLoggedModel):
         """
         raise NotImplementedError()
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Cache the original DeviceType ID for reference under clean()
+        self._original_device_type = self.device_type_id
+
     def to_objectchange(self, action):
         objectchange = super().to_objectchange(action)
         objectchange.related_object = self.device_type
@@ -90,7 +96,7 @@ class ComponentTemplateModel(WebhooksMixin, ChangeLoggedModel):
     def clean(self):
         super().clean()
 
-        if (not self._can_switch_device) and (self.pk is not None) and (self._original_device != self.device_id):
+        if (not self._can_switch_device) and (self.pk is not None) and (self._original_device_type != self.device_type_id):
             raise ValidationError({
                 "device_type": "Component templates cannot be moved to a different device type."
             })
@@ -128,12 +134,6 @@ class ModularComponentTemplateModel(ComponentTemplateModel):
                 name='%(app_label)s_%(class)s_unique_module_type_name'
             ),
         )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Cache the original DeviceType ID for reference under clean()
-        self._original_device_type = self.device_type_id
 
     def to_objectchange(self, action):
         objectchange = super().to_objectchange(action)

--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -59,7 +59,6 @@ class ComponentTemplateModel(WebhooksMixin, ChangeLoggedModel):
         max_length=200,
         blank=True
     )
-    _can_switch_device = False
 
     class Meta:
         abstract = True
@@ -96,7 +95,7 @@ class ComponentTemplateModel(WebhooksMixin, ChangeLoggedModel):
     def clean(self):
         super().clean()
 
-        if (not self._can_switch_device) and (self.pk is not None) and (self._original_device_type != self.device_type_id):
+        if self.pk is not None and self._original_device_type != self.device_type_id:
             raise ValidationError({
                 "device_type": "Component templates cannot be moved to a different device type."
             })
@@ -642,7 +641,6 @@ class InventoryItemTemplate(MPTTModel, ComponentTemplateModel):
 
     objects = TreeManager()
     component_model = InventoryItem
-    _can_switch_device = True
 
     class Meta:
         ordering = ('device_type__id', 'parent__id', '_name')

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -67,6 +67,7 @@ class ComponentModel(NetBoxModel):
         max_length=200,
         blank=True
     )
+    _can_switch_device = False
 
     class Meta:
         abstract = True
@@ -97,7 +98,7 @@ class ComponentModel(NetBoxModel):
     def clean(self):
         super().clean()
 
-        if self.pk is not None and self._original_device != self.device_id:
+        if (not self._can_switch_device) and (self.pk is not None) and (self._original_device != self.device_id):
             raise ValidationError({
                 "device": "Components cannot be moved to a different device."
             })
@@ -1128,6 +1129,7 @@ class InventoryItem(MPTTModel, ComponentModel):
     objects = TreeManager()
 
     clone_fields = ('device', 'parent', 'role', 'manufacturer', 'part_id',)
+    _can_switch_device = True
 
     class Meta:
         ordering = ('device__id', 'parent__id', '_name')

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -67,7 +67,6 @@ class ComponentModel(NetBoxModel):
         max_length=200,
         blank=True
     )
-    _can_switch_device = False
 
     class Meta:
         abstract = True
@@ -98,7 +97,8 @@ class ComponentModel(NetBoxModel):
     def clean(self):
         super().clean()
 
-        if (not self._can_switch_device) and (self.pk is not None) and (self._original_device != self.device_id):
+        # Check list of Modules that allow device field to be changed
+        if (type(self) not in [InventoryItem]) and (self.pk is not None) and (self._original_device != self.device_id):
             raise ValidationError({
                 "device": "Components cannot be moved to a different device."
             })
@@ -1129,7 +1129,6 @@ class InventoryItem(MPTTModel, ComponentModel):
     objects = TreeManager()
 
     clone_fields = ('device', 'parent', 'role', 'manufacturer', 'part_id',)
-    _can_switch_device = True
 
     class Meta:
         ordering = ('device__id', 'parent__id', '_name')


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12255 

<!--
    Please include a summary of the proposed changes below.
-->
Allows inventory item to change device.
Fixes template models setting device type - no exception needed for inventory_item_template as that is restricted from changing device_type in the UI as well.