### PR TITLE
Documentation: LDAP Update for Active Directory

### DIFF
--- a/docs/installation/6-ldap.md
+++ b/docs/installation/6-ldap.md
@@ -179,11 +179,11 @@ LOGGING = {
 Ensure the file and path specified in logfile exist and are writable and executable by the application service account. Restart the netbox service and attempt to log into the site to trigger log entries to this file.
 
 
-## Autneticating with Active Directory (with or without the @fqdn.tld suffix)
+## Authenticating with Active Directory (with or without the @fqdn.tld suffix)
 
-Interfacing with Active Directory for authentication can be a bit of a headache. One edge case you can easily solve is handling different login formats. The two main formats we are supporting is allowing the user to login with either the full UPN or just the username. To do so we need to filter the DN based on either the `sAMAccountName` or the `userPrincipalName`. Below we will define some basic configuration options which will allow your users to enter their usernames in the format `username` or `username@domain.tld`.
+Integrating Active Directory for authentication can be a bit challenging. Handling different login formats is an edge case you can easily resolve. This solution will allow users to log in either using their full UPN or their username alone. Therefore, we need to filter the DN according to either the `sAMAccountName` or the `userPrincipalName`. The following configuration options will allow your users to enter their usernames in the format `username` or `username@domain.tld`.
 
-These configuration options are definited within `ldap_config.py`. First, modify the `AUTH_LDAP_USER_SEARCH` option to match the following:
+Just as before, the configuration options are defined in the file ldap_config.py. First, modify the `AUTH_LDAP_USER_SEARCH` option to match the following:
 
 ```python
 AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=Users,dc=example,dc=com",
@@ -192,7 +192,7 @@ AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=Users,dc=example,dc=com",
                                   )
 ```
 
-Also, ensure that `AUTH_LDAP_USER_DN_TEMPLATE` is set to `None` as described above. Next, modify `AUTH_LDAP_USER_ATTR_MAP` to match the following:
+In addition, `AUTH_LDAP_USER_DN_TEMPLATE` should be set to `None` as described in the previous sections. Next, modify `AUTH_LDAP_USER_ATTR_MAP` to match the following:
 
 ```python
 AUTH_LDAP_USER_ATTR_MAP = {
@@ -203,10 +203,10 @@ AUTH_LDAP_USER_ATTR_MAP = {
 }
 ```
 
-Lastly, we need to add one aditional configuration option; `AUTH_LDAP_USER_QUERY_FIELD`. Add the following to your LDAP configuration file:
+Finally, we need to add one more configuration option, `AUTH_LDAP_USER_QUERY_FIELD`. The following should be added to your LDAP configuration file:
 
 ```python
 AUTH_LDAP_USER_QUERY_FIELD = "username"
 ```
 
-These configuration options will allow your users to login with either the UPN suffix or without it.
+With these configuration options, your users will be able to login either with or without the UPN suffix.

--- a/docs/installation/6-ldap.md
+++ b/docs/installation/6-ldap.md
@@ -148,49 +148,18 @@ AUTH_LDAP_CACHE_TIMEOUT = 3600
 !!! warning
     Authentication will fail if the groups (the distinguished names) do not exist in the LDAP directory.
 
-## Troubleshooting LDAP
-
-`systemctl restart netbox` restarts the NetBox service, and initiates any changes made to `ldap_config.py`. If there are syntax errors present, the NetBox process will not spawn an instance, and errors should be logged to `/var/log/messages`.
-
-For troubleshooting LDAP user/group queries, add or merge the following [logging](../configuration/system.md#logging) configuration to `configuration.py`:
-
-```python
-LOGGING = {
-    'version': 1,
-    'disable_existing_loggers': False,
-    'handlers': {
-        'netbox_auth_log': {
-            'level': 'DEBUG',
-            'class': 'logging.handlers.RotatingFileHandler',
-            'filename': '/opt/netbox/local/logs/django-ldap-debug.log',
-            'maxBytes': 1024 * 500,
-            'backupCount': 5,
-        },
-    },
-    'loggers': {
-        'django_auth_ldap': {
-            'handlers': ['netbox_auth_log'],
-            'level': 'DEBUG',
-        },
-    },
-}
-```
-
-Ensure the file and path specified in logfile exist and are writable and executable by the application service account. Restart the netbox service and attempt to log into the site to trigger log entries to this file.
-
-
 ## Authenticating with Active Directory
-### Authentication with or without UPN suffix (@fqdn.tld)
 
-Integrating Active Directory for authentication can be a bit challenging. Handling different login formats is an edge case you can easily resolve. This solution will allow users to log in either using their full UPN or their username alone. Therefore, we need to filter the DN according to either the `sAMAccountName` or the `userPrincipalName`. The following configuration options will allow your users to enter their usernames in the format `username` or `username@domain.tld`.
+Integrating Active Directory for authentication can be a bit challenging as it may require handling different login formats. This solution will allow users to log in either using their full User Principal Name (UPN) or their username alone, by filtering the DN according to either the `sAMAccountName` or the `userPrincipalName`. The following configuration options will allow your users to enter their usernames in the format `username` or `username@domain.tld`.
 
 Just as before, the configuration options are defined in the file ldap_config.py. First, modify the `AUTH_LDAP_USER_SEARCH` option to match the following:
 
 ```python
-AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=Users,dc=example,dc=com",
-                                    ldap.SCOPE_SUBTREE,
-                                    "(|(userPrincipalName=%(user)s)(sAMAccountName=%(user)s))",
-                                  )
+AUTH_LDAP_USER_SEARCH = LDAPSearch(
+    "ou=Users,dc=example,dc=com",
+    ldap.SCOPE_SUBTREE,
+    "(|(userPrincipalName=%(user)s)(sAMAccountName=%(user)s))"
+)
 ```
 
 In addition, `AUTH_LDAP_USER_DN_TEMPLATE` should be set to `None` as described in the previous sections. Next, modify `AUTH_LDAP_USER_ATTR_MAP` to match the following:
@@ -210,9 +179,9 @@ Finally, we need to add one more configuration option, `AUTH_LDAP_USER_QUERY_FIE
 AUTH_LDAP_USER_QUERY_FIELD = "username"
 ```
 
-With these configuration options, your users will be able to login either with or without the UPN suffix.
+With these configuration options, your users will be able to log in either with or without the UPN suffix.
 
-### Sample `ldap_config.py` for Active Directory with LDAP Server Verification
+### Example Configuration
 
 !!! info
     This configuration is intended to serve as a template, but may need to be modified in accordance with your environment.
@@ -250,10 +219,11 @@ LDAP_CA_CERT_FILE = '/path/to/example-CA.crt'
 
 # This search matches users with the sAMAccountName equal to the provided username. This is required if the user's
 # username is not in their DN (Active Directory).
-AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=Users,dc=example,dc=com",
-                                    ldap.SCOPE_SUBTREE,
-                                    "(|(userPrincipalName=%(user)s)(sAMAccountName=%(user)s))",
-                                  )
+AUTH_LDAP_USER_SEARCH = LDAPSearch(
+    "ou=Users,dc=example,dc=com",
+    ldap.SCOPE_SUBTREE,
+    "(|(userPrincipalName=%(user)s)(sAMAccountName=%(user)s))"
+)
 
 # If a user's DN is producible from their username, we don't need to search.
 AUTH_LDAP_USER_DN_TEMPLATE = None
@@ -270,8 +240,11 @@ AUTH_LDAP_USER_QUERY_FIELD = "username"
 
 # This search ought to return all groups to which the user belongs. django_auth_ldap uses this to determine group
 # hierarchy.
-AUTH_LDAP_GROUP_SEARCH = LDAPSearch("dc=example,dc=com", ldap.SCOPE_SUBTREE,
-                                    "(objectClass=group)")
+AUTH_LDAP_GROUP_SEARCH = LDAPSearch(
+    "dc=example,dc=com",
+    ldap.SCOPE_SUBTREE,
+    "(objectClass=group)"
+)
 AUTH_LDAP_GROUP_TYPE = NestedGroupOfNamesType()
 
 # Define a group required to login.
@@ -294,3 +267,33 @@ AUTH_LDAP_FIND_GROUP_PERMS = True
 AUTH_LDAP_CACHE_TIMEOUT = 3600
 AUTH_LDAP_ALWAYS_UPDATE_USER = True
 ```
+
+## Troubleshooting LDAP
+
+`systemctl restart netbox` restarts the NetBox service, and initiates any changes made to `ldap_config.py`. If there are syntax errors present, the NetBox process will not spawn an instance, and errors should be logged to `/var/log/messages`.
+
+For troubleshooting LDAP user/group queries, add or merge the following [logging](../configuration/system.md#logging) configuration to `configuration.py`:
+
+```python
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'handlers': {
+        'netbox_auth_log': {
+            'level': 'DEBUG',
+            'class': 'logging.handlers.RotatingFileHandler',
+            'filename': '/opt/netbox/local/logs/django-ldap-debug.log',
+            'maxBytes': 1024 * 500,
+            'backupCount': 5,
+        },
+    },
+    'loggers': {
+        'django_auth_ldap': {
+            'handlers': ['netbox_auth_log'],
+            'level': 'DEBUG',
+        },
+    },
+}
+```
+
+Ensure the file and path specified in logfile exist and are writable and executable by the application service account. Restart the netbox service and attempt to log into the site to trigger log entries to this file.

--- a/docs/installation/6-ldap.md
+++ b/docs/installation/6-ldap.md
@@ -179,7 +179,8 @@ LOGGING = {
 Ensure the file and path specified in logfile exist and are writable and executable by the application service account. Restart the netbox service and attempt to log into the site to trigger log entries to this file.
 
 
-## Authenticating with Active Directory (with or without the @fqdn.tld suffix)
+## Authenticating with Active Directory
+### Authentication with or without UPN suffix (@fqdn.tld)
 
 Integrating Active Directory for authentication can be a bit challenging. Handling different login formats is an edge case you can easily resolve. This solution will allow users to log in either using their full UPN or their username alone. Therefore, we need to filter the DN according to either the `sAMAccountName` or the `userPrincipalName`. The following configuration options will allow your users to enter their usernames in the format `username` or `username@domain.tld`.
 
@@ -210,3 +211,86 @@ AUTH_LDAP_USER_QUERY_FIELD = "username"
 ```
 
 With these configuration options, your users will be able to login either with or without the UPN suffix.
+
+### Sample `ldap_config.py` for Active Directory with LDAP Server Verification
+
+!!! info
+    This configuration is intended to serve as a template, but may need to be modified in accordance with your environment.
+
+```python
+import ldap
+from django_auth_ldap.config import LDAPSearch, NestedGroupOfNamesType
+
+# Server URI
+AUTH_LDAP_SERVER_URI = "ldaps://ad.example.com:3269"
+
+# The following may be needed if you are binding to Active Directory.
+AUTH_LDAP_CONNECTION_OPTIONS = {
+    ldap.OPT_REFERRALS: 0
+}
+
+# Set the DN and password for the NetBox service account.
+AUTH_LDAP_BIND_DN = "CN=NETBOXSA,OU=Service Accounts,DC=example,DC=com"
+AUTH_LDAP_BIND_PASSWORD = "demo"
+
+# Include this setting if you want to ignore certificate errors. This might be needed to accept a self-signed cert.
+# Note that this is a NetBox-specific setting which sets:
+#     ldap.set_option(ldap.OPT_X_TLS_REQUIRE_CERT, ldap.OPT_X_TLS_NEVER)
+LDAP_IGNORE_CERT_ERRORS = False
+
+# Include this setting if you want to validate the LDAP server certificates against a CA certificate directory on your server
+# Note that this is a NetBox-specific setting which sets:
+#     ldap.set_option(ldap.OPT_X_TLS_CACERTDIR, LDAP_CA_CERT_DIR)
+LDAP_CA_CERT_DIR = '/etc/ssl/certs'
+
+# Include this setting if you want to validate the LDAP server certificates against your own CA.
+# Note that this is a NetBox-specific setting which sets:
+#     ldap.set_option(ldap.OPT_X_TLS_CACERTFILE, LDAP_CA_CERT_FILE)
+LDAP_CA_CERT_FILE = '/path/to/example-CA.crt'
+
+# This search matches users with the sAMAccountName equal to the provided username. This is required if the user's
+# username is not in their DN (Active Directory).
+AUTH_LDAP_USER_SEARCH = LDAPSearch("ou=Users,dc=example,dc=com",
+                                    ldap.SCOPE_SUBTREE,
+                                    "(|(userPrincipalName=%(user)s)(sAMAccountName=%(user)s))",
+                                  )
+
+# If a user's DN is producible from their username, we don't need to search.
+AUTH_LDAP_USER_DN_TEMPLATE = None
+
+# You can map user attributes to Django attributes as so.
+AUTH_LDAP_USER_ATTR_MAP = {
+    "username": "sAMAccountName",
+    "email": "mail",
+    "first_name": "givenName",
+    "last_name": "sn",
+}
+
+AUTH_LDAP_USER_QUERY_FIELD = "username"
+
+# This search ought to return all groups to which the user belongs. django_auth_ldap uses this to determine group
+# hierarchy.
+AUTH_LDAP_GROUP_SEARCH = LDAPSearch("dc=example,dc=com", ldap.SCOPE_SUBTREE,
+                                    "(objectClass=group)")
+AUTH_LDAP_GROUP_TYPE = NestedGroupOfNamesType()
+
+# Define a group required to login.
+AUTH_LDAP_REQUIRE_GROUP = "CN=NETBOX_USERS,DC=example,DC=com"
+
+# Mirror LDAP group assignments.
+AUTH_LDAP_MIRROR_GROUPS = True
+
+# Define special user types using groups. Exercise great caution when assigning superuser status.
+AUTH_LDAP_USER_FLAGS_BY_GROUP = {
+    "is_active": "cn=active,ou=groups,dc=example,dc=com",
+    "is_staff": "cn=staff,ou=groups,dc=example,dc=com",
+    "is_superuser": "cn=superuser,ou=groups,dc=example,dc=com"
+}
+
+# For more granular permissions, we can map LDAP groups to Django groups.
+AUTH_LDAP_FIND_GROUP_PERMS = True
+
+# Cache groups for one hour to reduce LDAP traffic
+AUTH_LDAP_CACHE_TIMEOUT = 3600
+AUTH_LDAP_ALWAYS_UPDATE_USER = True
+```


### PR DESCRIPTION
### Fixes: #13715

- Added installation documentation to `6-ldap.md` which explains the configuration changes for authenticating with either a `sAMAccountName` and `userPrincipalName`
- Added section with a sample `ldap_config.py` configuration which can be used for Active Directory with the above addition as well
