### PR TITLE
Closes #15339: Consume entire viewport

### DIFF
--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -73,7 +73,6 @@ class ObjectView(BaseObjectView):
         return render(request, self.get_template_name(), {
             'object': instance,
             'tab': self.tab,
-            'page_width': 'xl',
             **self.get_extra_context(request, instance),
         })
 

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -73,6 +73,7 @@ class ObjectView(BaseObjectView):
         return render(request, self.get_template_name(), {
             'object': instance,
             'tab': self.tab,
+            'page_width': 'xl',
             **self.get_extra_context(request, instance),
         })
 

--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -41,7 +41,7 @@ Blocks:
 
     {# Top menu #}
     <header class="navbar navbar-expand-md d-none d-lg-flex d-print-none">
-      <div class="container-xl">
+      <div class="container-{{ page_width|default:"fluid" }}">
 
         {# Nav menu toggle #}
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false" aria-label="Toggle navigation">
@@ -105,7 +105,7 @@ Blocks:
       {# Page body #}
       {% block page %}
         <div class="page-body my-1">
-          <div class="container-xl tab-content py-3">
+          <div class="container-{{ page_width|default:"fluid" }} tab-content py-3">
 
             {# Page content #}
             {% block content %}{% endblock %}
@@ -124,7 +124,7 @@ Blocks:
 
       {# Page footer #}
       <footer class="footer footer-transparent d-print-none py-2">
-        <div class="container-xl d-flex justify-content-between align-items-center">
+        <div class="container-{{ page_width|default:"fluid" }} d-flex justify-content-between align-items-center">
           {% block footer %}
 
             {# Footer links #}

--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -41,7 +41,7 @@ Blocks:
 
     {# Top menu #}
     <header class="navbar navbar-expand-md d-none d-lg-flex d-print-none">
-      <div class="container-{{ page_width|default:"fluid" }}">
+      <div class="container-fluid">
 
         {# Nav menu toggle #}
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar-menu" aria-controls="navbar-menu" aria-expanded="false" aria-label="Toggle navigation">
@@ -105,7 +105,7 @@ Blocks:
       {# Page body #}
       {% block page %}
         <div class="page-body my-1">
-          <div class="container-{{ page_width|default:"fluid" }} tab-content py-3">
+          <div class="container-fluid tab-content py-3">
 
             {# Page content #}
             {% block content %}{% endblock %}
@@ -124,7 +124,7 @@ Blocks:
 
       {# Page footer #}
       <footer class="footer footer-transparent d-print-none py-2">
-        <div class="container-{{ page_width|default:"fluid" }} d-flex justify-content-between align-items-center">
+        <div class="container-fluid d-flex justify-content-between align-items-center">
           {% block footer %}
 
             {# Footer links #}

--- a/netbox/templates/core/rq_task_list.html
+++ b/netbox/templates/core/rq_task_list.html
@@ -5,7 +5,7 @@
 {% load render_table from django_tables2 %}
 
 {% block page-header %}
-  <div class="container-xl">
+  <div class="container-fluid">
     <div class="d-flex justify-content-between align-items-center mt-2">
       {# Breadcrumbs #}
       <nav class="breadcrumb-container" aria-label="breadcrumb">

--- a/netbox/templates/core/rq_worker_list.html
+++ b/netbox/templates/core/rq_worker_list.html
@@ -4,7 +4,7 @@
 {% load render_table from django_tables2 %}
 
 {% block page-header %}
-  <div class="container-xl">
+  <div class="container-fluid">
     <div class="d-flex justify-content-between align-items-center mt-2">
       {# Breadcrumbs #}
       <nav class="breadcrumb-container" aria-label="breadcrumb">

--- a/netbox/templates/extras/script_result.html
+++ b/netbox/templates/extras/script_result.html
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block page-header %}
-  <div class="container-xl mt-2">
+  <div class="container-fluid mt-2">
     <nav class="breadcrumb-container" aria-label="breadcrumb">
       <ol class="breadcrumb">
         <li class="breadcrumb-item"><a href="{% url 'extras:script_list' %}">{% trans "Scripts" %}</a></li>

--- a/netbox/templates/generic/_base.html
+++ b/netbox/templates/generic/_base.html
@@ -5,7 +5,7 @@
     {{ block.super }}
 
     {% block page-header %}
-      <div class="container-{{ page_width|default:"fluid" }} mt-2 d-print-none">
+      <div class="container-fluid mt-2 d-print-none">
         <div class="d-flex justify-content-between">
 
           {# Title #}
@@ -29,7 +29,7 @@
 
     {# Tabs #}
     <div class="page-tabs mt-3">
-      <div class="container-{{ page_width|default:"fluid" }}">
+      <div class="container-fluid">
         {% block tabs %}{% endblock %}
       </div>
     </div>

--- a/netbox/templates/generic/_base.html
+++ b/netbox/templates/generic/_base.html
@@ -5,7 +5,7 @@
     {{ block.super }}
 
     {% block page-header %}
-      <div class="container-xl mt-2 d-print-none">
+      <div class="container-{{ page_width|default:"fluid" }} mt-2 d-print-none">
         <div class="d-flex justify-content-between">
 
           {# Title #}
@@ -29,7 +29,7 @@
 
     {# Tabs #}
     <div class="page-tabs mt-3">
-      <div class="container-xl">
+      <div class="container-{{ page_width|default:"fluid" }}">
         {% block tabs %}{% endblock %}
       </div>
     </div>

--- a/netbox/templates/generic/bulk_delete.html
+++ b/netbox/templates/generic/bulk_delete.html
@@ -71,7 +71,7 @@ Context:
   {# Selected objects list #}
   <div class="tab-pane" id="object-list" role="tabpanel" aria-labelledby="object-list-tab">
     <div class="card">
-      <div class="card-body table-responsive">
+      <div class="table-responsive">
         {% render_table table 'inc/table.html' %}
       </div>
     </div>

--- a/netbox/templates/generic/bulk_remove.html
+++ b/netbox/templates/generic/bulk_remove.html
@@ -33,9 +33,11 @@
         </div>
       </div>
     </div>
-    <div class="container-xl px-0">
-      <div class="table-responsive">
-        {% render_table table 'inc/table.html' %}
+    <div class="container-fluid px-0">
+      <div class="card">
+        <div class="table-responsive">
+          {% render_table table 'inc/table.html' %}
+        </div>
       </div>
       <form action="." method="post" class="form">
         {% csrf_token %}

--- a/netbox/templates/generic/object.html
+++ b/netbox/templates/generic/object.html
@@ -19,7 +19,7 @@ Context:
 {% endcomment %}
 
 {% block page-header %}
-  <div class="container-{{ page_width|default:"fluid" }}">
+  <div class="container-fluid">
     <div class="d-flex justify-content-between align-items-center mt-2">
 
       {# Breadcrumbs #}

--- a/netbox/templates/generic/object.html
+++ b/netbox/templates/generic/object.html
@@ -19,7 +19,7 @@ Context:
 {% endcomment %}
 
 {% block page-header %}
-  <div class="container-xl">
+  <div class="container-{{ page_width|default:"fluid" }}">
     <div class="d-flex justify-content-between align-items-center mt-2">
 
       {# Breadcrumbs #}


### PR DESCRIPTION
### Fixes: #15339

- Tweak the base templates to render to the full width of the viewport ("fluid") by default
- Introduce the `page_width` context variable to override this for object detail views

I'm not super happy with this solution, but it seems the only feasible choice without upending our entire template structure.