### PR TITLE
Fixes 15652 - PROTECTION_RULES: Custom Validator does not show error message on object deletion

### DIFF
--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -425,7 +425,7 @@ class ObjectDeleteView(GetReturnURLMixin, BaseObjectView):
             except (ProtectedError, RestrictedError) as e:
                 logger.info(f"Caught {type(e)} while attempting to delete objects")
                 handle_protectederror([obj], request, e)
-                return redirect(self.get_return_url(request))
+                return redirect(obj.get_absolute_url())
 
             except AbortRequest as e:
                 logger.debug(e.message)

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -425,12 +425,12 @@ class ObjectDeleteView(GetReturnURLMixin, BaseObjectView):
             except (ProtectedError, RestrictedError) as e:
                 logger.info(f"Caught {type(e)} while attempting to delete objects")
                 handle_protectederror([obj], request, e)
-                return redirect(obj.get_absolute_url())
+                return redirect(self.get_return_url(request))
 
             except AbortRequest as e:
                 logger.debug(e.message)
                 messages.error(request, mark_safe(e.message))
-                return redirect(obj.get_absolute_url())
+                return redirect(self.get_return_url(request))
 
             msg = 'Deleted {} {}'.format(self.queryset.model._meta.verbose_name, obj)
             logger.info(msg)


### PR DESCRIPTION

### Fixes: #15652 

The issue was solved by replacing the line 433 of "netbox/netbox/views/generic/object_views.py" with "return redirect(self.get_return_url(request))".

**_Please let me know if I should also replace line 428 of the same file._**
