### PR TITLE
15427 Use endpoint_url in S3Backend

### DIFF
--- a/netbox/core/data_backends.py
+++ b/netbox/core/data_backends.py
@@ -149,7 +149,8 @@ class S3Backend(DataBackend):
             region_name=self._region_name,
             aws_access_key_id=aws_access_key_id,
             aws_secret_access_key=aws_secret_access_key,
-            config=self.config
+            config=self.config,
+            endpoint_url=self._endpoint_url
         )
         bucket = s3.Bucket(self._bucket_name)
 
@@ -175,6 +176,11 @@ class S3Backend(DataBackend):
     def _bucket_name(self):
         url_path = urlparse(self.url).path.lstrip('/')
         return url_path.split('/')[0]
+
+    @property
+    def _endpoint_url(self):
+        url_path = urlparse(self.url)
+        return url_path._replace(params="", fragment="", query="", path="").geturl()
 
     @property
     def _remote_path(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Closes: #15427

<!--
    Please include a summary of the proposed changes below.
-->

This PR includes the `endpoint_url` parameter to the call to `boto3.resource` for the `S3Backend`. This allows to use external S3 servers. 

I have tested the code against AWS S3 and and also against a local server using Minio. These url formats work correctly:
`https://s3.amazonaws.com/<bucket-name>`
`https://s3.<region-name>.amazonaws.com/<bucket-name>`
`https://<your-s3-server>/<bucket-name>`

[Virtual-host-style](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#virtual-hosted-style-access) and s3 protocol (s3://<bucket-name>) do not work, but they were not working before this PR.

