### PR TITLE
fix error for is_oob_ip for non-device parents

### DIFF
--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -892,7 +892,7 @@ class IPAddress(PrimaryModel):
     def is_oob_ip(self):
         if self.assigned_object:
             parent = getattr(self.assigned_object, 'parent_object', None)
-            if parent.oob_ip_id == self.pk:
+            if parent.__class__.__name__ == "Device" and parent.oob_ip_id == self.pk:
                 return True
         return False
 

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -892,7 +892,7 @@ class IPAddress(PrimaryModel):
     def is_oob_ip(self):
         if self.assigned_object:
             parent = getattr(self.assigned_object, 'parent_object', None)
-            if parent.__class__.__name__ == "Device" and parent.oob_ip_id == self.pk:
+            if hasattr(parent, "oob_ip_id") and parent.oob_ip_id == self.pk:
                 return True
         return False
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #13619

IP addresses assigned to non devices (eg virtual machines) would error during rendering as oob_ip_id did not exist on them. Adjusted the code to check if attribute exists first
