### PR TITLE
Fixes #13376: Restrict add/remove tag fields on bulk edit forms by model

### DIFF
--- a/netbox/netbox/forms/base.py
+++ b/netbox/netbox/forms/base.py
@@ -127,6 +127,11 @@ class NetBoxModelBulkEditForm(BootstrapMixin, CustomFieldsMixin, forms.Form):
 
         self.fields['pk'].queryset = self.model.objects.all()
 
+        # Restrict tag fields by model
+        ct = ContentType.objects.get_for_model(self.model)
+        self.fields['add_tags'].widget.add_query_param('for_object_type_id', ct.pk)
+        self.fields['remove_tags'].widget.add_query_param('for_object_type_id', ct.pk)
+
         self._extend_nullable_fields()
 
     def _get_form_field(self, customfield):


### PR DESCRIPTION
### Fixes: #13376

Extend NetBoxModelBulkEditForm to automatically apply the `for_object_type_id` query parameter to its `add_tags` and `remove_tags` fields.