### PR TITLE
12416 warning for missing script file

### DIFF
--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -56,7 +56,7 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
         module = None
         try:
             module = self.get_module()
-        except OSError as e:
+        except Exception as e:
             pass
 
         scripts = {}

--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -53,7 +53,12 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
             # For child objects in submodules use the full import path w/o the root module as the name
             return cls.full_name.split(".", maxsplit=1)[1]
 
-        module = self.get_module()
+        module = None
+        try:
+            module = self.get_module()
+        except OSError as e:
+            pass
+
         scripts = {}
         ordered = getattr(module, 'script_order', [])
 

--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -53,11 +53,10 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
             # For child objects in submodules use the full import path w/o the root module as the name
             return cls.full_name.split(".", maxsplit=1)[1]
 
-        module = None
         try:
             module = self.get_module()
         except Exception as e:
-            pass
+            module = None
 
         scripts = {}
         ordered = getattr(module, 'script_order', [])

--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -1,4 +1,5 @@
 import inspect
+import logging
 from functools import cached_property
 
 from django.db import models
@@ -15,6 +16,8 @@ __all__ = (
     'Script',
     'ScriptModule',
 )
+
+logger = logging.getLogger('netbox.data_backends')
 
 
 class Script(WebhooksMixin, models.Model):
@@ -56,6 +59,7 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
         try:
             module = self.get_module()
         except Exception as e:
+            logger.debug(f"Failed to load script: {self.python_name} error: {e}")
             module = None
 
         scripts = {}

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1033,7 +1033,6 @@ class ScriptView(ContentTypePermissionRequiredMixin, View):
         return 'extras.view_script'
 
     def get(self, request, module, name):
-        print(module)
         module = get_object_or_404(ScriptModule.objects.restrict(request.user), file_path__startswith=module)
         script = module.scripts[name]()
         form = script.as_form(initial=normalize_querydict(request.GET))

--- a/netbox/templates/extras/script_list.html
+++ b/netbox/templates/extras/script_list.html
@@ -39,9 +39,7 @@
           {% include 'inc/sync_warning.html' with object=module %}
           {% if not module.scripts %}
             <div class="alert alert-warning d-flex align-items-center" role="alert">
-              <div>
-                Warning: Script file at: <strong>{{ module.full_path }}"</strong> is either missing or has a problem with the script code, please check the file.
-              </div>
+              <i class="mdi mdi-alert"></i>&nbsp; Script file at: {{module.full_path}} could not be loaded.
             </div>
           {% else %}
             <table class="table table-hover table-headings reports">

--- a/netbox/templates/extras/script_list.html
+++ b/netbox/templates/extras/script_list.html
@@ -37,43 +37,51 @@
         </h5>
         <div class="card-body">
           {% include 'inc/sync_warning.html' with object=module %}
-          <table class="table table-hover table-headings reports">
-            <thead>
-              <tr>
-                <th width="250">Name</th>
-                <th>Description</th>
-                <th>Last Run</th>
-                <th class="text-end">Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% with jobs=module.get_latest_jobs %}
-                {% for script_name, script_class in module.scripts.items %}
-                  <tr>
-                    <td>
-                      <a href="{% url 'extras:script' module=module.python_name name=script_name %}" name="script.{{ script_name }}">{{ script_class.name }}</a>
-                    </td>
-                    <td>
-                      {{ script_class.Meta.description|markdown|placeholder }}
-                    </td>
-                    {% with last_result=jobs|get_key:script_class.name %}
-                      {% if last_result %}
-                        <td>
-                          <a href="{% url 'extras:script_result' job_pk=last_result.pk %}">{{ last_result.created|annotated_date }}</a>
-                        </td>
-                        <td class="text-end">
-                          {% badge last_result.get_status_display last_result.get_status_color %}
-                        </td>
-                      {% else %}
-                        <td class="text-muted">Never</td>
-                        <td class="text-end">{{ ''|placeholder }}</td>
-                      {% endif %}
-                    {% endwith %}
-                  </tr>
-                {% endfor %}
-              {% endwith %}
-            </tbody>
-          </table>
+          {% if not module.scripts %}
+            <div class="alert alert-warning d-flex align-items-center" role="alert">
+              <div>
+                Warning: Script file at: <strong>{{ module.full_path }}"</strong> is either missing or has a problem with the script code, please check the file.
+              </div>
+            </div>
+          {% else %}
+            <table class="table table-hover table-headings reports">
+              <thead>
+                <tr>
+                  <th width="250">Name</th>
+                  <th>Description</th>
+                  <th>Last Run</th>
+                  <th class="text-end">Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                {% with jobs=module.get_latest_jobs %}
+                  {% for script_name, script_class in module.scripts.items %}
+                    <tr>
+                      <td>
+                        <a href="{% url 'extras:script' module=module.python_name name=script_name %}" name="script.{{ script_name }}">{{ script_class.name }}</a>
+                      </td>
+                      <td>
+                        {{ script_class.Meta.description|markdown|placeholder }}
+                      </td>
+                      {% with last_result=jobs|get_key:script_class.name %}
+                        {% if last_result %}
+                          <td>
+                            <a href="{% url 'extras:script_result' job_pk=last_result.pk %}">{{ last_result.created|annotated_date }}</a>
+                          </td>
+                          <td class="text-end">
+                            {% badge last_result.get_status_display last_result.get_status_color %}
+                          </td>
+                        {% else %}
+                          <td class="text-muted">Never</td>
+                          <td class="text-end">{{ ''|placeholder }}</td>
+                        {% endif %}
+                      {% endwith %}
+                    </tr>
+                  {% endfor %}
+                {% endwith %}
+              </tbody>
+            </table>
+          {% endif %}
         </div>
       </div>
     {% empty %}


### PR DESCRIPTION
### Fixes: #12416 

Fixes the case of missing script files causing the script list view to error out.  Now shows a warning message for the admin to check the file (see screenshot below).  Also removed a left-over print statement in the code.

![Monosnap Scripts | NetBox 2023-05-03 14-26-20](https://user-images.githubusercontent.com/99642/236053537-0365aded-4245-4ff4-be64-90523a0dacda.png)
