### PR TITLE
Improved error message

### DIFF
--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -318,7 +318,7 @@ class RSSFeedWidget(DashboardWidget):
                 timeout=3
             )
             response.raise_for_status()
-        except requests.exceptions.RequestException as e:
+        except requests.exceptions.RequestException:
             feed_error = 'NetBox is unable to connect to feed server...'
             return {
                 'error': feed_error,

--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -319,8 +319,9 @@ class RSSFeedWidget(DashboardWidget):
             )
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
+            feed_error = 'NetBox is unable to connect to feed server...'
             return {
-                'error': 'NetBox is unable to connect to feed server...',
+                'error': feed_error,
             }
 
         # Parse feed content

--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -320,7 +320,7 @@ class RSSFeedWidget(DashboardWidget):
             response.raise_for_status()
         except requests.exceptions.RequestException as e:
             return {
-                'error': e,
+                'error': 'NetBox is unable to connect to feed server...',
             }
 
         # Parse feed content

--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -318,8 +318,23 @@ class RSSFeedWidget(DashboardWidget):
                 timeout=3
             )
             response.raise_for_status()
-        except requests.exceptions.RequestException:
-            feed_error = 'NetBox is unable to connect to feed server...'
+
+        except requests.exceptions.RequestException as e:
+            if 'response' in locals():
+                feed_error = f'HTTP {response.reason}'
+            else:
+                if isinstance(e, requests.exceptions.Timeout):
+                    feed_error = 'Timeout'
+                elif isinstance(e, requests.exceptions.URLRequired):
+                    feed_error = 'URL Required'
+                elif isinstance(e, requests.exceptions.TooManyRedirects):
+                    feed_error = 'Too Many Redirects'
+                else:
+                    if 'NameResolutionError' in str(e):
+                        feed_error = 'Failed to Resolve'
+                    else:
+                        feed_error = 'Connection Error'
+
             return {
                 'error': feed_error,
             }


### PR DESCRIPTION
### Fixes: #13956

Improved error handling in the get_feed() method to provide a more descriptive error message when NetBox is unable to connect to the feed server. Instead of returning the original exception, we now return a custom error message for better clarity and security.

Changing the error message when NetBox is unable to connect to feed server to 'NetBox is unable to connect to feed server...', instead to show the error exception variable content

