### PR TITLE
Add support for displaying port and interface information on a virtual chassis

### DIFF
--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -1103,6 +1103,22 @@ class Device(
             filter |= Q(device__virtual_chassis=self.virtual_chassis, mgmt_only=False)
         return Interface.objects.filter(filter)
 
+    @property
+    def front_ports_count(self):
+        return self.vc_front_ports().count()
+    
+    def vc_front_ports(self, if_master=True):
+        """
+        Return a QuerySet matching all FrontPorts assigned to this Device or, if this Device is a VC master, to another
+        Device belonging to the same VirtualChassis.
+
+        :param if_master: If True, return VC member front ports only if this Device is the VC master.
+        """
+        filter = Q(device=self)
+        if self.virtual_chassis and (self.virtual_chassis.master == self or not if_master):
+            filter |= Q(device__virtual_chassis=self.virtual_chassis)
+        return FrontPort.objects.filter(filter)
+    
     def get_cables(self, pk_list=False):
         """
         Return a QuerySet or PK list matching all Cables connected to a component of this Device.

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -1118,6 +1118,22 @@ class Device(
         if self.virtual_chassis and (self.virtual_chassis.master == self or not if_master):
             filter |= Q(device__virtual_chassis=self.virtual_chassis)
         return FrontPort.objects.filter(filter)
+
+    @property
+    def rear_ports_count(self):
+        return self.vc_rear_ports().count()
+
+    def vc_rear_ports(self, if_master=True):
+        """
+        Return a QuerySet matching all RearPorts assigned to this Device or, if this Device is a VC master, to another
+        Device belonging to the same VirtualChassis.
+
+        :param if_master: If True, return VC member rear ports only if this Device is the VC master.
+        """
+        filter = Q(device=self)
+        if self.virtual_chassis and (self.virtual_chassis.master == self or not if_master):
+            filter |= Q(device__virtual_chassis=self.virtual_chassis)
+        return RearPort.objects.filter(filter)
     
     def get_cables(self, pk_list=False):
         """

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1945,12 +1945,15 @@ class DeviceFrontPortsView(DeviceComponentsView):
     template_name = 'dcim/device/frontports.html'
     tab = ViewTab(
         label=_('Front Ports'),
-        badge=lambda obj: obj.front_port_count,
+        badge=lambda obj: obj.vc_front_ports().count(),
         permission='dcim.view_frontport',
         weight=530,
         hide_if_empty=True
     )
 
+    def get_children(self, request, parent):
+        return parent.vc_front_ports().restrict(request.user, 'view')
+    
 
 @register_model_view(Device, 'rearports', path='rear-ports')
 class DeviceRearPortsView(DeviceComponentsView):

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -3465,6 +3465,64 @@ class VirtualChassisAddMemberView(ObjectPermissionRequiredMixin, GetReturnURLMix
         })
 
 
+class VirtualChassisComponentsView(generic.ObjectChildrenView):
+    queryset = VirtualChassis.objects.all()
+
+
+@register_model_view(VirtualChassis, 'interfaces')
+class VirtualChassisInterfacesView(VirtualChassisComponentsView):
+    child_model = Interface
+    table = tables.DeviceInterfaceTable
+    filterset = filtersets.InterfaceFilterSet
+    template_name = 'dcim/device/interfaces.html'
+    tab = ViewTab(
+        label=_('Interfaces'),
+        badge=lambda obj: obj.master.vc_interfaces().count(),
+        permission='dcim.view_interface',
+        weight=520,
+        hide_if_empty=True
+    )
+
+    def get_children(self, request, parent):
+        return parent.master.vc_interfaces().restrict(request.user, 'view')
+
+
+@register_model_view(VirtualChassis, 'frontports', path='front-ports')
+class VirtualChassisFrontPortsView(VirtualChassisComponentsView):
+    child_model = FrontPort
+    table = tables.DeviceFrontPortTable
+    filterset = filtersets.FrontPortFilterSet
+    template_name = 'dcim/device/frontports.html'
+    tab = ViewTab(
+        label=_('Front Ports'),
+        badge=lambda obj: obj.master.vc_front_ports().count(),
+        permission='dcim.view_frontport',
+        weight=520,
+        hide_if_empty=True
+    )
+
+    def get_children(self, request, parent):
+        return parent.master.vc_front_ports().restrict(request.user, 'view')
+
+
+@register_model_view(VirtualChassis, 'rearports', path='rear-ports')
+class VirtualChassisRearPortsView(VirtualChassisComponentsView):
+    child_model = RearPort
+    table = tables.DeviceRearPortTable
+    filterset = filtersets.RearPortFilterSet
+    template_name = 'dcim/device/rearports.html'
+    tab = ViewTab(
+        label=_('Rear Ports'),
+        badge=lambda obj: obj.master.vc_rear_ports().count(),
+        permission='dcim.view_rearport',
+        weight=520,
+        hide_if_empty=True
+    )
+
+    def get_children(self, request, parent):
+        return parent.master.vc_rear_ports().restrict(request.user, 'view')
+
+
 class VirtualChassisRemoveMemberView(ObjectPermissionRequiredMixin, GetReturnURLMixin, View):
     queryset = Device.objects.all()
 


### PR DESCRIPTION
This is in support of fixing the issues discussed at https://github.com/netbox-community/netbox/discussions/12525

In addition to seeing the interfaces and ports on the master device in a virtual chassis this change allows one to view the interfaces and ports for all members on the virtual chassis device itself. This makes it easier to make cable connections from a virtual device as one can find all of the information on the virtual device itself.

By adding ports support to the virtual device one can create virtual patch panels in addition to stacked switches. This is useful when there are a number of physical patch panels in a rack where all ports are uniquely numbered and one needs to connect a cable from that stack of patch panels to another device. One doesn't need to remember which physical patch panel the port is on, only the label of the port.
