### PR TITLE
Add Brazilian power outlet standard to choices.py

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -553,6 +553,10 @@ class PowerOutletTypeChoices(ChoiceSet):
     TYPE_IEC_3PNE4H = 'iec-60309-3p-n-e-4h'
     TYPE_IEC_3PNE6H = 'iec-60309-3p-n-e-6h'
     TYPE_IEC_3PNE9H = 'iec-60309-3p-n-e-9h'
+    # IEC 60906-1
+    TYPE_IEC_60906_1 = 'iec-60906-1'
+    TYPE_NBR_14136_10A = 'nbr-14136-10a'
+    TYPE_NBR_14136_20A = 'nbr-14136-20a'
     # NEMA non-locking
     TYPE_NEMA_115R = 'nema-1-15r'
     TYPE_NEMA_515R = 'nema-5-15r'
@@ -616,9 +620,6 @@ class PowerOutletTypeChoices(ChoiceSet):
     TYPE_ITA_N = 'ita-n'
     TYPE_ITA_O = 'ita-o'
     TYPE_ITA_MULTISTANDARD = 'ita-multistandard'
-    # NBR 14136
-    TYPE_NBR_14136_10A = 'nbr-14136-10a'
-    TYPE_NBR_14136_20A = 'nbr-14136-20a'
     # USB
     TYPE_USB_A = 'usb-a'
     TYPE_USB_MICROB = 'usb-micro-b'
@@ -659,6 +660,11 @@ class PowerOutletTypeChoices(ChoiceSet):
             (TYPE_IEC_3PNE4H, '3P+N+E 4H'),
             (TYPE_IEC_3PNE6H, '3P+N+E 6H'),
             (TYPE_IEC_3PNE9H, '3P+N+E 9H'),
+        )),
+        ('IEC 60906-1', (
+            (TYPE_IEC_60906_1, 'IEC 60906-1'),
+            (TYPE_NBR_14136_10A, '2P+T 10A (NBR 14136)'),
+            (TYPE_NBR_14136_20A, '2P+T 20A (NBR 14136)'),
         )),
         ('NEMA (Non-locking)', (
             (TYPE_NEMA_115R, 'NEMA 1-15R'),
@@ -726,10 +732,6 @@ class PowerOutletTypeChoices(ChoiceSet):
             (TYPE_ITA_N, 'ITA Type N'),
             (TYPE_ITA_O, 'ITA Type O'),
             (TYPE_ITA_MULTISTANDARD, 'ITA Multistandard'),
-        )),
-        ('NBR 14136', (
-            (TYPE_NBR_14136_10A, 'NBR 2P+T 10A'),
-            (TYPE_NBR_14136_20A, 'NBR 2P+T 20A'),
         )),
         ('USB', (
             (TYPE_USB_A, 'USB Type A'),

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -616,6 +616,9 @@ class PowerOutletTypeChoices(ChoiceSet):
     TYPE_ITA_N = 'ita-n'
     TYPE_ITA_O = 'ita-o'
     TYPE_ITA_MULTISTANDARD = 'ita-multistandard'
+    # NBR 14136
+    TYPE_NBR_14136_10A = 'nbr-14136-10a'
+    TYPE_NBR_14136_20A = 'nbr-14136-20a'
     # USB
     TYPE_USB_A = 'usb-a'
     TYPE_USB_MICROB = 'usb-micro-b'
@@ -723,6 +726,10 @@ class PowerOutletTypeChoices(ChoiceSet):
             (TYPE_ITA_N, 'ITA Type N'),
             (TYPE_ITA_O, 'ITA Type O'),
             (TYPE_ITA_MULTISTANDARD, 'ITA Multistandard'),
+        )),
+        ('NBR 14136', (
+            (TYPE_NBR_14136_10A, '2P+T 10A'),
+            (TYPE_NBR_14136_20A, '2P+T 20A'),
         )),
         ('USB', (
             (TYPE_USB_A, 'USB Type A'),

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -728,8 +728,8 @@ class PowerOutletTypeChoices(ChoiceSet):
             (TYPE_ITA_MULTISTANDARD, 'ITA Multistandard'),
         )),
         ('NBR 14136', (
-            (TYPE_NBR_14136_10A, '2P+T 10A'),
-            (TYPE_NBR_14136_20A, '2P+T 20A'),
+            (TYPE_NBR_14136_10A, 'NBR 2P+T 10A'),
+            (TYPE_NBR_14136_20A, 'NBR 2P+T 20A'),
         )),
         ('USB', (
             (TYPE_USB_A, 'USB Type A'),

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -318,6 +318,10 @@ class PowerPortTypeChoices(ChoiceSet):
     TYPE_IEC_3PNE4H = 'iec-60309-3p-n-e-4h'
     TYPE_IEC_3PNE6H = 'iec-60309-3p-n-e-6h'
     TYPE_IEC_3PNE9H = 'iec-60309-3p-n-e-9h'
+    # IEC 60906-1
+    TYPE_IEC_60906_1 = 'iec-60906-1'
+    TYPE_NBR_14136_10A = 'nbr-14136-10a'
+    TYPE_NBR_14136_20A = 'nbr-14136-20a'
     # NEMA non-locking
     TYPE_NEMA_115P = 'nema-1-15p'
     TYPE_NEMA_515P = 'nema-5-15p'
@@ -428,6 +432,11 @@ class PowerPortTypeChoices(ChoiceSet):
             (TYPE_IEC_3PNE4H, '3P+N+E 4H'),
             (TYPE_IEC_3PNE6H, '3P+N+E 6H'),
             (TYPE_IEC_3PNE9H, '3P+N+E 9H'),
+        )),
+        ('IEC 60906-1', (
+            (TYPE_IEC_60906_1, 'IEC 60906-1'),
+            (TYPE_NBR_14136_10A, '2P+T 10A (NBR 14136)'),
+            (TYPE_NBR_14136_20A, '2P+T 20A (NBR 14136)'),
         )),
         ('NEMA (Non-locking)', (
             (TYPE_NEMA_115P, 'NEMA 1-15P'),


### PR DESCRIPTION
### Fixes: #13009

Add 10A and 20A plugs standardized by the Brazilian Association of Technical Standards.