### PR TITLE
Fix OpenAPI schema base path

### DIFF
--- a/netbox/core/api/schema.py
+++ b/netbox/core/api/schema.py
@@ -1,23 +1,12 @@
 import re
 import typing
 
-from drf_spectacular.extensions import (
-    OpenApiSerializerFieldExtension,
-    OpenApiViewExtension,
-)
+from drf_spectacular.extensions import OpenApiSerializerFieldExtension
 from drf_spectacular.openapi import AutoSchema
 from drf_spectacular.plumbing import (
-    ComponentRegistry,
-    ResolvedComponent,
-    build_basic_type,
-    build_choice_field,
-    build_media_type_object,
-    build_object_type,
-    get_doc,
-    is_serializer,
+    build_basic_type, build_choice_field, build_media_type_object, build_object_type, get_doc,
 )
 from drf_spectacular.types import OpenApiTypes
-from drf_spectacular.utils import extend_schema
 from rest_framework.relations import ManyRelatedField
 
 from netbox.api.fields import ChoiceField, SerializedPKRelatedField

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -616,13 +616,15 @@ REST_FRAMEWORK = {
 #
 
 SPECTACULAR_SETTINGS = {
-    'TITLE': 'NetBox API',
-    'DESCRIPTION': 'API to access NetBox',
+    'TITLE': 'NetBox REST API',
     'LICENSE': {'name': 'Apache v2 License'},
     'VERSION': VERSION,
     'COMPONENT_SPLIT_REQUEST': True,
     'REDOC_DIST': 'SIDECAR',
-    'SERVERS': [{'url': f'/{BASE_PATH}api'}],
+    'SERVERS': [{
+        'url': BASE_PATH,
+        'description': 'NetBox',
+    }],
     'SWAGGER_UI_DIST': 'SIDECAR',
     'SWAGGER_UI_FAVICON_HREF': 'SIDECAR',
     'POSTPROCESSING_HOOKS': [],


### PR DESCRIPTION
### Fixes: #12410

Removes the static `api/` portion from the base URL for the OpenAPI schema generator.
