### PR TITLE
Fixes: #14832 Extend GraphQL FHRPGroupType with IPAddressesMixin

### DIFF
--- a/netbox/ipam/graphql/types.py
+++ b/netbox/ipam/graphql/types.py
@@ -1,6 +1,7 @@
 import graphene
 
 from ipam import filtersets, models
+from .mixins import IPAddressesMixin
 from netbox.graphql.scalars import BigInt
 from netbox.graphql.types import BaseObjectType, OrganizationalObjectType, NetBoxObjectType
 
@@ -71,7 +72,7 @@ class AggregateType(NetBoxObjectType, BaseIPAddressFamilyType):
         filterset_class = filtersets.AggregateFilterSet
 
 
-class FHRPGroupType(NetBoxObjectType):
+class FHRPGroupType(NetBoxObjectType, IPAddressesMixin):
 
     class Meta:
         model = models.FHRPGroup


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #14832

<!--
    Please include a summary of the proposed changes below.
-->

This PR makes it possible to directly get the virtual ip_addresses from FHRPGroup

#### Example
```graphql
query {
  fhrp_ips: ip_address_list(fhrpgroup_id: "1") {
    address
  }
}
```

Responses:
```json
{
  "data": {
    "fhrp_ips": [
      {
        "address": "192.168.1.1/22"
      }
    ]
  }
}
```