### PR TITLE
Add PUBLIC_SWAGGER configuration option

### DIFF
--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -180,14 +180,6 @@ When determining the primary IP address for a device, IPv6 is preferred over IPv
 
 ---
 
-## PUBLIC_SWAGGER
-
-Default: True
-
-Swagger exposes by default the schemas to unauthenticated users. Set this to False to only expose them to authenticated users.
-
----
-
 ## QUEUE_MAPPINGS
 
 Allows changing which queues are used internally for background tasks.
@@ -242,3 +234,11 @@ This parameter controls how frequently a failed job is retried, up to the maximu
 Default: `0` (retries disabled)
 
 The maximum number of times a background task will be retried before being marked as failed.
+
+---
+
+## SWAGGER_PUBLIC
+
+Default: True
+
+The [REST API](../integrations/rest-api.md) interactive documentation (Swagger) exposes the schemas by default to unauthenticated users. As this UI is ressource intensive, it can be preferable to only expose the schemas to authenticated users, by setting this variable to False. Especially for public instances.

--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -180,6 +180,14 @@ When determining the primary IP address for a device, IPv6 is preferred over IPv
 
 ---
 
+## PUBLIC_SWAGGER
+
+Default: True
+
+Swagger exposes by default the schemas to unauthenticated users. Set this to False to only expose them to authenticated users.
+
+---
+
 ## QUEUE_MAPPINGS
 
 Allows changing which queues are used internally for background tasks.

--- a/netbox/netbox/configuration_example.py
+++ b/netbox/netbox/configuration_example.py
@@ -190,9 +190,6 @@ PLUGINS = []
 #     }
 # }
 
-# Expose the SWAGGER UI schemas to unauthenticated users
-PUBLIC_SWAGGER = True
-
 # Remote authentication support
 REMOTE_AUTH_ENABLED = False
 REMOTE_AUTH_BACKEND = 'netbox.authentication.RemoteUserBackend'

--- a/netbox/netbox/configuration_example.py
+++ b/netbox/netbox/configuration_example.py
@@ -190,6 +190,9 @@ PLUGINS = []
 #     }
 # }
 
+# Expose the SWAGGER UI schemas to unauthenticated users
+PUBLIC_SWAGGER = True
+
 # Remote authentication support
 REMOTE_AUTH_ENABLED = False
 REMOTE_AUTH_BACKEND = 'netbox.authentication.RemoteUserBackend'

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -653,6 +653,7 @@ SPECTACULAR_SETTINGS = {
     'VERSION': VERSION,
     'COMPONENT_SPLIT_REQUEST': True,
     'REDOC_DIST': 'SIDECAR',
+    'SERVE_PUBLIC': getattr(configuration, 'PUBLIC_SWAGGER', True),
     'SERVERS': [{
         'url': BASE_PATH,
         'description': 'NetBox',

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -171,6 +171,7 @@ SHORT_DATETIME_FORMAT = getattr(configuration, 'SHORT_DATETIME_FORMAT', 'Y-m-d H
 SHORT_TIME_FORMAT = getattr(configuration, 'SHORT_TIME_FORMAT', 'H:i:s')
 STORAGE_BACKEND = getattr(configuration, 'STORAGE_BACKEND', None)
 STORAGE_CONFIG = getattr(configuration, 'STORAGE_CONFIG', {})
+SWAGGER_PUBLIC = getattr(configuration, 'SWAGGER_PUBLIC', True),
 TIME_FORMAT = getattr(configuration, 'TIME_FORMAT', 'g:i a')
 TIME_ZONE = getattr(configuration, 'TIME_ZONE', 'UTC')
 ENABLE_LOCALIZATION = getattr(configuration, 'ENABLE_LOCALIZATION', False)
@@ -653,7 +654,7 @@ SPECTACULAR_SETTINGS = {
     'VERSION': VERSION,
     'COMPONENT_SPLIT_REQUEST': True,
     'REDOC_DIST': 'SIDECAR',
-    'SERVE_PUBLIC': getattr(configuration, 'PUBLIC_SWAGGER', True),
+    'SERVE_PUBLIC': SWAGGER_PUBLIC,
     'SERVERS': [{
         'url': BASE_PATH,
         'description': 'NetBox',


### PR DESCRIPTION
### Fixes: #14555

Swagger metadata are by default opened to unauthenticated users. Add a configuration option to be able to only expose them to authenticated users.

Even though it's only the metadata (and not read or write operations) public Netbox instances attract a significant amount of "Google traffic" and people experimenting with the API, slowing down Netbox.