### PR TITLE
15353 add better script error message

### DIFF
--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -96,6 +96,7 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
     Proxy model for script module files.
     """
     objects = ScriptModuleManager()
+    error = None
 
     class Meta:
         proxy = True
@@ -118,6 +119,7 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
         try:
             module = self.get_module()
         except Exception as e:
+            self.error = e
             logger.debug(f"Failed to load script: {self.python_name} error: {e}")
             module = None
 

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1044,11 +1044,11 @@ class BaseScriptView(generic.ObjectView):
     queryset = Script.objects.all()
 
     def _get_script_class(self, script):
-        script_class = script.python_class
-        if script_class:
-            script_class = script_class()
-
-        return script_class
+        """
+        Return an instance of the Script's Python class
+        """
+        if script_class := script.python_class:
+            return script_class()
 
 
 class ScriptView(BaseScriptView):

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1040,12 +1040,27 @@ class ScriptListView(ContentTypePermissionRequiredMixin, View):
         })
 
 
-class ScriptView(generic.ObjectView):
+class BaseScriptView(generic.ObjectView):
     queryset = Script.objects.all()
+
+    def _get_script_class(self, script):
+        script_class = script.python_class
+        if script_class:
+            script_class = script_class()
+
+        return script_class
+
+
+class ScriptView(BaseScriptView):
 
     def get(self, request, **kwargs):
         script = self.get_object(**kwargs)
-        script_class = script.python_class()
+        script_class = self._get_script_class(script)
+        if not script_class:
+            return render(request, 'extras/script.html', {
+                'script': script,
+            })
+
         form = script_class.as_form(initial=normalize_querydict(request.GET))
 
         return render(request, 'extras/script.html', {
@@ -1057,10 +1072,15 @@ class ScriptView(generic.ObjectView):
 
     def post(self, request, **kwargs):
         script = self.get_object(**kwargs)
-        script_class = script.python_class()
 
         if not request.user.has_perm('extras.run_script', obj=script):
             return HttpResponseForbidden()
+
+        script_class = self._get_script_class(script)
+        if not script_class:
+            return render(request, 'extras/script.html', {
+                'script': script,
+            })
 
         form = script_class.as_form(request.POST, request.FILES)
 
@@ -1091,21 +1111,22 @@ class ScriptView(generic.ObjectView):
         })
 
 
-class ScriptSourceView(generic.ObjectView):
+class ScriptSourceView(BaseScriptView):
     queryset = Script.objects.all()
 
     def get(self, request, **kwargs):
         script = self.get_object(**kwargs)
+        script_class = self._get_script_class(script)
 
         return render(request, 'extras/script/source.html', {
             'script': script,
-            'script_class': script.python_class(),
+            'script_class': script_class,
             'job_count': script.jobs.count(),
             'tab': 'source',
         })
 
 
-class ScriptJobsView(generic.ObjectView):
+class ScriptJobsView(BaseScriptView):
     queryset = Script.objects.all()
 
     def get(self, request, **kwargs):

--- a/netbox/templates/extras/script.html
+++ b/netbox/templates/extras/script.html
@@ -14,38 +14,43 @@
           {% trans "You do not have permission to run scripts" %}.
         </div>
       {% endif %}
-      <form action="" method="post" enctype="multipart/form-data" class="object-edit">
-        {% csrf_token %}
-        <div class="field-group my-4">
-          {# Render grouped fields according to declared fieldsets #}
-          {% for group, fields in script_class.get_fieldsets %}
-            {% if fields %}
-              <div class="field-group mb-5">
-                <div class="row">
-                  <h5 class="col-9 offset-3">{{ group }}</h5>
+      {% if form %}
+        <form action="" method="post" enctype="multipart/form-data" class="object-edit">
+          {% csrf_token %}
+          <div class="field-group my-4">
+            {# Render grouped fields according to declared fieldsets #}
+            {% for group, fields in script_class.get_fieldsets %}
+              {% if fields %}
+                <div class="field-group mb-5">
+                  <div class="row">
+                    <h5 class="col-9 offset-3">{{ group }}</h5>
+                  </div>
+                  {% for name in fields %}
+                    {% with field=form|getfield:name %}
+                      {% render_field field %}
+                    {% endwith %}
+                  {% endfor %}
                 </div>
-                {% for name in fields %}
-                  {% with field=form|getfield:name %}
-                    {% render_field field %}
-                  {% endwith %}
-                {% endfor %}
-              </div>
+              {% endif %}
+            {% endfor %}
+          </div>
+          <div class="text-end">
+            <a href="{% url 'extras:script_list' %}" class="btn btn-outline-secondary">{% trans "Cancel" %}</a>
+            {% if not request.user|can_run:script or not script.is_executable %}
+              <button class="btn btn-primary" disabled>
+                <i class="mdi mdi-play"></i> {% trans "Run Script" %}
+              </button>
+            {% else %}
+              <button type="submit" name="_run" class="btn btn-primary">
+                <i class="mdi mdi-play"></i> {% trans "Run Script" %}
+              </button>
             {% endif %}
-          {% endfor %}
-        </div>
-        <div class="text-end">
-          <a href="{% url 'extras:script_list' %}" class="btn btn-outline-secondary">{% trans "Cancel" %}</a>
-          {% if not request.user|can_run:script or not script.is_executable %}
-            <button class="btn btn-primary" disabled>
-              <i class="mdi mdi-play"></i> {% trans "Run Script" %}
-            </button>
-          {% else %}
-            <button type="submit" name="_run" class="btn btn-primary">
-              <i class="mdi mdi-play"></i> {% trans "Run Script" %}
-            </button>
-          {% endif %}
-        </div>
-      </form>
+          </div>
+        </form>
+      {% else %}
+          <p>{% trans "Error loading script" %}.</p>
+          <pre class="block">{{ script.module.error }}</pre>
+      {% endif %}
     </div>
   </div>
 {% endblock content %}

--- a/netbox/templates/extras/script/source.html
+++ b/netbox/templates/extras/script/source.html
@@ -1,6 +1,14 @@
 {% extends 'extras/script/base.html' %}
+{% load i18n %}
 
 {% block content %}
-  <code class="h6 my-3 d-block">{{ script_class.filename }}</code>
-  <pre class="block">{{ script_class.source }}</pre>
+
+  {% if script_class %}
+    <code class="h6 my-3 d-block">{{ script_class.filename }}</code>
+    <pre class="block">{{ script_class.source }}</pre>
+  {% else %}
+      <p>{% trans "Error loading script" %}.</p>
+      <pre class="block">{{ script.module.error }}</pre>
+  {% endif %}
+
 {% endblock %}


### PR DESCRIPTION
### Fixes: #15353 

Better error handling if the script module can't load (for example a syntax error).  Instead of crashing an error message of what error occurred is displayed.

![Monosnap NewBranchScript | NetBox 2024-03-14 15-07-39](https://github.com/netbox-community/netbox/assets/99642/fd8787fd-4f11-49cc-b0de-52935c10ae94)
