### PR TITLE
14405 render link_peer to CSV

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -359,6 +359,17 @@ class CableTerminationTable(NetBoxTable):
         verbose_name=_('Mark Connected'),
     )
 
+    def value_link_peer(self, value):
+        string = ""
+        for termination in value:
+            if value and not str:
+                string += " "
+            if termination.parent_object:
+                string += f"{termination.parent_object} > "
+            string += str(termination)
+
+        return string
+
 
 class PathEndpointTable(CableTerminationTable):
     connection = columns.TemplateColumn(

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -360,15 +360,9 @@ class CableTerminationTable(NetBoxTable):
     )
 
     def value_link_peer(self, value):
-        string = ""
-        for termination in value:
-            if value and not str:
-                string += " "
-            if termination.parent_object:
-                string += f"{termination.parent_object} > "
-            string += str(termination)
-
-        return string
+        return ', '.join([
+            f"{termination.parent_object} > {termination}" for termination in value
+        ])
 
 
 class PathEndpointTable(CableTerminationTable):


### PR DESCRIPTION
### Fixes: #14405 

Provides a value_link_peer to render link_peer fields to CSV files similar to what the template_code does for HTML rendering.  Instead of appearing as extra lines in the CSV (which is still valid) puts a ">" between the parent and child instead of a new line.
