### PR TITLE
Closes #14092: Remove backward compatibility for importing `extras.plugins`

### DIFF
--- a/netbox/extras/plugins/__init__.py
+++ b/netbox/extras/plugins/__init__.py
@@ -1,9 +1,0 @@
-from .navigation import *
-from .registration import *
-from .templates import *
-from .utils import *
-from netbox.plugins import PluginConfig
-
-
-# TODO: Remove in v4.0
-warnings.warn(f"{__name__} is deprecated. Import from netbox.plugins instead.", DeprecationWarning)

--- a/netbox/extras/plugins/navigation.py
+++ b/netbox/extras/plugins/navigation.py
@@ -1,7 +1,0 @@
-import warnings
-
-from netbox.plugins.navigation import *
-
-
-# TODO: Remove in v4.0
-warnings.warn(f"{__name__} is deprecated. Import from netbox.plugins instead.", DeprecationWarning)

--- a/netbox/extras/plugins/registration.py
+++ b/netbox/extras/plugins/registration.py
@@ -1,7 +1,0 @@
-import warnings
-
-from netbox.plugins.registration import *
-
-
-# TODO: Remove in v4.0
-warnings.warn(f"{__name__} is deprecated. Import from netbox.plugins instead.", DeprecationWarning)

--- a/netbox/extras/plugins/templates.py
+++ b/netbox/extras/plugins/templates.py
@@ -1,7 +1,0 @@
-import warnings
-
-from netbox.plugins.templates import *
-
-
-# TODO: Remove in v4.0
-warnings.warn(f"{__name__} is deprecated. Import from netbox.plugins instead.", DeprecationWarning)

--- a/netbox/extras/plugins/urls.py
+++ b/netbox/extras/plugins/urls.py
@@ -1,7 +1,0 @@
-import warnings
-
-from netbox.plugins.urls import *
-
-
-# TODO: Remove in v4.0
-warnings.warn(f"{__name__} is deprecated. Import from netbox.plugins instead.", DeprecationWarning)

--- a/netbox/extras/plugins/utils.py
+++ b/netbox/extras/plugins/utils.py
@@ -1,7 +1,0 @@
-import warnings
-
-from netbox.plugins.utils import *
-
-
-# TODO: Remove in v4.0
-warnings.warn(f"{__name__} is deprecated. Import from netbox.plugins instead.", DeprecationWarning)

--- a/netbox/extras/plugins/views.py
+++ b/netbox/extras/plugins/views.py
@@ -1,7 +1,0 @@
-import warnings
-
-from netbox.plugins.views import *
-
-
-# TODO: Remove in v4.0
-warnings.warn(f"{__name__} is deprecated. Import from netbox.plugins instead.", DeprecationWarning)


### PR DESCRIPTION
### Fixes: #14092

Remove backward compatibility per #14036