### PR TITLE
Fixes #12639 - Make sure name expansions throws a validation error on decrementing ranges

### DIFF
--- a/netbox/dcim/forms/object_create.py
+++ b/netbox/dcim/forms/object_create.py
@@ -52,7 +52,12 @@ class ComponentCreateForm(forms.Form):
         super().clean()
 
         # Validate that all replication fields generate an equal number of values
-        pattern_count = len(self.cleaned_data[self.replication_fields[0]])
+        patterns = self.cleaned_data.get(self.replication_fields[0])
+
+        if not patterns:
+            return
+
+        pattern_count = len(patterns)
         for field_name in self.replication_fields:
             value_count = len(self.cleaned_data[field_name])
             if self.cleaned_data[field_name] and value_count != pattern_count:

--- a/netbox/dcim/forms/object_create.py
+++ b/netbox/dcim/forms/object_create.py
@@ -52,9 +52,7 @@ class ComponentCreateForm(forms.Form):
         super().clean()
 
         # Validate that all replication fields generate an equal number of values
-        patterns = self.cleaned_data.get(self.replication_fields[0])
-
-        if not patterns:
+        if not (patterns := self.cleaned_data.get(self.replication_fields[0])):
             return
 
         pattern_count = len(patterns)

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -60,6 +60,9 @@ def parse_alphanumeric_range(string):
         except ValueError:
             begin, end = dash_range, dash_range
         if begin.isdigit() and end.isdigit():
+            if int(begin) > int(end):
+                raise forms.ValidationError(f'Range "{dash_range}" is invalid.')
+
             for n in list(range(int(begin), int(end) + 1)):
                 values.append(n)
         else:
@@ -71,6 +74,10 @@ def parse_alphanumeric_range(string):
                 # Not a valid range (more than a single character)
                 if not len(begin) == len(end) == 1:
                     raise forms.ValidationError(f'Range "{dash_range}" is invalid.')
+                
+                if ord(begin) > ord(end):
+                    raise forms.ValidationError(f'Range "{dash_range}" is invalid.')
+                
                 for n in list(range(ord(begin), ord(end) + 1)):
                     values.append(chr(n))
     return values

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -60,7 +60,7 @@ def parse_alphanumeric_range(string):
         except ValueError:
             begin, end = dash_range, dash_range
         if begin.isdigit() and end.isdigit():
-            if int(begin) > int(end):
+            if int(begin) >= int(end):
                 raise forms.ValidationError(f'Range "{dash_range}" is invalid.')
 
             for n in list(range(int(begin), int(end) + 1)):
@@ -75,7 +75,7 @@ def parse_alphanumeric_range(string):
                 if not len(begin) == len(end) == 1:
                     raise forms.ValidationError(f'Range "{dash_range}" is invalid.')
 
-                if ord(begin) > ord(end):
+                if ord(begin) >= ord(end):
                     raise forms.ValidationError(f'Range "{dash_range}" is invalid.')
 
                 for n in list(range(ord(begin), ord(end) + 1)):

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -74,10 +74,10 @@ def parse_alphanumeric_range(string):
                 # Not a valid range (more than a single character)
                 if not len(begin) == len(end) == 1:
                     raise forms.ValidationError(f'Range "{dash_range}" is invalid.')
-                
+
                 if ord(begin) > ord(end):
                     raise forms.ValidationError(f'Range "{dash_range}" is invalid.')
-                
+
                 for n in list(range(ord(begin), ord(end) + 1)):
                     values.append(chr(n))
     return values

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -264,8 +264,9 @@ class ExpandAlphanumeric(TestCase):
         self.assertEqual(sorted(expand_alphanumeric_pattern('r[a-9]a')), [])
 
     def test_invalid_range_bounds(self):
-        self.assertEqual(sorted(expand_alphanumeric_pattern('r[9-8]a')), [])
-        self.assertEqual(sorted(expand_alphanumeric_pattern('r[b-a]a')), [])
+        with self.assertRaises(forms.ValidationError):
+            sorted(expand_alphanumeric_pattern('r[9-8]a'))
+            sorted(expand_alphanumeric_pattern('r[b-a]a'))
 
     def test_invalid_range_len(self):
         with self.assertRaises(forms.ValidationError):


### PR DESCRIPTION
### Fixes: #12639

The code is a tiny bit messy, but I did my best.

Changes:

* `parse_alphanumeric_range` now throws a `ValidationError` when its passed decrementing ranges.
* The `ComponentCreateForm` clean method has been slightly reworked to bail out if the name field is not in cleaned_data. Not quite sure what is going on, but I think it's because validation continues even if the above ValidationError is thrown.
* The tests has been changed to expect an Exception instead of an empty list on decrementing ranges.

Tests passes now, but please give it a test to make sure I didn't mess anything up. The logic for expandable fields is a little hard to grok.