### PR TITLE
15582 check permissions on specific object when sync request

### DIFF
--- a/netbox/core/api/views.py
+++ b/netbox/core/api/views.py
@@ -37,6 +37,11 @@ class DataSourceViewSet(NetBoxModelViewSet):
             raise PermissionDenied("Syncing data sources requires the core.sync_datasource permission.")
 
         datasource = get_object_or_404(DataSource, pk=pk)
+
+        # have to check perms again against this specific object as there could be constraints
+        if not request.user.has_perm('core.sync_datasource', datasource):
+            raise PermissionDenied("User does not have the core.sync_datasource permission for this object.")
+
         datasource.enqueue_sync_job(request)
         serializer = serializers.DataSourceSerializer(datasource, context={'request': request})
 

--- a/netbox/core/api/views.py
+++ b/netbox/core/api/views.py
@@ -1,5 +1,5 @@
 from django.shortcuts import get_object_or_404
-
+from django.utils.translation import gettext_lazy as _
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.response import Response
@@ -35,9 +35,8 @@ class DataSourceViewSet(NetBoxModelViewSet):
         """
         datasource = get_object_or_404(DataSource, pk=pk)
 
-        # have to check perms again against this specific object as there could be constraints
-        if not request.user.has_perm('core.sync_datasource', datasource):
-            raise PermissionDenied("User does not have the core.sync_datasource permission for this object.")
+        if not request.user.has_perm('core.sync_datasource', obj=datasource):
+            raise PermissionDenied(_("This user does not have permission to synchronize this data source."))
 
         datasource.enqueue_sync_job(request)
         serializer = serializers.DataSourceSerializer(datasource, context={'request': request})

--- a/netbox/core/api/views.py
+++ b/netbox/core/api/views.py
@@ -33,9 +33,6 @@ class DataSourceViewSet(NetBoxModelViewSet):
         """
         Enqueue a job to synchronize the DataSource.
         """
-        if not request.user.has_perm('core.sync_datasource'):
-            raise PermissionDenied("Syncing data sources requires the core.sync_datasource permission.")
-
         datasource = get_object_or_404(DataSource, pk=pk)
 
         # have to check perms again against this specific object as there could be constraints


### PR DESCRIPTION
### Fixes: #15582 

Check permissions on specific object when sync request.  I kept the original permission check as that is before the object is loaded and the get_object_or_404 can return 404 if the object doesn't exist and the user doesn't have sync permission which is a security edge case of showing which ones exist.  

Once the object is actually loaded it needs to be re-checked in case there are constraints or perms tied to the specific object.