### PR TITLE
14550 fix EventRule HTMX change of action_type

### DIFF
--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -308,9 +308,10 @@ class EventRuleForm(NetBoxModelForm):
         self.fields['action_choice'].choices = choices
 
         if self.instance.pk:
-            scriptmodule_id = self.instance.action_object_id
-            if self.instance.action_parameters:
-                script_name = self.instance.action_parameters.get('script_name')
+            scriptmodule_id = get_field_value(self, 'action_object_id')
+            action_parameters = get_field_value(self, 'action_parameters')
+            if action_parameters and scriptmodule_id:
+                script_name = action_parameters.get('script_name')
                 self.fields['action_choice'].initial = f'{scriptmodule_id}:{script_name}'
             else:
                 self.fields['action_choice'].inital = None

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -309,9 +309,11 @@ class EventRuleForm(NetBoxModelForm):
 
         if self.instance.pk:
             scriptmodule_id = self.instance.action_object_id
-            script_name = self.instance.action_parameters.get('script_name')
-            self.fields['action_choice'].initial = f'{scriptmodule_id}:{script_name}'
-        print(self.fields['action_choice'].initial)
+            if self.instance.action_parameters:
+                script_name = self.instance.action_parameters.get('script_name')
+                self.fields['action_choice'].initial = f'{scriptmodule_id}:{script_name}'
+            else:
+                self.fields['action_choice'].inital = None
 
     def init_webhook_choice(self):
         initial = None

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -416,6 +416,16 @@ class EventRuleEditView(generic.ObjectEditView):
     queryset = EventRule.objects.all()
     form = forms.EventRuleForm
 
+    def get_initial_data(self, request):
+        initial_data = normalize_querydict(request.GET)
+
+        if is_htmx(request):
+            initial_data['action_object_type'] = None
+            initial_data['action_object_id'] = None
+            initial_data['action_parameters'] = None
+
+        return initial_data
+
 
 @register_model_view(EventRule, 'delete')
 class EventRuleDeleteView(generic.ObjectDeleteView):

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -204,6 +204,9 @@ class ObjectEditView(GetReturnURLMixin, BaseObjectView):
         """
         return {}
 
+    def get_initial_data(self, request):
+        return normalize_querydict(request.GET)
+
     #
     # Request handlers
     #
@@ -219,7 +222,8 @@ class ObjectEditView(GetReturnURLMixin, BaseObjectView):
         obj = self.alter_object(obj, request, args, kwargs)
         model = self.queryset.model
 
-        initial_data = normalize_querydict(request.GET)
+        initial_data = self.get_initial_data(request)
+
         form = self.form(instance=obj, initial=initial_data)
         restrict_form_fields(form, request.user)
 


### PR DESCRIPTION
### Fixes: #14550 

@jeremystretch if you can double-check added a get_initial_data to the base view which allows resetting form fields on an HTMX change which I thought would be the most flexible fix.