### PR TITLE
Closes #10244: Protection rules

### DIFF
--- a/docs/configuration/data-validation.md
+++ b/docs/configuration/data-validation.md
@@ -87,3 +87,24 @@ The following colors are supported:
 * `gray`
 * `black`
 * `white`
+
+---
+
+## PROTECTION_RULES
+
+!!! tip "Dynamic Configuration Parameter"
+
+This is a mapping of models to [custom validators](../customization/custom-validation.md) against which an object is evaluated immediately prior to its deletion. If validation fails, the object is not deleted. An example is provided below:
+
+```python
+PROTECTION_RULES = {
+    "dcim.site": [
+        {
+            "status": {
+                "eq": "decommissioning"
+            }
+        },
+        "my_plugin.validators.Validator1",
+    ]
+}
+```

--- a/docs/customization/custom-validation.md
+++ b/docs/customization/custom-validation.md
@@ -26,6 +26,8 @@ The `CustomValidator` class supports several validation types:
 * `regex`: Application of a [regular expression](https://en.wikipedia.org/wiki/Regular_expression)
 * `required`: A value must be specified
 * `prohibited`: A value must _not_ be specified
+* `eq`: A value must be equal to the specified value
+* `neq`: A value must _not_ be equal to the specified value
 
 The `min` and `max` types should be defined for numeric values, whereas `min_length`, `max_length`, and `regex` are suitable for character strings (text values). The `required` and `prohibited` validators may be used for any field, and should be passed a value of `True`.
 

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -491,7 +491,7 @@ class ConfigRevisionForm(BootstrapMixin, forms.ModelForm, metaclass=ConfigFormMe
         (_('Security'), ('ALLOWED_URL_SCHEMES',)),
         (_('Banners'), ('BANNER_LOGIN', 'BANNER_MAINTENANCE', 'BANNER_TOP', 'BANNER_BOTTOM')),
         (_('Pagination'), ('PAGINATE_COUNT', 'MAX_PAGE_SIZE')),
-        (_('Validation'), ('CUSTOM_VALIDATORS',)),
+        (_('Validation'), ('CUSTOM_VALIDATORS', 'PROTECTION_RULES')),
         (_('User Preferences'), ('DEFAULT_USER_PREFERENCES',)),
         (_('Miscellaneous'), (
             'MAINTENANCE_MODE', 'GRAPHQL_ENABLED', 'CHANGELOG_RETENTION', 'JOB_RETENTION', 'MAPS_URL',
@@ -508,6 +508,7 @@ class ConfigRevisionForm(BootstrapMixin, forms.ModelForm, metaclass=ConfigFormMe
             'BANNER_TOP': forms.Textarea(attrs={'class': 'font-monospace'}),
             'BANNER_BOTTOM': forms.Textarea(attrs={'class': 'font-monospace'}),
             'CUSTOM_VALIDATORS': forms.Textarea(attrs={'class': 'font-monospace'}),
+            'PROTECTION_RULES': forms.Textarea(attrs={'class': 'font-monospace'}),
             'comment': forms.Textarea(),
         }
 

--- a/netbox/extras/validators.py
+++ b/netbox/extras/validators.py
@@ -1,15 +1,38 @@
-from django.core.exceptions import ValidationError
 from django.core import validators
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 
 # NOTE: As this module may be imported by configuration.py, we cannot import
 # anything from NetBox itself.
+
+
+class IsEqualValidator(validators.BaseValidator):
+    """
+    Employed by CustomValidator to require a specific value.
+    """
+    message = _("Ensure this value is equal to %(limit_value)s.")
+    code = "is_equal"
+
+    def compare(self, a, b):
+        return a != b
+
+
+class IsNotEqualValidator(validators.BaseValidator):
+    """
+    Employed by CustomValidator to exclude a specific value.
+    """
+    message = _("Ensure this value does not equal %(limit_value)s.")
+    code = "is_not_equal"
+
+    def compare(self, a, b):
+        return a == b
 
 
 class IsEmptyValidator:
     """
     Employed by CustomValidator to enforce required fields.
     """
-    message = "This field must be empty."
+    message = _("This field must be empty.")
     code = 'is_empty'
 
     def __init__(self, enforce=True):
@@ -24,7 +47,7 @@ class IsNotEmptyValidator:
     """
     Employed by CustomValidator to enforce prohibited fields.
     """
-    message = "This field must not be empty."
+    message = _("This field must not be empty.")
     code = 'not_empty'
 
     def __init__(self, enforce=True):
@@ -50,6 +73,8 @@ class CustomValidator:
     :param validation_rules: A dictionary mapping object attributes to validation rules
     """
     VALIDATORS = {
+        'eq': IsEqualValidator,
+        'neq': IsNotEqualValidator,
         'min': validators.MinValueValidator,
         'max': validators.MaxValueValidator,
         'min_length': validators.MinLengthValidator,

--- a/netbox/netbox/config/parameters.py
+++ b/netbox/netbox/config/parameters.py
@@ -152,9 +152,17 @@ PARAMS = (
         description=_("Custom validation rules (JSON)"),
         field=forms.JSONField,
         field_kwargs={
-            'widget': forms.Textarea(
-                attrs={'class': 'vLargeTextField'}
-            ),
+            'widget': forms.Textarea(),
+        },
+    ),
+    ConfigParam(
+        name='PROTECTION_RULES',
+        label=_('Protection rules'),
+        default={},
+        description=_("Deletion protection rules (JSON)"),
+        field=forms.JSONField,
+        field_kwargs={
+            'widget': forms.Textarea(),
         },
     ),
 

--- a/netbox/templates/extras/configrevision.html
+++ b/netbox/templates/extras/configrevision.html
@@ -151,6 +151,10 @@
               <th scope="row">{% trans "Custom validators" %}</th>
               <td>{{ object.data.CUSTOM_VALIDATORS|placeholder }}</td>
             </tr>
+            <tr>
+              <th scope="row">{% trans "Protection rules" %}</th>
+              <td>{{ object.data.PROTECTION_RULES|placeholder }}</td>
+            </tr>
           </table>
         </div>
       </div>


### PR DESCRIPTION
### Closes: #10244

- Introduce the `PROTECTION_RULES` configuration parameter
- Refactor the `run_custom_validators()` signal handler into separate handlers for `post_clean` and `pre_delete`
- Raise `AbortRequest` when pre-delete validation fails
- Introduce `eq` (equal to) and `neq` (not equal to) validators
