### PR TITLE
Fixes #15771: Show id field as supported on all bulk import forms

### DIFF
--- a/netbox/netbox/forms/base.py
+++ b/netbox/netbox/forms/base.py
@@ -73,11 +73,6 @@ class NetBoxModelImportForm(CSVModelForm, NetBoxModelForm):
     """
     Base form for creating a NetBox objects from CSV data. Used for bulk importing.
     """
-    id = forms.IntegerField(
-        label=_('Id'),
-        required=False,
-        help_text='Numeric ID of an existing object to update (if not creating a new object)'
-    )
     tags = CSVModelMultipleChoiceField(
         label=_('Tags'),
         queryset=Tag.objects.all(),

--- a/netbox/utilities/forms/forms.py
+++ b/netbox/utilities/forms/forms.py
@@ -70,6 +70,12 @@ class CSVModelForm(forms.ModelForm):
     """
     ModelForm used for the import of objects in CSV format.
     """
+    id = forms.IntegerField(
+        label=_('ID'),
+        required=False,
+        help_text=_('Numeric ID of an existing object to update (if not creating a new object)')
+    )
+
     def __init__(self, *args, headers=None, **kwargs):
         self.headers = headers or {}
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
### Fixes: #15771

Move the `id` field from NetBoxModelImportForm to CSVModelForm to ensure it is applied to all relevant forms.