### PR TITLE
12625 hide datasource password

### DIFF
--- a/netbox/templates/core/datasource.html
+++ b/netbox/templates/core/datasource.html
@@ -89,11 +89,13 @@
             {% for name, field in object.get_backend.parameters.items %}
               <tr>
                 <th scope="row">{{ field.label }}</th>
-                {% if field.label == "Password" %}
+                {% if field.label == "Password" and object.parameters|get_key:name %}
                   <td>
                     {% if request.user|can_add:object or request.user|can_change:object or request.user|can_delete:object %}
                       <span id="secret" class="font-monospace" data-secret="{{ object.parameters|get_key:name }}">{{ object.parameters|get_key:name|placeholder }}</span>
                       <button type="button" class="btn btn-sm btn-primary toggle-secret float-end" data-bs-toggle="button">Show Secret</button>
+                    {% else %}
+                      <i>Password Hidden</i>
                     {% endif %}
                   </td>
                 {% else %}

--- a/netbox/templates/core/datasource.html
+++ b/netbox/templates/core/datasource.html
@@ -2,6 +2,7 @@
 {% load static %}
 {% load helpers %}
 {% load plugins %}
+{% load perms %}
 {% load render_table from django_tables2 %}
 
 {% block extra_controls %}
@@ -88,7 +89,16 @@
             {% for name, field in object.get_backend.parameters.items %}
               <tr>
                 <th scope="row">{{ field.label }}</th>
-                <td>{{ object.parameters|get_key:name|placeholder }}</td>
+                {% if field.label == "Password" %}
+                  <td>
+                    {% if request.user|can_add:object or request.user|can_change:object or request.user|can_delete:object %}
+                      <span id="secret" class="font-monospace" data-secret="{{ object.parameters|get_key:name }}">{{ object.parameters|get_key:name|placeholder }}</span>
+                      <button type="button" class="btn btn-sm btn-primary toggle-secret float-end" data-bs-toggle="button">Show Secret</button>
+                    {% endif %}
+                  </td>
+                {% else %}
+                  <td>{{ object.parameters|get_key:name|placeholder }}</td>
+                {% endif %}
               </tr>
             {% empty %}
               <tr>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12625 

Change datasource.html to hide password until the "show secret" button is clicked. I have the permissions to view set for update/change/add instead of view. As if a user doesn't have view for core/datasource, they wouldn't be able to see the page anyways. Unless I'm misunderstanding something.
