### PR TITLE
Fixes #15812: Add Date(Time)Var for scripts to allow much easier date…

### DIFF
--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -285,6 +285,14 @@ An IPv4 or IPv6 network with a mask. Returns a `netaddr.IPNetwork` object. Two a
 * `min_prefix_length` - Minimum length of the mask
 * `max_prefix_length` - Maximum length of the mask
 
+### DateVar
+
+A date. Returns a `datetime.date` object.
+
+### DateTimeVar
+
+A datetime. Returns a `datetime.datetime` object.
+
 ## Running Custom Scripts
 
 !!! note

--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -287,11 +287,11 @@ An IPv4 or IPv6 network with a mask. Returns a `netaddr.IPNetwork` object. Two a
 
 ### DateVar
 
-A date. Returns a `datetime.date` object.
+A calendar date. Returns a `datetime.date` object.
 
 ### DateTimeVar
 
-A datetime. Returns a `datetime.datetime` object.
+A complete date & time. Returns a `datetime.datetime` object.
 
 ## Running Custom Scripts
 

--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -24,6 +24,7 @@ from ipam.validators import MaxPrefixLengthValidator, MinPrefixLengthValidator, 
 from utilities.exceptions import AbortScript, AbortTransaction
 from utilities.forms import add_blank_choice
 from utilities.forms.fields import DynamicModelChoiceField, DynamicModelMultipleChoiceField
+from utilities.forms.widgets import DatePicker, DateTimePicker
 from .context_managers import event_tracking
 from .forms import ScriptForm
 
@@ -31,6 +32,8 @@ __all__ = (
     'BaseScript',
     'BooleanVar',
     'ChoiceVar',
+    'DateVar',
+    'DateTimeVar',
     'FileVar',
     'IntegerVar',
     'IPAddressVar',
@@ -170,6 +173,28 @@ class ChoiceVar(ScriptVariable):
 
         # Set field choices, adding a blank choice to avoid forced selections
         self.field_attrs['choices'] = add_blank_choice(choices)
+
+
+class DateVar(ScriptVariable):
+    """
+    A date.
+    """
+    form_field = forms.DateField
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.form_field.widget = DatePicker()
+
+
+class DateTimeVar(ScriptVariable):
+    """
+    A date and a time.
+    """
+    form_field = forms.DateTimeField
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.form_field.widget = DateTimePicker()
 
 
 class MultiChoiceVar(ScriptVariable):

--- a/netbox/extras/tests/test_scripts.py
+++ b/netbox/extras/tests/test_scripts.py
@@ -1,4 +1,5 @@
 import tempfile
+from datetime import date, datetime, timezone
 
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
@@ -322,3 +323,35 @@ class ScriptVariablesTest(TestCase):
         form = TestScript().as_form(data, None)
         self.assertTrue(form.is_valid())
         self.assertEqual(form.cleaned_data['var1'], IPNetwork(data['var1']))
+
+    def test_datevar(self):
+
+        class TestScript(Script):
+
+            var1 = DateVar()
+            var2 = DateVar(required=False)
+
+        # Validate valid data
+        input_date = date(2024, 4, 1)
+        data = {'var1': input_date}
+        form = TestScript().as_form(data, None)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['var1'], input_date)
+        # Validate required=False works for this Var type
+        self.assertEqual(form.cleaned_data['var2'], None)
+
+    def test_datetimevar(self):
+
+        class TestScript(Script):
+
+            var1 = DateTimeVar()
+            var2 = DateTimeVar(required=False)
+
+        # Validate valid data
+        input_datetime = datetime(2024, 4, 1, 8, 0, 0, 0, timezone.utc)
+        data = {'var1': input_datetime}
+        form = TestScript().as_form(data, None)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['var1'], input_datetime)
+        # Validate required=False works for this Var type
+        self.assertEqual(form.cleaned_data['var2'], None)

--- a/netbox/extras/tests/test_scripts.py
+++ b/netbox/extras/tests/test_scripts.py
@@ -331,6 +331,12 @@ class ScriptVariablesTest(TestCase):
             var1 = DateVar()
             var2 = DateVar(required=False)
 
+        # Test date validation
+        data = {'var1': 'not a date'}
+        form = TestScript().as_form(data, None)
+        self.assertFalse(form.is_valid())
+        self.assertIn('var1', form.errors)
+
         # Validate valid data
         input_date = date(2024, 4, 1)
         data = {'var1': input_date}
@@ -346,6 +352,12 @@ class ScriptVariablesTest(TestCase):
 
             var1 = DateTimeVar()
             var2 = DateTimeVar(required=False)
+
+        # Test datetime validation
+        data = {'var1': 'not a datetime'}
+        form = TestScript().as_form(data, None)
+        self.assertFalse(form.is_valid())
+        self.assertIn('var1', form.errors)
 
         # Validate valid data
         input_datetime = datetime(2024, 4, 1, 8, 0, 0, 0, timezone.utc)


### PR DESCRIPTION


Fixes: #15812

Adds a `DateVar` and a `DateTimeVar` to make it easier to input these data types. I've added some really basic ScriptTests.

![image](https://github.com/netbox-community/netbox/assets/63594136/b598ca90-49b6-4a52-b40c-4a4ec4f4832e)

![image](https://github.com/netbox-community/netbox/assets/63594136/9d640ded-63c9-4104-843f-04978a11e036)

These input fields use native datepicker widgets provided by the browser.
