### PR TITLE
Fixes #14703: Catch exceptions when rendering dashboard and revert to default

### DIFF
--- a/netbox/extras/dashboard/utils.py
+++ b/netbox/extras/dashboard/utils.py
@@ -53,13 +53,13 @@ def get_dashboard(user):
     return dashboard
 
 
-def get_default_dashboard():
+def get_default_dashboard(config=None):
     from extras.models import Dashboard
 
     dashboard = Dashboard()
-    default_config = settings.DEFAULT_DASHBOARD or DEFAULT_DASHBOARD
+    config = config or settings.DEFAULT_DASHBOARD or DEFAULT_DASHBOARD
 
-    for widget in default_config:
+    for widget in config:
         id = str(uuid.uuid4())
         dashboard.layout.append({
             'id': id,

--- a/netbox/netbox/views/misc.py
+++ b/netbox/netbox/views/misc.py
@@ -2,14 +2,17 @@ import re
 from collections import namedtuple
 
 from django.conf import settings
+from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
 from django.core.cache import cache
 from django.shortcuts import redirect, render
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
 from django_tables2 import RequestConfig
 from packaging import version
 
-from extras.dashboard.utils import get_dashboard
+from extras.constants import DEFAULT_DASHBOARD
+from extras.dashboard.utils import get_dashboard, get_default_dashboard
 from netbox.forms import SearchForm
 from netbox.search import LookupTypes
 from netbox.search.backends import search_backend
@@ -33,7 +36,13 @@ class HomeView(View):
             return redirect('login')
 
         # Construct the user's custom dashboard layout
-        dashboard = get_dashboard(request.user).get_layout()
+        try:
+            dashboard = get_dashboard(request.user).get_layout()
+        except Exception:
+            messages.error(request, _(
+                "There was an error loading the dashboard configuration. A default dashboard is in use."
+            ))
+            dashboard = get_default_dashboard(config=DEFAULT_DASHBOARD).get_layout()
 
         # Check whether a new release is available. (Only for staff/superusers.)
         new_release = None


### PR DESCRIPTION
### Fixes: #14703

- Extend `get_default_dashboard()` to allow passing a specific dashboard configuration
- Wrap the call to `get_layout()` in a `try`/`except` and fall back to the (hard-coded) default config