### PR TITLE
Fixes #13167- Use class_name instead of name to get script results

### DIFF
--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -303,7 +303,7 @@ class ScriptViewSet(ViewSet):
 
         # Attach Job objects to each script (if any)
         for script in script_list:
-            script.result = results.get(script.name, None)
+            script.result = results.get(script.class_name, None)
 
         serializer = serializers.ScriptSerializer(script_list, many=True, context={'request': request})
 
@@ -314,7 +314,7 @@ class ScriptViewSet(ViewSet):
         object_type = ContentType.objects.get(app_label='extras', model='scriptmodule')
         script.result = Job.objects.filter(
             object_type=object_type,
-            name=script.name,
+            name=script.class_name,
             status__in=JobStatusChoices.TERMINAL_STATE_CHOICES
         ).first()
         serializer = serializers.ScriptDetailSerializer(script, context={'request': request})


### PR DESCRIPTION
### Fixes: #13167

This is actually a fix to #13061, but as that was closed by solving a related but different issue, #13167 was opened while technically being a duplicate.