### PR TITLE
Closes #12622: Fix assigning VLAN without site to Prefix

### DIFF
--- a/netbox/ipam/forms/bulk_import.py
+++ b/netbox/ipam/forms/bulk_import.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
+from django.db.models import Q
 from django.utils.translation import gettext as _
 
 from dcim.models import Device, Interface, Site
@@ -181,23 +182,31 @@ class PrefixImportForm(NetBoxModelImportForm):
     def __init__(self, data=None, *args, **kwargs):
         super().__init__(data, *args, **kwargs)
 
-        if data:
+        if not data:
+            return
 
-            # Limit VLAN queryset by assigned site and/or group (if specified)
-            params = {}
-            if data.get('site'):
-                params[f"site__{self.fields['site'].to_field_name}"] = data.get('site')
-            if data.get('vlan_group'):
-                params[f"group__{self.fields['vlan_group'].to_field_name}"] = data.get('vlan_group')
-            if params:
-                queryset = self.fields['vlan'].queryset.filter(**params)
-                if data.get('site'):
-                    p = {
-                        f"site__{self.fields['site'].to_field_name}": None
-                    }
-                    queryset |= self.fields['vlan'].queryset.filter(**p)
+        site = data.get('site')
+        vlan_group = data.get('vlan_group')
 
-                self.fields['vlan'].queryset = queryset
+        # Limit VLAN queryset by assigned site and/or group (if specified)
+        query = Q()
+
+        if site:
+            query |= Q(**{
+                f"site__{self.fields['site'].to_field_name}": site
+            })
+            # Don't Forget to include VLANs without a site in the filter
+            query |= Q(**{
+                f"site__{self.fields['site'].to_field_name}__isnull": True
+            })
+
+        if vlan_group:
+            query &= Q(**{
+                f"group__{self.fields['vlan_group'].to_field_name}": vlan_group
+            })
+
+        queryset = self.fields['vlan'].queryset.filter(query)
+        self.fields['vlan'].queryset = queryset
 
 
 class IPRangeImportForm(NetBoxModelImportForm):

--- a/netbox/ipam/forms/bulk_import.py
+++ b/netbox/ipam/forms/bulk_import.py
@@ -190,7 +190,14 @@ class PrefixImportForm(NetBoxModelImportForm):
             if data.get('vlan_group'):
                 params[f"group__{self.fields['vlan_group'].to_field_name}"] = data.get('vlan_group')
             if params:
-                self.fields['vlan'].queryset = self.fields['vlan'].queryset.filter(**params)
+                queryset = self.fields['vlan'].queryset.filter(**params)
+                if data.get('site'):
+                    p = {
+                        f"site__{self.fields['site'].to_field_name}": None
+                    }
+                    queryset |= self.fields['vlan'].queryset.filter(**p)
+
+                self.fields['vlan'].queryset = queryset
 
 
 class IPRangeImportForm(NetBoxModelImportForm):

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
@@ -212,10 +211,8 @@ class PrefixForm(TenancyForm, NetBoxModelForm):
     vlan = DynamicModelChoiceField(
         queryset=VLAN.objects.all(),
         required=False,
+        selector=True,
         label=_('VLAN'),
-        query_params={
-            'site_id': ['$site', settings.FILTERS_NULL_CHOICE_VALUE],
-        }
     )
     role = DynamicModelChoiceField(
         queryset=Role.objects.all(),

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
@@ -213,7 +214,7 @@ class PrefixForm(TenancyForm, NetBoxModelForm):
         required=False,
         label=_('VLAN'),
         query_params={
-            'site_id': '$site',
+            'site_id': ['$site', settings.FILTERS_NULL_CHOICE_VALUE],
         }
     )
     role = DynamicModelChoiceField(


### PR DESCRIPTION
### Summary

This Pull Request enables users to be to select VLANs without a site assignment during creation and bulk import of Prefixes.

This Pull Request addresses issues #12622 and #12619. 

### Background

Previously, only VLANs assigned to the same site as the prefix were available for selection. However, as it is possible to create VLANs without a site assignment, a subset of selectable VLANs was excluded from the VLAN filter dropdown. Additionally, the import logic did not allow the assignment of a VLAN without a site when a site was specified for the prefix.

### Changes

This Pull Request introduces a selector dialog to facilitate filtering and searching for VLANs during assignment. Furthermore, the prefix import code is enhanced to include VLANs without a site assignment in the filtering logic.

### Benefits

This change enhances the usability of NetBox by allowing users to assign VLANs with a null site to Prefixes through the UI. Without this modification, Prefixes could only be assigned VLANs from the same site when a site was selected for a Prefix.

# Creation Test

1. Import the demo data into NetBox
2. Login into NetBox
3. Import the following VLAN from with the YAML format under IPAM > VLANS > VLANs > Import

```yaml
vid: 1000
name: management
status: active
```

4. Create a new Prefix from IPAM > PREFIXES > Prefixes > Add.
5. Set the Prefix field to `10.1.0.0/24`
6. Set the Site field to `DM-Akron`
7. Look for the new management VLAN in the selector dialog. The user can search for a site set to None to easily find the new managment VLAN without a site.

![image](https://github.com/netbox-community/netbox/assets/11417982/e859cc3d-5eff-43a8-b697-9d3812cb3eb6)

8. Click Create and Verify the new prefix is successfully created

# Import Test

Steps for reproducing importing a new Prefix:

1. Import the demo data into NetBox
2. Login to NetBox
3. Import the following VLAN from with the YAML format under IPAM > VLANS > VLANs > Import

```yaml
vid: 1000
name: management
status: active
```

4. Import a new Prefix from IPAM > PREFIXES > Prefixes > Import with the following YAML

```yaml
prefix: 10.1.1.0/24
status: active
site: DM-Akron
vlan: 1000
```

5. With the changes from this Pull Request, the import successfully assigns a VLAN without a site to a Prefix with a site.

### Import Query Tests

I manually tested importing different variations of prefixes to verify the new query in `PrefixImportForm`. The query results were collected by temporarily adding a print statement to `PrefixImportForm.__init__`

#### Import Test 1 

```yaml
prefix: 10.1.1.0/24
status: active
site: DM-Akron
vlan: 1002
vlan_group: JBB-Global
```

This resulted in the following query:

```
(AND: (OR: ('site__name', 'DM-Akron'), ('site__name__isnull', True)), ('group__name', 'JBB-Global'))
```

#### Import Test 2 

```yaml
prefix: 10.1.1.0/24
status: active
site: DM-Akron
vlan: 1000
```

This resulted in the following query:
```
(OR: ('site__name', 'DM-Akron'), ('site__name__isnull', True))
```

#### Import Test 3
```yaml
prefix: 10.1.1.0/24
status: active
vlan: 1000
```

This resulted in the following query:

```
(AND: )
```

#### Import Test 4
```yaml
prefix: 10.1.1.0/24
status: active
vlan: 1002
vlan_group: JBB-Global
```
This resulted in the following query:

```
(AND: ('group__name', 'JBB-Global'))
```