### PR TITLE
11578 mark swagger available- apis to accept lists in post

### DIFF
--- a/netbox/ipam/api/views.py
+++ b/netbox/ipam/api/views.py
@@ -388,7 +388,10 @@ class AvailableIPAddressesView(ObjectValidationMixin, APIView):
 
         return Response(serializer.data)
 
-    @extend_schema(methods=["post"], responses={201: serializers.IPAddressSerializer(many=True)})
+    @extend_schema(methods=["post"],
+                   responses={201: serializers.IPAddressSerializer(many=True)},
+                   request=serializers.IPAddressSerializer(many=True),
+                   )
     @advisory_lock(ADVISORY_LOCK_KEYS['available-ips'])
     def post(self, request, pk):
         self.queryset = self.queryset.restrict(request.user, 'add')

--- a/netbox/ipam/api/views.py
+++ b/netbox/ipam/api/views.py
@@ -224,7 +224,10 @@ class AvailableASNsView(ObjectValidationMixin, APIView):
 
         return Response(serializer.data)
 
-    @extend_schema(methods=["post"], responses={201: serializers.ASNSerializer(many=True)})
+    @extend_schema(methods=["post"],
+                   responses={201: serializers.ASNSerializer(many=True)},
+                   request=serializers.ASNSerializer(many=True),
+                   )
     @advisory_lock(ADVISORY_LOCK_KEYS['available-asns'])
     def post(self, request, pk):
         self.queryset = self.queryset.restrict(request.user, 'add')
@@ -293,7 +296,10 @@ class AvailablePrefixesView(ObjectValidationMixin, APIView):
 
         return Response(serializer.data)
 
-    @extend_schema(methods=["post"], responses={201: serializers.PrefixSerializer(many=True)})
+    @extend_schema(methods=["post"],
+                   responses={201: serializers.PrefixSerializer(many=True)},
+                   request=serializers.PrefixSerializer(many=True),
+                   )
     @advisory_lock(ADVISORY_LOCK_KEYS['available-prefixes'])
     def post(self, request, pk):
         self.queryset = self.queryset.restrict(request.user, 'add')
@@ -471,7 +477,10 @@ class AvailableVLANsView(ObjectValidationMixin, APIView):
 
         return Response(serializer.data)
 
-    @extend_schema(methods=["post"], responses={201: serializers.VLANSerializer(many=True)})
+    @extend_schema(methods=["post"],
+                   responses={201: serializers.VLANSerializer(many=True)},
+                   request=serializers.VLANSerializer(many=True),
+                   )
     @advisory_lock(ADVISORY_LOCK_KEYS['available-vlans'])
     def post(self, request, pk):
         self.queryset = self.queryset.restrict(request.user, 'add')


### PR DESCRIPTION
### Fixes: #11578 

Marks the available APIs as returning a list.  The technically correct fix would be using a PolymorphicProxySerializer as these can be called with a single object or a list, however this would cause the swagger to emit a "oneOf" which is not supported in Go OpenAPI generator, also it makes the spec more complex.   If you only have to request a single item, just use a list with a single object as request so there really isn't a downside for this.

@jeremystretch I was mistaken, these only effect the availalbe-api's so there weren't that many to change.