### PR TITLE
Closes #11670: Add ability to optionally import DeviceType and ModuleType weight

### DIFF
--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -292,12 +292,10 @@ class DeviceTypeImportForm(NetBoxModelImportForm):
         required=False,
         help_text=_('The default platform for devices of this type (optional)')
     )
-
     weight = forms.DecimalField(
         required=False,
-        help_text=_("Device weight"),
+        help_text=_('Device weight'),
     )
-
     weight_unit = CSVChoiceField(
         choices=WeightUnitChoices,
         required=False,
@@ -308,7 +306,7 @@ class DeviceTypeImportForm(NetBoxModelImportForm):
         model = DeviceType
         fields = [
             'manufacturer', 'default_platform', 'model', 'slug', 'part_number', 'u_height', 'is_full_depth',
-            'subdevice_role', 'airflow', 'description', 'comments', 'weight', 'weight_unit',
+            'subdevice_role', 'airflow', 'description', 'weight', 'weight_unit', 'comments',
         ]
 
 
@@ -317,12 +315,10 @@ class ModuleTypeImportForm(NetBoxModelImportForm):
         queryset=Manufacturer.objects.all(),
         to_field_name='name'
     )
-
     weight = forms.DecimalField(
         required=False,
-        help_text=_("Module weight"),
+        help_text=_('Module weight'),
     )
-
     weight_unit = CSVChoiceField(
         choices=WeightUnitChoices,
         required=False,
@@ -331,7 +327,7 @@ class ModuleTypeImportForm(NetBoxModelImportForm):
 
     class Meta:
         model = ModuleType
-        fields = ['manufacturer', 'model', 'part_number', 'description', 'comments', 'weight', 'weight_unit']
+        fields = ['manufacturer', 'model', 'part_number', 'description', 'weight', 'weight_unit', 'comments']
 
 
 class DeviceRoleImportForm(NetBoxModelImportForm):

--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -293,11 +293,22 @@ class DeviceTypeImportForm(NetBoxModelImportForm):
         help_text=_('The default platform for devices of this type (optional)')
     )
 
+    weight = forms.DecimalField(
+        required=False,
+        help_text=_("Device weight"),
+    )
+
+    weight_unit = CSVChoiceField(
+        choices=WeightUnitChoices,
+        required=False,
+        help_text=_('Unit for device weight')
+    )
+
     class Meta:
         model = DeviceType
         fields = [
             'manufacturer', 'default_platform', 'model', 'slug', 'part_number', 'u_height', 'is_full_depth',
-            'subdevice_role', 'airflow', 'description', 'comments',
+            'subdevice_role', 'airflow', 'description', 'comments', 'weight', 'weight_unit',
         ]
 
 

--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -318,9 +318,20 @@ class ModuleTypeImportForm(NetBoxModelImportForm):
         to_field_name='name'
     )
 
+    weight = forms.DecimalField(
+        required=False,
+        help_text=_("Module weight"),
+    )
+
+    weight_unit = CSVChoiceField(
+        choices=WeightUnitChoices,
+        required=False,
+        help_text=_('Unit for module weight')
+    )
+
     class Meta:
         model = ModuleType
-        fields = ['manufacturer', 'model', 'part_number', 'description', 'comments']
+        fields = ['manufacturer', 'model', 'part_number', 'description', 'comments', 'weight', 'weight_unit']
 
 
 class DeviceRoleImportForm(NetBoxModelImportForm):

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -363,6 +363,8 @@ class ModuleType(PrimaryModel, WeightMixin):
             'model': self.model,
             'part_number': self.part_number,
             'comments': self.comments,
+            'weight': float(self.weight) if self.weight is not None else None,
+            'weight_unit': self.weight_unit,
         }
 
         # Component templates

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -184,6 +184,8 @@ class DeviceType(PrimaryModel, WeightMixin):
             'subdevice_role': self.subdevice_role,
             'airflow': self.airflow,
             'comments': self.comments,
+            'weight': float(self.weight) if self.weight is not None else None,
+            'weight_unit': self.weight_unit,
         }
 
         # Component templates

--- a/netbox/dcim/tests/test_views.py
+++ b/netbox/dcim/tests/test_views.py
@@ -1196,6 +1196,46 @@ front-ports:
         self.assertEqual(fp1.rear_port, rp1)
         self.assertEqual(fp1.rear_port_position, 1)
 
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
+    def test_import_moduletype_with_weight(self):
+        """
+        Custom import test for JSON-based imports specifically including module weight
+        """
+        IMPORT_DATA = """
+{
+    "manufacturer": "Manufacturer 2",
+    "model": "TEST-1001",
+    "weight": 10,
+    "weight_unit": "lb"
+}
+"""
+
+        # Add all required permissions to the test user
+        self.add_permissions(
+            'dcim.view_moduletype',
+            'dcim.add_moduletype',
+            'dcim.add_consoleporttemplate',
+            'dcim.add_consoleserverporttemplate',
+            'dcim.add_powerporttemplate',
+            'dcim.add_poweroutlettemplate',
+            'dcim.add_interfacetemplate',
+            'dcim.add_frontporttemplate',
+            'dcim.add_rearporttemplate',
+        )
+
+        form_data = {
+            'data': IMPORT_DATA,
+            'format': 'json'
+        }
+        response = self.client.post(reverse('dcim:moduletype_import'), data=form_data, follow=True)
+        self.assertHttpStatus(response, 200)
+
+        module_type = ModuleType.objects.get(model='TEST-1001')
+
+        # Verify the weight is correct
+        self.assertEqual(module_type.weight, 10)
+        self.assertEqual(module_type.weight_unit, WeightUnitChoices.UNIT_POUND)
+
     def test_export_objects(self):
         url = reverse('dcim:moduletype_list')
         self.add_permissions('dcim.view_moduletype')

--- a/netbox/dcim/tests/test_views.py
+++ b/netbox/dcim/tests/test_views.py
@@ -681,11 +681,15 @@ class DeviceTypeTestCase(
         """
         IMPORT_DATA = """
 manufacturer: Generic
-default_platform: Platform
 model: TEST-1000
 slug: test-1000
+default_platform: Platform
 u_height: 2
+is_full_depth: false
+airflow: front-to-rear
 subdevice_role: parent
+weight: 10
+weight_unit: kg
 comments: Test comment
 console-ports:
   - name: Console Port 1
@@ -794,8 +798,16 @@ inventory-items:
         self.assertHttpStatus(response, 200)
 
         device_type = DeviceType.objects.get(model='TEST-1000')
-        self.assertEqual(device_type.comments, 'Test comment')
+        self.assertEqual(device_type.manufacturer.pk, manufacturer.pk)
         self.assertEqual(device_type.default_platform.pk, platform.pk)
+        self.assertEqual(device_type.slug, 'test-1000')
+        self.assertEqual(device_type.u_height, 2)
+        self.assertFalse(device_type.is_full_depth)
+        self.assertEqual(device_type.airflow, DeviceAirflowChoices.AIRFLOW_FRONT_TO_REAR)
+        self.assertEqual(device_type.subdevice_role, SubdeviceRoleChoices.ROLE_PARENT)
+        self.assertEqual(device_type.weight, 10)
+        self.assertEqual(device_type.weight_unit, WeightUnitChoices.UNIT_KILOGRAM)
+        self.assertEqual(device_type.comments, 'Test comment')
 
         # Verify all of the components were created
         self.assertEqual(device_type.consoleporttemplates.count(), 3)
@@ -851,56 +863,6 @@ inventory-items:
         self.assertEqual(device_type.inventoryitemtemplates.count(), 3)
         ii1 = InventoryItemTemplate.objects.first()
         self.assertEqual(ii1.name, 'Inventory Item 1')
-
-    @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
-    def test_import_devicetype_with_weight(self):
-        """
-        Custom import test for JSON-based imports specifically including device weight
-        """
-        IMPORT_DATA = """
-{
-    "manufacturer": "Manufacturer 1",
-    "model": "ABCDEFG",
-    "slug": "abcdefg",
-    "u_height": 1,
-    "is_full_depth": false,
-    "airflow": "front-to-rear",
-    "description": "DeviceType with weight",
-    "weight": 10,
-    "weight_unit": "kg"
-}
-"""
-        # Add all required permissions to the test user
-        self.add_permissions(
-            'dcim.view_devicetype',
-            'dcim.add_devicetype',
-            'dcim.add_consoleporttemplate',
-            'dcim.add_consoleserverporttemplate',
-            'dcim.add_powerporttemplate',
-            'dcim.add_poweroutlettemplate',
-            'dcim.add_interfacetemplate',
-            'dcim.add_frontporttemplate',
-            'dcim.add_rearporttemplate',
-            'dcim.add_modulebaytemplate',
-            'dcim.add_devicebaytemplate',
-            'dcim.add_inventoryitemtemplate',
-        )
-
-        form_data = {
-            'data': IMPORT_DATA,
-            'format': 'json'
-        }
-        response = self.client.post(reverse('dcim:devicetype_import'), data=form_data, follow=True)
-        self.assertHttpStatus(response, 200)
-
-        device_type = DeviceType.objects.get(model='ABCDEFG')
-        self.assertEqual(device_type.slug, "abcdefg")
-        self.assertEqual(device_type.u_height, 1)
-        self.assertFalse(device_type.is_full_depth)
-        self.assertEqual(device_type.airflow, DeviceAirflowChoices.AIRFLOW_FRONT_TO_REAR)
-        self.assertEqual(device_type.description, 'DeviceType with weight')
-        self.assertEqual(device_type.weight, 10)
-        self.assertEqual(device_type.weight_unit, WeightUnitChoices.UNIT_KILOGRAM)
 
     def test_export_objects(self):
         url = reverse('dcim:devicetype_list')
@@ -1069,6 +1031,8 @@ class ModuleTypeTestCase(
         IMPORT_DATA = """
 manufacturer: Generic
 model: TEST-1000
+weight: 10
+weight_unit: lb
 comments: Test comment
 console-ports:
   - name: Console Port 1
@@ -1132,7 +1096,8 @@ front-ports:
 """
 
         # Create the manufacturer
-        Manufacturer(name='Generic', slug='generic').save()
+        manufacturer = Manufacturer(name='Generic', slug='generic')
+        manufacturer.save()
 
         # Add all required permissions to the test user
         self.add_permissions(
@@ -1155,6 +1120,9 @@ front-ports:
         self.assertHttpStatus(response, 200)
 
         module_type = ModuleType.objects.get(model='TEST-1000')
+        self.assertEqual(module_type.manufacturer.pk, manufacturer.pk)
+        self.assertEqual(module_type.weight, 10)
+        self.assertEqual(module_type.weight_unit, WeightUnitChoices.UNIT_POUND)
         self.assertEqual(module_type.comments, 'Test comment')
 
         # Verify all the components were created
@@ -1195,46 +1163,6 @@ front-ports:
         self.assertEqual(fp1.name, 'Front Port 1')
         self.assertEqual(fp1.rear_port, rp1)
         self.assertEqual(fp1.rear_port_position, 1)
-
-    @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
-    def test_import_moduletype_with_weight(self):
-        """
-        Custom import test for JSON-based imports specifically including module weight
-        """
-        IMPORT_DATA = """
-{
-    "manufacturer": "Manufacturer 2",
-    "model": "TEST-1001",
-    "weight": 10,
-    "weight_unit": "lb"
-}
-"""
-
-        # Add all required permissions to the test user
-        self.add_permissions(
-            'dcim.view_moduletype',
-            'dcim.add_moduletype',
-            'dcim.add_consoleporttemplate',
-            'dcim.add_consoleserverporttemplate',
-            'dcim.add_powerporttemplate',
-            'dcim.add_poweroutlettemplate',
-            'dcim.add_interfacetemplate',
-            'dcim.add_frontporttemplate',
-            'dcim.add_rearporttemplate',
-        )
-
-        form_data = {
-            'data': IMPORT_DATA,
-            'format': 'json'
-        }
-        response = self.client.post(reverse('dcim:moduletype_import'), data=form_data, follow=True)
-        self.assertHttpStatus(response, 200)
-
-        module_type = ModuleType.objects.get(model='TEST-1001')
-
-        # Verify the weight is correct
-        self.assertEqual(module_type.weight, 10)
-        self.assertEqual(module_type.weight_unit, WeightUnitChoices.UNIT_POUND)
 
     def test_export_objects(self):
         url = reverse('dcim:moduletype_list')


### PR DESCRIPTION
### Fixes: #11670

### Summary 

This Pull Request adds the ability to import weight data via CSV, YAML, or JSON for Module Types and Device Types. Additionally, this PR adds the `weight` and `weight_unit` fields to the YAML export of Device Types and Module Types.

### Background

Prior to this PR, the ModuleType and DeviceType modules already contained weight and weight unit fields. However, there was no ability to import this data. This PR adds the necessary functionality.

### Changes 

To maintain consistency, the import design of the DeviceType weight follows the same pattern used for importing weight and weight units in DCIM Racks.

The PR description includes examples of YAML imports for Racks, Device Types, and Module Types, as well as YAML exports for Device Types and Module Types. These examples illustrate demonstrate how these new import and export changes look.

### Benefits

This feature improves the usability of NetBox by allowing users to import weight data for Module Types and Device Types, as requested in #11670. It also makes it easier to manage and maintain this data, as it can be imported/exported along with other relevant information.

## Examples

### Rack Import Example (YAML)

This is a YAML example of importing a Rack in NetBox. The below YAML worked in NetBox prior to this Pull Request.

```yaml
site: DM-Albany
name: blahabc
status: active
width: 19
u_height: 42
weight: 10
weight_unit: kg
```

### Device Type Import Example (YAML)

This is a YAML example of importing a Device Type in NetBox.

```yaml
manufacturer: Juniper
model: Switch
slug: switch
u_height: 1
weight: 10
weight_unit: kg
```

### Module Type Import Example (YAML)

This is a YAML example of importing a Module Type in NetBox.

```yaml
manufacturer: Juniper
model: TEST-1001
weight: 10
weight_unit: lb
```
### YAML Export

Attached below are example exports with the new `weight` and `weight_unit` fields included:

- [netbox_device_types_yaml.txt](https://github.com/netbox-community/netbox/files/11413947/netbox_device_types_yaml.txt)
- [netbox_module_types_yaml.txt](https://github.com/netbox-community/netbox/files/11413946/netbox_module_types_yaml.txt) 
