### PR TITLE
Fixes #14655: Document raw text configuration render

### DIFF
--- a/docs/features/configuration-rendering.md
+++ b/docs/features/configuration-rendering.md
@@ -39,7 +39,7 @@ When rendered for a specific NetBox device, the template's `device` variable wil
 
 ### Context Data
 
-The objet for which the configuration is being rendered is made available as template context as `device` or `virtualmachine` for devices and virtual machines, respectively. Additionally, NetBox model classes can be accessed by the app or plugin in which they reside. For example:
+The object for which the configuration is being rendered is made available as template context as `device` or `virtualmachine` for devices and virtual machines, respectively. Additionally, NetBox model classes can be accessed by the app or plugin in which they reside. For example:
 
 ```
 There are {{ dcim.Site.objects.count() }} sites.
@@ -69,6 +69,11 @@ This request will trigger resolution of the device's preferred config template i
 * The config template assigned to the device's platform
 
 If no config template has been assigned to any of these three objects, the request will fail.
+
+The configuration can be rendered as JSON or as plaintext by setting the `Accept:` HTTP header. For example:
+
+* `Accept: application/json`
+* `Accept: text/plain`
 
 ### General Purpose Use
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #14655

<!--
    Please include a summary of the proposed changes below.
-->

Add simple explanation how to use HTTP headers to render configuration
templates as either JSON or plaintext.

Also while there fix a nearby typo where "object" was typed as "objet".