### PR TITLE
15192 fix config revision if no revisions

### DIFF
--- a/netbox/core/models/config.py
+++ b/netbox/core/models/config.py
@@ -44,7 +44,7 @@ class ConfigRevision(models.Model):
         return gettext('Config revision #{id}').format(id=self.pk)
 
     def __getattr__(self, item):
-        if item in self.data:
+        if self.data and item in self.data:
             return self.data[item]
         return super().__getattribute__(item)
 

--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -166,7 +166,7 @@ class ConfigView(generic.ObjectView):
         except ConfigRevision.DoesNotExist:
             # Fall back to using the active config data if no record is found
             return ConfigRevision(
-                data=get_config()
+                data=get_config().defaults
             )
 
 


### PR DESCRIPTION
### Fixes: #15192 

Fixes two related cases when there are no current config revisions:

1. If there are no config revisions and you go to  http://localhost:8000/core/config/ it will error - that fix is in views.py to return the get_config().defaults.
2. If you are viewing the now working current config page and choose to edit you will get another error on the edit form for 'NoneType' is not iterable.  That is the fix in config.py
