### PR TITLE
Closes #15740: Fix typos and deprecated List in docs

### DIFF
--- a/docs/plugins/development/graphql-api.md
+++ b/docs/plugins/development/graphql-api.md
@@ -8,7 +8,6 @@ A plugin can extend NetBox's GraphQL API by registering its own schema class. By
 
 ```python
 # graphql.py
-from typing import List
 import strawberry
 import strawberry_django
 
@@ -28,7 +27,7 @@ class MyQuery:
     @strawberry.field
     def dummymodel(self, id: int) -> DummyModelType:
         return None
-    dummymodel_list: List[DummyModelType] = strawberry_django.field()
+    dummymodel_list: list[DummyModelType] = strawberry_django.field()
 
 
 schema = [

--- a/docs/plugins/development/migration-v4.md
+++ b/docs/plugins/development/migration-v4.md
@@ -276,8 +276,6 @@ class CircuitsQuery(graphene.ObjectType):
 ```
 
 ```python title="New"
-from typing import List
-
 import strawberry
 import strawberry_django
 
@@ -286,7 +284,7 @@ class CircuitsQuery:
     @strawberry.field
     def circuit(self, id: int) -> CircuitType:
         return models.Circuit.objects.get(pk=id)
-    circuit_list: List[CircuitType] = strawberry_django.field()
+    circuit_list: list[CircuitType] = strawberry_django.field()
 ```
 
 ### Change types.py
@@ -307,7 +305,7 @@ class CircuitType(NetBoxObjectType, ContactsMixin):
 ```
 
 ```python title="New"
-from typing import Annotated, List
+from typing import Annotated
 
 import strawberry
 import strawberry_django
@@ -321,7 +319,7 @@ class CircuitTypeType(OrganizationalObjectType):
     color: str
 
     @strawberry_django.field
-    def circuits(self) -> List[Annotated["CircuitType", strawberry.lazy('circuits.graphql.types')]]:
+    def circuits(self) -> list[Annotated["CircuitType", strawberry.lazy('circuits.graphql.types')]]:
         return self.circuits.all()
 ```
 

--- a/docs/plugins/development/migration-v4.md
+++ b/docs/plugins/development/migration-v4.md
@@ -85,7 +85,7 @@ from django import forms
 class MyForm(forms.Form):
 ```
 
-### Update Fieldset Definitions
+### Update Fieldset definitions
 
 NetBox v4.0 introduces [several new classes](./forms.md#form-rendering) for advanced form rendering, including FieldSet. Fieldset definitions on forms should use this new class instead of a tuple or list.
 
@@ -252,7 +252,7 @@ class SiteSerializer(NetBoxModelSerializer):
 
 ### Include description fields in brief mode
 
-NetBox now includes the `description` the field in "brief" mode for all models which have one. This is not required for plugins, but you may opt to do the same for consistency.
+NetBox now includes the `description` field in "brief" mode for all models which have one. This is not required for plugins, but you may opt to do the same for consistency.
 
 ## GraphQL
 
@@ -260,7 +260,7 @@ NetBox has replaced [Graphene-Django](https://github.com/graphql-python/graphene
 
 ### Change schema.py
 
-Strawberry uses [python typing](https://docs.python.org/3/library/typing.html) and generally only requires a small refactoring of the schema definition to update:
+Strawberry uses [Python typing](https://docs.python.org/3/library/typing.html) and generally only requires a small refactoring of the schema definition to update:
 
 ```python title="Old"
 import graphene


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #15740 

- Fix some typos
- Replace [deprecated](https://docs.python.org/3/library/typing.html#typing.List) `typing.List` with `list` (NetBox v4.0 will only support Python 3.10+)