### PR TITLE
Fixed password was not hashed on REST API update

### DIFF
--- a/netbox/users/api/serializers.py
+++ b/netbox/users/api/serializers.py
@@ -60,9 +60,7 @@ class UserSerializer(ValidatedModelSerializer):
         if password is not None:
             instance.set_password(password)
 
-        super().update(instance, validated_data)
-
-        return instance
+        return super().update(instance, validated_data)
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_display(self, obj):

--- a/netbox/users/api/serializers.py
+++ b/netbox/users/api/serializers.py
@@ -52,6 +52,18 @@ class UserSerializer(ValidatedModelSerializer):
 
         return user
 
+    def update(self, instance, validated_data):
+        """
+        Ensure proper updated password hash generation.
+        """
+        password = validated_data.pop('password', None)
+        if password is not None:
+            instance.set_password(password)
+
+        instance.save()
+
+        return instance
+
     @extend_schema_field(OpenApiTypes.STR)
     def get_display(self, obj):
         if full_name := obj.get_full_name():

--- a/netbox/users/api/serializers.py
+++ b/netbox/users/api/serializers.py
@@ -60,7 +60,7 @@ class UserSerializer(ValidatedModelSerializer):
         if password is not None:
             instance.set_password(password)
 
-        instance.save()
+        super().update(instance, validated_data)
 
         return instance
 

--- a/netbox/users/tests/test_api.py
+++ b/netbox/users/tests/test_api.py
@@ -55,6 +55,37 @@ class UserTest(APIViewTestCases.APIViewTestCase):
         User.objects.bulk_create(users)
 
 
+class ChangeUserPasswordTest(APITestCase):
+
+    user_permissions = ['auth.change_user']
+
+    def test_that_password_is_changed(self):
+        """
+        Test that password is changed
+        """
+
+        user_credentials = {
+            'username': 'user1',
+            'password': 'abc123',
+        }
+        user = User.objects.create_user(**user_credentials)
+
+        print(user.id)
+
+        data = {
+            'password': 'newpassword'
+        }
+        url = reverse('users-api:user-detail', kwargs={'pk': user.id})
+
+        response = self.client.patch(url, data, format='json', **self.header)
+
+        self.assertEqual(response.status_code, 200)
+
+        updated_user = User.objects.get(id=user.id)
+
+        self.assertTrue(updated_user.check_password(data['password']))
+
+
 class GroupTest(APIViewTestCases.APIViewTestCase):
     model = Group
     view_namespace = 'users'

--- a/netbox/users/tests/test_api.py
+++ b/netbox/users/tests/test_api.py
@@ -54,23 +54,24 @@ class UserTest(APIViewTestCases.APIViewTestCase):
         )
         User.objects.bulk_create(users)
 
-
-class ChangeUserPasswordTest(APITestCase):
-
-    user_permissions = ['auth.change_user']
-
     def test_that_password_is_changed(self):
         """
         Test that password is changed
         """
+
+        obj_perm = ObjectPermission(
+            name='Test permission',
+            actions=['change']
+        )
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(ContentType.objects.get_for_model(self.model))
 
         user_credentials = {
             'username': 'user1',
             'password': 'abc123',
         }
         user = User.objects.create_user(**user_credentials)
-
-        print(user.id)
 
         data = {
             'password': 'newpassword'


### PR DESCRIPTION
* When we updated a user password with a REST API call the password was stored in clear in plain text in the database.

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #14339
<!--
    Please include a summary of the proposed changes below.
-->

* Add an `update` method on the UserSerializer that set properly the new password if provided by the API call.
