### PR TITLE
Fixes #14575: Fix display of the tags column under VDC table

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -1078,7 +1078,7 @@ class VirtualDeviceContextTable(TenancyColumnsMixin, NetBoxTable):
     comments = columns.MarkdownColumn()
 
     tags = columns.TagColumn(
-        url_name='dcim:vdc_list'
+        url_name='dcim:virtualdevicecontext_list'
     )
 
     class Meta(NetBoxTable.Meta):


### PR DESCRIPTION
### Fixes: #14575

Correct view name for the `tags` column
