### PR TITLE
13813 fix virtual chassis member count

### DIFF
--- a/netbox/utilities/counters.py
+++ b/netbox/utilities/counters.py
@@ -52,12 +52,13 @@ def post_save_receiver(sender, instance, created, **kwargs):
     for field_name, counter_name in get_counters_for_model(sender):
         parent_model = sender._meta.get_field(field_name).related_model
         new_pk = getattr(instance, field_name, None)
-        old_pk = instance.tracker.get(field_name) if field_name in instance.tracker else None
+        has_old_field = field_name in instance.tracker
+        old_pk = instance.tracker.get(field_name) if has_old_field else None
 
         # Update the counters on the old and/or new parents as needed
         if old_pk is not None:
             update_counter(parent_model, old_pk, counter_name, -1)
-        if new_pk is not None and (old_pk or created):
+        if new_pk is not None and (has_old_field or created):
             update_counter(parent_model, new_pk, counter_name, 1)
 
 

--- a/netbox/utilities/tests/test_counters.py
+++ b/netbox/utilities/tests/test_counters.py
@@ -36,9 +36,17 @@ class CountersTest(TestCase):
         self.assertEqual(device1.interface_count, 3)
         self.assertEqual(device2.interface_count, 3)
 
+        # test saving an existing object - counter should not change
         interface1.save()
         device1.refresh_from_db()
         self.assertEqual(device1.interface_count, 3)
+
+        # test save where tracked object FK back pointer is None
+        vc = VirtualChassis.objects.create(name='Virtual Chassis 1')
+        device1.virtual_chassis = vc
+        device1.save()
+        vc.refresh_from_db()
+        self.assertEqual(vc.member_count, 1)
 
     def test_interface_count_deletion(self):
         """


### PR DESCRIPTION
### Fixes: #13813 

Fixes VirtualChassis member count - issue was in counter fields where the tracked object (Device) existed but had the FK pointer that was being tracked as None which caused the increment to get bypassed.  Added test for this condition.
