### PR TITLE
Fixes #13605: Specify batch size for cached counter migrations

### DIFF
--- a/netbox/dcim/migrations/0176_device_component_counters.py
+++ b/netbox/dcim/migrations/0176_device_component_counters.py
@@ -6,7 +6,7 @@ import utilities.fields
 
 def recalculate_device_counts(apps, schema_editor):
     Device = apps.get_model("dcim", "Device")
-    devices = list(Device.objects.all().annotate(
+    devices = Device.objects.annotate(
         _console_port_count=Count('consoleports', distinct=True),
         _console_server_port_count=Count('consoleserverports', distinct=True),
         _power_port_count=Count('powerports', distinct=True),
@@ -17,7 +17,7 @@ def recalculate_device_counts(apps, schema_editor):
         _device_bay_count=Count('devicebays', distinct=True),
         _module_bay_count=Count('modulebays', distinct=True),
         _inventory_item_count=Count('inventoryitems', distinct=True),
-    ))
+    )
 
     for device in devices:
         device.console_port_count = device._console_port_count
@@ -42,7 +42,7 @@ def recalculate_device_counts(apps, schema_editor):
         'device_bay_count',
         'module_bay_count',
         'inventory_item_count',
-    ])
+    ], batch_size=100)
 
 
 class Migration(migrations.Migration):

--- a/netbox/dcim/migrations/0178_virtual_chassis_member_counter.py
+++ b/netbox/dcim/migrations/0178_virtual_chassis_member_counter.py
@@ -12,7 +12,7 @@ def populate_virtualchassis_members(apps, schema_editor):
     for vc in vcs:
         vc.member_count = vc._member_count
 
-    VirtualChassis.objects.bulk_update(vcs, ['member_count'])
+    VirtualChassis.objects.bulk_update(vcs, ['member_count'], batch_size=100)
 
 
 class Migration(migrations.Migration):

--- a/netbox/dcim/migrations/0178_virtual_chassis_member_counter.py
+++ b/netbox/dcim/migrations/0178_virtual_chassis_member_counter.py
@@ -7,7 +7,7 @@ import utilities.fields
 def populate_virtualchassis_members(apps, schema_editor):
     VirtualChassis = apps.get_model('dcim', 'VirtualChassis')
 
-    vcs = list(VirtualChassis.objects.annotate(_member_count=Count('members', distinct=True)))
+    vcs = VirtualChassis.objects.annotate(_member_count=Count('members', distinct=True))
 
     for vc in vcs:
         vc.member_count = vc._member_count

--- a/netbox/virtualization/migrations/0035_virtualmachine_interface_count.py
+++ b/netbox/virtualization/migrations/0035_virtualmachine_interface_count.py
@@ -7,7 +7,7 @@ import utilities.fields
 def populate_virtualmachine_counts(apps, schema_editor):
     VirtualMachine = apps.get_model('virtualization', 'VirtualMachine')
 
-    vms = list(VirtualMachine.objects.annotate(_interface_count=Count('interfaces', distinct=True)))
+    vms = VirtualMachine.objects.annotate(_interface_count=Count('interfaces', distinct=True))
 
     for vm in vms:
         vm.interface_count = vm._interface_count

--- a/netbox/virtualization/migrations/0035_virtualmachine_interface_count.py
+++ b/netbox/virtualization/migrations/0035_virtualmachine_interface_count.py
@@ -12,7 +12,7 @@ def populate_virtualmachine_counts(apps, schema_editor):
     for vm in vms:
         vm.interface_count = vm._interface_count
 
-    VirtualMachine.objects.bulk_update(vms, ['interface_count'])
+    VirtualMachine.objects.bulk_update(vms, ['interface_count'], batch_size=100)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
### Fixes: #13605

Add `batch_size=100` to the `bulk_update()` calls in the cached counter migrations, to avoid very large SQL queries.
