### PR TITLE
13791 rename whitespace fix

### DIFF
--- a/netbox/utilities/forms/forms.py
+++ b/netbox/utilities/forms/forms.py
@@ -40,8 +40,11 @@ class BulkRenameForm(BootstrapMixin, forms.Form):
     """
     An extendable form to be used for renaming objects in bulk.
     """
-    find = forms.CharField()
+    find = forms.CharField(
+        strip=False
+    )
     replace = forms.CharField(
+        strip=False,
         required=False
     )
     use_regex = forms.BooleanField(

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -3,6 +3,7 @@ from django.test import TestCase
 
 from utilities.choices import ImportFormatChoices
 from utilities.forms.bulk_import import BulkImportForm
+from utilities.forms.forms import BulkRenameForm
 from utilities.forms.utils import expand_alphanumeric_pattern, expand_ipaddress_pattern
 
 
@@ -364,3 +365,16 @@ class ImportFormTest(TestCase):
             {'a': '1', 'b': '2', 'c': '3'},
             {'a': '4', 'b': '5', 'c': '6'},
         ])
+
+
+class BulkRenameFormTest(TestCase):
+    def test_no_strip_whitespace(self):
+        # Tests to make sure Bulk Rename Form isn't stripping whitespaces
+        # See: https://github.com/netbox-community/netbox/issues/13791
+        form = BulkRenameForm(data={
+            "find": " hello ",
+            "replace": " world "
+        })
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data["find"], " hello ")
+        self.assertEqual(form.cleaned_data["replace"], " world ")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #13791

<!--
    Please include a summary of the proposed changes below.
-->

Disables Django's form stripping of the "find" and "replace" fields of the BulkRenameForm. This should fix all bulk rename forms in the project that inherit from this base class. Also added a unit test to make sure this works.