### PR TITLE
14044 handle bulk rename if None name

### DIFF
--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -689,14 +689,19 @@ class BulkRenameView(GetReturnURLMixin, BaseMultiObjectView):
 
             find = form.cleaned_data['find']
             replace = form.cleaned_data['replace']
-            if form.cleaned_data['use_regex']:
-                try:
-                    obj.new_name = re.sub(find, replace, obj.name or '')
-                # Catch regex group reference errors
-                except re.error:
-                    obj.new_name = obj.name
+            if obj.name:
+                if form.cleaned_data['use_regex']:
+                    try:
+                        obj.new_name = re.sub(find, replace, obj.name or '')
+                    # Catch regex group reference errors
+                    except re.error:
+                        obj.new_name = obj.name
+                else:
+                    if obj.name:
+                        obj.new_name = obj.name.replace(find, replace)
             else:
-                obj.new_name = obj.name.replace(find, replace)
+                obj.new_name = obj.name
+
             renamed_pks.append(obj.pk)
 
         return renamed_pks

--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -689,16 +689,14 @@ class BulkRenameView(GetReturnURLMixin, BaseMultiObjectView):
 
             find = form.cleaned_data['find']
             replace = form.cleaned_data['replace']
-            if obj.name:
-                if form.cleaned_data['use_regex']:
-                    try:
-                        obj.new_name = re.sub(find, replace, obj.name or '')
-                    # Catch regex group reference errors
-                    except re.error:
-                        obj.new_name = obj.name
-                else:
-                    if obj.name:
-                        obj.new_name = obj.name.replace(find, replace)
+            if obj.name and form.cleaned_data['use_regex']:
+                try:
+                    obj.new_name = re.sub(find, replace, obj.name)
+                # Catch regex group reference errors
+                except re.error:
+                    obj.new_name = obj.name
+            elif obj.name:
+                obj.new_name = obj.name.replace(find, replace)
             else:
                 obj.new_name = obj.name
 


### PR DESCRIPTION
### Fixes: #14044 

Checks if name empty for bulk_rename - put at top of procedure as there is a bug (beyond the issue) where if you use regex you get '' (instead of None) for the name which can cause postgres duplicate error if in the same site.