### PR TITLE
Closes #12776: Utilize the htmx_table tag for all embedded object tables

### DIFF
--- a/netbox/templates/circuits/provider.html
+++ b/netbox/templates/circuits/provider.html
@@ -49,18 +49,13 @@
   <div class="col col-md-12">
     <div class="card">
       <h5 class="card-header">{% trans "Provider Accounts" %}</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'circuits:provideraccount_list' %}?provider_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'circuits:provideraccount_list' provider_id=object.pk %}
     </div>
+  </div>
   <div class="col col-md-12">
     <div class="card">
       <h5 class="card-header">{% trans "Circuits" %}</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'circuits:circuit_list' %}?provider_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'circuits:circuit_list' provider_id=object.pk %}
     </div>
     {% plugin_full_width_page object %}
   </div>

--- a/netbox/templates/circuits/provideraccount.html
+++ b/netbox/templates/circuits/provideraccount.html
@@ -42,10 +42,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Circuits" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'circuits:circuit_list' %}?provider_account_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'circuits:circuit_list' provider_account_id=object.pk %}
       </div>
     {% plugin_full_width_page object %}
     </div>

--- a/netbox/templates/circuits/providernetwork.html
+++ b/netbox/templates/circuits/providernetwork.html
@@ -48,10 +48,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Circuits" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'circuits:circuit_list' %}?provider_network_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'circuits:circuit_list' provider_network_id=object.pk %}
       </div>
       {% plugin_full_width_page object %}
     </div>

--- a/netbox/templates/core/datasource.html
+++ b/netbox/templates/core/datasource.html
@@ -112,10 +112,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Files" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'core:datafile_list' %}?source_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'core:datafile_list' source_id=object.pk %}
       </div>
       {% plugin_full_width_page object %}
     </div>

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -154,10 +154,7 @@
             {% include 'inc/panels/comments.html' %}
             <div class="card">
               <h5 class="card-header">{% trans "Virtual Device Contexts" %}</h5>
-              <div class="card-body htmx-container table-responsive p-0"
-                hx-get="{% url 'dcim:virtualdevicecontext_list' %}?device_id={{ object.pk }}"
-                hx-trigger="load"
-              ></div>
+              {% htmx_table 'dcim:virtualdevicecontext_list' device_id=object.pk %}
               {% if perms.dcim.add_virtualdevicecontext %}
                 <div class="card-footer text-end d-print-none">
                   <a href="{% url 'dcim:virtualdevicecontext_add' %}?device={{ object.pk }}" class="btn btn-primary">
@@ -292,10 +289,7 @@
             {% endif %}
             <div class="card">
               <h5 class="card-header">{% trans "Services" %}</h5>
-              <div class="card-body htmx-container table-responsive p-0"
-                hx-get="{% url 'ipam:service_list' %}?device_id={{ object.pk }}"
-                hx-trigger="load"
-              ></div>
+              {% htmx_table 'ipam:service_list' device_id=object.pk %}
               {% if perms.ipam.add_service %}
                 <div class="card-footer text-end d-print-none">
                   <a href="{% url 'ipam:service_add' %}?device={{ object.pk }}" class="btn btn-primary">

--- a/netbox/templates/dcim/interface.html
+++ b/netbox/templates/dcim/interface.html
@@ -336,10 +336,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "IP Addresses" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'ipam:ipaddress_list' %}?interface_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'ipam:ipaddress_list' interface_id=object.pk %}
         {% if perms.ipam.add_ipaddress %}
           <div class="card-footer text-end d-print-none">
             <a href="{% url 'ipam:ipaddress_add' %}?device={{ object.device.pk }}&interface={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary">

--- a/netbox/templates/dcim/location.html
+++ b/netbox/templates/dcim/location.html
@@ -70,10 +70,7 @@
 	<div class="col col-md-12">
     <div class="card">
       <h5 class="card-header">{% trans "Child Locations" %}</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'dcim:location_list' %}?parent_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'dcim:location_list' parent_id=object.pk %}
       {% if perms.dcim.add_location %}
         <div class="card-footer text-end d-print-none">
           <a href="{% url 'dcim:location_add' %}?site={{ object.site.pk }}&parent={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary">
@@ -84,10 +81,7 @@
     </div>
     <div class="card">
       <h5 class="card-header">Non-Racked Devices</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'dcim:device_list' %}?location_id={{ object.pk }}&rack_id=null&parent_bay_id=null"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'dcim:device_list' location_id=object.pk rack_id='null' parent_bay_id='null' %}
       {% if perms.dcim.add_device %}
         <div class="card-footer text-end d-print-none">
           <a href="{% url 'dcim:device_add' %}?site={{ object.site.pk }}&location={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary">

--- a/netbox/templates/dcim/powerpanel.html
+++ b/netbox/templates/dcim/powerpanel.html
@@ -49,10 +49,7 @@
       {% csrf_token %}
       <div class="card">
         <h5 class="card-header">{% trans "Power Feeds" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'dcim:powerfeed_list' %}?power_panel_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'dcim:powerfeed_list' power_panel_id=object.pk %}
         <div class="card-footer d-print-none">
           {% if perms.dcim.change_powerfeed %}
             <button type="submit" name="_edit" formaction="{% url 'dcim:powerfeed_bulk_edit' %}?return_url={% url 'dcim:powerpanel' pk=object.pk %}" class="btn btn-warning">

--- a/netbox/templates/dcim/region.html
+++ b/netbox/templates/dcim/region.html
@@ -52,10 +52,7 @@
 	<div class="col col-md-12">
     <div class="card">
       <h5 class="card-header">{% trans "Child Regions" %}</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'dcim:region_list' %}?parent_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'dcim:region_list' parent_id=object.pk %}
       {% if perms.dcim.add_region %}
         <div class="card-footer text-end d-print-none">
           <a href="{% url 'dcim:region_add' %}?parent={{ object.pk }}" class="btn btn-primary">

--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -125,10 +125,7 @@
   <div class="col col-md-12">
     <div class="card">
       <h5 class="card-header">Locations</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'dcim:location_list' %}?site_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'dcim:location_list' site_id=object.pk %}
       {% if perms.dcim.add_location %}
         <div class="card-footer text-end d-print-none">
           <a href="{% url 'dcim:location_add' %}?site={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary">
@@ -139,10 +136,7 @@
     </div>
     <div class="card">
       <h5 class="card-header">Non-Racked Devices</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'dcim:device_list' %}?site_id={{ object.pk }}&rack_id=null&parent_bay_id=null"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'dcim:device_list' site_id=object.pk rack_id='null' parent_bay_id='null' %}
       {% if perms.dcim.add_device %}
         <div class="card-footer text-end d-print-none">
           <a href="{% url 'dcim:device_add' %}?site={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary">

--- a/netbox/templates/dcim/sitegroup.html
+++ b/netbox/templates/dcim/sitegroup.html
@@ -52,10 +52,7 @@
 	<div class="col col-md-12">
     <div class="card">
       <h5 class="card-header">{% trans "Child Groups" %}</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'dcim:sitegroup_list' %}?parent_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'dcim:sitegroup_list' parent_id=object.pk %}
       {% if perms.dcim.add_sitegroup %}
         <div class="card-footer text-end d-print-none">
           <a href="{% url 'dcim:sitegroup_add' %}?parent={{ object.pk }}" class="btn btn-primary">

--- a/netbox/templates/dcim/virtualdevicecontext.html
+++ b/netbox/templates/dcim/virtualdevicecontext.html
@@ -79,10 +79,7 @@
   <div class="col col-md-12">
     <div class="card">
       <h5 class="card-header">{% trans "Interfaces" %}</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'dcim:interface_list' %}?vdc_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'dcim:interface_list' vdc_id=object.pk %}
     </div>
     {% plugin_full_width_page object %}
   </div>

--- a/netbox/templates/ipam/fhrpgroup.html
+++ b/netbox/templates/ipam/fhrpgroup.html
@@ -66,10 +66,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Virtual IP Addresses" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'ipam:ipaddress_list' %}?fhrpgroup_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'ipam:ipaddress_list' fhrpgroup_id=object.pk %}
         {% if perms.ipam.add_ipaddress %}
           <div class="card-footer text-end">
             <a href="{% url 'ipam:ipaddress_add' %}?fhrpgroup={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary">

--- a/netbox/templates/ipam/ipaddress.html
+++ b/netbox/templates/ipam/ipaddress.html
@@ -116,10 +116,7 @@
     {% endif %}
     <div class="card">
       <h5 class="card-header">{% trans "Services" %}</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'ipam:service_list' %}?ipaddress_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'ipam:service_list' ipaddress_id=object.pk %}
     </div>
     {% plugin_right_page object %}
 	</div>

--- a/netbox/templates/ipam/routetarget.html
+++ b/netbox/templates/ipam/routetarget.html
@@ -36,19 +36,13 @@
     <div class="col col-md-6">
       <div class="card">
         <h5 class="card-header">{% trans "Importing VRFs" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'ipam:vrf_list' %}?import_target_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'ipam:vrf_list' import_target_id=object.pk %}
       </div>
     </div>
     <div class="col col-md-6">
       <div class="card">
         <h5 class="card-header">{% trans "Exporting VRFs" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'ipam:vrf_list' %}?export_target_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'ipam:vrf_list' export_target_id=object.pk %}
       </div>
     </div>
   </div>
@@ -56,19 +50,13 @@
     <div class="col col-md-6">
       <div class="card">
         <h5 class="card-header">{% trans "Importing L2VPNs" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'vpn:l2vpn_list' %}?import_target_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'vpn:l2vpn_list' import_target_id=object.pk %}
       </div>
     </div>
     <div class="col col-md-6">
       <div class="card">
         <h5 class="card-header">{% trans "Exporting L2VPNs" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'vpn:l2vpn_list' %}?export_target_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'vpn:l2vpn_list' export_target_id=object.pk %}
       </div>
     </div>
   </div>

--- a/netbox/templates/ipam/vlan.html
+++ b/netbox/templates/ipam/vlan.html
@@ -81,10 +81,7 @@
       <div class="col col-md-12">
         <div class="card">
           <h5 class="card-header">{% trans "Prefixes" %}</h5>
-          <div class="card-body htmx-container table-responsive p-0"
-            hx-get="{% url 'ipam:prefix_list' %}?vlan_id={{ object.pk }}"
-            hx-trigger="load"
-          ></div>
+          {% htmx_table 'ipam:prefix_list' vlan_id=object.pk %}
           {% if perms.ipam.add_prefix %}
             <div class="card-footer text-end d-print-none">
               <a href="{% url 'ipam:prefix_add' %}?{% if object.tenant %}tenant={{ object.tenant.pk }}&{% endif %}site={{ object.site.pk }}&vlan={{ object.pk }}" class="btn btn-primary">

--- a/netbox/templates/tenancy/contact.html
+++ b/netbox/templates/tenancy/contact.html
@@ -82,10 +82,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Assignments" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'tenancy:contactassignment_list' %}?contact_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'tenancy:contactassignment_list' contact_id=object.pk %}
       </div>
       {% plugin_full_width_page object %}
     </div>

--- a/netbox/templates/tenancy/contactgroup.html
+++ b/netbox/templates/tenancy/contactgroup.html
@@ -43,10 +43,7 @@
   <div class="col col-md-12">
     <div class="card">
       <h5 class="card-header">{% trans "Child Groups" %}</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'tenancy:contactgroup_list' %}?parent_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'tenancy:contactgroup_list' parent_id=object.pk %}
       {% if perms.tenancy.add_contactgroup %}
         <div class="card-footer text-end d-print-none">
           <a href="{% url 'tenancy:contactgroup_add' %}?parent={{ object.pk }}" class="btn btn-primary">

--- a/netbox/templates/tenancy/tenantgroup.html
+++ b/netbox/templates/tenancy/tenantgroup.html
@@ -52,10 +52,7 @@
 	<div class="col col-md-12">
     <div class="card">
       <h5 class="card-header">{% trans "Child Groups" %}</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'tenancy:tenantgroup_list' %}?parent_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'tenancy:tenantgroup_list' parent_id=object.pk %}
       {% if perms.tenancy.add_tenantgroup %}
         <div class="card-footer text-end d-print-none">
           <a href="{% url 'tenancy:tenantgroup_add' %}?parent={{ object.pk }}" class="btn btn-primary">

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -147,10 +147,7 @@
         </div>
         <div class="card">
           <h5 class="card-header">{% trans "Services" %}</h5>
-          <div class="card-body htmx-container table-responsive p-0"
-            hx-get="{% url 'ipam:service_list' %}?virtual_machine_id={{ object.pk }}"
-            hx-trigger="load"
-          ></div>
+          {% htmx_table 'ipam:service_list' virtual_machine_id=object.pk %}
           {% if perms.ipam.add_service %}
             <div class="card-footer text-end d-print-none">
               <a href="{% url 'ipam:service_add' %}?virtual_machine={{ object.pk }}" class="btn btn-primary">
@@ -167,10 +164,7 @@
   <div class="col col-md-12">
     <div class="card">
       <h5 class="card-header">{% trans "Virtual Disks" %}</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'virtualization:virtualdisk_list' %}?virtual_machine_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'virtualization:virtualdisk_list' virtual_machine_id=object.pk %}
       {% if perms.virtualization.add_virtualdisk %}
         <div class="card-footer text-end d-print-none">
           <a href="{% url 'virtualization:virtualdisk_add' %}?device={{ object.device.pk }}&virtual_machine={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary">

--- a/netbox/templates/virtualization/vminterface.html
+++ b/netbox/templates/virtualization/vminterface.html
@@ -82,10 +82,7 @@
     <div class="col col-md-12">
         <div class="card">
             <h5 class="card-header">{% trans "IP Addresses" %}</h5>
-            <div class="card-body htmx-container table-responsive p-0"
-              hx-get="{% url 'ipam:ipaddress_list' %}?vminterface_id={{ object.pk }}"
-              hx-trigger="load"
-            ></div>
+            {% htmx_table 'ipam:ipaddress_list' vminterface_id=object.pk %}
             {% if perms.ipam.add_ipaddress %}
                 <div class="card-footer text-end d-print-none">
                     <a href="{% url 'ipam:ipaddress_add' %}?virtual_machine={{ object.virtual_machine.pk }}&vminterface={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary">

--- a/netbox/templates/vpn/ikepolicy.html
+++ b/netbox/templates/vpn/ikepolicy.html
@@ -55,10 +55,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Proposals" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'vpn:ikeproposal_list' %}?ike_policy_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'vpn:ikeproposal_list' ike_policy_id=object.pk %}
       </div>
       {% plugin_full_width_page object %}
     </div>

--- a/netbox/templates/vpn/ipsecpolicy.html
+++ b/netbox/templates/vpn/ipsecpolicy.html
@@ -43,10 +43,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Proposals" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'vpn:ipsecproposal_list' %}?ipsec_policy_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'vpn:ipsecproposal_list' ipsec_policy_id=object.pk %}
       </div>
       {% plugin_full_width_page object %}
     </div>

--- a/netbox/templates/vpn/l2vpn.html
+++ b/netbox/templates/vpn/l2vpn.html
@@ -53,10 +53,7 @@
 	<div class="col col-md-12">
     <div class="card">
       <h5 class="card-header">{% trans "Terminations" %}</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'vpn:l2vpntermination_list' %}?l2vpn_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'vpn:l2vpntermination_list' l2vpn_id=object.pk %}
       {% if perms.vpn.add_l2vpntermination %}
         <div class="card-footer text-end d-print-none">
           <a href="{% url 'vpn:l2vpntermination_add' %}?l2vpn={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary{% if not object.can_add_termination %} disabled" aria-disabled="true{% endif %}">

--- a/netbox/templates/vpn/tunnel.html
+++ b/netbox/templates/vpn/tunnel.html
@@ -69,10 +69,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Terminations" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'vpn:tunneltermination_list' %}?tunnel_id={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'vpn:tunneltermination_list' tunnel_id=object.pk %}
         {% if perms.vpn.add_tunneltermination %}
           <div class="card-footer text-end d-print-none">
             <a href="{% url 'vpn:tunneltermination_add' %}?tunnel={{ object.pk }}&return_url={{ object.get_absolute_url }}" class="btn btn-primary">

--- a/netbox/templates/vpn/tunneltermination.html
+++ b/netbox/templates/vpn/tunneltermination.html
@@ -49,10 +49,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h5 class="card-header">{% trans "Peer Terminations" %}</h5>
-        <div class="card-body htmx-container table-responsive p-0"
-          hx-get="{% url 'vpn:tunneltermination_list' %}?tunnel_id={{ object.tunnel.pk }}&id__n={{ object.pk }}"
-          hx-trigger="load"
-        ></div>
+        {% htmx_table 'vpn:tunneltermination_list' tunnel_id=object.tunnel.pk id__n=object.pk %}
       </div>
       {% plugin_full_width_page object %}
     </div>

--- a/netbox/templates/wireless/wirelesslangroup.html
+++ b/netbox/templates/wireless/wirelesslangroup.html
@@ -52,10 +52,7 @@
 	<div class="col col-md-12">
     <div class="card">
       <h5 class="card-header">{% trans "Child Groups" %}</h5>
-      <div class="card-body htmx-container table-responsive p-0"
-        hx-get="{% url 'wireless:wirelesslangroup_list' %}?parent_id={{ object.pk }}"
-        hx-trigger="load"
-      ></div>
+      {% htmx_table 'wireless:wirelesslangroup_list' parent_id=object.pk %}
       {% if perms.wireless.add_wirelesslangroup %}
         <div class="card-footer text-end d-print-none">
           <a href="{% url 'wireless:wirelesslangroup_add' %}?parent={{ object.pk }}" class="btn btn-primary">


### PR DESCRIPTION
### Fixes: #12776

Replace all instances of embedded HTMX-backed tables with the `{% htmx_table %}` template tag.