### PR TITLE
14346 fix missing function call convert

### DIFF
--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -283,7 +283,7 @@ class ReportViewSet(ViewSet):
 
         # Retrieve and run the Report. This will create a new Job.
         module, report_cls = self._get_report(pk)
-        report = report_cls()
+        report = report_cls
         input_serializer = serializers.ReportInputSerializer(
             data=request.data,
             context={'report': report}


### PR DESCRIPTION
In PR #13958 (commit 8224644) _get_report was modified to do the call on the variable without changing the call later on.

### Fixes: #14346

This commit fixes that and removes the call on the variable.
