### PR TITLE
Fixes #14349: Fix custom validation support for DataSource

### DIFF
--- a/netbox/core/models/data.py
+++ b/netbox/core/models/data.py
@@ -122,6 +122,7 @@ class DataSource(JobsMixin, PrimaryModel):
         )
 
     def clean(self):
+        super().clean()
 
         # Ensure URL scheme matches selected type
         if self.type == DataSourceTypeChoices.LOCAL and self.url_scheme not in ('file', ''):


### PR DESCRIPTION
### Fixes: #14349

Ensure `super().clean()` is called