### PR TITLE
Fix #12690 - Add Cluster/ClusterGroup Filtering to VLANGroup QuerySet

### DIFF
--- a/netbox/ipam/querysets.py
+++ b/netbox/ipam/querysets.py
@@ -64,6 +64,16 @@ class VLANQuerySet(RestrictedQuerySet):
                 scope_type=ContentType.objects.get_by_natural_key('dcim', 'rack'),
                 scope_id=device.rack_id
             )
+        if device.cluster:
+            q |= Q(
+                scope_type=ContentType.objects.get_by_natural_key('virtualization', 'cluster'),
+                scope_id=device.cluster.id
+            )
+            if device.cluster.group:
+                q |= Q(
+                    scope_type=ContentType.objects.get_by_natural_key('virtualization', 'clustergroup'),
+                    scope_id=device.cluster.group.id
+                )
 
         # Return all applicable VLANs
         return self.filter(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12690 

<!--
    Please include a summary of the proposed changes below.
-->
This changes adds additional filtering to the VLANGroup QuerySet to account for Cluster and Cluster Group scopes - enabling them to be returned by the `/api/ipam/vlans/?available_on_device` endpoint.

This has been validated against various test cases.