### PR TITLE
issue_13422: Ignore MPTT fields in serialisation if being used by staged changes

### DIFF
--- a/netbox/netbox/staging.py
+++ b/netbox/netbox/staging.py
@@ -116,7 +116,7 @@ class checkout:
         # Creating a new object
         if kwargs.get('created'):
             logger.debug(f"[{self.branch}] Staging creation of {object_type} {instance} (PK: {instance.pk})")
-            data = serialize_object(instance, resolve_tags=False)
+            data = serialize_object(instance, resolve_tags=False, mptt=True)
             self.queue[key] = (ChangeActionChoices.ACTION_CREATE, data)
             return
 
@@ -127,13 +127,13 @@ class checkout:
         # Object has already been created/updated in the queue; update its queued representation
         if key in self.queue:
             logger.debug(f"[{self.branch}] Updating staged value for {object_type} {instance} (PK: {instance.pk})")
-            data = serialize_object(instance, resolve_tags=False)
+            data = serialize_object(instance, resolve_tags=False, mptt=True)
             self.queue[key] = (self.queue[key][0], data)
             return
 
         # Modifying an existing object for the first time
         logger.debug(f"[{self.branch}] Staging changes to {object_type} {instance} (PK: {instance.pk})")
-        data = serialize_object(instance, resolve_tags=False)
+        data = serialize_object(instance, resolve_tags=False, mptt=True)
         self.queue[key] = (ChangeActionChoices.ACTION_UPDATE, data)
 
     def pre_delete_handler(self, sender, instance, **kwargs):

--- a/netbox/netbox/tests/test_staging.py
+++ b/netbox/netbox/tests/test_staging.py
@@ -70,7 +70,7 @@ class StagingTestCase(TransactionTestCase):
         # Verify that changes have been rolled back after exiting the context
         self.assertEqual(Provider.objects.count(), 3)
         self.assertEqual(Circuit.objects.count(), 9)
-        self.assertEqual(StagedChange.objects.count(), 5)
+        self.assertEqual(StagedChange.objects.count(), 6)
         self.assertEqual(Location.objects.count(), 0)
 
         # Verify that changes are replayed upon entering the context

--- a/netbox/netbox/tests/test_staging.py
+++ b/netbox/netbox/tests/test_staging.py
@@ -1,7 +1,7 @@
 from django.test import TransactionTestCase
 
 from circuits.models import Provider, Circuit, CircuitType
-from dcim.models import Location
+from dcim.models import Location, Site
 from extras.choices import ChangeActionChoices
 from extras.models import Branch, StagedChange, Tag
 from ipam.models import ASN, RIR
@@ -13,6 +13,8 @@ class StagingTestCase(TransactionTestCase):
 
     def setUp(self):
         create_tags('Alpha', 'Bravo', 'Charlie')
+
+        Site.objects.create(name="Site 1", slug="site-1")
 
         rir = RIR.objects.create(name='RIR 1', slug='rir-1')
         asns = (
@@ -47,6 +49,7 @@ class StagingTestCase(TransactionTestCase):
         branch = Branch.objects.create(name='Branch 1')
         tags = Tag.objects.all()
         asns = ASN.objects.all()
+        site = Site.objects.first()
 
         with checkout(branch):
             provider = Provider.objects.create(name='Provider D', slug='provider-d')
@@ -55,7 +58,7 @@ class StagingTestCase(TransactionTestCase):
             circuit.tags.set(tags)
 
             # Test MPTT Model
-            location = Location.objects.create(name='Location 1', slug='location-1')
+            location = Location.objects.create(name='Location 1', slug='location-1', site=site)
 
             # Sanity-checking
             self.assertEqual(Provider.objects.count(), 4)

--- a/netbox/utilities/utils.py
+++ b/netbox/utilities/utils.py
@@ -147,7 +147,7 @@ def count_related(model, field):
     return Coalesce(subquery, 0)
 
 
-def serialize_object(obj, resolve_tags=True, extra=None, exclude=None):
+def serialize_object(obj, resolve_tags=True, extra=None, exclude=None, mptt=False):
     """
     Return a generic JSON representation of an object using Django's built-in serializer. (This is used for things like
     change logging, not the REST API.) Optionally include a dictionary to supplement the object data. A list of keys
@@ -166,9 +166,10 @@ def serialize_object(obj, resolve_tags=True, extra=None, exclude=None):
     exclude = exclude or []
 
     # Exclude any MPTTModel fields
-    if issubclass(obj.__class__, MPTTModel):
-        for field in ['level', 'lft', 'rght', 'tree_id']:
-            data.pop(field)
+    if not mptt:
+        if issubclass(obj.__class__, MPTTModel):
+            for field in ['level', 'lft', 'rght', 'tree_id']:
+                data.pop(field)
 
     # Include custom_field_data as "custom_fields"
     if hasattr(obj, 'custom_field_data'):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #13422

<!--
    Please include a summary of the proposed changes below.
-->

Implement a check to disable the removal of MPTT fields during object serialisation. 
