### PR TITLE
Fixes: #13682 - Fix custom field exceptions and validation

### DIFF
--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -275,8 +275,6 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
             try:
                 if self.type in (CustomFieldTypeChoices.TYPE_TEXT, CustomFieldTypeChoices.TYPE_LONGTEXT):
                     default_value = str(self.default)
-                elif self.type in (CustomFieldTypeChoices.TYPE_MULTISELECT, CustomFieldTypeChoices.TYPE_MULTIOBJECT):
-                    default_value = [self.default]
                 else:
                     default_value = self.default
                 self.validate(default_value)
@@ -655,8 +653,11 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
             elif self.type == CustomFieldTypeChoices.TYPE_SELECT:
                 if value not in [c[0] for c in self.choices]:
                     raise ValidationError(
-                        _("Invalid choice ({value}). Available choices are: {choices}").format(
-                            value=value, choices=', '.join([c[0] for c in self.choices])
+                        _("Invalid choice ({value}). Available choices are: {choices} ({count})")
+                        .format(
+                            value=value,
+                            choices=', '.join([c[0] for c in self.choices[0:2]]),
+                            count=f'({len(self.choices)} choices)' if len(self.choices) > 2 else '',
                         )
                     )
 
@@ -664,8 +665,12 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
             elif self.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
                 if not set(value).issubset([c[0] for c in self.choices]):
                     raise ValidationError(
-                        _("Invalid choice(s) ({invalid_choices}). Available choices are: {available_choices}").format(
-                            invalid_choices=', '.join(value), available_choices=', '.join([c[0] for c in self.choices]))
+                        _("Invalid choice(s) ({invalid_choices}). Available choices are: {available_choices}")
+                        .format(
+                            invalid_choices=', '.join(value),
+                            available_choices=', '.join([c[0] for c in self.choices[0:2]]),
+                            count=f'({len(self.choices)} choices)' if len(self.choices) > 2 else '',
+                        )
                     )
 
             # Validate selected object

--- a/netbox/extras/tests/test_customfields.py
+++ b/netbox/extras/tests/test_customfields.py
@@ -427,6 +427,122 @@ class CustomFieldTest(TestCase):
         self.assertNotIn('field1', site.custom_field_data)
         self.assertEqual(site.custom_field_data['field2'], FIELD_DATA)
 
+    def test_default_value_validation(self):
+        choiceset = CustomFieldChoiceSet.objects.create(name="Test Choice Set", extra_choices=(('choice1', 'Choice 1'), ('choice2', 'Choice 2')))
+        site = Site.objects.create(
+            name='Site 1',
+            slug='site-1'
+        )
+        object_type = ContentType.objects.get_for_model(Site)
+
+        cfs = (
+            # Test Text
+            (
+                # Should Pass
+                CustomField(name='test', type='text', required=True, default="Test Text"),
+            ),
+            # Test Integer
+            (
+                # Should Pass
+                CustomField(name='test', type='integer', required=True, default=1),
+                # Should Fail
+                CustomField(name='test', type='integer', required=True, default="Not a  Integer"),
+            ),
+
+            # Test Boolean
+            (
+                # Should Pass
+                CustomField(name='test', type='boolean', required=True, default=True),
+                # Should Fail
+                CustomField(name='test', type='boolean', required=True, default="Not a  Boolean"),
+            ),
+            # Test Date
+            (
+                # Should Pass
+                CustomField(name='test', type='date', required=True, default="2023-02-25"),
+                # Should Fail
+                CustomField(name='test', type='date', required=True, default="Not a  Date"),
+            ),
+            # Test Date + Time
+            (
+                # Should Pass
+                CustomField(name='test', type='datetime', required=True, default="2023-02-25 02:02:02"),
+                # Should Fail
+                CustomField(name='test', type='datetime', required=True, default="Not a DateTime"),
+            ),
+            # Test URL
+            (
+                # Should Pass
+                CustomField(name='test', type='url', required=True, default="https://www.netbox.dev"),
+            ),
+            # Test JSON
+            (
+                # Should Pass
+                CustomField(name='test', type='json', required=True, default='{"test": "object"}'),
+            ),
+            # Test Selection
+            (
+                # Should Pass
+                CustomField(name='test', type='select', required=True, choice_set=choiceset, default='choice1'),
+                # Should Fail
+                CustomField(
+                    name='test',
+                    type='select',
+                    required=True,
+                    choice_set=choiceset,
+                    default="Not a Selection option"
+                ),
+            ),
+            # Test Multiple Selection
+            (
+                # Should Pass
+                CustomField(
+                    name='test',
+                    type='multiselect',
+                    required=True,
+                    choice_set=choiceset,
+                    default=['choice1', ]
+                ),
+                # Should Fail
+                CustomField(
+                    name='test',
+                    type='multiselect',
+                    required=True,
+                    choice_set=choiceset,
+                    default="Not a Selection option"
+                ),
+            ),
+            # Test Object
+            (
+                # Should Pass
+                CustomField(name='test', type='object', required=True, object_type=object_type, default=1),
+                # Should Fail
+                CustomField(name='test', type='object', required=True, object_type=object_type, default="Site 1"),
+            ),
+            # Test Multiple Object
+            (
+                # Should Pass
+                CustomField(
+                    name='test',
+                    type='multiobject',
+                    required=True,
+                    object_type=object_type,
+                    default=[site.pk, ]
+                ),
+                # Should Fail
+                CustomField(name='test', type='multiobject', required=True, object_type=object_type, default="Site 1"),
+            ),
+        )
+
+        for cftest in cfs:
+            # Check for valid default data
+            self.assertIsNone(cftest[0].full_clean())
+
+            # Check for invalid data
+            if len(cftest) > 1:
+                with self.assertRaises(ValidationError):
+                    cftest[1].full_clean()
+
 
 class CustomFieldManagerTest(TestCase):
 


### PR DESCRIPTION
### Fixes: #13682 

Fix custom field exceptions and validation

* Change self.message to err.message to properly reference nested exception
* Change clean logic to set "default_value" to list for multiselect and multiobject
* Change validation logic to deconstruct choice set tuple for select to only check the value