### PR TITLE
15809 Mark unions as nullable in GraphQL where appropriate

### DIFF
--- a/netbox/dcim/graphql/mixins.py
+++ b/netbox/dcim/graphql/mixins.py
@@ -23,7 +23,7 @@ class CabledObjectMixin:
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("LinkPeerType")]] | None
+    ], strawberry.union("LinkPeerType")]]
 
 
 @strawberry.type
@@ -40,4 +40,4 @@ class PathEndpointMixin:
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["ProviderNetworkType", strawberry.lazy('circuits.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("ConnectedEndpointType")]] | None
+    ], strawberry.union("ConnectedEndpointType")]]

--- a/netbox/dcim/graphql/mixins.py
+++ b/netbox/dcim/graphql/mixins.py
@@ -23,7 +23,7 @@ class CabledObjectMixin:
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("LinkPeerType")]]
+    ], strawberry.union("LinkPeerType")]] | None
 
 
 @strawberry.type
@@ -40,4 +40,4 @@ class PathEndpointMixin:
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["ProviderNetworkType", strawberry.lazy('circuits.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("ConnectedEndpointType")]]
+    ], strawberry.union("ConnectedEndpointType")]] | None

--- a/netbox/dcim/graphql/types.py
+++ b/netbox/dcim/graphql/types.py
@@ -130,7 +130,7 @@ class CableTerminationType(NetBoxObjectType):
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("CableTerminationTerminationType")]
+    ], strawberry.union("CableTerminationTerminationType")] | None
 
 
 @strawberry_django.type(
@@ -302,7 +302,7 @@ class InventoryItemTemplateType(ComponentTemplateType):
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("InventoryItemTemplateComponentType")]
+    ], strawberry.union("InventoryItemTemplateComponentType")] | None
 
 
 @strawberry_django.type(
@@ -431,7 +431,7 @@ class InventoryItemType(ComponentType):
         Annotated["PowerOutletType", strawberry.lazy('dcim.graphql.types')],
         Annotated["PowerPortType", strawberry.lazy('dcim.graphql.types')],
         Annotated["RearPortType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("InventoryItemComponentType")]
+    ], strawberry.union("InventoryItemComponentType")] | None
 
 
 @strawberry_django.type(

--- a/netbox/ipam/graphql/types.py
+++ b/netbox/ipam/graphql/types.py
@@ -133,7 +133,7 @@ class IPAddressType(NetBoxObjectType, BaseIPAddressFamilyType):
         Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')],
         Annotated["FHRPGroupType", strawberry.lazy('ipam.graphql.types')],
         Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')],
-    ], strawberry.union("IPAddressAssignmentType")]:
+    ], strawberry.union("IPAddressAssignmentType")] | None:
         return self.assigned_object
 
 
@@ -261,7 +261,7 @@ class VLANGroupType(OrganizationalObjectType):
         Annotated["RegionType", strawberry.lazy('dcim.graphql.types')],
         Annotated["SiteType", strawberry.lazy('dcim.graphql.types')],
         Annotated["SiteGroupType", strawberry.lazy('dcim.graphql.types')],
-    ], strawberry.union("VLANGroupScopeType")]:
+    ], strawberry.union("VLANGroupScopeType")] | None:
         return self.scope
 
 

--- a/netbox/utilities/testing/api.py
+++ b/netbox/utilities/testing/api.py
@@ -469,6 +469,9 @@ class APIViewTestCases:
                 elif type(field.type) is StrawberryUnion:
                     # this would require a fragment query
                     continue
+                elif type(field.type) is StrawberryOptional and type(field.type.of_type) is StrawberryUnion:
+                    # this would require a fragment query
+                    continue
                 elif type(field.type) is StrawberryOptional and type(field.type.of_type) is LazyType:
                     fields_string += f'{field.name} {{ id }}\n'
                 elif hasattr(field, 'is_relation') and field.is_relation:


### PR DESCRIPTION
### Fixes: #15809 

Several of the GraphQL typing for Unions were missing `| None` to mark that they could return null values.  Fixes the test suite as this change was causing them to incorrectly query if the union was optional.