### PR TITLE
Rewrite of parse_alphanumeric_range and expand_alphanumeric_pattern

### DIFF
--- a/netbox/utilities/forms/constants.py
+++ b/netbox/utilities/forms/constants.py
@@ -2,6 +2,11 @@
 NUMERIC_EXPANSION_PATTERN = r'\[((?:\d+[?:,-])+\d+)\]'
 ALPHANUMERIC_EXPANSION_PATTERN = r'\[((?:[a-zA-Z0-9]+[?:,-])+[a-zA-Z0-9]+)\]'
 
+# Patterns for parts of string expansion patterns
+ALPHABETIC_RANGE_PATTERN = fr'(?:[A-Z]-[A-Z]|[a-z]-[a-z])'
+NUMERIC_RANGE_PATTERN = r'(?:[0-9]+-[0-9]+)'
+ALPHANUMERIC_SINGLETON_PATTERN = r'(?:[a-zA-Z0-9]+)'
+
 # IP address expansion patterns
 IP4_EXPANSION_PATTERN = r'\[((?:[0-9]{1,3}[?:,-])+[0-9]{1,3})\]'
 IP6_EXPANSION_PATTERN = r'\[((?:[0-9a-f]{1,4}[?:,-])+[0-9a-f]{1,4})\]'

--- a/netbox/utilities/forms/fields/expandable.py
+++ b/netbox/utilities/forms/fields/expandable.py
@@ -30,7 +30,10 @@ class ExpandableNameField(forms.CharField):
         if not value:
             return ''
         if re.search(ALPHANUMERIC_EXPANSION_PATTERN, value):
-            return list(expand_alphanumeric_pattern(value))
+            try:
+                return list(expand_alphanumeric_pattern(value))
+            except ValueError as e:
+                raise forms.ValidationError(*e.args)
         return [value]
 
 

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -99,8 +99,7 @@ def expand_alphanumeric_pattern(pattern):
     # our option_matrix.
     listerator = cycle([lambda part: [part], parse_alphanumeric_range])
     try:
-        option_matrix = [to_options(part) for to_options, part in zip(listerator, pattern_parts)
-]
+        option_matrix = [to_options(part) for to_options, part in zip(listerator, pattern_parts)]
     except ValueError as e:
         # Another wart for legacy compatibility. A previous implementation of this function throws ValueError
         # in some cases, but forms.ValidationError in others, even though a generic utility function has no

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -57,12 +57,12 @@ def parse_alphanumeric_range(string):
             begin, end = map(ord, dash_range.split('-'))
             if begin > end:
                 raise ValueError(f'Range "{dash_range}" is invalid, because {begin} comes after {end}')
-            values.extend(map(chr, range(begin, end+1)))
+            values.extend(map(chr, range(begin, end + 1)))
         elif re.fullmatch(NUMERIC_RANGE_PATTERN, dash_range):
             begin, end = map(int, dash_range.split('-'))
             if begin > end:
                 raise ValueError(f'Range "{dash_range}" is invalid, because {begin} comes after {end}')
-            values.extend(map(str, range(begin, end+1)))
+            values.extend(map(str, range(begin, end + 1)))
         elif re.fullmatch(ALPHANUMERIC_SINGLETON_PATTERN, dash_range):
             values.append(dash_range)
         else:
@@ -80,7 +80,7 @@ def expand_alphanumeric_pattern(pattern):
     # Then parts will be split into:
     # parts = ['', 'Gi,Te', '/0/', '1-8', '']
     # I.e. it'll be a constant followed by pattern, constant, pattern, constant, etc...
-    
+
     # This check seems a little useless, after all if someone passed in a string with no patterns in it,
     # shouldn't it just return back that same string? But for unknown legacy reasons this is how a
     # previous implementation of this function worked, and we're trying to staying compatible.
@@ -117,6 +117,7 @@ def expand_alphanumeric_pattern(pattern):
 
     for parts in product(*option_matrix):
         yield ''.join(parts)
+
 
 def expand_ipaddress_pattern(string, family):
     """

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -96,12 +96,7 @@ def expand_alphanumeric_pattern(pattern):
     if not re.search(ALPHANUMERIC_EXPANSION_PATTERN, pattern):
         raise ValueError(f"String {repr(pattern)} contains no valid alphanumeric patterns")
 
-    try:
-        yield from expand_alphanumeric_pattern_impl(pattern)
-    except ValueError as e:
-        # Unit tests expect forms.ValidationError to be thrown if patterns were "valid" at a first glance,
-        # but then turned out to be invalid when looking closer. So we preserve this behaviour here.
-        raise forms.ValidationError(*e.args)
+    yield from expand_alphanumeric_pattern_impl(pattern)
 
 
 def expand_ipaddress_pattern(string, family):

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -53,8 +53,6 @@ def parse_alphanumeric_range(string):
     """
     values = []
     for dash_range in string.split(','):
-        range_split = dash_range.split('-')
-
         if re.fullmatch(ALPHABETIC_RANGE_PATTERN, dash_range):
             begin, end = map(ord, dash_range.split('-'))
             if begin > end:

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -245,6 +245,15 @@ class ExpandAlphanumeric(TestCase):
 
         self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
 
+    def test_numeric_set(self):
+        input = "vlan[123,456]"
+        output = sorted([
+            'vlan123',
+            'vlan456'
+        ])
+
+        self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
+
     def test_invalid_non_pattern(self):
         with self.assertRaises(ValueError):
             sorted(expand_alphanumeric_pattern('r9a'))

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -269,19 +269,19 @@ class ExpandAlphanumeric(TestCase):
             sorted(expand_alphanumeric_pattern('r[8--9]a'))
 
     def test_invalid_range_alphanumeric(self):
-        with self.assertRaises(forms.ValidationError):
+        with self.assertRaises(ValueError):
             sorted(expand_alphanumeric_pattern('r[9-a]a'))
 
-        with self.assertRaises(forms.ValidationError):
+        with self.assertRaises(ValueError):
             sorted(expand_alphanumeric_pattern('r[a-9]a'))
 
     def test_invalid_range_bounds(self):
-        with self.assertRaises(forms.ValidationError):
+        with self.assertRaises(ValueError):
             sorted(expand_alphanumeric_pattern('r[9-8]a'))
             sorted(expand_alphanumeric_pattern('r[b-a]a'))
 
     def test_invalid_range_len(self):
-        with self.assertRaises(forms.ValidationError):
+        with self.assertRaises(ValueError):
             sorted(expand_alphanumeric_pattern('r[a-bb]a'))
 
     def test_invalid_set(self):

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -269,8 +269,11 @@ class ExpandAlphanumeric(TestCase):
             sorted(expand_alphanumeric_pattern('r[8--9]a'))
 
     def test_invalid_range_alphanumeric(self):
-        self.assertEqual(sorted(expand_alphanumeric_pattern('r[9-a]a')), [])
-        self.assertEqual(sorted(expand_alphanumeric_pattern('r[a-9]a')), [])
+        with self.assertRaises(forms.ValidationError):
+            sorted(expand_alphanumeric_pattern('r[9-a]a'))
+
+        with self.assertRaises(forms.ValidationError):
+            sorted(expand_alphanumeric_pattern('r[a-9]a'))
 
     def test_invalid_range_bounds(self):
         with self.assertRaises(forms.ValidationError):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #13722

<!--
    Please include a summary of the proposed changes below.
-->

The code for `expand_alphanumeric_pattern` and `parse_alphanumeric_range` which is used to expand range expressions such as `Gi1/0/[1-24]` had got a bit unruly and at least one bug had snuck in where a case like `vlan[123,456]` could not be parsed correctly. (Issue #13722).

The goal here was to add a unit test for that broken behaviour and then fix it. Fixing it turned into a complete rewrite/refactor of these two functions, because they had reached a point where they were no longer maintainable as is.

This refactor surfaced two other unexpected behaviours:

1. When passing a pattern like `r[a-9]a`, which is invalid because it makes no sense to try to make a range from a letter to a number, the existing code returned an empty list. Surprisingly, the unit tests also seem to expect this very strange behaviour. Since the behaviour makes no sense, I didn't see any harm in changing the unit tests in order to reflect the new behaviour which is to throw an exception in thie case.

2. There are some warts as to how exception handling works. The old code ended up throwing exceptions implicitly when failing to do number conversion, etc. Instead, I have opted to do explicit checking and exception thowing in all cases I've thought of. However, this surfaced another wart. It seems that depending on the exact nature of the error, sometimes the unit tests expect a `forms.ValidationError` and sometimes a `ValueError`. In my opinion the correct exception type is `ValueError`, the functions are generic utility functions and should not be coupled to django forms in any way. However, in an effort to remain bug-for-bug compatible with existing unit tests, I have added some code to `expand_alphanumeric_pattern` to catch and rethrow the exceptions using the "correct" exception type, thereby containing the wart to one place in the code. Fixing it would have to involve changing the unit tests and auditing all calling code, and that didn't really seem to be in the scope of this issue so I've left it be. Instead I've just added some comments for any future housekeeping.

Anyway, original bug seems to be squashed, so... mission accomplished?