### PR TITLE
15789 make sure job completed before including config_form

### DIFF
--- a/netbox/templates/extras/script_result.html
+++ b/netbox/templates/extras/script_result.html
@@ -101,5 +101,7 @@
 {% endblock content %}
 
 {% block modals %}
+  {% if job.completed %}
   {% table_config_form table table_name="ObjectTable" %}
+  {% endif %}
 {% endblock modals %}


### PR DESCRIPTION
### Fixes: #15789

If the job isn't completed then there is no table, which is accounted for in the rest of the form but not for the include of the config_form.  Was a bit tricky as timing related, if the job finishes before display then it works fine.