### PR TITLE
Fix custom script documentation example script

### DIFF
--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -390,7 +390,7 @@ class NewBranchScript(Script):
                 name=f'{site.slug}-switch{i}',
                 site=site,
                 status=DeviceStatusChoices.STATUS_PLANNED,
-                role=switch_role
+                device_role=switch_role
             )
             switch.full_clean()
             switch.save()


### PR DESCRIPTION
The example script still uses the old "role" field when creating a Device object.

Fixes: #15052