### PR TITLE
Fixes #15605: Account for older sequence name in migration

### DIFF
--- a/netbox/extras/migrations/0111_rename_content_types.py
+++ b/netbox/extras/migrations/0111_rename_content_types.py
@@ -27,7 +27,11 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to='core.objecttype'),
         ),
         migrations.RunSQL(
-            "ALTER TABLE extras_customfield_content_types_id_seq RENAME TO extras_customfield_object_types_id_seq"
+            "ALTER TABLE IF EXISTS extras_customfield_content_types_id_seq RENAME TO extras_customfield_object_types_id_seq"
+        ),
+        # Pre-v2.10 sequence name (see #15605)
+        migrations.RunSQL(
+            "ALTER TABLE IF EXISTS extras_customfield_obj_type_id_seq RENAME TO extras_customfield_object_types_id_seq"
         ),
 
         # Custom links


### PR DESCRIPTION
### Fixes: #15605

Account for both possible names for the sequence associated with the `extras_customfield_content_types` table.