### PR TITLE
Fixes #14533: Fix quick search under VLAN group VLANs list

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -953,7 +953,7 @@ class VLANGroupVLANsView(generic.ObjectChildrenView):
 
     def prep_table_data(self, request, queryset, parent):
         if not get_table_ordering(request, self.table):
-            return add_available_vlans(parent.get_child_vlans(), parent)
+            return add_available_vlans(queryset, parent)
         return queryset
 
 


### PR DESCRIPTION
### Fixes: #14533

Pass the existing (filtered) queryset to `add_available_vlans()`