### PR TITLE
Closes #13550: Refactor view action mappings

### DIFF
--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -100,7 +100,9 @@ class DataFileListView(generic.ObjectListView):
     filterset = filtersets.DataFileFilterSet
     filterset_form = forms.DataFileFilterForm
     table = tables.DataFileTable
-    actions = ('bulk_delete',)
+    actions = {
+        'bulk_delete': {'delete'},
+    }
 
 
 @register_model_view(DataFile)
@@ -128,7 +130,10 @@ class JobListView(generic.ObjectListView):
     filterset = filtersets.JobFilterSet
     filterset_form = forms.JobFilterForm
     table = tables.JobTable
-    actions = ('export', 'delete', 'bulk_delete')
+    actions = {
+        'export': set(),
+        'bulk_delete': {'delete'},
+    }
 
 
 class JobView(generic.ObjectView):

--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -131,7 +131,7 @@ class JobListView(generic.ObjectListView):
     filterset_form = forms.JobFilterForm
     table = tables.JobTable
     actions = {
-        'export': set(),
+        'export': {'view'},
         'bulk_delete': {'delete'},
     }
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -20,6 +20,7 @@ from circuits.models import Circuit, CircuitTermination
 from extras.views import ObjectConfigContextView
 from ipam.models import ASN, IPAddress, Prefix, VLAN, VLANGroup
 from ipam.tables import InterfaceVLANTable
+from netbox.constants import DEFAULT_ACTION_PERMISSIONS
 from netbox.views import generic
 from tenancy.views import ObjectContactsView
 from utilities.forms import ConfirmationForm
@@ -47,11 +48,7 @@ CABLE_TERMINATION_TYPES = {
 
 class DeviceComponentsView(generic.ObjectChildrenView):
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
         'bulk_disconnect': {'change'},
     }
@@ -1978,11 +1975,7 @@ class DeviceModuleBaysView(DeviceComponentsView):
     filterset = filtersets.ModuleBayFilterSet
     template_name = 'dcim/device/modulebays.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
     tab = ViewTab(
@@ -2001,11 +1994,7 @@ class DeviceDeviceBaysView(DeviceComponentsView):
     filterset = filtersets.DeviceBayFilterSet
     template_name = 'dcim/device/devicebays.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
     tab = ViewTab(
@@ -2024,11 +2013,7 @@ class DeviceInventoryView(DeviceComponentsView):
     filterset = filtersets.InventoryItemFilterSet
     template_name = 'dcim/device/inventory.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
     tab = ViewTab(
@@ -2209,11 +2194,7 @@ class ConsolePortListView(generic.ObjectListView):
     table = tables.ConsolePortTable
     template_name = 'dcim/component_list.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
 
@@ -2281,11 +2262,7 @@ class ConsoleServerPortListView(generic.ObjectListView):
     table = tables.ConsoleServerPortTable
     template_name = 'dcim/component_list.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
 
@@ -2353,11 +2330,7 @@ class PowerPortListView(generic.ObjectListView):
     table = tables.PowerPortTable
     template_name = 'dcim/component_list.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
 
@@ -2425,11 +2398,7 @@ class PowerOutletListView(generic.ObjectListView):
     table = tables.PowerOutletTable
     template_name = 'dcim/component_list.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
 
@@ -2497,11 +2466,7 @@ class InterfaceListView(generic.ObjectListView):
     table = tables.InterfaceTable
     template_name = 'dcim/component_list.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
 
@@ -2617,11 +2582,7 @@ class FrontPortListView(generic.ObjectListView):
     table = tables.FrontPortTable
     template_name = 'dcim/component_list.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
 
@@ -2689,11 +2650,7 @@ class RearPortListView(generic.ObjectListView):
     table = tables.RearPortTable
     template_name = 'dcim/component_list.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
 
@@ -2761,11 +2718,7 @@ class ModuleBayListView(generic.ObjectListView):
     table = tables.ModuleBayTable
     template_name = 'dcim/component_list.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
 
@@ -2825,11 +2778,7 @@ class DeviceBayListView(generic.ObjectListView):
     table = tables.DeviceBayTable
     template_name = 'dcim/component_list.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
 
@@ -2958,11 +2907,7 @@ class InventoryItemListView(generic.ObjectListView):
     table = tables.InventoryItemTable
     template_name = 'dcim/component_list.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -49,7 +49,7 @@ class DeviceComponentsView(generic.ObjectChildrenView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -1980,7 +1980,7 @@ class DeviceModuleBaysView(DeviceComponentsView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -2003,7 +2003,7 @@ class DeviceDeviceBaysView(DeviceComponentsView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -2026,7 +2026,7 @@ class DeviceInventoryView(DeviceComponentsView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -2211,7 +2211,7 @@ class ConsolePortListView(generic.ObjectListView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -2283,7 +2283,7 @@ class ConsoleServerPortListView(generic.ObjectListView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -2355,7 +2355,7 @@ class PowerPortListView(generic.ObjectListView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -2427,7 +2427,7 @@ class PowerOutletListView(generic.ObjectListView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -2499,7 +2499,7 @@ class InterfaceListView(generic.ObjectListView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -2619,7 +2619,7 @@ class FrontPortListView(generic.ObjectListView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -2691,7 +2691,7 @@ class RearPortListView(generic.ObjectListView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -2763,7 +2763,7 @@ class ModuleBayListView(generic.ObjectListView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -2827,7 +2827,7 @@ class DeviceBayListView(generic.ObjectListView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -2960,7 +2960,7 @@ class InventoryItemListView(generic.ObjectListView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
@@ -3198,7 +3198,7 @@ class CableListView(generic.ObjectListView):
     table = tables.CableTable
     actions = {
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
     }
@@ -3296,7 +3296,7 @@ class ConsoleConnectionsListView(generic.ObjectListView):
     table = tables.ConsoleConnectionTable
     template_name = 'dcim/connections_list.html'
     actions = {
-        'export': set(),
+        'export': {'view'},
     }
 
     def get_extra_context(self, request):
@@ -3312,7 +3312,7 @@ class PowerConnectionsListView(generic.ObjectListView):
     table = tables.PowerConnectionTable
     template_name = 'dcim/connections_list.html'
     actions = {
-        'export': set(),
+        'export': {'view'},
     }
 
     def get_extra_context(self, request):
@@ -3328,7 +3328,7 @@ class InterfaceConnectionsListView(generic.ObjectListView):
     table = tables.InterfaceConnectionTable
     template_name = 'dcim/connections_list.html'
     actions = {
-        'export': set(),
+        'export': {'view'},
     }
 
     def get_extra_context(self, request):

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -46,15 +46,15 @@ CABLE_TERMINATION_TYPES = {
 
 
 class DeviceComponentsView(generic.ObjectChildrenView):
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename', 'bulk_disconnect')
-    action_perms = defaultdict(set, **{
+    actions = {
         'add': {'add'},
         'import': {'add'},
+        'export': set(),
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
         'bulk_disconnect': {'change'},
-    })
+    }
     queryset = Device.objects.all()
 
     def get_children(self, request, parent):
@@ -2187,14 +2187,14 @@ class ConsolePortListView(generic.ObjectListView):
     filterset_form = forms.ConsolePortFilterForm
     table = tables.ConsolePortTable
     template_name = 'dcim/component_list.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
-    action_perms = defaultdict(set, **{
+    actions = {
         'add': {'add'},
         'import': {'add'},
+        'export': set(),
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
-    })
+    }
 
 
 @register_model_view(ConsolePort)
@@ -2259,14 +2259,14 @@ class ConsoleServerPortListView(generic.ObjectListView):
     filterset_form = forms.ConsoleServerPortFilterForm
     table = tables.ConsoleServerPortTable
     template_name = 'dcim/component_list.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
-    action_perms = defaultdict(set, **{
+    actions = {
         'add': {'add'},
         'import': {'add'},
+        'export': set(),
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
-    })
+    }
 
 
 @register_model_view(ConsoleServerPort)
@@ -2331,14 +2331,14 @@ class PowerPortListView(generic.ObjectListView):
     filterset_form = forms.PowerPortFilterForm
     table = tables.PowerPortTable
     template_name = 'dcim/component_list.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
-    action_perms = defaultdict(set, **{
+    actions = {
         'add': {'add'},
         'import': {'add'},
+        'export': set(),
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
-    })
+    }
 
 
 @register_model_view(PowerPort)
@@ -2403,14 +2403,14 @@ class PowerOutletListView(generic.ObjectListView):
     filterset_form = forms.PowerOutletFilterForm
     table = tables.PowerOutletTable
     template_name = 'dcim/component_list.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
-    action_perms = defaultdict(set, **{
+    actions = {
         'add': {'add'},
         'import': {'add'},
+        'export': set(),
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
-    })
+    }
 
 
 @register_model_view(PowerOutlet)
@@ -2475,14 +2475,14 @@ class InterfaceListView(generic.ObjectListView):
     filterset_form = forms.InterfaceFilterForm
     table = tables.InterfaceTable
     template_name = 'dcim/component_list.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
-    action_perms = defaultdict(set, **{
+    actions = {
         'add': {'add'},
         'import': {'add'},
+        'export': set(),
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
-    })
+    }
 
 
 @register_model_view(Interface)
@@ -2595,14 +2595,14 @@ class FrontPortListView(generic.ObjectListView):
     filterset_form = forms.FrontPortFilterForm
     table = tables.FrontPortTable
     template_name = 'dcim/component_list.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
-    action_perms = defaultdict(set, **{
+    actions = {
         'add': {'add'},
         'import': {'add'},
+        'export': set(),
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
-    })
+    }
 
 
 @register_model_view(FrontPort)
@@ -2667,14 +2667,14 @@ class RearPortListView(generic.ObjectListView):
     filterset_form = forms.RearPortFilterForm
     table = tables.RearPortTable
     template_name = 'dcim/component_list.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
-    action_perms = defaultdict(set, **{
+    actions = {
         'add': {'add'},
         'import': {'add'},
+        'export': set(),
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
-    })
+    }
 
 
 @register_model_view(RearPort)
@@ -2739,14 +2739,14 @@ class ModuleBayListView(generic.ObjectListView):
     filterset_form = forms.ModuleBayFilterForm
     table = tables.ModuleBayTable
     template_name = 'dcim/component_list.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
-    action_perms = defaultdict(set, **{
+    actions = {
         'add': {'add'},
         'import': {'add'},
+        'export': set(),
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
-    })
+    }
 
 
 @register_model_view(ModuleBay)
@@ -2803,14 +2803,14 @@ class DeviceBayListView(generic.ObjectListView):
     filterset_form = forms.DeviceBayFilterForm
     table = tables.DeviceBayTable
     template_name = 'dcim/component_list.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
-    action_perms = defaultdict(set, **{
+    actions = {
         'add': {'add'},
         'import': {'add'},
+        'export': set(),
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
-    })
+    }
 
 
 @register_model_view(DeviceBay)
@@ -2936,14 +2936,14 @@ class InventoryItemListView(generic.ObjectListView):
     filterset_form = forms.InventoryItemFilterForm
     table = tables.InventoryItemTable
     template_name = 'dcim/component_list.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
-    action_perms = defaultdict(set, **{
+    actions = {
         'add': {'add'},
         'import': {'add'},
+        'export': set(),
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},
-    })
+    }
 
 
 @register_model_view(InventoryItem)

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1977,7 +1977,14 @@ class DeviceModuleBaysView(DeviceComponentsView):
     table = tables.DeviceModuleBayTable
     filterset = filtersets.ModuleBayFilterSet
     template_name = 'dcim/device/modulebays.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
+    actions = {
+        'add': {'add'},
+        'import': {'add'},
+        'export': set(),
+        'bulk_edit': {'change'},
+        'bulk_delete': {'delete'},
+        'bulk_rename': {'change'},
+    }
     tab = ViewTab(
         label=_('Module Bays'),
         badge=lambda obj: obj.module_bay_count,
@@ -1993,7 +2000,14 @@ class DeviceDeviceBaysView(DeviceComponentsView):
     table = tables.DeviceDeviceBayTable
     filterset = filtersets.DeviceBayFilterSet
     template_name = 'dcim/device/devicebays.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
+    actions = {
+        'add': {'add'},
+        'import': {'add'},
+        'export': set(),
+        'bulk_edit': {'change'},
+        'bulk_delete': {'delete'},
+        'bulk_rename': {'change'},
+    }
     tab = ViewTab(
         label=_('Device Bays'),
         badge=lambda obj: obj.device_bay_count,
@@ -2005,11 +2019,18 @@ class DeviceDeviceBaysView(DeviceComponentsView):
 
 @register_model_view(Device, 'inventory')
 class DeviceInventoryView(DeviceComponentsView):
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
     child_model = InventoryItem
     table = tables.DeviceInventoryItemTable
     filterset = filtersets.InventoryItemFilterSet
     template_name = 'dcim/device/inventory.html'
+    actions = {
+        'add': {'add'},
+        'import': {'add'},
+        'export': set(),
+        'bulk_edit': {'change'},
+        'bulk_delete': {'delete'},
+        'bulk_rename': {'change'},
+    }
     tab = ViewTab(
         label=_('Inventory Items'),
         badge=lambda obj: obj.inventory_item_count,
@@ -3175,7 +3196,12 @@ class CableListView(generic.ObjectListView):
     filterset = filtersets.CableFilterSet
     filterset_form = forms.CableFilterForm
     table = tables.CableTable
-    actions = ('import', 'export', 'bulk_edit', 'bulk_delete')
+    actions = {
+        'import': {'add'},
+        'export': set(),
+        'bulk_edit': {'change'},
+        'bulk_delete': {'delete'},
+    }
 
 
 @register_model_view(Cable)
@@ -3269,7 +3295,9 @@ class ConsoleConnectionsListView(generic.ObjectListView):
     filterset_form = forms.ConsoleConnectionFilterForm
     table = tables.ConsoleConnectionTable
     template_name = 'dcim/connections_list.html'
-    actions = ('export',)
+    actions = {
+        'export': set(),
+    }
 
     def get_extra_context(self, request):
         return {
@@ -3283,7 +3311,9 @@ class PowerConnectionsListView(generic.ObjectListView):
     filterset_form = forms.PowerConnectionFilterForm
     table = tables.PowerConnectionTable
     template_name = 'dcim/connections_list.html'
-    actions = ('export',)
+    actions = {
+        'export': set(),
+    }
 
     def get_extra_context(self, request):
         return {
@@ -3297,7 +3327,9 @@ class InterfaceConnectionsListView(generic.ObjectListView):
     filterset_form = forms.InterfaceConnectionFilterForm
     table = tables.InterfaceConnectionTable
     template_name = 'dcim/connections_list.html'
-    actions = ('export',)
+    actions = {
+        'export': set(),
+    }
 
     def get_extra_context(self, request):
         return {

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -16,6 +16,7 @@ from core.tables import JobTable
 from extras.dashboard.forms import DashboardWidgetAddForm, DashboardWidgetForm
 from extras.dashboard.utils import get_widget_class
 from netbox.config import get_config, PARAMS
+from netbox.constants import DEFAULT_ACTION_PERMISSIONS
 from netbox.views import generic
 from utilities.forms import ConfirmationForm, get_field_value
 from utilities.htmx import is_htmx
@@ -211,11 +212,7 @@ class ExportTemplateListView(generic.ObjectListView):
     table = tables.ExportTemplateTable
     template_name = 'extras/exporttemplate_list.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_sync': {'sync'},
     }
 
@@ -589,11 +586,7 @@ class ConfigTemplateListView(generic.ObjectListView):
     table = tables.ConfigTemplateTable
     template_name = 'extras/configtemplate_list.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_sync': {'sync'},
     }
 

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -213,10 +213,10 @@ class ExportTemplateListView(generic.ObjectListView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
-        'bulk_sync': set(),
+        'bulk_sync': {'sync'},
     }
 
 
@@ -483,7 +483,7 @@ class ConfigContextListView(generic.ObjectListView):
         'add': {'add'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
-        'bulk_sync': set(),
+        'bulk_sync': {'sync'},
     }
 
 
@@ -591,10 +591,10 @@ class ConfigTemplateListView(generic.ObjectListView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
-        'bulk_sync': set(),
+        'bulk_sync': {'sync'},
     }
 
 
@@ -647,7 +647,7 @@ class ObjectChangeListView(generic.ObjectListView):
     table = tables.ObjectChangeTable
     template_name = 'extras/objectchange_list.html'
     actions = {
-        'export': set(),
+        'export': {'view'},
     }
 
 
@@ -715,7 +715,7 @@ class ImageAttachmentListView(generic.ObjectListView):
     filterset_form = forms.ImageAttachmentFilterForm
     table = tables.ImageAttachmentTable
     actions = {
-        'export': set(),
+        'export': {'view'},
     }
 
 
@@ -761,7 +761,7 @@ class JournalEntryListView(generic.ObjectListView):
     table = tables.JournalEntryTable
     actions = {
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
     }

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -210,7 +210,14 @@ class ExportTemplateListView(generic.ObjectListView):
     filterset_form = forms.ExportTemplateFilterForm
     table = tables.ExportTemplateTable
     template_name = 'extras/exporttemplate_list.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_sync')
+    actions = {
+        'add': {'add'},
+        'import': {'add'},
+        'export': set(),
+        'bulk_edit': {'change'},
+        'bulk_delete': {'delete'},
+        'bulk_sync': set(),
+    }
 
 
 @register_model_view(ExportTemplate)
@@ -472,7 +479,12 @@ class ConfigContextListView(generic.ObjectListView):
     filterset_form = forms.ConfigContextFilterForm
     table = tables.ConfigContextTable
     template_name = 'extras/configcontext_list.html'
-    actions = ('add', 'bulk_edit', 'bulk_delete', 'bulk_sync')
+    actions = {
+        'add': {'add'},
+        'bulk_edit': {'change'},
+        'bulk_delete': {'delete'},
+        'bulk_sync': set(),
+    }
 
 
 @register_model_view(ConfigContext)
@@ -576,7 +588,14 @@ class ConfigTemplateListView(generic.ObjectListView):
     filterset_form = forms.ConfigTemplateFilterForm
     table = tables.ConfigTemplateTable
     template_name = 'extras/configtemplate_list.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_sync')
+    actions = {
+        'add': {'add'},
+        'import': {'add'},
+        'export': set(),
+        'bulk_edit': {'change'},
+        'bulk_delete': {'delete'},
+        'bulk_sync': set(),
+    }
 
 
 @register_model_view(ConfigTemplate)
@@ -627,7 +646,9 @@ class ObjectChangeListView(generic.ObjectListView):
     filterset_form = forms.ObjectChangeFilterForm
     table = tables.ObjectChangeTable
     template_name = 'extras/objectchange_list.html'
-    actions = ('export',)
+    actions = {
+        'export': set(),
+    }
 
 
 @register_model_view(ObjectChange)
@@ -693,7 +714,9 @@ class ImageAttachmentListView(generic.ObjectListView):
     filterset = filtersets.ImageAttachmentFilterSet
     filterset_form = forms.ImageAttachmentFilterForm
     table = tables.ImageAttachmentTable
-    actions = ('export',)
+    actions = {
+        'export': set(),
+    }
 
 
 @register_model_view(ImageAttachment, 'edit')
@@ -736,7 +759,12 @@ class JournalEntryListView(generic.ObjectListView):
     filterset = filtersets.JournalEntryFilterSet
     filterset_form = forms.JournalEntryFilterForm
     table = tables.JournalEntryTable
-    actions = ('import', 'export', 'bulk_edit', 'bulk_delete')
+    actions = {
+        'import': {'add'},
+        'export': set(),
+        'bulk_edit': {'change'},
+        'bulk_delete': {'delete'},
+    }
 
 
 @register_model_view(JournalEntry)

--- a/netbox/netbox/constants.py
+++ b/netbox/netbox/constants.py
@@ -27,3 +27,12 @@ ADVISORY_LOCK_KEYS = {
     'inventoryitem': 105700,
     'inventoryitemtemplate': 105800,
 }
+
+# Default view action permission mapping
+DEFAULT_ACTION_PERMISSIONS = {
+    'add': {'add'},
+    'import': {'add'},
+    'export': {'view'},
+    'bulk_edit': {'change'},
+    'bulk_delete': {'delete'},
+}

--- a/netbox/netbox/views/generic/mixins.py
+++ b/netbox/netbox/views/generic/mixins.py
@@ -1,5 +1,6 @@
 import warnings
 
+from netbox.constants import DEFAULT_ACTION_PERMISSIONS
 from utilities.permissions import get_permission_for_model
 
 __all__ = (
@@ -9,14 +10,15 @@ __all__ = (
 
 
 class ActionsMixin:
-    # Map action names to the set of required permissions for each
-    actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
-    }
+    """
+    Maps action names to the set of required permissions for each. Object list views reference this mapping to
+    determine whether to render the applicable button for each action: The button will be rendered only if the user
+    possesses the specified permission(s).
+
+    Standard actions include: add, import, export, bulk_edit, and bulk_delete. Some views extend this default map
+    with custom actions, such as bulk_sync.
+    """
+    actions = DEFAULT_ACTION_PERMISSIONS
 
     def get_permitted_actions(self, user, model=None):
         """

--- a/netbox/netbox/views/generic/mixins.py
+++ b/netbox/netbox/views/generic/mixins.py
@@ -12,7 +12,7 @@ class ActionsMixin:
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
     }

--- a/netbox/netbox/views/generic/mixins.py
+++ b/netbox/netbox/views/generic/mixins.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from utilities.permissions import get_permission_for_model
 
 __all__ = (
@@ -9,6 +7,7 @@ __all__ = (
 
 
 class ActionsMixin:
+    # Map action names to the set of required permissions for each
     actions = {
         'add': {'add'},
         'import': {'add'},

--- a/netbox/netbox/views/generic/mixins.py
+++ b/netbox/netbox/views/generic/mixins.py
@@ -1,3 +1,5 @@
+import warnings
+
 from utilities.permissions import get_permission_for_model
 
 __all__ = (
@@ -24,12 +26,16 @@ class ActionsMixin:
 
         # TODO: Remove backward compatibility in Netbox v4.0
         # Determine how permissions are being mapped to actions for the view
-        if type(self.actions) is dict:
-            # New actions format (3.7+)
-            permissions_map = self.actions
-        elif hasattr(self, 'action_perms'):
+        if hasattr(self, 'action_perms'):
             # Backward compatibility for <3.7
             permissions_map = self.action_perms
+            warnings.warn(
+                "Setting action_perms on views is deprecated and will be removed in NetBox v4.0. Use actions instead.",
+                DeprecationWarning
+            )
+        elif type(self.actions) is dict:
+            # New actions format (3.7+)
+            permissions_map = self.actions
         else:
             # actions is still defined as a list or tuple (<3.7) but no custom mapping is defined; use the old
             # default mapping
@@ -39,6 +45,11 @@ class ActionsMixin:
                 'bulk_edit': {'change'},
                 'bulk_delete': {'delete'},
             }
+            warnings.warn(
+                "View actions should be defined as a dictionary mapping. Support for the legacy list format will be "
+                "removed in NetBox v4.0.",
+                DeprecationWarning
+            )
 
         # Resolve required permissions for each action
         permitted_actions = []

--- a/netbox/tenancy/views.py
+++ b/netbox/tenancy/views.py
@@ -387,7 +387,7 @@ class ContactAssignmentListView(generic.ObjectListView):
     filterset_form = forms.ContactAssignmentFilterForm
     table = tables.ContactAssignmentTable
     actions = {
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
     }

--- a/netbox/tenancy/views.py
+++ b/netbox/tenancy/views.py
@@ -386,7 +386,11 @@ class ContactAssignmentListView(generic.ObjectListView):
     filterset = filtersets.ContactAssignmentFilterSet
     filterset_form = forms.ContactAssignmentFilterForm
     table = tables.ContactAssignmentTable
-    actions = ('export', 'bulk_edit', 'bulk_delete')
+    actions = {
+        'export': set(),
+        'bulk_edit': {'change'},
+        'bulk_delete': {'delete'},
+    }
 
 
 @register_model_view(ContactAssignment, 'edit')

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -202,7 +202,7 @@ class ClusterDevicesView(generic.ObjectChildrenView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_remove_devices': {'change'},
     }
@@ -362,7 +362,7 @@ class VirtualMachineInterfacesView(generic.ObjectChildrenView):
     actions = {
         'add': {'add'},
         'import': {'add'},
-        'export': set(),
+        'export': {'view'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
         'bulk_rename': {'change'},

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -16,6 +16,7 @@ from dcim.tables import DeviceTable
 from extras.views import ObjectConfigContextView
 from ipam.models import IPAddress
 from ipam.tables import InterfaceVLANTable
+from netbox.constants import DEFAULT_ACTION_PERMISSIONS
 from netbox.views import generic
 from tenancy.views import ObjectContactsView
 from utilities.utils import count_related
@@ -360,11 +361,7 @@ class VirtualMachineInterfacesView(generic.ObjectChildrenView):
     filterset = filtersets.VMInterfaceFilterSet
     template_name = 'virtualization/virtualmachine/interfaces.html'
     actions = {
-        'add': {'add'},
-        'import': {'add'},
-        'export': {'view'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
+        **DEFAULT_ACTION_PERMISSIONS,
         'bulk_rename': {'change'},
     }
     tab = ViewTab(

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -199,13 +199,13 @@ class ClusterDevicesView(generic.ObjectChildrenView):
     table = DeviceTable
     filterset = DeviceFilterSet
     template_name = 'virtualization/cluster/devices.html'
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_remove_devices')
-    action_perms = defaultdict(set, **{
+    actions = {
         'add': {'add'},
         'import': {'add'},
+        'export': set(),
         'bulk_edit': {'change'},
         'bulk_remove_devices': {'change'},
-    })
+    }
     tab = ViewTab(
         label=_('Devices'),
         badge=lambda obj: obj.devices.count(),
@@ -359,20 +359,20 @@ class VirtualMachineInterfacesView(generic.ObjectChildrenView):
     table = tables.VirtualMachineVMInterfaceTable
     filterset = filtersets.VMInterfaceFilterSet
     template_name = 'virtualization/virtualmachine/interfaces.html'
+    actions = {
+        'add': {'add'},
+        'import': {'add'},
+        'export': set(),
+        'bulk_edit': {'change'},
+        'bulk_delete': {'delete'},
+        'bulk_rename': {'change'},
+    }
     tab = ViewTab(
         label=_('Interfaces'),
         badge=lambda obj: obj.interface_count,
         permission='virtualization.view_vminterface',
         weight=500
     )
-    actions = ('add', 'import', 'export', 'bulk_edit', 'bulk_delete', 'bulk_rename')
-    action_perms = defaultdict(set, **{
-        'add': {'add'},
-        'import': {'add'},
-        'bulk_edit': {'change'},
-        'bulk_delete': {'delete'},
-        'bulk_rename': {'change'},
-    })
 
     def get_children(self, request, parent):
         return parent.interfaces.restrict(request.user, 'view').prefetch_related(


### PR DESCRIPTION
### Closes: #13550

- Delete `action_perms` map from ActionsMixin
- Convert `actions` from a tuple to a dictionary mapping
- Normalize permissions for all actions (every action should require at least one permission)
- Ensure backward compatibility for plugins
