### PR TITLE
13092 allow setnull for bulk edit power port maximum and allocated draw

### DIFF
--- a/netbox/dcim/forms/bulk_edit.py
+++ b/netbox/dcim/forms/bulk_edit.py
@@ -1106,7 +1106,7 @@ class PowerPortBulkEditForm(
         (None, ('module', 'type', 'label', 'description', 'mark_connected')),
         ('Power', ('maximum_draw', 'allocated_draw')),
     )
-    nullable_fields = ('module', 'label', 'description')
+    nullable_fields = ('module', 'label', 'description', 'maximum_draw', 'allocated_draw')
 
 
 class PowerOutletBulkEditForm(


### PR DESCRIPTION
### Fixes: #13092 

Allows to set-null on power port maximum and allocated draw when doing a bulk edit.