### PR TITLE
Add link to plugin certification program details in Plugin module of docs. Fixes #15769

### DIFF
--- a/docs/plugins/development/index.md
+++ b/docs/plugins/development/index.md
@@ -3,6 +3,9 @@
 !!! tip "Plugins Development Tutorial"
     Just getting started with plugins? Check out our [**NetBox Plugin Tutorial**](https://github.com/netbox-community/netbox-plugin-tutorial) on GitHub! This in-depth guide will walk you through the process of creating an entire plugin from scratch. It even includes a companion [demo plugin repo](https://github.com/netbox-community/netbox-plugin-demo) to ensure you can jump in at any step along the way. This will get you up and running with plugins in no time!
 
+!!! tip "Plugin Certification Program"
+    NetBox Labs offers a [**Plugin Certification Program**](https://github.com/netbox-community/netbox/wiki/Plugin-Certification-Program) for plugin developers interested in establishing a co-maintainer relationship. The program aims to assure ongoing compatibility, maintainability, and commercial supportability of key plugins.
+
 NetBox can be extended to support additional data models and functionality through the use of plugins. A plugin is essentially a self-contained [Django app](https://docs.djangoproject.com/en/stable/) which gets installed alongside NetBox to provide custom functionality. Multiple plugins can be installed in a single NetBox instance, and each plugin can be enabled and configured independently.
 
 !!! info "Django Development"


### PR DESCRIPTION
### Fixes: #15769

Adds a link to plugin certification program details in Plugin module of the NetBox docs.