### PR TITLE
Fixes #15609: Fix filtering providers list by assigned ASN

### DIFF
--- a/netbox/circuits/filtersets.py
+++ b/netbox/circuits/filtersets.py
@@ -64,6 +64,12 @@ class ProviderFilterSet(NetBoxModelFilterSet, ContactModelFilterSet):
         queryset=ASN.objects.all(),
         label=_('ASN (ID)'),
     )
+    asn = django_filters.ModelMultipleChoiceFilter(
+        field_name='asns__asn',
+        queryset=ASN.objects.all(),
+        to_field_name='asn',
+        label=_('ASN'),
+    )
 
     class Meta:
         model = Provider

--- a/netbox/circuits/forms/filtersets.py
+++ b/netbox/circuits/forms/filtersets.py
@@ -24,7 +24,7 @@ class ProviderFilterForm(ContactModelFilterForm, NetBoxModelFilterSetForm):
     fieldsets = (
         (None, ('q', 'filter_id', 'tag')),
         (_('Location'), ('region_id', 'site_group_id', 'site_id')),
-        (_('ASN'), ('asn',)),
+        (_('ASN'), ('asn_id',)),
         (_('Contacts'), ('contact', 'contact_role', 'contact_group')),
     )
     region_id = DynamicModelMultipleChoiceField(
@@ -45,10 +45,6 @@ class ProviderFilterForm(ContactModelFilterForm, NetBoxModelFilterSetForm):
             'site_group_id': '$site_group_id',
         },
         label=_('Site')
-    )
-    asn = forms.IntegerField(
-        required=False,
-        label=_('ASN (legacy)')
     )
     asn_id = DynamicModelMultipleChoiceField(
         queryset=ASN.objects.all(),

--- a/netbox/circuits/tests/test_filtersets.py
+++ b/netbox/circuits/tests/test_filtersets.py
@@ -90,9 +90,11 @@ class ProviderTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {'description': ['foobar1', 'foobar2']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-    def test_asn_id(self):  # ASN object assignment
+    def test_asn(self):
         asns = ASN.objects.all()[:2]
         params = {'asn_id': [asns[0].pk, asns[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'asn': [asns[0].asn, asns[1].asn]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_region(self):


### PR DESCRIPTION
### Fixes: #15609

- Update ProviderFilterForm to use the `asn_id` filter
- Add a numeric `asn` filter to ProviderFilterSet
- Update filterset test