### PR TITLE
15636 change content_type_id to object_type_id for imageattachment

### DIFF
--- a/netbox/templates/inc/panels/image_attachments.html
+++ b/netbox/templates/inc/panels/image_attachments.html
@@ -12,5 +12,5 @@
       </div>
     {% endif %}
   </h5>
-  {% htmx_table 'extras:imageattachment_list' content_type_id=object|content_type_id object_id=object.pk %}
+  {% htmx_table 'extras:imageattachment_list' object_type_id=object|content_type_id object_id=object.pk %}
 </div>


### PR DESCRIPTION
### Fixes: #15636 

This was from the change from rename content_type_id to object_type_id, just needed to be put into the image filter call
