### PR TITLE
assigning broadcast ip error fixes for ipv6 and /31/32

### DIFF
--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -370,7 +370,7 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
                     raise ValidationError(msg)
                 if address.version == 6 and address.prefixlen not in (127, 128):
                     raise ValidationError(msg)
-            if address.ip == address.broadcast:
+            if address.version == 4 and address.ip == address.broadcast and address.prefixlen not in (31, 32):
                 msg = f"{address} is a broadcast address, which may not be assigned to an interface."
                 raise ValidationError(msg)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12687

adding appropriate logic to raise assigning broadcast error on the correct ipv4 ip's