### PR TITLE
Closes #14536: Enable ENFORCE_GLOBAL_UNIQUE by default

### DIFF
--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -103,9 +103,12 @@ The maximum size (in bytes) of an incoming HTTP request (i.e. `GET` or `POST` da
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: False
+Default: True
 
-By default, NetBox will permit users to create duplicate prefixes and IP addresses in the global table (that is, those which are not assigned to any VRF). This behavior can be disabled by setting `ENFORCE_GLOBAL_UNIQUE` to True.
+By default, NetBox will prevent the creation of duplicate prefixes and IP addresses in the global table (that is, those which are not assigned to any VRF). This validation can be disabled by setting `ENFORCE_GLOBAL_UNIQUE` to False.
+
+!!! info "Changed in v3.7"
+    The default value for this parameter was changed from False to True in NetBox v3.7.
 
 ---
 

--- a/netbox/ipam/tests/test_models.py
+++ b/netbox/ipam/tests/test_models.py
@@ -232,7 +232,6 @@ class TestPrefix(TestCase):
         duplicate_prefix = Prefix(prefix=IPNetwork('192.0.2.0/24'))
         self.assertIsNone(duplicate_prefix.clean())
 
-    @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
     def test_duplicate_global_unique(self):
         Prefix.objects.create(prefix=IPNetwork('192.0.2.0/24'))
         duplicate_prefix = Prefix(prefix=IPNetwork('192.0.2.0/24'))
@@ -471,7 +470,6 @@ class TestIPAddress(TestCase):
         duplicate_ip = IPAddress(address=IPNetwork('192.0.2.1/24'))
         self.assertIsNone(duplicate_ip.clean())
 
-    @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
     def test_duplicate_global_unique(self):
         IPAddress.objects.create(address=IPNetwork('192.0.2.1/24'))
         duplicate_ip = IPAddress(address=IPNetwork('192.0.2.1/24'))
@@ -489,19 +487,16 @@ class TestIPAddress(TestCase):
         duplicate_ip = IPAddress(vrf=vrf, address=IPNetwork('192.0.2.1/24'))
         self.assertRaises(ValidationError, duplicate_ip.clean)
 
-    @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
     def test_duplicate_nonunique_nonrole_role(self):
         IPAddress.objects.create(address=IPNetwork('192.0.2.1/24'))
         duplicate_ip = IPAddress(address=IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)
         self.assertRaises(ValidationError, duplicate_ip.clean)
 
-    @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
     def test_duplicate_nonunique_role_nonrole(self):
         IPAddress.objects.create(address=IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)
         duplicate_ip = IPAddress(address=IPNetwork('192.0.2.1/24'))
         self.assertRaises(ValidationError, duplicate_ip.clean)
 
-    @override_settings(ENFORCE_GLOBAL_UNIQUE=True)
     def test_duplicate_nonunique_role(self):
         IPAddress.objects.create(address=IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)
         IPAddress.objects.create(address=IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)

--- a/netbox/netbox/config/parameters.py
+++ b/netbox/netbox/config/parameters.py
@@ -66,7 +66,7 @@ PARAMS = (
     ConfigParam(
         name='ENFORCE_GLOBAL_UNIQUE',
         label=_('Globally unique IP space'),
-        default=False,
+        default=True,
         description=_("Enforce unique IP addressing within the global table"),
         field=forms.BooleanField
     ),


### PR DESCRIPTION
### Fixes: #14536

Change the default value for the `ENFORCE_GLOBAL_UNIQUE` configuration parameter from False to True.