### PR TITLE
Render Action Data as Jinja2

### DIFF
--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -119,13 +119,22 @@ def process_event_rules(event_rules, model_name, event, data, username=None, sna
             script_name = event_rule.action_parameters['script_name']
             script = script_module.scripts[script_name]()
 
+            context = {
+                'event': event,
+                'timestamp': timezone.now().isoformat(),
+                'model': model_name,
+                'username': username,
+                'request_id': request_id,
+                'model': data,
+            }
+
             # Enqueue a Job to record the script's execution
             Job.enqueue(
                 "extras.scripts.run_script",
                 instance=script_module,
                 name=script.class_name,
                 user=user,
-                data=data
+                data=event_rule.render_script_data(context)
             )
 
         else:

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -171,6 +171,15 @@ class EventRule(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, ChangeLogged
             return True
 
         return ConditionSet(self.conditions).eval(data)
+    
+    def render_script_data(self, context):
+        """
+        Render Script Data, if defined. Otherwise, jump the context as a JSON object.
+        """
+        if self.action_data:
+            return render_jinja2(str(self.action_data), context)
+        else:
+            return json.dumps(context, cls=JSONEncoder)
 
 
 class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, ChangeLoggedModel):


### PR DESCRIPTION
### Fixes: #14884
### Fixes:  #14896

Changes the way `process_event_rules` schedules a Script Event, and add method `render_script_data` to  `EventRule` model.

Those changes allows users to send custom data to the Scripts scheduled by the EventRules.
Looking at the code implementation, maybe extending this implementation with some modifications allow a single code to schedule Job, and move Webhooks Body Data to the Action Data.