### PR TITLE
Closes #14638: Drop support for Python 3.8 and 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       NETBOX_CONFIGURATION: netbox.configuration_testing
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.10', '3.11']
         node-version: ['14.x']
     services:
       redis:

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -7,7 +7,7 @@ Getting started with NetBox development is pretty straightforward, and should fe
 * A Linux system or compatible environment
 * A PostgreSQL server, which can be installed locally [per the documentation](../installation/1-postgresql.md)
 * A Redis server, which can also be [installed locally](../installation/2-redis.md)
-* Python 3.8 or later
+* Python 3.10 or later
 
 ### 1. Fork the Repo
 

--- a/docs/installation/3-netbox.md
+++ b/docs/installation/3-netbox.md
@@ -6,8 +6,8 @@ This section of the documentation discusses installing and configuring the NetBo
 
 Begin by installing all system packages required by NetBox and its dependencies.
 
-!!! warning "Python 3.8 or later required"
-    NetBox requires Python 3.8, 3.9, 3.10 or 3.11.
+!!! warning "Python 3.10 or later required"
+    NetBox requires Python 3.10 or 3.11.
 
 === "Ubuntu"
 
@@ -21,7 +21,7 @@ Begin by installing all system packages required by NetBox and its dependencies.
     sudo yum install -y gcc libxml2-devel libxslt-devel libffi-devel libpq-devel openssl-devel redhat-rpm-config
     ```
 
-Before continuing, check that your installed Python version is at least 3.8:
+Before continuing, check that your installed Python version is at least 3.10:
 
 ```no-highlight
 python3 -V
@@ -255,10 +255,10 @@ Once NetBox has been configured, we're ready to proceed with the actual installa
 sudo /opt/netbox/upgrade.sh
 ```
 
-Note that **Python 3.8 or later is required** for NetBox v3.2 and later releases. If the default Python installation on your server is set to a lesser version,  pass the path to the supported installation as an environment variable named `PYTHON`. (Note that the environment variable must be passed _after_ the `sudo` command.)
+Note that **Python 3.10 or later is required** for NetBox v4.0 and later releases. If the default Python installation on your server is set to a lesser version,  pass the path to the supported installation as an environment variable named `PYTHON`. (Note that the environment variable must be passed _after_ the `sudo` command.)
 
 ```no-highlight
-sudo PYTHON=/usr/bin/python3.8 /opt/netbox/upgrade.sh
+sudo PYTHON=/usr/bin/python3.10 /opt/netbox/upgrade.sh
 ```
 
 !!! note

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -20,7 +20,7 @@ The following sections detail how to set up a new instance of NetBox:
 
 | Dependency | Minimum Version |
 |------------|-----------------|
-| Python     | 3.8             |
+| Python     | 3.10            |
 | PostgreSQL | 12              |
 | Redis      | 4.0             |
 

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -19,7 +19,7 @@ NetBox requires the following dependencies:
 
 | Dependency | Minimum Version |
 |------------|-----------------|
-| Python     | 3.8             |
+| Python     | 3.10            |
 | PostgreSQL | 12              |
 | Redis      | 4.0             |
 
@@ -108,10 +108,10 @@ sudo ./upgrade.sh
 ```
 
 !!! warning
-    If the default version of Python is not at least 3.8, you'll need to pass the path to a supported Python version as an environment variable when calling the upgrade script. For example:
+    If the default version of Python is not at least 3.10, you'll need to pass the path to a supported Python version as an environment variable when calling the upgrade script. For example:
 
     ```no-highlight
-    sudo PYTHON=/usr/bin/python3.8 ./upgrade.sh
+    sudo PYTHON=/usr/bin/python3.10 ./upgrade.sh
     ```
 
 This script performs the following actions:

--- a/docs/plugins/development/index.md
+++ b/docs/plugins/development/index.md
@@ -135,7 +135,7 @@ Any additional apps must be installed within the same Python environment as NetB
 
 ## Create setup.py
 
-`setup.py` is the [setup script](https://docs.python.org/3.8/distutils/setupscript.html) used to package and install our plugin once it's finished. The primary function of this script is to call the setuptools library's `setup()` function to create a Python distribution package. We can pass a number of keyword arguments to control the package creation as well as to provide metadata about the plugin. An example `setup.py` is below:
+`setup.py` is the [setup script](https://docs.python.org/3.10/distutils/setupscript.html) used to package and install our plugin once it's finished. The primary function of this script is to call the setuptools library's `setup()` function to create a Python distribution package. We can pass a number of keyword arguments to control the package creation as well as to provide metadata about the plugin. An example `setup.py` is below:
 
 ```python
 from setuptools import find_packages, setup
@@ -170,7 +170,7 @@ python3 -m venv ~/.virtualenvs/my_plugin
 You can make NetBox available within this environment by creating a path file pointing to its location. This will add NetBox to the Python path upon activation. (Be sure to adjust the command below to specify your actual virtual environment path, Python version, and NetBox installation.)
 
 ```shell
-echo /opt/netbox/netbox > $VENV/lib/python3.8/site-packages/netbox.pth
+echo /opt/netbox/netbox > $VENV/lib/python3.10/site-packages/netbox.pth
 ```
 
 ## Development Installation

--- a/netbox/dcim/tests/test_views.py
+++ b/netbox/dcim/tests/test_views.py
@@ -1,9 +1,5 @@
 from decimal import Decimal
-try:
-    from zoneinfo import ZoneInfo
-except ImportError:
-    # Python 3.8
-    from backports.zoneinfo import ZoneInfo
+from zoneinfo import ZoneInfo
 
 import yaml
 from django.contrib.auth import get_user_model

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -3,17 +3,18 @@ import importlib
 import importlib.util
 import os
 import platform
-import requests
 import sys
 import warnings
 from urllib.parse import urlencode, urlsplit
 
 import django
+import requests
 from django.contrib.messages import constants as messages
 from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.validators import URLValidator
 from django.utils.encoding import force_str
 from django.utils.translation import gettext_lazy as _
+
 try:
     import sentry_sdk
 except ModuleNotFoundError:
@@ -37,9 +38,9 @@ HOSTNAME = platform.node()
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Validate Python version
-if sys.version_info < (3, 8):
+if sys.version_info < (3, 10):
     raise RuntimeError(
-        f"NetBox requires Python 3.8 or later. (Currently installed: Python {platform.python_version()})"
+        f"NetBox requires Python 3.10 or later. (Currently installed: Python {platform.python_version()})"
     )
 
 #


### PR DESCRIPTION
### Fixes: #14638

- Remove CI runners for Python 3.8 and 3.9
- Update documented minimum required Python version to 3.10
