### PR TITLE
Closes #15754: Remove `staff_only=True` from admin menu items

### DIFF
--- a/netbox/netbox/navigation/menu.py
+++ b/netbox/netbox/navigation/menu.py
@@ -368,12 +368,10 @@ ADMIN_MENU = Menu(
         MenuGroup(
             label=_('Authentication'),
             items=(
-                # Proxy model for auth.User
                 MenuItem(
                     link=f'users:user_list',
                     link_text=_('Users'),
                     permissions=[f'auth.view_user'],
-                    staff_only=True,
                     buttons=(
                         MenuItemButton(
                             link=f'users:user_add',
@@ -389,12 +387,10 @@ ADMIN_MENU = Menu(
                         )
                     )
                 ),
-                # Proxy model for auth.Group
                 MenuItem(
                     link=f'users:group_list',
                     link_text=_('Groups'),
                     permissions=[f'auth.view_group'],
-                    staff_only=True,
                     buttons=(
                         MenuItemButton(
                             link=f'users:group_add',
@@ -414,14 +410,12 @@ ADMIN_MENU = Menu(
                     link=f'users:token_list',
                     link_text=_('API Tokens'),
                     permissions=[f'users.view_token'],
-                    staff_only=True,
                     buttons=get_model_buttons('users', 'token')
                 ),
                 MenuItem(
                     link=f'users:objectpermission_list',
                     link_text=_('Permissions'),
                     permissions=[f'users.view_objectpermission'],
-                    staff_only=True,
                     buttons=get_model_buttons('users', 'objectpermission', actions=['add'])
                 ),
             ),
@@ -432,14 +426,12 @@ ADMIN_MENU = Menu(
                 MenuItem(
                     link='core:config',
                     link_text=_('Current Config'),
-                    permissions=['core.view_configrevision'],
-                    staff_only=True
+                    permissions=['core.view_configrevision']
                 ),
                 MenuItem(
                     link='core:configrevision_list',
                     link_text=_('Config Revisions'),
-                    permissions=['core.view_configrevision'],
-                    staff_only=True
+                    permissions=['core.view_configrevision']
                 ),
             ),
         ),
@@ -448,13 +440,11 @@ ADMIN_MENU = Menu(
             items=(
                 MenuItem(
                     link='core:plugin_list',
-                    link_text=_('Plugins'),
-                    staff_only=True
+                    link_text=_('Plugins')
                 ),
                 MenuItem(
                     link='core:background_queue_list',
-                    link_text=_('Background Tasks'),
-                    staff_only=True
+                    link_text=_('Background Tasks')
                 ),
             ),
         ),

--- a/netbox/templates/users/token_edit.html
+++ b/netbox/templates/users/token_edit.html
@@ -1,0 +1,9 @@
+{% extends 'generic/object_edit.html' %}
+{% load i18n %}
+
+{% block content %}
+  {% if not request.user.is_superuser %}
+    {% include 'inc/alerts/warning.html' with title="Creating API Tokens" message="Non-superusers should generally create and modify API tokens under their user profile." %}
+  {% endif %}
+  {{ block.super }}
+{% endblock %}

--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -28,6 +28,7 @@ class TokenView(generic.ObjectView):
 class TokenEditView(generic.ObjectEditView):
     queryset = Token.objects.all()
     form = forms.TokenForm
+    template_name = 'users/token_edit.html'
 
 
 @register_model_view(Token, 'delete')


### PR DESCRIPTION
### Fixes: #15754

- Remove `staff_only=True` from all menu items
- Add a warning to the API token edit view for non-superusers

There's an odd issue here where regular users will see the API token items under the admin menu, because by default all users have permission to create their own tokens. We also can't hide the menu item from non-superusers entirely, because it's valid to assign a non-superuser permissions to create tokens for specific other accounts (e.g. service accounts), which can only be done via the admin views. So, I've settled on displaying a warning for non-superusers directing them to create tokens using the relevant account views.

(Note that there's no security issue here: Attempting to create/modify a token for another user will fail just as it will in the current release. I just want to mitigate the inevitable confusion of having two paths to create a token.)