### PR TITLE
Fixes #14749: Remove errant translation wrapper from DeviceBay installed_device

### DIFF
--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -1115,7 +1115,7 @@ class DeviceBay(ComponentModel, TrackingModelMixin):
     installed_device = models.OneToOneField(
         to='dcim.Device',
         on_delete=models.SET_NULL,
-        related_name=_('parent_bay'),
+        related_name='parent_bay',
         blank=True,
         null=True
     )


### PR DESCRIPTION
### Fixes: #14749

Remove errant application of `gettext_lazy()` to related name of `installed_device` field on DeviceBay
