### PR TITLE
Add additional characters to exclude from url encode

### DIFF
--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -279,7 +279,7 @@ class CustomLink(CloningMixin, ExportTemplatesMixin, WebhooksMixin, ChangeLogged
         text = clean_html(text, allowed_schemes)
 
         # Sanitize link
-        link = urllib.parse.quote_plus(link, safe='/:?&')
+        link = urllib.parse.quote_plus(link, safe='/:?&=%+[]@#')
 
         # Verify link scheme is allowed
         result = urllib.parse.urlparse(link)


### PR DESCRIPTION
### Fixes: #12355

Excludes additional characters from being encoded.  This prevents valid URI characters (such as `=`) from being encoded and encoded values from being encoded again (such as `%DD` or `+`).
