### PR TITLE
Fixes #13477 - Correct filter name in redirect after bulk edit

### DIFF
--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -458,7 +458,7 @@ class BulkImportView(GetReturnURLMixin, BaseMultiObjectView):
                     messages.success(request, msg)
 
                     view_name = get_viewname(model, action='list')
-                    results_url = f"{reverse(view_name)}?created_by_request={request.id}"
+                    results_url = f"{reverse(view_name)}?modified_by_request={request.id}"
                     return redirect(results_url)
 
             except (AbortTransaction, ValidationError):


### PR DESCRIPTION
### Fixes: #13477

Makes create_and_update_objects return an extra bool indicating if the operation was creation or updating. Uses this bool to choose the correct filter.