### PR TITLE
Fixes #14827: Ensure all matching event rules are processed in response to an event

### DIFF
--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -81,7 +81,7 @@ def process_event_rules(event_rules, model_name, event, data, username, snapshot
 
         # Evaluate event rule conditions (if any)
         if not event_rule.eval_conditions(data):
-            return
+            continue
 
         # Webhooks
         if event_rule.action_type == EventRuleActionChoices.WEBHOOK:


### PR DESCRIPTION
### Fixes: #14827

`process_event_rules()` was prematurely exiting after the first non-applicable EventRule it finds, even if other, potentially relevant rules exist.