### PR TITLE
resolve #15712 -  add imageattachments to virtualmachines

### DIFF
--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -158,6 +158,7 @@
           </h5>
           {% htmx_table 'ipam:service_list' virtual_machine_id=object.pk %}
         </div>
+        {% include 'inc/panels/image_attachments.html' %}
         {% plugin_right_page object %}
     </div>
 </div>

--- a/netbox/virtualization/models/virtualmachines.py
+++ b/netbox/virtualization/models/virtualmachines.py
@@ -15,7 +15,7 @@ from extras.models import ConfigContextModel
 from extras.querysets import ConfigContextModelQuerySet
 from netbox.config import get_config
 from netbox.models import NetBoxModel, PrimaryModel
-from netbox.models.features import ContactsMixin
+from netbox.models.features import ContactsMixin, ImageAttachmentsMixin
 from utilities.fields import CounterCacheField, NaturalOrderingField
 from utilities.ordering import naturalize_interface
 from utilities.query_functions import CollateAsChar
@@ -29,7 +29,7 @@ __all__ = (
 )
 
 
-class VirtualMachine(ContactsMixin, RenderConfigMixin, ConfigContextModel, PrimaryModel):
+class VirtualMachine(ContactsMixin, ImageAttachmentsMixin, RenderConfigMixin, ConfigContextModel, PrimaryModel):
     """
     A virtual machine which runs inside a Cluster.
     """


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #15712

<!--
    Please include a summary of the proposed changes below.
-->

In order to resolve #15712 this commit adds the Image Attachment template to the virtualmachine template. Furthermore, the VirtualMachine model inherits the ImageAttachmentsMixin to add support for image attachmentes to the model.

Screenshot of the added modal:
![image](https://github.com/netbox-community/netbox/assets/14820882/7c24bb72-929b-4faa-af7f-ff24b1b5b9a3)

![image](https://github.com/netbox-community/netbox/assets/14820882/0a3e2cd7-4286-4884-95c3-39706e914901)
