### PR TITLE
add elevation button to location view

### DIFF
--- a/netbox/templates/dcim/location.html
+++ b/netbox/templates/dcim/location.html
@@ -16,6 +16,9 @@
       <span class="mdi mdi-plus-thick" aria-hidden="true"></span> Add Child Location
     </a>
   {% endif %}
+  <a href="{% url 'dcim:rack_elevation_list' %}?site={{ object.site.slug }}&location_id={{ object.pk }}" class="btn btn-sm btn-primary" title="View elevations">
+    <i class="mdi mdi-server"></i> Elevation
+  </a>
 {% endblock extra_controls %}
 
 {% block content %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12748

elevation view button was removed from the locations view when racks counter was moved.
![previous view elevations link](https://github.com/netbox-community/netbox/assets/1613241/60aa173c-5c33-4a9a-85d0-8bed99695a5f)

![new elevation button](https://github.com/netbox-community/netbox/assets/1613241/37f57f02-c993-4b32-b6f9-edff6f71df66)
