### PR TITLE
Fixes #15608: Avoid caching values of null fields in search index

### DIFF
--- a/netbox/netbox/search/__init__.py
+++ b/netbox/netbox/search/__init__.py
@@ -59,9 +59,10 @@ class SearchIndex:
     @staticmethod
     def get_field_value(instance, field_name):
         """
-        Return the value of the specified model field as a string.
+        Return the value of the specified model field as a string (or None).
         """
-        return str(getattr(instance, field_name))
+        if value := getattr(instance, field_name):
+            return str(value)
 
     @classmethod
     def get_category(cls):


### PR DESCRIPTION
### Fixes: #15608

Tweak `get_field_value()` to avoid returning `"None"` for null values.