### PR TITLE
Closes #13729: Censor sensitive data source parameters in change log

### DIFF
--- a/netbox/core/tests/test_models.py
+++ b/netbox/core/tests/test_models.py
@@ -1,0 +1,122 @@
+from django.test import TestCase
+
+from core.models import DataSource
+from extras.choices import ObjectChangeActionChoices
+from netbox.constants import CENSOR_TOKEN, CENSOR_TOKEN_CHANGED
+
+
+class DataSourceChangeLoggingTestCase(TestCase):
+
+    def test_password_added_on_create(self):
+        datasource = DataSource.objects.create(
+            name='Data Source 1',
+            type='git',
+            source_url='http://localhost/',
+            parameters={
+                'username': 'jeff',
+                'password': 'foobar123',
+            }
+        )
+
+        objectchange = datasource.to_objectchange(ObjectChangeActionChoices.ACTION_CREATE)
+        self.assertIsNone(objectchange.prechange_data)
+        self.assertEqual(objectchange.postchange_data['parameters']['username'], 'jeff')
+        self.assertEqual(objectchange.postchange_data['parameters']['password'], CENSOR_TOKEN_CHANGED)
+
+    def test_password_added_on_update(self):
+        datasource = DataSource.objects.create(
+            name='Data Source 1',
+            type='git',
+            source_url='http://localhost/'
+        )
+        datasource.snapshot()
+
+        # Add a blank password
+        datasource.parameters = {
+            'username': 'jeff',
+            'password': '',
+        }
+
+        objectchange = datasource.to_objectchange(ObjectChangeActionChoices.ACTION_UPDATE)
+        self.assertIsNone(objectchange.prechange_data['parameters'])
+        self.assertEqual(objectchange.postchange_data['parameters']['username'], 'jeff')
+        self.assertEqual(objectchange.postchange_data['parameters']['password'], '')
+
+        # Add a password
+        datasource.parameters = {
+            'username': 'jeff',
+            'password': 'foobar123',
+        }
+
+        objectchange = datasource.to_objectchange(ObjectChangeActionChoices.ACTION_UPDATE)
+        self.assertEqual(objectchange.postchange_data['parameters']['username'], 'jeff')
+        self.assertEqual(objectchange.postchange_data['parameters']['password'], CENSOR_TOKEN_CHANGED)
+
+    def test_password_changed(self):
+        datasource = DataSource.objects.create(
+            name='Data Source 1',
+            type='git',
+            source_url='http://localhost/',
+            parameters={
+                'username': 'jeff',
+                'password': 'password1',
+            }
+        )
+        datasource.snapshot()
+
+        # Change the password
+        datasource.parameters['password'] = 'password2'
+
+        objectchange = datasource.to_objectchange(ObjectChangeActionChoices.ACTION_UPDATE)
+        self.assertEqual(objectchange.prechange_data['parameters']['username'], 'jeff')
+        self.assertEqual(objectchange.prechange_data['parameters']['password'], CENSOR_TOKEN)
+        self.assertEqual(objectchange.postchange_data['parameters']['username'], 'jeff')
+        self.assertEqual(objectchange.postchange_data['parameters']['password'], CENSOR_TOKEN_CHANGED)
+
+    def test_password_removed_on_update(self):
+        datasource = DataSource.objects.create(
+            name='Data Source 1',
+            type='git',
+            source_url='http://localhost/',
+            parameters={
+                'username': 'jeff',
+                'password': 'foobar123',
+            }
+        )
+        datasource.snapshot()
+
+        objectchange = datasource.to_objectchange(ObjectChangeActionChoices.ACTION_UPDATE)
+        self.assertEqual(objectchange.prechange_data['parameters']['username'], 'jeff')
+        self.assertEqual(objectchange.prechange_data['parameters']['password'], CENSOR_TOKEN)
+        self.assertEqual(objectchange.postchange_data['parameters']['username'], 'jeff')
+        self.assertEqual(objectchange.postchange_data['parameters']['password'], CENSOR_TOKEN)
+
+        # Remove the password
+        datasource.parameters['password'] = ''
+
+        objectchange = datasource.to_objectchange(ObjectChangeActionChoices.ACTION_UPDATE)
+        self.assertEqual(objectchange.prechange_data['parameters']['username'], 'jeff')
+        self.assertEqual(objectchange.prechange_data['parameters']['password'], CENSOR_TOKEN)
+        self.assertEqual(objectchange.postchange_data['parameters']['username'], 'jeff')
+        self.assertEqual(objectchange.postchange_data['parameters']['password'], '')
+
+    def test_password_not_modified(self):
+        datasource = DataSource.objects.create(
+            name='Data Source 1',
+            type='git',
+            source_url='http://localhost/',
+            parameters={
+                'username': 'username1',
+                'password': 'foobar123',
+            }
+        )
+        datasource.snapshot()
+
+        # Remove the password
+        datasource.parameters['username'] = 'username2'
+
+        objectchange = datasource.to_objectchange(ObjectChangeActionChoices.ACTION_UPDATE)
+        self.assertEqual(objectchange.prechange_data['parameters']['username'], 'username1')
+        self.assertEqual(objectchange.prechange_data['parameters']['password'], CENSOR_TOKEN)
+        self.assertEqual(objectchange.postchange_data['parameters']['username'], 'username2')
+        self.assertEqual(objectchange.postchange_data['parameters']['password'], CENSOR_TOKEN)

--- a/netbox/netbox/constants.py
+++ b/netbox/netbox/constants.py
@@ -36,3 +36,7 @@ DEFAULT_ACTION_PERMISSIONS = {
     'bulk_edit': {'change'},
     'bulk_delete': {'delete'},
 }
+
+# General-purpose tokens
+CENSOR_TOKEN = '********'
+CENSOR_TOKEN_CHANGED = '***CHANGED***'


### PR DESCRIPTION
### Fixes: #13729

This overrides the `to_objectchange()` method on DataSource to censor the values of any parameters designated as sensitive for the assigned backend. We're doing this here rather than directly in `serialize_object()` because we need to determine whether each sensitive value has been modified.