### PR TITLE
15823 remove openid from social-auth-core requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ psycopg[c,pool]==3.1.18
 PyYAML==6.0.1
 requests==2.31.0
 social-auth-app-django==5.4.0
-social-auth-core[openidconnect]==4.5.3
+social-auth-core==4.5.4
 strawberry-graphql==0.227.2
 strawberry-graphql-django==0.34.0
 svgwrite==1.4.3


### PR DESCRIPTION
### Fixes: #15823

