### PR TITLE
fix: SerializedPKRelatedField schema for openapi (drf-spectacular)

### DIFF
--- a/netbox/core/api/schema.py
+++ b/netbox/core/api/schema.py
@@ -256,3 +256,14 @@ class NetBoxAutoSchema(AutoSchema):
         if '{id}' in self.path:
             return f"{self.method.capitalize()} a {model_name} object."
         return f"{self.method.capitalize()} a list of {model_name} objects."
+
+
+class FixSerializedPKRelatedField(OpenApiSerializerFieldExtension):
+    target_class = 'netbox.api.fields.SerializedPKRelatedField'
+
+    def map_serializer_field(self, auto_schema, direction):
+        if direction == "response":
+            component = auto_schema.resolve_serializer(self.target.serializer, direction)
+            return component.ref if component else None
+        else:
+            return build_basic_type(OpenApiTypes.INT)


### PR DESCRIPTION
### Fixes: #14982 

Added a schema extension for drf-spectular for SerializedPKRelatedField  class, because request and response are different.

