### PR TITLE
Closes #13645: Make Sentry integration optional

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -126,10 +126,6 @@ PyYAML
 # https://github.com/psf/requests/blob/main/HISTORY.md
 requests
 
-# Sentry SDK
-# https://github.com/getsentry/sentry-python/blob/master/CHANGELOG.md
-sentry-sdk
-
 # Social authentication framework
 # https://github.com/python-social-auth/social-core/blob/master/CHANGELOG.md
 social-auth-core

--- a/docs/administration/error-reporting.md
+++ b/docs/administration/error-reporting.md
@@ -4,26 +4,14 @@
 
 ### Enabling Error Reporting
 
-NetBox supports native integration with [Sentry](https://sentry.io/) for automatic error reporting. To enable this functionality, simply set `SENTRY_ENABLED` to True in `configuration.py`. Errors will be sent to a Sentry ingestor maintained by the NetBox team for analysis.
-
-```python
-SENTRY_ENABLED = True
-```
-
-### Using a Custom DSN
-
-If you prefer instead to use your own Sentry ingestor, you'll need to first create a new project under your Sentry account to represent your NetBox deployment and obtain its corresponding data source name (DSN). This looks like a URL similar to the example below:
-
-```
-https://examplePublicKey@o0.ingest.sentry.io/0
-```
-
-Once you have obtained a DSN, configure Sentry in NetBox's `configuration.py` file with the following parameters:
+NetBox supports native integration with [Sentry](https://sentry.io/) for automatic error reporting. To enable this functionality, set `SENTRY_ENABLED` to True and define your unique [data source name (DSN)](https://docs.sentry.io/product/sentry-basics/concepts/dsn-explainer/) in `configuration.py`.
 
 ```python
 SENTRY_ENABLED = True
 SENTRY_DSN = "https://examplePublicKey@o0.ingest.sentry.io/0"
 ```
+
+Setting `SENTRY_ENABLED` to False will disable the Sentry integration.
 
 ### Assigning Tags
 

--- a/docs/configuration/error-reporting.md
+++ b/docs/configuration/error-reporting.md
@@ -18,6 +18,9 @@ Default: False
 
 Set to True to enable automatic error reporting via [Sentry](https://sentry.io/).
 
+!!! note
+    The `sentry-sdk` Python package is required to enable Sentry integration.
+
 ---
 
 ## SENTRY_SAMPLE_RATE

--- a/docs/installation/3-netbox.md
+++ b/docs/installation/3-netbox.md
@@ -227,6 +227,17 @@ sudo sh -c "echo 'boto3' >> /opt/netbox/local_requirements.txt"
 !!! info
     These packages were previously required in NetBox v3.5 but now are optional.
 
+### Sentry Integration
+
+NetBox may be configured to send error reports to [Sentry](../administration/error-reporting.md) for analysis. This integration requires installation of the `sentry-sdk` Python library.
+
+```no-highlight
+sudo sh -c "echo 'sentry-sdk' >> /opt/netbox/local_requirements.txt"
+```
+
+!!! info
+    Sentry integration was previously included by default in NetBox v3.6 but is now optional.
+
 ## Run the Upgrade Script
 
 Once NetBox has been configured, we're ready to proceed with the actual installation. We'll run the packaged upgrade script (`upgrade.sh`) to perform the following actions:

--- a/netbox/netbox/views/errors.py
+++ b/netbox/netbox/views/errors.py
@@ -9,7 +9,6 @@ from django.template.exceptions import TemplateDoesNotExist
 from django.views.decorators.csrf import requires_csrf_token
 from django.views.defaults import ERROR_500_TEMPLATE_NAME, page_not_found
 from django.views.generic import View
-from sentry_sdk import capture_message
 
 from netbox.plugins.utils import get_installed_plugins
 
@@ -34,7 +33,9 @@ def handler_404(request, exception):
     """
     Wrap Django's default 404 handler to enable Sentry reporting.
     """
-    capture_message("Page not found", level="error")
+    if settings.SENTRY_ENABLED:
+        from sentry_sdk import capture_message
+        capture_message("Page not found", level="error")
 
     return page_not_found(request, exception)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ Pillow==10.1.0
 psycopg[binary,pool]==3.1.12
 PyYAML==6.0.1
 requests==2.31.0
-sentry-sdk==1.34.0
 social-auth-app-django==5.4.0
 social-auth-core[openidconnect]==4.5.0
 svgwrite==1.4.3


### PR DESCRIPTION
### Fixes: #13645

- Remove `sentry-sdk` from required packages list
- Remove default DSN (maintained by community)
- Update import statements
- Add note to installation docs
