### PR TITLE
13358 Fix git DataSource clone authentication

### DIFF
--- a/netbox/core/data_backends.py
+++ b/netbox/core/data_backends.py
@@ -103,12 +103,13 @@ class GitBackend(DataBackend):
         }
 
         if self.url_scheme in ('http', 'https'):
-            clone_args.update(
-                {
-                    "username": self.params.get('username'),
-                    "password": self.params.get('password'),
-                }
-            )
+            if self.params.get('username'):
+                clone_args.update(
+                    {
+                        "username": self.params.get('username'),
+                        "password": self.params.get('password'),
+                    }
+                )
 
         if settings.HTTP_PROXIES and self.url_scheme in ('http', 'https'):
             if proxy := settings.HTTP_PROXIES.get(self.url_scheme):


### PR DESCRIPTION
### Fixes: #13358

Anonymous git clones (in GitLab) require the username and password (HTTP Basic authentication headers) not to be set in order to successfully clone. This patch will define clone args only, if the username passed is not empty.
