### PR TITLE
Closes #9068: validate addresses assigned to interfaces

### DIFF
--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -350,7 +350,7 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
             self.add_error(
                 'primary_for_parent', "Only IP addresses assigned to an interface can be designated as primary IPs."
             )
-        
+
         # Do not allow assigning a network ID or broadcast address to an interface.
         if interface:
             if address := self.cleaned_data.get('address'):

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -352,19 +352,16 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
             )
 
         # Do not allow assigning a network ID or broadcast address to an interface.
-        if interface:
-            if address := self.cleaned_data.get('address'):
-                if address.ip == address.network:
-                    msg = f"{address} is a network ID, which may not be assigned to an interface."
-                    if address.version == 4:
-                        if address.prefixlen not in (31, 32):
-                            raise ValidationError(msg)
-                    if address.version == 6:
-                        if address.prefixlen not in (127, 128):
-                            raise ValidationError(msg)
-                if address.ip == address.broadcast:
-                    msg = f"{address} is a broadcast address, which may not be assigned to an interface."
+        if interface and (address := self.cleaned_data.get('address')):
+            if address.ip == address.network:
+                msg = f"{address} is a network ID, which may not be assigned to an interface."
+                if address.version == 4 and address.prefixlen not in (31, 32):
                     raise ValidationError(msg)
+                if address.version == 6 and address.prefixlen not in (127, 128):
+                    raise ValidationError(msg)
+            if address.ip == address.broadcast:
+                msg = f"{address} is a broadcast address, which may not be assigned to an interface."
+                raise ValidationError(msg)
 
     def save(self, *args, **kwargs):
         ipaddress = super().save(*args, **kwargs)

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -350,6 +350,13 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
             self.add_error(
                 'primary_for_parent', "Only IP addresses assigned to an interface can be designated as primary IPs."
             )
+        
+        # Do not allow assigning a network ID or broadcast address to an interface
+        if interface:
+            if self.instance.ip == self.instance.network:
+                self.add_error('interface', "This address is a network ID, which may not be assigned to an interface.")
+            if self.instance.ip == self.instance.broadcast:
+                self.add_error('interface', "This address is a broadcast address, which may not be assigned to an interface.")
 
     def save(self, *args, **kwargs):
         ipaddress = super().save(*args, **kwargs)

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -351,12 +351,17 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
                 'primary_for_parent', "Only IP addresses assigned to an interface can be designated as primary IPs."
             )
         
-        # Do not allow assigning a network ID or broadcast address to an interface
+        # Do not allow assigning a network ID or broadcast address to an interface.
         if interface:
-            if self.instance.ip == self.instance.network:
-                self.add_error('interface', "This address is a network ID, which may not be assigned to an interface.")
-            if self.instance.ip == self.instance.broadcast:
-                self.add_error('interface', "This address is a broadcast address, which may not be assigned to an interface.")
+            if address := self.cleaned_data.get('address'):
+                if address.ip == address.network:
+                    self.add_error(
+                        'interface',
+                        "This address is a network ID, which may not be assigned to an interface.")
+                if address.ip == address.broadcast:
+                    self.add_error(
+                        'interface',
+                        "This is a broadcast address, which may not be assigned to an interface.")
 
     def save(self, *args, **kwargs):
         ipaddress = super().save(*args, **kwargs)

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -354,14 +354,14 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
         # Do not allow assigning a network ID or broadcast address to an interface.
         if interface:
             if address := self.cleaned_data.get('address'):
-                if address.ip == address.network:
+                if address.ip == address.network and address.prefixlen not in (31, 32, 127, 128):
                     self.add_error(
                         'interface',
-                        "This address is a network ID, which may not be assigned to an interface.")
+                        f"{address} is a network ID, which may not be assigned to an interface.")
                 if address.ip == address.broadcast:
                     self.add_error(
                         'interface',
-                        "This is a broadcast address, which may not be assigned to an interface.")
+                        f"{address} is a broadcast address, which may not be assigned to an interface.")
 
     def save(self, *args, **kwargs):
         ipaddress = super().save(*args, **kwargs)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #9068

Disallows assigning a broadcast address or network ID to an interface.
