### PR TITLE
Fixes #14325: Ensure expanded numeric arrays are ordered

### DIFF
--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -40,7 +40,7 @@ def parse_numeric_range(string, base=10):
         except ValueError:
             raise forms.ValidationError(f'Range "{dash_range}" is invalid.')
         values.extend(range(begin, end))
-    return list(set(values))
+    return sorted(list(set(values)))
 
 
 def parse_alphanumeric_range(string):

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -40,7 +40,7 @@ def parse_numeric_range(string, base=10):
         except ValueError:
             raise forms.ValidationError(f'Range "{dash_range}" is invalid.')
         values.extend(range(begin, end))
-    return sorted(list(set(values)))
+    return sorted(set(values))
 
 
 def parse_alphanumeric_range(string):


### PR DESCRIPTION
### Fixes: #14325

Call `sorted()` on the return value of `parse_numeric_range()` after casting to a `set()`.