### PR TITLE
Fix remote auth backend check

### DIFF
--- a/netbox/netbox/api/authentication.py
+++ b/netbox/netbox/api/authentication.py
@@ -60,7 +60,7 @@ class TokenAuthentication(authentication.TokenAuthentication):
 
         user = token.user
         # When LDAP authentication is active try to load user data from LDAP directory
-        if settings.REMOTE_AUTH_BACKEND == 'netbox.authentication.LDAPBackend':
+        if 'netbox.authentication.LDAPBackend' in settings.REMOTE_AUTH_BACKEND:
             from netbox.authentication import LDAPBackend
             ldap_backend = LDAPBackend()
 


### PR DESCRIPTION
### Fixes: #12849 

Support for [multiple remote authentication backend](https://github.com/netbox-community/netbox/pull/12012 ) made `REMOTE_AUTH_BACKEND` an iterable but we forgot to update this check in `api/authentication.py`