### PR TITLE
Fixes #13812: Record data source sync failure when run via syncdatasource command

### DIFF
--- a/netbox/core/management/commands/syncdatasource.py
+++ b/netbox/core/management/commands/syncdatasource.py
@@ -1,5 +1,6 @@
 from django.core.management.base import BaseCommand, CommandError
 
+from core.choices import DataSourceStatusChoices
 from core.models import DataSource
 
 
@@ -33,9 +34,13 @@ class Command(BaseCommand):
         for i, datasource in enumerate(datasources, start=1):
             self.stdout.write(f"[{i}] Syncing {datasource}... ", ending='')
             self.stdout.flush()
-            datasource.sync()
-            self.stdout.write(datasource.get_status_display())
-            self.stdout.flush()
+            try:
+                datasource.sync()
+                self.stdout.write(datasource.get_status_display())
+                self.stdout.flush()
+            except Exception as e:
+                DataSource.objects.filter(pk=datasource.pk).update(status=DataSourceStatusChoices.FAILED)
+                raise e
 
         if len(options['name']) > 1:
             self.stdout.write(f"Finished.")


### PR DESCRIPTION
### Fixes: #13812

Set DataSource status to failed before raising exception