### PR TITLE
15553 change graphql sub-queries from functions to types

### DIFF
--- a/netbox/circuits/graphql/types.py
+++ b/netbox/circuits/graphql/types.py
@@ -27,21 +27,10 @@ __all__ = (
 )
 class ProviderType(NetBoxObjectType, ContactsMixin):
 
-    @strawberry_django.field
-    def networks(self) -> List[Annotated["ProviderNetworkType", strawberry.lazy('circuits.graphql.types')]]:
-        return self.networks.all()
-
-    @strawberry_django.field
-    def circuits(self) -> List[Annotated["CircuitType", strawberry.lazy('circuits.graphql.types')]]:
-        return self.circuits.all()
-
-    @strawberry_django.field
-    def asns(self) -> List[Annotated["ASNType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.asns.all()
-
-    @strawberry_django.field
-    def accounts(self) -> List[Annotated["ProviderAccountType", strawberry.lazy('circuits.graphql.types')]]:
-        return self.accounts.all()
+    networks: List[Annotated["ProviderNetworkType", strawberry.lazy('circuits.graphql.types')]]
+    circuits: List[Annotated["CircuitType", strawberry.lazy('circuits.graphql.types')]]
+    asns: List[Annotated["ASNType", strawberry.lazy('ipam.graphql.types')]]
+    accounts: List[Annotated["ProviderAccountType", strawberry.lazy('circuits.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -52,9 +41,7 @@ class ProviderType(NetBoxObjectType, ContactsMixin):
 class ProviderAccountType(NetBoxObjectType):
     provider: Annotated["ProviderType", strawberry.lazy('circuits.graphql.types')]
 
-    @strawberry_django.field
-    def circuits(self) -> List[Annotated["CircuitType", strawberry.lazy('circuits.graphql.types')]]:
-        return self.circuits.all()
+    circuits: List[Annotated["CircuitType", strawberry.lazy('circuits.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -65,9 +52,7 @@ class ProviderAccountType(NetBoxObjectType):
 class ProviderNetworkType(NetBoxObjectType):
     provider: Annotated["ProviderType", strawberry.lazy('circuits.graphql.types')]
 
-    @strawberry_django.field
-    def circuit_terminations(self) -> List[Annotated["CircuitTerminationType", strawberry.lazy('circuits.graphql.types')]]:
-        return self.circuit_terminations.all()
+    circuit_terminations: List[Annotated["CircuitTerminationType", strawberry.lazy('circuits.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -89,9 +74,7 @@ class CircuitTerminationType(CustomFieldsMixin, TagsMixin, CabledObjectMixin, Ob
 class CircuitTypeType(OrganizationalObjectType):
     color: str
 
-    @strawberry_django.field
-    def circuits(self) -> List[Annotated["CircuitType", strawberry.lazy('circuits.graphql.types')]]:
-        return self.circuits.all()
+    circuits: List[Annotated["CircuitType", strawberry.lazy('circuits.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -107,6 +90,4 @@ class CircuitType(NetBoxObjectType, ContactsMixin):
     type: CircuitTypeType
     tenant: TenantType | None
 
-    @strawberry_django.field
-    def terminations(self) -> List[CircuitTerminationType]:
-        return self.terminations.all()
+    terminations: List[CircuitTerminationType]

--- a/netbox/core/graphql/types.py
+++ b/netbox/core/graphql/types.py
@@ -29,6 +29,4 @@ class DataFileType(BaseObjectType):
 )
 class DataSourceType(NetBoxObjectType):
 
-    @strawberry_django.field
-    def datafiles(self) -> List[Annotated["DataFileType", strawberry.lazy('core.graphql.types')]]:
-        return self.datafiles.all()
+    datafiles: List[Annotated["DataFileType", strawberry.lazy('core.graphql.types')]]

--- a/netbox/dcim/graphql/mixins.py
+++ b/netbox/dcim/graphql/mixins.py
@@ -13,8 +13,7 @@ __all__ = (
 class CabledObjectMixin:
     cable: Annotated["CableType", strawberry.lazy('dcim.graphql.types')] | None
 
-    @strawberry_django.field
-    def link_peers(self) -> List[Annotated[Union[
+    link_peers: List[Annotated[Union[
         Annotated["CircuitTerminationType", strawberry.lazy('circuits.graphql.types')],
         Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')],
@@ -24,15 +23,13 @@ class CabledObjectMixin:
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("LinkPeerType")]]:
-        return self.link_peers
+    ], strawberry.union("LinkPeerType")]]
 
 
 @strawberry.type
 class PathEndpointMixin:
 
-    @strawberry_django.field
-    def connected_endpoints(self) -> List[Annotated[Union[
+    connected_endpoints: List[Annotated[Union[
         Annotated["CircuitTerminationType", strawberry.lazy('circuits.graphql.types')],
         Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')],
@@ -43,5 +40,4 @@ class PathEndpointMixin:
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["ProviderNetworkType", strawberry.lazy('circuits.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("ConnectedEndpointType")]]:
-        return self.connected_endpoints or None
+    ], strawberry.union("ConnectedEndpointType")]]

--- a/netbox/dcim/graphql/types.py
+++ b/netbox/dcim/graphql/types.py
@@ -120,7 +120,7 @@ class ModularComponentTemplateType(ComponentTemplateType):
 )
 class CableTerminationType(NetBoxObjectType):
 
-    termination: List[Annotated[Union[
+    termination: Annotated[Union[
         Annotated["CircuitTerminationType", strawberry.lazy('circuits.graphql.types')],
         Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')],
@@ -130,7 +130,7 @@ class CableTerminationType(NetBoxObjectType):
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("CableTerminationTerminationType")]]
+    ], strawberry.union("CableTerminationTerminationType")]
 
 
 @strawberry_django.type(
@@ -294,7 +294,7 @@ class InventoryItemTemplateType(ComponentTemplateType):
 
     child_items: List[Annotated["InventoryItemTemplateType", strawberry.lazy('dcim.graphql.types')]]
 
-    component: List[Annotated[Union[
+    component: Annotated[Union[
         Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["FrontPortType", strawberry.lazy('dcim.graphql.types')],
@@ -302,7 +302,7 @@ class InventoryItemTemplateType(ComponentTemplateType):
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("InventoryItemTemplateComponentType")]]
+    ], strawberry.union("InventoryItemTemplateComponentType")]
 
 
 @strawberry_django.type(
@@ -423,7 +423,7 @@ class InventoryItemType(ComponentType):
     def parent(self) -> Annotated["InventoryItemType", strawberry.lazy('dcim.graphql.types')] | None:
         return self.parent
 
-    component: List[Annotated[Union[
+    component: Annotated[Union[
         Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["FrontPortType", strawberry.lazy('dcim.graphql.types')],
@@ -431,7 +431,7 @@ class InventoryItemType(ComponentType):
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("InventoryItemComponentType")]]
+    ], strawberry.union("InventoryItemComponentType")]
 
 
 @strawberry_django.type(

--- a/netbox/dcim/graphql/types.py
+++ b/netbox/dcim/graphql/types.py
@@ -120,8 +120,7 @@ class ModularComponentTemplateType(ComponentTemplateType):
 )
 class CableTerminationType(NetBoxObjectType):
 
-    @strawberry_django.field
-    def termination(self) -> List[Annotated[Union[
+    termination: List[Annotated[Union[
         Annotated["CircuitTerminationType", strawberry.lazy('circuits.graphql.types')],
         Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')],
@@ -131,8 +130,7 @@ class CableTerminationType(NetBoxObjectType):
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("CableTerminationTerminationType")]]:
-        return self.termination
+    ], strawberry.union("CableTerminationTerminationType")]]
 
 
 @strawberry_django.type(
@@ -144,12 +142,9 @@ class CableType(NetBoxObjectType):
     color: str
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
 
-    @strawberry_django.field
-    def terminations(self) -> List[CableTerminationType]:
-        return self.terminations.all()
+    terminations: List[CableTerminationType]
 
-    @strawberry_django.field
-    def a_terminations(self) -> List[Annotated[Union[
+    a_terminations: List[Annotated[Union[
         Annotated["CircuitTerminationType", strawberry.lazy('circuits.graphql.types')],
         Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')],
@@ -159,11 +154,9 @@ class CableType(NetBoxObjectType):
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("CableTerminationTerminationType")]]:
-        return self.a_terminations
+    ], strawberry.union("CableTerminationTerminationType")]]
 
-    @strawberry_django.field
-    def b_terminations(self) -> List[Annotated[Union[
+    b_terminations: List[Annotated[Union[
         Annotated["CircuitTerminationType", strawberry.lazy('circuits.graphql.types')],
         Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')],
@@ -173,8 +166,7 @@ class CableType(NetBoxObjectType):
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("CableTerminationTerminationType")]]:
-        return self.b_terminations
+    ], strawberry.union("CableTerminationTerminationType")]]
 
 
 @strawberry_django.type(
@@ -244,69 +236,28 @@ class DeviceType(ConfigContextMixin, ImageAttachmentsMixin, ContactsMixin, NetBo
     cluster: Annotated["ClusterType", strawberry.lazy('virtualization.graphql.types')] | None
     virtual_chassis: Annotated["VirtualChassisType", strawberry.lazy('dcim.graphql.types')] | None
 
+    virtual_machines: List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]
+    modules: List[Annotated["ModuleType", strawberry.lazy('dcim.graphql.types')]]
+    interfaces: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
+    rearports: List[Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')]]
+    consoleports: List[Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')]]
+    powerports: List[Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')]]
+    cabletermination_set: List[Annotated["CableTerminationType", strawberry.lazy('dcim.graphql.types')]]
+    consoleserverports: List[Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')]]
+    poweroutlets: List[Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')]]
+    frontports: List[Annotated["FrontPortType", strawberry.lazy('dcim.graphql.types')]]
+    modulebays: List[Annotated["ModuleBayType", strawberry.lazy('dcim.graphql.types')]]
+    services: List[Annotated["ServiceType", strawberry.lazy('ipam.graphql.types')]]
+    inventoryitems: List[Annotated["InventoryItemType", strawberry.lazy('dcim.graphql.types')]]
+    vdcs: List[Annotated["VirtualDeviceContextType", strawberry.lazy('dcim.graphql.types')]]
+
     @strawberry_django.field
     def vc_master_for(self) -> Annotated["VirtualChassisType", strawberry.lazy('dcim.graphql.types')] | None:
         return self.vc_master_for if hasattr(self, 'vc_master_for') else None
 
     @strawberry_django.field
-    def virtual_machines(self) -> List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.virtual_machines.all()
-
-    @strawberry_django.field
-    def modules(self) -> List[Annotated["ModuleType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.modules.all()
-
-    @strawberry_django.field
     def parent_bay(self) -> Annotated["DeviceBayType", strawberry.lazy('dcim.graphql.types')] | None:
         return self.parent_bay if hasattr(self, 'parent_bay') else None
-
-    @strawberry_django.field
-    def interfaces(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.interfaces.all()
-
-    @strawberry_django.field
-    def rearports(self) -> List[Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.rearports.all()
-
-    @strawberry_django.field
-    def consoleports(self) -> List[Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.consoleports.all()
-
-    @strawberry_django.field
-    def powerports(self) -> List[Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.powerports.all()
-
-    @strawberry_django.field
-    def cabletermination_set(self) -> List[Annotated["CableTerminationType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.cabletermination_set.all()
-
-    @strawberry_django.field
-    def consoleserverports(self) -> List[Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.consoleserverports.all()
-
-    @strawberry_django.field
-    def poweroutlets(self) -> List[Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.poweroutlets.all()
-
-    @strawberry_django.field
-    def frontports(self) -> List[Annotated["FrontPortType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.frontports.all()
-
-    @strawberry_django.field
-    def modulebays(self) -> List[Annotated["ModuleBayType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.modulebays.all()
-
-    @strawberry_django.field
-    def services(self) -> List[Annotated["ServiceType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.services.all()
-
-    @strawberry_django.field
-    def inventoryitems(self) -> List[Annotated["InventoryItemType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.inventoryitems.all()
-
-    @strawberry_django.field
-    def vdcs(self) -> List[Annotated["VirtualDeviceContextType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.vdcs.all()
 
 
 @strawberry_django.type(
@@ -341,12 +292,9 @@ class InventoryItemTemplateType(ComponentTemplateType):
     def parent(self) -> Annotated["InventoryItemTemplateType", strawberry.lazy('dcim.graphql.types')] | None:
         return self.parent
 
-    @strawberry_django.field
-    def child_items(self) -> List[Annotated["InventoryItemTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.child_items.all()
+    child_items: List[Annotated["InventoryItemTemplateType", strawberry.lazy('dcim.graphql.types')]]
 
-    @strawberry_django.field
-    def component(self) -> List[Annotated[Union[
+    component: List[Annotated[Union[
         Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["FrontPortType", strawberry.lazy('dcim.graphql.types')],
@@ -354,8 +302,7 @@ class InventoryItemTemplateType(ComponentTemplateType):
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("InventoryItemTemplateComponentType")]]:
-        return self.component
+    ], strawberry.union("InventoryItemTemplateComponentType")]]
 
 
 @strawberry_django.type(
@@ -367,13 +314,8 @@ class DeviceRoleType(OrganizationalObjectType):
     color: str
     config_template: Annotated["ConfigTemplateType", strawberry.lazy('extras.graphql.types')] | None
 
-    @strawberry_django.field
-    def virtual_machines(self) -> List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.virtual_machines.all()
-
-    @strawberry_django.field
-    def devices(self) -> List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.devices.all()
+    virtual_machines: List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]
+    devices: List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -397,49 +339,17 @@ class DeviceTypeType(NetBoxObjectType):
     manufacturer: Annotated["ManufacturerType", strawberry.lazy('dcim.graphql.types')]
     default_platform: Annotated["PlatformType", strawberry.lazy('dcim.graphql.types')] | None
 
-    @strawberry_django.field
-    def frontporttemplates(self) -> List[Annotated["FrontPortTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.frontporttemplates.all()
-
-    @strawberry_django.field
-    def modulebaytemplates(self) -> List[Annotated["ModuleBayTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.modulebaytemplates.all()
-
-    @strawberry_django.field
-    def instances(self) -> List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.instances.all()
-
-    @strawberry_django.field
-    def poweroutlettemplates(self) -> List[Annotated["PowerOutletTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.poweroutlettemplates.all()
-
-    @strawberry_django.field
-    def powerporttemplates(self) -> List[Annotated["PowerPortTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.powerporttemplates.all()
-
-    @strawberry_django.field
-    def inventoryitemtemplates(self) -> List[Annotated["InventoryItemTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.inventoryitemtemplates.all()
-
-    @strawberry_django.field
-    def rearporttemplates(self) -> List[Annotated["RearPortTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.rearporttemplates.all()
-
-    @strawberry_django.field
-    def consoleserverporttemplates(self) -> List[Annotated["ConsoleServerPortTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.consoleserverporttemplates.all()
-
-    @strawberry_django.field
-    def interfacetemplates(self) -> List[Annotated["InterfaceTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.interfacetemplates.all()
-
-    @strawberry_django.field
-    def devicebaytemplates(self) -> List[Annotated["DeviceBayTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.devicebaytemplates.all()
-
-    @strawberry_django.field
-    def consoleporttemplates(self) -> List[Annotated["ConsolePortTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.consoleporttemplates.all()
+    frontporttemplates: List[Annotated["FrontPortTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    modulebaytemplates: List[Annotated["ModuleBayTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    instances: List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]
+    poweroutlettemplates: List[Annotated["PowerOutletTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    powerporttemplates: List[Annotated["PowerPortTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    inventoryitemtemplates: List[Annotated["InventoryItemTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    rearporttemplates: List[Annotated["RearPortTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    consoleserverporttemplates: List[Annotated["ConsoleServerPortTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    interfacetemplates: List[Annotated["InterfaceTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    devicebaytemplates: List[Annotated["DeviceBayTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    consoleporttemplates: List[Annotated["ConsolePortTemplateType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -478,29 +388,12 @@ class InterfaceType(IPAddressesMixin, ModularComponentType, CabledObjectMixin, P
     untagged_vlan: Annotated["VLANType", strawberry.lazy('ipam.graphql.types')] | None
     vrf: Annotated["VRFType", strawberry.lazy('ipam.graphql.types')] | None
 
-    @strawberry_django.field
-    def vdcs(self) -> List[Annotated["VirtualDeviceContextType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.vdcs.all()
-
-    @strawberry_django.field
-    def tagged_vlans(self) -> List[Annotated["VLANType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.tagged_vlans.all()
-
-    @strawberry_django.field
-    def bridge_interfaces(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.bridge_interfaces.all()
-
-    @strawberry_django.field
-    def wireless_lans(self) -> List[Annotated["WirelessLANType", strawberry.lazy('wireless.graphql.types')]]:
-        return self.wireless_lans.all()
-
-    @strawberry_django.field
-    def member_interfaces(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.member_interfaces.all()
-
-    @strawberry_django.field
-    def child_interfaces(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.child_interfaces.all()
+    vdcs: List[Annotated["VirtualDeviceContextType", strawberry.lazy('dcim.graphql.types')]]
+    tagged_vlans: List[Annotated["VLANType", strawberry.lazy('ipam.graphql.types')]]
+    bridge_interfaces: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
+    wireless_lans: List[Annotated["WirelessLANType", strawberry.lazy('wireless.graphql.types')]]
+    member_interfaces: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
+    child_interfaces: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -512,9 +405,7 @@ class InterfaceTemplateType(ModularComponentTemplateType):
     _name: str
     bridge: Annotated["InterfaceTemplateType", strawberry.lazy('dcim.graphql.types')] | None
 
-    @strawberry_django.field
-    def bridge_interfaces(self) -> List[Annotated["InterfaceTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.bridge_interfaces.all()
+    bridge_interfaces: List[Annotated["InterfaceTemplateType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -526,16 +417,13 @@ class InventoryItemType(ComponentType):
     role: Annotated["InventoryItemRoleType", strawberry.lazy('dcim.graphql.types')] | None
     manufacturer: Annotated["ManufacturerType", strawberry.lazy('dcim.graphql.types')]
 
+    child_items: List[Annotated["InventoryItemType", strawberry.lazy('dcim.graphql.types')]]
+
     @strawberry_django.field
     def parent(self) -> Annotated["InventoryItemType", strawberry.lazy('dcim.graphql.types')] | None:
         return self.parent
 
-    @strawberry_django.field
-    def child_items(self) -> List[Annotated["InventoryItemType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.child_items.all()
-
-    @strawberry_django.field
-    def component(self) -> List[Annotated[Union[
+    component: List[Annotated[Union[
         Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["FrontPortType", strawberry.lazy('dcim.graphql.types')],
@@ -543,8 +431,7 @@ class InventoryItemType(ComponentType):
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("InventoryItemComponentType")]]:
-        return self.component
+    ], strawberry.union("InventoryItemComponentType")]]
 
 
 @strawberry_django.type(
@@ -555,13 +442,8 @@ class InventoryItemType(ComponentType):
 class InventoryItemRoleType(OrganizationalObjectType):
     color: str
 
-    @strawberry_django.field
-    def inventory_items(self) -> List[Annotated["InventoryItemType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.inventory_items.all()
-
-    @strawberry_django.field
-    def inventory_item_templates(self) -> List[Annotated["InventoryItemTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.inventory_item_templates.all()
+    inventory_items: List[Annotated["InventoryItemType", strawberry.lazy('dcim.graphql.types')]]
+    inventory_item_templates: List[Annotated["InventoryItemTemplateType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -575,25 +457,11 @@ class LocationType(VLANGroupsMixin, ImageAttachmentsMixin, ContactsMixin, Organi
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
     parent: Annotated["LocationType", strawberry.lazy('dcim.graphql.types')] | None
 
-    @strawberry_django.field
-    def powerpanel_set(self) -> List[Annotated["PowerPanelType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.powerpanel_set.all()
-
-    @strawberry_django.field
-    def cabletermination_set(self) -> List[Annotated["CableTerminationType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.cabletermination_set.all()
-
-    @strawberry_django.field
-    def racks(self) -> List[Annotated["RackType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.racks.all()
-
-    @strawberry_django.field
-    def devices(self) -> List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.devices.all()
-
-    @strawberry_django.field
-    def children(self) -> List[Annotated["LocationType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.children.all()
+    powerpanel_set: List[Annotated["PowerPanelType", strawberry.lazy('dcim.graphql.types')]]
+    cabletermination_set: List[Annotated["CableTerminationType", strawberry.lazy('dcim.graphql.types')]]
+    racks: List[Annotated["RackType", strawberry.lazy('dcim.graphql.types')]]
+    devices: List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]
+    children: List[Annotated["LocationType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -603,25 +471,11 @@ class LocationType(VLANGroupsMixin, ImageAttachmentsMixin, ContactsMixin, Organi
 )
 class ManufacturerType(OrganizationalObjectType, ContactsMixin):
 
-    @strawberry_django.field
-    def platforms(self) -> List[Annotated["PlatformType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.platforms.all()
-
-    @strawberry_django.field
-    def device_types(self) -> List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.device_types.all()
-
-    @strawberry_django.field
-    def inventory_item_templates(self) -> List[Annotated["InventoryItemTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.inventory_item_templates.all()
-
-    @strawberry_django.field
-    def inventory_items(self) -> List[Annotated["InventoryItemType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.inventory_items.all()
-
-    @strawberry_django.field
-    def module_types(self) -> List[Annotated["ModuleType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.module_types.all()
+    platforms: List[Annotated["PlatformType", strawberry.lazy('dcim.graphql.types')]]
+    device_types: List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]
+    inventory_item_templates: List[Annotated["InventoryItemTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    inventory_items: List[Annotated["InventoryItemType", strawberry.lazy('dcim.graphql.types')]]
+    module_types: List[Annotated["ModuleType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -634,33 +488,13 @@ class ModuleType(NetBoxObjectType):
     module_bay: Annotated["ModuleBayType", strawberry.lazy('dcim.graphql.types')]
     module_type: Annotated["ModuleTypeType", strawberry.lazy('dcim.graphql.types')]
 
-    @strawberry_django.field
-    def interfaces(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.interfaces.all()
-
-    @strawberry_django.field
-    def powerports(self) -> List[Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.powerports.all()
-
-    @strawberry_django.field
-    def consoleserverports(self) -> List[Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.consoleserverports.all()
-
-    @strawberry_django.field
-    def consoleports(self) -> List[Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.consoleports.all()
-
-    @strawberry_django.field
-    def poweroutlets(self) -> List[Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.poweroutlets.all()
-
-    @strawberry_django.field
-    def rearports(self) -> List[Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.rearports.all()
-
-    @strawberry_django.field
-    def frontports(self) -> List[Annotated["FrontPortType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.frontports.all()
+    interfaces: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
+    powerports: List[Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')]]
+    consoleserverports: List[Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')]]
+    consoleports: List[Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')]]
+    poweroutlets: List[Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')]]
+    rearports: List[Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')]]
+    frontports: List[Annotated["FrontPortType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -670,9 +504,7 @@ class ModuleType(NetBoxObjectType):
 )
 class ModuleBayType(ComponentType):
 
-    @strawberry_django.field
-    def installed_module(self) -> Annotated["ModuleType", strawberry.lazy('dcim.graphql.types')] | None:
-        return self.installed_module if hasattr(self, 'installed_module') else None
+    installed_module: Annotated["ModuleType", strawberry.lazy('dcim.graphql.types')] | None
 
 
 @strawberry_django.type(
@@ -692,37 +524,14 @@ class ModuleBayTemplateType(ComponentTemplateType):
 class ModuleTypeType(NetBoxObjectType):
     manufacturer: Annotated["ManufacturerType", strawberry.lazy('dcim.graphql.types')]
 
-    @strawberry_django.field
-    def frontporttemplates(self) -> List[Annotated["FrontPortTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.frontporttemplates.all()
-
-    @strawberry_django.field
-    def consoleserverporttemplates(self) -> List[Annotated["ConsoleServerPortTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.consoleserverporttemplates.all()
-
-    @strawberry_django.field
-    def interfacetemplates(self) -> List[Annotated["InterfaceTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.interfacetemplates.all()
-
-    @strawberry_django.field
-    def powerporttemplates(self) -> List[Annotated["PowerOutletTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.powerporttemplates.all()
-
-    @strawberry_django.field
-    def poweroutlettemplates(self) -> List[Annotated["PowerOutletTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.poweroutlettemplates.all()
-
-    @strawberry_django.field
-    def rearporttemplates(self) -> List[Annotated["RearPortTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.rearporttemplates.all()
-
-    @strawberry_django.field
-    def instances(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.instances.all()
-
-    @strawberry_django.field
-    def consoleporttemplates(self) -> List[Annotated["ModuleType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.consoleporttemplates.all()
+    frontporttemplates: List[Annotated["FrontPortTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    consoleserverporttemplates: List[Annotated["ConsoleServerPortTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    interfacetemplates: List[Annotated["InterfaceTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    powerporttemplates: List[Annotated["PowerOutletTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    poweroutlettemplates: List[Annotated["PowerOutletTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    rearporttemplates: List[Annotated["RearPortTemplateType", strawberry.lazy('dcim.graphql.types')]]
+    instances: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
+    consoleporttemplates: List[Annotated["ModuleType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -734,13 +543,8 @@ class PlatformType(OrganizationalObjectType):
     manufacturer: Annotated["ManufacturerType", strawberry.lazy('dcim.graphql.types')] | None
     config_template: Annotated["ConfigTemplateType", strawberry.lazy('extras.graphql.types')] | None
 
-    @strawberry_django.field
-    def virtual_machines(self) -> List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.virtual_machines.all()
-
-    @strawberry_django.field
-    def devices(self) -> List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.devices.all()
+    virtual_machines: List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]
+    devices: List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -782,9 +586,7 @@ class PowerPanelType(NetBoxObjectType, ContactsMixin):
     site: Annotated["SiteType", strawberry.lazy('dcim.graphql.types')]
     location: Annotated["LocationType", strawberry.lazy('dcim.graphql.types')] | None
 
-    @strawberry_django.field
-    def powerfeeds(self) -> List[Annotated["PowerFeedType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.powerfeeds.all()
+    powerfeeds: List[Annotated["PowerFeedType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -794,9 +596,7 @@ class PowerPanelType(NetBoxObjectType, ContactsMixin):
 )
 class PowerPortType(ModularComponentType, CabledObjectMixin, PathEndpointMixin):
 
-    @strawberry_django.field
-    def poweroutlets(self) -> List[Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.poweroutlets.all()
+    poweroutlets: List[Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -807,9 +607,7 @@ class PowerPortType(ModularComponentType, CabledObjectMixin, PathEndpointMixin):
 class PowerPortTemplateType(ModularComponentTemplateType):
     _name: str
 
-    @strawberry_django.field
-    def poweroutlet_templates(self) -> List[Annotated["PowerOutletTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.poweroutlet_templates.all()
+    poweroutlet_templates: List[Annotated["PowerOutletTemplateType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -824,21 +622,10 @@ class RackType(VLANGroupsMixin, ImageAttachmentsMixin, ContactsMixin, NetBoxObje
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
     role: Annotated["RackRoleType", strawberry.lazy('dcim.graphql.types')] | None
 
-    @strawberry_django.field
-    def reservations(self) -> List[Annotated["RackReservationType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.reservations.all()
-
-    @strawberry_django.field
-    def devices(self) -> List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.devices.all()
-
-    @strawberry_django.field
-    def powerfeeds(self) -> List[Annotated["PowerFeedType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.powerfeeds.all()
-
-    @strawberry_django.field
-    def cabletermination_set(self) -> List[Annotated["CableTerminationType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.cabletermination_set.all()
+    reservations: List[Annotated["RackReservationType", strawberry.lazy('dcim.graphql.types')]]
+    devices: List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]
+    powerfeeds: List[Annotated["PowerFeedType", strawberry.lazy('dcim.graphql.types')]]
+    cabletermination_set: List[Annotated["CableTerminationType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -861,9 +648,7 @@ class RackReservationType(NetBoxObjectType):
 class RackRoleType(OrganizationalObjectType):
     color: str
 
-    @strawberry_django.field
-    def racks(self) -> List[Annotated["RackType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.racks.all()
+    racks: List[Annotated["RackType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -874,9 +659,7 @@ class RackRoleType(OrganizationalObjectType):
 class RearPortType(ModularComponentType, CabledObjectMixin):
     color: str
 
-    @strawberry_django.field
-    def frontports(self) -> List[Annotated["FrontPortType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.frontports.all()
+    frontports: List[Annotated["FrontPortType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -888,9 +671,7 @@ class RearPortTemplateType(ModularComponentTemplateType):
     _name: str
     color: str
 
-    @strawberry_django.field
-    def frontport_templates(self) -> List[Annotated["FrontPortTemplateType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.frontport_templates.all()
+    frontport_templates: List[Annotated["FrontPortTemplateType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -901,17 +682,12 @@ class RearPortTemplateType(ModularComponentTemplateType):
 )
 class RegionType(VLANGroupsMixin, ContactsMixin, OrganizationalObjectType):
 
-    @strawberry_django.field
-    def sites(self) -> List[Annotated["SiteType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.sites.all()
+    sites: List[Annotated["SiteType", strawberry.lazy('dcim.graphql.types')]]
+    children: List[Annotated["RegionType", strawberry.lazy('dcim.graphql.types')]]
 
     @strawberry_django.field
     def parent(self) -> Annotated["RegionType", strawberry.lazy('dcim.graphql.types')] | None:
         return self.parent
-
-    @strawberry_django.field
-    def children(self) -> List[Annotated["RegionType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.children.all()
 
 
 @strawberry_django.type(
@@ -926,49 +702,17 @@ class SiteType(VLANGroupsMixin, ImageAttachmentsMixin, ContactsMixin, NetBoxObje
     group: Annotated["SiteGroupType", strawberry.lazy('dcim.graphql.types')] | None
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
 
-    @strawberry_django.field
-    def prefixes(self) -> List[Annotated["PrefixType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.prefixes.all()
-
-    @strawberry_django.field
-    def virtual_machines(self) -> List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.virtual_machines.all()
-
-    @strawberry_django.field
-    def racks(self) -> List[Annotated["RackType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.racks.all()
-
-    @strawberry_django.field
-    def cabletermination_set(self) -> List[Annotated["CableTerminationType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.cabletermination_set.all()
-
-    @strawberry_django.field
-    def powerpanel_set(self) -> List[Annotated["PowerPanelType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.powerpanel_set.all()
-
-    @strawberry_django.field
-    def devices(self) -> List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.devices.all()
-
-    @strawberry_django.field
-    def locations(self) -> List[Annotated["LocationType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.locations.all()
-
-    @strawberry_django.field
-    def asns(self) -> List[Annotated["ASNType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.asns.all()
-
-    @strawberry_django.field
-    def circuit_terminations(self) -> List[Annotated["CircuitTerminationType", strawberry.lazy('circuits.graphql.types')]]:
-        return self.circuit_terminations.all()
-
-    @strawberry_django.field
-    def clusters(self) -> List[Annotated["ClusterType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.clusters.all()
-
-    @strawberry_django.field
-    def vlans(self) -> List[Annotated["VLANType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.vlans.all()
+    prefixes: List[Annotated["PrefixType", strawberry.lazy('ipam.graphql.types')]]
+    virtual_machines: List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]
+    racks: List[Annotated["RackType", strawberry.lazy('dcim.graphql.types')]]
+    cabletermination_set: List[Annotated["CableTerminationType", strawberry.lazy('dcim.graphql.types')]]
+    powerpanel_set: List[Annotated["PowerPanelType", strawberry.lazy('dcim.graphql.types')]]
+    devices: List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]
+    locations: List[Annotated["LocationType", strawberry.lazy('dcim.graphql.types')]]
+    asns: List[Annotated["ASNType", strawberry.lazy('ipam.graphql.types')]]
+    circuit_terminations: List[Annotated["CircuitTerminationType", strawberry.lazy('circuits.graphql.types')]]
+    clusters: List[Annotated["ClusterType", strawberry.lazy('virtualization.graphql.types')]]
+    vlans: List[Annotated["VLANType", strawberry.lazy('ipam.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -979,17 +723,12 @@ class SiteType(VLANGroupsMixin, ImageAttachmentsMixin, ContactsMixin, NetBoxObje
 )
 class SiteGroupType(VLANGroupsMixin, ContactsMixin, OrganizationalObjectType):
 
-    @strawberry_django.field
-    def sites(self) -> List[Annotated["SiteType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.sites.all()
+    sites: List[Annotated["SiteType", strawberry.lazy('dcim.graphql.types')]]
+    children: List[Annotated["SiteGroupType", strawberry.lazy('dcim.graphql.types')]]
 
     @strawberry_django.field
     def parent(self) -> Annotated["SiteGroupType", strawberry.lazy('dcim.graphql.types')] | None:
         return self.parent
-
-    @strawberry_django.field
-    def children(self) -> List[Annotated["SiteGroupType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.children.all()
 
 
 @strawberry_django.type(
@@ -1001,9 +740,7 @@ class VirtualChassisType(NetBoxObjectType):
     member_count: BigInt
     master: Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')] | None
 
-    @strawberry_django.field
-    def members(self) -> List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.members.all()
+    members: List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -1017,6 +754,4 @@ class VirtualDeviceContextType(NetBoxObjectType):
     primary_ip6: Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')] | None
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
 
-    @strawberry_django.field
-    def interfaces(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.interfaces.all()
+    interfaces: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]

--- a/netbox/extras/graphql/mixins.py
+++ b/netbox/extras/graphql/mixins.py
@@ -69,14 +69,10 @@ class JournalEntriesMixin:
 @strawberry.type
 class TagsMixin:
 
-    @strawberry_django.field
-    def tags(self) -> List[Annotated["TagType", strawberry.lazy('.types')]]:
-        return self.tags.all()
+    tags: List[Annotated["TagType", strawberry.lazy('.types')]]
 
 
 @strawberry.type
 class ContactsMixin:
 
-    @strawberry_django.field
-    def contacts(self) -> List[Annotated["ContactAssignmentType", strawberry.lazy('tenancy.graphql.types')]]:
-        return list(self.contacts.all())
+    contacts: List[Annotated["ContactAssignmentType", strawberry.lazy('tenancy.graphql.types')]]

--- a/netbox/extras/graphql/types.py
+++ b/netbox/extras/graphql/types.py
@@ -34,57 +34,19 @@ class ConfigContextType(ObjectType):
     data_source: Annotated["DataSourceType", strawberry.lazy('core.graphql.types')] | None
     data_file: Annotated["DataFileType", strawberry.lazy('core.graphql.types')] | None
 
-    @strawberry_django.field
-    def roles(self) -> List[Annotated["DeviceRoleType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.roles.all()
-
-    @strawberry_django.field
-    def device_types(self) -> List[Annotated["DeviceTypeType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.device_types.all()
-
-    @strawberry_django.field
-    def tags(self) -> List[Annotated["TagType", strawberry.lazy('extras.graphql.types')]]:
-        return self.tags.all()
-
-    @strawberry_django.field
-    def platforms(self) -> List[Annotated["PlatformType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.platforms.all()
-
-    @strawberry_django.field
-    def regions(self) -> List[Annotated["RegionType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.regions.all()
-
-    @strawberry_django.field
-    def cluster_groups(self) -> List[Annotated["ClusterGroupType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.cluster_groups.all()
-
-    @strawberry_django.field
-    def tenant_groups(self) -> List[Annotated["TenantGroupType", strawberry.lazy('tenancy.graphql.types')]]:
-        return self.tenant_groups.all()
-
-    @strawberry_django.field
-    def cluster_types(self) -> List[Annotated["ClusterTypeType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.cluster_types.all()
-
-    @strawberry_django.field
-    def clusters(self) -> List[Annotated["ClusterType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.clusters.all()
-
-    @strawberry_django.field
-    def locations(self) -> List[Annotated["LocationType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.locations.all()
-
-    @strawberry_django.field
-    def sites(self) -> List[Annotated["SiteType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.sites.all()
-
-    @strawberry_django.field
-    def tenants(self) -> List[Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')]]:
-        return self.tenants.all()
-
-    @strawberry_django.field
-    def site_groups(self) -> List[Annotated["SiteGroupType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.site_groups.all()
+    roles: List[Annotated["DeviceRoleType", strawberry.lazy('dcim.graphql.types')]]
+    device_types: List[Annotated["DeviceTypeType", strawberry.lazy('dcim.graphql.types')]]
+    tags: List[Annotated["TagType", strawberry.lazy('extras.graphql.types')]]
+    platforms: List[Annotated["PlatformType", strawberry.lazy('dcim.graphql.types')]]
+    regions: List[Annotated["RegionType", strawberry.lazy('dcim.graphql.types')]]
+    cluster_groups: List[Annotated["ClusterGroupType", strawberry.lazy('virtualization.graphql.types')]]
+    tenant_groups: List[Annotated["TenantGroupType", strawberry.lazy('tenancy.graphql.types')]]
+    cluster_types: List[Annotated["ClusterTypeType", strawberry.lazy('virtualization.graphql.types')]]
+    clusters: List[Annotated["ClusterType", strawberry.lazy('virtualization.graphql.types')]]
+    locations: List[Annotated["LocationType", strawberry.lazy('dcim.graphql.types')]]
+    sites: List[Annotated["SiteType", strawberry.lazy('dcim.graphql.types')]]
+    tenants: List[Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')]]
+    site_groups: List[Annotated["SiteGroupType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -96,21 +58,10 @@ class ConfigTemplateType(TagsMixin, ObjectType):
     data_source: Annotated["DataSourceType", strawberry.lazy('core.graphql.types')] | None
     data_file: Annotated["DataFileType", strawberry.lazy('core.graphql.types')] | None
 
-    @strawberry_django.field
-    def virtualmachines(self) -> List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.virtualmachines.all()
-
-    @strawberry_django.field
-    def devices(self) -> List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.devices.all()
-
-    @strawberry_django.field
-    def platforms(self) -> List[Annotated["PlatformType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.platforms.all()
-
-    @strawberry_django.field
-    def device_roles(self) -> List[Annotated["DeviceRoleType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.device_roles.all()
+    virtualmachines: List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]
+    devices: List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]
+    platforms: List[Annotated["PlatformType", strawberry.lazy('dcim.graphql.types')]]
+    device_roles: List[Annotated["DeviceRoleType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -130,13 +81,8 @@ class CustomFieldType(ObjectType):
 )
 class CustomFieldChoiceSetType(ObjectType):
 
-    @strawberry_django.field
-    def choices_for(self) -> List[Annotated["CustomFieldType", strawberry.lazy('extras.graphql.types')]]:
-        return self.choices_for.all()
-
-    @strawberry_django.field
-    def extra_choices(self) -> List[str] | None:
-        return list(self.extra_choices)
+    choices_for: List[Annotated["CustomFieldType", strawberry.lazy('extras.graphql.types')]]
+    extra_choices: List[str] | None
 
 
 @strawberry_django.type(
@@ -203,9 +149,7 @@ class SavedFilterType(ObjectType):
 class TagType(ObjectType):
     color: str
 
-    @strawberry_django.field
-    def object_types(self) -> List[ContentTypeType]:
-        return self.object_types.all()
+    object_types: List[ContentTypeType]
 
 
 @strawberry_django.type(

--- a/netbox/ipam/graphql/mixins.py
+++ b/netbox/ipam/graphql/mixins.py
@@ -11,13 +11,9 @@ __all__ = (
 
 @strawberry.type
 class IPAddressesMixin:
-    @strawberry_django.field
-    def ip_addresses(self) -> List[Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.ip_addresses.all()
+    ip_addresses: List[Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')]]
 
 
 @strawberry.type
 class VLANGroupsMixin:
-    @strawberry_django.field
-    def vlan_groups(self) -> List[Annotated["VLANGroupType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.vlan_groups.all()
+    vlan_groups: List[Annotated["VLANGroupType", strawberry.lazy('ipam.graphql.types')]]

--- a/netbox/ipam/graphql/types.py
+++ b/netbox/ipam/graphql/types.py
@@ -196,10 +196,10 @@ class RoleType(OrganizationalObjectType):
 class RouteTargetType(NetBoxObjectType):
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
 
-    exporting_l2vpns: List[Annotated["L2VPNType", strawberry.lazy('vpn.graphql.types')]]
-    exporting_vrfs: List[Annotated["VRFType", strawberry.lazy('ipam.graphql.types')]]
-    importing_vrfs: List[Annotated["VRFType", strawberry.lazy('ipam.graphql.types')]]
     importing_l2vpns: List[Annotated["L2VPNType", strawberry.lazy('vpn.graphql.types')]]
+    exporting_l2vpns: List[Annotated["L2VPNType", strawberry.lazy('vpn.graphql.types')]]
+    importing_vrfs: List[Annotated["VRFType", strawberry.lazy('ipam.graphql.types')]]
+    exporting_vrfs: List[Annotated["VRFType", strawberry.lazy('ipam.graphql.types')]]
 
 
 @strawberry_django.type(

--- a/netbox/ipam/graphql/types.py
+++ b/netbox/ipam/graphql/types.py
@@ -60,13 +60,8 @@ class ASNType(NetBoxObjectType):
     rir: Annotated["RIRType", strawberry.lazy('ipam.graphql.types')] | None
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
 
-    @strawberry_django.field
-    def sites(self) -> List[SiteType]:
-        return self.sites.all()
-
-    @strawberry_django.field
-    def providers(self) -> List[ProviderType]:
-        return self.providers.all()
+    sites: List[SiteType]
+    providers: List[ProviderType]
 
 
 @strawberry_django.type(
@@ -99,9 +94,7 @@ class AggregateType(NetBoxObjectType, BaseIPAddressFamilyType):
 )
 class FHRPGroupType(NetBoxObjectType, IPAddressesMixin):
 
-    @strawberry_django.field
-    def fhrpgroupassignment_set(self) -> List[Annotated["FHRPGroupAssignmentType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.fhrpgroupassignment_set.all()
+    fhrpgroupassignment_set: List[Annotated["FHRPGroupAssignmentType", strawberry.lazy('ipam.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -131,17 +124,9 @@ class IPAddressType(NetBoxObjectType, BaseIPAddressFamilyType):
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
     nat_inside: Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')] | None
 
-    @strawberry_django.field
-    def nat_outside(self) -> List[Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.nat_outside.all()
-
-    @strawberry_django.field
-    def tunnel_terminations(self) -> List[Annotated["TunnelTerminationType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.tunnel_terminations.all()
-
-    @strawberry_django.field
-    def services(self) -> List[Annotated["ServiceType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.services.all()
+    nat_outside: List[Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')]]
+    tunnel_terminations: List[Annotated["TunnelTerminationType", strawberry.lazy('vpn.graphql.types')]]
+    services: List[Annotated["ServiceType", strawberry.lazy('ipam.graphql.types')]]
 
     @strawberry_django.field
     def assigned_object(self) -> Annotated[Union[
@@ -186,17 +171,9 @@ class PrefixType(NetBoxObjectType, BaseIPAddressFamilyType):
 )
 class RIRType(OrganizationalObjectType):
 
-    @strawberry_django.field
-    def asn_ranges(self) -> List[Annotated["ASNRangeType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.asn_ranges.all()
-
-    @strawberry_django.field
-    def asns(self) -> List[Annotated["ASNType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.asns.all()
-
-    @strawberry_django.field
-    def aggregates(self) -> List[Annotated["AggregateType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.aggregates.all()
+    asn_ranges: List[Annotated["ASNRangeType", strawberry.lazy('ipam.graphql.types')]]
+    asns: List[Annotated["ASNType", strawberry.lazy('ipam.graphql.types')]]
+    aggregates: List[Annotated["AggregateType", strawberry.lazy('ipam.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -206,17 +183,9 @@ class RIRType(OrganizationalObjectType):
 )
 class RoleType(OrganizationalObjectType):
 
-    @strawberry_django.field
-    def prefixes(self) -> List[Annotated["PrefixType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.prefixes.all()
-
-    @strawberry_django.field
-    def ip_ranges(self) -> List[Annotated["IPRangeType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.ip_ranges.all()
-
-    @strawberry_django.field
-    def vlans(self) -> List[Annotated["VLANType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.vlans.all()
+    prefixes: List[Annotated["PrefixType", strawberry.lazy('ipam.graphql.types')]]
+    ip_ranges: List[Annotated["IPRangeType", strawberry.lazy('ipam.graphql.types')]]
+    vlans: List[Annotated["VLANType", strawberry.lazy('ipam.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -227,21 +196,10 @@ class RoleType(OrganizationalObjectType):
 class RouteTargetType(NetBoxObjectType):
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
 
-    @strawberry_django.field
-    def exporting_l2vpns(self) -> List[Annotated["L2VPNType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.exporting_l2vpns.all()
-
-    @strawberry_django.field
-    def exporting_vrfs(self) -> List[Annotated["VRFType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.exporting_vrfs.all()
-
-    @strawberry_django.field
-    def importing_vrfs(self) -> List[Annotated["VRFType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.importing_vrfs.all()
-
-    @strawberry_django.field
-    def importing_l2vpns(self) -> List[Annotated["L2VPNType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.importing_l2vpns.all()
+    exporting_l2vpns: List[Annotated["L2VPNType", strawberry.lazy('vpn.graphql.types')]]
+    exporting_vrfs: List[Annotated["VRFType", strawberry.lazy('ipam.graphql.types')]]
+    importing_vrfs: List[Annotated["VRFType", strawberry.lazy('ipam.graphql.types')]]
+    importing_l2vpns: List[Annotated["L2VPNType", strawberry.lazy('vpn.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -254,9 +212,7 @@ class ServiceType(NetBoxObjectType):
     device: Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')] | None
     virtual_machine: Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')] | None
 
-    @strawberry_django.field
-    def ipaddresses(self) -> List[Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.ipaddresses.all()
+    ipaddresses: List[Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -279,29 +235,12 @@ class VLANType(NetBoxObjectType):
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
     role: Annotated["RoleType", strawberry.lazy('ipam.graphql.types')] | None
 
-    @strawberry_django.field
-    def interfaces_as_untagged(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.interfaces_as_untagged.all()
-
-    @strawberry_django.field
-    def vminterfaces_as_untagged(self) -> List[Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.vminterfaces_as_untagged.all()
-
-    @strawberry_django.field
-    def wirelesslan_set(self) -> List[Annotated["WirelessLANType", strawberry.lazy('wireless.graphql.types')]]:
-        return self.wirelesslan_set.all()
-
-    @strawberry_django.field
-    def prefixes(self) -> List[Annotated["PrefixType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.prefixes.all()
-
-    @strawberry_django.field
-    def interfaces_as_tagged(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.interfaces_as_tagged.all()
-
-    @strawberry_django.field
-    def vminterfaces_as_tagged(self) -> List[Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.vminterfaces_as_tagged.all()
+    interfaces_as_untagged: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
+    vminterfaces_as_untagged: List[Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')]]
+    wirelesslan_set: List[Annotated["WirelessLANType", strawberry.lazy('wireless.graphql.types')]]
+    prefixes: List[Annotated["PrefixType", strawberry.lazy('ipam.graphql.types')]]
+    interfaces_as_tagged: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
+    vminterfaces_as_tagged: List[Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -311,9 +250,7 @@ class VLANType(NetBoxObjectType):
 )
 class VLANGroupType(OrganizationalObjectType):
 
-    @strawberry_django.field
-    def vlans(self) -> List[VLANType]:
-        return self.vlans.all()
+    vlans: List[VLANType]
 
     @strawberry_django.field
     def scope(self) -> Annotated[Union[
@@ -336,30 +273,10 @@ class VLANGroupType(OrganizationalObjectType):
 class VRFType(NetBoxObjectType):
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
 
-    @strawberry_django.field
-    def interfaces(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.interfaces.all()
-
-    @strawberry_django.field
-    def ip_addresses(self) -> List[Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.ip_addresses.all()
-
-    @strawberry_django.field
-    def vminterfaces(self) -> List[Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.vminterfaces.all()
-
-    @strawberry_django.field
-    def ip_ranges(self) -> List[Annotated["IPRangeType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.ip_ranges.all()
-
-    @strawberry_django.field
-    def export_targets(self) -> List[Annotated["RouteTargetType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.export_targets.all()
-
-    @strawberry_django.field
-    def import_targets(self) -> List[Annotated["RouteTargetType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.import_targets.all()
-
-    @strawberry_django.field
-    def prefixes(self) -> List[Annotated["PrefixType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.prefixes.all()
+    interfaces: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
+    ip_addresses: List[Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')]]
+    vminterfaces: List[Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')]]
+    ip_ranges: List[Annotated["IPRangeType", strawberry.lazy('ipam.graphql.types')]]
+    export_targets: List[Annotated["RouteTargetType", strawberry.lazy('ipam.graphql.types')]]
+    import_targets: List[Annotated["RouteTargetType", strawberry.lazy('ipam.graphql.types')]]
+    prefixes: List[Annotated["PrefixType", strawberry.lazy('ipam.graphql.types')]]

--- a/netbox/tenancy/graphql/mixins.py
+++ b/netbox/tenancy/graphql/mixins.py
@@ -12,6 +12,4 @@ __all__ = (
 @strawberry.type
 class ContactAssignmentsMixin:
 
-    @strawberry_django.field
-    def assignments(self) -> List[Annotated["ContactAssignmentType", strawberry.lazy('tenancy.graphql.types')]]:
-        return self.assignments.all()
+    assignments: List[Annotated["ContactAssignmentType", strawberry.lazy('tenancy.graphql.types')]]

--- a/netbox/tenancy/graphql/types.py
+++ b/netbox/tenancy/graphql/types.py
@@ -31,101 +31,30 @@ __all__ = (
 class TenantType(NetBoxObjectType):
     group: Annotated["TenantGroupType", strawberry.lazy('tenancy.graphql.types')] | None
 
-    @strawberry_django.field
-    def asns(self) -> List[Annotated["ASNType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.asns.all()
-
-    @strawberry_django.field
-    def circuits(self) -> List[Annotated["CircuitType", strawberry.lazy('circuits.graphql.types')]]:
-        return self.circuits.all()
-
-    @strawberry_django.field
-    def sites(self) -> List[Annotated["SiteType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.sites.all()
-
-    @strawberry_django.field
-    def vlans(self) -> List[Annotated["VLANType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.vlans.all()
-
-    @strawberry_django.field
-    def wireless_lans(self) -> List[Annotated["WirelessLANType", strawberry.lazy('wireless.graphql.types')]]:
-        return self.wireless_lans.all()
-
-    @strawberry_django.field
-    def route_targets(self) -> List[Annotated["RouteTargetType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.route_targets.all()
-
-    @strawberry_django.field
-    def locations(self) -> List[Annotated["LocationType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.locations.all()
-
-    @strawberry_django.field
-    def ip_ranges(self) -> List[Annotated["IPRangeType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.ip_ranges.all()
-
-    @strawberry_django.field
-    def rackreservations(self) -> List[Annotated["RackReservationType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.rackreservations.all()
-
-    @strawberry_django.field
-    def racks(self) -> List[Annotated["RackType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.racks.all()
-
-    @strawberry_django.field
-    def vdcs(self) -> List[Annotated["VirtualDeviceContextType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.vdcs.all()
-
-    @strawberry_django.field
-    def prefixes(self) -> List[Annotated["PrefixType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.prefixes.all()
-
-    @strawberry_django.field
-    def cables(self) -> List[Annotated["CableType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.cables.all()
-
-    @strawberry_django.field
-    def virtual_machines(self) -> List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.virtual_machines.all()
-
-    @strawberry_django.field
-    def vrfs(self) -> List[Annotated["VRFType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.vrfs.all()
-
-    @strawberry_django.field
-    def asn_ranges(self) -> List[Annotated["ASNRangeType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.asn_ranges.all()
-
-    @strawberry_django.field
-    def wireless_links(self) -> List[Annotated["WirelessLinkType", strawberry.lazy('wireless.graphql.types')]]:
-        return self.wireless_links.all()
-
-    @strawberry_django.field
-    def aggregates(self) -> List[Annotated["AggregateType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.aggregates.all()
-
-    @strawberry_django.field
-    def power_feeds(self) -> List[Annotated["PowerFeedType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.power_feeds.all()
-
-    @strawberry_django.field
-    def devices(self) -> List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.devices.all()
-
-    @strawberry_django.field
-    def tunnels(self) -> List[Annotated["TunnelType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.tunnels.all()
-
-    @strawberry_django.field
-    def ip_addresses(self) -> List[Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.ip_addresses.all()
-
-    @strawberry_django.field
-    def clusters(self) -> List[Annotated["ClusterType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.clusters.all()
-
-    @strawberry_django.field
-    def l2vpns(self) -> List[Annotated["L2VPNType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.l2vpns.all()
+    asns: List[Annotated["ASNType", strawberry.lazy('ipam.graphql.types')]]
+    circuits: List[Annotated["CircuitType", strawberry.lazy('circuits.graphql.types')]]
+    sites: List[Annotated["SiteType", strawberry.lazy('dcim.graphql.types')]]
+    vlans: List[Annotated["VLANType", strawberry.lazy('ipam.graphql.types')]]
+    wireless_lans: List[Annotated["WirelessLANType", strawberry.lazy('wireless.graphql.types')]]
+    route_targets: List[Annotated["RouteTargetType", strawberry.lazy('ipam.graphql.types')]]
+    locations: List[Annotated["LocationType", strawberry.lazy('dcim.graphql.types')]]
+    ip_ranges: List[Annotated["IPRangeType", strawberry.lazy('ipam.graphql.types')]]
+    rackreservations: List[Annotated["RackReservationType", strawberry.lazy('dcim.graphql.types')]]
+    racks: List[Annotated["RackType", strawberry.lazy('dcim.graphql.types')]]
+    vdcs: List[Annotated["VirtualDeviceContextType", strawberry.lazy('dcim.graphql.types')]]
+    prefixes: List[Annotated["PrefixType", strawberry.lazy('ipam.graphql.types')]]
+    cables: List[Annotated["CableType", strawberry.lazy('dcim.graphql.types')]]
+    virtual_machines: List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]
+    vrfs: List[Annotated["VRFType", strawberry.lazy('ipam.graphql.types')]]
+    asn_ranges: List[Annotated["ASNRangeType", strawberry.lazy('ipam.graphql.types')]]
+    wireless_links: List[Annotated["WirelessLinkType", strawberry.lazy('wireless.graphql.types')]]
+    aggregates: List[Annotated["AggregateType", strawberry.lazy('ipam.graphql.types')]]
+    power_feeds: List[Annotated["PowerFeedType", strawberry.lazy('dcim.graphql.types')]]
+    devices: List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]
+    tunnels: List[Annotated["TunnelType", strawberry.lazy('vpn.graphql.types')]]
+    ip_addresses: List[Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')]]
+    clusters: List[Annotated["ClusterType", strawberry.lazy('virtualization.graphql.types')]]
+    l2vpns: List[Annotated["L2VPNType", strawberry.lazy('vpn.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -136,9 +65,7 @@ class TenantType(NetBoxObjectType):
 class TenantGroupType(OrganizationalObjectType):
     parent: Annotated["TenantGroupType", strawberry.lazy('tenancy.graphql.types')] | None
 
-    @strawberry_django.field
-    def tenants(self) -> List[TenantType]:
-        return self.tenants.all()
+    tenants: List[TenantType]
 
 
 #
@@ -171,9 +98,7 @@ class ContactRoleType(ContactAssignmentsMixin, OrganizationalObjectType):
 class ContactGroupType(OrganizationalObjectType):
     parent: Annotated["ContactGroupType", strawberry.lazy('tenancy.graphql.types')] | None
 
-    @strawberry_django.field
-    def contacts(self) -> List[ContactType]:
-        return self.contacts.all()
+    contacts: List[ContactType]
 
 
 @strawberry_django.type(

--- a/netbox/users/graphql/types.py
+++ b/netbox/users/graphql/types.py
@@ -34,6 +34,4 @@ class GroupType:
     filters=UserFilter
 )
 class UserType:
-    @strawberry_django.field
-    def groups(self) -> List[GroupType]:
-        return self.groups.all()
+    groups: List[GroupType]

--- a/netbox/virtualization/graphql/types.py
+++ b/netbox/virtualization/graphql/types.py
@@ -40,13 +40,8 @@ class ClusterType(VLANGroupsMixin, NetBoxObjectType):
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
     site: Annotated["SiteType", strawberry.lazy('dcim.graphql.types')] | None
 
-    @strawberry_django.field
-    def virtual_machines(self) -> List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.virtual_machines.all()
-
-    @strawberry_django.field
-    def devices(self) -> List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.devices.all()
+    virtual_machines: List[Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')]]
+    devices: List[Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -56,9 +51,7 @@ class ClusterType(VLANGroupsMixin, NetBoxObjectType):
 )
 class ClusterGroupType(VLANGroupsMixin, OrganizationalObjectType):
 
-    @strawberry_django.field
-    def clusters(self) -> List[Annotated["ClusterType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.clusters.all()
+    clusters: List[Annotated["ClusterType", strawberry.lazy('virtualization.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -68,9 +61,7 @@ class ClusterGroupType(VLANGroupsMixin, OrganizationalObjectType):
 )
 class ClusterTypeType(OrganizationalObjectType):
 
-    @strawberry_django.field
-    def clusters(self) -> List[ClusterType]:
-        return self.clusters.all()
+    clusters: List[ClusterType]
 
 
 @strawberry_django.type(
@@ -93,17 +84,9 @@ class VirtualMachineType(ConfigContextMixin, ContactsMixin, NetBoxObjectType):
     primary_ip4: Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')] | None
     primary_ip6: Annotated["IPAddressType", strawberry.lazy('ipam.graphql.types')] | None
 
-    @strawberry_django.field
-    def interfaces(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.interfaces.all()
-
-    @strawberry_django.field
-    def services(self) -> List[Annotated["ServiceType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.services.all()
-
-    @strawberry_django.field
-    def virtualdisks(self) -> List[Annotated["VirtualDiskType", strawberry.lazy('virtualization.graphql.types')]]:
-        return self.virtualdisks.all()
+    interfaces: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
+    services: List[Annotated["ServiceType", strawberry.lazy('ipam.graphql.types')]]
+    virtualdisks: List[Annotated["VirtualDiskType", strawberry.lazy('virtualization.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -118,17 +101,9 @@ class VMInterfaceType(IPAddressesMixin, ComponentType):
     untagged_vlan: Annotated["VLANType", strawberry.lazy('ipam.graphql.types')] | None
     vrf: Annotated["VRFType", strawberry.lazy('ipam.graphql.types')] | None
 
-    @strawberry_django.field
-    def tagged_vlans(self) -> List[Annotated["VLANType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.tagged_vlans.all()
-
-    @strawberry_django.field
-    def bridge_interfaces(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.bridge_interfaces.all()
-
-    @strawberry_django.field
-    def child_interfaces(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.child_interfaces.all()
+    tagged_vlans: List[Annotated["VLANType", strawberry.lazy('ipam.graphql.types')]]
+    bridge_interfaces: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
+    child_interfaces: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(

--- a/netbox/vpn/graphql/types.py
+++ b/netbox/vpn/graphql/types.py
@@ -29,9 +29,7 @@ __all__ = (
 )
 class TunnelGroupType(OrganizationalObjectType):
 
-    @strawberry_django.field
-    def tunnels(self) -> List[Annotated["TunnelType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.tunnels.all()
+    tunnels: List[Annotated["TunnelType", strawberry.lazy('vpn.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -55,9 +53,7 @@ class TunnelType(NetBoxObjectType):
     ipsec_profile: Annotated["IPSecProfileType", strawberry.lazy('vpn.graphql.types')] | None
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
 
-    @strawberry_django.field
-    def terminations(self) -> List[Annotated["TunnelTerminationType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.terminations.all()
+    terminations: List[Annotated["TunnelTerminationType", strawberry.lazy('vpn.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -67,9 +63,7 @@ class TunnelType(NetBoxObjectType):
 )
 class IKEProposalType(OrganizationalObjectType):
 
-    @strawberry_django.field
-    def ike_policies(self) -> List[Annotated["IKEPolicyType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.ike_policies.all()
+    ike_policies: List[Annotated["IKEPolicyType", strawberry.lazy('vpn.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -79,13 +73,8 @@ class IKEProposalType(OrganizationalObjectType):
 )
 class IKEPolicyType(OrganizationalObjectType):
 
-    @strawberry_django.field
-    def proposals(self) -> List[Annotated["IKEProposalType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.proposals.all()
-
-    @strawberry_django.field
-    def ipsec_profiles(self) -> List[Annotated["IPSecProposalType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.ipsec_profiles.all()
+    proposals: List[Annotated["IKEProposalType", strawberry.lazy('vpn.graphql.types')]]
+    ipsec_profiles: List[Annotated["IPSecProposalType", strawberry.lazy('vpn.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -95,9 +84,7 @@ class IKEPolicyType(OrganizationalObjectType):
 )
 class IPSecProposalType(OrganizationalObjectType):
 
-    @strawberry_django.field
-    def ipsec_policies(self) -> List[Annotated["IPSecPolicyType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.ipsec_policies.all()
+    ipsec_policies: List[Annotated["IPSecPolicyType", strawberry.lazy('vpn.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -107,13 +94,8 @@ class IPSecProposalType(OrganizationalObjectType):
 )
 class IPSecPolicyType(OrganizationalObjectType):
 
-    @strawberry_django.field
-    def proposals(self) -> List[Annotated["IPSecProposalType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.proposals.all()
-
-    @strawberry_django.field
-    def ipsec_profiles(self) -> List[Annotated["IPSecProfileType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.ipsec_profiles.all()
+    proposals: List[Annotated["IPSecProposalType", strawberry.lazy('vpn.graphql.types')]]
+    ipsec_profiles: List[Annotated["IPSecProfileType", strawberry.lazy('vpn.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -125,9 +107,7 @@ class IPSecProfileType(OrganizationalObjectType):
     ike_policy: Annotated["IKEPolicyType", strawberry.lazy('vpn.graphql.types')]
     ipsec_policy: Annotated["IPSecPolicyType", strawberry.lazy('vpn.graphql.types')]
 
-    @strawberry_django.field
-    def tunnels(self) -> List[Annotated["TunnelType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.tunnels.all()
+    tunnels: List[Annotated["TunnelType", strawberry.lazy('vpn.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -138,17 +118,9 @@ class IPSecProfileType(OrganizationalObjectType):
 class L2VPNType(ContactsMixin, NetBoxObjectType):
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
 
-    @strawberry_django.field
-    def export_targets(self) -> List[Annotated["RouteTargetType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.export_targets.all()
-
-    @strawberry_django.field
-    def terminations(self) -> List[Annotated["L2VPNTerminationType", strawberry.lazy('vpn.graphql.types')]]:
-        return self.terminations.all()
-
-    @strawberry_django.field
-    def import_targets(self) -> List[Annotated["RouteTargetType", strawberry.lazy('ipam.graphql.types')]]:
-        return self.import_targets.all()
+    export_targets: List[Annotated["RouteTargetType", strawberry.lazy('ipam.graphql.types')]]
+    terminations: List[Annotated["L2VPNTerminationType", strawberry.lazy('vpn.graphql.types')]]
+    import_targets: List[Annotated["RouteTargetType", strawberry.lazy('ipam.graphql.types')]]
 
 
 @strawberry_django.type(

--- a/netbox/wireless/graphql/types.py
+++ b/netbox/wireless/graphql/types.py
@@ -22,9 +22,7 @@ __all__ = (
 class WirelessLANGroupType(OrganizationalObjectType):
     parent: Annotated["WirelessLANGroupType", strawberry.lazy('wireless.graphql.types')] | None
 
-    @strawberry_django.field
-    def wireless_lans(self) -> List[Annotated["WirelessLANType", strawberry.lazy('wireless.graphql.types')]]:
-        return self.wireless_lans.all()
+    wireless_lans: List[Annotated["WirelessLANType", strawberry.lazy('wireless.graphql.types')]]
 
 
 @strawberry_django.type(
@@ -37,9 +35,7 @@ class WirelessLANType(NetBoxObjectType):
     vlan: Annotated["VLANType", strawberry.lazy('ipam.graphql.types')] | None
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
 
-    @strawberry_django.field
-    def interfaces(self) -> List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]:
-        return self.interfaces.all()
+    interfaces: List[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(


### PR DESCRIPTION
### Fixes: #15553 

GraphQL filtering doesn't work on functions, so define sub-queries as types.