### PR TITLE
Fix #12731: Add custom model validation from forms and serializers

### DIFF
--- a/netbox/extras/validators.py
+++ b/netbox/extras/validators.py
@@ -98,6 +98,27 @@ class CustomValidator:
         """
         return
 
+    def validate_data(self, data):
+        """
+        Custom validation method for model forms and model serializers, to be overridden by the user.
+        Validation failures should raise a ValidationError exception.
+        """
+        return
+
+    def validate_form_data(self, data):
+        """
+        Custom validation method for model forms, to be overridden by the user.
+        Validation failures should raise a ValidationError exception.
+        """
+        return self.validate_data(data)
+
+    def validate_serializer_data(self, data):
+        """
+        Custom validation method for model serializers, to be overridden by the user.
+        Validation failures should raise a ValidationError exception.
+        """
+        return self.validate_data(data)
+
     def fail(self, message, field=None):
         """
         Raise a ValidationError exception. Associate the provided message with a form/serializer field if specified.

--- a/netbox/netbox/api/serializers/base.py
+++ b/netbox/netbox/api/serializers/base.py
@@ -3,6 +3,8 @@ from rest_framework import serializers
 from drf_spectacular.utils import extend_schema_field
 from drf_spectacular.types import OpenApiTypes
 
+from netbox.signals import post_serializer_clean
+
 __all__ = (
     'BaseModelSerializer',
     'ValidatedModelSerializer',
@@ -42,5 +44,8 @@ class ValidatedModelSerializer(BaseModelSerializer):
             for k, v in attrs.items():
                 setattr(instance, k, v)
         instance.full_clean()
+
+        # Send the post_serializer_clean signal
+        post_serializer_clean.send(sender=self.Meta.model, data=data)
 
         return data

--- a/netbox/netbox/forms/base.py
+++ b/netbox/netbox/forms/base.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext_lazy as _
 from extras.choices import CustomFieldFilterLogicChoices, CustomFieldTypeChoices, CustomFieldVisibilityChoices
 from extras.forms.mixins import CustomFieldsMixin, SavedFiltersMixin, TagsMixin
 from extras.models import CustomField, Tag
+from netbox.signals import post_form_clean
 from utilities.forms import CSVModelForm
 from utilities.forms.fields import CSVModelMultipleChoiceField, DynamicModelMultipleChoiceField
 from utilities.forms.mixins import BootstrapMixin, CheckLastUpdatedMixin
@@ -54,6 +55,9 @@ class NetBoxModelForm(BootstrapMixin, CheckLastUpdatedMixin, CustomFieldsMixin, 
                 self.instance.custom_field_data[key] = None
             else:
                 self.instance.custom_field_data[key] = customfield.serialize(value)
+
+        # Send the post_form_clean signal
+        post_form_clean.send(sender=self._meta.model, data=self.cleaned_data)
 
         return super().clean()
 

--- a/netbox/netbox/signals.py
+++ b/netbox/netbox/signals.py
@@ -3,3 +3,9 @@ from django.dispatch import Signal
 
 # Signals that a model has completed its clean() method
 post_clean = Signal()
+
+# Signals that a model form has completed its clean() method
+post_form_clean = Signal()
+
+# Signals that a model serializer has completed its validate() method
+post_serializer_clean = Signal()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #12731

<!--
    Please include a summary of the proposed changes below.
-->

This allows for validation of any m2m relation like tags. The CustomValidator receives the cleaned data from the form/serializer. The model instance is not consistently available in the model forms/serializers so is omitted from both.

Note: the available fields can vary per form/serializer for a model. You should always check if a field is defined in the cleaned data. Alternatively the form/serializer class could be given to the validator to help identify the calling stack.

The patch extends the CustomValidator class with 3 validation functions, documentation is still needed.

```python
    def validate_data(self, data):                                              
        """                                                                     
        Custom validation method for model forms and model serializers, to be overridden by the user.
        Validation failures should raise a ValidationError exception.           
        """                                                                     
        return                                                                  
                                                                                
    def validate_form_data(self, data):                                         
        """                                                                     
        Custom validation method for model forms, to be overridden by the user. 
        Validation failures should raise a ValidationError exception.           
        """                                                                     
        return self.validate_data(data)                                         
                                                                                
    def validate_serializer_data(self, data):                                   
        """                                                                     
        Custom validation method for model serializers, to be overridden by the user.
        Validation failures should raise a ValidationError exception.           
        """                                                                     
        return self.validate_data(data)
```

These functions allow users to validate M2M relations with regular attributes in the form/serializer validation stage. Using this system you can make exclusive tags based on model attributes or validate combinations of M2M relations 
```python
class FooSiteValidator(CustomValidator):
    def validate_data(self, data):
        if data['name'] != 'foo':
            for tag in data['tags']:
                if tag.name == 'FOO':
                    self.fail('FOO tag is reserved for site foo', 'tags')
```