### PR TITLE
14008 Allow definition of webhook headers in configuration.py

### DIFF
--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -234,3 +234,11 @@ This parameter controls how frequently a failed job is retried, up to the maximu
 Default: `0` (retries disabled)
 
 The maximum number of times a background task will be retried before being marked as failed.
+
+---
+
+## WEBHOOK_HEADERS
+
+Default: {} (empty)
+
+Default, optional user-supplied HTTP headers to be sent with webhook requests in addition to the HTTP content type.

--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -241,4 +241,4 @@ The maximum number of times a background task will be retried before being marke
 
 Default: {} (empty)
 
-Default, optional user-supplied HTTP headers to be sent with webhook requests in addition to the HTTP content type.
+Optional default user-supplied HTTP headers to be sent with webhook requests in addition to the HTTP content type.

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -213,9 +213,9 @@ class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, ChangeLoggedMo
         verbose_name=_('additional headers'),
         blank=True,
         help_text=_(
-            "User-supplied HTTP headers to be sent with the request in addition to the HTTP content type. Headers "
-            "should be defined in the format <code>Name: Value</code>. Jinja2 template processing is supported with "
-            "the same context as the request body (below)."
+            "User-supplied HTTP headers to be sent with the request in addition to the HTTP content type and those "
+            "defined in configuration.py. Headers should be defined in the format <code>Name: Value</code>. Jinja2 "
+            "template processing is supported with the same context as the request body (below)."
         )
     )
     body_template = models.TextField(
@@ -284,10 +284,12 @@ class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, ChangeLoggedMo
         """
         Render additional_headers and return a dict of Header: Value pairs.
         """
-        if not self.additional_headers:
+        headers = get_config().WEBHOOK_HEADERS.update(self.additional_headers)
+
+        if not headers:
             return {}
         ret = {}
-        data = render_jinja2(self.additional_headers, context)
+        data = render_jinja2(headers, context)
         for line in data.splitlines():
             header, value = line.split(':', 1)
             ret[header.strip()] = value.strip()

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -284,16 +284,14 @@ class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, ChangeLoggedMo
         """
         Render additional_headers and return a dict of Header: Value pairs.
         """
-        headers = get_config().WEBHOOK_HEADERS.update(self.additional_headers)
+        headers = get_config().WEBHOOK_HEADERS
+        if self.additional_headers:
+            data = render_jinja2(self.additional_headers, context)
+            for line in data.splitlines():
+                header, value = line.split(':', 1)
+                headers[header.strip()] = value.strip()
 
-        if not headers:
-            return {}
-        ret = {}
-        data = render_jinja2(headers, context)
-        for line in data.splitlines():
-            header, value = line.split(':', 1)
-            ret[header.strip()] = value.strip()
-        return ret
+        return headers
 
     def render_body(self, context):
         """

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -177,6 +177,7 @@ STORAGE_CONFIG = getattr(configuration, 'STORAGE_CONFIG', {})
 TIME_FORMAT = getattr(configuration, 'TIME_FORMAT', 'g:i a')
 TIME_ZONE = getattr(configuration, 'TIME_ZONE', 'UTC')
 ENABLE_LOCALIZATION = getattr(configuration, 'ENABLE_LOCALIZATION', False)
+WEBHOOK_HEADERS = getattr(configuration, 'WEBHOOK_HEADERS', {})
 
 # Check for hard-coded dynamic config parameters
 for param in PARAMS:


### PR DESCRIPTION
### Fixes: #14008 

Adds WEBHOOK_HEADERS to configuration.py and uses them as defaults in webhook processing code.  This also fixes #14345 