### PR TITLE
13757 Fix ConfigContext reference to DeviceType

### DIFF
--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -98,10 +98,10 @@ class Cable(PrimaryModel):
         super().__init__(*args, **kwargs)
 
         # A copy of the PK to be used by __str__ in case the object is deleted
-        self._pk = self.pk
+        self._pk = self.__dict__.get('id')
 
         # Cache the original status so we can check later if it's been changed
-        self._orig_status = self.status
+        self._orig_status = self.__dict__.get('status')
 
         self._terminations_modified = False
 

--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -89,7 +89,7 @@ class ComponentTemplateModel(ChangeLoggedModel, TrackingModelMixin):
         super().__init__(*args, **kwargs)
 
         # Cache the original DeviceType ID for reference under clean()
-        self._original_device_type = self.device_type_id
+        self._original_device_type = self.__dict__.get('device_type_id')
 
     def to_objectchange(self, action):
         objectchange = super().to_objectchange(action)

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -86,7 +86,7 @@ class ComponentModel(NetBoxModel):
         super().__init__(*args, **kwargs)
 
         # Cache the original Device ID for reference under clean()
-        self._original_device = self.device_id
+        self._original_device = self.__dict__.get('device_id')
 
     def __str__(self):
         if self.label:

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -205,11 +205,11 @@ class DeviceType(ImageAttachmentsMixin, PrimaryModel, WeightMixin):
         super().__init__(*args, **kwargs)
 
         # Save a copy of u_height for validation in clean()
-        self._original_u_height = self.u_height
+        self._original_u_height = self.__dict__.get('u_height')
 
         # Save references to the original front/rear images
-        self._original_front_image = self.front_image
-        self._original_rear_image = self.rear_image
+        self._original_front_image = self.__dict__.get('front_image')
+        self._original_rear_image = self.__dict__.get('rear_image')
 
     def get_absolute_url(self):
         return reverse('dcim:devicetype', args=[self.pk])

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -219,7 +219,7 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
         super().__init__(*args, **kwargs)
 
         # Cache instance's original name so we can check later whether it has changed
-        self._name = self.name
+        self._name = self.__dict__.get('name')
 
     @property
     def search_type(self):

--- a/netbox/extras/tests/test_views.py
+++ b/netbox/extras/tests/test_views.py
@@ -6,7 +6,7 @@ from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
 
-from dcim.models import Site
+from dcim.models import DeviceType, Manufacturer, Site
 from extras.choices import *
 from extras.models import *
 from utilities.testing import ViewTestCases, TestCase
@@ -434,7 +434,8 @@ class ConfigContextTestCase(
     @classmethod
     def setUpTestData(cls):
 
-        site = Site.objects.create(name='Site 1', slug='site-1')
+        manufacturer = Manufacturer.objects.create(name='Manufacturer 1', slug='manufacturer-1')
+        devicetype = DeviceType.objects.create(manufacturer=manufacturer, model='Device Type 1', slug='device-type-1')
 
         # Create three ConfigContexts
         for i in range(1, 4):
@@ -443,7 +444,7 @@ class ConfigContextTestCase(
                 data={'foo': i}
             )
             configcontext.save()
-            configcontext.sites.add(site)
+            configcontext.device_types.add(devicetype)
 
         cls.form_data = {
             'name': 'Config Context X',
@@ -451,11 +452,12 @@ class ConfigContextTestCase(
             'description': 'A new config context',
             'is_active': True,
             'regions': [],
-            'sites': [site.pk],
+            'sites': [],
             'roles': [],
             'platforms': [],
             'tenant_groups': [],
             'tenants': [],
+            'device_types': [devicetype.id,],
             'tags': [],
             'data': '{"foo": 123}',
         }

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -467,7 +467,11 @@ class TagBulkDeleteView(generic.BulkDeleteView):
 #
 
 class ConfigContextListView(generic.ObjectListView):
-    queryset = ConfigContext.objects.all()
+    queryset = ConfigContext.objects.all().prefetch_related(
+        'regions', 'site_groups', 'sites', 'locations', 'device_types',
+        'roles', 'platforms', 'cluster_types', 'cluster_groups', 'clusters',
+        'tenant_groups', 'tenants', 'tags',
+    )
     filterset = filtersets.ConfigContextFilterSet
     filterset_form = forms.ConfigContextFilterForm
     table = tables.ConfigContextTable
@@ -515,12 +519,20 @@ class ConfigContextView(generic.ObjectView):
 
 @register_model_view(ConfigContext, 'edit')
 class ConfigContextEditView(generic.ObjectEditView):
-    queryset = ConfigContext.objects.all()
+    queryset = ConfigContext.objects.all().prefetch_related(
+        'regions', 'site_groups', 'sites', 'locations', 'device_types',
+        'roles', 'platforms', 'cluster_types', 'cluster_groups', 'clusters',
+        'tenant_groups', 'tenants', 'tags',
+    )
     form = forms.ConfigContextForm
 
 
 class ConfigContextBulkEditView(generic.BulkEditView):
-    queryset = ConfigContext.objects.all()
+    queryset = ConfigContext.objects.all().prefetch_related(
+        'regions', 'site_groups', 'sites', 'locations', 'device_types',
+        'roles', 'platforms', 'cluster_types', 'cluster_groups', 'clusters',
+        'tenant_groups', 'tenants', 'tags',
+    )
     filterset = filtersets.ConfigContextFilterSet
     table = tables.ConfigContextTable
     form = forms.ConfigContextBulkEditForm

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -467,11 +467,7 @@ class TagBulkDeleteView(generic.BulkDeleteView):
 #
 
 class ConfigContextListView(generic.ObjectListView):
-    queryset = ConfigContext.objects.all().prefetch_related(
-        'regions', 'site_groups', 'sites', 'locations', 'device_types',
-        'roles', 'platforms', 'cluster_types', 'cluster_groups', 'clusters',
-        'tenant_groups', 'tenants', 'tags',
-    )
+    queryset = ConfigContext.objects.all()
     filterset = filtersets.ConfigContextFilterSet
     filterset_form = forms.ConfigContextFilterForm
     table = tables.ConfigContextTable
@@ -519,20 +515,12 @@ class ConfigContextView(generic.ObjectView):
 
 @register_model_view(ConfigContext, 'edit')
 class ConfigContextEditView(generic.ObjectEditView):
-    queryset = ConfigContext.objects.all().prefetch_related(
-        'regions', 'site_groups', 'sites', 'locations', 'device_types',
-        'roles', 'platforms', 'cluster_types', 'cluster_groups', 'clusters',
-        'tenant_groups', 'tenants', 'tags',
-    )
+    queryset = ConfigContext.objects.all()
     form = forms.ConfigContextForm
 
 
 class ConfigContextBulkEditView(generic.BulkEditView):
-    queryset = ConfigContext.objects.all().prefetch_related(
-        'regions', 'site_groups', 'sites', 'locations', 'device_types',
-        'roles', 'platforms', 'cluster_types', 'cluster_groups', 'clusters',
-        'tenant_groups', 'tenants', 'tags',
-    )
+    queryset = ConfigContext.objects.all()
     filterset = filtersets.ConfigContextFilterSet
     table = tables.ConfigContextTable
     form = forms.ConfigContextBulkEditForm

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -290,8 +290,8 @@ class Prefix(GetAvailablePrefixesMixin, PrimaryModel):
         super().__init__(*args, **kwargs)
 
         # Cache the original prefix and VRF so we can check if they have changed on post_save
-        self._prefix = self.prefix
-        self._vrf_id = self.vrf_id
+        self._prefix = self.__dict__.get('prefix')
+        self._vrf_id = self.__dict__.get('vrf_id')
 
     def __str__(self):
         return str(self.prefix)


### PR DESCRIPTION
### Fixes: #13757 

As per Django issue https://code.djangoproject.com/ticket/34847 problem arises as DeviceType has variable references in init method.  Recommendation is to access vars in init with self.__dict as they state this will probably be documented this way as there is no good fix for dereferenced vars except for this.

Changed ConfigContext test case save devicetype to catch if this ever regresses.