### PR TITLE
Fixes #14512: Omit unused queryset annotations for REST API requests using brief mode

### DIFF
--- a/netbox/netbox/api/viewsets/mixins.py
+++ b/netbox/netbox/api/viewsets/mixins.py
@@ -56,8 +56,15 @@ class BriefModeMixin:
     def get_queryset(self):
         qs = super().get_queryset()
 
-        # If using brief mode, clear all prefetches from the queryset and append only brief_prefetch_fields (if any)
         if self.brief:
+            serializer_class = self.get_serializer_class()
+
+            # Clear any annotations for fields not present on the nested serializer
+            for annotation in list(qs.query.annotations.keys()):
+                if annotation not in serializer_class().fields:
+                    qs.query.annotations.pop(annotation)
+
+            # Clear any prefetches from the queryset and append only brief_prefetch_fields (if any)
             return qs.prefetch_related(None).prefetch_related(*self.brief_prefetch_fields)
 
         return qs


### PR DESCRIPTION
### Fixes: #14512

Remove any queryset annotations with keys that are not present as serializer fields.