### PR TITLE
11422 add power-panel-name to quick search of power feeds

### DIFF
--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -1900,6 +1900,7 @@ class PowerFeedFilterSet(NetBoxModelFilterSet, CabledObjectFilterSet, PathEndpoi
             return queryset
         qs_filter = (
             Q(name__icontains=value) |
+            Q(power_panel__name__icontains=value) |
             Q(comments__icontains=value)
         )
         return queryset.filter(qs_filter)


### PR DESCRIPTION
### Fixes: #11422 

Allow for PowerFeeds to be quick searched by their power panel name.