### PR TITLE
Adds selection custom field labels to UI

### DIFF
--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -232,6 +232,11 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
             return self.choice_set.choices
         return []
 
+    def get_choice_label(self, value):
+        if not hasattr(self, '_choice_map'):
+            self._choice_map = dict(self.choices)
+        return self._choice_map.get(value, value)
+
     def populate_initial_data(self, content_types):
         """
         Populate initial custom field data upon either a) the creation of a new CustomField, or

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -483,8 +483,10 @@ class CustomFieldColumn(tables.Column):
             return mark_safe('<i class="mdi mdi-close-thick text-danger"></i>')
         if self.customfield.type == CustomFieldTypeChoices.TYPE_URL:
             return mark_safe(f'<a href="{escape(value)}">{escape(value)}</a>')
+        if self.customfield.type == CustomFieldTypeChoices.TYPE_SELECT:
+            return self.customfield.get_choice_label(value)
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
-            return ', '.join(v for v in value)
+            return ', '.join(self.customfield.get_choice_label(v) for v in value)
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
             return mark_safe(', '.join(
                 self._linkify_item(obj) for obj in self.customfield.deserialize(value)

--- a/netbox/utilities/templatetags/builtins/tags.py
+++ b/netbox/utilities/templatetags/builtins/tags.py
@@ -1,6 +1,7 @@
 from django import template
 from django.http import QueryDict
 
+from extras.choices import CustomFieldTypeChoices
 from utilities.utils import dict_to_querydict
 
 __all__ = (
@@ -38,6 +39,11 @@ def customfield_value(customfield, value):
         customfield: A CustomField instance
         value: The custom field value applied to an object
     """
+    if value:
+        if customfield.type == CustomFieldTypeChoices.TYPE_SELECT:
+            value = customfield.get_choice_label(value)
+        elif customfield.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
+            value = [customfield.get_choice_label(v) for v in value]
     return {
         'customfield': customfield,
         'value': value,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #13950

<!--
    Please include a summary of the proposed changes below.
-->
Adds a function to the `CustomField` model to get the choice label for a given value, defaulting to the passed value if one cannot be found. Updates the `customfield_value` template tag to leverage the new function, as I could not find a way to call a function with an argument in the template without registering a new tag anyway. Updates the `render` function of the `CustomFieldColumn` class to leverage the new function, so that table columns are rendered properly. Please let me know if there is anywhere else in the UI where custom field values are rendered that I might have missed.