### PR TITLE
12474 update cable terminations when moving location between sites

### DIFF
--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -27,6 +27,7 @@ def handle_location_site_change(instance, created, **kwargs):
         Rack.objects.filter(location__in=locations).update(site=instance.site)
         Device.objects.filter(location__in=locations).update(site=instance.site)
         PowerPanel.objects.filter(location__in=locations).update(site=instance.site)
+        CableTermination.objects.filter(_location__in=locations).update(_site=instance.site)
 
 
 @receiver(post_save, sender=Rack)


### PR DESCRIPTION
### Fixes: #12474 

Updates cable termination site field when moving a location between sites.