### PR TITLE
Fixes #13666: Fix behavior for reports without test methods

### DIFF
--- a/netbox/extras/reports.py
+++ b/netbox/extras/reports.py
@@ -106,8 +106,6 @@ class Report(object):
                     'failure': 0,
                     'log': [],
                 }
-        if not test_methods:
-            raise Exception("A report must contain at least one test method.")
         self.test_methods = test_methods
 
     @classproperty

--- a/netbox/templates/extras/report.html
+++ b/netbox/templates/extras/report.html
@@ -12,7 +12,11 @@
             {% csrf_token %}
             {% render_form form %}
             <div class="float-end">
-              <button type="submit" name="_run" class="btn btn-primary">
+              <button type="submit" name="_run" class="btn btn-primary"
+              {% if not report.test_methods|length %}
+                disabled
+              {% endif %}
+              >
                 {% if report.result %}
                   <i class="mdi mdi-replay"></i> {% trans "Run Again" %}
                 {% else %}

--- a/netbox/templates/extras/report_list.html
+++ b/netbox/templates/extras/report_list.html
@@ -68,10 +68,16 @@
                           </td>
                         {% else %}
                           <td class="text-muted">{% trans "Never" %}</td>
-                          <td>{{ ''|placeholder }}</td>
+                          {% if report.test_methods|length %}
+                            <td>{{ ''|placeholder }}</td>
+                          {% else %}
+                            <td>
+                              Invalid (no test methods found)
+                           </td>
+                          {% endif %}
                         {% endif %}
                         <td>
-                          {% if perms.extras.run_report %}
+                          {% if perms.extras.run_report and report.test_methods|length %}
                             <div class="float-end noprint">
                               <form action="{% url 'extras:report' module=report.module name=report.class_name %}" method="post">
                                 {% csrf_token %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #13666

<!--
    Please include a summary of the proposed changes below.
-->
If you upload a report file without any test methods, the entire GUI for the reports page fails. This fixes the error by splitting up the `report_modules` into valid and empty ones. The valid `report_module`s are rendered as before, the empty ones are listed with the possibility to delete them. (Before you had to drop into the CLI to delete them)

The list of reports without test methods are at the top of the page to increase the visibility of them, but you could consider moving them into the normal list of reports, but show an error/warning there - similar to e.g. "Failed to load foo.py"

Additionally there is a second commit (But can be either dropped/moved to new PR as it changes the scope of the issue a little bit). It fixes the API by filtering out those reports

*Note: I wasn't able to run black, as `black --config pyproject.toml netbox/` wants to reformat everything, but `pycodestyle --ignore=W504,E501 netbox/` shows no warnings)*