### PR TITLE
Fixes #13011: Allow comma in custom links

### DIFF
--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -285,7 +285,7 @@ class CustomLink(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
         text = clean_html(text, allowed_schemes)
 
         # Sanitize link
-        link = urllib.parse.quote(link, safe='/:?&=%+[]@#')
+        link = urllib.parse.quote(link, safe='/:?&=%+[]@#,')
 
         # Verify link scheme is allowed
         result = urllib.parse.urlparse(link)


### PR DESCRIPTION
### Fixes: #13011

This adds the comma character to the list of safe characters for URL sanitization.
