### PR TITLE
14920 add help to status field in virtual device context import

### DIFF
--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -1359,6 +1359,10 @@ class VirtualDeviceContextImportForm(NetBoxModelImportForm):
         to_field_name='name',
         help_text='Assigned tenant'
     )
+    status = CSVChoiceField(
+        label=_('Status'),
+        choices=VirtualDeviceContextStatusChoices,
+    )
 
     class Meta:
         fields = [


### PR DESCRIPTION
### Fixes: #14920 

Adds help question mark to status field in virtual device context import form.
![Monosnap Virtual Device Context Bulk Import | NetBox 2024-01-24 12-34-32](https://github.com/netbox-community/netbox/assets/99642/67826ba5-7d79-439b-8948-dc44a5a1ecea)
