### PR TITLE
Round rack power utilization to nearest 0.1%

### DIFF
--- a/netbox/dcim/models/racks.py
+++ b/netbox/dcim/models/racks.py
@@ -466,7 +466,7 @@ class Rack(PrimaryModel, WeightMixin):
             powerport.get_power_draw()['allocated'] for powerport in powerports
         ])
 
-        return int(allocated_draw / available_power_total * 100)
+        return round(allocated_draw / available_power_total * 100, 1)
 
     @cached_property
     def total_weight(self):


### PR DESCRIPTION
### Fixes: #12838

Change `int(...)` to `round(..., 1)` for consistency with power-feed level display, and because rendering includes one decimal place of percentage already.