### PR TITLE
Fix typo in Add Components dropdown

### DIFF
--- a/netbox/templates/dcim/device/base.html
+++ b/netbox/templates/dcim/device/base.html
@@ -42,7 +42,7 @@
                 {% if perms.dcim.add_rearport %}
                     <li><a class="dropdown-item" href="{% url 'dcim:rearport_add' %}?device={{ object.pk }}&return_url={% url 'dcim:device_rearports' pk=object.pk %}">{% trans "Rear Ports" %}</a></li>
                 {% endif %}
-                {% if perms.dcim.add_devicebay %}
+                {% if perms.dcim.add_modulebay %}
                     <li><a class="dropdown-item" href="{% url 'dcim:modulebay_add' %}?device={{ object.pk }}&return_url={% url 'dcim:device_modulebays' pk=object.pk %}">{% trans "Module Bays" %}</a></li>
                 {% endif %}
                 {% if perms.dcim.add_devicebay %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #15435

As described in the issue, it's a typo that causes it to be hidden from view.
