### PR TITLE
In cable view display all devices for multi-termination cables

### DIFF
--- a/netbox/templates/dcim/inc/cable_termination.html
+++ b/netbox/templates/dcim/inc/cable_termination.html
@@ -16,14 +16,13 @@
         <td>{{ terminations.0.device.rack|linkify|placeholder }}</td>
       </tr>
       <tr>
-        <td>Device</td>
-        <td>{{ terminations.0.device|linkify }}</td>
-      </tr>
-      <tr>
         <td>{{ terminations.0|meta:"verbose_name"|capfirst }}</td>
         <td>
           {% for term in terminations %}
-            {{ term|linkify }}{% if not forloop.last %},{% endif %}
+	    {{term.device|linkify}}
+	    <i class="mdi mdi-chevron-right" aria-hidden="true"></i>
+	    {{ term|linkify }}
+	    {% if not forloop.last %}<br/>{% endif %}
           {% endfor %}
         </td>
       </tr>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Improves/Fixes: #12951

<!--
    Please include a summary of the proposed changes below.
-->

In a Cable view, device link is now displayed alongside each cable termination (instead of a device for just first termination), as described with screenshots in #12951