### PR TITLE
15688 remove USE_L10N setting

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -719,7 +719,6 @@ LOCALE_PATHS = (
 )
 if not ENABLE_LOCALIZATION:
     USE_I18N = False
-    USE_L10N = False
 
 #
 # Strawberry (GraphQL)


### PR DESCRIPTION
### Fixes: #15688 

Removes USE_L10N from settings as no longer used in Django 5.