### PR TITLE
Fixes the rackelevation api schema

### DIFF
--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -194,6 +194,7 @@ class RackViewSet(NetBoxModelViewSet):
     @extend_schema(
         operation_id='dcim_racks_elevation_retrieve',
         filters=False,
+        parameters=[serializers.RackElevationDetailFilterSerializer],
         responses={200: serializers.RackUnitSerializer(many=True)}
     )
     @action(detail=True)

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -191,6 +191,11 @@ class RackViewSet(NetBoxModelViewSet):
     serializer_class = serializers.RackSerializer
     filterset_class = filtersets.RackFilterSet
 
+    @extend_schema(
+        operation_id='dcim_racks_elevation_retrieve',
+        filters=False,
+        responses={200: serializers.RackUnitSerializer(many=True)}
+    )
     @action(detail=True)
     def elevation(self, request, pk=None):
         """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #15101

<!--
    Please include a summary of the proposed changes below.
-->
I had to disable `filters` as it was erronously using the `RackFilterSet` in the schema and replace with `RackElevationDetailFilterSerializer`