### PR TITLE
Closes #14690: Pretty-format JSON fields in the config form

### DIFF
--- a/netbox/core/forms/model_forms.py
+++ b/netbox/core/forms/model_forms.py
@@ -207,6 +207,9 @@ class ConfigRevisionForm(BootstrapMixin, forms.ModelForm, metaclass=ConfigFormMe
                 help_text += _(' (default)')
             self.fields[param.name].help_text = help_text
 
+            # Use the parameter-specific encoder
+            self.fields[param.name].encoder = param.encoder
+
     def save(self, commit=True):
         instance = super().save(commit=False)
 

--- a/netbox/core/forms/model_forms.py
+++ b/netbox/core/forms/model_forms.py
@@ -3,6 +3,7 @@ import json
 
 from django import forms
 from django.conf import settings
+from django.forms.fields import JSONField as _JSONField
 from django.utils.translation import gettext_lazy as _
 
 from core.forms.mixins import SyncedDataMixin
@@ -12,7 +13,7 @@ from netbox.forms import NetBoxModelForm
 from netbox.registry import registry
 from netbox.utils import get_data_backend_choices
 from utilities.forms import BootstrapMixin, get_field_value
-from utilities.forms.fields import CommentField
+from utilities.forms.fields import CommentField, JSONField
 from utilities.forms.widgets import HTMXSelect
 
 __all__ = (
@@ -132,6 +133,9 @@ class ConfigFormMetaclass(forms.models.ModelFormMetaclass):
                 'help_text': param.description,
             }
             field_kwargs.update(**param.field_kwargs)
+            if param.field == _JSONField:
+                # Replace with our own JSONField to get pretty JSON in config editor
+                param.field = JSONField
             param_fields[param.name] = param.field(**field_kwargs)
         attrs.update(param_fields)
 

--- a/netbox/core/forms/model_forms.py
+++ b/netbox/core/forms/model_forms.py
@@ -207,9 +207,6 @@ class ConfigRevisionForm(BootstrapMixin, forms.ModelForm, metaclass=ConfigFormMe
                 help_text += _(' (default)')
             self.fields[param.name].help_text = help_text
 
-            # Use the parameter-specific encoder
-            self.fields[param.name].encoder = param.encoder
-
     def save(self, commit=True):
         instance = super().save(commit=False)
 

--- a/netbox/core/forms/model_forms.py
+++ b/netbox/core/forms/model_forms.py
@@ -133,7 +133,7 @@ class ConfigFormMetaclass(forms.models.ModelFormMetaclass):
                 'help_text': param.description,
             }
             field_kwargs.update(**param.field_kwargs)
-            if param.field == _JSONField:
+            if param.field is _JSONField:
                 # Replace with our own JSONField to get pretty JSON in config editor
                 param.field = JSONField
             param_fields[param.name] = param.field(**field_kwargs)

--- a/netbox/netbox/config/parameters.py
+++ b/netbox/netbox/config/parameters.py
@@ -1,6 +1,13 @@
+import json
+
 from django import forms
 from django.contrib.postgres.forms import SimpleArrayField
 from django.utils.translation import gettext_lazy as _
+
+
+class PrettyJSONEncoder(json.JSONEncoder):
+    def __init__(self, indent, sort_keys, *args, **kwargs):
+        super().__init__(indent=4, sort_keys=True, *args, **kwargs)
 
 
 class ConfigParam:
@@ -12,6 +19,7 @@ class ConfigParam:
         self.field = field or forms.CharField
         self.description = description
         self.field_kwargs = field_kwargs or {}
+        self.encoder = PrettyJSONEncoder if self.field == forms.JSONField else None
 
 
 PARAMS = (

--- a/netbox/netbox/config/parameters.py
+++ b/netbox/netbox/config/parameters.py
@@ -1,13 +1,6 @@
-import json
-
 from django import forms
 from django.contrib.postgres.forms import SimpleArrayField
 from django.utils.translation import gettext_lazy as _
-
-
-class PrettyJSONEncoder(json.JSONEncoder):
-    def __init__(self, indent, sort_keys, *args, **kwargs):
-        super().__init__(indent=4, sort_keys=True, *args, **kwargs)
 
 
 class ConfigParam:
@@ -19,7 +12,6 @@ class ConfigParam:
         self.field = field or forms.CharField
         self.description = description
         self.field_kwargs = field_kwargs or {}
-        self.encoder = PrettyJSONEncoder if self.field == forms.JSONField else None
 
 
 PARAMS = (


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #14690

<!--
    Please include a summary of the proposed changes below.
-->
~~Adds `encoder` attribute in `ConfigParam` that is set to a custom JSON encoder if field is a `JSONField`.~~

Replaces the Django-original `JSONField` params with our own `JSONField`s, to get pretty JSON printing in the configuration editor.