### PR TITLE
fix: warning for script errors

### DIFF
--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -62,7 +62,7 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
         try:
             module = self.get_module()
         except Exception as e:
-            logger.debug(f"Failed to load script: {self.python_name} error: {e}")
+            logger.warning(f"Failed to load script: {self.python_name} error: {e}")
             module = None
 
         scripts = {}


### PR DESCRIPTION
### Improves: #12766

I don't see an easy way to bubble this up to the UI but at least logging with the correct severity makes debugging much easier.