### PR TITLE
9077 audit alters_data=True

### DIFF
--- a/netbox/core/models/data.py
+++ b/netbox/core/models/data.py
@@ -200,6 +200,7 @@ class DataSource(JobsMixin, PrimaryModel):
 
         # Emit the post_sync signal
         post_sync.send(sender=self.__class__, instance=self)
+    sync.alters_data = True
 
     def _walk(self, root):
         """

--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -359,6 +359,7 @@ class CableTermination(ChangeLoggedModel):
         # Circuit terminations
         elif getattr(self.termination, 'site', None):
             self._site = self.termination.site
+    cache_related_objects.alters_data = True
 
     def to_objectchange(self, action):
         objectchange = super().to_objectchange(action)
@@ -637,6 +638,7 @@ class CablePath(models.Model):
             self.save()
         else:
             self.delete()
+    retrace.alters_data = True
 
     def _get_path(self):
         """

--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -213,6 +213,7 @@ class ConsoleServerPortTemplate(ModularComponentTemplateModel):
             type=self.type,
             **kwargs
         )
+    instantiate.do_not_call_in_templates = True
 
     def to_yaml(self):
         return {
@@ -256,6 +257,7 @@ class PowerPortTemplate(ModularComponentTemplateModel):
             allocated_draw=self.allocated_draw,
             **kwargs
         )
+    instantiate.do_not_call_in_templates = True
 
     def clean(self):
         super().clean()
@@ -330,6 +332,7 @@ class PowerOutletTemplate(ModularComponentTemplateModel):
             feed_leg=self.feed_leg,
             **kwargs
         )
+    instantiate.do_not_call_in_templates = True
 
     def to_yaml(self):
         return {
@@ -413,6 +416,7 @@ class InterfaceTemplate(ModularComponentTemplateModel):
             poe_type=self.poe_type,
             **kwargs
         )
+    instantiate.do_not_call_in_templates = True
 
     def to_yaml(self):
         return {
@@ -507,6 +511,7 @@ class FrontPortTemplate(ModularComponentTemplateModel):
             rear_port_position=self.rear_port_position,
             **kwargs
         )
+    instantiate.do_not_call_in_templates = True
 
     def to_yaml(self):
         return {
@@ -550,6 +555,7 @@ class RearPortTemplate(ModularComponentTemplateModel):
             positions=self.positions,
             **kwargs
         )
+    instantiate.do_not_call_in_templates = True
 
     def to_yaml(self):
         return {
@@ -581,6 +587,7 @@ class ModuleBayTemplate(ComponentTemplateModel):
             label=self.label,
             position=self.position
         )
+    instantiate.do_not_call_in_templates = True
 
     def to_yaml(self):
         return {
@@ -603,6 +610,7 @@ class DeviceBayTemplate(ComponentTemplateModel):
             name=self.name,
             label=self.label
         )
+    instantiate.do_not_call_in_templates = True
 
     def clean(self):
         if self.device_type and self.device_type.subdevice_role != SubdeviceRoleChoices.ROLE_PARENT:
@@ -696,3 +704,4 @@ class InventoryItemTemplate(MPTTModel, ComponentTemplateModel):
             part_id=self.part_id,
             **kwargs
         )
+    instantiate.do_not_call_in_templates = True

--- a/netbox/extras/models/configs.py
+++ b/netbox/extras/models/configs.py
@@ -146,6 +146,7 @@ class ConfigContext(SyncedDataMixin, CloningMixin, ChangeLoggedModel):
         Synchronize context data from the designated DataFile (if any).
         """
         self.data = self.data_file.get_data()
+    sync_data.alters_data = True
 
 
 class ConfigContextModel(models.Model):
@@ -236,6 +237,7 @@ class ConfigTemplate(SyncedDataMixin, ExportTemplatesMixin, TagsMixin, ChangeLog
         Synchronize template content from the designated DataFile (if any).
         """
         self.template_code = self.data_file.data_as_string
+    sync_data.alters_data = True
 
     def render(self, context=None):
         """

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -362,6 +362,7 @@ class ExportTemplate(SyncedDataMixin, CloningMixin, ExportTemplatesMixin, Change
         Synchronize template content from the designated DataFile (if any).
         """
         self.template_code = self.data_file.data_as_string
+    sync_data.alters_data = True
 
     def render(self, queryset):
         """
@@ -625,6 +626,7 @@ class ConfigRevision(models.Model):
         """
         cache.set('config', self.data, None)
         cache.set('config_version', self.pk, None)
+    activate.alters_data = True
 
     @admin.display(boolean=True)
     def is_active(self):

--- a/netbox/extras/models/staging.py
+++ b/netbox/extras/models/staging.py
@@ -112,3 +112,4 @@ class StagedChange(ChangeLoggedModel):
             instance = self.model.objects.get(pk=self.object_id)
             logger.info(f'Deleting {self.model._meta.verbose_name} {instance}')
             instance.delete()
+    apply.alters_data = True

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -71,6 +71,7 @@ class ChangeLoggingMixin(models.Model):
         `_prechange_snapshot` on the instance.
         """
         self._prechange_snapshot = self.serialize_object()
+    snapshot.alters_data = True
 
     def to_objectchange(self, action):
         """
@@ -238,6 +239,7 @@ class CustomFieldsMixin(models.Model):
         """
         for cf in self.custom_fields:
             self.custom_field_data[cf.name] = cf.default
+    populate_custom_field_defaults.alters_data = True
 
     def clean(self):
         super().clean()
@@ -413,6 +415,7 @@ class SyncedDataMixin(models.Model):
             self.data_synced = None
 
         super().clean()
+    clean.alters_data = True
 
     def save(self, *args, **kwargs):
         from core.models import AutoSyncRecord
@@ -460,6 +463,7 @@ class SyncedDataMixin(models.Model):
         self.data_synced = timezone.now()
         if save:
             self.save()
+    sync.alters_data = True
 
     def sync_data(self):
         """


### PR DESCRIPTION
### Fixes: #9077 

adds alters_data=True to model functions with no params that modify data also sets some do_not_call_in_templates for several that should just be skipped.

Tested by manually setting string_if_invalid in settings and temporarily calling the method in a template to make sure it was skipped. easiest one is adding a call to sync_data in exporttemplate.html as it will throw an Attribute Error if the alters_data setting is removed.