### PR TITLE
Fixes #15640: add identifier field to search index of l2vpn

### DIFF
--- a/netbox/vpn/search.py
+++ b/netbox/vpn/search.py
@@ -75,6 +75,7 @@ class L2VPNIndex(SearchIndex):
     fields = (
         ('name', 100),
         ('slug', 110),
+        ('identifier', 200),
         ('description', 500),
         ('comments', 5000),
     )


### PR DESCRIPTION
### Fixes: #15640

<!--
    Please include a summary of the proposed changes below.
-->

This PR adds the `identifier` field of `L2VPN` to the corresponding search index.

We use it e.g., to note the VXLAN ID, this helps the users to find the correct L2VPN object for a VXLAN, through the global search.

I made the weight to 200 for "Secondary identifier". Other indexes use 200 for `label`, I hope it is correct.

![image](https://github.com/netbox-community/netbox/assets/40308458/d22268fc-ef3d-4670-ad6c-e5066d8bc430)
