### PR TITLE
Second attempt at fixing #13722 and refactoring alphanumeric range code

### DIFF
--- a/netbox/utilities/forms/constants.py
+++ b/netbox/utilities/forms/constants.py
@@ -2,6 +2,11 @@
 NUMERIC_EXPANSION_PATTERN = r'\[((?:\d+[?:,-])+\d+)\]'
 ALPHANUMERIC_EXPANSION_PATTERN = r'\[((?:[a-zA-Z0-9]+[?:,-])+[a-zA-Z0-9]+)\]'
 
+# Patterns for parts of string expansion patterns
+ALPHABETIC_RANGE_PATTERN = fr'(?:[A-Z]-[A-Z]|[a-z]-[a-z])'
+NUMERIC_RANGE_PATTERN = r'(?:[0-9]+-[0-9]+)'
+ALPHANUMERIC_SINGLETON_PATTERN = r'(?:[a-zA-Z0-9]+)'
+
 # IP address expansion patterns
 IP4_EXPANSION_PATTERN = r'\[((?:[0-9]{1,3}[?:,-])+[0-9]{1,3})\]'
 IP6_EXPANSION_PATTERN = r'\[((?:[0-9a-f]{1,4}[?:,-])+[0-9a-f]{1,4})\]'

--- a/netbox/utilities/forms/fields/expandable.py
+++ b/netbox/utilities/forms/fields/expandable.py
@@ -29,9 +29,7 @@ class ExpandableNameField(forms.CharField):
     def to_python(self, value):
         if not value:
             return ''
-        if re.search(ALPHANUMERIC_EXPANSION_PATTERN, value):
-            return list(expand_alphanumeric_pattern(value))
-        return [value]
+        return list(expand_alphanumeric_pattern(value))
 
 
 class ExpandableIPAddressField(forms.CharField):

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -65,7 +65,7 @@ def parse_alphanumeric_range(string):
         elif re.fullmatch(ALPHANUMERIC_SINGLETON_PATTERN, dash_range):
             values.append(dash_range)
         else:
-            raise forms.ValidationError(f'Range "{dash_range}" is invalid, must be a range of numbers (e.g. 7-11) or a range of letters (e.g. f-h or F-H)')
+            raise forms.ValidationError(f'Range "{dash_range}" is invalid, must be a range of numbers (e.g. 7-11), a range of letters (e.g. f-h or F-H), or a single alphanumeric string (e.g. abc1234)')
 
     return values
 

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -87,7 +87,11 @@ def expand_alphanumeric_pattern(string):
     """
     Expand an alphabetic pattern into a list of strings.
     """
-    lead, pattern, remnant = re.split(ALPHANUMERIC_EXPANSION_PATTERN, string, maxsplit=1)
+    try:
+        lead, pattern, remnant = re.split(ALPHANUMERIC_EXPANSION_PATTERN, string, maxsplit=1)
+    except ValueError:
+        yield string
+        return
     parsed_range = parse_alphanumeric_range(pattern)
     for i in parsed_range:
         if re.search(ALPHANUMERIC_EXPANSION_PATTERN, remnant):

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -94,11 +94,8 @@ def expand_alphanumeric_pattern(string):
         return
     parsed_range = parse_alphanumeric_range(pattern)
     for i in parsed_range:
-        if re.search(ALPHANUMERIC_EXPANSION_PATTERN, remnant):
-            for string in expand_alphanumeric_pattern(remnant):
-                yield "{}{}{}".format(lead, i, string)
-        else:
-            yield "{}{}{}".format(lead, i, remnant)
+        for string in expand_alphanumeric_pattern(remnant):
+            yield f"{lead}{i}{string}"
 
 
 def expand_ipaddress_pattern(string, family):

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -275,8 +275,10 @@ class ExpandAlphanumeric(TestCase):
         self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
 
     def test_invalid_range_alphanumeric(self):
-        self.assertEqual(sorted(expand_alphanumeric_pattern('r[9-a]a')), [])
-        self.assertEqual(sorted(expand_alphanumeric_pattern('r[a-9]a')), [])
+        with self.assertRaises(forms.ValidationError):
+            sorted(expand_alphanumeric_pattern('r[9-a]a'))
+        with self.assertRaises(forms.ValidationError):
+            sorted(expand_alphanumeric_pattern('r[a-9]a'))
 
     def test_invalid_range_bounds(self):
         with self.assertRaises(forms.ValidationError):

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -246,18 +246,22 @@ class ExpandAlphanumeric(TestCase):
         self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
 
     def test_invalid_non_pattern(self):
-        with self.assertRaises(ValueError):
-            sorted(expand_alphanumeric_pattern('r9a'))
+        input = 'r9a'
+        output = sorted([input])
+        self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
 
     def test_invalid_range(self):
-        with self.assertRaises(ValueError):
-            sorted(expand_alphanumeric_pattern('r[8-]a'))
+        input = 'r[8-]a'
+        output = sorted([input])
+        self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
 
-        with self.assertRaises(ValueError):
-            sorted(expand_alphanumeric_pattern('r[-8]a'))
+        input = 'r[-8]a'
+        output = sorted([input])
+        self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
 
-        with self.assertRaises(ValueError):
-            sorted(expand_alphanumeric_pattern('r[8--9]a'))
+        input = 'r[8--9]a'
+        output = sorted([input])
+        self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
 
     def test_invalid_range_alphanumeric(self):
         self.assertEqual(sorted(expand_alphanumeric_pattern('r[9-a]a')), [])
@@ -273,17 +277,21 @@ class ExpandAlphanumeric(TestCase):
             sorted(expand_alphanumeric_pattern('r[a-bb]a'))
 
     def test_invalid_set(self):
-        with self.assertRaises(ValueError):
-            sorted(expand_alphanumeric_pattern('r[a]a'))
+        input = 'r[a]a'
+        output = sorted([input])
+        self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
 
-        with self.assertRaises(ValueError):
-            sorted(expand_alphanumeric_pattern('r[a,]a'))
+        input = 'r[a,]a'
+        output = sorted([input])
+        self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
 
-        with self.assertRaises(ValueError):
-            sorted(expand_alphanumeric_pattern('r[,a]a'))
+        input = 'r[,a]a'
+        output = sorted([input])
+        self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
 
-        with self.assertRaises(ValueError):
-            sorted(expand_alphanumeric_pattern('r[a,,b]a'))
+        input = 'r[a,,b]a'
+        output = sorted([input])
+        self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
 
 
 class ImportFormTest(TestCase):

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -255,7 +255,6 @@ class ExpandAlphanumeric(TestCase):
 
         self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
 
-
     def test_invalid_non_pattern(self):
         input = 'r9a'
         output = sorted([input])

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -245,6 +245,17 @@ class ExpandAlphanumeric(TestCase):
 
         self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
 
+    # Checks for any regressions of https://github.com/netbox-community/netbox/issues/13722
+    def test_numeric_set(self):
+        input = "vlan[123,456]"
+        output = sorted([
+            'vlan123',
+            'vlan456'
+        ])
+
+        self.assertEqual(sorted(expand_alphanumeric_pattern(input)), output)
+
+
     def test_invalid_non_pattern(self):
         input = 'r9a'
         output = sorted([input])


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #13722

<!--
    Please include a summary of the proposed changes below.
-->

This pull request replaces my first train-wreck of an attempt in #13728.

The first two commits are preparatory refactoring work to improve the testability of current code.

First, I identified an issue where the tested behavious wasn't the actual behaviour. That's because `expand_alphanumeric_pattern` was only called from `ExpandableNameField.to_python`, which did its own regex matching on the input string before patting it over to `expand_alphanumeric_pattern`. It makes a lot more sense for that regex matching to only happen in `expand_alphanumeric_pattern`, so that was moved to that function, which, it turned out, was already doing it implicity by string splitting on the same regex.

Doing that change in turn made it possible to further simplify `expand_alphanumeric_pattern` by removing some unneccessary extra checks.

However, this caused some test failures. This is due to the fact that `expand_alphanumeric_pattern`'s behaviour was changed. Before, it would throw an exception if there are no patterns in it, now it instead returns the string unmodified, which is exactly what the appication as a whole was doing, but now it's all contained in that function. That made it neccessary to adjust the unit tests to reflect this change of responsibility.

Once the prep-work was done, I replaced `parse_alphanumeric_range` with an almost entirely new implementation which I believe is cleaner and easier to read. This is what actually fixes the bug. It also adds some better error messages for the user when something goes wrong.

During the work in refactoring, I discovered another unrelated bug that also somehow made it into the test suite as a feature. For some reason, entering a string like `r[a-9]a` would make `expand_alphanumeric_pattern` return an empty list. This behaviour made no sense to me, so again, I changed the tests. This shouldn't have changed the external behaviour of the application, since when an empty list was received by `to_python`, the "name" field just ended up be empty, which in turn caused the form validation to fail with an incorrect message that the field was required. This way, there's a clearer error message as to what's going on.

There's still some improvements that could be done here, for example, I don't like how a pure utility function throws forms.ValidationError, but I'm not going to change it because it's not really causing any issues at the moment, and it's easy enough to change in the future if it ever becomes a concern.