### PR TITLE
Closes: #14570 - Remove extra query for job under scripts and reports detailed view

### DIFF
--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1059,10 +1059,6 @@ class ReportView(ContentTypePermissionRequiredMixin, View):
         report = module.reports[name]()
         jobs = module.get_jobs(report.class_name)
 
-        report.result = jobs.filter(
-            status__in=JobStatusChoices.TERMINAL_STATE_CHOICES
-        ).first()
-
         return render(request, 'extras/report.html', {
             'job_count': jobs.count(),
             'module': module,
@@ -1232,11 +1228,6 @@ class ScriptView(ContentTypePermissionRequiredMixin, View):
         script = module.scripts[name]()
         jobs = module.get_jobs(script.class_name)
         form = script.as_form(initial=normalize_querydict(request.GET))
-
-        # Look for a pending Job (use the latest one by creation timestamp)
-        script.result = module.get_jobs(script.class_name).exclude(
-            status__in=JobStatusChoices.TERMINAL_STATE_CHOICES
-        ).first()
 
         return render(request, 'extras/script.html', {
             'job_count': jobs.count(),

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1059,6 +1059,10 @@ class ReportView(ContentTypePermissionRequiredMixin, View):
         report = module.reports[name]()
         jobs = module.get_jobs(report.class_name)
 
+        report.result = jobs.filter(
+            status__in=JobStatusChoices.TERMINAL_STATE_CHOICES
+        ).first()
+
         return render(request, 'extras/report.html', {
             'job_count': jobs.count(),
             'module': module,


### PR DESCRIPTION
### Closes: #14570

* Remove extra query for job under scripts and reports detailed view
  * This query supports populating the .results property on the script model, however this property is no longer used as the results have been moved to their own view.