### PR TITLE
Fixes #12768 - Update the install doc for PostgreSQL 15

### DIFF
--- a/docs/installation/1-postgresql.md
+++ b/docs/installation/1-postgresql.md
@@ -55,6 +55,9 @@ Within the shell, enter the following commands to create the database and user (
 CREATE DATABASE netbox;
 CREATE USER netbox WITH PASSWORD 'J5brHrAXFLQSif0K';
 ALTER DATABASE netbox OWNER TO netbox;
+-- the next two commands are needed on PostgreSQL 15 and later
+\connect netbox;
+GRANT CREATE ON SCHEMA public TO netbox;
 ```
 
 !!! danger "Use a strong password"


### PR DESCRIPTION
### Fixes: #12768

The PR updates the installation documentation to support PostgreSQL 15 and later, which changes the default permissions on the public schema.

As far as I could test, this is a one-time command during the installation. No further actions are needed on NetBox upgrades.