### PR TITLE
Closes #13638: Add optional staff_only attribute to MenuItem

### DIFF
--- a/docs/plugins/development/navigation.md
+++ b/docs/plugins/development/navigation.md
@@ -64,12 +64,13 @@ item1 = PluginMenuItem(
 
 A `PluginMenuItem` has the following attributes:
 
-| Attribute     | Required | Description                                          |
-|---------------|----------|------------------------------------------------------|
-| `link`        | Yes      | Name of the URL path to which this menu item links   |
-| `link_text`   | Yes      | The text presented to the user                       |
-| `permissions` | -        | A list of permissions required to display this link  |
-| `buttons`     | -        | An iterable of PluginMenuButton instances to include |
+| Attribute     | Required | Description                                                                                              |
+|---------------|----------|----------------------------------------------------------------------------------------------------------|
+| `link`        | Yes      | Name of the URL path to which this menu item links                                                       |
+| `link_text`   | Yes      | The text presented to the user                                                                           |
+| `permissions` | -        | A list of permissions required to display this link                                                      |
+| `staff_only`  | -        | Display only for users who have `is_staff` set to true (any specified permissions will also be required) |
+| `buttons`     | -        | An iterable of PluginMenuButton instances to include                                                     |
 
 ## Menu Buttons
 

--- a/docs/plugins/development/navigation.md
+++ b/docs/plugins/development/navigation.md
@@ -72,6 +72,8 @@ A `PluginMenuItem` has the following attributes:
 | `staff_only`  | -        | Display only for users who have `is_staff` set to true (any specified permissions will also be required) |
 | `buttons`     | -        | An iterable of PluginMenuButton instances to include                                                     |
 
+!!! info "The `staff_only` attribute was introduced in NetBox v3.6.1."
+
 ## Menu Buttons
 
 Each menu item can include a set of buttons. These can be handy for providing shortcuts related to the menu item. For instance, most items in NetBox's navigation menu include buttons to create and import new objects.

--- a/netbox/extras/plugins/navigation.py
+++ b/netbox/extras/plugins/navigation.py
@@ -36,9 +36,10 @@ class PluginMenuItem:
     permissions = []
     buttons = []
 
-    def __init__(self, link, link_text, permissions=None, buttons=None):
+    def __init__(self, link, link_text, staff_only=False, permissions=None, buttons=None):
         self.link = link
         self.link_text = link_text
+        self.staff_only = staff_only
         if permissions is not None:
             if type(permissions) not in (list, tuple):
                 raise TypeError("Permissions must be passed as a tuple or list.")

--- a/netbox/netbox/navigation/__init__.py
+++ b/netbox/netbox/navigation/__init__.py
@@ -34,6 +34,7 @@ class MenuItem:
     link: str
     link_text: str
     permissions: Optional[Sequence[str]] = ()
+    staff_only: Optional[bool] = False
     buttons: Optional[Sequence[MenuItemButton]] = ()
 
 

--- a/netbox/utilities/templatetags/navigation.py
+++ b/netbox/utilities/templatetags/navigation.py
@@ -26,11 +26,14 @@ def nav(context: Context) -> Dict:
         for group in menu.groups:
             items = []
             for item in group.items:
-                if user.has_perms(item.permissions):
-                    buttons = [
-                        button for button in item.buttons if user.has_perms(button.permissions)
-                    ]
-                    items.append((item, buttons))
+                if not user.has_perms(item.permissions):
+                    continue
+                if item.staff_only and not user.is_staff:
+                    continue
+                buttons = [
+                    button for button in item.buttons if user.has_perms(button.permissions)
+                ]
+                items.append((item, buttons))
             if items:
                 groups.append((group, items))
         if groups:


### PR DESCRIPTION
### Fixes: #13638

- Add optional `staff_only` boolean attribute to MenuItem dataclass
- Modify menu rendering logic to evaluate `staff_only` against user's `is_staff` status