### PR TITLE
Added Last Login to user/profile GUI views and the /users/user API output

### DIFF
--- a/netbox/templates/account/profile.html
+++ b/netbox/templates/account/profile.html
@@ -35,6 +35,10 @@
               <td>{{ request.user.date_joined|annotated_date }}</td>
             </tr>
             <tr>
+              <th scope="row">{% trans "Account Last Login" %}</th>
+              <td>{{ object.last_login|annotated_date }}</td>
+            </tr>
+            <tr>
               <th scope="row">{% trans "Superuser" %}</th>
               <td>{% checkmark request.user.is_superuser %}</td>
             </tr>

--- a/netbox/templates/account/profile.html
+++ b/netbox/templates/account/profile.html
@@ -36,7 +36,7 @@
             </tr>
             <tr>
               <th scope="row">{% trans "Account Last Login" %}</th>
-              <td>{{ object.last_login|annotated_date }}</td>
+              <td>{{ request.user.last_login|annotated_date }}</td>
             </tr>
             <tr>
               <th scope="row">{% trans "Superuser" %}</th>

--- a/netbox/templates/account/profile.html
+++ b/netbox/templates/account/profile.html
@@ -35,7 +35,7 @@
               <td>{{ request.user.date_joined|annotated_date }}</td>
             </tr>
             <tr>
-              <th scope="row">{% trans "Account Last Login" %}</th>
+              <th scope="row">{% trans "Last Login" %}</th>
               <td>{{ request.user.last_login|annotated_date }}</td>
             </tr>
             <tr>

--- a/netbox/templates/users/user.html
+++ b/netbox/templates/users/user.html
@@ -31,7 +31,7 @@
               <td>{{ object.date_joined|annotated_date }}</td>
             </tr>
             <tr>
-              <th scope="row">{% trans "Account Last Login" %}</th>
+              <th scope="row">{% trans "Last Login" %}</th>
               <td>{{ object.last_login|annotated_date }}</td>
             </tr>
             <tr>

--- a/netbox/templates/users/user.html
+++ b/netbox/templates/users/user.html
@@ -31,6 +31,10 @@
               <td>{{ object.date_joined|annotated_date }}</td>
             </tr>
             <tr>
+              <th scope="row">{% trans "Account Last Login" %}</th>
+              <td>{{ object.last_login|annotated_date }}</td>
+            </tr>
+            <tr>
               <th scope="row">{% trans "Active" %}</th>
               <td>{% checkmark object.is_active %}</td>
             </tr>

--- a/netbox/users/api/serializers.py
+++ b/netbox/users/api/serializers.py
@@ -35,7 +35,7 @@ class UserSerializer(ValidatedModelSerializer):
         model = get_user_model()
         fields = (
             'id', 'url', 'display', 'username', 'password', 'first_name', 'last_name', 'email', 'is_staff', 'is_active',
-            'date_joined', 'groups',
+            'date_joined', 'last_login', 'groups',
         )
         extra_kwargs = {
             'password': {'write_only': True}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #15177 

<!--
    Please include a summary of the proposed changes below.
-->
Added `last_login` to the per-user view and the account/profile page as "Account Last Login" under "Account Created", as well as in the API output of users.