### PR TITLE
Fixes #14239: Fix CustomFieldChoiceSet search filter

### DIFF
--- a/netbox/extras/filtersets.py
+++ b/netbox/extras/filtersets.py
@@ -122,8 +122,7 @@ class CustomFieldChoiceSetFilterSet(BaseFilterSet):
             return queryset
         return queryset.filter(
             Q(name__icontains=value) |
-            Q(description__icontains=value) |
-            Q(extra_choices__contains=value)
+            Q(description__icontains=value)
         )
 
     def filter_by_choice(self, queryset, name, value):


### PR DESCRIPTION
### Fixes: #14239

Omit `extra_choices` lookup from the search (`?q=`) filter for CustomFieldChoiceSet.