### PR TITLE
Fix Bug in report serialization 

### DIFF
--- a/netbox/extras/reports.py
+++ b/netbox/extras/reports.py
@@ -120,7 +120,7 @@ class Report(object):
     def full_name(self):
         return f'{self.module}.{self.class_name}'
 
-    @property
+    @classproperty
     def name(self):
         """
         Override this attribute to set a custom display name.


### PR DESCRIPTION
### Fixes: #[13944](https://github.com/netbox-community/netbox/issues/13944)

The name field should be `@classproperty` so that it can be serialized correctly.

Im not sure if there are other fields that should be `@classproperty` instead of `@property` but this change is enough to fix the Bug i encountered. 

