### PR TITLE
#15548 - False Positive Related Object in Custom Fields

### DIFF
--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -69,7 +69,7 @@ class CustomFieldEditView(generic.ObjectEditView):
 
 
 @register_model_view(CustomField, 'delete')
-class CustomFieldDeleteView(generic.ObjectDeleteView):
+class CustomFieldDeleteView(generic.CustomObjectDeleteView):
     queryset = CustomField.objects.select_related('choice_set')
 
 


### PR DESCRIPTION

### Fixes: #15548


I created the class CustomObjectDeleteView, which was inherited from ObjectDeleteView, and overwritten the "get" method and its dependent_objects variable. This way, the modal from delete_form.html  will not display messages about dependent objects.

Also, I changed the inherited class for CustomFieldDeleteView to use generic.CustomObjectDeleteView.
 