### PR TITLE
15826 update EXEMPT_EXCLUDE_MODELS with new user/group models

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -477,8 +477,8 @@ SERIALIZATION_MODULES = {
 # Exclude potentially sensitive models from wildcard view exemption. These may still be exempted
 # by specifying the model individually in the EXEMPT_VIEW_PERMISSIONS configuration parameter.
 EXEMPT_EXCLUDE_MODELS = (
-    ('auth', 'group'),
-    ('auth', 'user'),
+    ('users', 'group'),
+    ('users', 'user'),
     ('extras', 'configrevision'),
     ('users', 'objectpermission'),
     ('users', 'token'),

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -477,8 +477,6 @@ SERIALIZATION_MODULES = {
 # Exclude potentially sensitive models from wildcard view exemption. These may still be exempted
 # by specifying the model individually in the EXEMPT_VIEW_PERMISSIONS configuration parameter.
 EXEMPT_EXCLUDE_MODELS = (
-    ('users', 'group'),
-    ('users', 'user'),
     ('extras', 'configrevision'),
     ('users', 'objectpermission'),
     ('users', 'token'),


### PR DESCRIPTION
### Fixes: #15826 

Updated EXEMPT_EXCLUDE_MODELS for new user/group model.  @jeremystretch is it correct to remove these?  I tried switching them but it makes several tests fail.