### PR TITLE
Fixes #13656: Correct decoding of BinaryField content for Django 4.2

### DIFF
--- a/netbox/core/models/data.py
+++ b/netbox/core/models/data.py
@@ -316,7 +316,7 @@ class DataFile(models.Model):
         if not self.data:
             return None
         try:
-            return bytes(self.data, 'utf-8')
+            return self.data.decode('utf-8')
         except UnicodeDecodeError:
             return None
 


### PR DESCRIPTION
### Fixes: #13656

