### PR TITLE
Fixes #11209 - Fix PrefixIPAddress view with saved sort preferences

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -952,7 +952,9 @@ class VLANGroupVLANsView(generic.ObjectChildrenView):
         )
 
     def prep_table_data(self, request, queryset, parent):
-        return add_available_vlans(parent.get_child_vlans(), parent)
+        if not get_table_ordering(request, self.table):
+            return add_available_vlans(parent.get_child_vlans(), parent)
+        return queryset
 
 
 #

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -1,7 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import F, Prefetch
 from django.db.models.expressions import RawSQL
-from django.db.models.functions import Round
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -11,6 +10,7 @@ from dcim.filtersets import InterfaceFilterSet
 from dcim.models import Interface, Site
 from netbox.views import generic
 from tenancy.views import ObjectContactsView
+from utilities.tables import get_table_ordering
 from utilities.utils import count_related
 from utilities.views import ViewTab, register_model_view
 from virtualization.filtersets import VMInterfaceFilterSet
@@ -606,12 +606,7 @@ class PrefixIPAddressesView(generic.ObjectChildrenView):
         return parent.get_child_ips().restrict(request.user, 'view').prefetch_related('vrf', 'tenant', 'tenant__group')
 
     def prep_table_data(self, request, queryset, parent):
-        # Check for presence of a q string, an ordering string, or user preferences ordering and the ordering string
-        # is blank
-        if not request.GET.get('q') and not request.GET.get('sort') and not (
-                request.user.is_authenticated and request.user.config.get(f'tables.IPAddressTable.ordering') and
-                not request.GET.get('sort') == ''
-        ):
+        if not get_table_ordering(request, self.table):
             return add_available_ipaddresses(parent.prefix, queryset, parent.is_pool)
         return queryset
 

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -606,8 +606,11 @@ class PrefixIPAddressesView(generic.ObjectChildrenView):
         return parent.get_child_ips().restrict(request.user, 'view').prefetch_related('vrf', 'tenant', 'tenant__group')
 
     def prep_table_data(self, request, queryset, parent):
+        # Check for presence of a q string, an ordering string, or user preferences ordering and the ordering string
+        # is blank
         if not request.GET.get('q') and not request.GET.get('sort') and not (
-                request.user.is_authenticated and request.user.config.get(f'tables.IPAddressTable.ordering')
+                request.user.is_authenticated and request.user.config.get(f'tables.IPAddressTable.ordering') and
+                not request.GET.get('sort') == ''
         ):
             return add_available_ipaddresses(parent.prefix, queryset, parent.is_pool)
         return queryset

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -606,7 +606,9 @@ class PrefixIPAddressesView(generic.ObjectChildrenView):
         return parent.get_child_ips().restrict(request.user, 'view').prefetch_related('vrf', 'tenant', 'tenant__group')
 
     def prep_table_data(self, request, queryset, parent):
-        if not request.GET.get('q') and not request.GET.get('sort'):
+        if not request.GET.get('q') and not request.GET.get('sort') and not (
+                request.user.is_authenticated and request.user.config.get(f'tables.IPAddressTable.ordering')
+        ):
             return add_available_ipaddresses(parent.prefix, queryset, parent.is_pool)
         return queryset
 

--- a/netbox/utilities/tables.py
+++ b/netbox/utilities/tables.py
@@ -1,6 +1,22 @@
 __all__ = (
+    'get_table_ordering',
     'linkify_phone',
 )
+
+
+def get_table_ordering(request, table):
+    """
+    Given a request, return the prescribed table ordering, if any. This may be necessary to determine prior to rendering
+    the table itself.
+    """
+    # Check for an explicit ordering
+    if 'sort' in request.GET:
+        return request.GET['sort'] or None
+
+    # Check for a configured preference
+    if request.user.is_authenticated:
+        if preference := request.user.config.get(f'tables.{table.__name__}.ordering'):
+            return preference
 
 
 def linkify_phone(value):


### PR DESCRIPTION
### Fixes: #11209 - Do not add available ips when IPAddressTable sort preferences are saved

* Exclude the IPAddress ViewTab from adding available IP annotations when table is sorted.


Checked other views (PrefixPrefixes, PrefixIPRanges) for this and is only present in the IPAddress view (Prefixes are annotated with actual prefixes, IPRanges have no such annotation)