### PR TITLE
14947 fix for missing changelog if only update m2m

### DIFF
--- a/netbox/extras/signals.py
+++ b/netbox/extras/signals.py
@@ -69,6 +69,7 @@ def handle_changed_object(sender, instance, **kwargs):
         return
 
     # Record an ObjectChange if applicable
+    objectchange = instance.to_objectchange(action)
     if m2m_changed:
         qs = ObjectChange.objects.filter(
             changed_object_type=ContentType.objects.get_for_model(instance),
@@ -76,17 +77,15 @@ def handle_changed_object(sender, instance, **kwargs):
             request_id=request.id
         )
         if not qs:
-            objectchange = instance.to_objectchange(action)
             if objectchange and objectchange.has_changes:
                 objectchange.user = request.user
                 objectchange.request_id = request.id
                 objectchange.save()
         else:
             qs.update(
-                postchange_data=instance.to_objectchange(action).postchange_data
+                postchange_data=objectchange.postchange_data
             )
     else:
-        objectchange = instance.to_objectchange(action)
         if objectchange and objectchange.has_changes:
             objectchange.user = request.user
             objectchange.request_id = request.id

--- a/netbox/extras/signals.py
+++ b/netbox/extras/signals.py
@@ -70,7 +70,7 @@ def handle_changed_object(sender, instance, **kwargs):
 
     # Record an ObjectChange if applicable
     objectchange = instance.to_objectchange(action)
-    check_and_change = False
+    resave_objectchange = False
     if m2m_changed:
         qs = ObjectChange.objects.filter(
             changed_object_type=ContentType.objects.get_for_model(instance),
@@ -78,15 +78,15 @@ def handle_changed_object(sender, instance, **kwargs):
             request_id=request.id
         )
         if not qs:
-            check_and_change = True
+            resave_objectchange = True
         else:
             qs.update(
                 postchange_data=objectchange.postchange_data
             )
     else:
-        check_and_change = True
+        resave_objectchange = True
 
-    if check_and_change and objectchange and objectchange.has_changes:
+    if resave_objectchange and objectchange and objectchange.has_changes:
         objectchange.user = request.user
         objectchange.request_id = request.id
         objectchange.save()

--- a/netbox/extras/signals.py
+++ b/netbox/extras/signals.py
@@ -70,6 +70,7 @@ def handle_changed_object(sender, instance, **kwargs):
 
     # Record an ObjectChange if applicable
     objectchange = instance.to_objectchange(action)
+    check_and_change = False
     if m2m_changed:
         qs = ObjectChange.objects.filter(
             changed_object_type=ContentType.objects.get_for_model(instance),
@@ -77,19 +78,18 @@ def handle_changed_object(sender, instance, **kwargs):
             request_id=request.id
         )
         if not qs:
-            if objectchange and objectchange.has_changes:
-                objectchange.user = request.user
-                objectchange.request_id = request.id
-                objectchange.save()
+            check_and_change = True
         else:
             qs.update(
                 postchange_data=objectchange.postchange_data
             )
     else:
-        if objectchange and objectchange.has_changes:
-            objectchange.user = request.user
-            objectchange.request_id = request.id
-            objectchange.save()
+        check_and_change = True
+
+    if check_and_change and objectchange and objectchange.has_changes:
+        objectchange.user = request.user
+        objectchange.request_id = request.id
+        objectchange.save()
 
     # If this is an M2M change, update the previously queued webhook (from post_save)
     queue = events_queue.get()

--- a/netbox/extras/signals.py
+++ b/netbox/extras/signals.py
@@ -68,25 +68,20 @@ def handle_changed_object(sender, instance, **kwargs):
     else:
         return
 
-    # Record an ObjectChange if applicable
+    # Create/update an ObejctChange record for this change
     objectchange = instance.to_objectchange(action)
-    resave_objectchange = False
-    if m2m_changed:
-        qs = ObjectChange.objects.filter(
+    # If this is a many-to-many field change, check for a previous ObjectChange instance recorded
+    # for this object by this request and update it
+    if m2m_changed and (
+        prev_change := ObjectChange.objects.filter(
             changed_object_type=ContentType.objects.get_for_model(instance),
             changed_object_id=instance.pk,
             request_id=request.id
-        )
-        if not qs:
-            resave_objectchange = True
-        else:
-            qs.update(
-                postchange_data=objectchange.postchange_data
-            )
-    else:
-        resave_objectchange = True
-
-    if resave_objectchange and objectchange and objectchange.has_changes:
+        ).first()
+    ):
+        prev_change.postchange_data = objectchange.postchange_data
+        prev_change.save()
+    elif objectchange and objectchange.has_changes:
         objectchange.user = request.user
         objectchange.request_id = request.id
         objectchange.save()


### PR DESCRIPTION
### Fixes: #14947 

Fix for missing changelog if only update m2m (tag).  Issue is if you only update tags (no other edits) then the changelog entry for the post_save (not m2m_changed) is not created because there are no changes at that point.  When the m2m_changed comes in the update does not work because the query is empty.

Fix is if there is an m2m change and there isn't an existing objectchange then create one, otherwise do the update.