### PR TITLE
Fixes syntax error on reports

### DIFF
--- a/netbox/extras/models/reports.py
+++ b/netbox/extras/models/reports.py
@@ -1,7 +1,7 @@
 import inspect
+import logging
 from functools import cached_property
 
-from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.urls import reverse
 
@@ -11,6 +11,8 @@ from extras.utils import is_report
 from netbox.models.features import JobsMixin, WebhooksMixin
 from utilities.querysets import RestrictedQuerySet
 from .mixins import PythonModuleMixin
+
+logger = logging.getLogger('netbox.reports')
 
 __all__ = (
     'Report',
@@ -56,7 +58,8 @@ class ReportModule(PythonModuleMixin, JobsMixin, ManagedFile):
 
         try:
             module = self.get_module()
-        except ImportError:
+        except (ImportError, SyntaxError) as e:
+            logger.error(f"Unable to load report module {self.name}, exception: {e}")
             return {}
         reports = {}
         ordered = getattr(module, 'report_order', [])

--- a/netbox/templates/extras/report_list.html
+++ b/netbox/templates/extras/report_list.html
@@ -38,7 +38,7 @@
         </h5>
         <div class="card-body">
           {% include 'inc/sync_warning.html' with object=module %}
-          {% if module.reports|length %}
+          {% if module.reports %}
             <table class="table table-hover table-headings reports">
               <thead>
                 <tr>

--- a/netbox/templates/extras/report_list.html
+++ b/netbox/templates/extras/report_list.html
@@ -38,71 +38,77 @@
         </h5>
         <div class="card-body">
           {% include 'inc/sync_warning.html' with object=module %}
-          <table class="table table-hover table-headings reports">
-            <thead>
-              <tr>
-                <th width="250">Name</th>
-                <th>Description</th>
-                <th>Last Run</th>
-                <th>Status</th>
-                <th width="120"></th>
-              </tr>
-            </thead>
-            <tbody>
-              {% with jobs=module.get_latest_jobs %}
-                {% for report_name, report in module.reports.items %}
-                  {% with last_job=jobs|get_key:report.name %}
-                    <tr>
-                      <td>
-                        <a href="{% url 'extras:report' module=module.python_name name=report.class_name %}" id="{{ report.module }}.{{ report.class_name }}">{{ report.name }}</a>
-                      </td>
-                      <td>{{ report.description|markdown|placeholder }}</td>
-                      {% if last_job %}
-                        <td>
-                          <a href="{% url 'extras:report_result' job_pk=last_job.pk %}">{{ last_job.created|annotated_date }}</a>
-                        </td>
-                        <td>
-                          {% badge last_job.get_status_display last_job.get_status_color %}
-                        </td>
-                      {% else %}
-                        <td class="text-muted">Never</td>
-                        <td>{{ ''|placeholder }}</td>
-                      {% endif %}
-                      <td>
-                        {% if perms.extras.run_report %}
-                          <div class="float-end noprint">
-                            <form action="{% url 'extras:report' module=report.module name=report.class_name %}" method="post">
-                              {% csrf_token %}
-                              <button type="submit" name="_run" class="btn btn-primary btn-sm" style="width: 110px">
-                                {% if last_job %}
-                                  <i class="mdi mdi-replay"></i> Run Again
-                                {% else %}
-                                  <i class="mdi mdi-play"></i> Run Report
-                                {% endif %}
-                              </button>
-                            </form>
-                          </div>
-                        {% endif %}
-                      </td>
-                    </tr>
-                    {% for method, stats in last_job.data.items %}
+          {% if module.reports|length %}
+            <table class="table table-hover table-headings reports">
+              <thead>
+                <tr>
+                  <th width="250">Name</th>
+                  <th>Description</th>
+                  <th>Last Run</th>
+                  <th>Status</th>
+                  <th width="120"></th>
+                </tr>
+              </thead>
+              <tbody>
+                {% with jobs=module.get_latest_jobs %}
+                  {% for report_name, report in module.reports.items %}
+                    {% with last_job=jobs|get_key:report.name %}
                       <tr>
-                        <td colspan="4" class="method">
-                          <span class="ps-3">{{ method }}</span>
+                        <td>
+                          <a href="{% url 'extras:report' module=module.python_name name=report.class_name %}" id="{{ report.module }}.{{ report.class_name }}">{{ report.name }}</a>
                         </td>
-                        <td class="text-end text-nowrap report-stats">
-                          <span class="badge bg-success">{{ stats.success }}</span>
-                          <span class="badge bg-info">{{ stats.info }}</span>
-                          <span class="badge bg-warning">{{ stats.warning }}</span>
-                          <span class="badge bg-danger">{{ stats.failure }}</span>
+                        <td>{{ report.description|markdown|placeholder }}</td>
+                        {% if last_job %}
+                          <td>
+                            <a href="{% url 'extras:report_result' job_pk=last_job.pk %}">{{ last_job.created|annotated_date }}</a>
+                          </td>
+                          <td>
+                            {% badge last_job.get_status_display last_job.get_status_color %}
+                          </td>
+                        {% else %}
+                          <td class="text-muted">Never</td>
+                          <td>{{ ''|placeholder }}</td>
+                        {% endif %}
+                        <td>
+                          {% if perms.extras.run_report %}
+                            <div class="float-end noprint">
+                              <form action="{% url 'extras:report' module=report.module name=report.class_name %}" method="post">
+                                {% csrf_token %}
+                                <button type="submit" name="_run" class="btn btn-primary btn-sm" style="width: 110px">
+                                  {% if last_job %}
+                                    <i class="mdi mdi-replay"></i> Run Again
+                                  {% else %}
+                                    <i class="mdi mdi-play"></i> Run Report
+                                  {% endif %}
+                                </button>
+                              </form>
+                            </div>
+                          {% endif %}
                         </td>
                       </tr>
-                    {% endfor %}
-                  {% endwith %}
-                {% endfor %}
-              {% endwith %}
-            </tbody>
-          </table>
+                      {% for method, stats in last_job.data.items %}
+                        <tr>
+                          <td colspan="4" class="method">
+                            <span class="ps-3">{{ method }}</span>
+                          </td>
+                          <td class="text-end text-nowrap report-stats">
+                            <span class="badge bg-success">{{ stats.success }}</span>
+                            <span class="badge bg-info">{{ stats.info }}</span>
+                            <span class="badge bg-warning">{{ stats.warning }}</span>
+                            <span class="badge bg-danger">{{ stats.failure }}</span>
+                          </td>
+                        </tr>
+                      {% endfor %}
+                    {% endwith %}
+                  {% endfor %}
+                {% endwith %}
+              </tbody>
+            </table>
+          {% else %}
+            <div class="alert alert-warning" role="alert">
+              <i class="mdi mdi-alert"></i> Could not load reports from {{ module.name }}
+            </div>
+          {% endif %}
         </div>
       </div>
     {% empty %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12842

<!--
    Please include a summary of the proposed changes below.
-->
I could not figure how to also display the exception on the UI, however this now solves the blocker when the report was unable to load either due to ImportError or SyntaxError. A user can delete the report and upload the fixed version.

![image](https://github.com/netbox-community/netbox/assets/5083532/11f62915-5cdd-4165-8cef-2eeed5004791)

To ease with the issue, I have added a logger when the exception is caught.