### PR TITLE
Fixes #13064: Ensure unchecked checkboxes do not revert to original values upon HTMX form refresh

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -355,6 +355,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.humanize',
+    'django.forms',
     'corsheaders',
     'debug_toolbar',
     'graphiql_debug_toolbar',
@@ -429,6 +430,9 @@ TEMPLATES = [
         },
     },
 ]
+
+# This allows us to override Django's stock form widget templates
+FORM_RENDERER = 'django.forms.renderers.TemplatesSetting'
 
 # Set up authentication backends
 if type(REMOTE_AUTH_BACKEND) not in (list, tuple):

--- a/netbox/templates/django/forms/widgets/checkbox.html
+++ b/netbox/templates/django/forms/widgets/checkbox.html
@@ -1,0 +1,6 @@
+{% comment %}
+  Include a hidden field of the same name to ensure that unchecked checkboxes
+  are always included in the submitted form data.
+{% endcomment %}
+<input type="hidden" name="{{ widget.name }}" value="">
+{% include "django/forms/widgets/input.html" %}


### PR DESCRIPTION
### Fixes: #13064

- Set `FORM_RENDERER` to `TemplatesSetting`, which allows overriding Django's stock form widget HTML templates
- Embed a hidden form element above each checkbox widget to ensure an empty field value is sent for unchecked checkboxes as part of the form data
