### PR TITLE
Closes #15490: CustomValidator support for accessing related object attribute via dotted path

### DIFF
--- a/netbox/extras/validators.py
+++ b/netbox/extras/validators.py
@@ -151,13 +151,13 @@ class CustomValidator:
             return []
 
         # Raise a ValidationError for unknown attributes
-        if not hasattr(instance, name):
+        try:
+            return operator.attrgetter(name)(instance)
+        except AttributeError:
             raise ValidationError(_('Invalid attribute "{name}" for {model}').format(
                 name=name,
                 model=instance.__class__.__name__
             ))
-
-        return getattr(instance, name)
 
     def get_validator(self, descriptor, value):
         """


### PR DESCRIPTION
### Fixes: #15490

- Use `operator.attrgetter` to reference attributes of related objects by dotted path
- Rename `extras/tests/test_customvalidation.py` to avoid confusion with `test_custom_validation.py`
- Add a test for validating related object attributes