### PR TITLE
Fixes: 15668 - virtual disks tab on virtual machine view not showing for non-superadmins

### DIFF
--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -388,7 +388,7 @@ class VirtualMachineVirtualDisksView(generic.ObjectChildrenView):
     tab = ViewTab(
         label=_('Virtual Disks'),
         badge=lambda obj: obj.virtual_disk_count,
-        permission='virtualization.view_virtual_disk',
+        permission='virtualization.view_virtualdisk',
         weight=500
     )
     actions = {


### PR DESCRIPTION
### Fixes: #15668

Fixed line 391 in netbox/virtualization/views.py. It was replaced "view_virtual_disk" with "view_virtualdisk"