### PR TITLE
Fixes #14945: Fix "select all" button for device type components

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -58,7 +58,11 @@ class DeviceComponentsView(generic.ObjectChildrenView):
         return self.child_model.objects.restrict(request.user, 'view').filter(device=parent)
 
 
-class DeviceTypeComponentsView(DeviceComponentsView):
+class DeviceTypeComponentsView(generic.ObjectChildrenView):
+    actions = {
+        **DEFAULT_ACTION_PERMISSIONS,
+        'bulk_rename': {'change'},
+    }
     queryset = DeviceType.objects.all()
     template_name = 'dcim/devicetype/component_templates.html'
     viewname = None  # Used for return_url resolution

--- a/netbox/templates/dcim/devicetype/component_templates.html
+++ b/netbox/templates/dcim/devicetype/component_templates.html
@@ -1,45 +1,37 @@
-{% extends 'dcim/devicetype/base.html' %}
-{% load render_table from django_tables2 %}
+{% extends 'generic/object_children.html' %}
 {% load helpers %}
 {% load i18n %}
+{% load perms %}
 
-{% block content %}
-  {% if perms.dcim.change_devicetype %}
-    <form method="post">
-        {% csrf_token %}
-        <div class="card">
-            <h5 class="card-header">{{ title }}</h5>
-            <div class="card-body htmx-container table-responsive" id="object_list">
-              {% include 'htmx/table.html' %}
-            </div>
-            <div class="card-footer noprint">
-                {% if table.rows %}
-                    <button type="submit" name="_edit" formaction="{% url table.Meta.model|viewname:"bulk_rename" %}?return_url={{ return_url }}" class="btn btn-sm btn-warning">
-                        <span class="mdi mdi-pencil-outline" aria-hidden="true"></span> {% trans "Rename" %}
-                    </button>
-                    <button type="submit" name="_edit" formaction="{% url table.Meta.model|viewname:"bulk_edit" %}?return_url={{ return_url }}" class="btn btn-sm btn-warning">
-                        <span class="mdi mdi-pencil" aria-hidden="true"></span> {% trans "Edit" %}
-                    </button>
-                    <button type="submit" name="_delete" formaction="{% url table.Meta.model|viewname:"bulk_delete" %}?return_url={{ return_url }}" class="btn btn-sm btn-danger">
-                        <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i> {% trans "Delete" %}
-                    </button>
-                {% endif %}
-                <div class="float-end">
-                    <a href="{% url table.Meta.model|viewname:"add" %}?device_type={{ object.pk }}&return_url={{ return_url }}" class="btn btn-primary btn-sm">
-                        <i class="mdi mdi-plus-thick" aria-hidden="true"></i>
-                        {% trans "Add" %} {{ title }}
-                    </a>
-                </div>
-                <div class="clearfix"></div>
-            </div>
+{% block bulk_edit_controls %}
+    {% with bulk_edit_view=child_model|validated_viewname:"bulk_edit" %}
+        {% if 'bulk_edit' in actions and bulk_edit_view %}
+            <button type="submit" name="_edit"
+                    formaction="{% url bulk_edit_view %}?device={{ object.pk }}&return_url={{ return_url }}"
+                    class="btn btn-warning btn-sm">
+                <i class="mdi mdi-pencil" aria-hidden="true"></i> Edit Selected
+            </button>
+        {% endif %}
+    {% endwith %}
+    {% with bulk_rename_view=child_model|validated_viewname:"bulk_rename" %}
+        {% if 'bulk_rename' in actions and bulk_rename_view %}
+            <button type="submit" name="_rename"
+                    formaction="{% url bulk_rename_view %}?return_url={{ return_url }}"
+                    class="btn btn-outline-warning btn-sm">
+                <i class="mdi mdi-pencil-outline" aria-hidden="true"></i> Rename
+            </button>
+        {% endif %}
+    {% endwith %}
+{% endblock bulk_edit_controls %}
+
+{% block bulk_extra_controls %}
+    {{ block.super }}
+    {% if request.user|can_add:child_model %}
+        <div class="bulk-button-group">
+            <a href="{% url table.Meta.model|viewname:"add" %}?device_type={{ object.pk }}&return_url={{ return_url }}" class="btn btn-primary btn-sm">
+                <i class="mdi mdi-plus-thick" aria-hidden="true"></i>
+                {% trans "Add" %} {{ title }}
+            </a>
         </div>
-    </form>
-  {% else %}
-    <div class="card">
-      <h5 class="card-header">{{ title }}</h5>
-      <div class="card-body htmx-container table-responsive" id="object_list">
-        {% include 'htmx/table.html' %}
-      </div>
-    </div>
-  {% endif %}
-{% endblock content %}
+    {% endif %}
+{% endblock bulk_extra_controls %}


### PR DESCRIPTION
### Fixes: #14945

This updates the `component_templates.html` template to inherit from the standard template for subclasses of `generic.ObjectChildrenView`.