### PR TITLE
Fixes return_url for image attachment

### DIFF
--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -235,7 +235,7 @@ class ActionsColumn(tables.Column):
 
         model = table.Meta.model
         request = getattr(table, 'context', {}).get('request')
-        return_url = request.GET.get('return_url', request.get_full_path())
+        return_url = request.GET.get('return_url', request.get_full_path() if request else '')
         url_appendix = f'?return_url={quote(return_url)}' if return_url else ''
 
         html = ''

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -236,9 +236,9 @@ class ActionsColumn(tables.Column):
         model = table.Meta.model
         if request := getattr(table, 'context', {}).get('request'):
             return_url = request.GET.get('return_url', request.get_full_path())
+            url_appendix = f'?return_url={quote(return_url)}'
         else:
-            return_url = ''
-        url_appendix = f'?return_url={quote(return_url)}' if return_url else ''
+            url_appendix = ''
 
         html = ''
 

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -235,7 +235,12 @@ class ActionsColumn(tables.Column):
 
         model = table.Meta.model
         request = getattr(table, 'context', {}).get('request')
-        url_appendix = f'?return_url={quote(request.get_full_path())}' if request else ''
+        query_params = request.GET.copy() if request else {}
+        if return_url := query_params.pop('return_url', None):
+            url_appendix = f'?return_url={quote(return_url[0])}'
+        else:
+            url_appendix = f'?return_url={quote(request.get_full_path())}' if request else ''
+
         html = ''
 
         # Compile actions menu

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -234,8 +234,10 @@ class ActionsColumn(tables.Column):
             return ''
 
         model = table.Meta.model
-        request = getattr(table, 'context', {}).get('request')
-        return_url = request.GET.get('return_url', request.get_full_path() if request else '')
+        if request := getattr(table, 'context', {}).get('request'):
+            return_url = request.GET.get('return_url', request.get_full_path())
+        else:
+            return_url = ''
         url_appendix = f'?return_url={quote(return_url)}' if return_url else ''
 
         html = ''

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -235,11 +235,8 @@ class ActionsColumn(tables.Column):
 
         model = table.Meta.model
         request = getattr(table, 'context', {}).get('request')
-        query_params = request.GET.copy() if request else {}
-        if return_url := query_params.pop('return_url', None):
-            url_appendix = f'?return_url={quote(return_url[0])}'
-        else:
-            url_appendix = f'?return_url={quote(request.get_full_path())}' if request else ''
+        return_url = request.GET.get('return_url', request.get_full_path())
+        url_appendix = f'?return_url={quote(return_url)}' if return_url else ''
 
         html = ''
 

--- a/netbox/templates/inc/panels/image_attachments.html
+++ b/netbox/templates/inc/panels/image_attachments.html
@@ -1,12 +1,8 @@
 {% load helpers %}
 
 <div class="card">
-  <h5 class="card-header">
-    Images
-  </h5>
-  <div class="card-body htmx-container table-responsive"
-  hx-get="{% url 'extras:imageattachment_list' %}?content_type_id={{ object|content_type_id }}&object_id={{ object.pk }}&return_url={{ request.path }}"
-  hx-trigger="load"></div>
+  <h5 class="card-header">Images</h5>
+  {% htmx_table 'extras:imageattachment_list' content_type_id=object|content_type_id object_id=object.pk %}
   {% if perms.extras.add_imageattachment %}
     <div class="card-footer text-end noprint">
       <a href="{% url 'extras:imageattachment_add' %}?content_type={{ object|content_type_id }}&object_id={{ object.pk }}" class="btn btn-primary btn-sm">

--- a/netbox/templates/inc/panels/image_attachments.html
+++ b/netbox/templates/inc/panels/image_attachments.html
@@ -5,7 +5,7 @@
     Images
   </h5>
   <div class="card-body htmx-container table-responsive"
-  hx-get="{% url 'extras:imageattachment_list' %}?content_type_id={{ object|content_type_id }}&object_id={{ object.pk }}"
+  hx-get="{% url 'extras:imageattachment_list' %}?content_type_id={{ object|content_type_id }}&object_id={{ object.pk }}&return_url={{ request.path }}"
   hx-trigger="load"></div>
   {% if perms.extras.add_imageattachment %}
     <div class="card-footer text-end noprint">

--- a/netbox/utilities/templates/builtins/htmx_table.html
+++ b/netbox/utilities/templates/builtins/htmx_table.html
@@ -1,0 +1,4 @@
+<div class="card-body htmx-container table-responsive"
+  hx-get="{% url viewname %}{% if url_params %}?{{ url_params.urlencode }}{% endif %}"
+  hx-trigger="load"
+></div>

--- a/netbox/utilities/templatetags/builtins/tags.py
+++ b/netbox/utilities/templatetags/builtins/tags.py
@@ -1,4 +1,5 @@
 from django import template
+from django.http import QueryDict
 
 __all__ = (
     'badge',
@@ -73,4 +74,23 @@ def checkmark(value, show_false=True, true='Yes', false='No'):
         'show_false': show_false,
         'true_label': true,
         'false_label': false,
+    }
+
+
+@register.inclusion_tag('builtins/htmx_table.html', takes_context=True)
+def htmx_table(context, viewname, return_url=None, **kwargs):
+    """
+    Embed an object list table retrieved using HTMX. Any extra keyword arguments are passed as URL query parameters.
+
+    Args:
+        context: The current request context
+        viewname: The name of the view to use for the HTMX request (e.g. `dcim:site_list`)
+        return_url: The URL to pass as the `return_url`. If not provided, the current request's path will be used.
+    """
+    url_params = QueryDict(mutable=True)
+    url_params.update(kwargs)
+    url_params['return_url'] = return_url or context['request'].path
+    return {
+        'viewname': viewname,
+        'url_params': url_params,
     }


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12538

<!--
    Please include a summary of the proposed changes below.
-->
I have added support for parsing `return_url` from the request in the table if it exists. The old functionality is still retained if the parameter is not provided. I could not find any other clean way of redirecting the user back to where the request was initiated.