### PR TITLE
Closes #14134: Display additional object attributes in global search results

### DIFF
--- a/docs/development/search.md
+++ b/docs/development/search.md
@@ -17,6 +17,7 @@ class MyModelIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('site', 'device', 'status', 'description')
 ```
 
 A SearchIndex subclass defines both its model and a list of two-tuples specifying which model fields to be indexed and the weight (precedence) associated with each. Guidance on weight assignment for fields is provided below.

--- a/docs/plugins/development/search.md
+++ b/docs/plugins/development/search.md
@@ -14,7 +14,10 @@ class MyModelIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('site', 'device', 'status', 'description')
 ```
+
+Fields listed in `display_attrs` will not be cached for search, but will be displayed alongside the object when it appears in global search results. This is helpful for conveying to the user additional information about an object.
 
 To register one or more indexes with NetBox, define a list named `indexes` at the end of this file:
 

--- a/netbox/circuits/search.py
+++ b/netbox/circuits/search.py
@@ -10,6 +10,7 @@ class CircuitIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('provider', 'provider_account', 'type', 'status', 'tenant', 'description')
 
 
 @register_search
@@ -22,6 +23,7 @@ class CircuitTerminationIndex(SearchIndex):
         ('port_speed', 2000),
         ('upstream_speed', 2000),
     )
+    display_attrs = ('circuit', 'site', 'provider_network', 'description')
 
 
 @register_search
@@ -32,6 +34,7 @@ class CircuitTypeIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('description',)
 
 
 @register_search
@@ -42,6 +45,7 @@ class ProviderIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('description',)
 
 
 class ProviderAccountIndex(SearchIndex):
@@ -51,6 +55,7 @@ class ProviderAccountIndex(SearchIndex):
         ('account', 200),
         ('comments', 5000),
     )
+    display_attrs = ('provider', 'account', 'description')
 
 
 @register_search
@@ -62,3 +67,4 @@ class ProviderNetworkIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('provider', 'service_id', 'description')

--- a/netbox/core/search.py
+++ b/netbox/core/search.py
@@ -11,6 +11,7 @@ class DataSourceIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('type', 'status', 'description')
 
 
 @register_search

--- a/netbox/dcim/search.py
+++ b/netbox/dcim/search.py
@@ -44,6 +44,7 @@ class DeviceIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('site', 'location', 'rack', 'device_type', 'description')
 
 
 @register_search
@@ -282,6 +283,7 @@ class SiteIndex(SearchIndex):
         ('shipping_address', 2000),
         ('comments', 5000),
     )
+    display_attrs = ('region', 'group', 'status', 'description')
 
 
 @register_search

--- a/netbox/dcim/search.py
+++ b/netbox/dcim/search.py
@@ -10,6 +10,7 @@ class CableIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('type', 'status', 'tenant', 'label', 'description')
 
 
 @register_search
@@ -21,6 +22,7 @@ class ConsolePortIndex(SearchIndex):
         ('description', 500),
         ('speed', 2000),
     )
+    display_attrs = ('device', 'label', 'description')
 
 
 @register_search
@@ -32,6 +34,7 @@ class ConsoleServerPortIndex(SearchIndex):
         ('description', 500),
         ('speed', 2000),
     )
+    display_attrs = ('device', 'label', 'description')
 
 
 @register_search
@@ -44,7 +47,9 @@ class DeviceIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
-    display_attrs = ('site', 'location', 'rack', 'device_type', 'description')
+    display_attrs = (
+        'site', 'location', 'rack', 'device_type', 'role', 'tenant', 'platform', 'serial', 'asset_tag', 'description',
+    )
 
 
 @register_search
@@ -55,6 +60,7 @@ class DeviceBayIndex(SearchIndex):
         ('label', 200),
         ('description', 500),
     )
+    display_attrs = ('device', 'label', 'description')
 
 
 @register_search
@@ -65,6 +71,7 @@ class DeviceRoleIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('description',)
 
 
 @register_search
@@ -76,6 +83,7 @@ class DeviceTypeIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('manufacturer', 'part_number', 'description')
 
 
 @register_search
@@ -86,6 +94,7 @@ class FrontPortIndex(SearchIndex):
         ('label', 200),
         ('description', 500),
     )
+    display_attrs = ('device', 'label', 'description')
 
 
 @register_search
@@ -100,6 +109,7 @@ class InterfaceIndex(SearchIndex):
         ('mtu', 2000),
         ('speed', 2000),
     )
+    display_attrs = ('device', 'label', 'description')
 
 
 @register_search
@@ -113,6 +123,7 @@ class InventoryItemIndex(SearchIndex):
         ('description', 500),
         ('part_id', 2000),
     )
+    display_attrs = ('device', 'manufacturer', 'part_id', 'serial', 'asset_tag', 'description')
 
 
 @register_search
@@ -123,6 +134,7 @@ class LocationIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('site', 'status', 'tenant', 'description')
 
 
 @register_search
@@ -133,6 +145,7 @@ class ManufacturerIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('description',)
 
 
 @register_search
@@ -144,6 +157,7 @@ class ModuleIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('device', 'module_bay', 'module_type', 'status', 'serial', 'asset_tag', 'description')
 
 
 @register_search
@@ -154,6 +168,7 @@ class ModuleBayIndex(SearchIndex):
         ('label', 200),
         ('description', 500),
     )
+    display_attrs = ('device', 'label', 'position', 'description')
 
 
 @register_search
@@ -165,6 +180,7 @@ class ModuleTypeIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('manufacturer', 'model', 'part_number', 'description')
 
 
 @register_search
@@ -175,6 +191,7 @@ class PlatformIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('manufacturer', 'description')
 
 
 @register_search
@@ -185,6 +202,7 @@ class PowerFeedIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('power_panel', 'rack', 'status', 'description')
 
 
 @register_search
@@ -195,6 +213,7 @@ class PowerOutletIndex(SearchIndex):
         ('label', 200),
         ('description', 500),
     )
+    display_attrs = ('device', 'label', 'description')
 
 
 @register_search
@@ -205,6 +224,7 @@ class PowerPanelIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('site', 'location', 'description')
 
 
 @register_search
@@ -217,6 +237,7 @@ class PowerPortIndex(SearchIndex):
         ('maximum_draw', 2000),
         ('allocated_draw', 2000),
     )
+    display_attrs = ('device', 'label', 'description')
 
 
 @register_search
@@ -230,6 +251,7 @@ class RackIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('site', 'location', 'facility_id', 'tenant', 'status', 'role', 'description')
 
 
 @register_search
@@ -239,6 +261,7 @@ class RackReservationIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('rack', 'tenant', 'user', 'description')
 
 
 @register_search
@@ -249,6 +272,7 @@ class RackRoleIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('device', 'label', 'description',)
 
 
 @register_search
@@ -259,6 +283,7 @@ class RearPortIndex(SearchIndex):
         ('label', 200),
         ('description', 500),
     )
+    display_attrs = ('device', 'label', 'description')
 
 
 @register_search
@@ -269,6 +294,7 @@ class RegionIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('parent', 'description')
 
 
 @register_search
@@ -294,6 +320,7 @@ class SiteGroupIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('parent', 'description')
 
 
 @register_search
@@ -305,6 +332,7 @@ class VirtualChassisIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('master', 'domain', 'description')
 
 
 @register_search
@@ -316,3 +344,4 @@ class VirtualDeviceContextIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('device', 'status', 'identifier', 'description')

--- a/netbox/extras/models/search.py
+++ b/netbox/extras/models/search.py
@@ -4,6 +4,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+from netbox.search.utils import get_indexer
 from netbox.registry import registry
 from utilities.fields import RestrictedGenericForeignKey
 from utilities.utils import content_type_identifier
@@ -61,9 +62,12 @@ class CachedValue(models.Model):
 
     @property
     def display_attrs(self):
-        indexer = registry['search'].get(content_type_identifier(self.object_type))
+        """
+        Render any display attributes associated with this search result.
+        """
+        indexer = get_indexer(self.object_type)
         attrs = {}
-        for attr in getattr(indexer, 'display_attrs', []):
+        for attr in indexer.display_attrs:
             name = self.object._meta.get_field(attr).verbose_name
             if value := getattr(self.object, attr):
                 if display_func := getattr(self.object, f'get_{attr}_display', None):

--- a/netbox/ipam/search.py
+++ b/netbox/ipam/search.py
@@ -11,6 +11,7 @@ class AggregateIndex(SearchIndex):
         ('date_added', 2000),
         ('comments', 5000),
     )
+    display_attrs = ('rir', 'tenant', 'description')
 
 
 @register_search
@@ -20,6 +21,7 @@ class ASNIndex(SearchIndex):
         ('asn', 100),
         ('description', 500),
     )
+    display_attrs = ('rir', 'tenant', 'description')
 
 
 @register_search
@@ -28,6 +30,7 @@ class ASNRangeIndex(SearchIndex):
     fields = (
         ('description', 500),
     )
+    display_attrs = ('rir', 'tenant', 'description')
 
 
 @register_search
@@ -39,6 +42,7 @@ class FHRPGroupIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('protocol', 'auth_type', 'description')
 
 
 @register_search
@@ -50,6 +54,7 @@ class IPAddressIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('vrf', 'tenant', 'status', 'role', 'description')
 
 
 @register_search
@@ -61,6 +66,7 @@ class IPRangeIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('vrf', 'tenant', 'status', 'role', 'description')
 
 
 @register_search
@@ -72,6 +78,7 @@ class L2VPNIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('type', 'identifier', 'tenant', 'description')
 
 
 @register_search
@@ -82,6 +89,7 @@ class PrefixIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('site', 'vrf', 'tenant', 'vlan', 'status', 'role', 'description')
 
 
 @register_search
@@ -92,6 +100,7 @@ class RIRIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('description',)
 
 
 @register_search
@@ -102,6 +111,7 @@ class RoleIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('description',)
 
 
 @register_search
@@ -112,6 +122,7 @@ class RouteTargetIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('tenant', 'description')
 
 
 @register_search
@@ -122,6 +133,7 @@ class ServiceIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('device', 'virtual_machine', 'description')
 
 
 @register_search
@@ -132,6 +144,7 @@ class ServiceTemplateIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('description',)
 
 
 @register_search
@@ -143,6 +156,7 @@ class VLANIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('site', 'group', 'tenant', 'status', 'role', 'description')
 
 
 @register_search
@@ -154,6 +168,7 @@ class VLANGroupIndex(SearchIndex):
         ('description', 500),
         ('max_vid', 2000),
     )
+    display_attrs = ('scope_type', 'min_vid', 'max_vid', 'description')
 
 
 @register_search
@@ -165,3 +180,4 @@ class VRFIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('rd', 'tenant', 'description')

--- a/netbox/netbox/search/__init__.py
+++ b/netbox/netbox/search/__init__.py
@@ -33,10 +33,12 @@ class SearchIndex:
         category: The label of the group under which this indexer is categorized (for form field display). If none,
             the name of the model's app will be used.
         fields: An iterable of two-tuples defining the model fields to be indexed and the weight associated with each.
+        display_attrs: An iterable of additional object attributes to include when displaying search results.
     """
     model = None
     category = None
     fields = ()
+    display_attrs = ()
 
     @staticmethod
     def get_field_type(instance, field_name):

--- a/netbox/netbox/search/utils.py
+++ b/netbox/netbox/search/utils.py
@@ -1,0 +1,14 @@
+from netbox.registry import registry
+from utilities.utils import content_type_identifier
+
+__all__ = (
+    'get_indexer',
+)
+
+
+def get_indexer(content_type):
+    """
+    Return the registered search indexer for the given ContentType.
+    """
+    ct_identifier = content_type_identifier(content_type)
+    return registry['search'].get(ct_identifier)

--- a/netbox/netbox/tables/tables.py
+++ b/netbox/netbox/tables/tables.py
@@ -15,6 +15,7 @@ from extras.choices import CustomFieldVisibilityChoices
 from netbox.tables import columns
 from utilities.paginator import EnhancedPaginator, get_paginate_count
 from utilities.utils import get_viewname, highlight_string, title
+from .template_code import *
 
 __all__ = (
     'BaseTable',
@@ -235,6 +236,10 @@ class SearchTable(tables.Table):
     )
     value = tables.Column(
         verbose_name=_('Value'),
+    )
+    attrs = columns.TemplateColumn(
+        template_code=SEARCH_RESULT_ATTRS,
+        verbose_name=_('Attributes')
     )
 
     trim_length = 30

--- a/netbox/netbox/tables/template_code.py
+++ b/netbox/netbox/tables/template_code.py
@@ -1,0 +1,5 @@
+SEARCH_RESULT_ATTRS = """
+{% for name, value in record.display_attrs.items %}
+  <span class="badge bg-secondary">{{ name|bettertitle }}: {{ value }}</span>
+{% endfor %}
+"""

--- a/netbox/netbox/tables/template_code.py
+++ b/netbox/netbox/tables/template_code.py
@@ -1,7 +1,18 @@
 SEARCH_RESULT_ATTRS = """
 {% for name, value in record.display_attrs.items %}
-  <span class="badge bg-secondary" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ name|bettertitle }}">
-    {{ value|linkify }}
+  <span class="badge bg-secondary"
+      {% if value|length > 40 %} data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ value }}"{% endif %}
+    >
+    {{ name|bettertitle }}:
+    {% with url=value.get_absolute_url %}
+      {% if url %}<a href="url">{% endif %}
+      {% if value|length > 40 %}
+        {{ value|truncatechars:"40" }}
+      {% else %}
+        {{ value }}
+      {% endif %}
+      {% if url %}</a>{% endif %}
+    {% endwith %}
   </span>
 {% endfor %}
 """

--- a/netbox/netbox/tables/template_code.py
+++ b/netbox/netbox/tables/template_code.py
@@ -1,9 +1,9 @@
 SEARCH_RESULT_ATTRS = """
 {% for name, value in record.display_attrs.items %}
   {% with url=value.get_absolute_url %}
-    <span class="badge bg-secondary">
+    <span class="badge bg-secondary" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ name|bettertitle }}">
       {% if url %}<a href="{{ url }}">{% endif %}
-      {{ name|bettertitle }}: {{ value }}
+      {{ value }}
       {% if url %}</a>{% endif %}
     </span>
   {% endwith %}

--- a/netbox/netbox/tables/template_code.py
+++ b/netbox/netbox/tables/template_code.py
@@ -1,11 +1,7 @@
 SEARCH_RESULT_ATTRS = """
 {% for name, value in record.display_attrs.items %}
-  {% with url=value.get_absolute_url %}
-    <span class="badge bg-secondary" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ name|bettertitle }}">
-      {% if url %}<a href="{{ url }}">{% endif %}
-      {{ value }}
-      {% if url %}</a>{% endif %}
-    </span>
-  {% endwith %}
+  <span class="badge bg-secondary" data-bs-toggle="tooltip" data-bs-placement="bottom" title="{{ name|bettertitle }}">
+    {{ value|linkify }}
+  </span>
 {% endfor %}
 """

--- a/netbox/netbox/tables/template_code.py
+++ b/netbox/netbox/tables/template_code.py
@@ -1,5 +1,11 @@
 SEARCH_RESULT_ATTRS = """
 {% for name, value in record.display_attrs.items %}
-  <span class="badge bg-secondary">{{ name|bettertitle }}: {{ value }}</span>
+  {% with url=value.get_absolute_url %}
+    <span class="badge bg-secondary">
+      {% if url %}<a href="{{ url }}">{% endif %}
+      {{ name|bettertitle }}: {{ value }}
+      {% if url %}</a>{% endif %}
+    </span>
+  {% endwith %}
 {% endfor %}
 """

--- a/netbox/tenancy/search.py
+++ b/netbox/tenancy/search.py
@@ -15,6 +15,7 @@ class ContactIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('group', 'title', 'phone', 'email', 'description')
 
 
 @register_search
@@ -25,6 +26,7 @@ class ContactGroupIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('description',)
 
 
 @register_search
@@ -35,6 +37,7 @@ class ContactRoleIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('description',)
 
 
 @register_search
@@ -46,6 +49,7 @@ class TenantIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('group', 'description')
 
 
 @register_search
@@ -56,3 +60,4 @@ class TenantGroupIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('description',)

--- a/netbox/virtualization/search.py
+++ b/netbox/virtualization/search.py
@@ -10,6 +10,7 @@ class ClusterIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('type', 'group', 'status', 'tenant', 'site', 'description')
 
 
 @register_search
@@ -20,6 +21,7 @@ class ClusterGroupIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('description',)
 
 
 @register_search
@@ -30,6 +32,7 @@ class ClusterTypeIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('description',)
 
 
 @register_search
@@ -40,6 +43,7 @@ class VirtualMachineIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
+    display_attrs = ('site', 'cluster', 'device', 'tenant', 'platform', 'status', 'role', 'description')
 
 
 @register_search
@@ -51,3 +55,4 @@ class VMInterfaceIndex(SearchIndex):
         ('description', 500),
         ('mtu', 2000),
     )
+    display_attrs = ('virtual_machine', 'description')

--- a/netbox/wireless/search.py
+++ b/netbox/wireless/search.py
@@ -11,6 +11,7 @@ class WirelessLANIndex(SearchIndex):
         ('auth_psk', 2000),
         ('comments', 5000),
     )
+    display_attrs = ('group', 'status', 'vlan', 'tenant', 'description')
 
 
 @register_search
@@ -21,6 +22,7 @@ class WirelessLANGroupIndex(SearchIndex):
         ('slug', 110),
         ('description', 500),
     )
+    display_attrs = ('description',)
 
 
 @register_search
@@ -32,3 +34,4 @@ class WirelessLinkIndex(SearchIndex):
         ('auth_psk', 2000),
         ('comments', 5000),
     )
+    display_attrs = ('status', 'tenant', 'description')


### PR DESCRIPTION
### Closes: #14134

- Add `display_attrs` attribute to SearchIndex
- Add `display_attrs` property on CachedValue to render object attributes
- Extend CachedValueSearchBackend to support prefetching related objects