### PR TITLE
15029 check if duplicate FHRP group assignment

### DIFF
--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -521,6 +521,24 @@ class FHRPGroupAssignmentForm(BootstrapMixin, forms.ModelForm):
         for ipaddress in ipaddresses:
             self.fields['group'].widget.add_query_param('related_ip', ipaddress.pk)
 
+    def clean_group(self):
+        group = self.cleaned_data['group']
+
+        conflicting_assignments = FHRPGroupAssignment.objects.filter(
+            interface_type=self.instance.interface_type,
+            interface_id=self.instance.interface_id,
+            group=group
+        )
+        if self.instance.id:
+            conflicting_assignments = conflicting_assignments.exclude(id=self.instance.id)
+
+        if conflicting_assignments.exists():
+            raise forms.ValidationError(
+                _('Assignment already exists')
+            )
+
+        return group
+
 
 class VLANGroupForm(NetBoxModelForm):
     scope_type = ContentTypeChoiceField(


### PR DESCRIPTION
### Fixes: #15029 

Check for duplicate FHRP group assignment so IntegrityError isn't raised.