### PR TITLE
prefix is_pool check for ip assignments

### DIFF
--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -365,12 +365,12 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
             prefix_str = f"{self.instance.address.network}/{self.instance.address.prefixlen}"
             allow_assignment_error = True
             if self.instance.vrf is None:
-                prefix_obj =  Prefix.objects.get(prefix=prefix_str)
+                prefix_obj = Prefix.objects.get(prefix=prefix_str)
             else:
-                prefix_obj =  Prefix.objects.get(prefix=prefix_str, vrf=self.vrf)
+                prefix_obj = Prefix.objects.get(prefix=prefix_str, vrf=self.vrf)
             if prefix_obj and prefix_obj.is_pool:
                 allow_assignment_error = False
-            
+
             if allow_assignment_error:
                 if address.ip == address.network:
                     msg = f"{address} is a network ID, which may not be assigned to an interface unless the prefix is a pool."

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -362,13 +362,12 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
 
         # Do not allow assigning a network ID or broadcast address to an interface.
         if interface and (address := self.cleaned_data.get('address')):
-            prefix_str = f"{address.network}/{address.prefixlen}"
             allow_assignment_error = True
             if self.instance.vrf is None:
-                prefix_obj = Prefix.objects.filter(prefix=prefix_str)
+                prefix_obj = Prefix.objects.filter(prefix=address.cidr)
             else:
-                prefix_obj = Prefix.objects.filter(prefix=prefix_str, vrf=self.vrf)
-            if prefix_obj.exists() and prefix_obj[0].is_pool:
+                prefix_obj = Prefix.objects.filter(prefix=address.cidr, vrf=self.vrf)
+            if prefix_obj.exists() and prefix_obj.first().is_pool:
                 allow_assignment_error = False
 
             if allow_assignment_error:

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -362,7 +362,7 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
 
         # Do not allow assigning a network ID or broadcast address to an interface.
         if interface and (address := self.cleaned_data.get('address')):
-            prefix_str = f"{self.instance.address.network}/{self.instance.address.prefixlen}"
+            prefix_str = f"{address.network}/{address.prefixlen}"
             allow_assignment_error = True
             if self.instance.vrf is None:
                 prefix_obj = Prefix.objects.filter(prefix=prefix_str)

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -365,10 +365,10 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
             prefix_str = f"{self.instance.address.network}/{self.instance.address.prefixlen}"
             allow_assignment_error = True
             if self.instance.vrf is None:
-                prefix_obj = Prefix.objects.get(prefix=prefix_str)
+                prefix_obj = Prefix.objects.filter(prefix=prefix_str)
             else:
-                prefix_obj = Prefix.objects.get(prefix=prefix_str, vrf=self.vrf)
-            if prefix_obj and prefix_obj.is_pool:
+                prefix_obj = Prefix.objects.filter(prefix=prefix_str, vrf=self.vrf)
+            if prefix_obj.exists() and prefix_obj[0].is_pool:
                 allow_assignment_error = False
 
             if allow_assignment_error:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12962

<!--
    Please include a summary of the proposed changes below.
-->

some users pointed out in #12687 that I missed checking for prefixes where is_pool is true with my previous patch.
I added some logic to find a prefix matching the IP and checks to see if is_pool is set.
It is also safe for ip's that have no matching prefix in netbox.