### PR TITLE
Fixes #14482 - Fix validation error when primary IP is moved

### DIFF
--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -341,6 +341,17 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
             self.fields['vminterface'].disabled = True
             self.fields['fhrpgroup'].disabled = True
 
+    def add_error(self, field, errors):
+        if errors.error_dict.get('assigned_object', None):
+            error = errors.error_dict.pop('assigned_object')
+            if isinstance(self.instance.assigned_object, Interface):
+                errors.error_dict.update({'interface': error})
+            elif isinstance(self.instance.assigned_object, VMInterface):
+                errors.error_dict.update({'vminterface': error})
+            elif isinstance(self.instance.assigned_object, FHRPGroup):
+                errors.error_dict.update({'fhrpgroup': error})
+        super().add_error(field, errors)
+
     def clean(self):
         super().clean()
 

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -341,8 +341,10 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
             self.fields['vminterface'].disabled = True
             self.fields['fhrpgroup'].disabled = True
 
+    # Correctly assigned assigned_object if the error exists when validating this form.
     def add_error(self, field, errors):
-        if errors.error_dict.get('assigned_object', None):
+        if isinstance(errors, ValidationError) and hasattr(errors, 'error_dict') and \
+                errors.error_dict.get('assigned_object', None):
             error = errors.error_dict.pop('assigned_object')
             if isinstance(self.instance.assigned_object, Interface):
                 errors.error_dict.update({'interface': error})

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -370,9 +370,12 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
             )
 
         prev_interface = self.instance.interface.first() or self.instance.vminterface.first()
-        prev_parent = prev_interface.device or prev_interface.virtual_machine
-        if prev_interface and prev_parent and prev_interface != interface:
-            if prev_parent.primary_ip4 == self.instance or prev_parent.primary_ip6 == self.instance:
+        # If the prev interface exists and does not match the new interface, we need to validate it isn't set as primary
+        # for the parent
+        if prev_interface and prev_interface != interface:
+            prev_parent = prev_interface.device or prev_interface.virtual_machine
+            # Check that the parent exists and if it is set as a primary ip.
+            if prev_parent and prev_parent.primary_ip4 == self.instance or prev_parent.primary_ip6 == self.instance:
                 self.add_error(
                     selected_objects[0],
                     _("Cannot reassign IP address while it is designated as the primary IP for the parent object")

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -375,7 +375,7 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
             if prev_parent.primary_ip4 == self.instance or prev_parent.primary_ip6 == self.instance:
                 self.add_error(
                     selected_objects[0],
-                    _("Cannot reassign IP address while it is designated as the primary ip for the parent object")
+                    _("Cannot reassign IP address while it is designated as the primary IP for the parent object")
                 )
 
         # Do not allow assigning a network ID or broadcast address to an interface.

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -369,17 +369,18 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
                 'primary_for_parent', _("Only IP addresses assigned to an interface can be designated as primary IPs.")
             )
 
-        prev_interface = self.instance.interface.first() or self.instance.vminterface.first()
-        # If the prev interface exists and does not match the new interface, we need to validate it isn't set as primary
-        # for the parent
-        if prev_interface and prev_interface != interface:
-            prev_parent = prev_interface.device or prev_interface.virtual_machine
-            # Check that the parent exists and if it is set as a primary ip.
-            if prev_parent and prev_parent.primary_ip4 == self.instance or prev_parent.primary_ip6 == self.instance:
-                self.add_error(
-                    selected_objects[0],
-                    _("Cannot reassign IP address while it is designated as the primary IP for the parent object")
-                )
+        if self.instance.pk:
+            prev_interface = self.instance.interface.first() or self.instance.vminterface.first()
+            # If the prev interface exists and does not match the new interface, we need to validate it isn't set as primary
+            # for the parent
+            if prev_interface and prev_interface != interface:
+                prev_parent = prev_interface.device or prev_interface.virtual_machine
+                # Check that the parent exists and if it is set as a primary ip.
+                if prev_parent and prev_parent.primary_ip4 == self.instance or prev_parent.primary_ip6 == self.instance:
+                    self.add_error(
+                        selected_objects[0],
+                        _("Cannot reassign IP address while it is designated as the primary IP for the parent object")
+                    )
 
         # Do not allow assigning a network ID or broadcast address to an interface.
         if interface and (address := self.cleaned_data.get('address')):

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -369,19 +369,6 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
                 'primary_for_parent', _("Only IP addresses assigned to an interface can be designated as primary IPs.")
             )
 
-        if self.instance.pk:
-            prev_interface = self.instance.interface.first() or self.instance.vminterface.first()
-            # If the prev interface exists and does not match the new interface, we need to validate it isn't set as primary
-            # for the parent
-            if prev_interface and prev_interface != interface:
-                prev_parent = prev_interface.device or prev_interface.virtual_machine
-                # Check that the parent exists and if it is set as a primary ip.
-                if prev_parent and prev_parent.primary_ip4 == self.instance or prev_parent.primary_ip6 == self.instance:
-                    self.add_error(
-                        selected_objects[0],
-                        _("Cannot reassign IP address while it is designated as the primary IP for the parent object")
-                    )
-
         # Do not allow assigning a network ID or broadcast address to an interface.
         if interface and (address := self.cleaned_data.get('address')):
             if address.ip == address.network:

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -864,11 +864,9 @@ class IPAddress(PrimaryModel):
                 is_primary = True
 
             if is_primary and (parent != original_parent):
-                raise ValidationError({
-                    'assigned_object': _(
-                        "Cannot reassign IP address while it is designated as the primary IP for the parent object"
-                    )
-                })
+                raise ValidationError(
+                    _("Cannot reassign IP address while it is designated as the primary IP for the parent object")
+                )
 
         # Validate IP status selection
         if self.status == IPAddressStatusChoices.STATUS_SLAAC and self.family != 6:


### PR DESCRIPTION
### Fixes: #14482

When an Primary IP address is moved, it should result in a validation error.  However, it does not normally due to the fact that the `clean()` method on the model returns with the field `assigned_object` instead of `interface`, `vminterface`, or `fhrpgroup`.  When the `_post_clean()` method tries to resolve the fields, it will fail because the form does not contain `assigned_object` as a field and returns a ValueError.

This will correctly map the `assigned_object` field to the correct field, however we should maybe look at instead providing a method to have `assigned_object` (or similar GFK fields) as proper form fields in the future, perhaps using a custom form field.