### PR TITLE
12548 add prefetch_related for l2vpn and vdcs to interface api

### DIFF
--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -493,7 +493,8 @@ class PowerOutletViewSet(PathEndpointMixin, NetBoxModelViewSet):
 class InterfaceViewSet(PathEndpointMixin, NetBoxModelViewSet):
     queryset = Interface.objects.prefetch_related(
         'device', 'module__module_bay', 'parent', 'bridge', 'lag', '_path', 'cable__terminations', 'wireless_lans',
-        'untagged_vlan', 'tagged_vlans', 'vrf', 'ip_addresses', 'fhrp_group_assignments', 'tags'
+        'untagged_vlan', 'tagged_vlans', 'vrf', 'ip_addresses', 'fhrp_group_assignments', 'tags', 'l2vpn_terminations',
+        'vdcs',
     )
     serializer_class = serializers.InterfaceSerializer
     filterset_class = filtersets.InterfaceFilterSet


### PR DESCRIPTION
### Fixes: #12548 

Adds l2vpn_termiantions and vdcs to InterfaceViewSet to reduce n+1 queries for the Interface API.