### PR TITLE
Fixes asn_count on asn range

### DIFF
--- a/netbox/ipam/api/serializers.py
+++ b/netbox/ipam/api/serializers.py
@@ -1,4 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
+from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -24,7 +25,7 @@ class ASNRangeSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='ipam-api:asnrange-detail')
     rir = NestedRIRSerializer()
     tenant = NestedTenantSerializer(required=False, allow_null=True)
-    asn_count = serializers.IntegerField(read_only=True)
+    asn_count = serializers.SerializerMethodField(read_only=True)
 
     class Meta:
         model = ASNRange
@@ -32,6 +33,10 @@ class ASNRangeSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'rir', 'start', 'end', 'tenant', 'description', 'tags',
             'custom_fields', 'created', 'last_updated', 'asn_count',
         ]
+
+    @extend_schema_field(OpenApiTypes.INT)
+    def get_asn_count(self, obj):
+        return obj.get_child_asns().count()
 
 
 #

--- a/netbox/ipam/tables/asn.py
+++ b/netbox/ipam/tables/asn.py
@@ -21,10 +21,10 @@ class ASNRangeTable(TenancyColumnsMixin, NetBoxTable):
     tags = columns.TagColumn(
         url_name='ipam:asnrange_list'
     )
-    asn_count = columns.LinkedCountColumn(
-        viewname='ipam:asn_list',
-        url_params={'asn_id': 'pk'},
-        verbose_name=_('ASN Count')
+    asn_count = columns.TemplateColumn(
+        orderable=False,
+        verbose_name=_('ASN Count'),
+        template_code='''{{ record.get_child_asns.count }}'''
     )
 
     class Meta(NetBoxTable.Meta):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #13047

<!--
    Please include a summary of the proposed changes below.
-->

- `asn_count` was defined on the serializer but wasn't showing up in the results
- Replaced `LinkedCountColumn` with `TemplateColumn` due to 2 reasons:
  1. As per my understanding, LinkedCountColumn uses filtersets to find the information. I tried different variations but none worked.
  2. TemplateColumn does not produce a linkified cell, as there is no UI filter on the ASN table for the range