### PR TITLE
12252 allow sorting on object in search

### DIFF
--- a/netbox/netbox/search/backends.py
+++ b/netbox/netbox/search/backends.py
@@ -145,12 +145,11 @@ class CachedValueSearchBackend(SearchBackend):
         )
 
         # Omit any results pertaining to an object the user does not have permission to view
-        ret = [
-            r for r in results if r.object is not None
-        ]
-        for r in ret:
-            r.name = str(r.object)
-
+        ret = []
+        for r in results:
+            if r.object is not None:
+                r.name = str(r.object)
+                ret.append(r)
         return ret
 
     def cache(self, instances, indexer=None, remove_existing=True):

--- a/netbox/netbox/search/backends.py
+++ b/netbox/netbox/search/backends.py
@@ -145,9 +145,13 @@ class CachedValueSearchBackend(SearchBackend):
         )
 
         # Omit any results pertaining to an object the user does not have permission to view
-        return [
+        ret = [
             r for r in results if r.object is not None
         ]
+        for r in ret:
+            r.name = str(r.object)
+
+        return ret
 
     def cache(self, instances, indexer=None, remove_existing=True):
         content_type = None

--- a/netbox/netbox/tables/tables.py
+++ b/netbox/netbox/tables/tables.py
@@ -204,7 +204,8 @@ class SearchTable(tables.Table):
         order_by="object___meta__verbose_name",
     )
     object = tables.Column(
-        linkify=True
+        linkify=True,
+        order_by=('name', )
     )
     field = tables.Column()
     value = tables.Column()


### PR DESCRIPTION
### Fixes: #12252 

Adds a name column (str of object) to allow sorting of the object column in search results:

1. tables2 looks like it only supports sorting based on items in the query results.
2. There is not a consistent field on object to sort on that matches the str of the object.
3. There are max 1,000 search results returned that are already in a list, so going through all the items as doing a str should not be too bad performance wise

The alternative would be restricting this field from being sortable, but it sounds like people want to sort on this field.