### PR TITLE
14467 change ChoiceField separator from comma to colon

### DIFF
--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 from django import forms
 from django.conf import settings
@@ -107,7 +108,7 @@ class CustomFieldChoiceSetForm(BootstrapMixin, forms.ModelForm):
         data = []
         for line in self.cleaned_data['extra_choices'].splitlines():
             try:
-                value, label = line.split(':', maxsplit=1)
+                value, label = re.split(r'(?<!\\):', line, maxsplit=1)
             except ValueError:
                 value, label = line, line
             data.append((value, label))

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -95,8 +95,8 @@ class CustomFieldChoiceSetForm(BootstrapMixin, forms.ModelForm):
         required=False,
         help_text=mark_safe(_(
             'Enter one choice per line. An optional label may be specified for each choice by appending it with a '
-            'comma. Example:'
-        ) + ' <code>choice1,First Choice</code>')
+            'colon. Example:'
+        ) + ' <code>choice1:First Choice</code>')
     )
 
     class Meta:
@@ -107,7 +107,7 @@ class CustomFieldChoiceSetForm(BootstrapMixin, forms.ModelForm):
         data = []
         for line in self.cleaned_data['extra_choices'].splitlines():
             try:
-                value, label = line.split(',', maxsplit=1)
+                value, label = line.split(':', maxsplit=1)
             except ValueError:
                 value, label = line, line
             data.append((value, label))

--- a/netbox/extras/tests/test_views.py
+++ b/netbox/extras/tests/test_views.py
@@ -76,7 +76,6 @@ class CustomFieldTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 
 class CustomFieldChoiceSetTestCase(ViewTestCases.PrimaryObjectViewTestCase):
     model = CustomFieldChoiceSet
-    validation_excluded_fields = ('extra_choices',)
 
     @classmethod
     def setUpTestData(cls):
@@ -120,30 +119,12 @@ class CustomFieldChoiceSetTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             'description': 'New description',
         }
 
-    # These are here as extra_choices field splits on colon, but is returned
-    # from DB as comma separated.  So we exclude them in validation_excluded_fields
-    # but test they are actually set correctly here.
-    def _check_extra_choices_data(self):
-        instance = self._get_queryset().last()
-        form_data = self.form_data
-        form_data['extra_choices'] = form_data['extra_choices'].replace(':', ',')
-        self.assertInstanceEqual(instance, form_data)
-
-    def test_create_object_with_constrained_permission(self):
-        super().test_create_object_with_constrained_permission()
-        self._check_extra_choices_data()
-
-    def test_create_object_with_permission(self):
-        super().test_create_object_with_permission()
-        self._check_extra_choices_data()
-
-    def test_edit_object_with_constrained_permission(self):
-        super().test_edit_object_with_constrained_permission()
-        self._check_extra_choices_data()
-
-    def test_edit_object_with_permission(self):
-        super().test_edit_object_with_permission()
-        self._check_extra_choices_data()
+    # This is here as extra_choices field splits on colon, but is returned
+    # from DB as comma separated.
+    def assertInstanceEqual(self, instance, data, exclude=None, api=False):
+        if 'extra_choices' in data:
+            data['extra_choices'] = data['extra_choices'].replace(':', ',')
+        return super().assertInstanceEqual(instance, data, exclude, api)
 
 
 class CustomLinkTestCase(ViewTestCases.PrimaryObjectViewTestCase):

--- a/netbox/extras/tests/test_views.py
+++ b/netbox/extras/tests/test_views.py
@@ -76,6 +76,7 @@ class CustomFieldTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 
 class CustomFieldChoiceSetTestCase(ViewTestCases.PrimaryObjectViewTestCase):
     model = CustomFieldChoiceSet
+    validation_excluded_fields = ('extra_choices',)
 
     @classmethod
     def setUpTestData(cls):
@@ -98,7 +99,7 @@ class CustomFieldChoiceSetTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 
         cls.form_data = {
             'name': 'Choice Set X',
-            'extra_choices': '\n'.join(['X1,Choice 1', 'X2,Choice 2', 'X3,Choice 3'])
+            'extra_choices': '\n'.join(['X1:Choice 1', 'X2:Choice 2', 'X3:Choice 3'])
         }
 
         cls.csv_data = (

--- a/netbox/extras/tests/test_views.py
+++ b/netbox/extras/tests/test_views.py
@@ -120,6 +120,31 @@ class CustomFieldChoiceSetTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             'description': 'New description',
         }
 
+    # These are here as extra_choices field splits on colon, but is returned
+    # from DB as comma separated.  So we exclude them in validation_excluded_fields
+    # but test they are actually set correctly here.
+    def _check_extra_choices_data(self):
+        instance = self._get_queryset().last()
+        form_data = self.form_data
+        form_data['extra_choices'] = form_data['extra_choices'].replace(':', ',')
+        self.assertInstanceEqual(instance, form_data)
+
+    def test_create_object_with_constrained_permission(self):
+        super().test_create_object_with_constrained_permission()
+        self._check_extra_choices_data()
+
+    def test_create_object_with_permission(self):
+        super().test_create_object_with_permission()
+        self._check_extra_choices_data()
+
+    def test_edit_object_with_constrained_permission(self):
+        super().test_edit_object_with_constrained_permission()
+        self._check_extra_choices_data()
+
+    def test_edit_object_with_permission(self):
+        super().test_edit_object_with_permission()
+        self._check_extra_choices_data()
+
 
 class CustomLinkTestCase(ViewTestCases.PrimaryObjectViewTestCase):
     model = CustomLink

--- a/netbox/utilities/forms/widgets/misc.py
+++ b/netbox/utilities/forms/widgets/misc.py
@@ -65,5 +65,5 @@ class ChoicesWidget(forms.Textarea):
         if not value:
             return None
         if type(value) is list:
-            return '\n'.join([f'{k},{v}' for k, v in value])
+            return '\n'.join([f'{k}:{v}' for k, v in value])
         return value


### PR DESCRIPTION
### Fixes: #14467 

Changes the ChoiceField (for CustomFieldChoiceSetForm extra_choices) from a comma to colon.  This is to enable a clean fix for #13983

Should have no side-effects as the comma isn't stored anywhere and the change in the widget makes old saved values appear correctly with the new colon.  The only potential for issue is if someone has a colon stored as part of a label/choice which should be very unlikely.