### PR TITLE
Fixes: #13844 - Change Prefix form to use available_at_site

### DIFF
--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -216,7 +216,7 @@ class PrefixForm(TenancyForm, NetBoxModelForm):
         required=False,
         selector=True,
         query_params={
-            'site_id': '$site',
+            'available_at_site': '$site',
         },
         label=_('VLAN'),
     )


### PR DESCRIPTION
### Fixes: #13844 - Change Prefix form to use available_at_site

* Swap API call to when setting site on the Prefix model to use `available_at_site` instead of simply `site_id`
