### PR TITLE
Use .font-monospace instead of .text-monospace

### DIFF
--- a/netbox/templates/dcim/interface.html
+++ b/netbox/templates/dcim/interface.html
@@ -123,11 +123,11 @@
           <table class="table table-hover">
             <tr>
               <th scope="row">MAC Address</th>
-              <td><span class="text-monospace">{{ object.mac_address|placeholder }}</span></td>
+              <td><span class="font-monospace">{{ object.mac_address|placeholder }}</span></td>
             </tr>
             <tr>
               <th scope="row">WWN</th>
-              <td><span class="text-monospace">{{ object.wwn|placeholder }}</span></td>
+              <td><span class="font-monospace">{{ object.wwn|placeholder }}</span></td>
             </tr>
             <tr>
               <th scope="row">VRF</th>

--- a/netbox/templates/virtualization/vminterface.html
+++ b/netbox/templates/virtualization/vminterface.html
@@ -59,7 +59,7 @@
                     </tr>
                     <tr>
                         <th scope="row">MAC Address</th>
-                        <td><span class="text-monospace">{{ object.mac_address|placeholder }}</span></td>
+                        <td><span class="font-monospace">{{ object.mac_address|placeholder }}</span></td>
                     </tr>
                     <tr>
                         <th scope="row">802.1Q Mode</th>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12600 

<!--
    Please include a summary of the proposed changes below.
-->

Changes all uses of `.text-monospace` to `.font-monospace` for Bootstrap v5 (https://getbootstrap.com/docs/5.0/migration/).
