### PR TITLE
12336 make region API calls atomic

### DIFF
--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -1,3 +1,4 @@
+from django.db import transaction
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 from drf_spectacular.types import OpenApiTypes
@@ -108,6 +109,18 @@ class RegionViewSet(NetBoxModelViewSet):
     ).prefetch_related('tags')
     serializer_class = serializers.RegionSerializer
     filterset_class = filtersets.RegionFilterSet
+
+    @transaction.atomic
+    def create(self, request, *args, **kwargs):
+        return super().create(request, *args, **kwargs)
+
+    @transaction.atomic
+    def update(self, request, *args, **kwargs):
+        return super().update(request, *args, **kwargs)
+
+    @transaction.atomic
+    def destroy(self, request, *args, **kwargs):
+        return super().destroy(request, *args, **kwargs)
 
 
 #

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -1,6 +1,6 @@
-from django.db import transaction
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
+from django_pglocks import advisory_lock
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema, OpenApiParameter
 from rest_framework.decorators import action
@@ -23,7 +23,7 @@ from netbox.api.pagination import StripCountAnnotationsPaginator
 from netbox.api.renderers import TextRenderer
 from netbox.api.viewsets import NetBoxModelViewSet
 from netbox.api.viewsets.mixins import SequentialBulkCreatesMixin
-from netbox.constants import NESTED_SERIALIZER_PREFIX
+from netbox.constants import NESTED_SERIALIZER_PREFIX, ADVISORY_LOCK_KEYS
 from utilities.api import get_serializer_for_model
 from utilities.utils import count_related
 from virtualization.models import VirtualMachine
@@ -110,15 +110,15 @@ class RegionViewSet(NetBoxModelViewSet):
     serializer_class = serializers.RegionSerializer
     filterset_class = filtersets.RegionFilterSet
 
-    @transaction.atomic
+    @advisory_lock(ADVISORY_LOCK_KEYS['regions'])
     def create(self, request, *args, **kwargs):
         return super().create(request, *args, **kwargs)
 
-    @transaction.atomic
+    @advisory_lock(ADVISORY_LOCK_KEYS['regions'])
     def update(self, request, *args, **kwargs):
         return super().update(request, *args, **kwargs)
 
-    @transaction.atomic
+    @advisory_lock(ADVISORY_LOCK_KEYS['regions'])
     def destroy(self, request, *args, **kwargs):
         return super().destroy(request, *args, **kwargs)
 

--- a/netbox/netbox/api/viewsets/__init__.py
+++ b/netbox/netbox/api/viewsets/__init__.py
@@ -168,13 +168,13 @@ class MPTTLockedMixin(GenericViewSet):
     """
 
     def create(self, request, *args, **kwargs):
-        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.verbose_name.lower()]):
+        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.verbose_name.lower().replace(" ", "")]):
             return super().create(request, *args, **kwargs)
 
     def update(self, request, *args, **kwargs):
-        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.verbose_name.lower()]):
+        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.verbose_name.lower().replace(" ", "")]):
             return super().update(request, *args, **kwargs)
 
     def destroy(self, request, *args, **kwargs):
-        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.verbose_name.lower()]):
+        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.verbose_name.lower().replace(" ", "")]):
             return super().destroy(request, *args, **kwargs)

--- a/netbox/netbox/api/viewsets/__init__.py
+++ b/netbox/netbox/api/viewsets/__init__.py
@@ -161,20 +161,20 @@ class NetBoxModelViewSet(
         return super().perform_destroy(instance)
 
 
-class MPTTLockedMixin(GenericViewSet):
+class MPTTLockedMixin:
     """
     Puts pglock on objects that derive from MPTTModel for parallel API calling.
     Note: If adding this to a view, must add the model name to ADVISORY_LOCK_KEYS
     """
 
     def create(self, request, *args, **kwargs):
-        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.verbose_name.lower().replace(" ", "")]):
+        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.model_name]):
             return super().create(request, *args, **kwargs)
 
     def update(self, request, *args, **kwargs):
-        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.verbose_name.lower().replace(" ", "")]):
+        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.model_name]):
             return super().update(request, *args, **kwargs)
 
     def destroy(self, request, *args, **kwargs):
-        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.verbose_name.lower().replace(" ", "")]):
+        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.model_name]):
             return super().destroy(request, *args, **kwargs)

--- a/netbox/netbox/api/viewsets/__init__.py
+++ b/netbox/netbox/api/viewsets/__init__.py
@@ -3,6 +3,8 @@ import logging
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db import transaction
 from django.db.models import ProtectedError
+from django_pglocks import advisory_lock
+from netbox.constants import ADVISORY_LOCK_KEYS
 from rest_framework import mixins as drf_mixins
 from rest_framework.response import Response
 from rest_framework.viewsets import GenericViewSet
@@ -157,3 +159,22 @@ class NetBoxModelViewSet(
         logger.info(f"Deleting {model._meta.verbose_name} {instance} (PK: {instance.pk})")
 
         return super().perform_destroy(instance)
+
+
+class MPTTLockedMixin(GenericViewSet):
+    """
+    Puts pglock on objects that derive from MPTTModel for parallel API calling.
+    Note: If adding this to a view, must add the model name to ADVISORY_LOCK_KEYS
+    """
+
+    def create(self, request, *args, **kwargs):
+        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.verbose_name.lower()]):
+            return super().create(request, *args, **kwargs)
+
+    def update(self, request, *args, **kwargs):
+        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.verbose_name.lower()]):
+            return super().update(request, *args, **kwargs)
+
+    def destroy(self, request, *args, **kwargs):
+        with advisory_lock(ADVISORY_LOCK_KEYS[self.queryset.model._meta.verbose_name.lower()]):
+            return super().destroy(request, *args, **kwargs)

--- a/netbox/netbox/constants.py
+++ b/netbox/netbox/constants.py
@@ -15,4 +15,5 @@ ADVISORY_LOCK_KEYS = {
     'available-ips': 100200,
     'available-vlans': 100300,
     'available-asns': 100400,
+    'regions': 100500,
 }

--- a/netbox/netbox/constants.py
+++ b/netbox/netbox/constants.py
@@ -11,18 +11,19 @@ RQ_QUEUE_LOW = 'low'
 # When adding a new key, pick something arbitrary and unique so that it is easily searchable in
 # query logs.
 ADVISORY_LOCK_KEYS = {
+    # Available object locks
     'available-prefixes': 100100,
     'available-ips': 100200,
     'available-vlans': 100300,
     'available-asns': 100400,
 
     # MPTT locks
-    'region': 100500,
-    'sitegroup': 100501,
-    'location': 100502,
-    'tenantgroup': 100503,
-    'contactgroup': 100504,
-    'wirelesslangroup': 100505,
-    'inventoryitem': 100506,
-    'inventoryitemtemplate': 100507,
+    'region': 105100,
+    'sitegroup': 105200,
+    'location': 105300,
+    'tenantgroup': 105400,
+    'contactgroup': 105500,
+    'wirelesslangroup': 105600,
+    'inventoryitem': 105700,
+    'inventoryitemtemplate': 105800,
 }

--- a/netbox/netbox/constants.py
+++ b/netbox/netbox/constants.py
@@ -15,5 +15,14 @@ ADVISORY_LOCK_KEYS = {
     'available-ips': 100200,
     'available-vlans': 100300,
     'available-asns': 100400,
-    'regions': 100500,
+
+    # MPTT locks
+    'region': 100500,
+    'sitegroup': 100501,
+    'location': 100502,
+    'tenantgroup': 100503,
+    'contactgroup': 100504,
+    'wirelesslangroup': 100505,
+    'inventoryitem': 100506,
+    'inventoryitemtemplate': 100507,
 }

--- a/netbox/tenancy/api/views.py
+++ b/netbox/tenancy/api/views.py
@@ -3,7 +3,7 @@ from rest_framework.routers import APIRootView
 from circuits.models import Circuit
 from dcim.models import Device, Rack, Site
 from ipam.models import IPAddress, Prefix, VLAN, VRF
-from netbox.api.viewsets import NetBoxModelViewSet
+from netbox.api.viewsets import NetBoxModelViewSet, MPTTLockedMixin
 from tenancy import filtersets
 from tenancy.models import *
 from utilities.utils import count_related
@@ -23,7 +23,7 @@ class TenancyRootView(APIRootView):
 # Tenants
 #
 
-class TenantGroupViewSet(NetBoxModelViewSet):
+class TenantGroupViewSet(MPTTLockedMixin, NetBoxModelViewSet):
     queryset = TenantGroup.objects.add_related_count(
         TenantGroup.objects.all(),
         Tenant,
@@ -58,7 +58,7 @@ class TenantViewSet(NetBoxModelViewSet):
 # Contacts
 #
 
-class ContactGroupViewSet(NetBoxModelViewSet):
+class ContactGroupViewSet(MPTTLockedMixin, NetBoxModelViewSet):
     queryset = ContactGroup.objects.add_related_count(
         ContactGroup.objects.all(),
         Contact,

--- a/netbox/wireless/api/views.py
+++ b/netbox/wireless/api/views.py
@@ -1,6 +1,6 @@
 from rest_framework.routers import APIRootView
 
-from netbox.api.viewsets import NetBoxModelViewSet
+from netbox.api.viewsets import NetBoxModelViewSet, MPTTLockedMixin
 from wireless import filtersets
 from wireless.models import *
 from . import serializers
@@ -14,7 +14,7 @@ class WirelessRootView(APIRootView):
         return 'Wireless'
 
 
-class WirelessLANGroupViewSet(NetBoxModelViewSet):
+class WirelessLANGroupViewSet(MPTTLockedMixin, NetBoxModelViewSet):
     queryset = WirelessLANGroup.objects.add_related_count(
         WirelessLANGroup.objects.all(),
         WirelessLAN,

--- a/netbox/wireless/models.py
+++ b/netbox/wireless/models.py
@@ -2,7 +2,6 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
-from mptt.models import MPTTModel
 
 from dcim.choices import LinkStatusChoices
 from dcim.constants import WIRELESS_IFACE_TYPES


### PR DESCRIPTION
### Fixes: #12336 

added mixin to put pglocks (for MPTT) around view calls to create, update, destroy.  used the model name for the lock key (instead of a common 'mptt' one) so parallel calls could be made to different mptt objects (say sitegroups and regions) for better performance.