### PR TITLE
12114 show filename and line number on 500 error page

### DIFF
--- a/netbox/netbox/views/errors.py
+++ b/netbox/netbox/views/errors.py
@@ -1,3 +1,4 @@
+import os
 import platform
 import sys
 
@@ -49,10 +50,13 @@ def handler_500(request, template_name=ERROR_500_TEMPLATE_NAME):
     except TemplateDoesNotExist:
         return HttpResponseServerError('<h1>Server Error (500)</h1>', content_type='text/html')
     type_, error, traceback = sys.exc_info()
-
+    fname = os.path.split(traceback.tb_frame.f_code.co_filename)[1]
+    lineno = traceback.tb_lineno
     return HttpResponseServerError(template.render({
         'error': error,
         'exception': str(type_),
+        'fname': fname,
+        'lineno': lineno,
         'netbox_version': settings.VERSION,
         'python_version': platform.python_version(),
         'plugins': get_installed_plugins(),

--- a/netbox/templates/500.html
+++ b/netbox/templates/500.html
@@ -29,6 +29,8 @@
 <pre class="block"><strong>{{ exception }}</strong><br />
 {{ error }}
 
+file: {{ fname }} line: {{ lineno }}
+
 Python version: {{ python_version }}
 NetBox version: {{ netbox_version }}
 Plugins: {% for plugin, version in plugins.items %}


### PR DESCRIPTION
### Fixes: #12114 

Adds the filename and line number to 500 page error report that is potentially useful in tracking down the error without exposing a security risk.  Not as useful as a full stack trace, but as pointed out in the ticket it can sometimes help to quickly identify if it is in a plugin.  Note however that it only shows the last line of the stack-trace which can be a library routine (for example a raised exception) - doing the full stack trace would give much better debugging info but is probably too much of a potential security leak?

Note: screenshot is from a raise exception, so in this specific case not very useful.

![Monosnap Server Error 2023-08-18 12-43-26](https://github.com/netbox-community/netbox/assets/99642/9a4f346f-2c83-4f45-8a05-7d75fa4a21ac)
