### PR TITLE
13674 fix ReportSerializer

### DIFF
--- a/netbox/extras/api/serializers.py
+++ b/netbox/extras/api/serializers.py
@@ -479,7 +479,7 @@ class ReportSerializer(serializers.Serializer):
     module = serializers.CharField(max_length=255)
     name = serializers.CharField(max_length=255)
     description = serializers.CharField(max_length=255, required=False)
-    test_methods = serializers.ListField(child=serializers.CharField(max_length=255))
+    test_methods = serializers.ListField(child=serializers.CharField(max_length=255), read_only=True)
     result = NestedJobSerializer()
     display = serializers.SerializerMethodField(read_only=True)
 

--- a/netbox/extras/reports.py
+++ b/netbox/extras/reports.py
@@ -85,9 +85,9 @@ class Report(object):
     description = None
     scheduling_enabled = True
     job_timeout = None
+    test_methods = []
 
     def __init__(self):
-
         self._results = {}
         self.active_test = None
         self.failed = False

--- a/netbox/extras/reports.py
+++ b/netbox/extras/reports.py
@@ -85,9 +85,9 @@ class Report(object):
     description = None
     scheduling_enabled = True
     job_timeout = None
-    test_methods = []
 
     def __init__(self):
+
         self._results = {}
         self.active_test = None
         self.failed = False


### PR DESCRIPTION
### Fixes: #13674 

Fixes test_methods under report serializer, makes read-only and initializes it as class attribute (as opposed to just inside init) so that serializer sees it.