### PR TITLE
Add NetBox version output in `upgrade.sh`

### DIFF
--- a/upgrade.sh
+++ b/upgrade.sh
@@ -7,6 +7,10 @@
 # Python 3.8 or later.
 
 cd "$(dirname "$0")"
+
+NETBOX_VERSION="$(grep ^VERSION netbox/netbox/settings.py | cut -d\' -f2)"
+echo "You are installing (or upgrading to) NetBox version ${NETBOX_VERSION}"
+
 VIRTUALENV="$(pwd -P)/venv"
 PYTHON="${PYTHON:-python3}"
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #14507

<!--
    Please include a summary of the proposed changes below.
-->

NetBox version is fetched from `netbox/netbox/settings.py` (the script already `cd`'d to the location of `upgrade.sh` = the top-level directory of NetBox).