### PR TITLE
fix: add missing DH group 15 (3072)

### DIFF
--- a/netbox/vpn/choices.py
+++ b/netbox/vpn/choices.py
@@ -179,6 +179,7 @@ class DHGroupChoices(ChoiceSet):
         (GROUP_2, _('Group {n}').format(n=2)),
         (GROUP_5, _('Group {n}').format(n=5)),
         (GROUP_14, _('Group {n}').format(n=14)),
+        (GROUP_15, _('Group {n}').format(n=15)),
         (GROUP_16, _('Group {n}').format(n=16)),
         (GROUP_17, _('Group {n}').format(n=17)),
         (GROUP_18, _('Group {n}').format(n=18)),


### PR DESCRIPTION
### Fixes #14793

DH group 15 was not selectable in the UI, and I strongly suspect this PR will fix that, as that particular choices was missing in `choices.py`.