### PR TITLE
13818 add tags to l2vpntermination edit form

### DIFF
--- a/netbox/templates/ipam/l2vpntermination_edit.html
+++ b/netbox/templates/ipam/l2vpntermination_edit.html
@@ -41,6 +41,7 @@
         <div class="tab-pane {% if form.initial.vminterface %}active{% endif %}" id="vminterface" role="tabpanel" aria-labeled-by="vminterface_tab">
           {% render_field form.vminterface %}
         </div>
+        {% render_field form.tags %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Fixes: #13818 

L2VPN Termination form was missing tags.