### PR TITLE
Closes #13299: Improve options for controlling custom field visibility

### DIFF
--- a/docs/customization/custom-fields.md
+++ b/docs/customization/custom-fields.md
@@ -40,13 +40,21 @@ Related custom fields can be grouped together within the UI by assigning each th
 
 This parameter has no effect on the API representation of custom field data.
 
-### Visibility
+### Visibility & Editing
 
-When creating a custom field, there are three options for UI visibility. These control how and whether the custom field is displayed within the NetBox UI.
+!!! info "This feature was improved in NetBox v3.7."
 
-* **Read/write** (default): The custom field is included when viewing and editing objects.
-* **Read-only**: The custom field is displayed when viewing an object, but it cannot be edited via the UI. (It will appear in the form as a read-only field.)
+When creating a custom field, users can control the conditions under which it may be displayed and edited within the NetBox user interface. The following choices are available for controlling the display of a custom field on an object:
+
+* **Always** (default): The custom field is included when viewing an object.
+* **If Set**: The custom field is included only if a value has been defined for the object.
 * **Hidden**: The custom field will never be displayed within the UI. This option is recommended for fields which are not intended for use by human users.
+
+Additionally, the following options are available for controlling whether custom field values can be altered within the NetBox UI:
+
+* **Yes** (default): The custom field's value may be modified when editing an object.
+* **No**: The custom field is displayed for reference when editing an object, but its value may not be modified.
+* **Hidden**: The custom field is not displayed when editing an object.
 
 Note that this setting has no impact on the REST or GraphQL APIs: Custom field data will always be available via either API.
 

--- a/docs/models/extras/customfield.md
+++ b/docs/models/extras/customfield.md
@@ -64,16 +64,25 @@ Defines how filters are evaluated against custom field values.
 | Loose    | Match any occurrence of the value   |
 | Exact    | Match only the complete field value |
 
-### UI Visibility
+### UI Visible
 
-Controls how and whether the custom field is displayed within the NetBox user interface.
+Controls whether the custom field is displayed for objects within the NetBox user interface.
 
-| Option            | Description                                      |
-|-------------------|--------------------------------------------------|
-| Read/write        | Display and permit editing (default)             |
-| Read-only         | Display field but disallow editing               |
-| Hidden            | Do not display field in the UI                   |
-| Hidden (if unset) | Display in the UI only when a value has been set |
+| Option | Description                                                    |
+|--------|----------------------------------------------------------------|
+| Always | The field is always displayed when viewing an object (default) |
+| If set | The field is displayed only if a value has been defined        |
+| Hidden | The field is not displayed when viewing an object              |
+
+### UI Editable
+
+Controls whether the custom field is editable on objects within the NetBox user interface.
+
+| Option | Description                                                                  |
+|--------|------------------------------------------------------------------------------|
+| Yes    | The field's value may be changed when editing an object (default)            |
+| No     | The field's value is displayed when editing an object but may not be altered |
+| Hidden | The field is not displayed when editing an object                            |
 
 ### Default
 

--- a/netbox/extras/api/serializers.py
+++ b/netbox/extras/api/serializers.py
@@ -97,14 +97,16 @@ class CustomFieldSerializer(ValidatedModelSerializer):
     data_type = serializers.SerializerMethodField()
     choice_set = NestedCustomFieldChoiceSetSerializer(required=False)
     ui_visibility = ChoiceField(choices=CustomFieldVisibilityChoices, required=False)
+    ui_visible = ChoiceField(choices=CustomFieldUIVisibleChoices, required=False)
+    ui_editable = ChoiceField(choices=CustomFieldUIEditableChoices, required=False)
 
     class Meta:
         model = CustomField
         fields = [
             'id', 'url', 'display', 'content_types', 'type', 'object_type', 'data_type', 'name', 'label', 'group_name',
-            'description', 'required', 'search_weight', 'filter_logic', 'ui_visibility', 'is_cloneable', 'default',
-            'weight', 'validation_minimum', 'validation_maximum', 'validation_regex', 'choice_set', 'created',
-            'last_updated',
+            'description', 'required', 'search_weight', 'filter_logic', 'ui_visibility', 'ui_visible', 'ui_editable',
+            'is_cloneable', 'default', 'weight', 'validation_minimum', 'validation_maximum', 'validation_regex',
+            'choice_set', 'created', 'last_updated',
         ]
 
     def validate_type(self, value):

--- a/netbox/extras/api/serializers.py
+++ b/netbox/extras/api/serializers.py
@@ -96,7 +96,6 @@ class CustomFieldSerializer(ValidatedModelSerializer):
     filter_logic = ChoiceField(choices=CustomFieldFilterLogicChoices, required=False)
     data_type = serializers.SerializerMethodField()
     choice_set = NestedCustomFieldChoiceSetSerializer(required=False)
-    ui_visibility = ChoiceField(choices=CustomFieldVisibilityChoices, required=False)
     ui_visible = ChoiceField(choices=CustomFieldUIVisibleChoices, required=False)
     ui_editable = ChoiceField(choices=CustomFieldUIEditableChoices, required=False)
 
@@ -104,9 +103,9 @@ class CustomFieldSerializer(ValidatedModelSerializer):
         model = CustomField
         fields = [
             'id', 'url', 'display', 'content_types', 'type', 'object_type', 'data_type', 'name', 'label', 'group_name',
-            'description', 'required', 'search_weight', 'filter_logic', 'ui_visibility', 'ui_visible', 'ui_editable',
-            'is_cloneable', 'default', 'weight', 'validation_minimum', 'validation_maximum', 'validation_regex',
-            'choice_set', 'created', 'last_updated',
+            'description', 'required', 'search_weight', 'filter_logic', 'ui_visible', 'ui_editable', 'is_cloneable',
+            'default', 'weight', 'validation_minimum', 'validation_maximum', 'validation_regex', 'choice_set',
+            'created', 'last_updated',
         ]
 
     def validate_type(self, value):

--- a/netbox/extras/choices.py
+++ b/netbox/extras/choices.py
@@ -53,21 +53,6 @@ class CustomFieldFilterLogicChoices(ChoiceSet):
     )
 
 
-class CustomFieldVisibilityChoices(ChoiceSet):
-
-    VISIBILITY_READ_WRITE = 'read-write'
-    VISIBILITY_READ_ONLY = 'read-only'
-    VISIBILITY_HIDDEN = 'hidden'
-    VISIBILITY_HIDDEN_IFUNSET = 'hidden-ifunset'
-
-    CHOICES = (
-        (VISIBILITY_READ_WRITE, _('Read/write')),
-        (VISIBILITY_READ_ONLY, _('Read-only')),
-        (VISIBILITY_HIDDEN, _('Hidden')),
-        (VISIBILITY_HIDDEN_IFUNSET, _('Hidden (if unset)')),
-    )
-
-
 class CustomFieldUIVisibleChoices(ChoiceSet):
 
     ALWAYS = 'always'

--- a/netbox/extras/choices.py
+++ b/netbox/extras/choices.py
@@ -68,6 +68,32 @@ class CustomFieldVisibilityChoices(ChoiceSet):
     )
 
 
+class CustomFieldUIVisibleChoices(ChoiceSet):
+
+    ALWAYS = 'always'
+    IF_SET = 'if-set'
+    HIDDEN = 'hidden'
+
+    CHOICES = (
+        (ALWAYS, _('Always'), 'green'),
+        (IF_SET, _('If set'), 'yellow'),
+        (HIDDEN, _('Hidden'), 'gray'),
+    )
+
+
+class CustomFieldUIEditableChoices(ChoiceSet):
+
+    YES = 'yes'
+    NO = 'no'
+    HIDDEN = 'hidden'
+
+    CHOICES = (
+        (YES, _('Yes'), 'green'),
+        (NO, _('No'), 'red'),
+        (HIDDEN, _('Hidden'), 'gray'),
+    )
+
+
 class CustomFieldChoiceSetBaseChoices(ChoiceSet):
 
     IATA = 'IATA'

--- a/netbox/extras/filtersets.py
+++ b/netbox/extras/filtersets.py
@@ -87,8 +87,8 @@ class CustomFieldFilterSet(BaseFilterSet):
     class Meta:
         model = CustomField
         fields = [
-            'id', 'content_types', 'name', 'group_name', 'required', 'search_weight', 'filter_logic', 'ui_visibility',
-            'ui_visible', 'ui_editable', 'weight', 'is_cloneable', 'description',
+            'id', 'content_types', 'name', 'group_name', 'required', 'search_weight', 'filter_logic', 'ui_visible',
+            'ui_editable', 'weight', 'is_cloneable', 'description',
         ]
 
     def search(self, queryset, name, value):

--- a/netbox/extras/filtersets.py
+++ b/netbox/extras/filtersets.py
@@ -88,7 +88,7 @@ class CustomFieldFilterSet(BaseFilterSet):
         model = CustomField
         fields = [
             'id', 'content_types', 'name', 'group_name', 'required', 'search_weight', 'filter_logic', 'ui_visibility',
-            'weight', 'is_cloneable', 'description',
+            'ui_visible', 'ui_editable', 'weight', 'is_cloneable', 'description',
         ]
 
     def search(self, queryset, name, value):

--- a/netbox/extras/forms/bulk_edit.py
+++ b/netbox/extras/forms/bulk_edit.py
@@ -48,12 +48,6 @@ class CustomFieldBulkEditForm(BulkEditForm):
         queryset=CustomFieldChoiceSet.objects.all(),
         required=False
     )
-    ui_visibility = forms.ChoiceField(
-        label=_("UI visibility"),
-        choices=add_blank_choice(CustomFieldVisibilityChoices),
-        required=False,
-        initial=''
-    )
     ui_visible = forms.ChoiceField(
         label=_("UI visible"),
         choices=add_blank_choice(CustomFieldUIVisibleChoices),

--- a/netbox/extras/forms/bulk_edit.py
+++ b/netbox/extras/forms/bulk_edit.py
@@ -54,6 +54,16 @@ class CustomFieldBulkEditForm(BulkEditForm):
         required=False,
         initial=''
     )
+    ui_visible = forms.ChoiceField(
+        label=_("UI visible"),
+        choices=add_blank_choice(CustomFieldUIVisibleChoices),
+        required=False
+    )
+    ui_editable = forms.ChoiceField(
+        label=_("UI editable"),
+        choices=add_blank_choice(CustomFieldUIEditableChoices),
+        required=False
+    )
     is_cloneable = forms.NullBooleanField(
         label=_('Is cloneable'),
         required=False,

--- a/netbox/extras/forms/bulk_import.py
+++ b/netbox/extras/forms/bulk_import.py
@@ -51,11 +51,6 @@ class CustomFieldImportForm(CSVModelForm):
         required=False,
         help_text=_('Choice set (for selection fields)')
     )
-    ui_visibility = CSVChoiceField(
-        label=_('UI visibility'),
-        choices=CustomFieldVisibilityChoices,
-        help_text=_('How the custom field is displayed in the user interface')
-    )
     ui_visible = CSVChoiceField(
         label=_('UI visible'),
         choices=CustomFieldUIVisibleChoices,
@@ -74,7 +69,7 @@ class CustomFieldImportForm(CSVModelForm):
         fields = (
             'name', 'label', 'group_name', 'type', 'content_types', 'object_type', 'required', 'description',
             'search_weight', 'filter_logic', 'default', 'choice_set', 'weight', 'validation_minimum',
-            'validation_maximum', 'validation_regex', 'ui_visibility', 'ui_visible', 'ui_editable', 'is_cloneable',
+            'validation_maximum', 'validation_regex', 'ui_visible', 'ui_editable', 'is_cloneable',
         )
 
 

--- a/netbox/extras/forms/bulk_import.py
+++ b/netbox/extras/forms/bulk_import.py
@@ -56,13 +56,25 @@ class CustomFieldImportForm(CSVModelForm):
         choices=CustomFieldVisibilityChoices,
         help_text=_('How the custom field is displayed in the user interface')
     )
+    ui_visible = CSVChoiceField(
+        label=_('UI visible'),
+        choices=CustomFieldUIVisibleChoices,
+        required=False,
+        help_text=_('Whether the custom field is displayed in the UI')
+    )
+    ui_editable = CSVChoiceField(
+        label=_('UI editable'),
+        choices=CustomFieldUIEditableChoices,
+        required=False,
+        help_text=_('Whether the custom field is editable in the UI')
+    )
 
     class Meta:
         model = CustomField
         fields = (
             'name', 'label', 'group_name', 'type', 'content_types', 'object_type', 'required', 'description',
             'search_weight', 'filter_logic', 'default', 'choice_set', 'weight', 'validation_minimum',
-            'validation_maximum', 'validation_regex', 'ui_visibility', 'is_cloneable',
+            'validation_maximum', 'validation_regex', 'ui_visibility', 'ui_visible', 'ui_editable', 'is_cloneable',
         )
 
 

--- a/netbox/extras/forms/filtersets.py
+++ b/netbox/extras/forms/filtersets.py
@@ -40,7 +40,7 @@ class CustomFieldFilterForm(SavedFiltersMixin, FilterForm):
         (None, ('q', 'filter_id')),
         (_('Attributes'), (
             'type', 'content_type_id', 'group_name', 'weight', 'required', 'choice_set_id', 'ui_visibility',
-            'is_cloneable',
+            'ui_visible', 'ui_editable', 'is_cloneable',
         )),
     )
     content_type_id = ContentTypeMultipleChoiceField(
@@ -77,6 +77,16 @@ class CustomFieldFilterForm(SavedFiltersMixin, FilterForm):
         choices=add_blank_choice(CustomFieldVisibilityChoices),
         required=False,
         label=_('UI visibility')
+    )
+    ui_visible = forms.ChoiceField(
+        choices=add_blank_choice(CustomFieldUIVisibleChoices),
+        required=False,
+        label=_('UI visible')
+    )
+    ui_editable = forms.ChoiceField(
+        choices=add_blank_choice(CustomFieldUIEditableChoices),
+        required=False,
+        label=_('UI editable')
     )
     is_cloneable = forms.NullBooleanField(
         label=_('Is cloneable'),

--- a/netbox/extras/forms/filtersets.py
+++ b/netbox/extras/forms/filtersets.py
@@ -39,8 +39,8 @@ class CustomFieldFilterForm(SavedFiltersMixin, FilterForm):
     fieldsets = (
         (None, ('q', 'filter_id')),
         (_('Attributes'), (
-            'type', 'content_type_id', 'group_name', 'weight', 'required', 'choice_set_id', 'ui_visibility',
-            'ui_visible', 'ui_editable', 'is_cloneable',
+            'type', 'content_type_id', 'group_name', 'weight', 'required', 'choice_set_id', 'ui_visible', 'ui_editable',
+            'is_cloneable',
         )),
     )
     content_type_id = ContentTypeMultipleChoiceField(
@@ -72,11 +72,6 @@ class CustomFieldFilterForm(SavedFiltersMixin, FilterForm):
         queryset=CustomFieldChoiceSet.objects.all(),
         required=False,
         label=_('Choice set')
-    )
-    ui_visibility = forms.ChoiceField(
-        choices=add_blank_choice(CustomFieldVisibilityChoices),
-        required=False,
-        label=_('UI visibility')
     )
     ui_visible = forms.ChoiceField(
         choices=add_blank_choice(CustomFieldUIVisibleChoices),

--- a/netbox/extras/forms/mixins.py
+++ b/netbox/extras/forms/mixins.py
@@ -2,7 +2,7 @@ from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.utils.translation import gettext as _
 
-from extras.choices import CustomFieldVisibilityChoices
+from extras.choices import *
 from extras.models import *
 from utilities.forms.fields import DynamicModelMultipleChoiceField
 
@@ -40,7 +40,7 @@ class CustomFieldsMixin:
 
     def _get_custom_fields(self, content_type):
         return CustomField.objects.filter(content_types=content_type).exclude(
-            ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_HIDDEN
+            ui_visible=CustomFieldUIVisibleChoices.HIDDEN
         )
 
     def _get_form_field(self, customfield):
@@ -51,9 +51,6 @@ class CustomFieldsMixin:
         Append form fields for all CustomFields assigned to this object type.
         """
         for customfield in self._get_custom_fields(self._get_content_type()):
-            if customfield.ui_visibility == CustomFieldVisibilityChoices.VISIBILITY_HIDDEN:
-                continue
-
             field_name = f'cf_{customfield.name}'
             self.fields[field_name] = self._get_form_field(customfield)
 

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -61,7 +61,7 @@ class CustomFieldForm(BootstrapMixin, forms.ModelForm):
         (_('Custom Field'), (
             'content_types', 'name', 'label', 'group_name', 'type', 'object_type', 'required', 'description',
         )),
-        (_('Behavior'), ('search_weight', 'filter_logic', 'ui_visibility', 'ui_visible', 'ui_editable', 'weight', 'is_cloneable')),
+        (_('Behavior'), ('search_weight', 'filter_logic', 'ui_visible', 'ui_editable', 'weight', 'is_cloneable')),
         (_('Values'), ('default', 'choice_set')),
         (_('Validation'), ('validation_minimum', 'validation_maximum', 'validation_regex')),
     )

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -61,7 +61,7 @@ class CustomFieldForm(BootstrapMixin, forms.ModelForm):
         (_('Custom Field'), (
             'content_types', 'name', 'label', 'group_name', 'type', 'object_type', 'required', 'description',
         )),
-        (_('Behavior'), ('search_weight', 'filter_logic', 'ui_visibility', 'weight', 'is_cloneable')),
+        (_('Behavior'), ('search_weight', 'filter_logic', 'ui_visibility', 'ui_visible', 'ui_editable', 'weight', 'is_cloneable')),
         (_('Values'), ('default', 'choice_set')),
         (_('Validation'), ('validation_minimum', 'validation_maximum', 'validation_regex')),
     )

--- a/netbox/extras/migrations/0100_customfield_ui_attrs.py
+++ b/netbox/extras/migrations/0100_customfield_ui_attrs.py
@@ -1,6 +1,18 @@
 from django.db import migrations, models
 
 
+def update_ui_attrs(apps, schema_editor):
+    """
+    Replicate legacy ui_visibility values to the new ui_visible and ui_editable fields.
+    """
+    CustomField = apps.get_model('extras', 'CustomField')
+
+    CustomField.objects.filter(ui_visibility='read-write').update(ui_visible='always', ui_editable='yes')
+    CustomField.objects.filter(ui_visibility='read-only').update(ui_visible='always', ui_editable='no')
+    CustomField.objects.filter(ui_visibility='hidden').update(ui_visible='hidden', ui_editable='hidden')
+    CustomField.objects.filter(ui_visibility='hidden-ifunset').update(ui_visible='if-set', ui_editable='yes')
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -17,5 +29,9 @@ class Migration(migrations.Migration):
             model_name='customfield',
             name='ui_visible',
             field=models.CharField(default='always', max_length=50),
+        ),
+        migrations.RunPython(
+            code=update_ui_attrs,
+            reverse_code=migrations.RunPython.noop
         ),
     ]

--- a/netbox/extras/migrations/0100_customfield_ui_attrs.py
+++ b/netbox/extras/migrations/0100_customfield_ui_attrs.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('extras', '0099_cachedvalue_ordering'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='customfield',
+            name='ui_editable',
+            field=models.CharField(default='yes', max_length=50),
+        ),
+        migrations.AddField(
+            model_name='customfield',
+            name='ui_visible',
+            field=models.CharField(default='always', max_length=50),
+        ),
+    ]

--- a/netbox/extras/migrations/0100_customfield_ui_attrs.py
+++ b/netbox/extras/migrations/0100_customfield_ui_attrs.py
@@ -34,4 +34,8 @@ class Migration(migrations.Migration):
             code=update_ui_attrs,
             reverse_code=migrations.RunPython.noop
         ),
+        migrations.RemoveField(
+            model_name='customfield',
+            name='ui_visibility',
+        ),
     ]

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -179,13 +179,6 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
         blank=True,
         null=True
     )
-    ui_visibility = models.CharField(
-        max_length=50,
-        choices=CustomFieldVisibilityChoices,
-        default=CustomFieldVisibilityChoices.VISIBILITY_READ_WRITE,
-        verbose_name=_('UI visibility'),
-        help_text=_('Specifies the visibility of custom field in the UI')
-    )
     ui_visible = models.CharField(
         max_length=50,
         choices=CustomFieldUIVisibleChoices,
@@ -211,7 +204,7 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
     clone_fields = (
         'content_types', 'type', 'object_type', 'group_name', 'description', 'required', 'search_weight',
         'filter_logic', 'default', 'weight', 'validation_minimum', 'validation_maximum', 'validation_regex',
-        'choice_set', 'ui_visibility', 'ui_visible', 'ui_editable', 'is_cloneable',
+        'choice_set', 'ui_visible', 'ui_editable', 'is_cloneable',
     )
 
     class Meta:

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -71,9 +71,6 @@ class CustomFieldTable(NetBoxTable):
     required = columns.BooleanColumn(
         verbose_name=_('Required')
     )
-    ui_visibility = columns.ChoiceFieldColumn(
-        verbose_name=_('UI Visibility')
-    )
     ui_visible = columns.ChoiceFieldColumn(
         verbose_name=_('Visible')
     )
@@ -100,8 +97,8 @@ class CustomFieldTable(NetBoxTable):
         model = CustomField
         fields = (
             'pk', 'id', 'name', 'content_types', 'label', 'type', 'group_name', 'required', 'default', 'description',
-            'search_weight', 'filter_logic', 'ui_visibility', 'ui_visible', 'ui_editable', 'is_cloneable', 'weight',
-            'choice_set', 'choices', 'created', 'last_updated',
+            'search_weight', 'filter_logic', 'ui_visible', 'ui_editable', 'is_cloneable', 'weight', 'choice_set',
+            'choices', 'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'content_types', 'label', 'group_name', 'type', 'required', 'description')
 

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -74,6 +74,12 @@ class CustomFieldTable(NetBoxTable):
     ui_visibility = columns.ChoiceFieldColumn(
         verbose_name=_('UI Visibility')
     )
+    ui_visible = columns.ChoiceFieldColumn(
+        verbose_name=_('Visible')
+    )
+    ui_editable = columns.ChoiceFieldColumn(
+        verbose_name=_('Editable')
+    )
     description = columns.MarkdownColumn(
         verbose_name=_('Description')
     )
@@ -94,8 +100,8 @@ class CustomFieldTable(NetBoxTable):
         model = CustomField
         fields = (
             'pk', 'id', 'name', 'content_types', 'label', 'type', 'group_name', 'required', 'default', 'description',
-            'search_weight', 'filter_logic', 'ui_visibility', 'is_cloneable', 'weight', 'choice_set', 'choices',
-            'created', 'last_updated',
+            'search_weight', 'filter_logic', 'ui_visibility', 'ui_visible', 'ui_editable', 'is_cloneable', 'weight',
+            'choice_set', 'choices', 'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'content_types', 'label', 'group_name', 'type', 'required', 'description')
 

--- a/netbox/extras/tests/test_filtersets.py
+++ b/netbox/extras/tests/test_filtersets.py
@@ -40,7 +40,8 @@ class CustomFieldTestCase(TestCase, BaseFilterSetTests):
                 required=True,
                 weight=100,
                 filter_logic=CustomFieldFilterLogicChoices.FILTER_LOOSE,
-                ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_READ_WRITE
+                ui_visible=CustomFieldUIVisibleChoices.ALWAYS,
+                ui_editable=CustomFieldUIEditableChoices.YES
             ),
             CustomField(
                 name='Custom Field 2',
@@ -48,7 +49,8 @@ class CustomFieldTestCase(TestCase, BaseFilterSetTests):
                 required=False,
                 weight=200,
                 filter_logic=CustomFieldFilterLogicChoices.FILTER_EXACT,
-                ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_READ_ONLY
+                ui_visible=CustomFieldUIVisibleChoices.IF_SET,
+                ui_editable=CustomFieldUIEditableChoices.NO
             ),
             CustomField(
                 name='Custom Field 3',
@@ -56,7 +58,8 @@ class CustomFieldTestCase(TestCase, BaseFilterSetTests):
                 required=False,
                 weight=300,
                 filter_logic=CustomFieldFilterLogicChoices.FILTER_DISABLED,
-                ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_HIDDEN
+                ui_visible=CustomFieldUIVisibleChoices.HIDDEN,
+                ui_editable=CustomFieldUIEditableChoices.HIDDEN
             ),
             CustomField(
                 name='Custom Field 4',
@@ -64,7 +67,8 @@ class CustomFieldTestCase(TestCase, BaseFilterSetTests):
                 required=False,
                 weight=400,
                 filter_logic=CustomFieldFilterLogicChoices.FILTER_DISABLED,
-                ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_HIDDEN,
+                ui_visible=CustomFieldUIVisibleChoices.HIDDEN,
+                ui_editable=CustomFieldUIEditableChoices.HIDDEN,
                 choice_set=choice_sets[0]
             ),
             CustomField(
@@ -73,7 +77,8 @@ class CustomFieldTestCase(TestCase, BaseFilterSetTests):
                 required=False,
                 weight=500,
                 filter_logic=CustomFieldFilterLogicChoices.FILTER_DISABLED,
-                ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_HIDDEN,
+                ui_visible=CustomFieldUIVisibleChoices.HIDDEN,
+                ui_editable=CustomFieldUIEditableChoices.HIDDEN,
                 choice_set=choice_sets[1]
             ),
         )
@@ -106,8 +111,12 @@ class CustomFieldTestCase(TestCase, BaseFilterSetTests):
         params = {'filter_logic': CustomFieldFilterLogicChoices.FILTER_LOOSE}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
-    def test_ui_visibility(self):
-        params = {'ui_visibility': CustomFieldVisibilityChoices.VISIBILITY_READ_WRITE}
+    def test_ui_visible(self):
+        params = {'ui_visible': CustomFieldUIVisibleChoices.ALWAYS}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_ui_editable(self):
+        params = {'ui_editable': CustomFieldUIEditableChoices.YES}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_choice_set(self):

--- a/netbox/extras/tests/test_views.py
+++ b/netbox/extras/tests/test_views.py
@@ -50,15 +50,16 @@ class CustomFieldTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             'default': None,
             'weight': 200,
             'required': True,
-            'ui_visibility': CustomFieldVisibilityChoices.VISIBILITY_READ_WRITE,
+            'ui_visible': CustomFieldUIVisibleChoices.ALWAYS,
+            'ui_editable': CustomFieldUIEditableChoices.YES,
         }
 
         cls.csv_data = (
-            'name,label,type,content_types,object_type,weight,search_weight,filter_logic,choice_set,validation_minimum,validation_maximum,validation_regex,ui_visibility',
-            'field4,Field 4,text,dcim.site,,100,1000,exact,,,,[a-z]{3},read-write',
-            'field5,Field 5,integer,dcim.site,,100,2000,exact,,1,100,,read-write',
-            'field6,Field 6,select,dcim.site,,100,3000,exact,Choice Set 1,,,,read-write',
-            'field7,Field 7,object,dcim.site,dcim.region,100,4000,exact,,,,,read-write',
+            'name,label,type,content_types,object_type,weight,search_weight,filter_logic,choice_set,validation_minimum,validation_maximum,validation_regex,ui_visible,ui_editable',
+            'field4,Field 4,text,dcim.site,,100,1000,exact,,,,[a-z]{3},always,yes',
+            'field5,Field 5,integer,dcim.site,,100,2000,exact,,1,100,,always,yes',
+            'field6,Field 6,select,dcim.site,,100,3000,exact,Choice Set 1,,,,always,yes',
+            'field7,Field 7,object,dcim.site,dcim.region,100,4000,exact,,,,,always,yes',
         )
 
         cls.csv_update_data = (

--- a/netbox/netbox/forms/base.py
+++ b/netbox/netbox/forms/base.py
@@ -3,7 +3,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
-from extras.choices import CustomFieldFilterLogicChoices, CustomFieldTypeChoices, CustomFieldVisibilityChoices
+from extras.choices import *
 from extras.forms.mixins import CustomFieldsMixin, SavedFiltersMixin, TagsMixin
 from extras.models import CustomField, Tag
 from utilities.forms import CSVModelForm
@@ -76,11 +76,9 @@ class NetBoxModelImportForm(CSVModelForm, NetBoxModelForm):
     )
 
     def _get_custom_fields(self, content_type):
-        return CustomField.objects.filter(content_types=content_type).filter(
-            ui_visibility__in=[
-                CustomFieldVisibilityChoices.VISIBILITY_READ_WRITE,
-                CustomFieldVisibilityChoices.VISIBILITY_HIDDEN_IFUNSET,
-            ]
+        return CustomField.objects.filter(
+            content_types=content_type,
+            ui_editable=CustomFieldUIEditableChoices.YES
         )
 
     def _get_form_field(self, customfield):
@@ -131,7 +129,8 @@ class NetBoxModelBulkEditForm(BootstrapMixin, CustomFieldsMixin, forms.Form):
 
     def _extend_nullable_fields(self):
         nullable_custom_fields = [
-            name for name, customfield in self.custom_fields.items() if (not customfield.required and customfield.ui_visibility == CustomFieldVisibilityChoices.VISIBILITY_READ_WRITE)
+            name for name, customfield in self.custom_fields.items()
+            if (not customfield.required and customfield.ui_editable == CustomFieldUIEditableChoices.YES)
         ]
         self.nullable_fields = (*self.nullable_fields, *nullable_custom_fields)
 

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -13,7 +13,7 @@ from django.utils.translation import gettext_lazy as _
 from taggit.managers import TaggableManager
 
 from core.choices import JobStatusChoices
-from extras.choices import CustomFieldVisibilityChoices, ObjectChangeActionChoices
+from extras.choices import *
 from extras.utils import is_taggable, register_features
 from netbox.registry import registry
 from netbox.signals import post_clean
@@ -205,12 +205,11 @@ class CustomFieldsMixin(models.Model):
         for field in CustomField.objects.get_for_model(self):
             value = self.custom_field_data.get(field.name)
 
-            # Skip fields that are hidden if 'omit_hidden' is set
-            if omit_hidden:
-                if field.ui_visibility == CustomFieldVisibilityChoices.VISIBILITY_HIDDEN:
-                    continue
-                if field.ui_visibility == CustomFieldVisibilityChoices.VISIBILITY_HIDDEN_IFUNSET and not value:
-                    continue
+            # Skip hidden fields if 'omit_hidden' is True
+            if omit_hidden and field.ui_visible == CustomFieldUIVisibleChoices.HIDDEN:
+                continue
+            elif omit_hidden and field.ui_visible == CustomFieldUIVisibleChoices.IF_SET and not value:
+                continue
 
             data[field] = field.deserialize(value)
 
@@ -232,12 +231,12 @@ class CustomFieldsMixin(models.Model):
         from extras.models import CustomField
         groups = defaultdict(dict)
         visible_custom_fields = CustomField.objects.get_for_model(self).exclude(
-            ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_HIDDEN
+            ui_visible=CustomFieldUIVisibleChoices.HIDDEN
         )
 
         for cf in visible_custom_fields:
             value = self.custom_field_data.get(cf.name)
-            if value in (None, []) and cf.ui_visibility == CustomFieldVisibilityChoices.VISIBILITY_HIDDEN_IFUNSET:
+            if value in (None, []) and cf.ui_visible == CustomFieldUIVisibleChoices.IF_SET:
                 continue
             value = cf.deserialize(value)
             groups[cf.group_name][cf] = value

--- a/netbox/netbox/tables/tables.py
+++ b/netbox/netbox/tables/tables.py
@@ -11,7 +11,7 @@ from django.utils.translation import gettext_lazy as _
 from django_tables2.data import TableQuerysetData
 
 from extras.models import CustomField, CustomLink
-from extras.choices import CustomFieldVisibilityChoices
+from extras.choices import *
 from netbox.tables import columns
 from utilities.paginator import EnhancedPaginator, get_paginate_count
 from utilities.utils import get_viewname, highlight_string, title
@@ -195,7 +195,7 @@ class NetBoxTable(BaseTable):
         content_type = ContentType.objects.get_for_model(self._meta.model)
         custom_fields = CustomField.objects.filter(
             content_types=content_type
-        ).exclude(ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_HIDDEN)
+        ).exclude(ui_visible=CustomFieldUIVisibleChoices.HIDDEN)
 
         extra_columns.extend([
             (f'cf_{cf.name}', columns.CustomFieldColumn(cf)) for cf in custom_fields

--- a/netbox/templates/extras/customfield.html
+++ b/netbox/templates/extras/customfield.html
@@ -79,8 +79,12 @@
             <td>{{ object.weight }}</td>
           </tr>
           <tr>
-            <th scope="row">{% trans "UI Visibility" %}</th>
-            <td>{{ object.get_ui_visibility_display }}</td>
+            <th scope="row">{% trans "UI Visible" %}</th>
+            <td>{{ object.get_ui_visible_display }}</td>
+          </tr>
+          <tr>
+            <th scope="row">{% trans "UI Editable" %}</th>
+            <td>{{ object.get_ui_editable_display }}</td>
           </tr>
         </table>
       </div>


### PR DESCRIPTION
### Closes: #13299

- Add two new fields to the CustomField model: `ui_visible` and `ui_editable`
- Migrate existing custom fields, setting the appropriate values depending on the value of the legacy `ui_visibility` field
- Remove the `ui_visibility` field
- Update documentation
