### PR TITLE
Fixes: #11715 - Fix Parent Prefix table display

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -496,7 +496,7 @@ class PrefixView(generic.ObjectView):
 
         # Parent prefixes table
         parent_prefixes = Prefix.objects.restrict(request.user, 'view').filter(
-            Q(vrf=instance.vrf) | Q(Q(vrf__isnull=True) & Q(status=PrefixStatusChoices.STATUS_CONTAINER))
+            Q(vrf=instance.vrf) | Q(vrf__isnull=True, status=PrefixStatusChoices.STATUS_CONTAINER)
         ).filter(
             prefix__net_contains=str(instance.prefix)
         ).prefetch_related(

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -14,6 +14,7 @@ from utilities.views import ViewTab, register_model_view
 from virtualization.filtersets import VMInterfaceFilterSet
 from virtualization.models import VMInterface
 from . import filtersets, forms, tables
+from .choices import PrefixStatusChoices
 from .constants import *
 from .models import *
 from .tables.l2vpn import L2VPNTable, L2VPNTerminationTable
@@ -495,7 +496,7 @@ class PrefixView(generic.ObjectView):
 
         # Parent prefixes table
         parent_prefixes = Prefix.objects.restrict(request.user, 'view').filter(
-            Q(vrf=instance.vrf) | Q(vrf__isnull=True)
+            Q(vrf=instance.vrf) | Q(Q(vrf__isnull=True) & Q(status=PrefixStatusChoices.STATUS_CONTAINER))
         ).filter(
             prefix__net_contains=str(instance.prefix)
         ).prefetch_related(


### PR DESCRIPTION
### Fixes: #11715 

Fixes the display of a prefix's parent(s) in the prefix detailed view when the prefix is in a VRF and there are global prefixes that could be parents.  If the "parent" prefixes have an active status, they will also show even though they should only show when the status is "container"
