### PR TITLE
15671 save module before sync_classes

### DIFF
--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -165,9 +165,8 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
 
     def save(self, *args, **kwargs):
         self.file_root = ManagedFileRootPathChoices.SCRIPTS
-        obj = super().save(*args, **kwargs)
+        super().save(*args, **kwargs)
         self.sync_classes()
-        return obj
 
 
 @receiver(post_save, sender=ScriptModule)

--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -165,8 +165,9 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
 
     def save(self, *args, **kwargs):
         self.file_root = ManagedFileRootPathChoices.SCRIPTS
+        obj = super().save(*args, **kwargs)
         self.sync_classes()
-        return super().save(*args, **kwargs)
+        return obj
 
 
 @receiver(post_save, sender=ScriptModule)


### PR DESCRIPTION
### Fixes: #15671 

save Module before doing sync_classes as it can cause M2M error: `ValueError: save() prohibited to prevent data loss due to unsaved related object 'module'.`