### PR TITLE
13972 allow filtering of cables if have terminations

### DIFF
--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -1745,6 +1745,14 @@ class CableFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
         method='filter_by_cable_end_b',
         field_name='terminations__termination_id'
     )
+    has_a_terminations = django_filters.BooleanFilter(
+        method='_has_a_terminations',
+        label=_('Has a terminations'),
+    )
+    has_b_terminations = django_filters.BooleanFilter(
+        method='_has_b_terminations',
+        label=_('Has b terminations'),
+    )
     type = django_filters.MultipleChoiceFilter(
         choices=CableTypeChoices
     )
@@ -1811,6 +1819,18 @@ class CableFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
     def filter_by_cable_end_b(self, queryset, name, value):
         # Filter by termination id and cable_end type
         return self.filter_by_cable_end(queryset, name, value, CableEndChoices.SIDE_B)
+
+    def _has_a_terminations(self, queryset, name, value):
+        if value:
+            return queryset.filter(terminations__cable_end=CableEndChoices.SIDE_A)
+        else:
+            return queryset.exclude(terminations__cable_end=CableEndChoices.SIDE_A)
+
+    def _has_b_terminations(self, queryset, name, value):
+        if value:
+            return queryset.filter(terminations__cable_end=CableEndChoices.SIDE_B)
+        else:
+            return queryset.exclude(terminations__cable_end=CableEndChoices.SIDE_B)
 
 
 class CableTerminationFilterSet(BaseFilterSet):

--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -1,6 +1,5 @@
 import django_filters
 from django.contrib.auth import get_user_model
-from django.db.models import Q
 from django.utils.translation import gettext as _
 
 from extras.filtersets import LocalConfigContextFilterSet
@@ -1819,10 +1818,16 @@ class CableFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
 
     def _unterminated(self, queryset, name, value):
         if value:
-            terminated_ids = queryset.filter(terminations__cable_end=CableEndChoices.SIDE_A).filter(terminations__cable_end=CableEndChoices.SIDE_B).values("id")
+            terminated_ids = (
+                queryset.filter(terminations__cable_end=CableEndChoices.SIDE_A)
+                .filter(terminations__cable_end=CableEndChoices.SIDE_B)
+                .values("id")
+            )
             return queryset.exclude(id__in=terminated_ids)
         else:
-            return queryset.filter(terminations__cable_end=CableEndChoices.SIDE_A).filter(terminations__cable_end=CableEndChoices.SIDE_B)
+            return queryset.filter(terminations__cable_end=CableEndChoices.SIDE_A).filter(
+                terminations__cable_end=CableEndChoices.SIDE_B
+            )
 
 
 class CableTerminationFilterSet(BaseFilterSet):

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -908,7 +908,7 @@ class VirtualChassisFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
 class CableFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
     model = Cable
     fieldsets = (
-        (None, ('q', 'filter_id', 'has_a_terminations', 'has_b_terminations', 'tag')),
+        (None, ('q', 'filter_id', 'unterminated', 'tag')),
         (_('Location'), ('site_id', 'location_id', 'rack_id', 'device_id')),
         (_('Attributes'), ('type', 'status', 'color', 'length', 'length_unit')),
         (_('Tenant'), ('tenant_group_id', 'tenant_id')),
@@ -979,15 +979,8 @@ class CableFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
         choices=add_blank_choice(CableLengthUnitChoices),
         required=False
     )
-    has_a_terminations = forms.NullBooleanField(
-        label=_('Has a terminations'),
-        required=False,
-        widget=forms.Select(
-            choices=BOOLEAN_WITH_BLANK_CHOICES
-        )
-    )
-    has_b_terminations = forms.NullBooleanField(
-        label=_('Has b terminations'),
+    unterminated = forms.NullBooleanField(
+        label=_('Unterminated'),
         required=False,
         widget=forms.Select(
             choices=BOOLEAN_WITH_BLANK_CHOICES

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -908,9 +908,9 @@ class VirtualChassisFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
 class CableFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
     model = Cable
     fieldsets = (
-        (None, ('q', 'filter_id', 'unterminated', 'tag')),
+        (None, ('q', 'filter_id', 'tag')),
         (_('Location'), ('site_id', 'location_id', 'rack_id', 'device_id')),
-        (_('Attributes'), ('type', 'status', 'color', 'length', 'length_unit')),
+        (_('Attributes'), ('type', 'status', 'color', 'length', 'length_unit', 'unterminated')),
         (_('Tenant'), ('tenant_group_id', 'tenant_id')),
     )
     region_id = DynamicModelMultipleChoiceField(

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -908,7 +908,7 @@ class VirtualChassisFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
 class CableFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
     model = Cable
     fieldsets = (
-        (None, ('q', 'filter_id', 'tag')),
+        (None, ('q', 'filter_id', 'has_a_terminations', 'has_b_terminations', 'tag')),
         (_('Location'), ('site_id', 'location_id', 'rack_id', 'device_id')),
         (_('Attributes'), ('type', 'status', 'color', 'length', 'length_unit')),
         (_('Tenant'), ('tenant_group_id', 'tenant_id')),
@@ -978,6 +978,20 @@ class CableFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
         label=_('Length unit'),
         choices=add_blank_choice(CableLengthUnitChoices),
         required=False
+    )
+    has_a_terminations = forms.NullBooleanField(
+        label=_('Has a terminations'),
+        required=False,
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        )
+    )
+    has_b_terminations = forms.NullBooleanField(
+        label=_('Has b terminations'),
+        required=False,
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        )
     )
     tag = TagFilterField(model)
 

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -4290,7 +4290,9 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
         Cable(a_terminations=[interfaces[9]], b_terminations=[interfaces[10]], label='Cable 5', type=CableTypeChoices.TYPE_CAT6, tenant=tenants[2], status=LinkStatusChoices.STATUS_PLANNED, color='e91e63', length=10, length_unit=CableLengthUnitChoices.UNIT_METER).save()
         Cable(a_terminations=[interfaces[11]], b_terminations=[interfaces[0]], label='Cable 6', type=CableTypeChoices.TYPE_CAT6, tenant=tenants[2], status=LinkStatusChoices.STATUS_PLANNED, color='e91e63', length=20, length_unit=CableLengthUnitChoices.UNIT_METER).save()
         Cable(a_terminations=[console_port], b_terminations=[console_server_port], label='Cable 7').save()
-        Cable(a_terminations=[interfaces[12]], label='Cable 8', type=CableTypeChoices.TYPE_CAT6, tenant=tenants[2], status=LinkStatusChoices.STATUS_DECOMMISSIONING, color='e91e63', length=20, length_unit=CableLengthUnitChoices.UNIT_METER).save()
+
+        # Cable for unterminated test
+        Cable(a_terminations=[interfaces[12]], label='Cable 8', type=CableTypeChoices.TYPE_CAT6, status=LinkStatusChoices.STATUS_DECOMMISSIONING).save()
 
     def test_label(self):
         params = {'label': ['Cable 1', 'Cable 2']}
@@ -4298,7 +4300,7 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
 
     def test_length(self):
         params = {'length': [10, 20]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_length_unit(self):
         params = {'length_unit': CableLengthUnitChoices.UNIT_FOOT}

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -4275,6 +4275,7 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
             Interface(device=devices[4], name='Interface 10', type=InterfaceTypeChoices.TYPE_1GE_FIXED),
             Interface(device=devices[5], name='Interface 11', type=InterfaceTypeChoices.TYPE_1GE_FIXED),
             Interface(device=devices[5], name='Interface 12', type=InterfaceTypeChoices.TYPE_1GE_FIXED),
+            Interface(device=devices[5], name='Interface 13', type=InterfaceTypeChoices.TYPE_1GE_FIXED),
         )
         Interface.objects.bulk_create(interfaces)
 
@@ -4289,6 +4290,7 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
         Cable(a_terminations=[interfaces[9]], b_terminations=[interfaces[10]], label='Cable 5', type=CableTypeChoices.TYPE_CAT6, tenant=tenants[2], status=LinkStatusChoices.STATUS_PLANNED, color='e91e63', length=10, length_unit=CableLengthUnitChoices.UNIT_METER).save()
         Cable(a_terminations=[interfaces[11]], b_terminations=[interfaces[0]], label='Cable 6', type=CableTypeChoices.TYPE_CAT6, tenant=tenants[2], status=LinkStatusChoices.STATUS_PLANNED, color='e91e63', length=20, length_unit=CableLengthUnitChoices.UNIT_METER).save()
         Cable(a_terminations=[console_port], b_terminations=[console_server_port], label='Cable 7').save()
+        Cable(a_terminations=[interfaces[12]], label='Cable 8', type=CableTypeChoices.TYPE_CAT6, tenant=tenants[2], status=LinkStatusChoices.STATUS_DECOMMISSIONING, color='e91e63', length=20, length_unit=CableLengthUnitChoices.UNIT_METER).save()
 
     def test_label(self):
         params = {'label': ['Cable 1', 'Cable 2']}
@@ -4296,7 +4298,7 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
 
     def test_length(self):
         params = {'length': [10, 20]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)
 
     def test_length_unit(self):
         params = {'length_unit': CableLengthUnitChoices.UNIT_FOOT}
@@ -4367,6 +4369,12 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
             'termination_a_id': list(interface_ids),
         }
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+
+    def test_unterminated(self):
+        params = {'unterminated': True}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {'unterminated': False}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 7)
 
 
 class PowerPanelTestCase(TestCase, ChangeLoggedFilterSetTests):


### PR DESCRIPTION
### Fixes: #13972  

Changed from bug #10769 to resolving FR #13972 - this allows filtering of unterminated cables (either A, B or both).  Even if #10769 is done to remove cables when the last termination is deleted, this still leaves unterminated cables either from before the functionality or if the deletion is done via the API, hence the FR and this PR.
