### PR TITLE
Adds full_clean in examples

### DIFF
--- a/docs/administration/netbox-shell.md
+++ b/docs/administration/netbox-shell.md
@@ -157,12 +157,6 @@ New objects can be created by instantiating the desired model, defining values f
 >>> myvlan.save()
 ```
 
-Alternatively, the above can be performed as a single operation. (Note, however, that `save()` does _not_ return the new instance for reuse.)
-
-```
->>> VLAN(vid=123, name='MyNewVLAN', site=Site.objects.get(pk=7)).save()
-```
-
 To modify an existing object, we retrieve it, update the desired field(s), and call `save()` again.
 
 ```

--- a/docs/administration/netbox-shell.md
+++ b/docs/administration/netbox-shell.md
@@ -153,6 +153,7 @@ New objects can be created by instantiating the desired model, defining values f
 ```
 >>> lab1 = Site.objects.get(pk=7)
 >>> myvlan = VLAN(vid=123, name='MyNewVLAN', site=lab1)
+>>> myvlan.full_clean()
 >>> myvlan.save()
 ```
 
@@ -169,6 +170,7 @@ To modify an existing object, we retrieve it, update the desired field(s), and c
 >>> vlan.name
 'MyNewVLAN'
 >>> vlan.name = 'BetterName'
+>>> vlan.full_clean()
 >>> vlan.save()
 >>> VLAN.objects.get(pk=1280).name
 'BetterName'

--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -378,6 +378,7 @@ class NewBranchScript(Script):
             slug=slugify(data['site_name']),
             status=SiteStatusChoices.STATUS_PLANNED
         )
+        site.full_clean()
         site.save()
         self.log_success(f"Created new site: {site}")
 
@@ -391,6 +392,7 @@ class NewBranchScript(Script):
                 status=DeviceStatusChoices.STATUS_PLANNED,
                 device_role=switch_role
             )
+            switch.full_clean()
             switch.save()
             self.log_success(f"Created new switch: {switch}")
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #11689

<!--
    Please include a summary of the proposed changes below.
-->

One question, since it's not possible to provide a 1-liner along with `full_clean`, should I remove this from the doc?

https://github.com/netbox-community/netbox/blob/develop/docs/administration/netbox-shell.md?plain=1#L159-L163

```
Alternatively, the above can be performed as a single operation. (Note, however, that `save()` does _not_ return the new instance for reuse.)

>>> VLAN(vid=123, name='MyNewVLAN', site=Site.objects.get(pk=7)).save()
```