### PR TITLE
Fixes #15641: Fix adding/removing filters on advanced object selector widget

### DIFF
--- a/netbox/templates/htmx/object_selector.html
+++ b/netbox/templates/htmx/object_selector.html
@@ -9,8 +9,8 @@
   <div class="col-3">
     <div class="list-group list-group-flush">
       {% for field in form.visible_fields %}
-        <a href="#" class="list-group-item list-group-item-action px-0 py-1" data-bs-toggle="collapse" data-bs-target="#checkmark{{ forloop.counter }}, #selector{{ forloop.counter }}">
-          <span id="checkmark{{ forloop.counter }}" class="collapse{% if forloop.counter < 3 or field.name in form.selector_fields %} show{% endif %}"><i class="mdi mdi-check-bold"></i></span>
+        <a href="#" class="list-group-item list-group-item-action px-0 py-1" data-bs-toggle="collapse" data-bs-target=".selector{{ forloop.counter }}">
+          <span class="collapse selector{{ forloop.counter }}{% if forloop.counter < 3 or field.name in form.selector_fields %} show{% endif %}"><i class="mdi mdi-check-bold"></i></span>
           {{ field.label }}
         </a>
       {% endfor %}
@@ -21,7 +21,7 @@
       <input type="hidden" name="_search" value="true" />
       <div class="tab-content p-1">
         {% for field in form.visible_fields %}
-          <div class="collapse{% if field.name in form.selector_fields %} show{% endif %}" id="selector{{ forloop.counter }}">{% render_field field %}</div>
+          <div class="collapse selector{{ forloop.counter }}{% if field.name in form.selector_fields %} show{% endif %}">{% render_field field %}</div>
         {% endfor %}
       </div>
       <div class="text-end">

--- a/netbox/templates/htmx/object_selector_results.html
+++ b/netbox/templates/htmx/object_selector_results.html
@@ -1,12 +1,10 @@
 <div class="list-group">
   {% for object in results %}
-    <a href="#" class="list-group-item list-group-item-action" data-label="{{ object }}" data-value="{{ object.pk }}" data-bs-dismiss="modal">
-      <h6 class="mb-1">
-        {{ object }}
-        {% if object.status %}{% badge object.get_status_display bg_color=object.get_status_color %}{% endif %}
-      </h6>
+    <a href="#" class="list-group-item list-group-item-action p-2" data-label="{{ object }}" data-value="{{ object.pk }}" data-bs-dismiss="modal">
+      {{ object }}
+      {% if object.status %}{% badge object.get_status_display bg_color=object.get_status_color %}{% endif %}
       {% if object.description %}
-        <small>{{ object.description }}</small>
+        <small class="d-block text-muted">{{ object.description }}</small>
       {% endif %}
     </a>
   {% endfor %}


### PR DESCRIPTION
### Fixes: #15641

- Switch `data-bs-target` from a list of IDs (worked previously?) to a single class name
- Miscellaneous cosmetic improvements to the objects list