### PR TITLE
Closes #11039: List parent prefixes under IP range view

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -661,6 +661,26 @@ class IPRangeListView(generic.ObjectListView):
 class IPRangeView(generic.ObjectView):
     queryset = IPRange.objects.all()
 
+    def get_extra_context(self, request, instance):
+
+        # Parent prefixes table
+        parent_prefixes = Prefix.objects.restrict(request.user, 'view').filter(
+            Q(prefix__net_contains_or_equals=str(instance.start_address.ip)),
+            Q(prefix__net_contains_or_equals=str(instance.end_address.ip)),
+            vrf=instance.vrf
+        ).prefetch_related(
+            'site', 'role', 'tenant', 'vlan', 'role'
+        )
+        parent_prefixes_table = tables.PrefixTable(
+            list(parent_prefixes),
+            exclude=('vrf', 'utilization'),
+            orderable=False
+        )
+
+        return {
+            'parent_prefixes_table': parent_prefixes_table,
+        }
+
 
 @register_model_view(IPRange, 'ipaddresses', path='ip-addresses')
 class IPRangeIPAddressesView(generic.ObjectChildrenView):

--- a/netbox/templates/ipam/iprange.html
+++ b/netbox/templates/ipam/iprange.html
@@ -83,6 +83,11 @@
     </div>
 </div>
 <div class="row">
+  <div class="col col-md-12">
+    {% include 'inc/panel_table.html' with table=parent_prefixes_table heading='Parent Prefixes' %}
+  </div>
+</div>
+<div class="row">
     <div class="col col-md-12">
         {% plugin_full_width_page object %}
     </div>


### PR DESCRIPTION
### Fixes: #11039

Replicates the parent prefixes from the IP address view for IP ranges