### PR TITLE
Fixed permission for config context UI view

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -2055,7 +2055,6 @@ class DeviceConfigContextView(ObjectConfigContextView):
     base_template = 'dcim/device/base.html'
     tab = ViewTab(
         label=_('Config Context'),
-        permission='extras.view_configcontext',
         weight=2000
     )
 

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -17,7 +17,6 @@ from extras.dashboard.utils import get_widget_class
 from netbox.views import generic
 from utilities.forms import ConfirmationForm, get_field_value
 from utilities.htmx import is_htmx
-from utilities.permissions import get_permission_for_model
 from utilities.rqworker import get_workers_for_queue
 from utilities.templatetags.builtins.filters import render_markdown
 from utilities.utils import copy_safe_request, count_related, get_viewname, normalize_querydict, shallow_compare_dict
@@ -434,9 +433,6 @@ class ConfigContextBulkSyncDataView(generic.BulkSyncDataView):
 class ObjectConfigContextView(generic.ObjectView):
     base_template = None
     template_name = 'extras/object_configcontext.html'
-
-    def get_required_permission(self):
-        return get_permission_for_model(ConfigContext, 'view')
 
     def get_extra_context(self, request, instance):
         source_contexts = ConfigContext.objects.restrict(request.user, 'view').get_for_object(instance)

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -17,6 +17,7 @@ from extras.dashboard.utils import get_widget_class
 from netbox.views import generic
 from utilities.forms import ConfirmationForm, get_field_value
 from utilities.htmx import is_htmx
+from utilities.permissions import get_permission_for_model
 from utilities.rqworker import get_workers_for_queue
 from utilities.templatetags.builtins.filters import render_markdown
 from utilities.utils import copy_safe_request, count_related, get_viewname, normalize_querydict, shallow_compare_dict
@@ -433,6 +434,9 @@ class ConfigContextBulkSyncDataView(generic.BulkSyncDataView):
 class ObjectConfigContextView(generic.ObjectView):
     base_template = None
     template_name = 'extras/object_configcontext.html'
+
+    def get_required_permission(self):
+        return get_permission_for_model(ConfigContext, 'view')
 
     def get_extra_context(self, request, instance):
         source_contexts = ConfigContext.objects.restrict(request.user, 'view').get_for_object(instance)

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -384,7 +384,6 @@ class VirtualMachineConfigContextView(ObjectConfigContextView):
     base_template = 'virtualization/virtualmachine.html'
     tab = ViewTab(
         label=_('Config Context'),
-        permission='extras.view_configcontext',
         weight=2000
     )
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #13543

<!--
    Please include a summary of the proposed changes below.
-->

Note: The OP also requested to remove `config_context` from the API. I could not figure out how that's possible considering the data could also be sourced from local context.