### PR TITLE
Fixes #12845: Fix pagination of related IP addresses table

### DIFF
--- a/netbox/templates/ipam/ipaddress/ip_addresses.html
+++ b/netbox/templates/ipam/ipaddress/ip_addresses.html
@@ -2,18 +2,18 @@
 {% load helpers %}
 
 {% block content %}
-    {% include 'inc/table_controls_htmx.html' with table_modal="IPAddressTable_config" %}
-    <form method="post">
-        {% csrf_token %}
-        <div class="card">
-            <div class="card-body" id="object_list">
-                {% include 'htmx/table.html' %}
-            </div>
-        </div>
-    </form>
-{% endblock content %}
+  {% include 'inc/table_controls_htmx.html' with table_modal="IPAddressTable_config" %}
+  <form method="post">
+    {% csrf_token %}
+    <div class="card">
+      <div class="card-body htmx-container table-responsive" id="object_list">
+        {% include 'htmx/table.html' %}
+      </div>
+    </div>
+  </form>
+{% endblock %}
 
 {% block modals %}
-    {{ block.super }}
-    {% table_config_form table %}
+  {{ block.super }}
+  {% table_config_form table %}
 {% endblock modals %}


### PR DESCRIPTION
### Fixes: #12845

- Apply the `htmx-container` CSS class to the `<div>`
- General formatting cleanup