### PR TITLE
Closes #11619: Include VLANs with a null site in query during bulk interface edit for Devices > DEVICE COMPONENTS > Interfaces

### DIFF
--- a/netbox/dcim/forms/bulk_edit.py
+++ b/netbox/dcim/forms/bulk_edit.py
@@ -1292,8 +1292,9 @@ class InterfaceBulkEditForm(
                         break
 
                 if site is not None:
-                    self.fields['untagged_vlan'].widget.add_query_param('site_id', site.pk)
-                    self.fields['tagged_vlans'].widget.add_query_param('site_id', site.pk)
+                    # Query for VLANs assigned to the same site and VLANs with no site assigned (null).
+                    self.fields['untagged_vlan'].widget.add_query_param('site_id', [site.pk, 'null'])
+                    self.fields['tagged_vlans'].widget.add_query_param('site_id', [site.pk, 'null'])
 
             self.fields['parent'].choices = ()
             self.fields['parent'].widget.attrs['disabled'] = True

--- a/netbox/dcim/forms/bulk_edit.py
+++ b/netbox/dcim/forms/bulk_edit.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.utils.translation import gettext as _
 from timezone_field import TimeZoneFormField
@@ -1293,8 +1294,12 @@ class InterfaceBulkEditForm(
 
                 if site is not None:
                     # Query for VLANs assigned to the same site and VLANs with no site assigned (null).
-                    self.fields['untagged_vlan'].widget.add_query_param('site_id', [site.pk, 'null'])
-                    self.fields['tagged_vlans'].widget.add_query_param('site_id', [site.pk, 'null'])
+                    self.fields['untagged_vlan'].widget.add_query_param(
+                        'site_id', [site.pk, settings.FILTERS_NULL_CHOICE_VALUE]
+                    )
+                    self.fields['tagged_vlans'].widget.add_query_param(
+                        'site_id', [site.pk, settings.FILTERS_NULL_CHOICE_VALUE]
+                    )
 
             self.fields['parent'].choices = ()
             self.fields['parent'].widget.attrs['disabled'] = True


### PR DESCRIPTION
### Fixes: #11619

### Summary 

This Pull Request enables users to be to select VLANs **without** a site assignment during bulk interface edits under Devices > DEVICE COMPONENTS > Interfaces.

### Background

Previously, only VLANs assigned to the same site as the filtered device were available for selection. However, since it is possible to create VLANs without a site assignment, this led to a subset of selectable VLANs being omitted from the VLAN filter dropdown. This Pull Request addresses this issue by enhancing the functionality to include all selectable VLANs in the filter dropdown.

### Changes

This Pull Request updates the query parameters in the code behind the bulk edit to search for VLANs with the site set to null, allowing the selection of VLANs without a site assignment.

### Benefits

By incorporating this change, NetBox's usability is improved as users can now assign VLANs with a null site during a bulk interface edit. Without this modification, each interface would need to be individually edited through a different section of the UI that already worked.

## Test

To reproduce the bug described in issue #11619, follow these steps:

1. Create a site named SITE_TEST.
2. Import a new VLAN with the following details:

```yaml
vid: 10
name: VLAN 10 SITE_TEST
status: active
site: SITE_TEST
```

4. Import another VLAN without specifying a site:

```yaml
vid: 20
name: VLAN 20 SITE_TEST
status: active
```

5. Create a device `DEV_TEST` in Site `SITE_TEST` with at least two interfaces. You can use the ISR 1111-8P defined in [this GitHub repository](https://github.com/netbox-community/netbox-demo-data), or alternatively, import the device using the following YAML:

```yaml
name: DEV_TEST
site: SITE_TEST
device_role: Access Switch
status: active
manufacturer: Cisco
device_type: ISR 1111-8P
```

7. Navigate to [Devices -> DEVICE COMPONENTS -> Interfaces](https://demo.netbox.dev/dcim/interfaces/)
8. Filter for all interfaces belonging to the `DEV_TEST` device.

![image](https://github.com/netbox-community/netbox/assets/11417982/17104b61-2b41-4d90-8973-253b83ae0946)


10. The changes introduced by this Pull Request can be visually compared in the following sections:


### Prior to this Pull Request

Edit multiple interfaces -> 802.1Q Switching Mode: Tagged -> Untagged VLAN includes only VLAN 10

![image](https://github.com/netbox-community/netbox/assets/11417982/fede615e-fec2-4eb7-80f2-85aa0272b757)

Edit multiple interfaces -> 802.1Q Switching Mode: Tagged -> Tagged VLANs includes only VLAN 10

![image](https://github.com/netbox-community/netbox/assets/11417982/228d1592-0921-43b5-a6e1-e8a9f544c7a0)


### With this Pull Request

Edit multiple interfaces -> 802.1Q Switching Mode: Tagged -> Untagged VLAN includes VLAN 10 and VLAN 20

![image](https://github.com/netbox-community/netbox/assets/11417982/b8c0212b-4a8e-4dc1-8fea-fecbab0d4520)

Edit multiple interfaces -> 802.1Q Switching Mode: Tagged -> Tagged VLANs includes VLAN 10 and VLAN 20

![image](https://github.com/netbox-community/netbox/assets/11417982/c29400f6-cdb1-41d8-b7bb-0e2689def3b0)

