### PR TITLE
12685 use markdown for custom fields added to form

### DIFF
--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -76,7 +76,8 @@ class CustomFieldForm(BootstrapMixin, forms.ModelForm):
             'type': _(
                 "The type of data stored in this field. For object/multi-object fields, select the related object "
                 "type below."
-            )
+            ),
+            'description': _("This will be displayed as help text for the form field. Markdown is supported.")
         }
 
     def __init__(self, *args, **kwargs):

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -1,4 +1,5 @@
 import decimal
+import markdown
 import re
 from datetime import datetime, date
 
@@ -498,7 +499,7 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
         field.model = self
         field.label = str(self)
         if self.description:
-            field.help_text = escape(self.description)
+            field.help_text = markdown.markdown(escape(self.description))
 
         # Annotate read-only fields
         if enforce_visibility and self.ui_visibility == CustomFieldVisibilityChoices.VISIBILITY_READ_ONLY:

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -1,5 +1,4 @@
 import decimal
-import markdown
 import re
 from datetime import datetime, date
 
@@ -29,6 +28,7 @@ from utilities.forms.fields import (
 from utilities.forms.utils import add_blank_choice
 from utilities.forms.widgets import APISelect, APISelectMultiple, DatePicker, DateTimePicker
 from utilities.querysets import RestrictedQuerySet
+from utilities.templatetags.builtins.filters import render_markdown
 from utilities.validators import validate_regex
 
 __all__ = (
@@ -499,7 +499,7 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
         field.model = self
         field.label = str(self)
         if self.description:
-            field.help_text = markdown.markdown(escape(self.description))
+            field.help_text = render_markdown(self.description)
 
         # Annotate read-only fields
         if enforce_visibility and self.ui_visibility == CustomFieldVisibilityChoices.VISIBILITY_READ_ONLY:


### PR DESCRIPTION
### Fixes: #12685 

Renders custom field description (for help text) using markdown for forms.  Did the escape first so it catches html and just process markdown afterwards.