### PR TITLE
Fixes #15340: Fix flicker on page load with dark mode enabled

### DIFF
--- a/netbox/project-static/js/setmode.js
+++ b/netbox/project-static/js/setmode.js
@@ -5,10 +5,11 @@
  * @param inferred {boolean} Value is inferred from browser/system preference.
  */
 function setMode(mode, inferred) {
-    document.documentElement.setAttribute("data-netbox-color-mode", mode);
+    document.documentElement.setAttribute("data-bs-theme", mode);
     localStorage.setItem("netbox-color-mode", mode);
     localStorage.setItem("netbox-color-mode-inferred", inferred);
 }
+
 /**
  * Determine the best initial color mode to use prior to rendering.
  */
@@ -69,4 +70,4 @@ function initMode() {
         console.error(error);
     }
     return setMode("light", true);
-};
+}

--- a/netbox/templates/base/base.html
+++ b/netbox/templates/base/base.html
@@ -9,9 +9,7 @@
   data-netbox-url-name="{{ request.resolver_match.url_name }}"
   data-netbox-base-path="{{ settings.BASE_PATH }}"
   {% with preferences|get_key:'ui.colormode' as color_mode %}
-    {% if color_mode %}
-      data-netbox-color-mode="{{ color_mode }}"
-    {% endif %}
+    data-netbox-color-mode="{{ color_mode|default:"unset" }}"
   {% endwith %}
   >
   <head>

--- a/netbox/templates/base/base.html
+++ b/netbox/templates/base/base.html
@@ -9,12 +9,8 @@
   data-netbox-url-name="{{ request.resolver_match.url_name }}"
   data-netbox-base-path="{{ settings.BASE_PATH }}"
   {% with preferences|get_key:'ui.colormode' as color_mode %}
-    {% if color_mode == 'dark'%}
-      data-netbox-color-mode="dark"
-    {% elif color_mode == 'light' %}
-      data-netbox-color-mode="light"
-    {% else %}
-      data-netbox-color-mode="unset"
+    {% if color_mode %}
+      data-netbox-color-mode="{{ color_mode }}"
     {% endif %}
   {% endwith %}
   >
@@ -25,7 +21,16 @@
     {# Page title #}
     <title>{% block title %}{% trans "Home" %}{% endblock %} | NetBox</title>
 
+    {# Initialize color mode #}
+    <script
+      type="text/javascript"
+      src="{% static 'setmode.js' %}"
+      onerror="window.location='{% url 'media_failure' %}?filename=setmode.js'">
+    </script>
     <script type="text/javascript">
+      (function () {
+        initMode()
+      })();
       window.CSRF_TOKEN = "{{ csrf_token }}";
     </script>
 
@@ -53,13 +58,9 @@
 
     {# Additional <head> content #}
     {% block head %}{% endblock %}
-  </head>
 
-  <body
-    {% if preferences|get_key:'ui.colormode' == 'dark' %}
-      data-bs-theme="dark"
-    {% endif %}
-  >
+  </head>
+  <body>
 
     {# Page layout #}
     {% block layout %}{% endblock %}


### PR DESCRIPTION
### Fixes: #15340

- Call `initMode()` on page load
- Set `data-bs-theme` attribute on `<html>` element