### PR TITLE
Closes #14631: Ensure description filters are available on all relevant models

### DIFF
--- a/netbox/circuits/filtersets.py
+++ b/netbox/circuits/filtersets.py
@@ -67,13 +67,14 @@ class ProviderFilterSet(NetBoxModelFilterSet, ContactModelFilterSet):
 
     class Meta:
         model = Provider
-        fields = ['id', 'name', 'slug']
+        fields = ['id', 'name', 'slug', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
         return queryset.filter(
             Q(name__icontains=value) |
+            Q(description__icontains=value) |
             Q(accounts__account__icontains=value) |
             Q(accounts__name__icontains=value) |
             Q(comments__icontains=value)
@@ -101,6 +102,7 @@ class ProviderAccountFilterSet(NetBoxModelFilterSet):
             return queryset
         return queryset.filter(
             Q(name__icontains=value) |
+            Q(description__icontains=value) |
             Q(account__icontains=value) |
             Q(comments__icontains=value)
         ).distinct()

--- a/netbox/circuits/tests/test_filtersets.py
+++ b/netbox/circuits/tests/test_filtersets.py
@@ -25,8 +25,8 @@ class ProviderTestCase(TestCase, ChangeLoggedFilterSetTests):
         ASN.objects.bulk_create(asns)
 
         providers = (
-            Provider(name='Provider 1', slug='provider-1'),
-            Provider(name='Provider 2', slug='provider-2'),
+            Provider(name='Provider 1', slug='provider-1', description='foobar1'),
+            Provider(name='Provider 2', slug='provider-2', description='foobar2'),
             Provider(name='Provider 3', slug='provider-3'),
             Provider(name='Provider 4', slug='provider-4'),
             Provider(name='Provider 5', slug='provider-5'),
@@ -74,12 +74,20 @@ class ProviderTestCase(TestCase, ChangeLoggedFilterSetTests):
             CircuitTermination(circuit=circuits[1], site=sites[0], term_side='A'),
         ))
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Provider 1', 'Provider 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_slug(self):
         params = {'slug': ['provider-1', 'provider-2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_asn_id(self):  # ASN object assignment
@@ -121,6 +129,10 @@ class CircuitTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
             CircuitType(name='Circuit Type 2', slug='circuit-type-2', description='foobar2'),
             CircuitType(name='Circuit Type 3', slug='circuit-type-3'),
         ))
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Circuit Type 1']}
@@ -226,6 +238,10 @@ class CircuitTestCase(TestCase, ChangeLoggedFilterSetTests):
             CircuitTermination(circuit=circuits[5], provider_network=provider_networks[2], term_side='A'),
         ))
         CircuitTermination.objects.bulk_create(circuit_terminations)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_cid(self):
         params = {'cid': ['Test Circuit 1', 'Test Circuit 2']}
@@ -369,6 +385,10 @@ class CircuitTerminationTestCase(TestCase, ChangeLoggedFilterSetTests):
 
         Cable(a_terminations=[circuit_terminations[0]], b_terminations=[circuit_terminations[1]]).save()
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_term_side(self):
         params = {'term_side': 'A'}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 7)
@@ -440,6 +460,10 @@ class ProviderNetworkTestCase(TestCase, ChangeLoggedFilterSetTests):
         )
         ProviderNetwork.objects.bulk_create(provider_networks)
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Provider Network 1', 'Provider Network 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -476,6 +500,10 @@ class ProviderAccountTestCase(TestCase, ChangeLoggedFilterSetTests):
             ProviderAccount(name='Provider Account 3', provider=providers[2], account='3456'),
         )
         ProviderAccount.objects.bulk_create(provider_accounts)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Provider Account 1', 'Provider Account 2']}

--- a/netbox/core/filtersets.py
+++ b/netbox/core/filtersets.py
@@ -26,7 +26,7 @@ class DataSourceFilterSet(NetBoxModelFilterSet):
 
     class Meta:
         model = DataSource
-        fields = ('id', 'name', 'enabled')
+        fields = ('id', 'name', 'enabled', 'description')
 
     def search(self, queryset, name, value):
         if not value.strip():

--- a/netbox/core/tests/test_filtersets.py
+++ b/netbox/core/tests/test_filtersets.py
@@ -21,14 +21,16 @@ class DataSourceTestCase(TestCase, ChangeLoggedFilterSetTests):
                 type=DataSourceTypeChoices.LOCAL,
                 source_url='file:///var/tmp/source1/',
                 status=DataSourceStatusChoices.NEW,
-                enabled=True
+                enabled=True,
+                description='foobar1'
             ),
             DataSource(
                 name='Data Source 2',
                 type=DataSourceTypeChoices.LOCAL,
                 source_url='file:///var/tmp/source2/',
                 status=DataSourceStatusChoices.SYNCING,
-                enabled=True
+                enabled=True,
+                description='foobar2'
             ),
             DataSource(
                 name='Data Source 3',
@@ -40,8 +42,16 @@ class DataSourceTestCase(TestCase, ChangeLoggedFilterSetTests):
         )
         DataSource.objects.bulk_create(data_sources)
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Data Source 1', 'Data Source 2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
@@ -96,6 +106,10 @@ class DataFileTestCase(TestCase, ChangeLoggedFilterSetTests):
             ),
         )
         DataFile.objects.bulk_create(data_files)
+
+    def test_q(self):
+        params = {'q': 'file1.txt'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_source(self):
         sources = DataSource.objects.all()

--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -325,7 +325,7 @@ class RackFilterSet(NetBoxModelFilterSet, TenancyFilterSet, ContactModelFilterSe
         model = Rack
         fields = [
             'id', 'name', 'facility_id', 'asset_tag', 'u_height', 'starting_unit', 'desc_units', 'outer_width',
-            'outer_depth', 'outer_unit', 'mounting_depth', 'weight', 'max_weight', 'weight_unit'
+            'outer_depth', 'outer_unit', 'mounting_depth', 'weight', 'max_weight', 'weight_unit', 'description',
         ]
 
     def search(self, queryset, name, value):
@@ -336,6 +336,7 @@ class RackFilterSet(NetBoxModelFilterSet, TenancyFilterSet, ContactModelFilterSe
             Q(facility_id__icontains=value) |
             Q(serial__icontains=value.strip()) |
             Q(asset_tag__icontains=value.strip()) |
+            Q(description__icontains=value) |
             Q(comments__icontains=value)
         )
 
@@ -497,7 +498,8 @@ class DeviceTypeFilterSet(NetBoxModelFilterSet):
     class Meta:
         model = DeviceType
         fields = [
-            'id', 'model', 'slug', 'part_number', 'u_height', 'is_full_depth', 'subdevice_role', 'airflow', 'weight', 'weight_unit',
+            'id', 'model', 'slug', 'part_number', 'u_height', 'is_full_depth', 'subdevice_role', 'airflow', 'weight',
+            'weight_unit', 'description',
         ]
 
     def search(self, queryset, name, value):
@@ -507,6 +509,7 @@ class DeviceTypeFilterSet(NetBoxModelFilterSet):
             Q(manufacturer__name__icontains=value) |
             Q(model__icontains=value) |
             Q(part_number__icontains=value) |
+            Q(description__icontains=value) |
             Q(comments__icontains=value)
         )
 
@@ -591,7 +594,7 @@ class ModuleTypeFilterSet(NetBoxModelFilterSet):
 
     class Meta:
         model = ModuleType
-        fields = ['id', 'model', 'part_number', 'weight', 'weight_unit']
+        fields = ['id', 'model', 'part_number', 'weight', 'weight_unit', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():
@@ -600,6 +603,7 @@ class ModuleTypeFilterSet(NetBoxModelFilterSet):
             Q(manufacturer__name__icontains=value) |
             Q(model__icontains=value) |
             Q(part_number__icontains=value) |
+            Q(description__icontains=value) |
             Q(comments__icontains=value)
         )
 
@@ -639,7 +643,10 @@ class DeviceTypeComponentFilterSet(django_filters.FilterSet):
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(name__icontains=value)
+        return queryset.filter(
+            Q(name__icontains=value) |
+            Q(description__icontains=value)
+        )
 
 
 class ModularDeviceTypeComponentFilterSet(DeviceTypeComponentFilterSet):
@@ -654,21 +661,21 @@ class ConsolePortTemplateFilterSet(ChangeLoggedModelFilterSet, ModularDeviceType
 
     class Meta:
         model = ConsolePortTemplate
-        fields = ['id', 'name', 'type']
+        fields = ['id', 'name', 'type', 'description']
 
 
 class ConsoleServerPortTemplateFilterSet(ChangeLoggedModelFilterSet, ModularDeviceTypeComponentFilterSet):
 
     class Meta:
         model = ConsoleServerPortTemplate
-        fields = ['id', 'name', 'type']
+        fields = ['id', 'name', 'type', 'description']
 
 
 class PowerPortTemplateFilterSet(ChangeLoggedModelFilterSet, ModularDeviceTypeComponentFilterSet):
 
     class Meta:
         model = PowerPortTemplate
-        fields = ['id', 'name', 'type', 'maximum_draw', 'allocated_draw']
+        fields = ['id', 'name', 'type', 'maximum_draw', 'allocated_draw', 'description']
 
 
 class PowerOutletTemplateFilterSet(ChangeLoggedModelFilterSet, ModularDeviceTypeComponentFilterSet):
@@ -679,7 +686,7 @@ class PowerOutletTemplateFilterSet(ChangeLoggedModelFilterSet, ModularDeviceType
 
     class Meta:
         model = PowerOutletTemplate
-        fields = ['id', 'name', 'type', 'feed_leg']
+        fields = ['id', 'name', 'type', 'feed_leg', 'description']
 
 
 class InterfaceTemplateFilterSet(ChangeLoggedModelFilterSet, ModularDeviceTypeComponentFilterSet):
@@ -703,7 +710,7 @@ class InterfaceTemplateFilterSet(ChangeLoggedModelFilterSet, ModularDeviceTypeCo
 
     class Meta:
         model = InterfaceTemplate
-        fields = ['id', 'name', 'type', 'enabled', 'mgmt_only']
+        fields = ['id', 'name', 'type', 'enabled', 'mgmt_only', 'description']
 
 
 class FrontPortTemplateFilterSet(ChangeLoggedModelFilterSet, ModularDeviceTypeComponentFilterSet):
@@ -714,7 +721,7 @@ class FrontPortTemplateFilterSet(ChangeLoggedModelFilterSet, ModularDeviceTypeCo
 
     class Meta:
         model = FrontPortTemplate
-        fields = ['id', 'name', 'type', 'color']
+        fields = ['id', 'name', 'type', 'color', 'description']
 
 
 class RearPortTemplateFilterSet(ChangeLoggedModelFilterSet, ModularDeviceTypeComponentFilterSet):
@@ -725,21 +732,21 @@ class RearPortTemplateFilterSet(ChangeLoggedModelFilterSet, ModularDeviceTypeCom
 
     class Meta:
         model = RearPortTemplate
-        fields = ['id', 'name', 'type', 'color', 'positions']
+        fields = ['id', 'name', 'type', 'color', 'positions', 'description']
 
 
 class ModuleBayTemplateFilterSet(ChangeLoggedModelFilterSet, DeviceTypeComponentFilterSet):
 
     class Meta:
         model = ModuleBayTemplate
-        fields = ['id', 'name']
+        fields = ['id', 'name', 'description']
 
 
 class DeviceBayTemplateFilterSet(ChangeLoggedModelFilterSet, DeviceTypeComponentFilterSet):
 
     class Meta:
         model = DeviceBayTemplate
-        fields = ['id', 'name']
+        fields = ['id', 'name', 'description']
 
 
 class InventoryItemTemplateFilterSet(ChangeLoggedModelFilterSet, DeviceTypeComponentFilterSet):
@@ -772,7 +779,7 @@ class InventoryItemTemplateFilterSet(ChangeLoggedModelFilterSet, DeviceTypeCompo
 
     class Meta:
         model = InventoryItemTemplate
-        fields = ['id', 'name', 'label', 'part_id']
+        fields = ['id', 'name', 'label', 'part_id', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():
@@ -1008,7 +1015,10 @@ class DeviceFilterSet(
 
     class Meta:
         model = Device
-        fields = ['id', 'asset_tag', 'face', 'position', 'latitude', 'longitude', 'airflow', 'vc_position', 'vc_priority']
+        fields = [
+            'id', 'asset_tag', 'face', 'position', 'latitude', 'longitude', 'airflow', 'vc_position', 'vc_priority',
+            'description',
+        ]
 
     def search(self, queryset, name, value):
         if not value.strip():
@@ -1088,13 +1098,16 @@ class VirtualDeviceContextFilterSet(NetBoxModelFilterSet, TenancyFilterSet, Prim
 
     class Meta:
         model = VirtualDeviceContext
-        fields = ['id', 'device', 'name']
+        fields = ['id', 'device', 'name', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
 
-        qs_filter = Q(name__icontains=value)
+        qs_filter = (
+            Q(name__icontains=value) |
+            Q(description__icontains=value)
+        )
         try:
             qs_filter |= Q(identifier=int(value))
         except ValueError:
@@ -1151,7 +1164,7 @@ class ModuleFilterSet(NetBoxModelFilterSet):
 
     class Meta:
         model = Module
-        fields = ['id', 'status', 'asset_tag']
+        fields = ['id', 'status', 'asset_tag', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():
@@ -1160,6 +1173,7 @@ class ModuleFilterSet(NetBoxModelFilterSet):
             Q(device__name__icontains=value.strip()) |
             Q(serial__icontains=value.strip()) |
             Q(asset_tag__icontains=value.strip()) |
+            Q(description__icontains=value) |
             Q(comments__icontains=value)
         ).distinct()
 
@@ -1650,7 +1664,7 @@ class InventoryItemRoleFilterSet(OrganizationalModelFilterSet):
 
     class Meta:
         model = InventoryItemRole
-        fields = ['id', 'name', 'slug', 'color']
+        fields = ['id', 'name', 'slug', 'color', 'description']
 
 
 class VirtualChassisFilterSet(NetBoxModelFilterSet):
@@ -1715,13 +1729,14 @@ class VirtualChassisFilterSet(NetBoxModelFilterSet):
 
     class Meta:
         model = VirtualChassis
-        fields = ['id', 'domain', 'name']
+        fields = ['id', 'domain', 'name', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
         qs_filter = (
             Q(name__icontains=value) |
+            Q(description__icontains=value) |
             Q(members__name__icontains=value) |
             Q(domain__icontains=value)
         )
@@ -1790,12 +1805,16 @@ class CableFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
 
     class Meta:
         model = Cable
-        fields = ['id', 'label', 'length', 'length_unit']
+        fields = ['id', 'label', 'length', 'length_unit', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
-        return queryset.filter(label__icontains=value)
+        qs_filter = (
+            Q(label__icontains=value) |
+            Q(description__icontains=value)
+        )
+        return queryset.filter(qs_filter)
 
     def filter_by_termination(self, queryset, name, value):
         # Filter by a related object cached on CableTermination. Note the underscore preceding the field name.
@@ -1882,13 +1901,14 @@ class PowerPanelFilterSet(NetBoxModelFilterSet, ContactModelFilterSet):
 
     class Meta:
         model = PowerPanel
-        fields = ['id', 'name']
+        fields = ['id', 'name', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
         qs_filter = (
-            Q(name__icontains=value)
+            Q(name__icontains=value) |
+            Q(description__icontains=value)
         )
         return queryset.filter(qs_filter)
 
@@ -1949,6 +1969,7 @@ class PowerFeedFilterSet(NetBoxModelFilterSet, CabledObjectFilterSet, PathEndpoi
         model = PowerFeed
         fields = [
             'id', 'name', 'status', 'type', 'supply', 'phase', 'voltage', 'amperage', 'max_utilization', 'cable_end',
+            'description',
         ]
 
     def search(self, queryset, name, value):
@@ -1956,6 +1977,7 @@ class PowerFeedFilterSet(NetBoxModelFilterSet, CabledObjectFilterSet, PathEndpoi
             return queryset
         qs_filter = (
             Q(name__icontains=value) |
+            Q(description__icontains=value) |
             Q(power_panel__name__icontains=value) |
             Q(comments__icontains=value)
         )

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -17,6 +17,14 @@ User = get_user_model()
 
 class DeviceComponentFilterSetTests:
 
+    def test_q(self):
+        params = {'q': 'First'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_description(self):
+        params = {'description': ['First', 'Second']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
     def test_device_type(self):
         device_types = DeviceType.objects.all()[:2]
         params = {'device_type_id': [device_types[0].pk, device_types[1].pk]}
@@ -32,6 +40,22 @@ class DeviceComponentFilterSetTests:
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
+class DeviceComponentTemplateFilterSetTests:
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_devicetype_id(self):
+        device_types = DeviceType.objects.all()[:2]
+        params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+
 class RegionTestCase(TestCase, ChangeLoggedFilterSetTests):
     queryset = Region.objects.all()
     filterset = RegionFilterSet
@@ -40,9 +64,9 @@ class RegionTestCase(TestCase, ChangeLoggedFilterSetTests):
     def setUpTestData(cls):
 
         regions = (
-            Region(name='Region 1', slug='region-1', description='A'),
-            Region(name='Region 2', slug='region-2', description='B'),
-            Region(name='Region 3', slug='region-3', description='C'),
+            Region(name='Region 1', slug='region-1', description='foobar1'),
+            Region(name='Region 2', slug='region-2', description='foobar2'),
+            Region(name='Region 3', slug='region-3', description='foobar3'),
         )
         for region in regions:
             region.save()
@@ -58,6 +82,10 @@ class RegionTestCase(TestCase, ChangeLoggedFilterSetTests):
         for region in child_regions:
             region.save()
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Region 1', 'Region 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -67,7 +95,7 @@ class RegionTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
-        params = {'description': ['A', 'B']}
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_parent(self):
@@ -86,9 +114,9 @@ class SiteGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
     def setUpTestData(cls):
 
         sitegroups = (
-            SiteGroup(name='Site Group 1', slug='site-group-1', description='A'),
-            SiteGroup(name='Site Group 2', slug='site-group-2', description='B'),
-            SiteGroup(name='Site Group 3', slug='site-group-3', description='C'),
+            SiteGroup(name='Site Group 1', slug='site-group-1', description='foobar1'),
+            SiteGroup(name='Site Group 2', slug='site-group-2', description='foobar2'),
+            SiteGroup(name='Site Group 3', slug='site-group-3', description='foobar3'),
         )
         for sitegroup in sitegroups:
             sitegroup.save()
@@ -104,6 +132,10 @@ class SiteGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         for sitegroup in child_sitegroups:
             sitegroup.save()
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Site Group 1', 'Site Group 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -113,7 +145,7 @@ class SiteGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
-        params = {'description': ['A', 'B']}
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_parent(self):
@@ -172,13 +204,17 @@ class SiteTestCase(TestCase, ChangeLoggedFilterSetTests):
 
         sites = (
             Site(name='Site 1', slug='site-1', region=regions[0], group=groups[0], tenant=tenants[0], status=SiteStatusChoices.STATUS_ACTIVE, facility='Facility 1', latitude=10, longitude=10, description='foobar1'),
-            Site(name='Site 2', slug='site-2', region=regions[1], group=groups[1], tenant=tenants[1], status=SiteStatusChoices.STATUS_PLANNED, facility='Facility 2', latitude=20, longitude=20, description='foobar1'),
+            Site(name='Site 2', slug='site-2', region=regions[1], group=groups[1], tenant=tenants[1], status=SiteStatusChoices.STATUS_PLANNED, facility='Facility 2', latitude=20, longitude=20, description='foobar2'),
             Site(name='Site 3', slug='site-3', region=regions[2], group=groups[2], tenant=tenants[2], status=SiteStatusChoices.STATUS_RETIRED, facility='Facility 3', latitude=30, longitude=30),
         )
         Site.objects.bulk_create(sites)
         sites[0].asns.set([asns[0]])
         sites[1].asns.set([asns[1]])
         sites[2].asns.set([asns[2]])
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Site 1', 'Site 2']}
@@ -285,12 +321,16 @@ class LocationTestCase(TestCase, ChangeLoggedFilterSetTests):
             location.save()
 
         locations = (
-            Location(name='Location 1', slug='location-1', site=sites[0], parent=parent_locations[0], status=LocationStatusChoices.STATUS_PLANNED, description='A'),
-            Location(name='Location 2', slug='location-2', site=sites[1], parent=parent_locations[1], status=LocationStatusChoices.STATUS_STAGING, description='B'),
-            Location(name='Location 3', slug='location-3', site=sites[2], parent=parent_locations[2], status=LocationStatusChoices.STATUS_DECOMMISSIONING, description='C'),
+            Location(name='Location 1', slug='location-1', site=sites[0], parent=parent_locations[0], status=LocationStatusChoices.STATUS_PLANNED, description='foobar1'),
+            Location(name='Location 2', slug='location-2', site=sites[1], parent=parent_locations[1], status=LocationStatusChoices.STATUS_STAGING, description='foobar2'),
+            Location(name='Location 3', slug='location-3', site=sites[2], parent=parent_locations[2], status=LocationStatusChoices.STATUS_DECOMMISSIONING, description='foobar3'),
         )
         for location in locations:
             location.save()
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Location 1', 'Location 2']}
@@ -305,7 +345,7 @@ class LocationTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
-        params = {'description': ['A', 'B']}
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
@@ -350,6 +390,10 @@ class RackRoleTestCase(TestCase, ChangeLoggedFilterSetTests):
             RackRole(name='Rack Role 3', slug='rack-role-3', color='0000ff'),
         )
         RackRole.objects.bulk_create(rack_roles)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Rack Role 1', 'Rack Role 2']}
@@ -429,11 +473,78 @@ class RackTestCase(TestCase, ChangeLoggedFilterSetTests):
         Tenant.objects.bulk_create(tenants)
 
         racks = (
-            Rack(name='Rack 1', facility_id='rack-1', site=sites[0], location=locations[0], tenant=tenants[0], status=RackStatusChoices.STATUS_ACTIVE, role=rack_roles[0], serial='ABC', asset_tag='1001', type=RackTypeChoices.TYPE_2POST, width=RackWidthChoices.WIDTH_19IN, u_height=42, desc_units=False, outer_width=100, outer_depth=100, outer_unit=RackDimensionUnitChoices.UNIT_MILLIMETER, weight=10, max_weight=1000, weight_unit=WeightUnitChoices.UNIT_POUND),
-            Rack(name='Rack 2', facility_id='rack-2', site=sites[1], location=locations[1], tenant=tenants[1], status=RackStatusChoices.STATUS_PLANNED, role=rack_roles[1], serial='DEF', asset_tag='1002', type=RackTypeChoices.TYPE_4POST, width=RackWidthChoices.WIDTH_21IN, u_height=43, desc_units=False, outer_width=200, outer_depth=200, outer_unit=RackDimensionUnitChoices.UNIT_MILLIMETER, weight=20, max_weight=2000, weight_unit=WeightUnitChoices.UNIT_POUND),
-            Rack(name='Rack 3', facility_id='rack-3', site=sites[2], location=locations[2], tenant=tenants[2], status=RackStatusChoices.STATUS_RESERVED, role=rack_roles[2], serial='GHI', asset_tag='1003', type=RackTypeChoices.TYPE_CABINET, width=RackWidthChoices.WIDTH_23IN, u_height=44, desc_units=True, outer_width=300, outer_depth=300, outer_unit=RackDimensionUnitChoices.UNIT_INCH, weight=30, max_weight=3000, weight_unit=WeightUnitChoices.UNIT_KILOGRAM),
+            Rack(
+                name='Rack 1',
+                facility_id='rack-1',
+                site=sites[0],
+                location=locations[0],
+                tenant=tenants[0],
+                status=RackStatusChoices.STATUS_ACTIVE,
+                role=rack_roles[0],
+                serial='ABC',
+                asset_tag='1001',
+                type=RackTypeChoices.TYPE_2POST,
+                width=RackWidthChoices.WIDTH_19IN,
+                u_height=42,
+                desc_units=False,
+                outer_width=100,
+                outer_depth=100,
+                outer_unit=RackDimensionUnitChoices.UNIT_MILLIMETER,
+                weight=10,
+                max_weight=1000,
+                weight_unit=WeightUnitChoices.UNIT_POUND,
+                description='foobar1'
+            ),
+            Rack(
+                name='Rack 2',
+                facility_id='rack-2',
+                site=sites[1],
+                location=locations[1],
+                tenant=tenants[1],
+                status=RackStatusChoices.STATUS_PLANNED,
+                role=rack_roles[1],
+                serial='DEF',
+                asset_tag='1002',
+                type=RackTypeChoices.TYPE_4POST,
+                width=RackWidthChoices.WIDTH_21IN,
+                u_height=43,
+                desc_units=False,
+                outer_width=200,
+                outer_depth=200,
+                outer_unit=RackDimensionUnitChoices.UNIT_MILLIMETER,
+                weight=20,
+                max_weight=2000,
+                weight_unit=WeightUnitChoices.UNIT_POUND,
+                description='foobar2'
+            ),
+            Rack(
+                name='Rack 3',
+                facility_id='rack-3',
+                site=sites[2],
+                location=locations[2],
+                tenant=tenants[2],
+                status=RackStatusChoices.STATUS_RESERVED,
+                role=rack_roles[2],
+                serial='GHI',
+                asset_tag='1003',
+                type=RackTypeChoices.TYPE_CABINET,
+                width=RackWidthChoices.WIDTH_23IN,
+                u_height=44,
+                desc_units=True,
+                outer_width=300,
+                outer_depth=300,
+                outer_unit=RackDimensionUnitChoices.UNIT_INCH,
+                weight=30,
+                max_weight=3000,
+                weight_unit=WeightUnitChoices.UNIT_KILOGRAM,
+                description='foobar3'
+            ),
         )
         Rack.objects.bulk_create(racks)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Rack 1', 'Rack 2']}
@@ -445,6 +556,10 @@ class RackTestCase(TestCase, ChangeLoggedFilterSetTests):
 
     def test_asset_tag(self):
         params = {'asset_tag': ['1001', '1002']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
@@ -626,9 +741,13 @@ class RackReservationTestCase(TestCase, ChangeLoggedFilterSetTests):
         reservations = (
             RackReservation(rack=racks[0], units=[1, 2, 3], user=users[0], tenant=tenants[0], description='foobar1'),
             RackReservation(rack=racks[1], units=[4, 5, 6], user=users[1], tenant=tenants[1], description='foobar2'),
-            RackReservation(rack=racks[2], units=[7, 8, 9], user=users[2], tenant=tenants[2]),
+            RackReservation(rack=racks[2], units=[7, 8, 9], user=users[2], tenant=tenants[2], description='foobar3'),
         )
         RackReservation.objects.bulk_create(reservations)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_region(self):
         regions = Region.objects.all()[:2]
@@ -692,11 +811,15 @@ class ManufacturerTestCase(TestCase, ChangeLoggedFilterSetTests):
     def setUpTestData(cls):
 
         manufacturers = (
-            Manufacturer(name='Manufacturer 1', slug='manufacturer-1', description='A'),
-            Manufacturer(name='Manufacturer 2', slug='manufacturer-2', description='B'),
-            Manufacturer(name='Manufacturer 3', slug='manufacturer-3', description='C'),
+            Manufacturer(name='Manufacturer 1', slug='manufacturer-1', description='foobar1'),
+            Manufacturer(name='Manufacturer 2', slug='manufacturer-2', description='foobar2'),
+            Manufacturer(name='Manufacturer 3', slug='manufacturer-3', description='foobar3'),
         )
         Manufacturer.objects.bulk_create(manufacturers)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Manufacturer 1', 'Manufacturer 2']}
@@ -707,7 +830,7 @@ class ManufacturerTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
-        params = {'description': ['A', 'B']}
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
@@ -733,9 +856,47 @@ class DeviceTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
         Platform.objects.bulk_create(platforms)
 
         device_types = (
-            DeviceType(manufacturer=manufacturers[0], default_platform=platforms[0], model='Model 1', slug='model-1', part_number='Part Number 1', u_height=1, is_full_depth=True, front_image='front.png', rear_image='rear.png', weight=10, weight_unit=WeightUnitChoices.UNIT_POUND),
-            DeviceType(manufacturer=manufacturers[1], default_platform=platforms[1], model='Model 2', slug='model-2', part_number='Part Number 2', u_height=2, is_full_depth=True, subdevice_role=SubdeviceRoleChoices.ROLE_PARENT, airflow=DeviceAirflowChoices.AIRFLOW_FRONT_TO_REAR, weight=20, weight_unit=WeightUnitChoices.UNIT_POUND),
-            DeviceType(manufacturer=manufacturers[2], model='Model 3', slug='model-3', part_number='Part Number 3', u_height=3, is_full_depth=False, subdevice_role=SubdeviceRoleChoices.ROLE_CHILD, airflow=DeviceAirflowChoices.AIRFLOW_REAR_TO_FRONT, weight=30, weight_unit=WeightUnitChoices.UNIT_KILOGRAM),
+            DeviceType(
+                manufacturer=manufacturers[0],
+                default_platform=platforms[0],
+                model='Model 1',
+                slug='model-1',
+                part_number='Part Number 1',
+                u_height=1,
+                is_full_depth=True,
+                front_image='front.png',
+                rear_image='rear.png',
+                weight=10,
+                weight_unit=WeightUnitChoices.UNIT_POUND,
+                description='foobar1'
+            ),
+            DeviceType(
+                manufacturer=manufacturers[1],
+                default_platform=platforms[1],
+                model='Model 2',
+                slug='model-2',
+                part_number='Part Number 2',
+                u_height=2,
+                is_full_depth=True,
+                subdevice_role=SubdeviceRoleChoices.ROLE_PARENT,
+                airflow=DeviceAirflowChoices.AIRFLOW_FRONT_TO_REAR,
+                weight=20,
+                weight_unit=WeightUnitChoices.UNIT_POUND,
+                description='foobar2'
+            ),
+            DeviceType(
+                manufacturer=manufacturers[2],
+                model='Model 3',
+                slug='model-3',
+                part_number='Part Number 3',
+                u_height=3,
+                is_full_depth=False,
+                subdevice_role=SubdeviceRoleChoices.ROLE_CHILD,
+                airflow=DeviceAirflowChoices.AIRFLOW_REAR_TO_FRONT,
+                weight=30,
+                weight_unit=WeightUnitChoices.UNIT_KILOGRAM,
+                description='foobar3'
+            ),
         )
         DeviceType.objects.bulk_create(device_types)
 
@@ -781,6 +942,10 @@ class DeviceTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
         inventory_item = InventoryItemTemplate(device_type=device_types[1], name='Inventory Item 1')
         inventory_item.save()
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_model(self):
         params = {'model': ['Model 1', 'Model 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -791,6 +956,10 @@ class DeviceTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
 
     def test_part_number(self):
         params = {'part_number': ['Part Number 1', 'Part Number 2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_u_height(self):
@@ -915,9 +1084,30 @@ class ModuleTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
         Manufacturer.objects.bulk_create(manufacturers)
 
         module_types = (
-            ModuleType(manufacturer=manufacturers[0], model='Model 1', part_number='Part Number 1', weight=10, weight_unit=WeightUnitChoices.UNIT_POUND),
-            ModuleType(manufacturer=manufacturers[1], model='Model 2', part_number='Part Number 2', weight=20, weight_unit=WeightUnitChoices.UNIT_POUND),
-            ModuleType(manufacturer=manufacturers[2], model='Model 3', part_number='Part Number 3', weight=30, weight_unit=WeightUnitChoices.UNIT_KILOGRAM),
+            ModuleType(
+                manufacturer=manufacturers[0],
+                model='Model 1',
+                part_number='Part Number 1',
+                weight=10,
+                weight_unit=WeightUnitChoices.UNIT_POUND,
+                description='foobar1'
+            ),
+            ModuleType(
+                manufacturer=manufacturers[1],
+                model='Model 2',
+                part_number='Part Number 2',
+                weight=20,
+                weight_unit=WeightUnitChoices.UNIT_POUND,
+                description='foobar2'
+            ),
+            ModuleType(
+                manufacturer=manufacturers[2],
+                model='Model 3',
+                part_number='Part Number 3',
+                weight=30,
+                weight_unit=WeightUnitChoices.UNIT_KILOGRAM,
+                description='foobar3'
+            ),
         )
         ModuleType.objects.bulk_create(module_types)
 
@@ -952,12 +1142,20 @@ class ModuleTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
             FrontPortTemplate(module_type=module_types[1], name='Front Port 2', type=PortTypeChoices.TYPE_8P8C, rear_port=rear_ports[1]),
         ))
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_model(self):
         params = {'model': ['Model 1', 'Model 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_part_number(self):
         params = {'part_number': ['Part Number 1', 'Part Number 2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_manufacturer(self):
@@ -1012,7 +1210,7 @@ class ModuleTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ConsolePortTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ConsolePortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
     queryset = ConsolePortTemplate.objects.all()
     filterset = ConsolePortTemplateFilterSet
 
@@ -1029,22 +1227,17 @@ class ConsolePortTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         DeviceType.objects.bulk_create(device_types)
 
         ConsolePortTemplate.objects.bulk_create((
-            ConsolePortTemplate(device_type=device_types[0], name='Console Port 1'),
-            ConsolePortTemplate(device_type=device_types[1], name='Console Port 2'),
-            ConsolePortTemplate(device_type=device_types[2], name='Console Port 3'),
+            ConsolePortTemplate(device_type=device_types[0], name='Console Port 1', description='foobar1'),
+            ConsolePortTemplate(device_type=device_types[1], name='Console Port 2', description='foobar2'),
+            ConsolePortTemplate(device_type=device_types[2], name='Console Port 3', description='foobar3'),
         ))
 
     def test_name(self):
         params = {'name': ['Console Port 1', 'Console Port 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-    def test_devicetype_id(self):
-        device_types = DeviceType.objects.all()[:2]
-        params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-
-class ConsoleServerPortTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ConsoleServerPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
     queryset = ConsoleServerPortTemplate.objects.all()
     filterset = ConsoleServerPortTemplateFilterSet
 
@@ -1061,22 +1254,17 @@ class ConsoleServerPortTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         DeviceType.objects.bulk_create(device_types)
 
         ConsoleServerPortTemplate.objects.bulk_create((
-            ConsoleServerPortTemplate(device_type=device_types[0], name='Console Server Port 1'),
-            ConsoleServerPortTemplate(device_type=device_types[1], name='Console Server Port 2'),
-            ConsoleServerPortTemplate(device_type=device_types[2], name='Console Server Port 3'),
+            ConsoleServerPortTemplate(device_type=device_types[0], name='Console Server Port 1', description='foobar1'),
+            ConsoleServerPortTemplate(device_type=device_types[1], name='Console Server Port 2', description='foobar2'),
+            ConsoleServerPortTemplate(device_type=device_types[2], name='Console Server Port 3', description='foobar3'),
         ))
 
     def test_name(self):
         params = {'name': ['Console Server Port 1', 'Console Server Port 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-    def test_devicetype_id(self):
-        device_types = DeviceType.objects.all()[:2]
-        params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-
-class PowerPortTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class PowerPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
     queryset = PowerPortTemplate.objects.all()
     filterset = PowerPortTemplateFilterSet
 
@@ -1093,18 +1281,31 @@ class PowerPortTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         DeviceType.objects.bulk_create(device_types)
 
         PowerPortTemplate.objects.bulk_create((
-            PowerPortTemplate(device_type=device_types[0], name='Power Port 1', maximum_draw=100, allocated_draw=50),
-            PowerPortTemplate(device_type=device_types[1], name='Power Port 2', maximum_draw=200, allocated_draw=100),
-            PowerPortTemplate(device_type=device_types[2], name='Power Port 3', maximum_draw=300, allocated_draw=150),
+            PowerPortTemplate(
+                device_type=device_types[0],
+                name='Power Port 1',
+                maximum_draw=100,
+                allocated_draw=50,
+                description='foobar1'
+            ),
+            PowerPortTemplate(
+                device_type=device_types[1],
+                name='Power Port 2',
+                maximum_draw=200,
+                allocated_draw=100,
+                description='foobar2'
+            ),
+            PowerPortTemplate(
+                device_type=device_types[2],
+                name='Power Port 3',
+                maximum_draw=300,
+                allocated_draw=150,
+                description='foobar3'
+            ),
         ))
 
     def test_name(self):
         params = {'name': ['Power Port 1', 'Power Port 2']}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    def test_devicetype_id(self):
-        device_types = DeviceType.objects.all()[:2]
-        params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_maximum_draw(self):
@@ -1116,7 +1317,7 @@ class PowerPortTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class PowerOutletTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class PowerOutletTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
     queryset = PowerOutletTemplate.objects.all()
     filterset = PowerOutletTemplateFilterSet
 
@@ -1133,18 +1334,28 @@ class PowerOutletTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         DeviceType.objects.bulk_create(device_types)
 
         PowerOutletTemplate.objects.bulk_create((
-            PowerOutletTemplate(device_type=device_types[0], name='Power Outlet 1', feed_leg=PowerOutletFeedLegChoices.FEED_LEG_A),
-            PowerOutletTemplate(device_type=device_types[1], name='Power Outlet 2', feed_leg=PowerOutletFeedLegChoices.FEED_LEG_B),
-            PowerOutletTemplate(device_type=device_types[2], name='Power Outlet 3', feed_leg=PowerOutletFeedLegChoices.FEED_LEG_C),
+            PowerOutletTemplate(
+                device_type=device_types[0],
+                name='Power Outlet 1',
+                feed_leg=PowerOutletFeedLegChoices.FEED_LEG_A,
+                description='foobar1'
+            ),
+            PowerOutletTemplate(
+                device_type=device_types[1],
+                name='Power Outlet 2',
+                feed_leg=PowerOutletFeedLegChoices.FEED_LEG_B,
+                description='foobar2'
+            ),
+            PowerOutletTemplate(
+                device_type=device_types[2],
+                name='Power Outlet 3',
+                feed_leg=PowerOutletFeedLegChoices.FEED_LEG_C,
+                description='foobar3'
+            ),
         ))
 
     def test_name(self):
         params = {'name': ['Power Outlet 1', 'Power Outlet 2']}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    def test_devicetype_id(self):
-        device_types = DeviceType.objects.all()[:2]
-        params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_feed_leg(self):
@@ -1152,7 +1363,7 @@ class PowerOutletTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class InterfaceTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class InterfaceTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
     queryset = InterfaceTemplate.objects.all()
     filterset = InterfaceTemplateFilterSet
 
@@ -1176,7 +1387,8 @@ class InterfaceTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
                 enabled=True,
                 mgmt_only=True,
                 poe_mode=InterfacePoEModeChoices.MODE_PD,
-                poe_type=InterfacePoETypeChoices.TYPE_1_8023AF
+                poe_type=InterfacePoETypeChoices.TYPE_1_8023AF,
+                description='foobar1'
             ),
             InterfaceTemplate(
                 device_type=device_types[1],
@@ -1185,13 +1397,15 @@ class InterfaceTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
                 enabled=False,
                 mgmt_only=False,
                 poe_mode=InterfacePoEModeChoices.MODE_PSE,
-                poe_type=InterfacePoETypeChoices.TYPE_2_8023AT
+                poe_type=InterfacePoETypeChoices.TYPE_2_8023AT,
+                description='foobar2'
             ),
             InterfaceTemplate(
                 device_type=device_types[2],
                 name='Interface 3',
                 type=InterfaceTypeChoices.TYPE_1GE_SFP,
-                mgmt_only=False
+                mgmt_only=False,
+                description='foobar3'
             ),
         )
         InterfaceTemplate.objects.bulk_create(interface_templates)
@@ -1201,11 +1415,6 @@ class InterfaceTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
 
     def test_name(self):
         params = {'name': ['Interface 1', 'Interface 2']}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    def test_devicetype_id(self):
-        device_types = DeviceType.objects.all()[:2]
-        params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
@@ -1237,7 +1446,7 @@ class InterfaceTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class FrontPortTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class FrontPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
     queryset = FrontPortTemplate.objects.all()
     filterset = FrontPortTemplateFilterSet
 
@@ -1261,18 +1470,34 @@ class FrontPortTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         RearPortTemplate.objects.bulk_create(rear_ports)
 
         FrontPortTemplate.objects.bulk_create((
-            FrontPortTemplate(device_type=device_types[0], name='Front Port 1', rear_port=rear_ports[0], type=PortTypeChoices.TYPE_8P8C, color=ColorChoices.COLOR_RED),
-            FrontPortTemplate(device_type=device_types[1], name='Front Port 2', rear_port=rear_ports[1], type=PortTypeChoices.TYPE_110_PUNCH, color=ColorChoices.COLOR_GREEN),
-            FrontPortTemplate(device_type=device_types[2], name='Front Port 3', rear_port=rear_ports[2], type=PortTypeChoices.TYPE_BNC, color=ColorChoices.COLOR_BLUE),
+            FrontPortTemplate(
+                device_type=device_types[0],
+                name='Front Port 1',
+                rear_port=rear_ports[0],
+                type=PortTypeChoices.TYPE_8P8C,
+                color=ColorChoices.COLOR_RED,
+                description='foobar1'
+            ),
+            FrontPortTemplate(
+                device_type=device_types[1],
+                name='Front Port 2',
+                rear_port=rear_ports[1],
+                type=PortTypeChoices.TYPE_110_PUNCH,
+                color=ColorChoices.COLOR_GREEN,
+                description='foobar2'
+            ),
+            FrontPortTemplate(
+                device_type=device_types[2],
+                name='Front Port 3',
+                rear_port=rear_ports[2],
+                type=PortTypeChoices.TYPE_BNC,
+                color=ColorChoices.COLOR_BLUE,
+                description='foobar3'
+            ),
         ))
 
     def test_name(self):
         params = {'name': ['Front Port 1', 'Front Port 2']}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    def test_devicetype_id(self):
-        device_types = DeviceType.objects.all()[:2]
-        params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
@@ -1284,7 +1509,7 @@ class FrontPortTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class RearPortTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class RearPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
     queryset = RearPortTemplate.objects.all()
     filterset = RearPortTemplateFilterSet
 
@@ -1301,18 +1526,34 @@ class RearPortTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         DeviceType.objects.bulk_create(device_types)
 
         RearPortTemplate.objects.bulk_create((
-            RearPortTemplate(device_type=device_types[0], name='Rear Port 1', type=PortTypeChoices.TYPE_8P8C, color=ColorChoices.COLOR_RED, positions=1),
-            RearPortTemplate(device_type=device_types[1], name='Rear Port 2', type=PortTypeChoices.TYPE_110_PUNCH, color=ColorChoices.COLOR_GREEN, positions=2),
-            RearPortTemplate(device_type=device_types[2], name='Rear Port 3', type=PortTypeChoices.TYPE_BNC, color=ColorChoices.COLOR_BLUE, positions=3),
+            RearPortTemplate(
+                device_type=device_types[0],
+                name='Rear Port 1',
+                type=PortTypeChoices.TYPE_8P8C,
+                color=ColorChoices.COLOR_RED,
+                positions=1,
+                description='foobar1'
+            ),
+            RearPortTemplate(
+                device_type=device_types[1],
+                name='Rear Port 2',
+                type=PortTypeChoices.TYPE_110_PUNCH,
+                color=ColorChoices.COLOR_GREEN,
+                positions=2,
+                description='foobar2'
+            ),
+            RearPortTemplate(
+                device_type=device_types[2],
+                name='Rear Port 3',
+                type=PortTypeChoices.TYPE_BNC,
+                color=ColorChoices.COLOR_BLUE,
+                positions=3,
+                description='foobar3'
+            ),
         ))
 
     def test_name(self):
         params = {'name': ['Rear Port 1', 'Rear Port 2']}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-
-    def test_devicetype_id(self):
-        device_types = DeviceType.objects.all()[:2]
-        params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
@@ -1328,7 +1569,7 @@ class RearPortTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ModuleBayTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ModuleBayTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
     queryset = ModuleBayTemplate.objects.all()
     filterset = ModuleBayTemplateFilterSet
 
@@ -1345,22 +1586,17 @@ class ModuleBayTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         DeviceType.objects.bulk_create(device_types)
 
         ModuleBayTemplate.objects.bulk_create((
-            ModuleBayTemplate(device_type=device_types[0], name='Module Bay 1'),
-            ModuleBayTemplate(device_type=device_types[1], name='Module Bay 2'),
-            ModuleBayTemplate(device_type=device_types[2], name='Module Bay 3'),
+            ModuleBayTemplate(device_type=device_types[0], name='Module Bay 1', description='foobar1'),
+            ModuleBayTemplate(device_type=device_types[1], name='Module Bay 2', description='foobar2'),
+            ModuleBayTemplate(device_type=device_types[2], name='Module Bay 3', description='foobar3'),
         ))
 
     def test_name(self):
         params = {'name': ['Module Bay 1', 'Module Bay 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-    def test_devicetype_id(self):
-        device_types = DeviceType.objects.all()[:2]
-        params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-
-class DeviceBayTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class DeviceBayTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
     queryset = DeviceBayTemplate.objects.all()
     filterset = DeviceBayTemplateFilterSet
 
@@ -1377,22 +1613,17 @@ class DeviceBayTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         DeviceType.objects.bulk_create(device_types)
 
         DeviceBayTemplate.objects.bulk_create((
-            DeviceBayTemplate(device_type=device_types[0], name='Device Bay 1'),
-            DeviceBayTemplate(device_type=device_types[1], name='Device Bay 2'),
-            DeviceBayTemplate(device_type=device_types[2], name='Device Bay 3'),
+            DeviceBayTemplate(device_type=device_types[0], name='Device Bay 1', description='foobar1'),
+            DeviceBayTemplate(device_type=device_types[1], name='Device Bay 2', description='foobar2'),
+            DeviceBayTemplate(device_type=device_types[2], name='Device Bay 3', description='foobar3'),
         ))
 
     def test_name(self):
         params = {'name': ['Device Bay 1', 'Device Bay 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-    def test_devicetype_id(self):
-        device_types = DeviceType.objects.all()[:2]
-        params = {'devicetype_id': [device_types[0].pk, device_types[1].pk]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-
-class InventoryItemTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class InventoryItemTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
     queryset = InventoryItemTemplate.objects.all()
     filterset = InventoryItemTemplateFilterSet
 
@@ -1420,9 +1651,33 @@ class InventoryItemTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         InventoryItemRole.objects.bulk_create(inventory_item_roles)
 
         inventory_item_templates = (
-            InventoryItemTemplate(device_type=device_types[0], name='Inventory Item 1', label='A', role=inventory_item_roles[0], manufacturer=manufacturers[0], part_id='1001'),
-            InventoryItemTemplate(device_type=device_types[1], name='Inventory Item 2', label='B', role=inventory_item_roles[1], manufacturer=manufacturers[1], part_id='1002'),
-            InventoryItemTemplate(device_type=device_types[2], name='Inventory Item 3', label='C', role=inventory_item_roles[2], manufacturer=manufacturers[2], part_id='1003'),
+            InventoryItemTemplate(
+                device_type=device_types[0],
+                name='Inventory Item 1',
+                label='A',
+                role=inventory_item_roles[0],
+                manufacturer=manufacturers[0],
+                part_id='1001',
+                description='foobar1'
+            ),
+            InventoryItemTemplate(
+                device_type=device_types[1],
+                name='Inventory Item 2',
+                label='B',
+                role=inventory_item_roles[1],
+                manufacturer=manufacturers[1],
+                part_id='1002',
+                description='foobar2'
+            ),
+            InventoryItemTemplate(
+                device_type=device_types[2],
+                name='Inventory Item 3',
+                label='C',
+                role=inventory_item_roles[2],
+                manufacturer=manufacturers[2],
+                part_id='1003',
+                description='foobar3'
+            ),
         )
         for item in inventory_item_templates:
             item.save()
@@ -1486,6 +1741,10 @@ class DeviceRoleTestCase(TestCase, ChangeLoggedFilterSetTests):
         )
         DeviceRole.objects.bulk_create(roles)
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Device Role 1', 'Device Role 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -1524,11 +1783,15 @@ class PlatformTestCase(TestCase, ChangeLoggedFilterSetTests):
         Manufacturer.objects.bulk_create(manufacturers)
 
         platforms = (
-            Platform(name='Platform 1', slug='platform-1', manufacturer=manufacturers[0], description='A'),
-            Platform(name='Platform 2', slug='platform-2', manufacturer=manufacturers[1], description='B'),
-            Platform(name='Platform 3', slug='platform-3', manufacturer=manufacturers[2], description='C'),
+            Platform(name='Platform 1', slug='platform-1', manufacturer=manufacturers[0], description='foobar1'),
+            Platform(name='Platform 2', slug='platform-2', manufacturer=manufacturers[1], description='foobar2'),
+            Platform(name='Platform 3', slug='platform-3', manufacturer=manufacturers[2], description='foobar3'),
         )
         Platform.objects.bulk_create(platforms)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Platform 1', 'Platform 2']}
@@ -1539,7 +1802,7 @@ class PlatformTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
-        params = {'description': ['A', 'B']}
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_manufacturer(self):
@@ -1647,9 +1910,66 @@ class DeviceTestCase(TestCase, ChangeLoggedFilterSetTests):
         Tenant.objects.bulk_create(tenants)
 
         devices = (
-            Device(name='Device 1', device_type=device_types[0], role=roles[0], platform=platforms[0], tenant=tenants[0], serial='ABC', asset_tag='1001', site=sites[0], location=locations[0], rack=racks[0], position=1, face=DeviceFaceChoices.FACE_FRONT, latitude=10, longitude=10, status=DeviceStatusChoices.STATUS_ACTIVE, cluster=clusters[0], local_context_data={"foo": 123}),
-            Device(name='Device 2', device_type=device_types[1], role=roles[1], platform=platforms[1], tenant=tenants[1], serial='DEF', asset_tag='1002', site=sites[1], location=locations[1], rack=racks[1], position=2, face=DeviceFaceChoices.FACE_FRONT, latitude=20, longitude=20, status=DeviceStatusChoices.STATUS_STAGED, airflow=DeviceAirflowChoices.AIRFLOW_FRONT_TO_REAR, cluster=clusters[1]),
-            Device(name='Device 3', device_type=device_types[2], role=roles[2], platform=platforms[2], tenant=tenants[2], serial='GHI', asset_tag='1003', site=sites[2], location=locations[2], rack=racks[2], position=3, face=DeviceFaceChoices.FACE_REAR, latitude=30, longitude=30, status=DeviceStatusChoices.STATUS_FAILED, airflow=DeviceAirflowChoices.AIRFLOW_REAR_TO_FRONT, cluster=clusters[2]),
+            Device(
+                name='Device 1',
+                device_type=device_types[0],
+                role=roles[0],
+                platform=platforms[0],
+                tenant=tenants[0],
+                serial='ABC',
+                asset_tag='1001',
+                site=sites[0],
+                location=locations[0],
+                rack=racks[0],
+                position=1,
+                face=DeviceFaceChoices.FACE_FRONT,
+                latitude=10,
+                longitude=10,
+                status=DeviceStatusChoices.STATUS_ACTIVE,
+                cluster=clusters[0],
+                local_context_data={"foo": 123},
+                description='foobar1'
+            ),
+            Device(
+                name='Device 2',
+                device_type=device_types[1],
+                role=roles[1],
+                platform=platforms[1],
+                tenant=tenants[1],
+                serial='DEF',
+                asset_tag='1002',
+                site=sites[1],
+                location=locations[1],
+                rack=racks[1],
+                position=2,
+                face=DeviceFaceChoices.FACE_FRONT,
+                latitude=20,
+                longitude=20,
+                status=DeviceStatusChoices.STATUS_STAGED,
+                airflow=DeviceAirflowChoices.AIRFLOW_FRONT_TO_REAR,
+                cluster=clusters[1],
+                description='foobar2'
+            ),
+            Device(
+                name='Device 3',
+                device_type=device_types[2],
+                role=roles[2],
+                platform=platforms[2],
+                tenant=tenants[2],
+                serial='GHI',
+                asset_tag='1003',
+                site=sites[2],
+                location=locations[2],
+                rack=racks[2],
+                position=3,
+                face=DeviceFaceChoices.FACE_REAR,
+                latitude=30,
+                longitude=30,
+                status=DeviceStatusChoices.STATUS_FAILED,
+                airflow=DeviceAirflowChoices.AIRFLOW_REAR_TO_FRONT,
+                cluster=clusters[2],
+                description='foobar3'
+            ),
         )
         Device.objects.bulk_create(devices)
 
@@ -1711,11 +2031,19 @@ class DeviceTestCase(TestCase, ChangeLoggedFilterSetTests):
         Device.objects.filter(pk=devices[0].pk).update(virtual_chassis=virtual_chassis, vc_position=1, vc_priority=1)
         Device.objects.filter(pk=devices[1].pk).update(virtual_chassis=virtual_chassis, vc_position=2, vc_priority=2)
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Device 1', 'Device 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         # Test case insensitivity
         params = {'name': ['DEVICE 1', 'DEVICE 2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_asset_tag(self):
@@ -1977,17 +2305,87 @@ class ModuleTestCase(TestCase, ChangeLoggedFilterSetTests):
         ModuleBay.objects.bulk_create(module_bays)
 
         modules = (
-            Module(device=devices[0], module_bay=module_bays[0], module_type=module_types[0], status=ModuleStatusChoices.STATUS_ACTIVE, serial='A', asset_tag='A'),
-            Module(device=devices[0], module_bay=module_bays[1], module_type=module_types[1], status=ModuleStatusChoices.STATUS_ACTIVE, serial='B', asset_tag='B'),
-            Module(device=devices[0], module_bay=module_bays[2], module_type=module_types[2], status=ModuleStatusChoices.STATUS_ACTIVE, serial='C', asset_tag='C'),
-            Module(device=devices[1], module_bay=module_bays[3], module_type=module_types[0], status=ModuleStatusChoices.STATUS_ACTIVE, serial='D', asset_tag='D'),
-            Module(device=devices[1], module_bay=module_bays[4], module_type=module_types[1], status=ModuleStatusChoices.STATUS_ACTIVE, serial='E', asset_tag='E'),
-            Module(device=devices[1], module_bay=module_bays[5], module_type=module_types[2], status=ModuleStatusChoices.STATUS_ACTIVE, serial='F', asset_tag='F'),
-            Module(device=devices[2], module_bay=module_bays[6], module_type=module_types[0], status=ModuleStatusChoices.STATUS_ACTIVE, serial='G', asset_tag='G'),
-            Module(device=devices[2], module_bay=module_bays[7], module_type=module_types[1], status=ModuleStatusChoices.STATUS_PLANNED, serial='H', asset_tag='H'),
-            Module(device=devices[2], module_bay=module_bays[8], module_type=module_types[2], status=ModuleStatusChoices.STATUS_FAILED, serial='I', asset_tag='I'),
+            Module(
+                device=devices[0],
+                module_bay=module_bays[0],
+                module_type=module_types[0],
+                status=ModuleStatusChoices.STATUS_ACTIVE,
+                serial='A',
+                asset_tag='A',
+                description='foobar1'
+            ),
+            Module(
+                device=devices[0],
+                module_bay=module_bays[1],
+                module_type=module_types[1],
+                status=ModuleStatusChoices.STATUS_ACTIVE,
+                serial='B',
+                asset_tag='B',
+                description='foobar2'
+            ),
+            Module(
+                device=devices[0],
+                module_bay=module_bays[2],
+                module_type=module_types[2],
+                status=ModuleStatusChoices.STATUS_ACTIVE,
+                serial='C',
+                asset_tag='C',
+                description='foobar3'
+            ),
+            Module(
+                device=devices[1],
+                module_bay=module_bays[3],
+                module_type=module_types[0],
+                status=ModuleStatusChoices.STATUS_ACTIVE,
+                serial='D',
+                asset_tag='D'
+            ),
+            Module(
+                device=devices[1],
+                module_bay=module_bays[4],
+                module_type=module_types[1],
+                status=ModuleStatusChoices.STATUS_ACTIVE,
+                serial='E',
+                asset_tag='E'
+            ),
+            Module(
+                device=devices[1],
+                module_bay=module_bays[5],
+                module_type=module_types[2],
+                status=ModuleStatusChoices.STATUS_ACTIVE,
+                serial='F',
+                asset_tag='F'
+            ),
+            Module(
+                device=devices[2],
+                module_bay=module_bays[6],
+                module_type=module_types[0],
+                status=ModuleStatusChoices.STATUS_ACTIVE,
+                serial='G',
+                asset_tag='G'
+            ),
+            Module(
+                device=devices[2],
+                module_bay=module_bays[7],
+                module_type=module_types[1],
+                status=ModuleStatusChoices.STATUS_PLANNED,
+                serial='H',
+                asset_tag='H'
+            ),
+            Module(
+                device=devices[2],
+                module_bay=module_bays[8],
+                module_type=module_types[2],
+                status=ModuleStatusChoices.STATUS_FAILED,
+                serial='I',
+                asset_tag='I'
+            ),
         )
         Module.objects.bulk_create(modules)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_manufacturer(self):
         manufacturers = Manufacturer.objects.all()[:2]
@@ -2002,6 +2400,10 @@ class ModuleTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
         params = {'module_type': [module_types[0].model, module_types[1].model]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_module_bay(self):
         module_bays = ModuleBay.objects.all()[:2]
@@ -4101,11 +4503,30 @@ class InventoryItemRoleTestCase(TestCase, ChangeLoggedFilterSetTests):
     def setUpTestData(cls):
 
         roles = (
-            InventoryItemRole(name='Inventory Item Role 1', slug='inventory-item-role-1', color='ff0000'),
-            InventoryItemRole(name='Inventory Item Role 2', slug='inventory-item-role-2', color='00ff00'),
-            InventoryItemRole(name='Inventory Item Role 3', slug='inventory-item-role-3', color='0000ff'),
+            InventoryItemRole(
+                name='Inventory Item Role 1',
+                slug='inventory-item-role-1',
+                color='ff0000',
+                description='foobar1'
+            ),
+            InventoryItemRole(
+                name='Inventory Item Role 2',
+                slug='inventory-item-role-2',
+                color='00ff00',
+                description='foobar2'
+            ),
+            InventoryItemRole(
+                name='Inventory Item Role 3',
+                slug='inventory-item-role-3',
+                color='0000ff',
+                description='foobar3'
+            ),
         )
         InventoryItemRole.objects.bulk_create(roles)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Inventory Item Role 1', 'Inventory Item Role 2']}
@@ -4113,6 +4534,10 @@ class InventoryItemRoleTestCase(TestCase, ChangeLoggedFilterSetTests):
 
     def test_slug(self):
         params = {'slug': ['inventory-item-role-1', 'inventory-item-role-2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_color(self):
@@ -4165,15 +4590,19 @@ class VirtualChassisTestCase(TestCase, ChangeLoggedFilterSetTests):
         Device.objects.bulk_create(devices)
 
         virtual_chassis = (
-            VirtualChassis(name='VC 1', master=devices[0], domain='Domain 1'),
-            VirtualChassis(name='VC 2', master=devices[2], domain='Domain 2'),
-            VirtualChassis(name='VC 3', master=devices[4], domain='Domain 3'),
+            VirtualChassis(name='VC 1', master=devices[0], domain='Domain 1', description='foobar1'),
+            VirtualChassis(name='VC 2', master=devices[2], domain='Domain 2', description='foobar2'),
+            VirtualChassis(name='VC 3', master=devices[4], domain='Domain 3', description='foobar3'),
         )
         VirtualChassis.objects.bulk_create(virtual_chassis)
 
         Device.objects.filter(pk=devices[1].pk).update(virtual_chassis=virtual_chassis[0])
         Device.objects.filter(pk=devices[3].pk).update(virtual_chassis=virtual_chassis[1])
         Device.objects.filter(pk=devices[5].pk).update(virtual_chassis=virtual_chassis[2])
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_domain(self):
         params = {'domain': ['Domain 1', 'Domain 2']}
@@ -4188,6 +4617,10 @@ class VirtualChassisTestCase(TestCase, ChangeLoggedFilterSetTests):
 
     def test_name(self):
         params = {'name': ['VC 1', 'VC 2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
@@ -4283,16 +4716,96 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
         console_server_port = ConsoleServerPort.objects.create(device=devices[0], name='Console Server Port 1')
 
         # Cables
-        Cable(a_terminations=[interfaces[1]], b_terminations=[interfaces[2]], label='Cable 1', type=CableTypeChoices.TYPE_CAT3, tenant=tenants[0], status=LinkStatusChoices.STATUS_CONNECTED, color='aa1409', length=10, length_unit=CableLengthUnitChoices.UNIT_FOOT).save()
-        Cable(a_terminations=[interfaces[3]], b_terminations=[interfaces[4]], label='Cable 2', type=CableTypeChoices.TYPE_CAT3, tenant=tenants[0], status=LinkStatusChoices.STATUS_CONNECTED, color='aa1409', length=20, length_unit=CableLengthUnitChoices.UNIT_FOOT).save()
-        Cable(a_terminations=[interfaces[5]], b_terminations=[interfaces[6]], label='Cable 3', type=CableTypeChoices.TYPE_CAT5E, tenant=tenants[1], status=LinkStatusChoices.STATUS_CONNECTED, color='f44336', length=30, length_unit=CableLengthUnitChoices.UNIT_FOOT).save()
-        Cable(a_terminations=[interfaces[7]], b_terminations=[interfaces[8]], label='Cable 4', type=CableTypeChoices.TYPE_CAT5E, tenant=tenants[1], status=LinkStatusChoices.STATUS_PLANNED, color='f44336', length=40, length_unit=CableLengthUnitChoices.UNIT_FOOT).save()
-        Cable(a_terminations=[interfaces[9]], b_terminations=[interfaces[10]], label='Cable 5', type=CableTypeChoices.TYPE_CAT6, tenant=tenants[2], status=LinkStatusChoices.STATUS_PLANNED, color='e91e63', length=10, length_unit=CableLengthUnitChoices.UNIT_METER).save()
-        Cable(a_terminations=[interfaces[11]], b_terminations=[interfaces[0]], label='Cable 6', type=CableTypeChoices.TYPE_CAT6, tenant=tenants[2], status=LinkStatusChoices.STATUS_PLANNED, color='e91e63', length=20, length_unit=CableLengthUnitChoices.UNIT_METER).save()
-        Cable(a_terminations=[console_port], b_terminations=[console_server_port], label='Cable 7').save()
+        cables = (
+            Cable(
+                a_terminations=[interfaces[1]],
+                b_terminations=[interfaces[2]],
+                label='Cable 1',
+                type=CableTypeChoices.TYPE_CAT3,
+                tenant=tenants[0],
+                status=LinkStatusChoices.STATUS_CONNECTED,
+                color='aa1409',
+                length=10,
+                length_unit=CableLengthUnitChoices.UNIT_FOOT,
+                description='foobar1'
+            ),
+            Cable(
+                a_terminations=[interfaces[3]],
+                b_terminations=[interfaces[4]],
+                label='Cable 2',
+                type=CableTypeChoices.TYPE_CAT3,
+                tenant=tenants[0],
+                status=LinkStatusChoices.STATUS_CONNECTED,
+                color='aa1409',
+                length=20,
+                length_unit=CableLengthUnitChoices.UNIT_FOOT,
+                description='foobar2'
+            ),
+            Cable(
+                a_terminations=[interfaces[5]],
+                b_terminations=[interfaces[6]],
+                label='Cable 3',
+                type=CableTypeChoices.TYPE_CAT5E,
+                tenant=tenants[1],
+                status=LinkStatusChoices.STATUS_CONNECTED,
+                color='f44336',
+                length=30,
+                length_unit=CableLengthUnitChoices.UNIT_FOOT,
+                description='foobar3'
+            ),
+            Cable(
+                a_terminations=[interfaces[7]],
+                b_terminations=[interfaces[8]],
+                label='Cable 4',
+                type=CableTypeChoices.TYPE_CAT5E,
+                tenant=tenants[1],
+                status=LinkStatusChoices.STATUS_PLANNED,
+                color='f44336',
+                length=40,
+                length_unit=CableLengthUnitChoices.UNIT_FOOT
+            ),
+            Cable(
+                a_terminations=[interfaces[9]],
+                b_terminations=[interfaces[10]],
+                label='Cable 5',
+                type=CableTypeChoices.TYPE_CAT6,
+                tenant=tenants[2],
+                status=LinkStatusChoices.STATUS_PLANNED,
+                color='e91e63',
+                length=10,
+                length_unit=CableLengthUnitChoices.UNIT_METER
+            ),
+            Cable(
+                a_terminations=[interfaces[11]],
+                b_terminations=[interfaces[0]],
+                label='Cable 6',
+                type=CableTypeChoices.TYPE_CAT6,
+                tenant=tenants[2],
+                status=LinkStatusChoices.STATUS_PLANNED,
+                color='e91e63',
+                length=20,
+                length_unit=CableLengthUnitChoices.UNIT_METER
+            ),
+            Cable(
+                a_terminations=[console_port],
+                b_terminations=[console_server_port],
+                label='Cable 7'
+            ),
 
-        # Cable for unterminated test
-        Cable(a_terminations=[interfaces[12]], label='Cable 8', type=CableTypeChoices.TYPE_CAT6, status=LinkStatusChoices.STATUS_DECOMMISSIONING).save()
+            # Cable for unterminated test
+            Cable(
+                a_terminations=[interfaces[12]],
+                label='Cable 8',
+                type=CableTypeChoices.TYPE_CAT6,
+                status=LinkStatusChoices.STATUS_DECOMMISSIONING
+            ),
+        )
+        for cable in cables:
+            cable.save()
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_label(self):
         params = {'label': ['Cable 1', 'Cable 2']}
@@ -4319,6 +4832,10 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
     def test_color(self):
         params = {'color': ['aa1409', 'f44336']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_device(self):
         devices = Device.objects.all()[:2]
@@ -4418,14 +4935,22 @@ class PowerPanelTestCase(TestCase, ChangeLoggedFilterSetTests):
             location.save()
 
         power_panels = (
-            PowerPanel(name='Power Panel 1', site=sites[0], location=locations[0]),
-            PowerPanel(name='Power Panel 2', site=sites[1], location=locations[1]),
-            PowerPanel(name='Power Panel 3', site=sites[2], location=locations[2]),
+            PowerPanel(name='Power Panel 1', site=sites[0], location=locations[0], description='foobar1'),
+            PowerPanel(name='Power Panel 2', site=sites[1], location=locations[1], description='foobar2'),
+            PowerPanel(name='Power Panel 3', site=sites[2], location=locations[2], description='foobar3'),
         )
         PowerPanel.objects.bulk_create(power_panels)
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Power Panel 1', 'Power Panel 2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
@@ -4526,7 +5051,8 @@ class PowerFeedTestCase(TestCase, ChangeLoggedFilterSetTests):
                 phase=PowerFeedPhaseChoices.PHASE_3PHASE,
                 voltage=100,
                 amperage=100,
-                max_utilization=10
+                max_utilization=10,
+                description='foobar1'
             ),
             PowerFeed(
                 power_panel=power_panels[1],
@@ -4539,7 +5065,9 @@ class PowerFeedTestCase(TestCase, ChangeLoggedFilterSetTests):
                 phase=PowerFeedPhaseChoices.PHASE_3PHASE,
                 voltage=200,
                 amperage=200,
-                max_utilization=20),
+                max_utilization=20,
+                description='foobar2'
+            ),
             PowerFeed(
                 power_panel=power_panels[2],
                 rack=racks[2],
@@ -4551,7 +5079,8 @@ class PowerFeedTestCase(TestCase, ChangeLoggedFilterSetTests):
                 phase=PowerFeedPhaseChoices.PHASE_SINGLE,
                 voltage=300,
                 amperage=300,
-                max_utilization=30
+                max_utilization=30,
+                description='foobar3'
             ),
         )
         PowerFeed.objects.bulk_create(power_feeds)
@@ -4567,6 +5096,10 @@ class PowerFeedTestCase(TestCase, ChangeLoggedFilterSetTests):
         PowerPort.objects.bulk_create(power_ports)
         Cable(a_terminations=[power_feeds[0]], b_terminations=[power_ports[0]]).save()
         Cable(a_terminations=[power_feeds[1]], b_terminations=[power_ports[1]]).save()
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Power Feed 1', 'Power Feed 2']}
@@ -4598,6 +5131,10 @@ class PowerFeedTestCase(TestCase, ChangeLoggedFilterSetTests):
 
     def test_max_utilization(self):
         params = {'max_utilization': [10, 20]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
@@ -4691,12 +5228,41 @@ class VirtualDeviceContextTestCase(TestCase, ChangeLoggedFilterSetTests):
         Device.objects.bulk_create(devices)
 
         vdcs = (
-            VirtualDeviceContext(device=devices[0], name='VDC 1', identifier=1, status=VirtualDeviceContextStatusChoices.STATUS_ACTIVE),
-            VirtualDeviceContext(device=devices[0], name='VDC 2', identifier=2, status=VirtualDeviceContextStatusChoices.STATUS_PLANNED),
-            VirtualDeviceContext(device=devices[1], name='VDC 1', status=VirtualDeviceContextStatusChoices.STATUS_OFFLINE),
-            VirtualDeviceContext(device=devices[1], name='VDC 2', status=VirtualDeviceContextStatusChoices.STATUS_PLANNED),
-            VirtualDeviceContext(device=devices[2], name='VDC 1', status=VirtualDeviceContextStatusChoices.STATUS_ACTIVE),
-            VirtualDeviceContext(device=devices[2], name='VDC 2', status=VirtualDeviceContextStatusChoices.STATUS_ACTIVE),
+            VirtualDeviceContext(
+                device=devices[0],
+                name='VDC 1',
+                identifier=1,
+                status=VirtualDeviceContextStatusChoices.STATUS_ACTIVE,
+                description='foobar1'
+            ),
+            VirtualDeviceContext(
+                device=devices[0],
+                name='VDC 2',
+                identifier=2,
+                status=VirtualDeviceContextStatusChoices.STATUS_PLANNED,
+                description='foobar2'
+            ),
+            VirtualDeviceContext(
+                device=devices[1],
+                name='VDC 1',
+                status=VirtualDeviceContextStatusChoices.STATUS_OFFLINE,
+                description='foobar3'
+            ),
+            VirtualDeviceContext(
+                device=devices[1],
+                name='VDC 2',
+                status=VirtualDeviceContextStatusChoices.STATUS_PLANNED
+            ),
+            VirtualDeviceContext(
+                device=devices[2],
+                name='VDC 1',
+                status=VirtualDeviceContextStatusChoices.STATUS_ACTIVE
+            ),
+            VirtualDeviceContext(
+                device=devices[2],
+                name='VDC 2',
+                status=VirtualDeviceContextStatusChoices.STATUS_ACTIVE
+            ),
         )
         VirtualDeviceContext.objects.bulk_create(vdcs)
 
@@ -4726,6 +5292,10 @@ class VirtualDeviceContextTestCase(TestCase, ChangeLoggedFilterSetTests):
         vdcs[1].primary_ip6 = addresses[4]
         vdcs[1].save()
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_device(self):
         params = {'device': ['Device 1', 'Device 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
@@ -4733,6 +5303,10 @@ class VirtualDeviceContextTestCase(TestCase, ChangeLoggedFilterSetTests):
     def test_status(self):
         params = {'status': ['active']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_device_id(self):
         devices = Device.objects.filter(name__in=['Device 1', 'Device 2'])

--- a/netbox/extras/filtersets.py
+++ b/netbox/extras/filtersets.py
@@ -512,7 +512,7 @@ class ConfigContextFilterSet(ChangeLoggedModelFilterSet):
 
     class Meta:
         model = ConfigContext
-        fields = ['id', 'name', 'is_active', 'data_synced']
+        fields = ['id', 'name', 'is_active', 'data_synced', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():

--- a/netbox/extras/tests/test_filtersets.py
+++ b/netbox/extras/tests/test_filtersets.py
@@ -40,7 +40,8 @@ class CustomFieldTestCase(TestCase, BaseFilterSetTests):
                 required=True,
                 weight=100,
                 filter_logic=CustomFieldFilterLogicChoices.FILTER_LOOSE,
-                ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_READ_WRITE
+                ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_READ_WRITE,
+                description='foobar1'
             ),
             CustomField(
                 name='Custom Field 2',
@@ -48,7 +49,8 @@ class CustomFieldTestCase(TestCase, BaseFilterSetTests):
                 required=False,
                 weight=200,
                 filter_logic=CustomFieldFilterLogicChoices.FILTER_EXACT,
-                ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_READ_ONLY
+                ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_READ_ONLY,
+                description='foobar2'
             ),
             CustomField(
                 name='Custom Field 3',
@@ -56,7 +58,8 @@ class CustomFieldTestCase(TestCase, BaseFilterSetTests):
                 required=False,
                 weight=300,
                 filter_logic=CustomFieldFilterLogicChoices.FILTER_DISABLED,
-                ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_HIDDEN
+                ui_visibility=CustomFieldVisibilityChoices.VISIBILITY_HIDDEN,
+                description='foobar3'
             ),
             CustomField(
                 name='Custom Field 4',
@@ -83,6 +86,10 @@ class CustomFieldTestCase(TestCase, BaseFilterSetTests):
         custom_fields[2].content_types.add(ContentType.objects.get_by_natural_key('dcim', 'device'))
         custom_fields[3].content_types.add(ContentType.objects.get_by_natural_key('dcim', 'device'))
         custom_fields[4].content_types.add(ContentType.objects.get_by_natural_key('dcim', 'device'))
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Custom Field 1', 'Custom Field 2']}
@@ -116,6 +123,10 @@ class CustomFieldTestCase(TestCase, BaseFilterSetTests):
         params = {'choice_set_id': CustomFieldChoiceSet.objects.values_list('pk', flat=True)}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
 
 class CustomFieldChoiceSetTestCase(TestCase, BaseFilterSetTests):
     queryset = CustomFieldChoiceSet.objects.all()
@@ -124,11 +135,15 @@ class CustomFieldChoiceSetTestCase(TestCase, BaseFilterSetTests):
     @classmethod
     def setUpTestData(cls):
         choice_sets = (
-            CustomFieldChoiceSet(name='Choice Set 1', extra_choices=['A', 'B', 'C']),
-            CustomFieldChoiceSet(name='Choice Set 2', extra_choices=['D', 'E', 'F']),
-            CustomFieldChoiceSet(name='Choice Set 3', extra_choices=['G', 'H', 'I']),
+            CustomFieldChoiceSet(name='Choice Set 1', extra_choices=['A', 'B', 'C'], description='foobar1'),
+            CustomFieldChoiceSet(name='Choice Set 2', extra_choices=['D', 'E', 'F'], description='foobar2'),
+            CustomFieldChoiceSet(name='Choice Set 3', extra_choices=['G', 'H', 'I'], description='foobar3'),
         )
         CustomFieldChoiceSet.objects.bulk_create(choice_sets)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Choice Set 1', 'Choice Set 2']}
@@ -136,6 +151,10 @@ class CustomFieldChoiceSetTestCase(TestCase, BaseFilterSetTests):
 
     def test_choice(self):
         params = {'choice': ['A', 'D']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
@@ -215,6 +234,10 @@ class WebhookTestCase(TestCase, BaseFilterSetTests):
         webhooks[2].content_types.add(content_types[2])
         webhooks[3].content_types.add(content_types[3])
         webhooks[4].content_types.add(content_types[4])
+
+    def test_q(self):
+        params = {'q': 'Webhook 1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Webhook 1', 'Webhook 2']}
@@ -297,6 +320,10 @@ class CustomLinkTestCase(TestCase, BaseFilterSetTests):
         for i, custom_link in enumerate(custom_links):
             custom_link.content_types.set([content_types[i]])
 
+    def test_q(self):
+        params = {'q': 'Custom Link 1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Custom Link 1', 'Custom Link 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -347,7 +374,8 @@ class SavedFilterTestCase(TestCase, BaseFilterSetTests):
                 weight=100,
                 enabled=True,
                 shared=True,
-                parameters={'status': ['active']}
+                parameters={'status': ['active']},
+                description='foobar1'
             ),
             SavedFilter(
                 name='Saved Filter 2',
@@ -356,7 +384,8 @@ class SavedFilterTestCase(TestCase, BaseFilterSetTests):
                 weight=200,
                 enabled=True,
                 shared=True,
-                parameters={'status': ['planned']}
+                parameters={'status': ['planned']},
+                description='foobar2'
             ),
             SavedFilter(
                 name='Saved Filter 3',
@@ -365,12 +394,17 @@ class SavedFilterTestCase(TestCase, BaseFilterSetTests):
                 weight=300,
                 enabled=False,
                 shared=False,
-                parameters={'status': ['retired']}
+                parameters={'status': ['retired']},
+                description='foobar3'
             ),
         )
         SavedFilter.objects.bulk_create(saved_filters)
         for i, savedfilter in enumerate(saved_filters):
             savedfilter.content_types.set([content_types[i]])
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Saved Filter 1', 'Saved Filter 2']}
@@ -378,6 +412,10 @@ class SavedFilterTestCase(TestCase, BaseFilterSetTests):
 
     def test_slug(self):
         params = {'slug': ['saved-filter-1', 'saved-filter-2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_content_types(self):
@@ -423,8 +461,6 @@ class BookmarkTestCase(TestCase, BaseFilterSetTests):
 
     @classmethod
     def setUpTestData(cls):
-        content_types = ContentType.objects.filter(model__in=['site', 'rack', 'device'])
-
         users = (
             User(username='User 1'),
             User(username='User 2'),
@@ -505,6 +541,10 @@ class ExportTemplateTestCase(TestCase, BaseFilterSetTests):
         for i, et in enumerate(export_templates):
             et.content_types.set([content_types[i]])
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Export Template 1', 'Export Template 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -578,6 +618,10 @@ class ImageAttachmentTestCase(TestCase, BaseFilterSetTests):
         )
         ImageAttachment.objects.bulk_create(image_attachments)
 
+    def test_q(self):
+        params = {'q': 'Attachment 1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Image Attachment 1', 'Image Attachment 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -630,40 +674,44 @@ class JournalEntryTestCase(TestCase, ChangeLoggedFilterSetTests):
                 assigned_object=sites[0],
                 created_by=users[0],
                 kind=JournalEntryKindChoices.KIND_INFO,
-                comments='New journal entry'
+                comments='foobar1'
             ),
             JournalEntry(
                 assigned_object=sites[0],
                 created_by=users[1],
                 kind=JournalEntryKindChoices.KIND_SUCCESS,
-                comments='New journal entry'
+                comments='foobar2'
             ),
             JournalEntry(
                 assigned_object=sites[1],
                 created_by=users[2],
                 kind=JournalEntryKindChoices.KIND_WARNING,
-                comments='New journal entry'
+                comments='foobar3'
             ),
             JournalEntry(
                 assigned_object=racks[0],
                 created_by=users[0],
                 kind=JournalEntryKindChoices.KIND_INFO,
-                comments='New journal entry'
+                comments='foobar4'
             ),
             JournalEntry(
                 assigned_object=racks[0],
                 created_by=users[1],
                 kind=JournalEntryKindChoices.KIND_SUCCESS,
-                comments='New journal entry'
+                comments='foobar5'
             ),
             JournalEntry(
                 assigned_object=racks[1],
                 created_by=users[2],
                 kind=JournalEntryKindChoices.KIND_WARNING,
-                comments='New journal entry'
+                comments='foobar6'
             ),
         )
         JournalEntry.objects.bulk_create(journal_entries)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_created_by(self):
         users = User.objects.filter(username__in=['Alice', 'Bob'])
@@ -800,9 +848,10 @@ class ConfigContextTestCase(TestCase, ChangeLoggedFilterSetTests):
         for i in range(0, 3):
             is_active = bool(i % 2)
             c = ConfigContext.objects.create(
-                name='Config Context {}'.format(i + 1),
+                name=f"Config Context {i + 1}",
                 is_active=is_active,
-                data='{"foo": 123}'
+                data='{"foo": 123}',
+                description=f"foobar{i + 1}"
             )
             c.regions.set([regions[i]])
             c.site_groups.set([site_groups[i]])
@@ -818,6 +867,10 @@ class ConfigContextTestCase(TestCase, ChangeLoggedFilterSetTests):
             c.tenants.set([tenants[i]])
             c.tags.set([tags[i]])
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Config Context 1', 'Config Context 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -826,6 +879,10 @@ class ConfigContextTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {'is_active': True}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
         params = {'is_active': False}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
@@ -929,6 +986,10 @@ class ConfigTemplateTestCase(TestCase, BaseFilterSetTests):
         )
         ConfigTemplate.objects.bulk_create(config_templates)
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Config Template 1', 'Config Template 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -964,6 +1025,10 @@ class TagTestCase(TestCase, ChangeLoggedFilterSetTests):
 
         site.tags.set([tags[0]])
         provider.tags.set([tags[1]])
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Tag 1', 'Tag 2']}
@@ -1075,6 +1140,10 @@ class ObjectChangeTestCase(TestCase, BaseFilterSetTests):
             ),
         )
         ObjectChange.objects.bulk_create(object_changes)
+
+    def test_q(self):
+        params = {'q': 'Site 1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
     def test_user(self):
         params = {'user_id': User.objects.filter(username__in=['user1', 'user2']).values_list('pk', flat=True)}

--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -759,7 +759,7 @@ class FHRPGroupFilterSet(NetBoxModelFilterSet):
 
     class Meta:
         model = FHRPGroup
-        fields = ['id', 'group_id', 'name', 'auth_key']
+        fields = ['id', 'group_id', 'name', 'auth_key', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():
@@ -1009,12 +1009,15 @@ class ServiceTemplateFilterSet(NetBoxModelFilterSet):
 
     class Meta:
         model = ServiceTemplate
-        fields = ['id', 'name', 'protocol']
+        fields = ['id', 'name', 'protocol', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
-        qs_filter = Q(name__icontains=value) | Q(description__icontains=value)
+        qs_filter = (
+            Q(name__icontains=value) |
+            Q(description__icontains=value)
+        )
         return queryset.filter(qs_filter)
 
 

--- a/netbox/ipam/tests/test_filtersets.py
+++ b/netbox/ipam/tests/test_filtersets.py
@@ -39,7 +39,7 @@ class ASNRangeTestCase(TestCase, ChangeLoggedFilterSetTests):
                 tenant=None,
                 start=65000,
                 end=65009,
-                description='aaa'
+                description='foobar1'
             ),
             ASNRange(
                 name='ASN Range 2',
@@ -48,7 +48,7 @@ class ASNRangeTestCase(TestCase, ChangeLoggedFilterSetTests):
                 tenant=tenants[0],
                 start=65010,
                 end=65019,
-                description='bbb'
+                description='foobar2'
             ),
             ASNRange(
                 name='ASN Range 3',
@@ -57,10 +57,14 @@ class ASNRangeTestCase(TestCase, ChangeLoggedFilterSetTests):
                 tenant=tenants[1],
                 start=65020,
                 end=65029,
-                description='ccc'
+                description='foobar3'
             ),
         )
         ASNRange.objects.bulk_create(asn_ranges)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['ASN Range 1', 'ASN Range 2']}
@@ -89,7 +93,7 @@ class ASNRangeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
-        params = {'description': ['aaa', 'bbb']}
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
@@ -123,9 +127,9 @@ class ASNTestCase(TestCase, ChangeLoggedFilterSetTests):
         Tenant.objects.bulk_create(tenants)
 
         asns = (
-            ASN(asn=65001, rir=rirs[0], tenant=tenants[0], description='aaa'),
-            ASN(asn=65002, rir=rirs[1], tenant=tenants[1], description='bbb'),
-            ASN(asn=65003, rir=rirs[2], tenant=tenants[2], description='ccc'),
+            ASN(asn=65001, rir=rirs[0], tenant=tenants[0], description='foobar1'),
+            ASN(asn=65002, rir=rirs[1], tenant=tenants[1], description='foobar2'),
+            ASN(asn=65003, rir=rirs[2], tenant=tenants[2], description='foobar3'),
             ASN(asn=4200000000, rir=rirs[0], tenant=tenants[0]),
             ASN(asn=4200000001, rir=rirs[1], tenant=tenants[1]),
             ASN(asn=4200000002, rir=rirs[2], tenant=tenants[2]),
@@ -138,6 +142,10 @@ class ASNTestCase(TestCase, ChangeLoggedFilterSetTests):
         asns[3].sites.set([sites[0]])
         asns[4].sites.set([sites[1]])
         asns[5].sites.set([sites[2]])
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_asn(self):
         params = {'asn': [65001, 4200000000]}
@@ -165,7 +173,7 @@ class ASNTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_description(self):
-        params = {'description': ['aaa', 'bbb']}
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
@@ -213,6 +221,10 @@ class VRFTestCase(TestCase, ChangeLoggedFilterSetTests):
         vrfs[1].export_targets.add(route_targets[1])
         vrfs[2].import_targets.add(route_targets[2])
         vrfs[2].export_targets.add(route_targets[2])
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['VRF 1', 'VRF 2']}
@@ -310,6 +322,10 @@ class RouteTargetTestCase(TestCase, ChangeLoggedFilterSetTests):
         vrfs[1].import_targets.add(route_targets[4], route_targets[5])
         vrfs[1].export_targets.add(route_targets[6], route_targets[7])
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['65000:1001', '65000:1002', '65000:1003']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
@@ -355,14 +371,18 @@ class RIRTestCase(TestCase, ChangeLoggedFilterSetTests):
     def setUpTestData(cls):
 
         rirs = (
-            RIR(name='RIR 1', slug='rir-1', is_private=False, description='A'),
-            RIR(name='RIR 2', slug='rir-2', is_private=False, description='B'),
-            RIR(name='RIR 3', slug='rir-3', is_private=False, description='C'),
-            RIR(name='RIR 4', slug='rir-4', is_private=True, description='D'),
-            RIR(name='RIR 5', slug='rir-5', is_private=True, description='E'),
-            RIR(name='RIR 6', slug='rir-6', is_private=True, description='F'),
+            RIR(name='RIR 1', slug='rir-1', is_private=False, description='foobar1'),
+            RIR(name='RIR 2', slug='rir-2', is_private=False, description='foobar2'),
+            RIR(name='RIR 3', slug='rir-3', is_private=False, description='foobar3'),
+            RIR(name='RIR 4', slug='rir-4', is_private=True),
+            RIR(name='RIR 5', slug='rir-5', is_private=True),
+            RIR(name='RIR 6', slug='rir-6', is_private=True),
         )
         RIR.objects.bulk_create(rirs)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['RIR 1', 'RIR 2']}
@@ -373,7 +393,7 @@ class RIRTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
-        params = {'description': ['A', 'B']}
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_is_private(self):
@@ -421,6 +441,10 @@ class AggregateTestCase(TestCase, ChangeLoggedFilterSetTests):
             Aggregate(prefix='2001:db8:3::/48', rir=rirs[2], tenant=tenants[2], date_added='2020-01-06'),
         )
         Aggregate.objects.bulk_create(aggregates)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_family(self):
         params = {'family': '4'}
@@ -474,6 +498,10 @@ class RoleTestCase(TestCase, ChangeLoggedFilterSetTests):
             Role(name='Role 3', slug='role-3'),
         )
         Role.objects.bulk_create(roles)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Role 1', 'Role 2']}
@@ -578,6 +606,10 @@ class PrefixTestCase(TestCase, ChangeLoggedFilterSetTests):
         )
         for prefix in prefixes:
             prefix.save()
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_family(self):
         params = {'family': '6'}
@@ -745,16 +777,86 @@ class IPRangeTestCase(TestCase, ChangeLoggedFilterSetTests):
         Tenant.objects.bulk_create(tenants)
 
         ip_ranges = (
-            IPRange(start_address='10.0.1.100/24', end_address='10.0.1.199/24', size=100, vrf=None, tenant=None, role=None, status=IPRangeStatusChoices.STATUS_ACTIVE, description='foobar1'),
-            IPRange(start_address='10.0.2.100/24', end_address='10.0.2.199/24', size=100, vrf=vrfs[0], tenant=tenants[0], role=roles[0], status=IPRangeStatusChoices.STATUS_ACTIVE, description='foobar2'),
-            IPRange(start_address='10.0.3.100/24', end_address='10.0.3.199/24', size=100, vrf=vrfs[1], tenant=tenants[1], role=roles[1], status=IPRangeStatusChoices.STATUS_DEPRECATED),
-            IPRange(start_address='10.0.4.100/24', end_address='10.0.4.199/24', size=100, vrf=vrfs[2], tenant=tenants[2], role=roles[2], status=IPRangeStatusChoices.STATUS_RESERVED),
-            IPRange(start_address='2001:db8:0:1::1/64', end_address='2001:db8:0:1::100/64', size=100, vrf=None, tenant=None, role=None, status=IPRangeStatusChoices.STATUS_ACTIVE),
-            IPRange(start_address='2001:db8:0:2::1/64', end_address='2001:db8:0:2::100/64', size=100, vrf=vrfs[0], tenant=tenants[0], role=roles[0], status=IPRangeStatusChoices.STATUS_ACTIVE),
-            IPRange(start_address='2001:db8:0:3::1/64', end_address='2001:db8:0:3::100/64', size=100, vrf=vrfs[1], tenant=tenants[1], role=roles[1], status=IPRangeStatusChoices.STATUS_DEPRECATED),
-            IPRange(start_address='2001:db8:0:4::1/64', end_address='2001:db8:0:4::100/64', size=100, vrf=vrfs[2], tenant=tenants[2], role=roles[2], status=IPRangeStatusChoices.STATUS_RESERVED),
+            IPRange(
+                start_address='10.0.1.100/24',
+                end_address='10.0.1.199/24',
+                size=100,
+                vrf=None,
+                tenant=None,
+                role=None,
+                status=IPRangeStatusChoices.STATUS_ACTIVE,
+                description='foobar1'
+            ),
+            IPRange(
+                start_address='10.0.2.100/24',
+                end_address='10.0.2.199/24',
+                size=100,
+                vrf=vrfs[0],
+                tenant=tenants[0],
+                role=roles[0],
+                status=IPRangeStatusChoices.STATUS_ACTIVE,
+                description='foobar2'
+            ),
+            IPRange(
+                start_address='10.0.3.100/24',
+                end_address='10.0.3.199/24',
+                size=100,
+                vrf=vrfs[1],
+                tenant=tenants[1],
+                role=roles[1],
+                status=IPRangeStatusChoices.STATUS_DEPRECATED
+            ),
+            IPRange(
+                start_address='10.0.4.100/24',
+                end_address='10.0.4.199/24',
+                size=100,
+                vrf=vrfs[2],
+                tenant=tenants[2],
+                role=roles[2],
+                status=IPRangeStatusChoices.STATUS_RESERVED
+            ),
+            IPRange(
+                start_address='2001:db8:0:1::1/64',
+                end_address='2001:db8:0:1::100/64',
+                size=100,
+                vrf=None,
+                tenant=None,
+                role=None,
+                status=IPRangeStatusChoices.STATUS_ACTIVE
+            ),
+            IPRange(
+                start_address='2001:db8:0:2::1/64',
+                end_address='2001:db8:0:2::100/64',
+                size=100,
+                vrf=vrfs[0],
+                tenant=tenants[0],
+                role=roles[0],
+                status=IPRangeStatusChoices.STATUS_ACTIVE
+            ),
+            IPRange(
+                start_address='2001:db8:0:3::1/64',
+                end_address='2001:db8:0:3::100/64',
+                size=100,
+                vrf=vrfs[1],
+                tenant=tenants[1],
+                role=roles[1],
+                status=IPRangeStatusChoices.STATUS_DEPRECATED
+            ),
+            IPRange(
+                start_address='2001:db8:0:4::1/64',
+                end_address='2001:db8:0:4::100/64',
+                size=100,
+                vrf=vrfs[2],
+                tenant=tenants[2],
+                role=roles[2],
+                status=IPRangeStatusChoices.STATUS_RESERVED
+            ),
         )
         IPRange.objects.bulk_create(ip_ranges)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_family(self):
         params = {'family': '6'}
@@ -889,20 +991,110 @@ class IPAddressTestCase(TestCase, ChangeLoggedFilterSetTests):
         Tenant.objects.bulk_create(tenants)
 
         ipaddresses = (
-            IPAddress(address='10.0.0.1/24', tenant=None, vrf=None, assigned_object=None, status=IPAddressStatusChoices.STATUS_ACTIVE, dns_name='ipaddress-a', description='foobar1'),
-            IPAddress(address='10.0.0.2/24', tenant=tenants[0], vrf=vrfs[0], assigned_object=interfaces[0], status=IPAddressStatusChoices.STATUS_ACTIVE, dns_name='ipaddress-b'),
-            IPAddress(address='10.0.0.3/24', tenant=tenants[1], vrf=vrfs[1], assigned_object=interfaces[1], status=IPAddressStatusChoices.STATUS_RESERVED, role=IPAddressRoleChoices.ROLE_VIP, dns_name='ipaddress-c'),
-            IPAddress(address='10.0.0.4/24', tenant=tenants[2], vrf=vrfs[2], assigned_object=interfaces[2], status=IPAddressStatusChoices.STATUS_DEPRECATED, role=IPAddressRoleChoices.ROLE_SECONDARY, dns_name='ipaddress-d'),
-            IPAddress(address='10.0.0.5/24', tenant=None, vrf=None, assigned_object=fhrp_groups[0], status=IPAddressStatusChoices.STATUS_ACTIVE),
-            IPAddress(address='10.0.0.1/25', tenant=None, vrf=None, assigned_object=None, status=IPAddressStatusChoices.STATUS_ACTIVE),
-            IPAddress(address='2001:db8::1/64', tenant=None, vrf=None, assigned_object=None, status=IPAddressStatusChoices.STATUS_ACTIVE, dns_name='ipaddress-a', description='foobar2'),
-            IPAddress(address='2001:db8::2/64', tenant=tenants[0], vrf=vrfs[0], assigned_object=vminterfaces[0], status=IPAddressStatusChoices.STATUS_ACTIVE, dns_name='ipaddress-b'),
-            IPAddress(address='2001:db8::3/64', tenant=tenants[1], vrf=vrfs[1], assigned_object=vminterfaces[1], status=IPAddressStatusChoices.STATUS_RESERVED, role=IPAddressRoleChoices.ROLE_VIP, dns_name='ipaddress-c'),
-            IPAddress(address='2001:db8::4/64', tenant=tenants[2], vrf=vrfs[2], assigned_object=vminterfaces[2], status=IPAddressStatusChoices.STATUS_DEPRECATED, role=IPAddressRoleChoices.ROLE_SECONDARY, dns_name='ipaddress-d'),
-            IPAddress(address='2001:db8::5/64', tenant=None, vrf=None, assigned_object=fhrp_groups[1], status=IPAddressStatusChoices.STATUS_ACTIVE),
-            IPAddress(address='2001:db8::1/65', tenant=None, vrf=None, assigned_object=None, status=IPAddressStatusChoices.STATUS_ACTIVE),
+            IPAddress(
+                address='10.0.0.1/24',
+                tenant=None,
+                vrf=None,
+                assigned_object=None,
+                status=IPAddressStatusChoices.STATUS_ACTIVE,
+                dns_name='ipaddress-a',
+                description='foobar1'
+            ),
+            IPAddress(
+                address='10.0.0.2/24',
+                tenant=tenants[0],
+                vrf=vrfs[0],
+                assigned_object=interfaces[0],
+                status=IPAddressStatusChoices.STATUS_ACTIVE,
+                dns_name='ipaddress-b'
+            ),
+            IPAddress(
+                address='10.0.0.3/24',
+                tenant=tenants[1],
+                vrf=vrfs[1],
+                assigned_object=interfaces[1],
+                status=IPAddressStatusChoices.STATUS_RESERVED,
+                role=IPAddressRoleChoices.ROLE_VIP,
+                dns_name='ipaddress-c'
+            ),
+            IPAddress(
+                address='10.0.0.4/24',
+                tenant=tenants[2],
+                vrf=vrfs[2],
+                assigned_object=interfaces[2],
+                status=IPAddressStatusChoices.STATUS_DEPRECATED,
+                role=IPAddressRoleChoices.ROLE_SECONDARY,
+                dns_name='ipaddress-d'
+            ),
+            IPAddress(
+                address='10.0.0.5/24',
+                tenant=None,
+                vrf=None,
+                assigned_object=fhrp_groups[0],
+                status=IPAddressStatusChoices.STATUS_ACTIVE
+            ),
+            IPAddress(
+                address='10.0.0.1/25',
+                tenant=None,
+                vrf=None,
+                assigned_object=None,
+                status=IPAddressStatusChoices.STATUS_ACTIVE
+            ),
+            IPAddress(
+                address='2001:db8::1/64',
+                tenant=None,
+                vrf=None,
+                assigned_object=None,
+                status=IPAddressStatusChoices.STATUS_ACTIVE,
+                dns_name='ipaddress-a',
+                description='foobar2'
+            ),
+            IPAddress(
+                address='2001:db8::2/64',
+                tenant=tenants[0],
+                vrf=vrfs[0],
+                assigned_object=vminterfaces[0],
+                status=IPAddressStatusChoices.STATUS_ACTIVE,
+                dns_name='ipaddress-b'
+            ),
+            IPAddress(
+                address='2001:db8::3/64',
+                tenant=tenants[1],
+                vrf=vrfs[1],
+                assigned_object=vminterfaces[1],
+                status=IPAddressStatusChoices.STATUS_RESERVED,
+                role=IPAddressRoleChoices.ROLE_VIP,
+                dns_name='ipaddress-c'
+            ),
+            IPAddress(
+                address='2001:db8::4/64',
+                tenant=tenants[2],
+                vrf=vrfs[2],
+                assigned_object=vminterfaces[2],
+                status=IPAddressStatusChoices.STATUS_DEPRECATED,
+                role=IPAddressRoleChoices.ROLE_SECONDARY,
+                dns_name='ipaddress-d'
+            ),
+            IPAddress(
+                address='2001:db8::5/64',
+                tenant=None,
+                vrf=None,
+                assigned_object=fhrp_groups[1],
+                status=IPAddressStatusChoices.STATUS_ACTIVE
+            ),
+            IPAddress(
+                address='2001:db8::1/65',
+                tenant=None,
+                vrf=None,
+                assigned_object=None,
+                status=IPAddressStatusChoices.STATUS_ACTIVE
+            ),
         )
         IPAddress.objects.bulk_create(ipaddresses)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_family(self):
         params = {'family': '4'}
@@ -1055,14 +1247,35 @@ class FHRPGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         IPAddress.objects.bulk_create(ip_addresses)
 
         fhrp_groups = (
-            FHRPGroup(protocol=FHRPGroupProtocolChoices.PROTOCOL_VRRP2, group_id=10, auth_type=FHRPGroupAuthTypeChoices.AUTHENTICATION_PLAINTEXT, auth_key='foo123'),
-            FHRPGroup(protocol=FHRPGroupProtocolChoices.PROTOCOL_VRRP3, group_id=20, auth_type=FHRPGroupAuthTypeChoices.AUTHENTICATION_MD5, auth_key='bar456', name='bar123'),
-            FHRPGroup(protocol=FHRPGroupProtocolChoices.PROTOCOL_HSRP, group_id=30),
+            FHRPGroup(
+                protocol=FHRPGroupProtocolChoices.PROTOCOL_VRRP2,
+                group_id=10,
+                auth_type=FHRPGroupAuthTypeChoices.AUTHENTICATION_PLAINTEXT,
+                auth_key='foo123',
+                description='foobar1'
+            ),
+            FHRPGroup(
+                protocol=FHRPGroupProtocolChoices.PROTOCOL_VRRP3,
+                group_id=20,
+                auth_type=FHRPGroupAuthTypeChoices.AUTHENTICATION_MD5,
+                auth_key='bar456',
+                name='bar123',
+                description='foobar2'
+            ),
+            FHRPGroup(
+                protocol=FHRPGroupProtocolChoices.PROTOCOL_HSRP,
+                group_id=30,
+                description='foobar3'
+            ),
         )
         FHRPGroup.objects.bulk_create(fhrp_groups)
         fhrp_groups[0].ip_addresses.set([ip_addresses[0]])
         fhrp_groups[1].ip_addresses.set([ip_addresses[1]])
         fhrp_groups[2].ip_addresses.set([ip_addresses[2]])
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_protocol(self):
         params = {'protocol': [FHRPGroupProtocolChoices.PROTOCOL_VRRP2, FHRPGroupProtocolChoices.PROTOCOL_VRRP3]}
@@ -1083,6 +1296,10 @@ class FHRPGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
     def test_name(self):
         params = {'name': ['bar123', ]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_related_ip(self):
         # Create some regular IPs to query for related IPs
@@ -1199,16 +1416,20 @@ class VLANGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         cluster.save()
 
         vlan_groups = (
-            VLANGroup(name='VLAN Group 1', slug='vlan-group-1', scope=region, description='A'),
-            VLANGroup(name='VLAN Group 2', slug='vlan-group-2', scope=sitegroup, description='B'),
-            VLANGroup(name='VLAN Group 3', slug='vlan-group-3', scope=site, description='C'),
-            VLANGroup(name='VLAN Group 4', slug='vlan-group-4', scope=location, description='D'),
-            VLANGroup(name='VLAN Group 5', slug='vlan-group-5', scope=rack, description='E'),
-            VLANGroup(name='VLAN Group 6', slug='vlan-group-6', scope=clustergroup, description='F'),
-            VLANGroup(name='VLAN Group 7', slug='vlan-group-7', scope=cluster, description='G'),
+            VLANGroup(name='VLAN Group 1', slug='vlan-group-1', scope=region, description='foobar1'),
+            VLANGroup(name='VLAN Group 2', slug='vlan-group-2', scope=sitegroup, description='foobar2'),
+            VLANGroup(name='VLAN Group 3', slug='vlan-group-3', scope=site, description='foobar3'),
+            VLANGroup(name='VLAN Group 4', slug='vlan-group-4', scope=location),
+            VLANGroup(name='VLAN Group 5', slug='vlan-group-5', scope=rack),
+            VLANGroup(name='VLAN Group 6', slug='vlan-group-6', scope=clustergroup),
+            VLANGroup(name='VLAN Group 7', slug='vlan-group-7', scope=cluster),
             VLANGroup(name='VLAN Group 8', slug='vlan-group-8'),
         )
         VLANGroup.objects.bulk_create(vlan_groups)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['VLAN Group 1', 'VLAN Group 2']}
@@ -1219,7 +1440,7 @@ class VLANGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
-        params = {'description': ['A', 'B']}
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
@@ -1424,6 +1645,10 @@ class VLANTestCase(TestCase, ChangeLoggedFilterSetTests):
         )
         VLAN.objects.bulk_create(vlans)
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['VLAN 101', 'VLAN 102']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -1512,14 +1737,45 @@ class ServiceTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
     @classmethod
     def setUpTestData(cls):
         service_templates = (
-            ServiceTemplate(name='Service Template 1', protocol=ServiceProtocolChoices.PROTOCOL_TCP, ports=[1001]),
-            ServiceTemplate(name='Service Template 2', protocol=ServiceProtocolChoices.PROTOCOL_TCP, ports=[1002]),
-            ServiceTemplate(name='Service Template 3', protocol=ServiceProtocolChoices.PROTOCOL_UDP, ports=[1003]),
-            ServiceTemplate(name='Service Template 4', protocol=ServiceProtocolChoices.PROTOCOL_TCP, ports=[2001]),
-            ServiceTemplate(name='Service Template 5', protocol=ServiceProtocolChoices.PROTOCOL_TCP, ports=[2002]),
-            ServiceTemplate(name='Service Template 6', protocol=ServiceProtocolChoices.PROTOCOL_UDP, ports=[2003]),
+            ServiceTemplate(
+                name='Service Template 1',
+                protocol=ServiceProtocolChoices.PROTOCOL_TCP,
+                ports=[1001],
+                description='foobar1'
+            ),
+            ServiceTemplate(
+                name='Service Template 2',
+                protocol=ServiceProtocolChoices.PROTOCOL_TCP,
+                ports=[1002],
+                description='foobar2'
+            ),
+            ServiceTemplate(
+                name='Service Template 3',
+                protocol=ServiceProtocolChoices.PROTOCOL_UDP,
+                ports=[1003],
+                description='foobar3'
+            ),
+            ServiceTemplate(
+                name='Service Template 4',
+                protocol=ServiceProtocolChoices.PROTOCOL_TCP,
+                ports=[2001]
+            ),
+            ServiceTemplate(
+                name='Service Template 5',
+                protocol=ServiceProtocolChoices.PROTOCOL_TCP,
+                ports=[2002]
+            ),
+            ServiceTemplate(
+                name='Service Template 6',
+                protocol=ServiceProtocolChoices.PROTOCOL_UDP,
+                ports=[2003]
+            ),
         )
         ServiceTemplate.objects.bulk_create(service_templates)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Service Template 1', 'Service Template 2']}
@@ -1532,6 +1788,10 @@ class ServiceTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
     def test_port(self):
         params = {'port': '1001'}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class ServiceTestCase(TestCase, ChangeLoggedFilterSetTests):
@@ -1589,6 +1849,10 @@ class ServiceTestCase(TestCase, ChangeLoggedFilterSetTests):
         services[1].ipaddresses.add(ip_addresses[1])
         services[2].ipaddresses.add(ip_addresses[2])
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Service 1', 'Service 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -1645,9 +1909,26 @@ class L2VPNTestCase(TestCase, ChangeLoggedFilterSetTests):
         RouteTarget.objects.bulk_create(route_targets)
 
         l2vpns = (
-            L2VPN(name='L2VPN 1', slug='l2vpn-1', type=L2VPNTypeChoices.TYPE_VXLAN, identifier=65001),
-            L2VPN(name='L2VPN 2', slug='l2vpn-2', type=L2VPNTypeChoices.TYPE_VPWS, identifier=65002),
-            L2VPN(name='L2VPN 3', slug='l2vpn-3', type=L2VPNTypeChoices.TYPE_VPLS),
+            L2VPN(
+                name='L2VPN 1',
+                slug='l2vpn-1',
+                type=L2VPNTypeChoices.TYPE_VXLAN,
+                identifier=65001,
+                description='foobar1'
+            ),
+            L2VPN(
+                name='L2VPN 2',
+                slug='l2vpn-2',
+                type=L2VPNTypeChoices.TYPE_VPWS,
+                identifier=65002,
+                description='foobar2'
+            ),
+            L2VPN(
+                name='L2VPN 3',
+                slug='l2vpn-3',
+                type=L2VPNTypeChoices.TYPE_VPLS,
+                description='foobar3'
+            ),
         )
         L2VPN.objects.bulk_create(l2vpns)
         l2vpns[0].import_targets.add(route_targets[0])
@@ -1656,6 +1937,10 @@ class L2VPNTestCase(TestCase, ChangeLoggedFilterSetTests):
         l2vpns[0].export_targets.add(route_targets[3])
         l2vpns[1].export_targets.add(route_targets[4])
         l2vpns[2].export_targets.add(route_targets[5])
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['L2VPN 1', 'L2VPN 2']}
@@ -1671,6 +1956,10 @@ class L2VPNTestCase(TestCase, ChangeLoggedFilterSetTests):
 
     def test_type(self):
         params = {'type': [L2VPNTypeChoices.TYPE_VXLAN, L2VPNTypeChoices.TYPE_VPWS]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_import_targets(self):

--- a/netbox/netbox/filtersets.py
+++ b/netbox/netbox/filtersets.py
@@ -315,5 +315,6 @@ class OrganizationalModelFilterSet(NetBoxModelFilterSet):
             return queryset
         return queryset.filter(
             models.Q(name__icontains=value) |
-            models.Q(slug__icontains=value)
+            models.Q(slug__icontains=value) |
+            models.Q(description__icontains=value)
         )

--- a/netbox/tenancy/filtersets.py
+++ b/netbox/tenancy/filtersets.py
@@ -65,7 +65,7 @@ class ContactFilterSet(NetBoxModelFilterSet):
 
     class Meta:
         model = Contact
-        fields = ['id', 'name', 'title', 'phone', 'email', 'address', 'link']
+        fields = ['id', 'name', 'title', 'phone', 'email', 'address', 'link', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():
@@ -77,6 +77,7 @@ class ContactFilterSet(NetBoxModelFilterSet):
             Q(email__icontains=value) |
             Q(address__icontains=value) |
             Q(link__icontains=value) |
+            Q(description__icontains=value) |
             Q(comments__icontains=value)
         )
 

--- a/netbox/tenancy/tests/test_filtersets.py
+++ b/netbox/tenancy/tests/test_filtersets.py
@@ -23,12 +23,31 @@ class TenantGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
             tenantgroup.save()
 
         tenant_groups = (
-            TenantGroup(name='Tenant Group 1', slug='tenant-group-1', parent=parent_tenant_groups[0], description='A'),
-            TenantGroup(name='Tenant Group 2', slug='tenant-group-2', parent=parent_tenant_groups[1], description='B'),
-            TenantGroup(name='Tenant Group 3', slug='tenant-group-3', parent=parent_tenant_groups[2], description='C'),
+            TenantGroup(
+                name='Tenant Group 1',
+                slug='tenant-group-1',
+                parent=parent_tenant_groups[0],
+                description='foobar1'
+            ),
+            TenantGroup(
+                name='Tenant Group 2',
+                slug='tenant-group-2',
+                parent=parent_tenant_groups[1],
+                description='foobar2'
+            ),
+            TenantGroup(
+                name='Tenant Group 3',
+                slug='tenant-group-3',
+                parent=parent_tenant_groups[2],
+                description='foobar3'
+            ),
         )
         for tenantgroup in tenant_groups:
             tenantgroup.save()
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Tenant Group 1', 'Tenant Group 2']}
@@ -39,7 +58,7 @@ class TenantGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
-        params = {'description': ['A', 'B']}
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_parent(self):
@@ -68,9 +87,13 @@ class TenantTestCase(TestCase, ChangeLoggedFilterSetTests):
         tenants = (
             Tenant(name='Tenant 1', slug='tenant-1', group=tenant_groups[0], description='foobar1'),
             Tenant(name='Tenant 2', slug='tenant-2', group=tenant_groups[1], description='foobar2'),
-            Tenant(name='Tenant 3', slug='tenant-3', group=tenant_groups[2]),
+            Tenant(name='Tenant 3', slug='tenant-3', group=tenant_groups[2], description='foobar3'),
         )
         Tenant.objects.bulk_create(tenants)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Tenant 1', 'Tenant 2']}
@@ -108,12 +131,31 @@ class ContactGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
             contactgroup.save()
 
         contact_groups = (
-            ContactGroup(name='Contact Group 1', slug='contact-group-1', parent=parent_contact_groups[0], description='A'),
-            ContactGroup(name='Contact Group 2', slug='contact-group-2', parent=parent_contact_groups[1], description='B'),
-            ContactGroup(name='Contact Group 3', slug='contact-group-3', parent=parent_contact_groups[2], description='C'),
+            ContactGroup(
+                name='Contact Group 1',
+                slug='contact-group-1',
+                parent=parent_contact_groups[0],
+                description='foobar1'
+            ),
+            ContactGroup(
+                name='Contact Group 2',
+                slug='contact-group-2',
+                parent=parent_contact_groups[1],
+                description='foobar2'
+            ),
+            ContactGroup(
+                name='Contact Group 3',
+                slug='contact-group-3',
+                parent=parent_contact_groups[2],
+                description='foobar3'
+            ),
         )
         for contactgroup in contact_groups:
             contactgroup.save()
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Contact Group 1', 'Contact Group 2']}
@@ -124,7 +166,7 @@ class ContactGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
-        params = {'description': ['A', 'B']}
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_parent(self):
@@ -145,9 +187,13 @@ class ContactRoleTestCase(TestCase, ChangeLoggedFilterSetTests):
         contact_roles = (
             ContactRole(name='Contact Role 1', slug='contact-role-1', description='foobar1'),
             ContactRole(name='Contact Role 2', slug='contact-role-2', description='foobar2'),
-            ContactRole(name='Contact Role 3', slug='contact-role-3'),
+            ContactRole(name='Contact Role 3', slug='contact-role-3', description='foobar3'),
         )
         ContactRole.objects.bulk_create(contact_roles)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Contact Role 1', 'Contact Role 2']}
@@ -178,14 +224,22 @@ class ContactTestCase(TestCase, ChangeLoggedFilterSetTests):
             contactgroup.save()
 
         contacts = (
-            Contact(name='Contact 1', group=contact_groups[0]),
-            Contact(name='Contact 2', group=contact_groups[1]),
-            Contact(name='Contact 3', group=contact_groups[2]),
+            Contact(name='Contact 1', group=contact_groups[0], description='foobar1'),
+            Contact(name='Contact 2', group=contact_groups[1], description='foobar2'),
+            Contact(name='Contact 3', group=contact_groups[2], description='foobar3'),
         )
         Contact.objects.bulk_create(contacts)
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Contact 1', 'Contact 2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_group(self):

--- a/netbox/users/tests/test_filtersets.py
+++ b/netbox/users/tests/test_filtersets.py
@@ -67,6 +67,10 @@ class UserTestCase(TestCase, BaseFilterSetTests):
         users[1].groups.set([groups[1]])
         users[2].groups.set([groups[2]])
 
+    def test_q(self):
+        params = {'q': 'user1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_username(self):
         params = {'username': ['User1', 'User2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -117,6 +121,10 @@ class GroupTestCase(TestCase, BaseFilterSetTests):
         )
         Group.objects.bulk_create(groups)
 
+    def test_q(self):
+        params = {'q': 'group 1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Group 1', 'Group 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -163,6 +171,10 @@ class ObjectPermissionTestCase(TestCase, BaseFilterSetTests):
             permissions[i].groups.set([groups[i]])
             permissions[i].users.set([users[i]])
             permissions[i].object_types.set([object_types[i]])
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Permission 1', 'Permission 2']}
@@ -234,6 +246,10 @@ class TokenTestCase(TestCase, BaseFilterSetTests):
             Token(user=users[2], key=Token.generate_key(), expires=past_date, write_enabled=False),
         )
         Token.objects.bulk_create(tokens)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_user(self):
         users = User.objects.order_by('id')[:2]

--- a/netbox/virtualization/filtersets.py
+++ b/netbox/virtualization/filtersets.py
@@ -100,13 +100,14 @@ class ClusterFilterSet(NetBoxModelFilterSet, TenancyFilterSet, ContactModelFilte
 
     class Meta:
         model = Cluster
-        fields = ['id', 'name']
+        fields = ['id', 'name', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
         return queryset.filter(
             Q(name__icontains=value) |
+            Q(description__icontains=value) |
             Q(comments__icontains=value)
         )
 
@@ -238,13 +239,14 @@ class VirtualMachineFilterSet(
 
     class Meta:
         model = VirtualMachine
-        fields = ['id', 'cluster', 'vcpus', 'memory', 'disk']
+        fields = ['id', 'cluster', 'vcpus', 'memory', 'disk', 'description']
 
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
         return queryset.filter(
             Q(name__icontains=value) |
+            Q(description__icontains=value) |
             Q(comments__icontains=value) |
             Q(primary_ip4__address__startswith=value) |
             Q(primary_ip6__address__startswith=value)

--- a/netbox/virtualization/tests/test_filtersets.py
+++ b/netbox/virtualization/tests/test_filtersets.py
@@ -17,11 +17,15 @@ class ClusterTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
     def setUpTestData(cls):
 
         cluster_types = (
-            ClusterType(name='Cluster Type 1', slug='cluster-type-1', description='A'),
-            ClusterType(name='Cluster Type 2', slug='cluster-type-2', description='B'),
-            ClusterType(name='Cluster Type 3', slug='cluster-type-3', description='C'),
+            ClusterType(name='Cluster Type 1', slug='cluster-type-1', description='foobar1'),
+            ClusterType(name='Cluster Type 2', slug='cluster-type-2', description='foobar2'),
+            ClusterType(name='Cluster Type 3', slug='cluster-type-3', description='foobar3'),
         )
         ClusterType.objects.bulk_create(cluster_types)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Cluster Type 1', 'Cluster Type 2']}
@@ -32,7 +36,7 @@ class ClusterTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
-        params = {'description': ['A', 'B']}
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
@@ -44,11 +48,15 @@ class ClusterGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
     def setUpTestData(cls):
 
         cluster_groups = (
-            ClusterGroup(name='Cluster Group 1', slug='cluster-group-1', description='A'),
-            ClusterGroup(name='Cluster Group 2', slug='cluster-group-2', description='B'),
-            ClusterGroup(name='Cluster Group 3', slug='cluster-group-3', description='C'),
+            ClusterGroup(name='Cluster Group 1', slug='cluster-group-1', description='foobar1'),
+            ClusterGroup(name='Cluster Group 2', slug='cluster-group-2', description='foobar2'),
+            ClusterGroup(name='Cluster Group 3', slug='cluster-group-3', description='foobar3'),
         )
         ClusterGroup.objects.bulk_create(cluster_groups)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Cluster Group 1', 'Cluster Group 2']}
@@ -59,7 +67,7 @@ class ClusterGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_description(self):
-        params = {'description': ['A', 'B']}
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
@@ -123,14 +131,46 @@ class ClusterTestCase(TestCase, ChangeLoggedFilterSetTests):
         Tenant.objects.bulk_create(tenants)
 
         clusters = (
-            Cluster(name='Cluster 1', type=cluster_types[0], group=cluster_groups[0], status=ClusterStatusChoices.STATUS_PLANNED, site=sites[0], tenant=tenants[0]),
-            Cluster(name='Cluster 2', type=cluster_types[1], group=cluster_groups[1], status=ClusterStatusChoices.STATUS_STAGING, site=sites[1], tenant=tenants[1]),
-            Cluster(name='Cluster 3', type=cluster_types[2], group=cluster_groups[2], status=ClusterStatusChoices.STATUS_ACTIVE, site=sites[2], tenant=tenants[2]),
+            Cluster(
+                name='Cluster 1',
+                type=cluster_types[0],
+                group=cluster_groups[0],
+                status=ClusterStatusChoices.STATUS_PLANNED,
+                site=sites[0],
+                tenant=tenants[0],
+                description='foobar1'
+            ),
+            Cluster(
+                name='Cluster 2',
+                type=cluster_types[1],
+                group=cluster_groups[1],
+                status=ClusterStatusChoices.STATUS_STAGING,
+                site=sites[1],
+                tenant=tenants[1],
+                description='foobar2'
+            ),
+            Cluster(
+                name='Cluster 3',
+                type=cluster_types[2],
+                group=cluster_groups[2],
+                status=ClusterStatusChoices.STATUS_ACTIVE,
+                site=sites[2],
+                tenant=tenants[2],
+                description='foobar3'
+            ),
         )
         Cluster.objects.bulk_create(clusters)
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Cluster 1', 'Cluster 2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):
@@ -274,9 +314,49 @@ class VirtualMachineTestCase(TestCase, ChangeLoggedFilterSetTests):
         Tenant.objects.bulk_create(tenants)
 
         vms = (
-            VirtualMachine(name='Virtual Machine 1', site=sites[0], cluster=clusters[0], device=devices[0], platform=platforms[0], role=roles[0], tenant=tenants[0], status=VirtualMachineStatusChoices.STATUS_ACTIVE, vcpus=1, memory=1, disk=1, local_context_data={"foo": 123}),
-            VirtualMachine(name='Virtual Machine 2', site=sites[1], cluster=clusters[1], device=devices[1], platform=platforms[1], role=roles[1], tenant=tenants[1], status=VirtualMachineStatusChoices.STATUS_STAGED, vcpus=2, memory=2, disk=2),
-            VirtualMachine(name='Virtual Machine 3', site=sites[2], cluster=clusters[2], device=devices[2], platform=platforms[2], role=roles[2], tenant=tenants[2], status=VirtualMachineStatusChoices.STATUS_OFFLINE, vcpus=3, memory=3, disk=3),
+            VirtualMachine(
+                name='Virtual Machine 1',
+                site=sites[0],
+                cluster=clusters[0],
+                device=devices[0],
+                platform=platforms[0],
+                role=roles[0],
+                tenant=tenants[0],
+                status=VirtualMachineStatusChoices.STATUS_ACTIVE,
+                vcpus=1,
+                memory=1,
+                disk=1,
+                description='foobar1',
+                local_context_data={"foo": 123}
+            ),
+            VirtualMachine(
+                name='Virtual Machine 2',
+                site=sites[1],
+                cluster=clusters[1],
+                device=devices[1],
+                platform=platforms[1],
+                role=roles[1],
+                tenant=tenants[1],
+                status=VirtualMachineStatusChoices.STATUS_STAGED,
+                vcpus=2,
+                memory=2,
+                disk=2,
+                description='foobar2'
+            ),
+            VirtualMachine(
+                name='Virtual Machine 3',
+                site=sites[2],
+                cluster=clusters[2],
+                device=devices[2],
+                platform=platforms[2],
+                role=roles[2],
+                tenant=tenants[2],
+                status=VirtualMachineStatusChoices.STATUS_OFFLINE,
+                vcpus=3,
+                memory=3,
+                disk=3,
+                description='foobar3'
+            ),
         )
         VirtualMachine.objects.bulk_create(vms)
 
@@ -300,11 +380,19 @@ class VirtualMachineTestCase(TestCase, ChangeLoggedFilterSetTests):
         VirtualMachine.objects.filter(pk=vms[0].pk).update(primary_ip4=ipaddresses[0], primary_ip6=ipaddresses[3])
         VirtualMachine.objects.filter(pk=vms[1].pk).update(primary_ip4=ipaddresses[1], primary_ip6=ipaddresses[4])
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Virtual Machine 1', 'Virtual Machine 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         # Test case insensitivity
         params = {'name': ['VIRTUAL MACHINE 1', 'VIRTUAL MACHINE 2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_vcpus(self):
@@ -467,11 +555,39 @@ class VMInterfaceTestCase(TestCase, ChangeLoggedFilterSetTests):
         VirtualMachine.objects.bulk_create(vms)
 
         interfaces = (
-            VMInterface(virtual_machine=vms[0], name='Interface 1', enabled=True, mtu=100, mac_address='00-00-00-00-00-01', vrf=vrfs[0], description='foobar1'),
-            VMInterface(virtual_machine=vms[1], name='Interface 2', enabled=True, mtu=200, mac_address='00-00-00-00-00-02', vrf=vrfs[1], description='foobar2'),
-            VMInterface(virtual_machine=vms[2], name='Interface 3', enabled=False, mtu=300, mac_address='00-00-00-00-00-03', vrf=vrfs[2]),
+            VMInterface(
+                virtual_machine=vms[0],
+                name='Interface 1',
+                enabled=True,
+                mtu=100,
+                mac_address='00-00-00-00-00-01',
+                vrf=vrfs[0],
+                description='foobar1'
+            ),
+            VMInterface(
+                virtual_machine=vms[1],
+                name='Interface 2',
+                enabled=True,
+                mtu=200,
+                mac_address='00-00-00-00-00-02',
+                vrf=vrfs[1],
+                description='foobar2'
+            ),
+            VMInterface(
+                virtual_machine=vms[2],
+                name='Interface 3',
+                enabled=False,
+                mtu=300,
+                mac_address='00-00-00-00-00-03',
+                vrf=vrfs[2],
+                description='foobar3'
+            ),
         )
         VMInterface.objects.bulk_create(interfaces)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_name(self):
         params = {'name': ['Interface 1', 'Interface 2']}

--- a/netbox/wireless/tests/test_filtersets.py
+++ b/netbox/wireless/tests/test_filtersets.py
@@ -36,6 +36,10 @@ class WirelessLANGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         for group in child_groups:
             group.save()
 
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
     def test_name(self):
         params = {'name': ['Wireless LAN Group 1', 'Wireless LAN Group 2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -103,7 +107,8 @@ class WirelessLANTestCase(TestCase, ChangeLoggedFilterSetTests):
                 tenant=tenants[0],
                 auth_type=WirelessAuthTypeChoices.TYPE_OPEN,
                 auth_cipher=WirelessAuthCipherChoices.CIPHER_AUTO,
-                auth_psk='PSK1'
+                auth_psk='PSK1',
+                description='foobar1'
             ),
             WirelessLAN(
                 ssid='WLAN2',
@@ -113,7 +118,8 @@ class WirelessLANTestCase(TestCase, ChangeLoggedFilterSetTests):
                 tenant=tenants[1],
                 auth_type=WirelessAuthTypeChoices.TYPE_WEP,
                 auth_cipher=WirelessAuthCipherChoices.CIPHER_TKIP,
-                auth_psk='PSK2'
+                auth_psk='PSK2',
+                description='foobar2'
             ),
             WirelessLAN(
                 ssid='WLAN3',
@@ -123,10 +129,15 @@ class WirelessLANTestCase(TestCase, ChangeLoggedFilterSetTests):
                 tenant=tenants[2],
                 auth_type=WirelessAuthTypeChoices.TYPE_WPA_PERSONAL,
                 auth_cipher=WirelessAuthCipherChoices.CIPHER_AES,
-                auth_psk='PSK3'
+                auth_psk='PSK3',
+                description='foobar3'
             ),
         )
         WirelessLAN.objects.bulk_create(wireless_lans)
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_ssid(self):
         params = {'ssid': ['WLAN1', 'WLAN2']}
@@ -158,6 +169,10 @@ class WirelessLANTestCase(TestCase, ChangeLoggedFilterSetTests):
 
     def test_auth_psk(self):
         params = {'auth_psk': ['PSK1', 'PSK2']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_description(self):
+        params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_tenant(self):
@@ -239,6 +254,10 @@ class WirelessLinkTestCase(TestCase, ChangeLoggedFilterSetTests):
             interface_b=interfaces[7],
             ssid='LINK4'
         ).save()
+
+    def test_q(self):
+        params = {'q': 'foobar1'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
     def test_ssid(self):
         params = {'ssid': ['LINK1', 'LINK2']}


### PR DESCRIPTION
### Fixes: #14631

- Add a `description` filter to any applicable FilterSets which do not already have one
- Ensure that all `q` filters match against the `description` field if one exists on the associated model
- Extend FilterSet tests to test all `q` and `description` filters (closes #14629)