### PR TITLE
Closes #15413: Enable caching of object attributes in search index

### DIFF
--- a/netbox/netbox/search/__init__.py
+++ b/netbox/netbox/search/__init__.py
@@ -1,6 +1,9 @@
 from collections import namedtuple
+from decimal import Decimal
 
+from django.core.exceptions import FieldDoesNotExist
 from django.db import models
+from netaddr import IPAddress, IPNetwork
 
 from ipam.fields import IPAddressField, IPNetworkField
 from netbox.registry import registry
@@ -57,6 +60,24 @@ class SearchIndex:
         return FieldTypes.STRING
 
     @staticmethod
+    def get_attr_type(instance, field_name):
+        """
+        Return the data type of the specified object attribute.
+        """
+        value = getattr(instance, field_name)
+        if type(value) is str:
+            return FieldTypes.STRING
+        if type(value) is int:
+            return FieldTypes.INTEGER
+        if type(value) in (float, Decimal):
+            return FieldTypes.FLOAT
+        if type(value) is IPNetwork:
+            return FieldTypes.CIDR
+        if type(value) is IPAddress:
+            return FieldTypes.INET
+        return FieldTypes.STRING
+
+    @staticmethod
     def get_field_value(instance, field_name):
         """
         Return the value of the specified model field as a string.
@@ -82,7 +103,11 @@ class SearchIndex:
 
         # Capture built-in fields
         for name, weight in cls.fields:
-            type_ = cls.get_field_type(instance, name)
+            try:
+                type_ = cls.get_field_type(instance, name)
+            except FieldDoesNotExist:
+                # Not a concrete field; handle as an object attribute
+                type_ = cls.get_attr_type(instance, name)
             value = cls.get_field_value(instance, name)
             if type_ and value:
                 values.append(

--- a/netbox/netbox/tables/tables.py
+++ b/netbox/netbox/tables/tables.py
@@ -263,9 +263,11 @@ class SearchTable(tables.Table):
         super().__init__(data, **kwargs)
 
     def render_field(self, value, record):
-        if hasattr(record.object, value):
-            return title(record.object._meta.get_field(value).verbose_name)
-        return value
+        try:
+            model_field = record.object._meta.get_field(value)
+            return title(model_field.verbose_name)
+        except FieldDoesNotExist:
+            return value
 
     def render_value(self, value):
         if not self.highlight:


### PR DESCRIPTION
### Closes: #15413

- Extends `SearchIndex` to support caching object attribute values in addition to concrete model fields