### PR TITLE
Fixes choice field schema for OpenAPI response

### DIFF
--- a/netbox/core/api/schema.py
+++ b/netbox/core/api/schema.py
@@ -1,5 +1,6 @@
 import re
 import typing
+from collections import OrderedDict
 
 from drf_spectacular.extensions import OpenApiSerializerFieldExtension
 from drf_spectacular.openapi import AutoSchema
@@ -28,14 +29,19 @@ class ChoiceFieldFix(OpenApiSerializerFieldExtension):
     target_class = 'netbox.api.fields.ChoiceField'
 
     def map_serializer_field(self, auto_schema, direction):
+        build_cf = build_choice_field(self.target)
+
         if direction == 'request':
-            return build_choice_field(self.target)
+            return build_cf
 
         elif direction == "response":
+            value = build_cf
+            label = {**build_basic_type(OpenApiTypes.STR), "enum": list(OrderedDict.fromkeys(self.target.choices.values()))}
+
             return build_object_type(
                 properties={
-                    "value": build_basic_type(OpenApiTypes.STR),
-                    "label": build_basic_type(OpenApiTypes.STR),
+                    "value": value,
+                    "label": label
                 }
             )
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12960 and #12644

<!--
    Please include a summary of the proposed changes below.
-->

For the example in the issue, here is the new definition

```json
{
  "type": "object",
  "properties": {
    "value": {
      "enum": [
        "connected",
        "planned",
        "decommissioning"
      ],
      "type": "string",
      "description": "* `connected` - Connected\n* `planned` - Planned\n* `decommissioning` - Decommissioning"
    },
    "label": {
      "type": "string",
      "enum": [
        "Connected",
        "Planned",
        "Decommissioning"
      ]
    }
  }
}

```

For IPAddress, the schema looks like

```json
{
  "type": "object",
  "properties": {
    "value": {
      "enum": [
        4,
        6
      ],
      "type": "integer",
      "description": "* `4` - IPv4\n* `6` - IPv6"
    },
    "label": {
      "type": "string",
      "enum": [
        "IPv4",
        "IPv6"
      ]
    }
  },
  "readOnly": true
}
```