### PR TITLE
Closes #14454: Include member devices for virtual chassis in REST API

### DIFF
--- a/netbox/dcim/api/serializers_/virtualchassis.py
+++ b/netbox/dcim/api/serializers_/virtualchassis.py
@@ -12,6 +12,7 @@ __all__ = (
 class VirtualChassisSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:virtualchassis-detail')
     master = NestedDeviceSerializer(required=False, allow_null=True, default=None)
+    members = NestedDeviceSerializer(many=True, read_only=True)
 
     # Counter fields
     member_count = serializers.IntegerField(read_only=True)
@@ -20,6 +21,6 @@ class VirtualChassisSerializer(NetBoxModelSerializer):
         model = VirtualChassis
         fields = [
             'id', 'url', 'display', 'name', 'domain', 'master', 'description', 'comments', 'tags', 'custom_fields',
-            'created', 'last_updated', 'member_count',
+            'created', 'last_updated', 'member_count', 'members',
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'master', 'description', 'member_count')

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -511,7 +511,10 @@ class CableTerminationViewSet(NetBoxModelViewSet):
 #
 
 class VirtualChassisViewSet(NetBoxModelViewSet):
-    queryset = VirtualChassis.objects.all()
+    queryset = VirtualChassis.objects.prefetch_related(
+        # Prefetch related object for the display of unnamed devices
+        'master__virtual_chassis',
+    )
     serializer_class = serializers.VirtualChassisSerializer
     filterset_class = filtersets.VirtualChassisFilterSet
 


### PR DESCRIPTION
### Fixes: #14454

- Add the `members` field to the API serializer for VirtualChassis
- Prefetch `master__virtual_chassis` on the view to avoid extra SQL queries for unnamed master devices