### PR TITLE
11272 make position field work correctly when internationalization enabled

### DIFF
--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -401,12 +401,13 @@ class DeviceForm(TenancyForm, NetBoxModelForm):
     position = forms.DecimalField(
         required=False,
         help_text=_("The lowest-numbered unit occupied by the device"),
+        localize=True,
         widget=APISelect(
             api_url='/api/dcim/racks/{{rack}}/elevation/',
             attrs={
                 'disabled-indicator': 'device',
                 'data-dynamic-params': '[{"fieldName":"face","queryParam":"face"}]'
-            }
+            },
         )
     )
     device_type = DynamicModelChoiceField(


### PR DESCRIPTION
### Fixes: #11272 

Fixes position form field when turning on ENABLE_INTERNATIONALIZATION and selecting browser language that uses commas as separators.