### PR TITLE
14999 fix FHRP create and add another

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -1068,6 +1068,12 @@ class FHRPGroupAssignmentEditView(generic.ObjectEditView):
             instance.interface = get_object_or_404(content_type.model_class(), pk=request.GET.get('interface_id'))
         return instance
 
+    def get_extra_addanother_params(self, request):
+        return {
+            'interface_type': request.GET.get('interface_type'),
+            'interface_id': request.GET.get('interface_id'),
+        }
+
 
 @register_model_view(FHRPGroupAssignment, 'delete')
 class FHRPGroupAssignmentDeleteView(generic.ObjectDeleteView):


### PR DESCRIPTION
### Fixes: #14999 

Fixes the "create and add another" button on assigning FHRP groups, however found another bug if assign duplicate group which will open separate ticket for.