### PR TITLE
Closes #14657: Remove backward compatibility for old permissions mapping under ActionsMixin

### DIFF
--- a/netbox/netbox/views/generic/mixins.py
+++ b/netbox/netbox/views/generic/mixins.py
@@ -1,5 +1,3 @@
-import warnings
-
 from netbox.constants import DEFAULT_ACTION_PERMISSIONS
 from utilities.permissions import get_permission_for_model
 
@@ -26,38 +24,11 @@ class ActionsMixin:
         """
         model = model or self.queryset.model
 
-        # TODO: Remove backward compatibility in Netbox v4.0
-        # Determine how permissions are being mapped to actions for the view
-        if hasattr(self, 'action_perms'):
-            # Backward compatibility for <3.7
-            permissions_map = self.action_perms
-            warnings.warn(
-                "Setting action_perms on views is deprecated and will be removed in NetBox v4.0. Use actions instead.",
-                DeprecationWarning
-            )
-        elif type(self.actions) is dict:
-            # New actions format (3.7+)
-            permissions_map = self.actions
-        else:
-            # actions is still defined as a list or tuple (<3.7) but no custom mapping is defined; use the old
-            # default mapping
-            permissions_map = {
-                'add': {'add'},
-                'import': {'add'},
-                'bulk_edit': {'change'},
-                'bulk_delete': {'delete'},
-            }
-            warnings.warn(
-                "View actions should be defined as a dictionary mapping. Support for the legacy list format will be "
-                "removed in NetBox v4.0.",
-                DeprecationWarning
-            )
-
         # Resolve required permissions for each action
         permitted_actions = []
         for action in self.actions:
             required_permissions = [
-                get_permission_for_model(model, name) for name in permissions_map.get(action, set())
+                get_permission_for_model(model, name) for name in self.actions.get(action, set())
             ]
             if not required_permissions or user.has_perms(required_permissions):
                 permitted_actions.append(action)


### PR DESCRIPTION
### Fixes: #14657

Remove backward compatibility per #13550.