### PR TITLE
Fixes: #11478 - Alters interface serializers get_display to include device to string representation

### DIFF
--- a/netbox/dcim/api/nested_serializers.py
+++ b/netbox/dcim/api/nested_serializers.py
@@ -391,6 +391,9 @@ class NestedInterfaceSerializer(WritableNestedSerializer):
         model = models.Interface
         fields = ['id', 'url', 'display', 'device', 'name', 'cable', '_occupied']
 
+    def get_display(self, obj):
+        return f"{obj.name} ({obj.device})"
+
 
 class NestedRearPortSerializer(WritableNestedSerializer):
     device = NestedDeviceSerializer(read_only=True)

--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -925,6 +925,9 @@ class InterfaceSerializer(NetBoxModelSerializer, CabledObjectSerializer, Connect
             'last_updated', 'count_ipaddresses', 'count_fhrp_groups', '_occupied',
         ]
 
+    def get_display(self, obj):
+        return f"{obj.name} ({obj.device})"
+
     def validate(self, data):
 
         # Validate many-to-many VLAN assignments


### PR DESCRIPTION
### Fixes: #11478 

Alters interface serializers get_display to include device to string representation in brackets to better denote what device the specific interface is connected to.