### PR TITLE
15193 use psycopg compiled

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,7 @@ mkdocstrings[python-legacy]==0.24.1
 netaddr==1.2.1
 nh3==0.2.15
 Pillow==10.2.0
-psycopg[binary,pool]==3.1.18
+psycopg[c,pool]==3.1.18
 PyYAML==6.0.1
 requests==2.31.0
 social-auth-app-django==5.4.0


### PR DESCRIPTION
### Fixes: #15193 

Switch to use the compiled (Local Installation)of psycopg (https://www.psycopg.org/psycopg3/docs/basic/install.html#local-installation)

Wasn't sure all what to test here, it installs and runs locally, also installs and runs on the github environment.  The required C packages to build should be installed from following the docs.