### PR TITLE
Fixes #12405 - Fix the filtervar being set to site_id instead of site in SiteView related_models

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -371,7 +371,7 @@ class SiteView(generic.ObjectView):
             (VLANGroup.objects.restrict(request.user, 'view').filter(
                 scope_type=ContentType.objects.get_for_model(Site),
                 scope_id=instance.pk
-            ), 'site_id'),
+            ), 'site'),
             (VLAN.objects.restrict(request.user, 'view').filter(site=instance), 'site_id'),
             # Circuits
             (Circuit.objects.restrict(request.user, 'view').filter(terminations__site=instance).distinct(), 'site_id'),


### PR DESCRIPTION
### Fixes: #12405 