### PR TITLE
Fixes #13596: Always display "render config" tab for devices & VMs

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -2033,7 +2033,6 @@ class DeviceRenderConfigView(generic.ObjectView):
     template_name = 'dcim/device/render_config.html'
     tab = ViewTab(
         label=_('Render Config'),
-        permission='extras.view_configtemplate',
         weight=2100
     )
 

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -397,7 +397,6 @@ class VirtualMachineRenderConfigView(generic.ObjectView):
     template_name = 'virtualization/virtualmachine/render_config.html'
     tab = ViewTab(
         label=_('Render Config'),
-        permission='extras.view_configtemplate',
         weight=2100
     )
 


### PR DESCRIPTION
### Fixes: #13596

Remove the permission association from the "render config" tab for devices and virtual machines (see also #13547)