### PR TITLE
14799 dont cache report member names

### DIFF
--- a/netbox/extras/models/reports.py
+++ b/netbox/extras/models/reports.py
@@ -52,7 +52,7 @@ class ReportModule(PythonModuleMixin, JobsMixin, ManagedFile):
     def __str__(self):
         return self.python_name
 
-    @cached_property
+    @property
     def reports(self):
 
         def _get_name(cls):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #14799 

Remove the caching on reports property so will pick up changes to report file content on data-sources.