### PR TITLE
Fixes #15717 - Unable to assign a VM in Site to Cluster without Site

### DIFF
--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -465,7 +465,10 @@ class DeviceForm(TenancyForm, NetBoxModelForm):
         label=_('Cluster'),
         queryset=Cluster.objects.all(),
         required=False,
-        selector=True
+        selector=True,
+        query_params={
+            'site_id': ['$site', 'null']
+        },
     )
     comments = CommentField()
     local_context_data = JSONField(

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -560,9 +560,6 @@ class DeviceTestCase(TestCase):
         # Device with site, cluster non-site should pass
         Device(name='device1', site=sites[0], device_type=device_type, role=device_role, cluster=clusters[2]).full_clean()
 
-        # Device with non-site cluster only should pass
-        Device(name='device1', site=sites[0], device_type=device_type, role=device_role, cluster=clusters[2]).full_clean()
-
         # Device with mismatched site & cluster should fail
         with self.assertRaises(ValidationError):
             Device(name='device1', site=sites[0], device_type=device_type, role=device_role, cluster=clusters[1]).full_clean()

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -564,30 +564,6 @@ class DeviceTestCase(TestCase):
         with self.assertRaises(ValidationError):
             Device(name='device1', site=sites[0], device_type=device_type, role=device_role, cluster=clusters[1]).full_clean()
 
-    def test_old_device_role_field(self):
-        """
-        Ensure that the old device role field sets the value in the new role field.
-        """
-
-        # Test getter method
-        device = Device(
-            site=Site.objects.first(),
-            device_type=DeviceType.objects.first(),
-            role=DeviceRole.objects.first(),
-            name='Test Device 1',
-            device_role=DeviceRole.objects.first()
-        )
-        device.full_clean()
-        device.save()
-
-        self.assertEqual(device.role, device.device_role)
-
-        # Test setter method
-        device.device_role = DeviceRole.objects.last()
-        device.full_clean()
-        device.save()
-        self.assertEqual(device.role, device.device_role)
-
 
 class CableTestCase(TestCase):
 

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -8,6 +8,7 @@ from dcim.models import *
 from extras.models import CustomField
 from tenancy.models import Tenant
 from utilities.data import drange
+from virtualization.models import Cluster, ClusterType
 
 
 class LocationTestCase(TestCase):
@@ -532,6 +533,63 @@ class DeviceTestCase(TestCase):
         # Two devices assigned to the same Site and different Tenants should pass validation
         device2.full_clean()
         device2.save()
+
+    def test_device_mismatched_site_cluster(self):
+        cluster_type = ClusterType.objects.create(name='Cluster Type 1', slug='cluster-type-1')
+        Cluster.objects.create(name='Cluster 1', type=cluster_type)
+
+        sites = (
+            Site(name='Site 1', slug='site-1'),
+            Site(name='Site 2', slug='site-2'),
+        )
+        Site.objects.bulk_create(sites)
+
+        clusters = (
+            Cluster(name='Cluster 1', type=cluster_type, site=sites[0]),
+            Cluster(name='Cluster 2', type=cluster_type, site=sites[1]),
+            Cluster(name='Cluster 3', type=cluster_type, site=None),
+        )
+        Cluster.objects.bulk_create(clusters)
+
+        device_type = DeviceType.objects.first()
+        device_role = DeviceRole.objects.first()
+
+        # Device with site only should pass
+        Device(name='device1', site=sites[0], device_type=device_type, role=device_role).full_clean()
+
+        # Device with site, cluster non-site should pass
+        Device(name='device1', site=sites[0], device_type=device_type, role=device_role, cluster=clusters[2]).full_clean()
+
+        # Device with non-site cluster only should pass
+        Device(name='device1', site=sites[0], device_type=device_type, role=device_role, cluster=clusters[2]).full_clean()
+
+        # Device with mismatched site & cluster should fail
+        with self.assertRaises(ValidationError):
+            Device(name='device1', site=sites[0], device_type=device_type, role=device_role, cluster=clusters[1]).full_clean()
+
+    def test_old_device_role_field(self):
+        """
+        Ensure that the old device role field sets the value in the new role field.
+        """
+
+        # Test getter method
+        device = Device(
+            site=Site.objects.first(),
+            device_type=DeviceType.objects.first(),
+            role=DeviceRole.objects.first(),
+            name='Test Device 1',
+            device_role=DeviceRole.objects.first()
+        )
+        device.full_clean()
+        device.save()
+
+        self.assertEqual(device.role, device.device_role)
+
+        # Test setter method
+        device.device_role = DeviceRole.objects.last()
+        device.full_clean()
+        device.save()
+        self.assertEqual(device.role, device.device_role)
 
 
 class CableTestCase(TestCase):

--- a/netbox/virtualization/forms/model_forms.py
+++ b/netbox/virtualization/forms/model_forms.py
@@ -177,6 +177,9 @@ class VirtualMachineForm(TenancyForm, NetBoxModelForm):
         queryset=Cluster.objects.all(),
         required=False,
         selector=True,
+        query_params={
+            'site_id': ['$site', 'null']
+        },
     )
     device = DynamicModelChoiceField(
         label=_('Device'),

--- a/netbox/virtualization/forms/model_forms.py
+++ b/netbox/virtualization/forms/model_forms.py
@@ -177,9 +177,6 @@ class VirtualMachineForm(TenancyForm, NetBoxModelForm):
         queryset=Cluster.objects.all(),
         required=False,
         selector=True,
-        query_params={
-            'site_id': '$site',
-        }
     )
     device = DynamicModelChoiceField(
         label=_('Device'),

--- a/netbox/virtualization/models/virtualmachines.py
+++ b/netbox/virtualization/models/virtualmachines.py
@@ -180,7 +180,7 @@ class VirtualMachine(ContactsMixin, ImageAttachmentsMixin, RenderConfigMixin, Co
             })
 
         # Validate site for cluster & device
-        if self.cluster and self.site and self.cluster.site != self.site:
+        if self.cluster and self.cluster.site is not None and self.cluster.site != self.site:
             raise ValidationError({
                 'cluster': _(
                     'The selected cluster ({cluster}) is not assigned to this site ({site}).'

--- a/netbox/virtualization/tests/test_models.py
+++ b/netbox/virtualization/tests/test_models.py
@@ -63,6 +63,9 @@ class VirtualMachineTestCase(TestCase):
         # VM with site only should pass
         VirtualMachine(name='vm1', site=sites[0]).full_clean()
 
+        # VM with site, cluster non-site should pass
+        VirtualMachine(name='vm1', site=sites[0], cluster=clusters[2]).full_clean()
+
         # VM with non-site cluster only should pass
         VirtualMachine(name='vm1', cluster=clusters[2]).full_clean()
 


### PR DESCRIPTION
### Fixes: #15717 

Adds to existing IF statement for VirtualMachine.clean()  (to match existing check for Device.clean()) to allow for VM to be assigned to a Cluster without a Site. 

Updated existing VM test to check for this new use case, and added Device tests for Clusters with Sites matching/not matching as well.