### PR TITLE
Closes #15736: Remove annotated_date() template filter and annotated_now() template tag

### DIFF
--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -179,9 +179,9 @@ Blocks:
             {# /Footer links #}
 
             {# Footer text #}
-            <ul class="list-inline list-inline-dots mb-0" id="footer-stamp" hx-swap-oob="true">
+            <ul class="list-inline list-inline-dots fs-5 mb-0" id="footer-stamp" hx-swap-oob="true">
               <li class="list-inline-item">
-                {% annotated_now %} {% now 'T' %}
+                {% now 'Y-m-d H:i:s T' %}
               </li>
               <li class="list-inline-item">
                 {{ settings.HOSTNAME }} (v{{ settings.VERSION }})

--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -64,7 +64,7 @@
           <td>
             {% if object.time_zone %}
               {{ object.time_zone }} ({% trans "UTC" %} {{ object.time_zone|tzoffset }})<br />
-              <small class="text-muted">{% trans "Site time" %}: {% timezone object.time_zone %}{% annotated_now %}{% endtimezone %}</small>
+              <small class="text-muted">{% trans "Site time" %}: {% timezone object.time_zone %}{% now 'Y-m-d H:i' %}{% endtimezone %}</small>
             {% else %}
               {{ ''|placeholder }}
             {% endif %}

--- a/netbox/utilities/templatetags/helpers.py
+++ b/netbox/utilities/templatetags/helpers.py
@@ -15,8 +15,6 @@ from utilities.forms import get_selected_values, TableConfigForm
 from utilities.views import get_viewname
 
 __all__ = (
-    'annotated_date',
-    'annotated_now',
     'applied_filters',
     'as_range',
     'divide',
@@ -103,34 +101,6 @@ def humanize_megabytes(mb):
     if not mb % 1024:
         return f'{int(mb / 1024)} GB'
     return f'{mb} MB'
-
-
-@register.filter(expects_localtime=True)
-def annotated_date(date_value):
-    """
-    Returns date as HTML span with short date format as the content and the
-    (long) date format as the title.
-    """
-    if not date_value:
-        return ''
-
-    if type(date_value) is datetime.date:
-        long_ts = date(date_value, 'DATE_FORMAT')
-        short_ts = date(date_value, 'SHORT_DATE_FORMAT')
-    else:
-        long_ts = date(date_value, 'DATETIME_FORMAT')
-        short_ts = date(date_value, 'SHORT_DATETIME_FORMAT')
-
-    return mark_safe(f'<span title="{long_ts}">{short_ts}</span>')
-
-
-@register.simple_tag
-def annotated_now():
-    """
-    Returns the current date piped through the annotated_date filter.
-    """
-    tzinfo = timezone.get_current_timezone() if settings.USE_TZ else None
-    return annotated_date(datetime.datetime.now(tz=tzinfo))
 
 
 @register.filter()


### PR DESCRIPTION
### Closes: #15736

- Replace uses of `{% annotated_now %}` with Django's `{% now %}` tag (using ISO 8601 format)
- Remove the `annotated_date()` template filter
- Remove the `annotated_now()` template tag
