### PR TITLE
Add support for TSV and semicolon-seperated CSV

### DIFF
--- a/netbox/netbox/tests/test_import.py
+++ b/netbox/netbox/tests/test_import.py
@@ -63,6 +63,61 @@ class CSVImportTestCase(ModelViewTestCase):
         return self._test_valid_tags(csv_data, ImportFormatChoices.CSV)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
+    def test_valid_tags_csv_autodetect(self):
+        csv_data = (
+            'name,slug,tags',
+            'Region 1,region-1,"alpha,bravo"',
+            'Region 2,region-2,"charlie,delta"',
+            'Region 3,region-3,echo',
+            'Region 4,region-4,',
+        )
+        return self._test_valid_tags(csv_data, ImportFormatChoices.AUTO)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
+    def test_valid_tags_csv_semicolon(self):
+        csv_data = (
+            'name;slug;tags',
+            'Region 1;region-1;"alpha,bravo"',
+            'Region 2;region-2;charlie,delta',
+            'Region 3;region-3;echo',
+            'Region 4;region-4;',
+        )
+        return self._test_valid_tags(csv_data, ImportFormatChoices.CSV_SEMICOLON)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
+    def test_valid_tags_csv_semicolon_autodetect(self):
+        csv_data = (
+            'name;slug;tags',
+            'Region 1;region-1;"alpha,bravo"',
+            'Region 2;region-2;charlie,delta',
+            'Region 3;region-3;echo',
+            'Region 4;region-4;',
+        )
+        return self._test_valid_tags(csv_data, ImportFormatChoices.AUTO)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
+    def test_valid_tags_tsv(self):
+        csv_data = (
+            'name\tslug\ttags',
+            'Region 1\tregion-1\t"alpha,bravo"',
+            'Region 2\tregion-2\tcharlie,delta',
+            'Region 3\tregion-3\techo',
+            'Region 4\tregion-4\t',
+        )
+        return self._test_valid_tags(csv_data, ImportFormatChoices.TSV)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
+    def test_valid_tags_tsv_autodetect(self):
+        csv_data = (
+            'name\tslug\ttags',
+            'Region 1\tregion-1\t"alpha,bravo"',
+            'Region 2\tregion-2\tcharlie,delta',
+            'Region 3\tregion-3\techo',
+            'Region 4\tregion-4\t',
+        )
+        return self._test_valid_tags(csv_data, ImportFormatChoices.AUTO)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
     def test_invalid_tags(self):
         csv_data = (
             'name,slug,tags',

--- a/netbox/netbox/tests/test_import.py
+++ b/netbox/netbox/tests/test_import.py
@@ -17,18 +17,9 @@ class CSVImportTestCase(ModelViewTestCase):
     def _get_csv_data(self, csv_data):
         return '\n'.join(csv_data)
 
-    @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
-    def test_valid_tags(self):
-        csv_data = (
-            'name,slug,tags',
-            'Region 1,region-1,"alpha,bravo"',
-            'Region 2,region-2,"charlie,delta"',
-            'Region 3,region-3,echo',
-            'Region 4,region-4,',
-        )
-
+    def _test_valid_tags(self, csv_data, importformat):
         data = {
-            'format': ImportFormatChoices.CSV,
+            'format': importformat,
             'data': self._get_csv_data(csv_data),
         }
 
@@ -59,6 +50,17 @@ class CSVImportTestCase(ModelViewTestCase):
             ['Echo']
         )
         self.assertEqual(regions[3].tags.count(), 0)
+
+    @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
+    def test_valid_tags_csv(self):
+        csv_data = (
+            'name,slug,tags',
+            'Region 1,region-1,"alpha,bravo"',
+            'Region 2,region-2,"charlie,delta"',
+            'Region 3,region-3,echo',
+            'Region 4,region-4,',
+        )
+        return self._test_valid_tags(csv_data, ImportFormatChoices.CSV)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
     def test_invalid_tags(self):

--- a/netbox/utilities/choices.py
+++ b/netbox/utilities/choices.py
@@ -221,12 +221,16 @@ class ImportMethodChoices(ChoiceSet):
 class ImportFormatChoices(ChoiceSet):
     AUTO = 'auto'
     CSV = 'csv'
+    CSV_SEMICOLON = "csv-semicolon"
+    TSV = "tsv"
     JSON = 'json'
     YAML = 'yaml'
 
     CHOICES = [
         (AUTO, _('Auto-detect')),
         (CSV, 'CSV'),
+        (CSV_SEMICOLON, 'CSV with semicolon seperators'),
+        (TSV, 'TSV'),
         (JSON, 'JSON'),
         (YAML, 'YAML'),
     ]

--- a/netbox/utilities/forms/bulk_import.py
+++ b/netbox/utilities/forms/bulk_import.py
@@ -68,7 +68,7 @@ class BulkImportForm(BootstrapMixin, SyncedDataMixin, forms.Form):
         elif format == ImportFormatChoices.CSV_SEMICOLON:
             self.cleaned_data['data'] = self._clean_csv(data, delimiter=';')
         elif format == ImportFormatChoices.TSV:
-            self.cleaned_data['data'] = self._clean_tsv(data, dialect='excel-tab')
+            self.cleaned_data['data'] = self._clean_csv(data, dialect='excel-tab')
         elif format == ImportFormatChoices.JSON:
             self.cleaned_data['data'] = self._clean_json(data)
         elif format == ImportFormatChoices.YAML:

--- a/netbox/utilities/forms/bulk_import.py
+++ b/netbox/utilities/forms/bulk_import.py
@@ -81,12 +81,12 @@ class BulkImportForm(BootstrapMixin, SyncedDataMixin, forms.Form):
         Attempt to automatically detect the format (CSV, JSON, or YAML) of the given data, or raise
         a ValidationError.
         """
+        first_line = data.strip().split('\n', 1)[0]
         try:
-            if data[0] in ('{', '['):
+            if first_line[0] in ('{', '['):
                 return ImportFormatChoices.JSON
-            if data.startswith('---') or data.startswith('- '):
+            if first_line.startswith('---') or first_line.startswith('- '):
                 return ImportFormatChoices.YAML
-            first_line = data.split('\n', 1)[0]
             if ',' in first_line:
                 return ImportFormatChoices.CSV
             if ';' in first_line:

--- a/netbox/utilities/forms/bulk_import.py
+++ b/netbox/utilities/forms/bulk_import.py
@@ -21,7 +21,7 @@ class BulkImportForm(BootstrapMixin, SyncedDataMixin, forms.Form):
     data = forms.CharField(
         required=False,
         widget=forms.Textarea(attrs={'class': 'font-monospace'}),
-        help_text=_("Enter object data in CSV, JSON or YAML format."),
+        help_text=_("Enter object data in CSV, TSV, JSON or YAML format."),
         # Do not let Django strip data, because this can mess with TSV files.
         # When the last column of the last row is empty, the TSV will end with
         # a '\t' and that should not be stripped out!

--- a/netbox/utilities/forms/bulk_import.py
+++ b/netbox/utilities/forms/bulk_import.py
@@ -104,7 +104,7 @@ class BulkImportForm(BootstrapMixin, SyncedDataMixin, forms.Form):
         Clean CSV-formatted data. The first row will be treated as column headers.
         """
         # Strip spaces and newlines only, leave tabs alone because they are significant in TSV mode
-        stream = StringIO(data(' \n'))
+        stream = StringIO(data.strip(' \n'))
         reader = csv.reader(stream, **csv_reader_kwargs)
         headers, records = parse_csv(reader)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #13239

<!--
    Please include a summary of the proposed changes below.
-->

This is an alternative PR for issue #13239. A different PR #13563 exists that attempts to solve the same issue, however I think my approach is better.

1. The other approach creates a new field for CSV seperators. This makes the UI a lot messier and adds more clicks to importing CSV files for the user. In this solution, instead, semicolon-seperated CSV and tab-seperated CSV are added as new formats and the user only has one drop-down to make a selection in.
2. There was some confusion in the code regarding auto-detection of file formats in general and autodetecting different types of CSV file specifically. @abhi1693 was attempting to use csv.Sniff to detect a specific CSV file format, but was running into some problems that I don't understand with making it work with tab-seperated files. Anyway, this approach completely sidesteps csv.Sniff, just adding a couple more cases into _detect_format.
3. The other approach wasn't complete, for example, it was not able to automatically detect tab- or semicolon-seperated CSV files when set to automatic mode. This I think is also due there being two ways of detecting CSV files.

There's one area of concern for breakage here. I've had to disable Django's own built-in stripping of whitespace, because with TSV files, whitespace is significant, and removing trailing tabs can remove an empty column, which isn't what you want. I think I've anticipated every case where this could break something (for example, _detect_format expects the file to be stripped, so I had to add some stripping back into that function) but this could probably use a second pair of eyes to make sure.