### PR TITLE
Fixes #13649: Permit zero-length cables

### DIFF
--- a/netbox/dcim/migrations/0182_zero_length_cable_fix.py
+++ b/netbox/dcim/migrations/0182_zero_length_cable_fix.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+def update_cable_lengths(apps, schema_editor):
+    Cable = apps.get_model('dcim', 'Cable')
+
+    # Set the absolute length for any zero-length Cables
+    Cable.objects.filter(length=0).update(_abs_length=0)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dcim', '0181_rename_device_role_device_role'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=update_cable_lengths,
+            reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -201,7 +201,7 @@ class Cable(PrimaryModel):
         _created = self.pk is None
 
         # Store the given length (if any) in meters for use in database ordering
-        if self.length and self.length_unit:
+        if self.length is not None and self.length_unit:
             self._abs_length = to_meters(self.length, self.length_unit)
         else:
             self._abs_length = None

--- a/netbox/dcim/svg/cables.py
+++ b/netbox/dcim/svg/cables.py
@@ -274,7 +274,7 @@ class CableTraceSVG:
             if cable.type:
                 # Include the cable type in the tooltip
                 description.append(cable.get_type_display())
-            if cable.length and cable.length_unit:
+            if cable.length is not None and cable.length_unit:
                 # Include the cable length in the tooltip
                 description.append(f'{cable.length} {cable.get_length_unit_display()}')
         else:
@@ -285,7 +285,7 @@ class CableTraceSVG:
             description = []
             if cable.type:
                 labels.append(cable.get_type_display())
-            if cable.length and cable.length_unit:
+            if cable.length is not None and cable.length_unit:
                 # Include the cable length in the tooltip
                 labels.append(f'{cable.length} {cable.get_length_unit_display()}')
 

--- a/netbox/templates/dcim/cable.html
+++ b/netbox/templates/dcim/cable.html
@@ -50,7 +50,7 @@
             <tr>
               <th scope="row">{% trans "Length" %}</th>
               <td>
-                {% if object.length %}
+                {% if object.length is not None %}
                   {{ object.length|floatformat }} {{ object.get_length_unit_display }}
                 {% else %}
                   {{ ''|placeholder }}


### PR DESCRIPTION
### Fixes: #13649

- Set the absolute length (`_abs_length`) when `length` is zero
- Run a simple migration to update existing cables
- Misc tweaks to report values of zero