### PR TITLE
12328 update GFK object in clean

### DIFF
--- a/netbox/netbox/models/__init__.py
+++ b/netbox/netbox/models/__init__.py
@@ -1,5 +1,6 @@
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
+from django.core.exceptions import ObjectDoesNotExist
 from django.core.validators import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _

--- a/netbox/netbox/models/__init__.py
+++ b/netbox/netbox/models/__init__.py
@@ -85,10 +85,15 @@ class NetBoxModel(NetBoxFeatureSet, models.Model):
 
                 if ct_value and fk_value:
                     klass = getattr(self, field.ct_field).model_class()
-                    if not klass.objects.filter(pk=fk_value).exists():
+                    try:
+                        obj = klass.objects.get(pk=fk_value)
+                    except ObjectDoesNotExist:
                         raise ValidationError({
                             field.fk_field: f"Related object not found using the provided value: {fk_value}."
                         })
+
+                    # update the GFK field value
+                    setattr(self, field.name, obj)
 
 
 #


### PR DESCRIPTION
### Fixes: #12328 

Potentially a bug in DRF, for the GFK field the _id and _type are set correctly but the content_object isn't set jut on return for a creation on REST API calls.  We are already going through all the GFK fields in the clean method so this just adds the actual setting of the content_object field.  A very slight performance hit changing from checking existence to actually getting the object.  Little bit of a hack to work-around the issue, but I can't think of any side-effects this should have.