### PR TITLE
Fix #15506 Update documentation for plugins index.md

### DIFF
--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -82,7 +82,7 @@ Plugins may package static files to be served directly by the HTTP front end. En
 
 ### Restart WSGI Service
 
-Restart the WSGI service to load the new plugin and restart rqworkers for using plugin in custom scripts:
+Restart the WSGI service and RQ workers to load the new plugin:
 
 ```no-highlight
 # sudo systemctl restart netbox netbox-rq

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -82,10 +82,10 @@ Plugins may package static files to be served directly by the HTTP front end. En
 
 ### Restart WSGI Service
 
-Restart the WSGI service to load the new plugin:
+Restart the WSGI service to load the new plugin and restart rqworkers for using plugin in custom scripts:
 
 ```no-highlight
-# sudo systemctl restart netbox
+# sudo systemctl restart netbox netbox-rq
 ```
 
 ## Removing Plugins


### PR DESCRIPTION
### Fixes: #15506

This commit improves documentation for using plugins: You should restart netbox-rq workers if you added a plugin. Otherwise you can't load modules from plugin to custom scripts later.
