### PR TITLE
13872 fix bulk import

### DIFF
--- a/netbox/templates/generic/bulk_import.html
+++ b/netbox/templates/generic/bulk_import.html
@@ -67,6 +67,7 @@ Context:
           <input type="hidden" name="import_method" value="upload" />
           {% render_field form.upload_file %}
           {% render_field form.format %}
+          {% render_field form.csv_delimiter %}
           <div class="form-group">
             <div class="col col-md-12 text-end">
               <button type="submit" name="file_submit" class="btn btn-primary">{% trans "Submit" %}</button>
@@ -88,6 +89,7 @@ Context:
           {% render_field form.data_source %}
           {% render_field form.data_file %}
           {% render_field form.format %}
+          {% render_field form.csv_delimiter %}
           <div class="form-group">
             <div class="col col-md-12 text-end">
               <button type="submit" name="file_submit" class="btn btn-primary">{% trans "Submit" %}</button>


### PR DESCRIPTION
### Fixes: #13872 

The CSV delimiter field needs to be on all the file upload type forms as it is used in the processing, if not there it gets returned as a space (not a valid type) which caused errors.