### PR TITLE
Fixes #13369: Fix job termination status for failed reports

### DIFF
--- a/netbox/extras/reports.py
+++ b/netbox/extras/reports.py
@@ -214,20 +214,18 @@ class Report(object):
                 self.active_test = method_name
                 test_method = getattr(self, method_name)
                 test_method()
+            job.data = self._results
             if self.failed:
                 self.logger.warning("Report failed")
-                job.status = JobStatusChoices.STATUS_FAILED
+                job.terminate(status=JobStatusChoices.STATUS_FAILED)
             else:
                 self.logger.info("Report completed successfully")
-                job.status = JobStatusChoices.STATUS_COMPLETED
+                job.terminate()
         except Exception as e:
             stacktrace = traceback.format_exc()
             self.log_failure(None, f"An exception occurred: {type(e).__name__}: {e} <pre>{stacktrace}</pre>")
             logger.error(f"Exception raised during report execution: {e}")
             job.terminate(status=JobStatusChoices.STATUS_ERRORED)
-        finally:
-            job.data = self._results
-            job.terminate()
 
         # Perform any post-run tasks
         self.post_run()


### PR DESCRIPTION
### Fixes: #13369

Refactor the logic for terminating report jobs to avoid overwriting a status of "failed."
