### PR TITLE
Fixes #13684: Enable modying the configuration when maintenance mode is enabled

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -496,6 +496,7 @@ AUTH_EXEMPT_PATHS = (
 # All URLs starting with a string listed here are exempt from maintenance mode enforcement
 MAINTENANCE_EXEMPT_PATHS = (
     f'/{BASE_PATH}admin/',
+    f'/{BASE_PATH}extras/config-revisions/',  # Allow modifying the configuration
 )
 
 SERIALIZATION_MODULES = {


### PR DESCRIPTION
### Fixes: #13684

Add `/extras/config-revisions/` to `MAINTENANCE_EXEMPT_PATHS` to allow creating new ConfigRevisions
