### PR TITLE
Fixes #13642: Move migration logic overrides from individual management commands to core

### DIFF
--- a/netbox/core/apps.py
+++ b/netbox/core/apps.py
@@ -1,4 +1,15 @@
 from django.apps import AppConfig
+from django.db import models
+from django.db.migrations.operations import AlterModelOptions
+
+from utilities.migration import custom_deconstruct
+
+# Ignore verbose_name & verbose_name_plural Meta options when calculating model migrations
+AlterModelOptions.ALTER_OPTION_KEYS.remove('verbose_name')
+AlterModelOptions.ALTER_OPTION_KEYS.remove('verbose_name_plural')
+
+# Use our custom destructor to ignore certain attributes when calculating field migrations
+models.Field.deconstruct = custom_deconstruct
 
 
 class CoreConfig(AppConfig):

--- a/netbox/core/management/commands/makemigrations.py
+++ b/netbox/core/management/commands/makemigrations.py
@@ -1,18 +1,6 @@
-# noinspection PyUnresolvedReferences
 from django.conf import settings
 from django.core.management.base import CommandError
 from django.core.management.commands.makemigrations import Command as _Command
-from django.db import models
-from django.db.migrations.operations import AlterModelOptions
-
-from utilities.migration import custom_deconstruct
-
-# Monkey patch AlterModelOptions to ignore verbose name attributes
-AlterModelOptions.ALTER_OPTION_KEYS.remove('verbose_name')
-AlterModelOptions.ALTER_OPTION_KEYS.remove('verbose_name_plural')
-
-# Set our custom deconstructor for fields
-models.Field.deconstruct = custom_deconstruct
 
 
 class Command(_Command):

--- a/netbox/core/management/commands/migrate.py
+++ b/netbox/core/management/commands/migrate.py
@@ -1,7 +1,0 @@
-# noinspection PyUnresolvedReferences
-from django.core.management.commands.migrate import Command
-from django.db import models
-
-from utilities.migration import custom_deconstruct
-
-models.Field.deconstruct = custom_deconstruct


### PR DESCRIPTION
### Fixes: #13642

Move our customizations of `AlterModelOptions` and `models.Field.deconstruct` from the individual `migrate` and `makemigrations` management commands to the core app. This ensures that the `AlterModelOptions` changes go into effect for both commands while reducing duplicate code.