### PR TITLE
Fixes #14892: Omit username when running report/script via command line

### DIFF
--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -71,10 +71,10 @@ def enqueue_object(queue, instance, user, request_id, action):
     })
 
 
-def process_event_rules(event_rules, model_name, event, data, username, snapshots=None, request_id=None):
-    try:
+def process_event_rules(event_rules, model_name, event, data, username=None, snapshots=None, request_id=None):
+    if username:
         user = get_user_model().objects.get(username=username)
-    except ObjectDoesNotExist:
+    else:
         user = None
 
     for event_rule in event_rules:

--- a/netbox/extras/signals.py
+++ b/netbox/extras/signals.py
@@ -251,7 +251,8 @@ def process_job_start_event_rules(sender, **kwargs):
     Process event rules for jobs starting.
     """
     event_rules = EventRule.objects.filter(type_job_start=True, enabled=True, content_types=sender.object_type)
-    process_event_rules(event_rules, sender.object_type.model, EVENT_JOB_START, sender.data, sender.user.username)
+    username = sender.user.username if sender.user else None
+    process_event_rules(event_rules, sender.object_type.model, EVENT_JOB_START, sender.data, username)
 
 
 @receiver(job_end)
@@ -260,4 +261,5 @@ def process_job_end_event_rules(sender, **kwargs):
     Process event rules for jobs terminating.
     """
     event_rules = EventRule.objects.filter(type_job_end=True, enabled=True, content_types=sender.object_type)
-    process_event_rules(event_rules, sender.object_type.model, EVENT_JOB_END, sender.data, sender.user.username)
+    username = sender.user.username if sender.user else None
+    process_event_rules(event_rules, sender.object_type.model, EVENT_JOB_END, sender.data, username)


### PR DESCRIPTION
### Fixes: #14892

`process_event_rules()` no longer requires that a username be passed