### PR TITLE
Fix #12983 bulk edit of M2M fields when nothing is selected

### DIFF
--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -551,7 +551,7 @@ class BulkEditView(GetReturnURLMixin, BaseMultiObjectView):
             for name, m2m_field in m2m_fields.items():
                 if name in form.nullable_fields and name in nullified_fields:
                     getattr(obj, name).clear()
-                else:
+                elif form.cleaned_data[name]:
                     getattr(obj, name).set(form.cleaned_data[name])
 
             # Add/remove tags


### PR DESCRIPTION
### Fixes: #12983

Partially revert 41c92483a0b9b820dd0ca0c43c6c6d6e560043ed to restore bulk edit with m2m fields. The m2m cleaned_data yields a empty queryset when nothing is selected. By setting the m2m relation unless set null is checked even when nothing is selected the m2m relation is always cleared.

This commit only sets the m2m relation when a selection is made.