### PR TITLE
Fixes #13864: Remove 'default' choice for dashboard widget color

### DIFF
--- a/netbox/extras/choices.py
+++ b/netbox/extras/choices.py
@@ -244,3 +244,39 @@ class ChangeActionChoices(ChoiceSet):
         (ACTION_UPDATE, _('Update'), 'blue'),
         (ACTION_DELETE, _('Delete'), 'red'),
     )
+
+
+#
+# Dashboard widgets
+#
+
+class DashboardWidgetColorChoices(ChoiceSet):
+    BLUE = 'blue'
+    INDIGO = 'indigo'
+    PURPLE = 'purple'
+    PINK = 'pink'
+    RED = 'red'
+    ORANGE = 'orange'
+    YELLOW = 'yellow'
+    GREEN = 'green'
+    TEAL = 'teal'
+    CYAN = 'cyan'
+    GRAY = 'gray'
+    BLACK = 'black'
+    WHITE = 'white'
+
+    CHOICES = (
+        (BLUE, _('Blue')),
+        (INDIGO, _('Indigo')),
+        (PURPLE, _('Purple')),
+        (PINK, _('Pink')),
+        (RED, _('Red')),
+        (ORANGE, _('Orange')),
+        (YELLOW, _('Yellow')),
+        (GREEN, _('Green')),
+        (TEAL, _('Teal')),
+        (CYAN, _('Cyan')),
+        (GRAY, _('Gray')),
+        (BLACK, _('Black')),
+        (WHITE, _('White')),
+    )

--- a/netbox/extras/dashboard/forms.py
+++ b/netbox/extras/dashboard/forms.py
@@ -2,9 +2,9 @@ from django import forms
 from django.urls import reverse_lazy
 from django.utils.translation import gettext as _
 
+from extras.choices import DashboardWidgetColorChoices
 from netbox.registry import registry
 from utilities.forms import BootstrapMixin, add_blank_choice
-from utilities.choices import ButtonColorChoices
 
 __all__ = (
     'DashboardWidgetAddForm',
@@ -21,7 +21,7 @@ class DashboardWidgetForm(BootstrapMixin, forms.Form):
         required=False
     )
     color = forms.ChoiceField(
-        choices=add_blank_choice(ButtonColorChoices),
+        choices=add_blank_choice(DashboardWidgetColorChoices),
         required=False,
     )
 


### PR DESCRIPTION
### Fixes: #13864

- Create `DashboardWidgetColorChoices`
- Remove the "default" option. An empty value will continue to default to the `secondary` Bootstrap color class