### PR TITLE
Closes #14365: Introduce job_start and job_end signals

### DIFF
--- a/docs/development/signals.md
+++ b/docs/development/signals.md
@@ -9,3 +9,15 @@ This signal is sent by models which inherit from `CustomValidationMixin` at the 
 ### Receivers
 
 * `extras.signals.run_custom_validators()`
+
+## core.job_start
+
+* `extras..signals.process_job_start_event_rules()`
+
+## core.job_end
+
+* `extras..signals.process_job_end_event_rules()`
+
+## core.pre_sync
+
+## core.post_sync

--- a/docs/development/signals.md
+++ b/docs/development/signals.md
@@ -12,12 +12,24 @@ This signal is sent by models which inherit from `CustomValidationMixin` at the 
 
 ## core.job_start
 
-* `extras..signals.process_job_start_event_rules()`
+This signal is sent whenever a [background job](../features/background-jobs.md) is started.
+
+### Receivers
+
+* `extras.signals.process_job_start_event_rules()`
 
 ## core.job_end
 
-* `extras..signals.process_job_end_event_rules()`
+This signal is sent whenever a [background job](../features/background-jobs.md) is terminated.
+
+### Receivers
+
+* `extras.signals.process_job_end_event_rules()`
 
 ## core.pre_sync
 
+This signal is sent when the [DataSource](../models/core/datasource.md) model's `sync()` method is called.
+
 ## core.post_sync
+
+This signal is sent when a [DataSource](../models/core/datasource.md) finishes synchronizing.

--- a/netbox/core/signals.py
+++ b/netbox/core/signals.py
@@ -4,9 +4,15 @@ from django.dispatch import Signal, receiver
 from .models import ConfigRevision
 
 __all__ = (
+    'job_end',
+    'job_start',
     'post_sync',
     'pre_sync',
 )
+
+# Job signals
+job_start = Signal()
+job_end = Signal()
 
 # DataSource signals
 pre_sync = Signal()


### PR DESCRIPTION
### Closes: #14365

- Introduce two new signals in `core`: `job_start` and `job_end`
- Move `Job.process_event()` logic for EventRule processing to receiver functions under `extras`