### PR TITLE
Allow configuring redis to use unix sockets

### DIFF
--- a/docs/configuration/required-parameters.md
+++ b/docs/configuration/required-parameters.md
@@ -105,11 +105,11 @@ REDIS = {
 
 ### Using Redis Sentinel
 
-If you are using [Redis Sentinel](https://redis.io/topics/sentinel) for high-availability purposes, there is minimal 
-configuration necessary to convert NetBox to recognize it. It requires the removal of the `HOST` and `PORT` keys from 
+If you are using [Redis Sentinel](https://redis.io/topics/sentinel) for high-availability purposes, there is minimal
+configuration necessary to convert NetBox to recognize it. It requires the removal of the `HOST` and `PORT` keys from
 above and the addition of three new keys.
 
-* `SENTINELS`: List of tuples or tuple of tuples with each inner tuple containing the name or IP address 
+* `SENTINELS`: List of tuples or tuple of tuples with each inner tuple containing the name or IP address
 of the Redis server and port for each sentinel instance to connect to
 * `SENTINEL_SERVICE`: Name of the master / service to connect to
 * `SENTINEL_TIMEOUT`: Connection timeout, in seconds
@@ -141,6 +141,36 @@ REDIS = {
 
 !!! note
     It is permissible to use Sentinel for only one database and not the other.
+
+
+### Using Redis with Unix Sockets
+
+If you'd like to configure NetBox to access Redis over unix sockets, set `PROTO: 'unix'`
+
+Example:
+
+```python
+REDIS = {
+    'tasks': {
+        'PROTO': 'unix',
+        'HOST': '/var/run/redis/redis.sock',
+        'PASSWORD': '',
+        'USERNAME': '',
+    }
+}
+```
+Alternatively, you may specify the location string yourself:
+```python
+REDIS = {
+    'tasks': {
+        'LOCATION': 'unix://netbox@/var/run/redis/redis.sock?db=0'
+        'PASSWORD': '',
+    }
+}
+
+!!! note
+    the `PASSWORD` option is still provided even when using `LOCATION` directly so you don't have to url-encode your password yourself.
+
 
 ---
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #4377 

oh well this will get autoclosed anyway because I didn't realize the "please open an issue" was a *requirement* and not just for larger changes.

This PR was supposed to allow the admin to configure a unix socket for redis - something the underlying libaries already support but was inaccessible due to templating in the `settings.py`.

I felt this was a very small change and may even be considered a bug since it works just fine with postgres and from what I can tell the intention is for the configuration to diverge as little as possible.