### PR TITLE
11607 make CableSerializer use WritableNestedSerializer

### DIFF
--- a/netbox/dcim/api/nested_serializers.py
+++ b/netbox/dcim/api/nested_serializers.py
@@ -425,7 +425,7 @@ class NestedInventoryItemRoleSerializer(WritableNestedSerializer):
 # Cables
 #
 
-class NestedCableSerializer(BaseModelSerializer):
+class NestedCableSerializer(WritableNestedSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:cable-detail')
 
     class Meta:


### PR DESCRIPTION

### Fixes: #11607 

This code (https://github.com/netbox-community/netbox/blob/develop/netbox/extras/api/customfields.py#L86) assumes that the nested serializer gets instantiated after is_valid is called, this occurs for the other NestedSerializers in to_internal_value function in NestedWritableSerializer.

NestedCableSerializer was currently derived from BaseModelSerializer which doesn't do this.

@jeremystretch I'm not aware of any side-effects of deriving from WritableNestedSerializer which only adds this to_internal_value method.  Not sure why NestedCableSerializer was different?