### PR TITLE
Fixes #14363: Fix bulk editing of interfaces assigned to VM with no cluster

### DIFF
--- a/netbox/virtualization/forms/bulk_edit.py
+++ b/netbox/virtualization/forms/bulk_edit.py
@@ -294,9 +294,10 @@ class VMInterfaceBulkEditForm(NetBoxModelBulkEditForm):
                 # Check interface sites.  First interface should set site, further interfaces will either continue the
                 # loop or reset back to no site and break the loop.
                 for interface in interfaces:
+                    vm_site = interface.virtual_machine.site or interface.virtual_machine.cluster.site
                     if site is None:
-                        site = interface.virtual_machine.cluster.site
-                    elif interface.virtual_machine.cluster.site is not site:
+                        site = vm_site
+                    elif vm_site is not site:
                         site = None
                         break
 


### PR DESCRIPTION
### Fixes: #14363

Check both VM and cluster for site
