### PR TITLE
Fixes #14952: Update existing AutoSyncRecord when changing the data file of an auto-synced object

### DIFF
--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -489,10 +489,10 @@ class SyncedDataMixin(models.Model):
         # Create/delete AutoSyncRecord as needed
         content_type = ContentType.objects.get_for_model(self)
         if self.auto_sync_enabled:
-            AutoSyncRecord.objects.get_or_create(
-                datafile=self.data_file,
+            AutoSyncRecord.objects.update_or_create(
                 object_type=content_type,
-                object_id=self.pk
+                object_id=self.pk,
+                defaults={'datafile': self.data_file}
             )
         else:
             AutoSyncRecord.objects.filter(


### PR DESCRIPTION
### Fixes: #14952

Change `get_or_create()` to `update_or_create()` to ensure we update the existing AutoSyncRecord, if any.