### PR TITLE
12433 update object list widget to correctly parameterize urls

### DIFF
--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -229,7 +229,13 @@ class ObjectListWidget(DashboardWidget):
             htmx_url = reverse(viewname)
         except NoReverseMatch:
             htmx_url = None
-        if parameters := self.config.get('url_params'):
+        parameters = self.config.get('url_params')
+        if page_size := self.config.get('page_size'):
+            if not parameters:
+                parameters = {}
+            parameters['page_size'] = page_size
+
+        if parameters:
             try:
                 htmx_url = f'{htmx_url}?{urlencode(parameters, doseq=True)}'
             except ValueError:
@@ -238,7 +244,6 @@ class ObjectListWidget(DashboardWidget):
             'viewname': viewname,
             'has_permission': has_permission,
             'htmx_url': htmx_url,
-            'page_size': self.config.get('page_size'),
         })
 
 

--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -229,11 +229,9 @@ class ObjectListWidget(DashboardWidget):
             htmx_url = reverse(viewname)
         except NoReverseMatch:
             htmx_url = None
-        parameters = self.config.get('url_params')
+        parameters = self.config.get('url_params', {})
         if page_size := self.config.get('page_size'):
-            if not parameters:
-                parameters = {}
-            parameters['page_size'] = page_size
+          parameters['page_size'] = page_size
 
         if parameters:
             try:

--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -229,9 +229,9 @@ class ObjectListWidget(DashboardWidget):
             htmx_url = reverse(viewname)
         except NoReverseMatch:
             htmx_url = None
-        parameters = self.config.get('url_params', {})
+        parameters = self.config.get('url_params') or {}
         if page_size := self.config.get('page_size'):
-            parameters['page_size'] = page_size
+            parameters['per_page'] = page_size
 
         if parameters:
             try:

--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -231,7 +231,7 @@ class ObjectListWidget(DashboardWidget):
             htmx_url = None
         parameters = self.config.get('url_params', {})
         if page_size := self.config.get('page_size'):
-          parameters['page_size'] = page_size
+            parameters['page_size'] = page_size
 
         if parameters:
             try:

--- a/netbox/templates/extras/dashboard/widgets/objectlist.html
+++ b/netbox/templates/extras/dashboard/widgets/objectlist.html
@@ -1,5 +1,5 @@
 {% if htmx_url and has_permission %}
-  <div class="htmx-container" hx-get="{{ htmx_url }}{% if page_size %}?per_page={{ page_size }}{% endif %}" hx-trigger="load"></div>
+  <div class="htmx-container" hx-get="{{ htmx_url }}" hx-trigger="load"></div>
 {% elif htmx_url %}
   <div class="text-muted text-center">
     <i class="mdi mdi-lock-outline"></i> No permission to view this content.


### PR DESCRIPTION
### Fixes: #12433 

Moves the page_size concatenation for object list view widget from the template to the widget code so parameter concatenation is done correctly.