### PR TITLE
14033 raise validation error if A and B term go to same object

### DIFF
--- a/netbox/dcim/forms/connections.py
+++ b/netbox/dcim/forms/connections.py
@@ -103,4 +103,10 @@ def get_cable_form(a_type, b_type):
             self.instance.a_terminations = self.cleaned_data['a_terminations']
             self.instance.b_terminations = self.cleaned_data['b_terminations']
 
+            if a_type == b_type and self.instance.a_terminations and self.instance.b_terminations:
+                if self.instance.a_terminations.intersection(self.instance.b_terminations):
+                    raise forms.ValidationError(
+                        _("A and B terminations cannot connect to the same object.")
+                    )
+
     return _CableForm

--- a/netbox/dcim/forms/connections.py
+++ b/netbox/dcim/forms/connections.py
@@ -103,10 +103,4 @@ def get_cable_form(a_type, b_type):
             self.instance.a_terminations = self.cleaned_data['a_terminations']
             self.instance.b_terminations = self.cleaned_data['b_terminations']
 
-            if a_type == b_type and self.instance.a_terminations and self.instance.b_terminations:
-                if self.instance.a_terminations.intersection(self.instance.b_terminations):
-                    raise forms.ValidationError(
-                        _("A and B terminations cannot connect to the same object.")
-                    )
-
     return _CableForm

--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -181,7 +181,12 @@ class Cable(PrimaryModel):
                     raise ValidationError(f"Incompatible termination types: {a_type} and {b_type}")
 
                 if a_type == b_type:
-                    if (set(self.a_terminations) & set(self.b_terminations)):
+                    # can't directly use self.a_terminations here as possible they
+                    # don't have pk yet
+                    a_pks = set(obj.pk for obj in self.a_terminations if obj.pk)
+                    b_pks = set(obj.pk for obj in self.b_terminations if obj.pk)
+
+                    if (a_pks & b_pks):
                         raise ValidationError(
                             _("A and B terminations cannot connect to the same object.")
                         )

--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -180,6 +180,12 @@ class Cable(PrimaryModel):
                 if b_type not in COMPATIBLE_TERMINATION_TYPES.get(a_type):
                     raise ValidationError(f"Incompatible termination types: {a_type} and {b_type}")
 
+                if a_type == b_type:
+                    if (set(self.a_terminations) & set(self.b_terminations)):
+                        raise ValidationError(
+                            _("A and B terminations cannot connect to the same object.")
+                        )
+
             # Run clean() on any new CableTerminations
             for termination in self.a_terminations:
                 CableTermination(cable=self, cable_end='A', termination=termination).clean()


### PR DESCRIPTION
### Fixes: #14033 

On cable creation, don't allow cables to have A and B terminations pointing to the same object.
