### PR TITLE
Fixes #14838: JSONField should treat initial form data as JSON

### DIFF
--- a/netbox/utilities/forms/fields/fields.py
+++ b/netbox/utilities/forms/fields/fields.py
@@ -105,7 +105,12 @@ class JSONField(_JSONField):
             return value
         if value in ('', None):
             return ''
-        return json.dumps(value, sort_keys=True, indent=4)
+        if type(value) is str:
+            try:
+                value = json.loads(value, cls=self.decoder)
+            except json.decoder.JSONDecodeError:
+                return value
+        return json.dumps(value, sort_keys=True, indent=4, ensure_ascii=False, cls=self.encoder)
 
 
 class MACAddressField(forms.Field):


### PR DESCRIPTION
### Fixes: #14838

If the field's initial value is a string, attempt to load it as JSON. Also updates the call to `dumps()` afterward with additional arguments from the parent class' implementation.
