### PR TITLE
Add Molex Micro-Fit connectors to `PowerPortTypeChoices`

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -402,7 +402,9 @@ class PowerPortTypeChoices(ChoiceSet):
     TYPE_NEUTRIK_POWERCON_TRUE1 = 'neutrik-powercon-true1'
     TYPE_NEUTRIK_POWERCON_TRUE1_TOP = 'neutrik-powercon-true1-top'
     TYPE_UBIQUITI_SMARTPOWER = 'ubiquiti-smartpower'
+    TYPE_MOLEX_MICRO_FIT_1X2 = 'molex-micro-fit-1x2'
     TYPE_MOLEX_MICRO_FIT_2X2 = 'molex-micro-fit-2x2'
+    TYPE_MOLEX_MICRO_FIT_2X4 = 'molex-micro-fit-2x4'
     # Other
     TYPE_HARDWIRED = 'hardwired'
     TYPE_OTHER = 'other'
@@ -520,7 +522,9 @@ class PowerPortTypeChoices(ChoiceSet):
             (TYPE_NEUTRIK_POWERCON_TRUE1, 'Neutrik powerCON TRUE1'),
             (TYPE_NEUTRIK_POWERCON_TRUE1_TOP, 'Neutrik powerCON TRUE1 TOP'),
             (TYPE_UBIQUITI_SMARTPOWER, 'Ubiquiti SmartPower'),
+            (TYPE_MOLEX_MICRO_FIT_1X2, 'Molex Micro-Fit 1x2'),
             (TYPE_MOLEX_MICRO_FIT_2X2, 'Molex Micro-Fit 2x2'),
+            (TYPE_MOLEX_MICRO_FIT_2X4, 'Molex Micro-Fit 2x4'),
         )),
         ('Other', (
             (TYPE_HARDWIRED, 'Hardwired'),

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -402,6 +402,7 @@ class PowerPortTypeChoices(ChoiceSet):
     TYPE_NEUTRIK_POWERCON_TRUE1 = 'neutrik-powercon-true1'
     TYPE_NEUTRIK_POWERCON_TRUE1_TOP = 'neutrik-powercon-true1-top'
     TYPE_UBIQUITI_SMARTPOWER = 'ubiquiti-smartpower'
+    TYPE_MOLEX_MICRO_FIT_2X2 = 'molex-micro-fit-2x2'
     # Other
     TYPE_HARDWIRED = 'hardwired'
     TYPE_OTHER = 'other'
@@ -519,6 +520,7 @@ class PowerPortTypeChoices(ChoiceSet):
             (TYPE_NEUTRIK_POWERCON_TRUE1, 'Neutrik powerCON TRUE1'),
             (TYPE_NEUTRIK_POWERCON_TRUE1_TOP, 'Neutrik powerCON TRUE1 TOP'),
             (TYPE_UBIQUITI_SMARTPOWER, 'Ubiquiti SmartPower'),
+            (TYPE_MOLEX_MICRO_FIT_2X2, 'Molex Micro-Fit 2x2'),
         )),
         ('Other', (
             (TYPE_HARDWIRED, 'Hardwired'),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12984

<!--
    Please include a summary of the proposed changes below.
-->

Added only for `PowerPortTypeChoices`. These are usually powered by external power adapters so I'm not sure if we should add it to `PowerOutletTypeChoices` as well.

I added 1x2 and 2x4 variants (alongside 2x2 requested in #12984) as these are the ones known to me to be used by Cisco (ASA 5505, UC500, ...).