### PR TITLE
Fixes #15025: can_add() template filter should accept a model (not an instance)

### DIFF
--- a/netbox/utilities/templatetags/perms.py
+++ b/netbox/utilities/templatetags/perms.py
@@ -24,8 +24,9 @@ def can_view(user, instance):
 
 
 @register.filter()
-def can_add(user, instance):
-    return _check_permission(user, instance, 'add')
+def can_add(user, model):
+    permission = get_permission_for_model(model, 'add')
+    return user.has_perm(perm=permission)
 
 
 @register.filter()


### PR DESCRIPTION
### Fixes: #15025
