### PR TITLE
15588 set readonly nullable fields as allow_null=True

### DIFF
--- a/netbox/dcim/api/serializers.py
+++ b/netbox/dcim/api/serializers.py
@@ -612,7 +612,7 @@ class InventoryItemTemplateSerializer(ValidatedModelSerializer):
         required=False,
         allow_null=True
     )
-    component = serializers.SerializerMethodField(read_only=True)
+    component = serializers.SerializerMethodField(read_only=True, allow_null=True)
     _depth = serializers.IntegerField(source='level', read_only=True)
 
     class Meta:
@@ -685,7 +685,7 @@ class DeviceSerializer(NetBoxModelSerializer):
     )
     status = ChoiceField(choices=DeviceStatusChoices, required=False)
     airflow = ChoiceField(choices=DeviceAirflowChoices, allow_blank=True, required=False)
-    primary_ip = NestedIPAddressSerializer(read_only=True)
+    primary_ip = NestedIPAddressSerializer(read_only=True, allow_null=True)
     primary_ip4 = NestedIPAddressSerializer(required=False, allow_null=True)
     primary_ip6 = NestedIPAddressSerializer(required=False, allow_null=True)
     oob_ip = NestedIPAddressSerializer(required=False, allow_null=True)
@@ -735,7 +735,7 @@ class DeviceSerializer(NetBoxModelSerializer):
 
 
 class DeviceWithConfigContextSerializer(DeviceSerializer):
-    config_context = serializers.SerializerMethodField(read_only=True)
+    config_context = serializers.SerializerMethodField(read_only=True, allow_null=True)
 
     class Meta(DeviceSerializer.Meta):
         fields = [
@@ -1067,7 +1067,7 @@ class InventoryItemSerializer(NetBoxModelSerializer):
         required=False,
         allow_null=True
     )
-    component = serializers.SerializerMethodField(read_only=True)
+    component = serializers.SerializerMethodField(read_only=True, allow_null=True)
     _depth = serializers.IntegerField(source='level', read_only=True)
 
     class Meta:

--- a/netbox/ipam/api/serializers.py
+++ b/netbox/ipam/api/serializers.py
@@ -262,7 +262,7 @@ class AvailableVLANSerializer(serializers.Serializer):
     Representation of a VLAN which does not exist in the database.
     """
     vid = serializers.IntegerField(read_only=True)
-    group = NestedVLANGroupSerializer(read_only=True)
+    group = NestedVLANGroupSerializer(read_only=True, allow_null=True)
 
     def to_representation(self, instance):
         return {
@@ -348,9 +348,9 @@ class AvailablePrefixSerializer(serializers.Serializer):
     """
     Representation of a prefix which does not exist in the database.
     """
-    family = serializers.IntegerField(read_only=True)
+    family = serializers.IntegerField(read_only=True, allow_null=True)
     prefix = serializers.CharField(read_only=True)
-    vrf = NestedVRFSerializer(read_only=True)
+    vrf = NestedVRFSerializer(read_only=True, allow_null=True)
 
     def to_representation(self, instance):
         if self.context.get('vrf'):
@@ -429,9 +429,9 @@ class AvailableIPSerializer(serializers.Serializer):
     """
     Representation of an IP address which does not exist in the database.
     """
-    family = serializers.IntegerField(read_only=True)
+    family = serializers.IntegerField(read_only=True, allow_null=True)
     address = serializers.CharField(read_only=True)
-    vrf = NestedVRFSerializer(read_only=True)
+    vrf = NestedVRFSerializer(read_only=True, allow_null=True)
     description = serializers.CharField(required=False)
 
     def to_representation(self, instance):

--- a/netbox/virtualization/api/serializers.py
+++ b/netbox/virtualization/api/serializers.py
@@ -76,7 +76,7 @@ class VirtualMachineSerializer(NetBoxModelSerializer):
     role = NestedDeviceRoleSerializer(required=False, allow_null=True)
     tenant = NestedTenantSerializer(required=False, allow_null=True)
     platform = NestedPlatformSerializer(required=False, allow_null=True)
-    primary_ip = NestedIPAddressSerializer(read_only=True)
+    primary_ip = NestedIPAddressSerializer(read_only=True, allow_null=True)
     primary_ip4 = NestedIPAddressSerializer(required=False, allow_null=True)
     primary_ip6 = NestedIPAddressSerializer(required=False, allow_null=True)
     config_template = NestedConfigTemplateSerializer(required=False, allow_null=True, default=None)


### PR DESCRIPTION
### Fixes: #15588 

As mentioned in the bug report, several fields are readonly but can also allow null return.  I did a scan through the code and tried to identify all issues of this - checking that the model can actually return a null for those fields.