### PR TITLE
12665 add semicolon to link sanitation safe string

### DIFF
--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -285,7 +285,7 @@ class CustomLink(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
         text = clean_html(text, allowed_schemes)
 
         # Sanitize link
-        link = urllib.parse.quote(link, safe='/:?&=%+[]@#,')
+        link = urllib.parse.quote(link, safe='/:?&=%+[]@#,;')
 
         # Verify link scheme is allowed
         result = urllib.parse.urlparse(link)


### PR DESCRIPTION
### Fixes: #12665 

Adds semicolon to safe string for link sanitation.