### PR TITLE
15532 fix autotype_decorator for method fields

### DIFF
--- a/netbox/netbox/graphql/filter_mixins.py
+++ b/netbox/netbox/graphql/filter_mixins.py
@@ -4,6 +4,7 @@ from typing import List
 import django_filters
 import strawberry
 import strawberry_django
+from django.core.exceptions import FieldDoesNotExist
 from strawberry import auto
 from ipam.fields import ASNField
 from netbox.graphql.scalars import BigInt
@@ -164,7 +165,11 @@ def autotype_decorator(filterset):
             should_create_function = False
             attr_type = auto
             if fieldname not in cls.__annotations__:
-                field = model._meta.get_field(fieldname)
+                try:
+                    field = model._meta.get_field(fieldname)
+                except FieldDoesNotExist:
+                    continue
+
                 if isinstance(field, CounterCacheField):
                     should_create_function = True
                     attr_type = BigInt | None


### PR DESCRIPTION
### Fixes: #15532 

Fixes the case found in migrating the DNS plugin to NB 4 where an annotated field was declared (therefore not appearing in the model) and filtered on.  This causes an error as the current code expects fields to be in the model definition. 

Fix is to skip any undefined fields, they will need to be explicitly defined in the GraphQL filter class.