### PR TITLE
13809 fix ConfigRevision edit if custom validators

### DIFF
--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -532,13 +532,11 @@ class ConfigRevisionForm(BootstrapMixin, forms.ModelForm, metaclass=ConfigFormMe
                     value = ', '.join(value)
                 self.fields[param.name].initial = value
 
-                if param.name == 'CUSTOM_VALIDATORS':
-                    # custom validators can be either dict or functions
-                    try:
-                        json.dumps(value)
-                    except TypeError:
-                        self.fields[param.name].initial = None
-                        self.fields[param.name].disabled = True
+                try:
+                    json.dumps(value)
+                except TypeError:
+                    self.fields[param.name].initial = None
+                    self.fields[param.name].disabled = True
 
             if is_static:
                 self.fields[param.name].disabled = True

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -531,6 +531,15 @@ class ConfigRevisionForm(BootstrapMixin, forms.ModelForm, metaclass=ConfigFormMe
                 if type(value) in (tuple, list):
                     value = ', '.join(value)
                 self.fields[param.name].initial = value
+
+                if param.name == 'CUSTOM_VALIDATORS':
+                    # custom validators can be either dict or functions
+                    try:
+                        json.dumps(value)
+                    except TypeError:
+                        self.fields[param.name].initial = None
+                        self.fields[param.name].disabled = True
+
             if is_static:
                 self.fields[param.name].disabled = True
 

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -517,29 +517,34 @@ class ConfigRevisionForm(BootstrapMixin, forms.ModelForm, metaclass=ConfigFormMe
         config = get_config()
         for param in PARAMS:
             value = getattr(config, param.name)
-            is_static = hasattr(settings, param.name)
-            if value:
-                help_text = self.fields[param.name].help_text
-                if help_text:
-                    help_text += '<br />'  # Line break
-                help_text += _('Current value: <strong>{value}</strong>').format(value=value)
-                if is_static:
-                    help_text += _(' (defined statically)')
-                elif value == param.default:
-                    help_text += _(' (default)')
-                self.fields[param.name].help_text = help_text
+
+            # Set the field's initial value, if it can be serialized. (This may not be the case e.g. for
+            # CUSTOM_VALIDATORS, which may reference Python objects.)
+            try:
+                json.dumps(value)
                 if type(value) in (tuple, list):
-                    value = ', '.join(value)
-                self.fields[param.name].initial = value
+                    self.fields[param.name].initial = ', '.join(value)
+                else:
+                    self.fields[param.name].initial = value
+            except TypeError:
+                pass
 
-                try:
-                    json.dumps(value)
-                except TypeError:
-                    self.fields[param.name].initial = None
-                    self.fields[param.name].disabled = True
-
-            if is_static:
+            # Check whether this parameter is statically configured (e.g. in configuration.py)
+            if hasattr(settings, param.name):
                 self.fields[param.name].disabled = True
+                self.fields[param.name].help_text = _(
+                    'This parameter has been defined statically and cannot be modified.'
+                )
+                continue
+
+            # Set the field's help text
+            help_text = self.fields[param.name].help_text
+            if help_text:
+                help_text += '<br />'  # Line break
+            help_text += _('Current value: <strong>{value}</strong>').format(value=value or '&mdash;')
+            if value == param.default:
+                help_text += _(' (default)')
+            self.fields[param.name].help_text = help_text
 
     def save(self, commit=True):
         instance = super().save(commit=False)


### PR DESCRIPTION
### Fixes: #13809 

Disables the CUSTOM_VALIDATORS field if field is not JSON serializable (because it uses custom functions).