### PR TITLE
13815 document view permissions for scripts

### DIFF
--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -288,7 +288,7 @@ An IPv4 or IPv6 network with a mask. Returns a `netaddr.IPNetwork` object. Two a
 ## Running Custom Scripts
 
 !!! note
-    To run a custom script, a user must be assigned the `extras.run_script` permission. This is achieved by assigning the user (or group) a permission on the Script object and specifying the `run` action in the admin UI as shown below.
+    To run a custom script, a user must be assigned via permissions for `Extras > Script`, `Extras > ScriptModule`, and `Core > ManagedFile` objects. They must also be assigned the `extras.run_script` permission.  This is achieved by assigning the user (or group) a permission on the Script object and specifying the `run` action in the admin UI as shown below.
 
     ![Adding the run action to a permission](../media/admin_ui_run_permission.png)
 

--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -288,16 +288,13 @@ An IPv4 or IPv6 network with a mask. Returns a `netaddr.IPNetwork` object. Two a
 ## Running Custom Scripts
 
 !!! note
-    To run a custom script, a user must be assigned via permissions for `Extras > Script`, `Extras > ScriptModule`, and `Core > ManagedFile` objects. They must also be assigned the `extras.run_script` permission.  This is achieved by assigning the user (or group) a permission on the Script object and specifying the `run` action in the admin UI as shown below.
+    To run a custom script, a user must be assigned via permissions for `Extras > Script`, `Extras > ScriptModule`, and `Core > ManagedFile` objects. They must also be assigned the `extras.run_script` permission. This is achieved by assigning the user (or group) a permission on the Script object and specifying the `run` action in the admin UI as shown below.
 
     ![Adding the run action to a permission](../media/admin_ui_run_permission.png)
 
 ### Via the Web UI
 
 Custom scripts can be run via the web UI by navigating to the script, completing any required form data, and clicking the "run script" button. It is possible to schedule a script to be executed at specified time in the future. A scheduled script can be canceled by deleting the associated job result object.
-
-!!! note
-    To be able to view and run a custom script, a user must have the following view permissions:  `Extras > Script`, `Extras > ScriptModule`, `Core > ManagedFile`. As well as be assigned the extras.run_script permission as shown above.
 
 ### Via the API
 

--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -296,6 +296,9 @@ An IPv4 or IPv6 network with a mask. Returns a `netaddr.IPNetwork` object. Two a
 
 Custom scripts can be run via the web UI by navigating to the script, completing any required form data, and clicking the "run script" button. It is possible to schedule a script to be executed at specified time in the future. A scheduled script can be canceled by deleting the associated job result object.
 
+!!! note
+    To be able to view and run a custom script, a user must have the following view permissions:  `Extras > Script`, `Extras > ScriptModule`, `Core > ManagedFile`. As well as be assigned the extras.run_script permission as shown above.
+
 ### Via the API
 
 To run a script via the REST API, issue a POST request to the script's endpoint specifying the form data and commitment. For example, to run a script named `example.MyReport`, we would make a request such as the following:

--- a/docs/customization/reports.md
+++ b/docs/customization/reports.md
@@ -132,7 +132,7 @@ Once you have created a report, it will appear in the reports list. Initially, r
 ## Running Reports
 
 !!! note
-    To run a report, a user must be assigned the `extras.run_report` permission. This is achieved by assigning the user (or group) a permission on the Report object and specifying the `run` action in the admin UI as shown below.
+    To run a report, a user must be assigned via permissions for `Extras > Report`, `Extras > ReportModule`, and `Core > ManagedFile` objects. They must also be assigned the `extras.run_report` permission. This is achieved by assigning the user (or group) a permission on the Report object and specifying the `run` action in the admin UI as shown below.
 
     ![Adding the run action to a permission](../media/admin_ui_run_permission.png)
 


### PR DESCRIPTION
### Fixes: #13815 

Adds documentation for permission needed to view and run scripts as it requires several non-obvious permissions.