### PR TITLE
Fixes #12760 - Adds Vary header to prevent caching of HTMX requests

### DIFF
--- a/netbox/netbox/middleware.py
+++ b/netbox/netbox/middleware.py
@@ -49,6 +49,9 @@ class CoreMiddleware:
         # Attach the unique request ID as an HTTP header.
         response['X-Request-ID'] = request.id
 
+        # Enable the Vary header to help with caching of HTMX responses
+        response['Vary'] = 'HX-Request'
+
         # If this is an API request, attach an HTTP header annotating the API version (e.g. '3.5').
         if is_api_request(request):
             response['API-Version'] = settings.REST_FRAMEWORK_VERSION


### PR DESCRIPTION
### Fixes: #12760

* Adds Vary header to CoreMiddleware to cause caching to depend on the URL and the HX-Request flag.