### PR TITLE
Fixes #15090: Run deletion protection rules prior to enqueueing events

### DIFF
--- a/netbox/extras/validators.py
+++ b/netbox/extras/validators.py
@@ -1,3 +1,5 @@
+import importlib
+
 from django.core import validators
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
@@ -149,3 +151,21 @@ class CustomValidator:
         if field is not None:
             raise ValidationError({field: message})
         raise ValidationError(message)
+
+
+def run_validators(instance, validators):
+    """
+    Run the provided iterable of validators for the instance.
+    """
+    for validator in validators:
+
+        # Loading a validator class by dotted path
+        if type(validator) is str:
+            module, cls = validator.rsplit('.', 1)
+            validator = getattr(importlib.import_module(module), cls)()
+
+        # Constructing a new instance on the fly from a ruleset
+        elif type(validator) is dict:
+            validator = CustomValidator(validator)
+
+        validator(instance)


### PR DESCRIPTION
### Fixes: #15090

- Move `run_validators()` to `extras.validators`
- Absorb `run_delete_validators()` logic into `handle_deleted_object()`, ensuring that it is executed before events are enqueued