### PR TITLE
Issue #14962 VM to merge directly related site context

### DIFF
--- a/netbox/extras/querysets.py
+++ b/netbox/extras/querysets.py
@@ -126,25 +126,23 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
 
         base_query.add((Q(roles=OuterRef('role')) | Q(roles=None)), Q.AND)
         base_query.add((Q(sites=OuterRef('site')) | Q(sites=None)), Q.AND)
-        region_field = 'site__region'
-        sitegroup_field = 'site__group'
 
         base_query.add(
             (Q(
-                regions__tree_id=OuterRef(f'{region_field}__tree_id'),
-                regions__level__lte=OuterRef(f'{region_field}__level'),
-                regions__lft__lte=OuterRef(f'{region_field}__lft'),
-                regions__rght__gte=OuterRef(f'{region_field}__rght'),
+                regions__tree_id=OuterRef('site__region__tree_id'),
+                regions__level__lte=OuterRef('site__region__level'),
+                regions__lft__lte=OuterRef('site__region__lft'),
+                regions__rght__gte=OuterRef('site__region__rght'),
             ) | Q(regions=None)),
             Q.AND
         )
 
         base_query.add(
             (Q(
-                site_groups__tree_id=OuterRef(f'{sitegroup_field}__tree_id'),
-                site_groups__level__lte=OuterRef(f'{sitegroup_field}__level'),
-                site_groups__lft__lte=OuterRef(f'{sitegroup_field}__lft'),
-                site_groups__rght__gte=OuterRef(f'{sitegroup_field}__rght'),
+                site_groups__tree_id=OuterRef('site__group__tree_id'),
+                site_groups__level__lte=OuterRef('site__group__level'),
+                site_groups__lft__lte=OuterRef('site__group__lft'),
+                site_groups__rght__gte=OuterRef('site__group__rght'),
             ) | Q(site_groups=None)),
             Q.AND
         )

--- a/netbox/extras/querysets.py
+++ b/netbox/extras/querysets.py
@@ -120,17 +120,14 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
         if self.model._meta.model_name == 'device':
             base_query.add((Q(locations=OuterRef('location')) | Q(locations=None)), Q.AND)
             base_query.add((Q(device_types=OuterRef('device_type')) | Q(device_types=None)), Q.AND)
-            base_query.add((Q(roles=OuterRef('role')) | Q(roles=None)), Q.AND)
-            base_query.add((Q(sites=OuterRef('site')) | Q(sites=None)), Q.AND)
-            region_field = 'site__region'
-            sitegroup_field = 'site__group'
 
         elif self.model._meta.model_name == 'virtualmachine':
-            base_query.add((Q(roles=OuterRef('role')) | Q(roles=None)), Q.AND)
-            base_query.add((Q(sites=OuterRef('cluster__site')) | Q(sites=None)), Q.AND)
             base_query.add(Q(device_types=None), Q.AND)
-            region_field = 'cluster__site__region'
-            sitegroup_field = 'cluster__site__group'
+
+        base_query.add((Q(roles=OuterRef('role')) | Q(roles=None)), Q.AND)
+        base_query.add((Q(sites=OuterRef('site')) | Q(sites=None)), Q.AND)
+        region_field = 'site__region'
+        sitegroup_field = 'site__group'
 
         base_query.add(
             (Q(

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -270,7 +270,12 @@ class ConfigContextTest(TestCase):
         tag = Tag.objects.first()
         cluster_type = ClusterType.objects.create(name="Cluster Type")
         cluster_group = ClusterGroup.objects.create(name="Cluster Group")
-        cluster = Cluster.objects.create(name="Cluster", group=cluster_group, type=cluster_type)
+        cluster = Cluster.objects.create(
+            name="Cluster",
+            group=cluster_group,
+            type=cluster_type,
+            site=site,
+        )
 
         region_context = ConfigContext.objects.create(
             name="region",
@@ -352,6 +357,106 @@ class ConfigContextTest(TestCase):
         virtual_machine.tags.add(tag)
 
         annotated_queryset = VirtualMachine.objects.filter(name=virtual_machine.name).annotate_config_context_data()
+        self.assertEqual(virtual_machine.get_config_context(), annotated_queryset[0].get_config_context())
+
+    def test_annotation_same_as_get_for_object_virtualmachine_relations_direct_site(self):
+        region = Region.objects.first()
+        sitegroup = SiteGroup.objects.first()
+        site = Site.objects.first()
+        platform = Platform.objects.first()
+        tenantgroup = TenantGroup.objects.first()
+        tenant = Tenant.objects.first()
+        tag = Tag.objects.first()
+        cluster_type = ClusterType.objects.create(name="Cluster Type")
+        cluster_group = ClusterGroup.objects.create(name="Cluster Group")
+        cluster = Cluster.objects.create(
+            name="Cluster",
+            group=cluster_group,
+            type=cluster_type,
+            site=site,
+        )
+
+        region_context = ConfigContext.objects.create(
+            name="region",
+            weight=100,
+            data={"region": 1}
+        )
+        region_context.regions.add(region)
+
+        sitegroup_context = ConfigContext.objects.create(
+            name="sitegroup",
+            weight=100,
+            data={"sitegroup": 1}
+        )
+        sitegroup_context.site_groups.add(sitegroup)
+
+        site_context = ConfigContext.objects.create(
+            name="site",
+            weight=100,
+            data={"site": 1}
+        )
+        site_context.sites.add(site)
+
+        platform_context = ConfigContext.objects.create(
+            name="platform",
+            weight=100,
+            data={"platform": 1}
+        )
+        platform_context.platforms.add(platform)
+
+        tenant_group_context = ConfigContext.objects.create(
+            name="tenant group",
+            weight=100,
+            data={"tenant_group": 1}
+        )
+        tenant_group_context.tenant_groups.add(tenantgroup)
+
+        tenant_context = ConfigContext.objects.create(
+            name="tenant",
+            weight=100,
+            data={"tenant": 1}
+        )
+        tenant_context.tenants.add(tenant)
+
+        tag_context = ConfigContext.objects.create(
+            name="tag",
+            weight=100,
+            data={"tag": 1}
+        )
+        tag_context.tags.add(tag)
+
+        cluster_type_context = ConfigContext.objects.create(
+            name="cluster type",
+            weight=100,
+            data={"cluster_type": 1}
+        )
+        cluster_type_context.cluster_types.add(cluster_type)
+
+        cluster_group_context = ConfigContext.objects.create(
+            name="cluster group",
+            weight=100,
+            data={"cluster_group": 1}
+        )
+        cluster_group_context.cluster_groups.add(cluster_group)
+
+        cluster_context = ConfigContext.objects.create(
+            name="cluster",
+            weight=100,
+            data={"cluster": 1}
+        )
+        cluster_context.clusters.add(cluster)
+
+        virtual_machine = VirtualMachine.objects.create(
+            name="VM 2",
+            site=site,
+            tenant=tenant,
+            platform=platform,
+            role=DeviceRole.objects.first()
+        )
+        virtual_machine.tags.add(tag)
+
+        annotated_queryset = VirtualMachine.objects.filter(name=virtual_machine.name).annotate_config_context_data()
+
         self.assertEqual(virtual_machine.get_config_context(), annotated_queryset[0].get_config_context())
 
     def test_multiple_tags_return_distinct_objects(self):

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -359,105 +359,40 @@ class ConfigContextTest(TestCase):
         annotated_queryset = VirtualMachine.objects.filter(name=virtual_machine.name).annotate_config_context_data()
         self.assertEqual(virtual_machine.get_config_context(), annotated_queryset[0].get_config_context())
 
-    def test_annotation_same_as_get_for_object_virtualmachine_relations_direct_site(self):
-        region = Region.objects.first()
-        sitegroup = SiteGroup.objects.first()
+    def test_virtualmachine_site_context(self):
+        """
+        Check that config context associated with a site applies to a VM whether the VM is assigned
+        directly to that site or via its cluster.
+        """
         site = Site.objects.first()
-        platform = Platform.objects.first()
-        tenantgroup = TenantGroup.objects.first()
-        tenant = Tenant.objects.first()
-        tag = Tag.objects.first()
         cluster_type = ClusterType.objects.create(name="Cluster Type")
-        cluster_group = ClusterGroup.objects.create(name="Cluster Group")
-        cluster = Cluster.objects.create(
-            name="Cluster",
-            group=cluster_group,
-            type=cluster_type,
-            site=site,
-        )
+        cluster = Cluster.objects.create(name="Cluster", type=cluster_type, site=site)
+        vm_role = DeviceRole.objects.first()
 
-        region_context = ConfigContext.objects.create(
-            name="region",
+        # Create a ConfigContext associated with the site
+        context = ConfigContext.objects.create(
+            name="context1",
             weight=100,
-            data={"region": 1}
+            data={"foo": True}
         )
-        region_context.regions.add(region)
+        context.sites.add(site)
 
-        sitegroup_context = ConfigContext.objects.create(
-            name="sitegroup",
-            weight=100,
-            data={"sitegroup": 1}
+        # Create one VM assigned directly to the site, and one assigned via the cluster
+        vm1 = VirtualMachine.objects.create(name="VM 1", site=site, role=vm_role)
+        vm2 = VirtualMachine.objects.create(name="VM 2", cluster=cluster, role=vm_role)
+
+        # Check that their individually-rendered config contexts are identical
+        self.assertEqual(
+            vm1.get_config_context(),
+            vm2.get_config_context()
         )
-        sitegroup_context.site_groups.add(sitegroup)
 
-        site_context = ConfigContext.objects.create(
-            name="site",
-            weight=100,
-            data={"site": 1}
+        # Check that their annotated config contexts are identical
+        vms = VirtualMachine.objects.filter(pk__in=(vm1.pk, vm2.pk)).annotate_config_context_data()
+        self.assertEqual(
+            vms[0].get_config_context(),
+            vms[1].get_config_context()
         )
-        site_context.sites.add(site)
-
-        platform_context = ConfigContext.objects.create(
-            name="platform",
-            weight=100,
-            data={"platform": 1}
-        )
-        platform_context.platforms.add(platform)
-
-        tenant_group_context = ConfigContext.objects.create(
-            name="tenant group",
-            weight=100,
-            data={"tenant_group": 1}
-        )
-        tenant_group_context.tenant_groups.add(tenantgroup)
-
-        tenant_context = ConfigContext.objects.create(
-            name="tenant",
-            weight=100,
-            data={"tenant": 1}
-        )
-        tenant_context.tenants.add(tenant)
-
-        tag_context = ConfigContext.objects.create(
-            name="tag",
-            weight=100,
-            data={"tag": 1}
-        )
-        tag_context.tags.add(tag)
-
-        cluster_type_context = ConfigContext.objects.create(
-            name="cluster type",
-            weight=100,
-            data={"cluster_type": 1}
-        )
-        cluster_type_context.cluster_types.add(cluster_type)
-
-        cluster_group_context = ConfigContext.objects.create(
-            name="cluster group",
-            weight=100,
-            data={"cluster_group": 1}
-        )
-        cluster_group_context.cluster_groups.add(cluster_group)
-
-        cluster_context = ConfigContext.objects.create(
-            name="cluster",
-            weight=100,
-            data={"cluster": 1}
-        )
-        cluster_context.clusters.add(cluster)
-
-        virtual_machine = VirtualMachine.objects.create(
-            name="VM 2",
-            site=site,
-            tenant=tenant,
-            platform=platform,
-            role=DeviceRole.objects.first()
-        )
-        virtual_machine.tags.add(tag)
-
-        annotated_queryset = VirtualMachine.objects.filter(name=virtual_machine.name).annotate_config_context_data()
-
-        self.assertEqual(virtual_machine.get_config_context(), annotated_queryset[0].get_config_context())
 
     def test_multiple_tags_return_distinct_objects(self):
         """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #14962 

<!--
    Please include a summary of the proposed changes below.
-->
Update the code such that site attached context data is accessed via the site attribute on the virtual machine rather than the site attribute on the optionally associated cluster.
Noting that the `full_clean` of a virtual machine will transpose the cluster's site directly onto the virtual machine if it is not already set.
