### PR TITLE
Allow users to define the LOGIN_URL.

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -455,8 +455,11 @@ MESSAGE_TAGS = {
     messages.ERROR: 'danger',
 }
 
-# Authentication URLs
-LOGIN_URL = f'/{BASE_PATH}login/'
+# Authentication URLs, if the LOGIN_URL have not been defined in the configuration, default to '/{BASE_PATH}login/'
+# Typical usecase for defining the LOGIN_URL will be to redirect to a SSO provider.
+if 'LOGIN_URL' not in vars():
+    LOGIN_URL = f'/{BASE_PATH}login/'
+
 LOGIN_REDIRECT_URL = f'/{BASE_PATH}'
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'


### PR DESCRIPTION
### Fixes: #13002 #11672

If you rely on a single SSO provider, it can
be confusing for users to see the username/password login with the SSO provider below. By allowing the LOGIN_URL to be overwritten users can be redirect
directly to the SSO provider.

Simply check if the LOGIN_URL has already been defined, if not fallback to f'/{BASE_PATH}login/'
