### PR TITLE
Fix #12579 create cable and add another error

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -8,7 +8,7 @@ from django.db.models import Prefetch
 from django.forms import ModelMultipleChoiceField, MultipleHiddenInput, modelformset_factory
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
-from django.urls import reverse, resolve
+from django.urls import reverse
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
@@ -3138,15 +3138,9 @@ class CableEditView(generic.ObjectEditView):
             'b_terminations_type': request.GET.get('b_terminations_type')
         }
 
-        pk = resolve(request.GET.get('return_url')).kwargs.get('pk')
-        a_type = CABLE_TERMINATION_TYPES.get(request.GET.get('a_terminations_type'))
-
-        if hasattr(a_type, 'device'):
-            params.update({'termination_a_device': pk})
-        elif hasattr(a_type, 'power_panel'):
-            params.update({'termination_a_powerpanel': pk})
-        elif hasattr(a_type, 'circuit'):
-            params.update({'termination_a_circuit': pk})
+        for key in request.POST:
+            if 'device' in key or 'power_panel' in key or 'circuit' in key:
+                params.update({key: request.POST.get(key)})
 
         return params
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -3132,11 +3132,23 @@ class CableEditView(generic.ObjectEditView):
         return obj
 
     def get_extra_addanother_params(self, request):
-        return {
-            'termination_a_device': resolve(request.GET.get('return_url')).kwargs.get('pk'),
+
+        params = {
             'a_terminations_type': request.GET.get('a_terminations_type'),
             'b_terminations_type': request.GET.get('b_terminations_type')
         }
+
+        pk = resolve(request.GET.get('return_url')).kwargs.get('pk')
+        a_type = CABLE_TERMINATION_TYPES.get(request.GET.get('a_terminations_type'))
+
+        if hasattr(a_type, 'device'):
+            params.update({'termination_a_device': pk})
+        elif hasattr(a_type, 'power_panel'):
+            params.update({'termination_a_powerpanel': pk})
+        elif hasattr(a_type, 'circuit'):
+            params.update({'termination_a_circuit': pk})
+
+        return params
 
 
 @register_model_view(Cable, 'delete')

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -8,7 +8,7 @@ from django.db.models import Prefetch
 from django.forms import ModelMultipleChoiceField, MultipleHiddenInput, modelformset_factory
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
-from django.urls import reverse
+from django.urls import reverse, resolve
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
@@ -3130,6 +3130,13 @@ class CableEditView(generic.ObjectEditView):
             self.form = forms.get_cable_form(a_type, b_type)
 
         return obj
+
+    def get_extra_addanother_params(self, request):
+        return {
+            'termination_a_device': resolve(request.GET.get('return_url')).kwargs.get('pk'),
+            'a_terminations_type': request.GET.get('a_terminations_type'),
+            'b_terminations_type': request.GET.get('b_terminations_type')
+        }
 
 
 @register_model_view(Cable, 'delete')


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12579 

<!--
    Please include a summary of the proposed changes below.
-->
Add `get_extra_addanother_params` function to `CableEditView` which return :

- previous selected parent object (`a_termination_device` or `a_termination_powerpanel` or `a_termination_circuit`)
- previous selected termination type (`a_termination_type` and ` b_termination_type`)