### PR TITLE
Closes #15238: Include description field in brief mode

### DIFF
--- a/netbox/circuits/api/serializers.py
+++ b/netbox/circuits/api/serializers.py
@@ -4,8 +4,8 @@ from circuits.choices import CircuitStatusChoices
 from circuits.models import *
 from dcim.api.nested_serializers import NestedSiteSerializer
 from dcim.api.serializers import CabledObjectSerializer
-from ipam.models import ASN
 from ipam.api.nested_serializers import NestedASNSerializer
+from ipam.models import ASN
 from netbox.api.fields import ChoiceField, RelatedObjectCountField, SerializedPKRelatedField
 from netbox.api.serializers import NetBoxModelSerializer, WritableNestedSerializer
 from tenancy.api.nested_serializers import NestedTenantSerializer
@@ -40,7 +40,7 @@ class ProviderSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'accounts', 'description', 'comments', 'asns', 'tags',
             'custom_fields', 'created', 'last_updated', 'circuit_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'circuit_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'circuit_count')
 
 
 #
@@ -57,7 +57,7 @@ class ProviderAccountSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'provider', 'name', 'account', 'description', 'comments', 'tags', 'custom_fields',
             'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'account')
+        brief_fields = ('id', 'url', 'display', 'name', 'account', 'description')
 
 
 #
@@ -74,7 +74,7 @@ class ProviderNetworkSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'provider', 'name', 'service_id', 'description', 'comments', 'tags',
             'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 #
@@ -93,7 +93,7 @@ class CircuitTypeSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'color', 'description', 'tags', 'custom_fields', 'created',
             'last_updated', 'circuit_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'circuit_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'circuit_count')
 
 
 class CircuitCircuitTerminationSerializer(WritableNestedSerializer):
@@ -126,7 +126,7 @@ class CircuitSerializer(NetBoxModelSerializer):
             'termination_date', 'commit_rate', 'description', 'termination_a', 'termination_z', 'comments', 'tags',
             'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'cid')
+        brief_fields = ('id', 'url', 'display', 'cid', 'description')
 
 
 class CircuitTerminationSerializer(NetBoxModelSerializer, CabledObjectSerializer):
@@ -142,4 +142,4 @@ class CircuitTerminationSerializer(NetBoxModelSerializer, CabledObjectSerializer
             'xconnect_id', 'pp_info', 'description', 'mark_connected', 'cable', 'cable_end', 'link_peers',
             'link_peers_type', 'tags', 'custom_fields', 'created', 'last_updated', '_occupied',
         ]
-        brief_fields = ('id', 'url', 'display', 'circuit', 'term_side', 'cable', '_occupied')
+        brief_fields = ('id', 'url', 'display', 'circuit', 'term_side', 'description', 'cable', '_occupied')

--- a/netbox/circuits/tests/test_api.py
+++ b/netbox/circuits/tests/test_api.py
@@ -18,7 +18,7 @@ class AppTest(APITestCase):
 
 class ProviderTest(APIViewTestCases.APIViewTestCase):
     model = Provider
-    brief_fields = ['circuit_count', 'display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['circuit_count', 'description', 'display', 'id', 'name', 'slug', 'url']
     bulk_update_data = {
         'comments': 'New comments',
     }
@@ -60,7 +60,7 @@ class ProviderTest(APIViewTestCases.APIViewTestCase):
 
 class CircuitTypeTest(APIViewTestCases.APIViewTestCase):
     model = CircuitType
-    brief_fields = ['circuit_count', 'display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['circuit_count', 'description', 'display', 'id', 'name', 'slug', 'url']
     create_data = (
         {
             'name': 'Circuit Type 4',
@@ -92,7 +92,7 @@ class CircuitTypeTest(APIViewTestCases.APIViewTestCase):
 
 class CircuitTest(APIViewTestCases.APIViewTestCase):
     model = Circuit
-    brief_fields = ['cid', 'display', 'id', 'url']
+    brief_fields = ['cid', 'description', 'display', 'id', 'url']
     bulk_update_data = {
         'status': 'planned',
     }
@@ -149,7 +149,7 @@ class CircuitTest(APIViewTestCases.APIViewTestCase):
 
 class CircuitTerminationTest(APIViewTestCases.APIViewTestCase):
     model = CircuitTermination
-    brief_fields = ['_occupied', 'cable', 'circuit', 'display', 'id', 'term_side', 'url']
+    brief_fields = ['_occupied', 'cable', 'circuit', 'description', 'display', 'id', 'term_side', 'url']
 
     @classmethod
     def setUpTestData(cls):
@@ -208,7 +208,7 @@ class CircuitTerminationTest(APIViewTestCases.APIViewTestCase):
 
 class ProviderAccountTest(APIViewTestCases.APIViewTestCase):
     model = ProviderAccount
-    brief_fields = ['account', 'display', 'id', 'name', 'url']
+    brief_fields = ['account', 'description', 'display', 'id', 'name', 'url']
 
     @classmethod
     def setUpTestData(cls):
@@ -251,7 +251,7 @@ class ProviderAccountTest(APIViewTestCases.APIViewTestCase):
 
 class ProviderNetworkTest(APIViewTestCases.APIViewTestCase):
     model = ProviderNetwork
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
 
     @classmethod
     def setUpTestData(cls):

--- a/netbox/core/api/serializers.py
+++ b/netbox/core/api/serializers.py
@@ -36,7 +36,7 @@ class DataSourceSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'type', 'source_url', 'enabled', 'status', 'description', 'comments',
             'parameters', 'ignore_rules', 'custom_fields', 'created', 'last_updated', 'file_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class DataFileSerializer(NetBoxModelSerializer):

--- a/netbox/core/tests/test_api.py
+++ b/netbox/core/tests/test_api.py
@@ -16,7 +16,7 @@ class AppTest(APITestCase):
 
 class DataSourceTest(APIViewTestCases.APIViewTestCase):
     model = DataSource
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'enabled': False,
         'description': 'foo bar baz',

--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -114,7 +114,7 @@ class RegionSerializer(NestedGroupModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'parent', 'description', 'tags', 'custom_fields', 'created',
             'last_updated', 'site_count', '_depth',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'site_count', '_depth')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'site_count', '_depth')
 
 
 class SiteGroupSerializer(NestedGroupModelSerializer):
@@ -128,7 +128,7 @@ class SiteGroupSerializer(NestedGroupModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'parent', 'description', 'tags', 'custom_fields', 'created',
             'last_updated', 'site_count', '_depth',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'site_count', '_depth')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'site_count', '_depth')
 
 
 class SiteSerializer(NetBoxModelSerializer):
@@ -161,7 +161,7 @@ class SiteSerializer(NetBoxModelSerializer):
             'custom_fields', 'created', 'last_updated', 'circuit_count', 'device_count', 'prefix_count', 'rack_count',
             'virtualmachine_count', 'vlan_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug')
+        brief_fields = ('id', 'url', 'display', 'name', 'description', 'slug')
 
 
 #
@@ -183,7 +183,7 @@ class LocationSerializer(NestedGroupModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'site', 'parent', 'status', 'tenant', 'description', 'tags',
             'custom_fields', 'created', 'last_updated', 'rack_count', 'device_count', '_depth',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'rack_count', '_depth')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'rack_count', '_depth')
 
 
 class RackRoleSerializer(NetBoxModelSerializer):
@@ -198,7 +198,7 @@ class RackRoleSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'color', 'description', 'tags', 'custom_fields', 'created',
             'last_updated', 'rack_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'rack_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'rack_count')
 
 
 class RackSerializer(NetBoxModelSerializer):
@@ -227,7 +227,7 @@ class RackSerializer(NetBoxModelSerializer):
             'desc_units', 'outer_width', 'outer_depth', 'outer_unit', 'mounting_depth', 'description', 'comments',
             'tags', 'custom_fields', 'created', 'last_updated', 'device_count', 'powerfeed_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'device_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'description', 'device_count')
 
 
 class RackUnitSerializer(serializers.Serializer):
@@ -262,7 +262,7 @@ class RackReservationSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'rack', 'units', 'created', 'last_updated', 'user', 'tenant', 'description',
             'comments', 'tags', 'custom_fields',
         ]
-        brief_fields = ('id', 'url', 'display', 'user', 'units')
+        brief_fields = ('id', 'url', 'display', 'user', 'description', 'units')
 
 
 class RackElevationDetailFilterSerializer(serializers.Serializer):
@@ -322,7 +322,7 @@ class ManufacturerSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'description', 'tags', 'custom_fields', 'created', 'last_updated',
             'devicetype_count', 'inventoryitem_count', 'platform_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'devicetype_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'devicetype_count')
 
 
 class DeviceTypeSerializer(NetBoxModelSerializer):
@@ -368,7 +368,7 @@ class DeviceTypeSerializer(NetBoxModelSerializer):
             'rear_port_template_count', 'device_bay_template_count', 'module_bay_template_count',
             'inventory_item_template_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'manufacturer', 'model', 'slug', 'device_count')
+        brief_fields = ('id', 'url', 'display', 'manufacturer', 'model', 'slug', 'description', 'device_count')
 
 
 class ModuleTypeSerializer(NetBoxModelSerializer):
@@ -382,7 +382,7 @@ class ModuleTypeSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'manufacturer', 'model', 'part_number', 'weight', 'weight_unit', 'description',
             'comments', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'manufacturer', 'model')
+        brief_fields = ('id', 'url', 'display', 'manufacturer', 'model', 'description')
 
 
 #
@@ -413,7 +413,7 @@ class ConsolePortTemplateSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'device_type', 'module_type', 'name', 'label', 'type', 'description', 'created',
             'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class ConsoleServerPortTemplateSerializer(ValidatedModelSerializer):
@@ -440,7 +440,7 @@ class ConsoleServerPortTemplateSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'device_type', 'module_type', 'name', 'label', 'type', 'description', 'created',
             'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class PowerPortTemplateSerializer(ValidatedModelSerializer):
@@ -468,7 +468,7 @@ class PowerPortTemplateSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'device_type', 'module_type', 'name', 'label', 'type', 'maximum_draw',
             'allocated_draw', 'description', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class PowerOutletTemplateSerializer(ValidatedModelSerializer):
@@ -506,7 +506,7 @@ class PowerOutletTemplateSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'device_type', 'module_type', 'name', 'label', 'type', 'power_port', 'feed_leg',
             'description', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class InterfaceTemplateSerializer(ValidatedModelSerializer):
@@ -551,7 +551,7 @@ class InterfaceTemplateSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'device_type', 'module_type', 'name', 'label', 'type', 'enabled', 'mgmt_only',
             'description', 'bridge', 'poe_mode', 'poe_type', 'rf_role', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class RearPortTemplateSerializer(ValidatedModelSerializer):
@@ -574,7 +574,7 @@ class RearPortTemplateSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'device_type', 'module_type', 'name', 'label', 'type', 'color', 'positions',
             'description', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class FrontPortTemplateSerializer(ValidatedModelSerializer):
@@ -598,7 +598,7 @@ class FrontPortTemplateSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'device_type', 'module_type', 'name', 'label', 'type', 'color', 'rear_port',
             'rear_port_position', 'description', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class ModuleBayTemplateSerializer(ValidatedModelSerializer):
@@ -611,7 +611,7 @@ class ModuleBayTemplateSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'device_type', 'name', 'label', 'position', 'description', 'created',
             'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class DeviceBayTemplateSerializer(ValidatedModelSerializer):
@@ -621,7 +621,7 @@ class DeviceBayTemplateSerializer(ValidatedModelSerializer):
     class Meta:
         model = DeviceBayTemplate
         fields = ['id', 'url', 'display', 'device_type', 'name', 'label', 'description', 'created', 'last_updated']
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class InventoryItemTemplateSerializer(ValidatedModelSerializer):
@@ -648,7 +648,7 @@ class InventoryItemTemplateSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'device_type', 'parent', 'name', 'label', 'role', 'manufacturer', 'part_id',
             'description', 'component_type', 'component_id', 'component', 'created', 'last_updated', '_depth',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', '_depth')
+        brief_fields = ('id', 'url', 'display', 'name', 'description', '_depth')
 
     @extend_schema_field(serializers.JSONField(allow_null=True))
     def get_component(self, obj):
@@ -677,7 +677,7 @@ class DeviceRoleSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'color', 'vm_role', 'config_template', 'description', 'tags',
             'custom_fields', 'created', 'last_updated', 'device_count', 'virtualmachine_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'device_count', 'virtualmachine_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'device_count', 'virtualmachine_count')
 
 
 class PlatformSerializer(NetBoxModelSerializer):
@@ -695,7 +695,7 @@ class PlatformSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'manufacturer', 'config_template', 'description', 'tags',
             'custom_fields', 'created', 'last_updated', 'device_count', 'virtualmachine_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'device_count', 'virtualmachine_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'device_count', 'virtualmachine_count')
 
 
 class DeviceSerializer(NetBoxModelSerializer):
@@ -752,7 +752,7 @@ class DeviceSerializer(NetBoxModelSerializer):
             'power_port_count', 'power_outlet_count', 'interface_count', 'front_port_count', 'rear_port_count',
             'device_bay_count', 'module_bay_count', 'inventory_item_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
     @extend_schema_field(NestedDeviceSerializer)
     def get_parent_device(self, obj):
@@ -807,7 +807,7 @@ class VirtualDeviceContextSerializer(NetBoxModelSerializer):
             'primary_ip6', 'status', 'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
             'interface_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'identifier', 'device')
+        brief_fields = ('id', 'url', 'display', 'name', 'identifier', 'device', 'description')
 
 
 class ModuleSerializer(NetBoxModelSerializer):
@@ -823,7 +823,7 @@ class ModuleSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'device', 'module_bay', 'module_type', 'status', 'serial', 'asset_tag',
             'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'device', 'module_bay', 'module_type')
+        brief_fields = ('id', 'url', 'display', 'device', 'module_bay', 'module_type', 'description')
 
 
 #
@@ -856,7 +856,7 @@ class ConsoleServerPortSerializer(NetBoxModelSerializer, CabledObjectSerializer,
             'connected_endpoints_type', 'connected_endpoints_reachable', 'tags', 'custom_fields', 'created',
             'last_updated', '_occupied',
         ]
-        brief_fields = ('id', 'url', 'display', 'device', 'name', 'cable', '_occupied')
+        brief_fields = ('id', 'url', 'display', 'device', 'name', 'description', 'cable', '_occupied')
 
 
 class ConsolePortSerializer(NetBoxModelSerializer, CabledObjectSerializer, ConnectedEndpointsSerializer):
@@ -885,7 +885,7 @@ class ConsolePortSerializer(NetBoxModelSerializer, CabledObjectSerializer, Conne
             'connected_endpoints_type', 'connected_endpoints_reachable', 'tags', 'custom_fields', 'created',
             'last_updated', '_occupied',
         ]
-        brief_fields = ('id', 'url', 'display', 'device', 'name', 'cable', '_occupied')
+        brief_fields = ('id', 'url', 'display', 'device', 'name', 'description', 'cable', '_occupied')
 
 
 class PowerOutletSerializer(NetBoxModelSerializer, CabledObjectSerializer, ConnectedEndpointsSerializer):
@@ -920,7 +920,7 @@ class PowerOutletSerializer(NetBoxModelSerializer, CabledObjectSerializer, Conne
             'connected_endpoints', 'connected_endpoints_type', 'connected_endpoints_reachable', 'tags', 'custom_fields',
             'created', 'last_updated', '_occupied',
         ]
-        brief_fields = ('id', 'url', 'display', 'device', 'name', 'cable', '_occupied')
+        brief_fields = ('id', 'url', 'display', 'device', 'name', 'description', 'cable', '_occupied')
 
 
 class PowerPortSerializer(NetBoxModelSerializer, CabledObjectSerializer, ConnectedEndpointsSerializer):
@@ -945,7 +945,7 @@ class PowerPortSerializer(NetBoxModelSerializer, CabledObjectSerializer, Connect
             'connected_endpoints', 'connected_endpoints_type', 'connected_endpoints_reachable', 'tags', 'custom_fields',
             'created', 'last_updated', '_occupied',
         ]
-        brief_fields = ('id', 'url', 'display', 'device', 'name', 'cable', '_occupied')
+        brief_fields = ('id', 'url', 'display', 'device', 'name', 'description', 'cable', '_occupied')
 
 
 class InterfaceSerializer(NetBoxModelSerializer, CabledObjectSerializer, ConnectedEndpointsSerializer):
@@ -1008,7 +1008,7 @@ class InterfaceSerializer(NetBoxModelSerializer, CabledObjectSerializer, Connect
             'connected_endpoints_type', 'connected_endpoints_reachable', 'tags', 'custom_fields', 'created',
             'last_updated', 'count_ipaddresses', 'count_fhrp_groups', '_occupied',
         ]
-        brief_fields = ('id', 'url', 'display', 'device', 'name', 'cable', '_occupied')
+        brief_fields = ('id', 'url', 'display', 'device', 'name', 'description', 'cable', '_occupied')
 
     def validate(self, data):
 
@@ -1040,7 +1040,7 @@ class RearPortSerializer(NetBoxModelSerializer, CabledObjectSerializer):
             'mark_connected', 'cable', 'cable_end', 'link_peers', 'link_peers_type', 'tags', 'custom_fields', 'created',
             'last_updated', '_occupied',
         ]
-        brief_fields = ('id', 'url', 'display', 'device', 'name', 'cable', '_occupied')
+        brief_fields = ('id', 'url', 'display', 'device', 'name', 'description', 'cable', '_occupied')
 
 
 class FrontPortRearPortSerializer(WritableNestedSerializer):
@@ -1071,7 +1071,7 @@ class FrontPortSerializer(NetBoxModelSerializer, CabledObjectSerializer):
             'rear_port_position', 'description', 'mark_connected', 'cable', 'cable_end', 'link_peers',
             'link_peers_type', 'tags', 'custom_fields', 'created', 'last_updated', '_occupied',
         ]
-        brief_fields = ('id', 'url', 'display', 'device', 'name', 'cable', '_occupied')
+        brief_fields = ('id', 'url', 'display', 'device', 'name', 'description', 'cable', '_occupied')
 
 
 class ModuleBaySerializer(NetBoxModelSerializer):
@@ -1085,7 +1085,7 @@ class ModuleBaySerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'device', 'name', 'installed_module', 'label', 'position', 'description', 'tags',
             'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'installed_module', 'name')
+        brief_fields = ('id', 'url', 'display', 'installed_module', 'name', 'description')
 
 
 class DeviceBaySerializer(NetBoxModelSerializer):
@@ -1099,7 +1099,7 @@ class DeviceBaySerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'device', 'name', 'label', 'description', 'installed_device', 'tags',
             'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'device', 'name')
+        brief_fields = ('id', 'url', 'display', 'device', 'name', 'description')
 
 
 class InventoryItemSerializer(NetBoxModelSerializer):
@@ -1123,7 +1123,7 @@ class InventoryItemSerializer(NetBoxModelSerializer):
             'asset_tag', 'discovered', 'description', 'component_type', 'component_id', 'component', 'tags',
             'custom_fields', 'created', 'last_updated', '_depth',
         ]
-        brief_fields = ('id', 'url', 'display', 'device', 'name', '_depth')
+        brief_fields = ('id', 'url', 'display', 'device', 'name', 'description', '_depth')
 
     @extend_schema_field(serializers.JSONField(allow_null=True))
     def get_component(self, obj):
@@ -1150,7 +1150,7 @@ class InventoryItemRoleSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'color', 'description', 'tags', 'custom_fields', 'created',
             'last_updated', 'inventoryitem_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'inventoryitem_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'inventoryitem_count')
 
 
 #
@@ -1171,7 +1171,7 @@ class CableSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'type', 'a_terminations', 'b_terminations', 'status', 'tenant', 'label', 'color',
             'length', 'length_unit', 'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'label')
+        brief_fields = ('id', 'url', 'display', 'label', 'description')
 
 
 class TracedCableSerializer(serializers.ModelSerializer):
@@ -1242,7 +1242,7 @@ class VirtualChassisSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'domain', 'master', 'description', 'comments', 'tags', 'custom_fields',
             'created', 'last_updated', 'member_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'master', 'member_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'master', 'description', 'member_count')
 
 
 #
@@ -1267,7 +1267,7 @@ class PowerPanelSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'site', 'location', 'name', 'description', 'comments', 'tags', 'custom_fields',
             'powerfeed_count', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'powerfeed_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'description', 'powerfeed_count')
 
 
 class PowerFeedSerializer(NetBoxModelSerializer, CabledObjectSerializer, ConnectedEndpointsSerializer):
@@ -1307,4 +1307,4 @@ class PowerFeedSerializer(NetBoxModelSerializer, CabledObjectSerializer, Connect
             'connected_endpoints', 'connected_endpoints_type', 'connected_endpoints_reachable', 'description',
             'tenant', 'comments', 'tags', 'custom_fields', 'created', 'last_updated', '_occupied',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'cable', '_occupied')
+        brief_fields = ('id', 'url', 'display', 'name', 'description', 'cable', '_occupied')

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -378,12 +378,8 @@ class DeviceViewSet(
 
         Else, return the DeviceWithConfigContextSerializer
         """
-
         request = self.get_serializer_context()['request']
-        if request.query_params.get('brief', False):
-            return serializers.NestedDeviceSerializer
-
-        elif 'config_context' in request.query_params.get('exclude', []):
+        if self.brief or 'config_context' in request.query_params.get('exclude', []):
             return serializers.DeviceSerializer
 
         return serializers.DeviceWithConfigContextSerializer

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -68,7 +68,7 @@ class Mixins:
 
 class RegionTest(APIViewTestCases.APIViewTestCase):
     model = Region
-    brief_fields = ['_depth', 'display', 'id', 'name', 'site_count', 'slug', 'url']
+    brief_fields = ['_depth', 'description', 'display', 'id', 'name', 'site_count', 'slug', 'url']
     create_data = [
         {
             'name': 'Region 4',
@@ -97,7 +97,7 @@ class RegionTest(APIViewTestCases.APIViewTestCase):
 
 class SiteGroupTest(APIViewTestCases.APIViewTestCase):
     model = SiteGroup
-    brief_fields = ['_depth', 'display', 'id', 'name', 'site_count', 'slug', 'url']
+    brief_fields = ['_depth', 'description', 'display', 'id', 'name', 'site_count', 'slug', 'url']
     create_data = [
         {
             'name': 'Site Group 4',
@@ -126,7 +126,7 @@ class SiteGroupTest(APIViewTestCases.APIViewTestCase):
 
 class SiteTest(APIViewTestCases.APIViewTestCase):
     model = Site
-    brief_fields = ['display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url']
     bulk_update_data = {
         'status': 'planned',
     }
@@ -188,7 +188,7 @@ class SiteTest(APIViewTestCases.APIViewTestCase):
 
 class LocationTest(APIViewTestCases.APIViewTestCase):
     model = Location
-    brief_fields = ['_depth', 'display', 'id', 'name', 'rack_count', 'slug', 'url']
+    brief_fields = ['_depth', 'description', 'display', 'id', 'name', 'rack_count', 'slug', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -238,7 +238,7 @@ class LocationTest(APIViewTestCases.APIViewTestCase):
 
 class RackRoleTest(APIViewTestCases.APIViewTestCase):
     model = RackRole
-    brief_fields = ['display', 'id', 'name', 'rack_count', 'slug', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'rack_count', 'slug', 'url']
     create_data = [
         {
             'name': 'Rack Role 4',
@@ -273,7 +273,7 @@ class RackRoleTest(APIViewTestCases.APIViewTestCase):
 
 class RackTest(APIViewTestCases.APIViewTestCase):
     model = Rack
-    brief_fields = ['device_count', 'display', 'id', 'name', 'url']
+    brief_fields = ['description', 'device_count', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'planned',
     }
@@ -361,7 +361,7 @@ class RackTest(APIViewTestCases.APIViewTestCase):
 
 class RackReservationTest(APIViewTestCases.APIViewTestCase):
     model = RackReservation
-    brief_fields = ['display', 'id', 'units', 'url', 'user']
+    brief_fields = ['description', 'display', 'id', 'units', 'url', 'user']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -408,7 +408,7 @@ class RackReservationTest(APIViewTestCases.APIViewTestCase):
 
 class ManufacturerTest(APIViewTestCases.APIViewTestCase):
     model = Manufacturer
-    brief_fields = ['devicetype_count', 'display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['description', 'devicetype_count', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'Manufacturer 4',
@@ -440,7 +440,7 @@ class ManufacturerTest(APIViewTestCases.APIViewTestCase):
 
 class DeviceTypeTest(APIViewTestCases.APIViewTestCase):
     model = DeviceType
-    brief_fields = ['device_count', 'display', 'id', 'manufacturer', 'model', 'slug', 'url']
+    brief_fields = ['description', 'device_count', 'display', 'id', 'manufacturer', 'model', 'slug', 'url']
     bulk_update_data = {
         'part_number': 'ABC123',
     }
@@ -485,7 +485,7 @@ class DeviceTypeTest(APIViewTestCases.APIViewTestCase):
 
 class ModuleTypeTest(APIViewTestCases.APIViewTestCase):
     model = ModuleType
-    brief_fields = ['display', 'id', 'manufacturer', 'model', 'url']
+    brief_fields = ['description', 'display', 'id', 'manufacturer', 'model', 'url']
     bulk_update_data = {
         'part_number': 'ABC123',
     }
@@ -524,7 +524,7 @@ class ModuleTypeTest(APIViewTestCases.APIViewTestCase):
 
 class ConsolePortTemplateTest(APIViewTestCases.APIViewTestCase):
     model = ConsolePortTemplate
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -568,7 +568,7 @@ class ConsolePortTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class ConsoleServerPortTemplateTest(APIViewTestCases.APIViewTestCase):
     model = ConsoleServerPortTemplate
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -612,7 +612,7 @@ class ConsoleServerPortTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class PowerPortTemplateTest(APIViewTestCases.APIViewTestCase):
     model = PowerPortTemplate
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -656,7 +656,7 @@ class PowerPortTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class PowerOutletTemplateTest(APIViewTestCases.APIViewTestCase):
     model = PowerOutletTemplate
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -713,7 +713,7 @@ class PowerOutletTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class InterfaceTemplateTest(APIViewTestCases.APIViewTestCase):
     model = InterfaceTemplate
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -761,7 +761,7 @@ class InterfaceTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class FrontPortTemplateTest(APIViewTestCases.APIViewTestCase):
     model = FrontPortTemplate
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -850,7 +850,7 @@ class FrontPortTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class RearPortTemplateTest(APIViewTestCases.APIViewTestCase):
     model = RearPortTemplate
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -898,7 +898,7 @@ class RearPortTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class ModuleBayTemplateTest(APIViewTestCases.APIViewTestCase):
     model = ModuleBayTemplate
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -938,7 +938,7 @@ class ModuleBayTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class DeviceBayTemplateTest(APIViewTestCases.APIViewTestCase):
     model = DeviceBayTemplate
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -978,7 +978,7 @@ class DeviceBayTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class InventoryItemTemplateTest(APIViewTestCases.APIViewTestCase):
     model = InventoryItemTemplate
-    brief_fields = ['_depth', 'display', 'id', 'name', 'url']
+    brief_fields = ['_depth', 'description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1029,7 +1029,7 @@ class InventoryItemTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class DeviceRoleTest(APIViewTestCases.APIViewTestCase):
     model = DeviceRole
-    brief_fields = ['device_count', 'display', 'id', 'name', 'slug', 'url', 'virtualmachine_count']
+    brief_fields = ['description', 'device_count', 'display', 'id', 'name', 'slug', 'url', 'virtualmachine_count']
     create_data = [
         {
             'name': 'Device Role 4',
@@ -1064,7 +1064,7 @@ class DeviceRoleTest(APIViewTestCases.APIViewTestCase):
 
 class PlatformTest(APIViewTestCases.APIViewTestCase):
     model = Platform
-    brief_fields = ['device_count', 'display', 'id', 'name', 'slug', 'url', 'virtualmachine_count']
+    brief_fields = ['description', 'device_count', 'display', 'id', 'name', 'slug', 'url', 'virtualmachine_count']
     create_data = [
         {
             'name': 'Platform 4',
@@ -1096,7 +1096,7 @@ class PlatformTest(APIViewTestCases.APIViewTestCase):
 
 class DeviceTest(APIViewTestCases.APIViewTestCase):
     model = Device
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'failed',
     }
@@ -1286,7 +1286,7 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
 
 class ModuleTest(APIViewTestCases.APIViewTestCase):
     model = Module
-    brief_fields = ['device', 'display', 'id', 'module_bay', 'module_type', 'url']
+    brief_fields = ['description', 'device', 'display', 'id', 'module_bay', 'module_type', 'url']
     bulk_update_data = {
         'serial': '1234ABCD',
     }
@@ -1350,7 +1350,7 @@ class ModuleTest(APIViewTestCases.APIViewTestCase):
 
 class ConsolePortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = ConsolePort
-    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1392,7 +1392,7 @@ class ConsolePortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCa
 
 class ConsoleServerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = ConsoleServerPort
-    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1434,7 +1434,7 @@ class ConsoleServerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIView
 
 class PowerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = PowerPort
-    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1473,7 +1473,7 @@ class PowerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase
 
 class PowerOutletTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = PowerOutlet
-    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1521,7 +1521,7 @@ class PowerOutletTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCa
 
 class InterfaceTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = Interface
-    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1655,7 +1655,7 @@ class InterfaceTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase
 
 class FrontPortTest(APIViewTestCases.APIViewTestCase):
     model = FrontPort
-    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1713,7 +1713,7 @@ class FrontPortTest(APIViewTestCases.APIViewTestCase):
 
 class RearPortTest(APIViewTestCases.APIViewTestCase):
     model = RearPort
-    brief_fields = ['_occupied', 'cable', 'device', 'display', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1755,7 +1755,7 @@ class RearPortTest(APIViewTestCases.APIViewTestCase):
 
 class ModuleBayTest(APIViewTestCases.APIViewTestCase):
     model = ModuleBay
-    brief_fields = ['display', 'id', 'installed_module', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'installed_module', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1794,7 +1794,7 @@ class ModuleBayTest(APIViewTestCases.APIViewTestCase):
 
 class DeviceBayTest(APIViewTestCases.APIViewTestCase):
     model = DeviceBay
-    brief_fields = ['device', 'display', 'id', 'name', 'url']
+    brief_fields = ['description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1857,7 +1857,7 @@ class DeviceBayTest(APIViewTestCases.APIViewTestCase):
 
 class InventoryItemTest(APIViewTestCases.APIViewTestCase):
     model = InventoryItem
-    brief_fields = ['_depth', 'device', 'display', 'id', 'name', 'url']
+    brief_fields = ['_depth', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1917,7 +1917,7 @@ class InventoryItemTest(APIViewTestCases.APIViewTestCase):
 
 class InventoryItemRoleTest(APIViewTestCases.APIViewTestCase):
     model = InventoryItemRole
-    brief_fields = ['display', 'id', 'inventoryitem_count', 'name', 'slug', 'url']
+    brief_fields = ['description', 'display', 'id', 'inventoryitem_count', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'Inventory Item Role 4',
@@ -1952,7 +1952,7 @@ class InventoryItemRoleTest(APIViewTestCases.APIViewTestCase):
 
 class CableTest(APIViewTestCases.APIViewTestCase):
     model = Cable
-    brief_fields = ['display', 'id', 'label', 'url']
+    brief_fields = ['description', 'display', 'id', 'label', 'url']
     bulk_update_data = {
         'length': 100,
         'length_unit': 'm',
@@ -2075,7 +2075,7 @@ class ConnectedDeviceTest(APITestCase):
 
 class VirtualChassisTest(APIViewTestCases.APIViewTestCase):
     model = VirtualChassis
-    brief_fields = ['display', 'id', 'master', 'member_count', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'master', 'member_count', 'name', 'url']
 
     @classmethod
     def setUpTestData(cls):
@@ -2156,7 +2156,7 @@ class VirtualChassisTest(APIViewTestCases.APIViewTestCase):
 
 class PowerPanelTest(APIViewTestCases.APIViewTestCase):
     model = PowerPanel
-    brief_fields = ['display', 'id', 'name', 'powerfeed_count', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'powerfeed_count', 'url']
 
     @classmethod
     def setUpTestData(cls):
@@ -2205,7 +2205,7 @@ class PowerPanelTest(APIViewTestCases.APIViewTestCase):
 
 class PowerFeedTest(APIViewTestCases.APIViewTestCase):
     model = PowerFeed
-    brief_fields = ['_occupied', 'cable', 'display', 'id', 'name', 'url']
+    brief_fields = ['_occupied', 'cable', 'description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'planned',
     }
@@ -2260,7 +2260,7 @@ class PowerFeedTest(APIViewTestCases.APIViewTestCase):
 
 class VirtualDeviceContextTest(APIViewTestCases.APIViewTestCase):
     model = VirtualDeviceContext
-    brief_fields = ['device', 'display', 'id', 'identifier', 'name', 'url']
+    brief_fields = ['description', 'device', 'display', 'id', 'identifier', 'name', 'url']
     bulk_update_data = {
         'status': 'planned',
     }

--- a/netbox/extras/api/serializers.py
+++ b/netbox/extras/api/serializers.py
@@ -76,7 +76,7 @@ class EventRuleSerializer(NetBoxModelSerializer):
             'type_job_start', 'type_job_end', 'enabled', 'conditions', 'action_type', 'action_object_type',
             'action_object_id', 'action_object', 'description', 'custom_fields', 'tags', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
     @extend_schema_field(OpenApiTypes.OBJECT)
     def get_action_object(self, instance):
@@ -108,7 +108,7 @@ class WebhookSerializer(NetBoxModelSerializer):
             'additional_headers', 'body_template', 'secret', 'ssl_verification', 'ca_file_path', 'custom_fields',
             'tags', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 #
@@ -144,7 +144,7 @@ class CustomFieldSerializer(ValidatedModelSerializer):
             'default', 'weight', 'validation_minimum', 'validation_maximum', 'validation_regex', 'choice_set',
             'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
     def validate_type(self, value):
         if self.instance and self.instance.type != value:
@@ -187,7 +187,7 @@ class CustomFieldChoiceSetSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'name', 'description', 'base_choices', 'extra_choices', 'order_alphabetically',
             'choices_count', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'choices_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'description', 'choices_count')
 
 
 #
@@ -234,7 +234,7 @@ class ExportTemplateSerializer(ValidatedModelSerializer):
             'file_extension', 'as_attachment', 'data_source', 'data_path', 'data_file', 'data_synced', 'created',
             'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 #
@@ -254,7 +254,7 @@ class SavedFilterSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'content_types', 'name', 'slug', 'description', 'user', 'weight', 'enabled',
             'shared', 'parameters', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description')
 
 
 #
@@ -303,7 +303,7 @@ class TagSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'color', 'description', 'object_types', 'tagged_items', 'created',
             'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'color')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'color', 'description')
 
 
 #
@@ -497,7 +497,7 @@ class ConfigContextSerializer(ValidatedModelSerializer):
             'tenant_groups', 'tenants', 'tags', 'data_source', 'data_path', 'data_file', 'data_synced', 'data',
             'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 #
@@ -519,7 +519,7 @@ class ConfigTemplateSerializer(TaggableModelSerializer, ValidatedModelSerializer
             'id', 'url', 'display', 'name', 'description', 'environment_params', 'template_code', 'data_source',
             'data_path', 'data_file', 'data_synced', 'tags', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 #
@@ -537,7 +537,7 @@ class ScriptSerializer(ValidatedModelSerializer):
         fields = [
             'id', 'url', 'module', 'name', 'description', 'vars', 'result', 'display', 'is_executable',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
     @extend_schema_field(serializers.JSONField(allow_null=True))
     def get_vars(self, obj):

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -29,7 +29,7 @@ class AppTest(APITestCase):
 
 class WebhookTest(APIViewTestCases.APIViewTestCase):
     model = Webhook
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
         {
             'name': 'Webhook 4',
@@ -71,7 +71,7 @@ class WebhookTest(APIViewTestCases.APIViewTestCase):
 
 class EventRuleTest(APIViewTestCases.APIViewTestCase):
     model = EventRule
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'enabled': False,
         'description': 'New description',
@@ -149,7 +149,7 @@ class EventRuleTest(APIViewTestCases.APIViewTestCase):
 
 class CustomFieldTest(APIViewTestCases.APIViewTestCase):
     model = CustomField
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
         {
             'content_types': ['dcim.site'],
@@ -201,7 +201,7 @@ class CustomFieldTest(APIViewTestCases.APIViewTestCase):
 
 class CustomFieldChoiceSetTest(APIViewTestCases.APIViewTestCase):
     model = CustomFieldChoiceSet
-    brief_fields = ['choices_count', 'display', 'id', 'name', 'url']
+    brief_fields = ['choices_count', 'description', 'display', 'id', 'name', 'url']
     create_data = [
         {
             'name': 'Choice Set 4',
@@ -330,7 +330,7 @@ class CustomLinkTest(APIViewTestCases.APIViewTestCase):
 
 class SavedFilterTest(APIViewTestCases.APIViewTestCase):
     model = SavedFilter
-    brief_fields = ['display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'content_types': ['dcim.site'],
@@ -455,7 +455,7 @@ class BookmarkTest(
 
 class ExportTemplateTest(APIViewTestCases.APIViewTestCase):
     model = ExportTemplate
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
         {
             'content_types': ['dcim.device'],
@@ -500,7 +500,7 @@ class ExportTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class TagTest(APIViewTestCases.APIViewTestCase):
     model = Tag
-    brief_fields = ['color', 'display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['color', 'description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'Tag 4',
@@ -627,7 +627,7 @@ class JournalEntryTest(APIViewTestCases.APIViewTestCase):
 
 class ConfigContextTest(APIViewTestCases.APIViewTestCase):
     model = ConfigContext
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
         {
             'name': 'Config Context 4',
@@ -708,7 +708,7 @@ class ConfigContextTest(APIViewTestCases.APIViewTestCase):
 
 class ConfigTemplateTest(APIViewTestCases.APIViewTestCase):
     model = ConfigTemplate
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
         {
             'name': 'Config Template 4',

--- a/netbox/ipam/api/serializers.py
+++ b/netbox/ipam/api/serializers.py
@@ -33,7 +33,7 @@ class ASNRangeSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'rir', 'start', 'end', 'tenant', 'description', 'tags',
             'custom_fields', 'created', 'last_updated', 'asn_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 #
@@ -55,7 +55,7 @@ class ASNSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'asn', 'rir', 'tenant', 'description', 'comments', 'tags', 'custom_fields',
             'created', 'last_updated', 'site_count', 'provider_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'asn')
+        brief_fields = ('id', 'url', 'display', 'asn', 'description')
 
 
 class AvailableASNSerializer(serializers.Serializer):
@@ -106,7 +106,7 @@ class VRFSerializer(NetBoxModelSerializer):
             'import_targets', 'export_targets', 'tags', 'custom_fields', 'created', 'last_updated', 'ipaddress_count',
             'prefix_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'rd', 'prefix_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'rd', 'description', 'prefix_count')
 
 
 #
@@ -123,7 +123,7 @@ class RouteTargetSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'tenant', 'description', 'comments', 'tags', 'custom_fields', 'created',
             'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 #
@@ -142,7 +142,7 @@ class RIRSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'is_private', 'description', 'tags', 'custom_fields', 'created',
             'last_updated', 'aggregate_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'aggregate_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'aggregate_count')
 
 
 class AggregateSerializer(NetBoxModelSerializer):
@@ -158,7 +158,7 @@ class AggregateSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'family', 'prefix', 'rir', 'tenant', 'date_added', 'description', 'comments',
             'tags', 'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'family', 'prefix')
+        brief_fields = ('id', 'url', 'display', 'family', 'prefix', 'description')
 
 
 #
@@ -175,7 +175,7 @@ class FHRPGroupSerializer(NetBoxModelSerializer):
             'id', 'name', 'url', 'display', 'protocol', 'group_id', 'auth_type', 'auth_key', 'description', 'comments',
             'tags', 'custom_fields', 'created', 'last_updated', 'ip_addresses',
         ]
-        brief_fields = ('id', 'url', 'display', 'protocol', 'group_id')
+        brief_fields = ('id', 'url', 'display', 'protocol', 'group_id', 'description')
 
 
 class FHRPGroupAssignmentSerializer(NetBoxModelSerializer):
@@ -220,7 +220,7 @@ class RoleSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'weight', 'description', 'tags', 'custom_fields', 'created',
             'last_updated', 'prefix_count', 'vlan_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'prefix_count', 'vlan_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'prefix_count', 'vlan_count')
 
 
 class VLANGroupSerializer(NetBoxModelSerializer):
@@ -246,7 +246,7 @@ class VLANGroupSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'scope_type', 'scope_id', 'scope', 'min_vid', 'max_vid',
             'description', 'tags', 'custom_fields', 'created', 'last_updated', 'vlan_count', 'utilization'
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'vlan_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'vlan_count')
         validators = []
 
     @extend_schema_field(serializers.JSONField(allow_null=True))
@@ -277,7 +277,7 @@ class VLANSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'site', 'group', 'vid', 'name', 'tenant', 'status', 'role', 'description',
             'comments', 'l2vpn_termination', 'tags', 'custom_fields', 'created', 'last_updated', 'prefix_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'vid', 'name')
+        brief_fields = ('id', 'url', 'display', 'vid', 'name', 'description')
 
 
 class AvailableVLANSerializer(serializers.Serializer):
@@ -338,7 +338,7 @@ class PrefixSerializer(NetBoxModelSerializer):
             'mark_utilized', 'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated', 'children',
             '_depth',
         ]
-        brief_fields = ('id', 'url', 'display', 'family', 'prefix', '_depth')
+        brief_fields = ('id', 'url', 'display', 'family', 'prefix', 'description', '_depth')
 
 
 class PrefixLengthSerializer(serializers.Serializer):
@@ -409,7 +409,7 @@ class IPRangeSerializer(NetBoxModelSerializer):
             'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
             'mark_utilized', 'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'family', 'start_address', 'end_address')
+        brief_fields = ('id', 'url', 'display', 'family', 'start_address', 'end_address', 'description')
 
 
 #
@@ -440,7 +440,7 @@ class IPAddressSerializer(NetBoxModelSerializer):
             'assigned_object_id', 'assigned_object', 'nat_inside', 'nat_outside', 'dns_name', 'description', 'comments',
             'tags', 'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'family', 'address')
+        brief_fields = ('id', 'url', 'display', 'family', 'address', 'description')
 
     @extend_schema_field(serializers.JSONField(allow_null=True))
     def get_assigned_object(self, obj):
@@ -483,10 +483,10 @@ class ServiceTemplateSerializer(NetBoxModelSerializer):
     class Meta:
         model = ServiceTemplate
         fields = [
-            'id', 'url', 'display', 'name', 'ports', 'protocol', 'description', 'comments', 'tags', 'custom_fields',
+            'id', 'url', 'display', 'name', 'protocol', 'ports', 'description', 'comments', 'tags', 'custom_fields',
             'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'protocol', 'ports')
+        brief_fields = ('id', 'url', 'display', 'name', 'protocol', 'ports', 'description')
 
 
 class ServiceSerializer(NetBoxModelSerializer):
@@ -504,7 +504,7 @@ class ServiceSerializer(NetBoxModelSerializer):
     class Meta:
         model = Service
         fields = [
-            'id', 'url', 'display', 'device', 'virtual_machine', 'name', 'ports', 'protocol', 'ipaddresses',
+            'id', 'url', 'display', 'device', 'virtual_machine', 'name', 'protocol', 'ports', 'ipaddresses',
             'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'protocol', 'ports')
+        brief_fields = ('id', 'url', 'display', 'name', 'protocol', 'ports', 'description')

--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -23,7 +23,7 @@ class AppTest(APITestCase):
 
 class ASNRangeTest(APIViewTestCases.APIViewTestCase):
     model = ASNRange
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -135,7 +135,7 @@ class ASNRangeTest(APIViewTestCases.APIViewTestCase):
 
 class ASNTest(APIViewTestCases.APIViewTestCase):
     model = ASN
-    brief_fields = ['asn', 'display', 'id', 'url']
+    brief_fields = ['asn', 'description', 'display', 'id', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -191,7 +191,7 @@ class ASNTest(APIViewTestCases.APIViewTestCase):
 
 class VRFTest(APIViewTestCases.APIViewTestCase):
     model = VRF
-    brief_fields = ['display', 'id', 'name', 'prefix_count', 'rd', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'prefix_count', 'rd', 'url']
     create_data = [
         {
             'name': 'VRF 4',
@@ -223,7 +223,7 @@ class VRFTest(APIViewTestCases.APIViewTestCase):
 
 class RouteTargetTest(APIViewTestCases.APIViewTestCase):
     model = RouteTarget
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
         {
             'name': '65000:1004',
@@ -252,7 +252,7 @@ class RouteTargetTest(APIViewTestCases.APIViewTestCase):
 
 class RIRTest(APIViewTestCases.APIViewTestCase):
     model = RIR
-    brief_fields = ['aggregate_count', 'display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['aggregate_count', 'description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'RIR 4',
@@ -284,7 +284,7 @@ class RIRTest(APIViewTestCases.APIViewTestCase):
 
 class AggregateTest(APIViewTestCases.APIViewTestCase):
     model = Aggregate
-    brief_fields = ['display', 'family', 'id', 'prefix', 'url']
+    brief_fields = ['description', 'display', 'family', 'id', 'prefix', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -323,7 +323,7 @@ class AggregateTest(APIViewTestCases.APIViewTestCase):
 
 class RoleTest(APIViewTestCases.APIViewTestCase):
     model = Role
-    brief_fields = ['display', 'id', 'name', 'prefix_count', 'slug', 'url', 'vlan_count']
+    brief_fields = ['description', 'display', 'id', 'name', 'prefix_count', 'slug', 'url', 'vlan_count']
     create_data = [
         {
             'name': 'Role 4',
@@ -355,7 +355,7 @@ class RoleTest(APIViewTestCases.APIViewTestCase):
 
 class PrefixTest(APIViewTestCases.APIViewTestCase):
     model = Prefix
-    brief_fields = ['_depth', 'display', 'family', 'id', 'prefix', 'url']
+    brief_fields = ['_depth', 'description', 'display', 'family', 'id', 'prefix', 'url']
     create_data = [
         {
             'prefix': '192.168.4.0/24',
@@ -534,7 +534,7 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
 
 class IPRangeTest(APIViewTestCases.APIViewTestCase):
     model = IPRange
-    brief_fields = ['display', 'end_address', 'family', 'id', 'start_address', 'url']
+    brief_fields = ['description', 'display', 'end_address', 'family', 'id', 'start_address', 'url']
     create_data = [
         {
             'start_address': '192.168.4.10/24',
@@ -633,7 +633,7 @@ class IPRangeTest(APIViewTestCases.APIViewTestCase):
 
 class IPAddressTest(APIViewTestCases.APIViewTestCase):
     model = IPAddress
-    brief_fields = ['address', 'display', 'family', 'id', 'url']
+    brief_fields = ['address', 'description', 'display', 'family', 'id', 'url']
     create_data = [
         {
             'address': '192.168.0.4/24',
@@ -718,7 +718,7 @@ class IPAddressTest(APIViewTestCases.APIViewTestCase):
 
 class FHRPGroupTest(APIViewTestCases.APIViewTestCase):
     model = FHRPGroup
-    brief_fields = ['display', 'group_id', 'id', 'protocol', 'url']
+    brief_fields = ['description', 'display', 'group_id', 'id', 'protocol', 'url']
     bulk_update_data = {
         'protocol': FHRPGroupProtocolChoices.PROTOCOL_GLBP,
         'group_id': 200,
@@ -839,7 +839,7 @@ class FHRPGroupAssignmentTest(APIViewTestCases.APIViewTestCase):
 
 class VLANGroupTest(APIViewTestCases.APIViewTestCase):
     model = VLANGroup
-    brief_fields = ['display', 'id', 'name', 'slug', 'url', 'vlan_count']
+    brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url', 'vlan_count']
     create_data = [
         {
             'name': 'VLAN Group 4',
@@ -960,7 +960,7 @@ class VLANGroupTest(APIViewTestCases.APIViewTestCase):
 
 class VLANTest(APIViewTestCases.APIViewTestCase):
     model = VLAN
-    brief_fields = ['display', 'id', 'name', 'url', 'vid']
+    brief_fields = ['description', 'display', 'id', 'name', 'url', 'vid']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1020,7 +1020,7 @@ class VLANTest(APIViewTestCases.APIViewTestCase):
 
 class ServiceTemplateTest(APIViewTestCases.APIViewTestCase):
     model = ServiceTemplate
-    brief_fields = ['display', 'id', 'name', 'ports', 'protocol', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'ports', 'protocol', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -1055,7 +1055,7 @@ class ServiceTemplateTest(APIViewTestCases.APIViewTestCase):
 
 class ServiceTest(APIViewTestCases.APIViewTestCase):
     model = Service
-    brief_fields = ['display', 'id', 'name', 'ports', 'protocol', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'ports', 'protocol', 'url']
     bulk_update_data = {
         'description': 'New description',
     }

--- a/netbox/tenancy/api/serializers.py
+++ b/netbox/tenancy/api/serializers.py
@@ -27,7 +27,7 @@ class TenantGroupSerializer(NestedGroupModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'parent', 'description', 'tags', 'custom_fields', 'created',
             'last_updated', 'tenant_count', '_depth',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'tenant_count', '_depth')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'tenant_count', '_depth')
 
 
 class TenantSerializer(NetBoxModelSerializer):
@@ -53,7 +53,7 @@ class TenantSerializer(NetBoxModelSerializer):
             'created', 'last_updated', 'circuit_count', 'device_count', 'ipaddress_count', 'prefix_count', 'rack_count',
             'site_count', 'virtualmachine_count', 'vlan_count', 'vrf_count', 'cluster_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description')
 
 
 #
@@ -71,7 +71,7 @@ class ContactGroupSerializer(NestedGroupModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'parent', 'description', 'tags', 'custom_fields', 'created',
             'last_updated', 'contact_count', '_depth',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'contact_count', '_depth')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'contact_count', '_depth')
 
 
 class ContactRoleSerializer(NetBoxModelSerializer):
@@ -82,7 +82,7 @@ class ContactRoleSerializer(NetBoxModelSerializer):
         fields = [
             'id', 'url', 'display', 'name', 'slug', 'description', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description')
 
 
 class ContactSerializer(NetBoxModelSerializer):
@@ -95,7 +95,7 @@ class ContactSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'group', 'name', 'title', 'phone', 'email', 'address', 'link', 'description',
             'comments', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class ContactAssignmentSerializer(NetBoxModelSerializer):

--- a/netbox/tenancy/tests/test_api.py
+++ b/netbox/tenancy/tests/test_api.py
@@ -18,7 +18,7 @@ class AppTest(APITestCase):
 
 class TenantGroupTest(APIViewTestCases.APIViewTestCase):
     model = TenantGroup
-    brief_fields = ['_depth', 'display', 'id', 'name', 'slug', 'tenant_count', 'url']
+    brief_fields = ['_depth', 'description', 'display', 'id', 'name', 'slug', 'tenant_count', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -56,7 +56,7 @@ class TenantGroupTest(APIViewTestCases.APIViewTestCase):
 
 class TenantTest(APIViewTestCases.APIViewTestCase):
     model = Tenant
-    brief_fields = ['display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url']
     bulk_update_data = {
         'group': None,
         'description': 'New description',
@@ -98,7 +98,7 @@ class TenantTest(APIViewTestCases.APIViewTestCase):
 
 class ContactGroupTest(APIViewTestCases.APIViewTestCase):
     model = ContactGroup
-    brief_fields = ['_depth', 'contact_count', 'display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['_depth', 'contact_count', 'description', 'display', 'id', 'name', 'slug', 'url']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -136,7 +136,7 @@ class ContactGroupTest(APIViewTestCases.APIViewTestCase):
 
 class ContactRoleTest(APIViewTestCases.APIViewTestCase):
     model = ContactRole
-    brief_fields = ['display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'Contact Role 4',
@@ -168,7 +168,7 @@ class ContactRoleTest(APIViewTestCases.APIViewTestCase):
 
 class ContactTest(APIViewTestCases.APIViewTestCase):
     model = Contact
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'group': None,
         'comments': 'New comments',

--- a/netbox/users/api/serializers.py
+++ b/netbox/users/api/serializers.py
@@ -103,7 +103,7 @@ class TokenSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'user', 'created', 'expires', 'last_used', 'key', 'write_enabled', 'description',
             'allowed_ips',
         )
-        brief_fields = ('id', 'url', 'display', 'key', 'write_enabled')
+        brief_fields = ('id', 'url', 'display', 'key', 'write_enabled', 'description')
 
     def to_internal_value(self, data):
         if 'key' not in data:
@@ -184,4 +184,6 @@ class ObjectPermissionSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'name', 'description', 'enabled', 'object_types', 'groups', 'users', 'actions',
             'constraints',
         )
-        brief_fields = ('id', 'url', 'display', 'name', 'enabled', 'object_types', 'groups', 'users', 'actions')
+        brief_fields = (
+            'id', 'url', 'display', 'name', 'description', 'enabled', 'object_types', 'groups', 'users', 'actions',
+        )

--- a/netbox/users/tests/test_api.py
+++ b/netbox/users/tests/test_api.py
@@ -129,7 +129,7 @@ class TokenTest(
     APIViewTestCases.DeleteObjectViewTestCase
 ):
     model = Token
-    brief_fields = ['display', 'id', 'key', 'url', 'write_enabled']
+    brief_fields = ['description', 'display', 'id', 'key', 'url', 'write_enabled']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -241,7 +241,9 @@ class ObjectPermissionTest(
     APIViewTestCases.DeleteObjectViewTestCase
 ):
     model = ObjectPermission
-    brief_fields = ['actions', 'display', 'enabled', 'groups', 'id', 'name', 'object_types', 'url', 'users']
+    brief_fields = [
+        'actions', 'description', 'display', 'enabled', 'groups', 'id', 'name', 'object_types', 'url', 'users',
+    ]
 
     @classmethod
     def setUpTestData(cls):

--- a/netbox/virtualization/api/serializers.py
+++ b/netbox/virtualization/api/serializers.py
@@ -33,7 +33,7 @@ class ClusterTypeSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'description', 'tags', 'custom_fields', 'created', 'last_updated',
             'cluster_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'cluster_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'cluster_count')
 
 
 class ClusterGroupSerializer(NetBoxModelSerializer):
@@ -48,7 +48,7 @@ class ClusterGroupSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'description', 'tags', 'custom_fields', 'created', 'last_updated',
             'cluster_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'cluster_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'cluster_count')
 
 
 class ClusterSerializer(NetBoxModelSerializer):
@@ -69,7 +69,7 @@ class ClusterSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'type', 'group', 'status', 'tenant', 'site', 'description', 'comments',
             'tags', 'custom_fields', 'created', 'last_updated', 'device_count', 'virtualmachine_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'virtualmachine_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'description', 'virtualmachine_count')
 
 
 #
@@ -102,7 +102,7 @@ class VirtualMachineSerializer(NetBoxModelSerializer):
             'config_template', 'local_context_data', 'tags', 'custom_fields', 'created', 'last_updated',
             'interface_count', 'virtual_disk_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
         validators = []
 
 
@@ -156,7 +156,7 @@ class VMInterfaceSerializer(NetBoxModelSerializer):
             'description', 'mode', 'untagged_vlan', 'tagged_vlans', 'vrf', 'l2vpn_termination', 'tags', 'custom_fields',
             'created', 'last_updated', 'count_ipaddresses', 'count_fhrp_groups',
         ]
-        brief_fields = ('id', 'url', 'display', 'virtual_machine', 'name')
+        brief_fields = ('id', 'url', 'display', 'virtual_machine', 'name', 'description')
 
     def validate(self, data):
 
@@ -186,4 +186,4 @@ class VirtualDiskSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'virtual_machine', 'name', 'description', 'size', 'tags', 'custom_fields',
             'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'virtual_machine', 'name', 'size')
+        brief_fields = ('id', 'url', 'display', 'virtual_machine', 'name', 'description', 'size')

--- a/netbox/virtualization/api/views.py
+++ b/netbox/virtualization/api/views.py
@@ -56,12 +56,8 @@ class VirtualMachineViewSet(ConfigContextQuerySetMixin, RenderConfigMixin, NetBo
 
         Else, return the VirtualMachineWithConfigContextSerializer
         """
-
         request = self.get_serializer_context()['request']
-        if request.query_params.get('brief', False):
-            return serializers.NestedVirtualMachineSerializer
-
-        elif 'config_context' in request.query_params.get('exclude', []):
+        if self.brief or 'config_context' in request.query_params.get('exclude', []):
             return serializers.VirtualMachineSerializer
 
         return serializers.VirtualMachineWithConfigContextSerializer

--- a/netbox/virtualization/tests/test_api.py
+++ b/netbox/virtualization/tests/test_api.py
@@ -22,7 +22,7 @@ class AppTest(APITestCase):
 
 class ClusterTypeTest(APIViewTestCases.APIViewTestCase):
     model = ClusterType
-    brief_fields = ['cluster_count', 'display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['cluster_count', 'description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'Cluster Type 4',
@@ -54,7 +54,7 @@ class ClusterTypeTest(APIViewTestCases.APIViewTestCase):
 
 class ClusterGroupTest(APIViewTestCases.APIViewTestCase):
     model = ClusterGroup
-    brief_fields = ['cluster_count', 'display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['cluster_count', 'description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'Cluster Group 4',
@@ -86,7 +86,7 @@ class ClusterGroupTest(APIViewTestCases.APIViewTestCase):
 
 class ClusterTest(APIViewTestCases.APIViewTestCase):
     model = Cluster
-    brief_fields = ['display', 'id', 'name', 'url', 'virtualmachine_count']
+    brief_fields = ['description', 'display', 'id', 'name', 'url', 'virtualmachine_count']
     bulk_update_data = {
         'status': 'offline',
         'comments': 'New comment',
@@ -138,7 +138,7 @@ class ClusterTest(APIViewTestCases.APIViewTestCase):
 
 class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
     model = VirtualMachine
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'staged',
     }
@@ -248,7 +248,7 @@ class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
 
 class VMInterfaceTest(APIViewTestCases.APIViewTestCase):
     model = VMInterface
-    brief_fields = ['display', 'id', 'name', 'url', 'virtual_machine']
+    brief_fields = ['description', 'display', 'id', 'name', 'url', 'virtual_machine']
     bulk_update_data = {
         'description': 'New description',
     }
@@ -337,7 +337,7 @@ class VMInterfaceTest(APIViewTestCases.APIViewTestCase):
 
 class VirtualDiskTest(APIViewTestCases.APIViewTestCase):
     model = VirtualDisk
-    brief_fields = ['display', 'id', 'name', 'size', 'url', 'virtual_machine']
+    brief_fields = ['description', 'display', 'id', 'name', 'size', 'url', 'virtual_machine']
     bulk_update_data = {
         'size': 888,
     }

--- a/netbox/vpn/api/serializers.py
+++ b/netbox/vpn/api/serializers.py
@@ -39,7 +39,7 @@ class TunnelGroupSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'description', 'tags', 'custom_fields', 'created', 'last_updated',
             'tunnel_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'tunnel_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'tunnel_count')
 
 
 class TunnelSerializer(NetBoxModelSerializer):
@@ -74,7 +74,7 @@ class TunnelSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'status', 'group', 'encapsulation', 'ipsec_profile', 'tenant', 'tunnel_id',
             'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated', 'terminations_count',
         )
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class TunnelTerminationSerializer(NetBoxModelSerializer):
@@ -135,7 +135,7 @@ class IKEProposalSerializer(NetBoxModelSerializer):
             'authentication_algorithm', 'group', 'sa_lifetime', 'comments', 'tags', 'custom_fields', 'created',
             'last_updated',
         )
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class IKEPolicySerializer(NetBoxModelSerializer):
@@ -161,7 +161,7 @@ class IKEPolicySerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'description', 'version', 'mode', 'proposals', 'preshared_key', 'comments',
             'tags', 'custom_fields', 'created', 'last_updated',
         )
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class IPSecProposalSerializer(NetBoxModelSerializer):
@@ -181,7 +181,7 @@ class IPSecProposalSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'description', 'encryption_algorithm', 'authentication_algorithm',
             'sa_lifetime_seconds', 'sa_lifetime_data', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
         )
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class IPSecPolicySerializer(NetBoxModelSerializer):
@@ -205,7 +205,7 @@ class IPSecPolicySerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'description', 'proposals', 'pfs_group', 'comments', 'tags',
             'custom_fields', 'created', 'last_updated',
         )
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 class IPSecProfileSerializer(NetBoxModelSerializer):
@@ -224,7 +224,7 @@ class IPSecProfileSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'name', 'description', 'mode', 'ike_policy', 'ipsec_policy', 'comments', 'tags',
             'custom_fields', 'created', 'last_updated',
         )
-        brief_fields = ('id', 'url', 'display', 'name')
+        brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
 #
@@ -254,7 +254,7 @@ class L2VPNSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'identifier', 'name', 'slug', 'type', 'import_targets', 'export_targets',
             'description', 'comments', 'tenant', 'tags', 'custom_fields', 'created', 'last_updated'
         ]
-        brief_fields = ('id', 'url', 'display', 'identifier', 'name', 'slug', 'type')
+        brief_fields = ('id', 'url', 'display', 'identifier', 'name', 'slug', 'type', 'description')
 
 
 class L2VPNTerminationSerializer(NetBoxModelSerializer):

--- a/netbox/vpn/tests/test_api.py
+++ b/netbox/vpn/tests/test_api.py
@@ -19,7 +19,7 @@ class AppTest(APITestCase):
 
 class TunnelGroupTest(APIViewTestCases.APIViewTestCase):
     model = TunnelGroup
-    brief_fields = ['display', 'id', 'name', 'slug', 'tunnel_count', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'slug', 'tunnel_count', 'url']
     create_data = (
         {
             'name': 'Tunnel Group 4',
@@ -51,7 +51,7 @@ class TunnelGroupTest(APIViewTestCases.APIViewTestCase):
 
 class TunnelTest(APIViewTestCases.APIViewTestCase):
     model = Tunnel
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': TunnelStatusChoices.STATUS_PLANNED,
         'encapsulation': TunnelEncapsulationChoices.ENCAP_GRE,
@@ -179,7 +179,7 @@ class TunnelTerminationTest(APIViewTestCases.APIViewTestCase):
 
 class IKEProposalTest(APIViewTestCases.APIViewTestCase):
     model = IKEProposal
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'authentication_method': AuthenticationMethodChoices.CERTIFICATES,
         'encryption_algorithm': EncryptionAlgorithmChoices.ENCRYPTION_AES192_CBC,
@@ -243,7 +243,7 @@ class IKEProposalTest(APIViewTestCases.APIViewTestCase):
 
 class IKEPolicyTest(APIViewTestCases.APIViewTestCase):
     model = IKEPolicy
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'version': IKEVersionChoices.VERSION_1,
         'mode': IKEModeChoices.AGGRESSIVE,
@@ -317,7 +317,7 @@ class IKEPolicyTest(APIViewTestCases.APIViewTestCase):
 
 class IPSecProposalTest(APIViewTestCases.APIViewTestCase):
     model = IPSecProposal
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'encryption_algorithm': EncryptionAlgorithmChoices.ENCRYPTION_AES192_CBC,
         'authentication_algorithm': AuthenticationAlgorithmChoices.AUTH_HMAC_MD5,
@@ -367,7 +367,7 @@ class IPSecProposalTest(APIViewTestCases.APIViewTestCase):
 
 class IPSecPolicyTest(APIViewTestCases.APIViewTestCase):
     model = IPSecPolicy
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'pfs_group': DHGroupChoices.GROUP_5,
         'description': 'New description',
@@ -429,7 +429,7 @@ class IPSecPolicyTest(APIViewTestCases.APIViewTestCase):
 
 class IPSecProfileTest(APIViewTestCases.APIViewTestCase):
     model = IPSecProfile
-    brief_fields = ['display', 'id', 'name', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'url']
 
     @classmethod
     def setUpTestData(cls):
@@ -519,7 +519,7 @@ class IPSecProfileTest(APIViewTestCases.APIViewTestCase):
 
 class L2VPNTest(APIViewTestCases.APIViewTestCase):
     model = L2VPN
-    brief_fields = ['display', 'id', 'identifier', 'name', 'slug', 'type', 'url']
+    brief_fields = ['description', 'display', 'id', 'identifier', 'name', 'slug', 'type', 'url']
     create_data = [
         {
             'name': 'L2VPN 4',

--- a/netbox/wireless/api/serializers.py
+++ b/netbox/wireless/api/serializers.py
@@ -28,7 +28,7 @@ class WirelessLANGroupSerializer(NestedGroupModelSerializer):
             'id', 'url', 'display', 'name', 'slug', 'parent', 'description', 'tags', 'custom_fields', 'created',
             'last_updated', 'wirelesslan_count', '_depth',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'wirelesslan_count', '_depth')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'wirelesslan_count', '_depth')
 
 
 class WirelessLANSerializer(NetBoxModelSerializer):
@@ -46,7 +46,7 @@ class WirelessLANSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'ssid', 'description', 'group', 'status', 'vlan', 'tenant', 'auth_type',
             'auth_cipher', 'auth_psk', 'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'ssid')
+        brief_fields = ('id', 'url', 'display', 'ssid', 'description')
 
 
 class WirelessLinkSerializer(NetBoxModelSerializer):
@@ -64,4 +64,4 @@ class WirelessLinkSerializer(NetBoxModelSerializer):
             'id', 'url', 'display', 'interface_a', 'interface_b', 'ssid', 'status', 'tenant', 'auth_type',
             'auth_cipher', 'auth_psk', 'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
-        brief_fields = ('id', 'url', 'display', 'ssid')
+        brief_fields = ('id', 'url', 'display', 'ssid', 'description')

--- a/netbox/wireless/tests/test_api.py
+++ b/netbox/wireless/tests/test_api.py
@@ -19,7 +19,7 @@ class AppTest(APITestCase):
 
 class WirelessLANGroupTest(APIViewTestCases.APIViewTestCase):
     model = WirelessLANGroup
-    brief_fields = ['_depth', 'display', 'id', 'name', 'slug', 'url', 'wirelesslan_count']
+    brief_fields = ['_depth', 'description', 'display', 'id', 'name', 'slug', 'url', 'wirelesslan_count']
     create_data = [
         {
             'name': 'Wireless LAN Group 4',
@@ -48,7 +48,7 @@ class WirelessLANGroupTest(APIViewTestCases.APIViewTestCase):
 
 class WirelessLANTest(APIViewTestCases.APIViewTestCase):
     model = WirelessLAN
-    brief_fields = ['display', 'id', 'ssid', 'url']
+    brief_fields = ['description', 'display', 'id', 'ssid', 'url']
 
     @classmethod
     def setUpTestData(cls):
@@ -110,7 +110,7 @@ class WirelessLANTest(APIViewTestCases.APIViewTestCase):
 
 class WirelessLinkTest(APIViewTestCases.APIViewTestCase):
     model = WirelessLink
-    brief_fields = ['display', 'id', 'ssid', 'url']
+    brief_fields = ['description', 'display', 'id', 'ssid', 'url']
     bulk_update_data = {
         'status': 'planned',
     }


### PR DESCRIPTION
### Fixes: #15238

- Add `description` to `brief_fields` on REST API serializers where applicable
- Update API tests
- Fix serializer class resolution for device & VM viewsets