### PR TITLE
Fixes #15580: Fix rendering of modals with HTMX enabled

### DIFF
--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -126,6 +126,9 @@ Blocks:
       {% endif %}
       {# /Bottom banner #}
 
+      {# BS5 pop-up modals #}
+      {% block modals %}{% endblock %}
+
       </div>
 
       {# Page footer #}
@@ -196,9 +199,6 @@ Blocks:
 
     {# /Page content #}
     </div>
-
-    {# BS5 pop-up modals #}
-    {% block modals %}{% endblock %}
 
   </div>
 {% endblock layout %}


### PR DESCRIPTION
### Fixes: #15580

Moves the `modals` block into the main page content to ensure proper display of modals.
