### PR TITLE
Closes #15042: Move model registration logic to AppConfigs

### DIFF
--- a/netbox/circuits/apps.py
+++ b/netbox/circuits/apps.py
@@ -6,4 +6,9 @@ class CircuitsConfig(AppConfig):
     verbose_name = "Circuits"
 
     def ready(self):
+        from netbox.models.features import register_model
         from . import signals, search
+
+        # Register models
+        for model in self.get_models():
+            register_model(model)

--- a/netbox/circuits/apps.py
+++ b/netbox/circuits/apps.py
@@ -6,9 +6,8 @@ class CircuitsConfig(AppConfig):
     verbose_name = "Circuits"
 
     def ready(self):
-        from netbox.models.features import register_model
+        from netbox.models.features import register_models
         from . import signals, search
 
         # Register models
-        for model in self.get_models():
-            register_model(model)
+        register_models(*self.get_models())

--- a/netbox/core/apps.py
+++ b/netbox/core/apps.py
@@ -17,9 +17,8 @@ class CoreConfig(AppConfig):
 
     def ready(self):
         from core.api import schema  # noqa
-        from netbox.models.features import register_model
+        from netbox.models.features import register_models
         from . import data_backends, search
 
         # Register models
-        for model in self.get_models():
-            register_model(model)
+        register_models(*self.get_models())

--- a/netbox/core/apps.py
+++ b/netbox/core/apps.py
@@ -16,5 +16,10 @@ class CoreConfig(AppConfig):
     name = "core"
 
     def ready(self):
+        from core.api import schema  # noqa
+        from netbox.models.features import register_model
         from . import data_backends, search
-        from core.api import schema  # noqa: E402
+
+        # Register models
+        for model in self.get_models():
+            register_model(model)

--- a/netbox/dcim/apps.py
+++ b/netbox/dcim/apps.py
@@ -8,14 +8,13 @@ class DCIMConfig(AppConfig):
     verbose_name = "DCIM"
 
     def ready(self):
-        from netbox.models.features import register_model
+        from netbox.models.features import register_models
         from utilities.counters import connect_counters
         from . import signals, search
         from .models import CableTermination, Device, DeviceType, VirtualChassis
 
         # Register models
-        for model in self.get_models():
-            register_model(model)
+        register_models(*self.get_models())
 
         # Register denormalized fields
         denormalized.register(CableTermination, '_device', {

--- a/netbox/dcim/apps.py
+++ b/netbox/dcim/apps.py
@@ -8,9 +8,14 @@ class DCIMConfig(AppConfig):
     verbose_name = "DCIM"
 
     def ready(self):
+        from netbox.models.features import register_model
+        from utilities.counters import connect_counters
         from . import signals, search
         from .models import CableTermination, Device, DeviceType, VirtualChassis
-        from utilities.counters import connect_counters
+
+        # Register models
+        for model in self.get_models():
+            register_model(model)
 
         # Register denormalized fields
         denormalized.register(CableTermination, '_device', {

--- a/netbox/extras/apps.py
+++ b/netbox/extras/apps.py
@@ -5,4 +5,9 @@ class ExtrasConfig(AppConfig):
     name = "extras"
 
     def ready(self):
+        from netbox.models.features import register_model
         from . import dashboard, lookups, search, signals
+
+        # Register models
+        for model in self.get_models():
+            register_model(model)

--- a/netbox/extras/apps.py
+++ b/netbox/extras/apps.py
@@ -5,9 +5,8 @@ class ExtrasConfig(AppConfig):
     name = "extras"
 
     def ready(self):
-        from netbox.models.features import register_model
+        from netbox.models.features import register_models
         from . import dashboard, lookups, search, signals
 
         # Register models
-        for model in self.get_models():
-            register_model(model)
+        register_models(*self.get_models())

--- a/netbox/extras/utils.py
+++ b/netbox/extras/utils.py
@@ -1,7 +1,5 @@
 from taggit.managers import _TaggableManager
 
-from netbox.registry import registry
-
 
 def is_taggable(obj):
     """
@@ -27,24 +25,6 @@ def image_upload(instance, filename):
         filename = instance.name
 
     return '{}{}_{}_{}'.format(path, instance.content_type.name, instance.object_id, filename)
-
-
-def register_features(model, features):
-    """
-    Register model features in the application registry.
-    """
-    app_label, model_name = model._meta.label_lower.split('.')
-    for feature in features:
-        try:
-            registry['model_features'][feature][app_label].add(model_name)
-        except KeyError:
-            raise KeyError(
-                f"{feature} is not a valid model feature! Valid keys are: {registry['model_features'].keys()}"
-            )
-
-    # Register public models
-    if not getattr(model, '_netbox_private', False):
-        registry['models'][app_label].add(model_name)
 
 
 def is_script(obj):

--- a/netbox/ipam/apps.py
+++ b/netbox/ipam/apps.py
@@ -6,4 +6,9 @@ class IPAMConfig(AppConfig):
     verbose_name = "IPAM"
 
     def ready(self):
+        from netbox.models.features import register_model
         from . import signals, search
+
+        # Register models
+        for model in self.get_models():
+            register_model(model)

--- a/netbox/ipam/apps.py
+++ b/netbox/ipam/apps.py
@@ -6,9 +6,8 @@ class IPAMConfig(AppConfig):
     verbose_name = "IPAM"
 
     def ready(self):
-        from netbox.models.features import register_model
+        from netbox.models.features import register_models
         from . import signals, search
 
         # Register models
-        for model in self.get_models():
-            register_model(model)
+        register_models(*self.get_models())

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -5,8 +5,6 @@ from functools import cached_property
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.validators import ValidationError
 from django.db import models
-from django.db.models.signals import class_prepared
-from django.dispatch import receiver
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from taggit.managers import TaggableManager
@@ -14,7 +12,7 @@ from taggit.managers import TaggableManager
 from core.choices import JobStatusChoices
 from core.models import ContentType
 from extras.choices import *
-from extras.utils import is_taggable, register_features
+from extras.utils import is_taggable
 from netbox.config import get_config
 from netbox.registry import registry
 from netbox.signals import post_clean
@@ -37,6 +35,7 @@ __all__ = (
     'JournalingMixin',
     'SyncedDataMixin',
     'TagsMixin',
+    'register_model',
 )
 
 
@@ -576,36 +575,48 @@ registry['model_features'].update({
 })
 
 
-@receiver(class_prepared)
-def _register_features(sender, **kwargs):
+def register_model(model, **kwargs):
+    """
+    Register a model in NetBox. This entails:
+
+     - Determining whether the model is considered "public" (available for reference by other models)
+     - Registering which features the model supports (e.g. bookmarks, custom fields, etc.)
+     - Registering any feature-specific views for the model (e.g. ObjectJournalView instances)
+
+    register_model() should be called for each relevant model under the ready() of an app's AppConfig class.
+    """
+    app_label, model_name = model._meta.label_lower.split('.')
+
+    # Register public models
+    if not getattr(model, '_netbox_private', False):
+        registry['models'][app_label].add(model_name)
+
     # Record each applicable feature for the model in the registry
     features = {
-        feature for feature, cls in FEATURES_MAP.items() if issubclass(sender, cls)
+        feature for feature, cls in FEATURES_MAP.items() if issubclass(model, cls)
     }
-    register_features(sender, features)
+    for feature in features:
+        try:
+            registry['model_features'][feature][app_label].add(model_name)
+        except KeyError:
+            raise KeyError(
+                f"{feature} is not a valid model feature! Valid keys are: {registry['model_features'].keys()}"
+            )
 
     # Register applicable feature views for the model
-    if issubclass(sender, JournalingMixin):
-        register_model_view(
-            sender,
-            'journal',
-            kwargs={'model': sender}
-        )('netbox.views.generic.ObjectJournalView')
-    if issubclass(sender, ChangeLoggingMixin):
-        register_model_view(
-            sender,
-            'changelog',
-            kwargs={'model': sender}
-        )('netbox.views.generic.ObjectChangeLogView')
-    if issubclass(sender, JobsMixin):
-        register_model_view(
-            sender,
-            'jobs',
-            kwargs={'model': sender}
-        )('netbox.views.generic.ObjectJobsView')
-    if issubclass(sender, SyncedDataMixin):
-        register_model_view(
-            sender,
-            'sync',
-            kwargs={'model': sender}
-        )('netbox.views.generic.ObjectSyncDataView')
+    if issubclass(model, JournalingMixin):
+        register_model_view(model, 'journal', kwargs={'model': model})(
+            'netbox.views.generic.ObjectJournalView'
+        )
+    if issubclass(model, ChangeLoggingMixin):
+        register_model_view(model, 'changelog', kwargs={'model': model})(
+            'netbox.views.generic.ObjectChangeLogView'
+        )
+    if issubclass(model, JobsMixin):
+        register_model_view(model, 'jobs', kwargs={'model': model})(
+            'netbox.views.generic.ObjectJobsView'
+        )
+    if issubclass(model, SyncedDataMixin):
+        register_model_view(model, 'sync', kwargs={'model': model})(
+            'netbox.views.generic.ObjectSyncDataView'
+        )

--- a/netbox/netbox/plugins/__init__.py
+++ b/netbox/netbox/plugins/__init__.py
@@ -94,6 +94,12 @@ class PluginConfig(AppConfig):
             pass
 
     def ready(self):
+        from netbox.models.features import register_model
+
+        # Register models
+        for model in self.get_models():
+            register_model(model)
+
         plugin_name = self.name.rsplit('.', 1)[-1]
 
         # Register search extensions (if defined)

--- a/netbox/netbox/plugins/__init__.py
+++ b/netbox/netbox/plugins/__init__.py
@@ -94,11 +94,10 @@ class PluginConfig(AppConfig):
             pass
 
     def ready(self):
-        from netbox.models.features import register_model
+        from netbox.models.features import register_models
 
         # Register models
-        for model in self.get_models():
-            register_model(model)
+        register_models(*self.get_models())
 
         plugin_name = self.name.rsplit('.', 1)[-1]
 

--- a/netbox/netbox/tests/test_plugins.py
+++ b/netbox/netbox/tests/test_plugins.py
@@ -20,6 +20,10 @@ class PluginTest(TestCase):
 
         self.assertIn('netbox.tests.dummy_plugin.DummyPluginConfig', settings.INSTALLED_APPS)
 
+    def test_model_registration(self):
+        self.assertIn('dummy_plugin', registry['models'])
+        self.assertIn('dummymodel', registry['models']['dummy_plugin'])
+
     def test_models(self):
         from netbox.tests.dummy_plugin.models import DummyModel
 

--- a/netbox/tenancy/apps.py
+++ b/netbox/tenancy/apps.py
@@ -5,9 +5,8 @@ class TenancyConfig(AppConfig):
     name = 'tenancy'
 
     def ready(self):
-        from netbox.models.features import register_model
+        from netbox.models.features import register_models
         from . import search
 
         # Register models
-        for model in self.get_models():
-            register_model(model)
+        register_models(*self.get_models())

--- a/netbox/tenancy/apps.py
+++ b/netbox/tenancy/apps.py
@@ -5,4 +5,9 @@ class TenancyConfig(AppConfig):
     name = 'tenancy'
 
     def ready(self):
+        from netbox.models.features import register_model
         from . import search
+
+        # Register models
+        for model in self.get_models():
+            register_model(model)

--- a/netbox/users/apps.py
+++ b/netbox/users/apps.py
@@ -5,9 +5,8 @@ class UsersConfig(AppConfig):
     name = 'users'
 
     def ready(self):
-        from netbox.models.features import register_model
+        from netbox.models.features import register_models
         from . import signals
 
         # Register models
-        for model in self.get_models():
-            register_model(model)
+        register_models(*self.get_models())

--- a/netbox/users/apps.py
+++ b/netbox/users/apps.py
@@ -5,15 +5,9 @@ class UsersConfig(AppConfig):
     name = 'users'
 
     def ready(self):
-        import users.signals
-        from .models import NetBoxGroup, ObjectPermission, Token, User, UserConfig
-        from netbox.models.features import _register_features
+        from netbox.models.features import register_model
+        from . import signals
 
-        # have to register these manually as the signal handler for class_prepared does
-        # not get registered until after these models are loaded. Any models defined in
-        # users.models should be registered here.
-        _register_features(NetBoxGroup)
-        _register_features(ObjectPermission)
-        _register_features(Token)
-        _register_features(User)
-        _register_features(UserConfig)
+        # Register models
+        for model in self.get_models():
+            register_model(model)

--- a/netbox/virtualization/apps.py
+++ b/netbox/virtualization/apps.py
@@ -7,14 +7,13 @@ class VirtualizationConfig(AppConfig):
     name = 'virtualization'
 
     def ready(self):
-        from netbox.models.features import register_model
+        from netbox.models.features import register_models
         from utilities.counters import connect_counters
         from . import search, signals
         from .models import VirtualMachine
 
         # Register models
-        for model in self.get_models():
-            register_model(model)
+        register_models(*self.get_models())
 
         # Register denormalized fields
         denormalized.register(VirtualMachine, 'cluster', {

--- a/netbox/virtualization/apps.py
+++ b/netbox/virtualization/apps.py
@@ -7,9 +7,14 @@ class VirtualizationConfig(AppConfig):
     name = 'virtualization'
 
     def ready(self):
+        from netbox.models.features import register_model
+        from utilities.counters import connect_counters
         from . import search, signals
         from .models import VirtualMachine
-        from utilities.counters import connect_counters
+
+        # Register models
+        for model in self.get_models():
+            register_model(model)
 
         # Register denormalized fields
         denormalized.register(VirtualMachine, 'cluster', {

--- a/netbox/vpn/apps.py
+++ b/netbox/vpn/apps.py
@@ -6,4 +6,9 @@ class VPNConfig(AppConfig):
     verbose_name = 'VPN'
 
     def ready(self):
+        from netbox.models.features import register_model
         from . import search
+
+        # Register models
+        for model in self.get_models():
+            register_model(model)

--- a/netbox/vpn/apps.py
+++ b/netbox/vpn/apps.py
@@ -6,9 +6,8 @@ class VPNConfig(AppConfig):
     verbose_name = 'VPN'
 
     def ready(self):
-        from netbox.models.features import register_model
+        from netbox.models.features import register_models
         from . import search
 
         # Register models
-        for model in self.get_models():
-            register_model(model)
+        register_models(*self.get_models())

--- a/netbox/wireless/apps.py
+++ b/netbox/wireless/apps.py
@@ -5,4 +5,9 @@ class WirelessConfig(AppConfig):
     name = 'wireless'
 
     def ready(self):
+        from netbox.models.features import register_model
         from . import signals, search
+
+        # Register models
+        for model in self.get_models():
+            register_model(model)

--- a/netbox/wireless/apps.py
+++ b/netbox/wireless/apps.py
@@ -5,9 +5,8 @@ class WirelessConfig(AppConfig):
     name = 'wireless'
 
     def ready(self):
-        from netbox.models.features import register_model
+        from netbox.models.features import register_models
         from . import signals, search
 
         # Register models
-        for model in self.get_models():
-            register_model(model)
+        register_models(*self.get_models())


### PR DESCRIPTION
### Fixes: #15042

- Move code from `extras.utils.register_features()` into `netbox.models.features._register_features()`
- Rename `netbox.models.features._register_features()` to `register_model()`
- Decouple model registration from the `class_prepared` signal
- Call `register_model()` for each model under `AppConfig.ready()` for each app
- Extend `PluginConfig.ready()` to also call `register_model()` for each model
- Add a plugin test for model registration