### PR TITLE
Refactor 32264ac3 to re-separate bulk and single device creation. Fix…

### DIFF
--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -996,17 +996,16 @@ class Device(
             bulk_create: If True, bulk_create() will be called to create all components in a single query
                          (default). Otherwise, save() will be called on each instance individually.
         """
-        components = [obj.instantiate(device=self) for obj in queryset]
-        if not components:
-            return
-
-        # Set default values for any applicable custom fields
         model = queryset.model.component_model
-        if cf_defaults := CustomField.objects.get_defaults_for_model(model):
-            for component in components:
-                component.custom_field_data = cf_defaults
 
         if bulk_create:
+            components = [obj.instantiate(device=self) for obj in queryset]
+            if not components:
+                return
+            # Set default values for any applicable custom fields
+            if cf_defaults := CustomField.objects.get_defaults_for_model(model):
+                for component in components:
+                    component.custom_field_data = cf_defaults
             model.objects.bulk_create(components)
             # Manually send the post_save signal for each of the newly created components
             for component in components:
@@ -1019,7 +1018,11 @@ class Device(
                     update_fields=None
                 )
         else:
-            for component in components:
+            for obj in queryset:
+                component = obj.instantiate(device=self)
+                # Set default values for any applicable custom fields
+                if cf_defaults := CustomField.objects.get_defaults_for_model(model):
+                    component.custom_field_data = cf_defaults
                 component.save()
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
…es #15598.

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #15598

<!--
    Please include a summary of the proposed changes below.
-->
In 32264ac3 `_instantiate_components()` was refactored to ensure all custom fields are initialized with default values.  Unfortunately that change broke the separation of singleton and `bulk_create` behaviors which led to issue #15598.  This PR refactors `_instantiate_components()` to recover that separation while retaining custom field default value initialization.