### PR TITLE
10587 script pagination

### DIFF
--- a/netbox/extras/migrations/0108_convert_reports_to_scripts.py
+++ b/netbox/extras/migrations/0108_convert_reports_to_scripts.py
@@ -25,7 +25,4 @@ class Migration(migrations.Migration):
         migrations.DeleteModel(
             name='Report',
         ),
-        migrations.DeleteModel(
-            name='ReportModule',
-        ),
     ]

--- a/netbox/extras/migrations/0109_script_model.py
+++ b/netbox/extras/migrations/0109_script_model.py
@@ -99,7 +99,7 @@ def update_scripts(apps, schema_editor):
                 object_type=scriptmodule_ct,
                 object_id=module.pk,
                 name=script_name
-            ).update(object_type=script_ct, object_id=script.pk)
+            ).update(object_type_id=script_ct.id, object_id=script.pk)
 
 
 def update_event_rules(apps, schema_editor):

--- a/netbox/extras/migrations/0109_script_model.py
+++ b/netbox/extras/migrations/0109_script_model.py
@@ -96,7 +96,7 @@ def update_scripts(apps, schema_editor):
 
             # Update all Jobs associated with this ScriptModule & script name to point to the new Script object
             Job.objects.filter(
-                object_type=scriptmodule_ct,
+                object_type_id=scriptmodule_ct.id,
                 object_id=module.pk,
                 name=script_name
             ).update(object_type_id=script_ct.id, object_id=script.pk)

--- a/netbox/extras/migrations/0109_script_model.py
+++ b/netbox/extras/migrations/0109_script_model.py
@@ -82,10 +82,12 @@ def update_scripts(apps, schema_editor):
     ContentType = apps.get_model('contenttypes', 'ContentType')
     Script = apps.get_model('extras', 'Script')
     ScriptModule = apps.get_model('extras', 'ScriptModule')
+    ReportModule = apps.get_model('extras', 'ReportModule')
     Job = apps.get_model('core', 'Job')
 
-    script_ct = ContentType.objects.get_for_model(Script)
-    scriptmodule_ct = ContentType.objects.get_for_model(ScriptModule)
+    script_ct = ContentType.objects.get_for_model(Script, for_concrete_model=False)
+    scriptmodule_ct = ContentType.objects.get_for_model(ScriptModule, for_concrete_model=False)
+    reportmodule_ct = ContentType.objects.get_for_model(ReportModule, for_concrete_model=False)
 
     for module in ScriptModule.objects.all():
         for script_name in get_module_scripts(module):
@@ -97,6 +99,12 @@ def update_scripts(apps, schema_editor):
             # Update all Jobs associated with this ScriptModule & script name to point to the new Script object
             Job.objects.filter(
                 object_type_id=scriptmodule_ct.id,
+                object_id=module.pk,
+                name=script_name
+            ).update(object_type_id=script_ct.id, object_id=script.pk)
+            # Update all Jobs associated with this ScriptModule & script name to point to the new Script object
+            Job.objects.filter(
+                object_type_id=reportmodule_ct.id,
                 object_id=module.pk,
                 name=script_name
             ).update(object_type_id=script_ct.id, object_id=script.pk)

--- a/netbox/extras/migrations/0110_remove_eventrule_action_parameters.py
+++ b/netbox/extras/migrations/0110_remove_eventrule_action_parameters.py
@@ -12,4 +12,7 @@ class Migration(migrations.Migration):
             model_name='eventrule',
             name='action_parameters',
         ),
+        migrations.DeleteModel(
+            name='ReportModule',
+        ),
     ]

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from extras.models import *
-from netbox.tables import NetBoxTable, columns
+from netbox.tables import BaseTable, NetBoxTable, columns
 from .template_code import *
 
 __all__ = (
@@ -21,6 +21,8 @@ __all__ = (
     'JournalEntryTable',
     'ObjectChangeTable',
     'SavedFilterTable',
+    'ReportResultsTable',
+    'ScriptResultsTable',
     'TaggedItemTable',
     'TagTable',
     'WebhookTable',
@@ -506,4 +508,68 @@ class JournalEntryTable(NetBoxTable):
         )
         default_columns = (
             'pk', 'created', 'created_by', 'assigned_object_type', 'assigned_object', 'kind', 'comments'
+        )
+
+
+class ScriptResultsTable(BaseTable):
+    index = tables.Column(
+        verbose_name=_('Line')
+    )
+    time = tables.Column(
+        verbose_name=_('Time')
+    )
+    status = tables.TemplateColumn(
+        template_code="""{% load log_levels %}{% log_level record.status %}""",
+        verbose_name=_('Level')
+    )
+    message = tables.Column(
+        verbose_name=_('Message')
+    )
+
+    class Meta(BaseTable.Meta):
+        empty_text = _('No results found')
+        fields = (
+            'index', 'time', 'status', 'message',
+        )
+        default_columns = (
+            'index', 'time', 'status', 'message',
+        )
+
+
+class ReportResultsTable(BaseTable):
+    index = tables.Column(
+        verbose_name=_('Line')
+    )
+    method = tables.Column(
+        verbose_name=_('Method')
+    )
+    time = tables.Column(
+        verbose_name=_('Time')
+    )
+    status = tables.Column(
+        empty_values=(),
+        verbose_name=_('Level')
+    )
+    status = tables.TemplateColumn(
+        template_code="""{% load log_levels %}{% log_level record.status %}""",
+        verbose_name=_('Level')
+    )
+
+    object = tables.Column(
+        verbose_name=_('Object')
+    )
+    url = tables.Column(
+        verbose_name=_('Url')
+    )
+    message = tables.Column(
+        verbose_name=_('Message')
+    )
+
+    class Meta(BaseTable.Meta):
+        empty_text = _('No results found')
+        fields = (
+            'index', 'method', 'time', 'status', 'object', 'url', 'message',
+        )
+        default_columns = (
+            'index', 'method', 'time', 'status', 'object', 'url', 'message',
         )

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -531,9 +531,6 @@ class ScriptResultsTable(BaseTable):
         fields = (
             'index', 'time', 'status', 'message',
         )
-        default_columns = (
-            'index', 'time', 'status', 'message',
-        )
 
 
 class ReportResultsTable(BaseTable):
@@ -559,7 +556,7 @@ class ReportResultsTable(BaseTable):
         verbose_name=_('Object')
     )
     url = tables.Column(
-        verbose_name=_('Url')
+        verbose_name=_('URL')
     )
     message = tables.Column(
         verbose_name=_('Message')
@@ -568,8 +565,5 @@ class ReportResultsTable(BaseTable):
     class Meta(BaseTable.Meta):
         empty_text = _('No results found')
         fields = (
-            'index', 'method', 'time', 'status', 'object', 'url', 'message',
-        )
-        default_columns = (
             'index', 'method', 'time', 'status', 'object', 'url', 'message',
         )

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1204,6 +1204,7 @@ class ScriptResultView(TableMixin, generic.ObjectView):
         if job.completed:
             table_logs, table_tests = self.get_table(job, request, bulk_actions=False)
 
+        breakpoint()
         context = {
             'script': job.object,
             'job': job,

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1154,7 +1154,7 @@ class ScriptResultView(TableMixin, generic.ObjectView):
     def get_table(self, job, request, bulk_actions=True):
         data = []
         tests = None
-        table_logs = table_tests = None
+        table = None
         index = 0
         if job.data:
             if 'log' in job.data:
@@ -1171,8 +1171,8 @@ class ScriptResultView(TableMixin, generic.ObjectView):
                     }
                     data.append(result)
 
-                table_logs = ScriptResultsTable(data, user=request.user)
-                table_logs.configure(request)
+                table = ScriptResultsTable(data, user=request.user)
+                table.configure(request)
             else:
                 tests = job.data
 
@@ -1192,24 +1192,22 @@ class ScriptResultView(TableMixin, generic.ObjectView):
                         }
                         data.append(result)
 
-            table_tests = ReportResultsTable(data, user=request.user)
-            table_tests.configure(request)
+            table = ReportResultsTable(data, user=request.user)
+            table.configure(request)
 
-        return table_logs, table_tests
+        return table
 
     def get(self, request, **kwargs):
         job = get_object_or_404(Job.objects.all(), pk=kwargs.get('job_pk'))
         table_logs = table_tests = None
 
         if job.completed:
-            table_logs, table_tests = self.get_table(job, request, bulk_actions=False)
+            table = self.get_table(job, request, bulk_actions=False)
 
-        breakpoint()
         context = {
             'script': job.object,
             'job': job,
-            'table_logs': table_logs,
-            'table_tests': table_tests,
+            'table': table,
         }
 
         if job.data and 'log' in job.data:

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1149,6 +1149,34 @@ class ScriptResultView(generic.ObjectView):
     def get_required_permission(self):
         return 'extras.view_script'
 
+    def job_to_result_array(self, job):
+        results = []
+        if job.data:
+            if 'log' in job.data:
+                for log in job.data['log']:
+                    result = {
+                        'method': None,
+                        'time': log.get('time', None),
+                        'level': log.get('level', None),
+                        'object': log.get('object', None),
+                        'message': log.get('message', None),
+                    }
+                    results.append(result)
+            else:
+                for test in job.data:
+                    if 'log' in test:
+                        for time, level, obj, url, message in test['log']:
+                            result = {
+                                'method': test,
+                                'time': time,
+                                'level': level,
+                                'object': obj,
+                                'url': url,
+                                'message': message,
+                            }
+
+        return data
+
     def get(self, request, **kwargs):
         job = get_object_or_404(Job.objects.all(), pk=kwargs.get('job_pk'))
 

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1165,15 +1165,16 @@ class ScriptResultView(TableMixin, generic.ObjectView):
                     index += 1
                     result = {
                         'index': index,
-                        'time': log.get('time', None),
-                        'status': log.get('status', None),
-                        'message': log.get('message', None),
+                        'time': log.get('time'),
+                        'status': log.get('status'),
+                        'message': log.get('message'),
                     }
                     data.append(result)
 
                 table = ScriptResultsTable(data, user=request.user)
                 table.configure(request)
             else:
+                # for legacy reports
                 tests = job.data
 
         if tests:
@@ -1198,8 +1199,8 @@ class ScriptResultView(TableMixin, generic.ObjectView):
         return table
 
     def get(self, request, **kwargs):
+        table = None
         job = get_object_or_404(Job.objects.all(), pk=kwargs.get('job_pk'))
-        table_logs = table_tests = None
 
         if job.completed:
             table = self.get_table(job, request, bulk_actions=False)

--- a/netbox/templates/extras/htmx/script_result.html
+++ b/netbox/templates/extras/htmx/script_result.html
@@ -19,12 +19,14 @@
   </p>
   {% if job.completed %}
 
+    {% if table.logs and not table_tests %}
     <div class="card">
       <div class="table-responsive" id="object_list">
         <h5 class="card-header">{% trans "Log" %}</h5>
         {% include 'htmx/table.html' with table=table_logs %}
       </div>
     </div>
+    {% endif %}
 
     {# Script output. Legacy reports will not have this. #}
     {% if 'output' in job.data %}

--- a/netbox/templates/extras/htmx/script_result.html
+++ b/netbox/templates/extras/htmx/script_result.html
@@ -18,29 +18,7 @@
     <span id="pending-result-label">{% badge job.get_status_display job.get_status_color %}</span>
   </p>
   {% if job.completed %}
-
-    {% if table.logs and not table_tests %}
-    <div class="card">
-      <div class="table-responsive" id="object_list">
-        <h5 class="card-header">{% trans "Log" %}</h5>
-        {% include 'htmx/table.html' with table=table_logs %}
-      </div>
-    </div>
-    {% endif %}
-
-    {# Script output. Legacy reports will not have this. #}
-    {% if 'output' in job.data %}
-      <div class="card mb-3">
-      <h5 class="card-header">{% trans "Output" %}</h5>
-        {% if job.data.output %}
-          <pre class="card-body font-monospace">{{ job.data.output }}</pre>
-        {% else %}
-          <div class="card-body text-muted">{% trans "None" %}</div>
-        {% endif %}
-      </div>
-    {% endif %}
-
-    {% if table_tests %}
+    {% if tests %}
       {# Summary of test methods #}
       <div class="card">
         <h5 class="card-header">{% trans "Test Summary" %}</h5>
@@ -58,15 +36,29 @@
           {% endfor %}
         </table>
       </div>
+    {% endif %}
 
-      {# Detailed results for individual tests #}
-      <div class="card">
-        <div class="table-responsive" id="object_list">
-          <h5 class="card-header">{% trans "Test Details" %}</h5>
-          {% include 'htmx/table.html' with table=table_tests %}
-        </div>
+    {% if table %}
+    <div class="card">
+      <div class="table-responsive" id="object_list">
+        <h5 class="card-header">{% trans "Log" %}</h5>
+        {% include 'htmx/table.html' %}
+      </div>
+    </div>
+    {% endif %}
+
+    {# Script output. Legacy reports will not have this. #}
+    {% if 'output' in job.data %}
+      <div class="card mb-3">
+      <h5 class="card-header">{% trans "Output" %}</h5>
+        {% if job.data.output %}
+          <pre class="card-body font-monospace">{{ job.data.output }}</pre>
+        {% else %}
+          <div class="card-body text-muted">{% trans "None" %}</div>
+        {% endif %}
       </div>
     {% endif %}
+
   {% elif job.started %}
     {% include 'extras/inc/result_pending.html' %}
   {% endif %}

--- a/netbox/templates/extras/htmx/script_result.html
+++ b/netbox/templates/extras/htmx/script_result.html
@@ -3,124 +3,69 @@
 {% load log_levels %}
 {% load i18n %}
 
-<p>
-  {% if job.started %}
-    {% trans "Started" %}: <strong>{{ job.started|annotated_date }}</strong>
-  {% elif job.scheduled %}
-    {% trans "Scheduled for" %}: <strong>{{ job.scheduled|annotated_date }}</strong> ({{ job.scheduled|naturaltime }})
-  {% else %}
-    {% trans "Created" %}: <strong>{{ job.created|annotated_date }}</strong>
-  {% endif %}
+<div class="htmx-container">
+  <p>
+    {% if job.started %}
+      {% trans "Started" %}: <strong>{{ job.started|annotated_date }}</strong>
+    {% elif job.scheduled %}
+      {% trans "Scheduled for" %}: <strong>{{ job.scheduled|annotated_date }}</strong> ({{ job.scheduled|naturaltime }})
+    {% else %}
+      {% trans "Created" %}: <strong>{{ job.created|annotated_date }}</strong>
+    {% endif %}
+    {% if job.completed %}
+      {% trans "Duration" %}: <strong>{{ job.duration }}</strong>
+    {% endif %}
+    <span id="pending-result-label">{% badge job.get_status_display job.get_status_color %}</span>
+  </p>
   {% if job.completed %}
-    {% trans "Duration" %}: <strong>{{ job.duration }}</strong>
-  {% endif %}
-  <span id="pending-result-label">{% badge job.get_status_display job.get_status_color %}</span>
-</p>
-{% if job.completed %}
 
-  {# Script log. Legacy reports will not have this. #}
-  {% if 'log' in job.data %}
-    <div class="card mb-3">
-      <h5 class="card-header">{% trans "Log" %}</h5>
-      {% if job.data.log %}
-        <table class="table table-hover panel-body">
-          <tr>
-            <th>{% trans "Line" %}</th>
-            <th>{% trans "Time" %}</th>
-            <th>{% trans "Level" %}</th>
-            <th>{% trans "Message" %}</th>
-          </tr>
-          {% for log in job.data.log %}
+    <div class="card">
+      <div class="table-responsive" id="object_list">
+        <h5 class="card-header">{% trans "Log" %}</h5>
+        {% include 'htmx/table.html' with table=table_logs %}
+      </div>
+    </div>
+
+    {# Script output. Legacy reports will not have this. #}
+    {% if 'output' in job.data %}
+      <div class="card mb-3">
+      <h5 class="card-header">{% trans "Output" %}</h5>
+        {% if job.data.output %}
+          <pre class="card-body font-monospace">{{ job.data.output }}</pre>
+        {% else %}
+          <div class="card-body text-muted">{% trans "None" %}</div>
+        {% endif %}
+      </div>
+    {% endif %}
+
+    {% if table_tests %}
+      {# Summary of test methods #}
+      <div class="card">
+        <h5 class="card-header">{% trans "Test Summary" %}</h5>
+        <table class="table table-hover">
+          {% for test, data in tests.items %}
             <tr>
-              <td>{{ forloop.counter }}</td>
-              <td>{{ log.time|placeholder }}</td>
-              <td>{% log_level log.status %}</td>
-              <td>{{ log.message|markdown }}</td>
+              <td class="font-monospace"><a href="#{{ test }}">{{ test }}</a></td>
+              <td class="text-end report-stats">
+                <span class="badge text-bg-success">{{ data.success }}</span>
+                <span class="badge text-bg-info">{{ data.info }}</span>
+                <span class="badge text-bg-warning">{{ data.warning }}</span>
+                <span class="badge text-bg-danger">{{ data.failure }}</span>
+              </td>
             </tr>
           {% endfor %}
         </table>
-      {% else %}
-        <div class="card-body text-muted">{% trans "None" %}</div>
-      {% endif %}
-    </div>
+      </div>
+
+      {# Detailed results for individual tests #}
+      <div class="card">
+        <div class="table-responsive" id="object_list">
+          <h5 class="card-header">{% trans "Test Details" %}</h5>
+          {% include 'htmx/table.html' with table=table_tests %}
+        </div>
+      </div>
+    {% endif %}
+  {% elif job.started %}
+    {% include 'extras/inc/result_pending.html' %}
   {% endif %}
-
-  {# Script output. Legacy reports will not have this. #}
-  {% if 'output' in job.data %}
-    <div class="card mb-3">
-    <h5 class="card-header">{% trans "Output" %}</h5>
-      {% if job.data.output %}
-        <pre class="card-body font-monospace">{{ job.data.output }}</pre>
-      {% else %}
-        <div class="card-body text-muted">{% trans "None" %}</div>
-      {% endif %}
-    </div>
-  {% endif %}
-
-  {# Test method logs (for legacy Reports) #}
-  {% if tests %}
-
-    {# Summary of test methods #}
-    <div class="card">
-      <h5 class="card-header">{% trans "Test Summary" %}</h5>
-      <table class="table table-hover">
-        {% for test, data in tests.items %}
-          <tr>
-            <td class="font-monospace"><a href="#{{ test }}">{{ test }}</a></td>
-            <td class="text-end report-stats">
-              <span class="badge text-bg-success">{{ data.success }}</span>
-              <span class="badge text-bg-info">{{ data.info }}</span>
-              <span class="badge text-bg-warning">{{ data.warning }}</span>
-              <span class="badge text-bg-danger">{{ data.failure }}</span>
-            </td>
-          </tr>
-        {% endfor %}
-      </table>
-    </div>
-
-    {# Detailed results for individual tests #}
-    <div class="card">
-      <h5 class="card-header">{% trans "Test Details" %}</h5>
-      <table class="table table-hover report">
-        <thead>
-          <tr class="table-headings">
-            <th>{% trans "Time" %}</th>
-            <th>{% trans "Level" %}</th>
-            <th>{% trans "Object" %}</th>
-            <th>{% trans "Message" %}</th>
-          </tr>
-        </thead>
-        <tbody>
-          {% for test, data in tests.items %}
-            <tr>
-              <th colspan="4" style="font-family: monospace">
-                <a name="{{ test }}"></a>{{ test }}
-              </th>
-            </tr>
-            {% for time, level, obj, url, message in data.log %}
-              <tr class="{% if level == 'failure' %}danger{% elif level %}{{ level }}{% endif %}">
-                <td>{{ time }}</td>
-                <td>
-                  <label class="badge text-bg-{% if level == 'failure' %}danger{% else %}{{ level }}{% endif %}">{{ level|title }}</label>
-                </td>
-                <td>
-                  {% if obj and url %}
-                    <a href="{{ url }}">{{ obj }}</a>
-                  {% elif obj %}
-                    {{ obj }}
-                  {% else %}
-                    {{ ''|placeholder }}
-                  {% endif %}
-                </td>
-                <td class="rendered-markdown">{{ message|markdown }}</td>
-              </tr>
-            {% endfor %}
-          {% endfor %}
-        </tbody>
-      </table>
-    </div>
-
-  {% endif %}
-{% elif job.started %}
-  {% include 'extras/inc/result_pending.html' %}
-{% endif %}
+</div>

--- a/netbox/templates/extras/script_result.html
+++ b/netbox/templates/extras/script_result.html
@@ -32,28 +32,74 @@
 {% block tabs %}
   <ul class="nav nav-tabs" role="tablist">
     <li class="nav-item" role="presentation">
-      <a href="#log" role="tab" data-bs-toggle="tab" class="nav-link active">{% trans "Log" %}</a>
-    </li>
-    <li class="nav-item" role="presentation">
-      <a href="#source" role="tab" data-bs-toggle="tab" class="nav-link">{% trans "Source" %}</a>
+      <a href="#results" role="tab" data-bs-toggle="tab" class="nav-link active">{% trans "Results" %}</a>
     </li>
   </ul>
 {% endblock %}
 
 {% block content %}
-  <div role="tabpanel" class="tab-pane active" id="log">
-    <div class="row">
-      <div class="col col-md-12"{% if not job.completed %} hx-get="{% url 'extras:script_result' job_pk=job.pk %}" hx-trigger="load delay:0.5s, every 5s"{% endif %}>
-        {% include 'extras/htmx/script_result.html' %}
+    {# Object list tab #}
+    <div class="tab-pane show active" id="results" role="tabpanel" aria-labelledby="results-tab">
+
+      {# Object table controls #}
+      <div class="row mb-3">
+        <div class="col-auto ms-auto d-print-none">
+          {% if request.user.is_authenticated %}
+            <div class="table-configure input-group">
+              <button type="button" data-bs-toggle="modal" title="{% trans "Configure Table" %}" data-bs-target="#ObjectTable_config"
+                class="btn">
+                <i class="mdi mdi-cog"></i> {% trans "Configure Table" %}
+              </button>
+            </div>
+          {% endif %}
+        </div>
       </div>
+
+      <form method="post" class="form form-horizontal">
+        {% csrf_token %}
+        {# "Select all" form #}
+        {% if table.paginator.num_pages > 1 %}
+          <div id="select-all-box" class="d-none card d-print-none">
+            <div class="form col-md-12">
+              <div class="card-body">
+                <div class="form-check">
+                  <input type="checkbox" id="select-all" name="_all" class="form-check-input" />
+                  <label for="select-all" class="form-check-label">
+                    {% blocktrans trimmed with count=table.rows|length object_type_plural=table.data.verbose_name_plural %}
+                      Select <strong>all {{ count }} {{ object_type_plural }}</strong> matching query
+                    {% endblocktrans %}
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+        {% endif %}
+
+        <div class="form form-horizontal">
+          {% csrf_token %}
+          <input type="hidden" name="return_url" value="{% if return_url %}{{ return_url }}{% else %}{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" />
+
+          {# Objects table #}
+            <div class="col col-md-12"{% if not job.completed %} hx-get="{% url 'extras:script_result' job_pk=job.pk %}" hx-trigger="load delay:0.5s, every 5s"{% endif %}>
+              {% include 'extras/htmx/script_result.html' %}
+            </div>
+          {# /Objects table #}
+
+        </div>
+      </form>
     </div>
-  </div>
-  <div role="tabpanel" class="tab-pane" id="source">
-    <p><code>{{ script.filename }}</code></p>
-    <pre class="block">{{ script.source }}</pre>
-  </div>
+    {# /Object list tab #}
+
+    {# Filters tab #}
+    {% if filter_form %}
+      <div class="tab-pane show" id="filters-form" role="tabpanel" aria-labelledby="filters-form-tab">
+        {% include 'inc/filter_list.html' %}
+      </div>
+    {% endif %}
+    {# /Filters tab #}
+
 {% endblock content %}
 
 {% block modals %}
-  {% include 'inc/htmx_modal.html' %}
+  {% table_config_form table table_name="ObjectTable" %}
 {% endblock modals %}


### PR DESCRIPTION
### Fixes: #10587 

Makes the script logs use a tables2 table which allows pagination and sorting of columns.  There were a couple bugs in the scripts migrations which this fixes (was causing jobs not to get correctly mapped from old script/report runs).

Original FR asked for filtering and export, however the logs are stored as a dict and filtering requires a queryset so filtering is not possible without converting the individual logs lines to be stored as regular DB objects.
Table configuration is implemented but not tested as table configuration is currently broken across all views.

![Monosnap DeviceConnectionsReport | NetBox 2024-03-04 13-44-08](https://github.com/netbox-community/netbox/assets/99642/3ea76094-ce45-499f-9635-fdfed991f55c)
