### PR TITLE
Fixes: #10757 - Change IP interface assignment to use new selector

### DIFF
--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -262,30 +262,18 @@ class IPRangeForm(TenancyForm, NetBoxModelForm):
 
 
 class IPAddressForm(TenancyForm, NetBoxModelForm):
-    device = DynamicModelChoiceField(
-        queryset=Device.objects.all(),
-        required=False,
-        initial_params={
-            'interfaces': '$interface'
-        }
-    )
     interface = DynamicModelChoiceField(
         queryset=Interface.objects.all(),
         required=False,
+        selector=True,
         query_params={
             'device_id': '$device'
-        }
-    )
-    virtual_machine = DynamicModelChoiceField(
-        queryset=VirtualMachine.objects.all(),
-        required=False,
-        initial_params={
-            'interfaces': '$vminterface'
         }
     )
     vminterface = DynamicModelChoiceField(
         queryset=VMInterface.objects.all(),
         required=False,
+        selector=True,
         label=_('Interface'),
         query_params={
             'virtual_machine_id': '$virtual_machine'
@@ -294,24 +282,13 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
     fhrpgroup = DynamicModelChoiceField(
         queryset=FHRPGroup.objects.all(),
         required=False,
+        selector=True,
         label=_('FHRP Group')
     )
     vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
         required=False,
         label=_('VRF')
-    )
-    nat_device = DynamicModelChoiceField(
-        queryset=Device.objects.all(),
-        required=False,
-        selector=True,
-        label=_('Device')
-    )
-    nat_virtual_machine = DynamicModelChoiceField(
-        queryset=VirtualMachine.objects.all(),
-        required=False,
-        selector=True,
-        label=_('Virtual Machine')
     )
     nat_vrf = DynamicModelChoiceField(
         queryset=VRF.objects.all(),
@@ -322,10 +299,9 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
     nat_inside = DynamicModelChoiceField(
         queryset=IPAddress.objects.all(),
         required=False,
+        selector=True,
         label=_('IP Address'),
         query_params={
-            'device_id': '$nat_device',
-            'virtual_machine_id': '$nat_virtual_machine',
             'vrf_id': '$nat_vrf',
         }
     )
@@ -338,8 +314,8 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
     class Meta:
         model = IPAddress
         fields = [
-            'address', 'vrf', 'status', 'role', 'dns_name', 'primary_for_parent', 'nat_device', 'nat_virtual_machine',
-            'nat_vrf', 'nat_inside', 'tenant_group', 'tenant', 'description', 'comments', 'tags',
+            'address', 'vrf', 'status', 'role', 'dns_name', 'primary_for_parent', 'nat_vrf', 'nat_inside',
+            'tenant_group', 'tenant', 'description', 'comments', 'tags',
         ]
 
     def __init__(self, *args, **kwargs):
@@ -354,17 +330,6 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
                 initial['vminterface'] = instance.assigned_object
             elif type(instance.assigned_object) is FHRPGroup:
                 initial['fhrpgroup'] = instance.assigned_object
-            if instance.nat_inside:
-                nat_inside_parent = instance.nat_inside.assigned_object
-                if type(nat_inside_parent) is Interface:
-                    initial['nat_site'] = nat_inside_parent.device.site.pk
-                    if nat_inside_parent.device.rack:
-                        initial['nat_rack'] = nat_inside_parent.device.rack.pk
-                    initial['nat_device'] = nat_inside_parent.device.pk
-                elif type(nat_inside_parent) is VMInterface:
-                    if cluster := nat_inside_parent.virtual_machine.cluster:
-                        initial['nat_cluster'] = cluster.pk
-                    initial['nat_virtual_machine'] = nat_inside_parent.virtual_machine.pk
         kwargs['initial'] = initial
 
         super().__init__(*args, **kwargs)

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -266,18 +266,12 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
         queryset=Interface.objects.all(),
         required=False,
         selector=True,
-        query_params={
-            'device_id': '$device'
-        }
     )
     vminterface = DynamicModelChoiceField(
         queryset=VMInterface.objects.all(),
         required=False,
         selector=True,
         label=_('Interface'),
-        query_params={
-            'virtual_machine_id': '$virtual_machine'
-        }
     )
     fhrpgroup = DynamicModelChoiceField(
         queryset=FHRPGroup.objects.all(),
@@ -290,20 +284,11 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
         required=False,
         label=_('VRF')
     )
-    nat_vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(),
-        required=False,
-        selector=True,
-        label=_('VRF')
-    )
     nat_inside = DynamicModelChoiceField(
         queryset=IPAddress.objects.all(),
         required=False,
         selector=True,
         label=_('IP Address'),
-        query_params={
-            'vrf_id': '$nat_vrf',
-        }
     )
     primary_for_parent = forms.BooleanField(
         required=False,
@@ -314,8 +299,8 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
     class Meta:
         model = IPAddress
         fields = [
-            'address', 'vrf', 'status', 'role', 'dns_name', 'primary_for_parent', 'nat_vrf', 'nat_inside',
-            'tenant_group', 'tenant', 'description', 'comments', 'tags',
+            'address', 'vrf', 'status', 'role', 'dns_name', 'primary_for_parent', 'nat_inside', 'tenant_group',
+            'tenant', 'description', 'comments', 'tags',
         ]
 
     def __init__(self, *args, **kwargs):

--- a/netbox/templates/ipam/ipaddress_edit.html
+++ b/netbox/templates/ipam/ipaddress_edit.html
@@ -56,11 +56,9 @@
       </div>
       <div class="tab-content p-0 border-0">
         <div class="tab-pane {% if not form.initial.vminterface and not form.initial.fhrpgroup %}active{% endif %}" id="device" role="tabpanel" aria-labeled-by="device_tab">
-          {% render_field form.device %}
           {% render_field form.interface %}
         </div>
         <div class="tab-pane {% if form.initial.vminterface %}active{% endif %}" id="vm" role="tabpanel" aria-labeled-by="vm_tab">
-          {% render_field form.virtual_machine %}
           {% render_field form.vminterface %}
         </div>
         <div class="tab-pane {% if form.initial.fhrpgroup %}active{% endif %}" id="fhrpgroup" role="tabpanel" aria-labeled-by="fhrpgroup_tab">
@@ -75,60 +73,6 @@
         <h5 class="offset-sm-3">NAT IP (Inside)</h5>
       </div>
       <div class="row mb-2">
-        <div class="offset-sm-3">
-          <ul class="nav nav-pills" role="tablist">
-            <li class="nav-item" role="presentation">
-                <button
-                    role="tab"
-                    type="button"
-                    id="device_tab"
-                    data-bs-toggle="tab"
-                    class="nav-link active"
-                    data-bs-target="#by_device"
-                    aria-controls="by_device"
-                >
-                    By Device
-                </button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button
-                    role="tab"
-                    type="button"
-                    id="vm_tab"
-                    data-bs-toggle="tab"
-                    class="nav-link"
-                    data-bs-target="#by_vm"
-                    aria-controls="by_vm"
-                >
-                    By VM
-                </button>
-            </li>
-            <li class="nav-item" role="presentation">
-                <button
-                    role="tab"
-                    type="button"
-                    id="vrf_tab"
-                    data-bs-toggle="tab"
-                    class="nav-link"
-                    data-bs-target="#by_vrf"
-                    aria-controls="by_vrf"
-                >
-                    By IP
-                </button>
-            </li>
-          </ul>
-        </div>
-      </div>
-      <div class="tab-content p-0 border-0">
-          <div class="tab-pane active" id="by_device" aria-labelledby="device_tab" role="tabpanel">
-              {% render_field form.nat_device %}
-          </div>
-          <div class="tab-pane" id="by_vm" aria-labelledby="vm_tab" role="tabpanel">
-              {% render_field form.nat_virtual_machine %}
-          </div>
-          <div class="tab-pane" id="by_vrf" aria-labelledby="vrf_tab" role="tabpanel">
-              {% render_field form.nat_vrf %}
-          </div>
           {% render_field form.nat_inside %}
       </div>
     </div>


### PR DESCRIPTION
### Fixes: #10757

Convert the interface/FHRP assignment on IPAddress edit form to use the new selector system.  This should reduce the confusion as to whether a "device" is assigned or not.

This will also resolve #11477 in a similar manner.