### PR TITLE
15872 don't escape BANNER_MAINTENANCE

### DIFF
--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -81,7 +81,7 @@ Blocks:
         {% if config.MAINTENANCE_MODE and config.BANNER_MAINTENANCE %}
           <div class="alert alert-warning text-center mx-3" role="alert">
             <h5><i class="mdi mdi-alert"></i> {% trans "Maintenance Mode" %}</h5>
-            {{ config.BANNER_MAINTENANCE|escape }}
+            {{ config.BANNER_MAINTENANCE }}
           </div>
         {% endif %}
 

--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -81,7 +81,7 @@ Blocks:
         {% if config.MAINTENANCE_MODE and config.BANNER_MAINTENANCE %}
           <div class="alert alert-warning text-center mx-3" role="alert">
             <h5><i class="mdi mdi-alert"></i> {% trans "Maintenance Mode" %}</h5>
-            {{ config.BANNER_MAINTENANCE }}
+            {{ config.BANNER_MAINTENANCE|safe }}
           </div>
         {% endif %}
 


### PR DESCRIPTION
### Fixes: #15872

Don't escape (make safe) BANNER_MAINTENANCE to match other banner content in allowing HTML.

![Monosnap Home | NetBox 2024-04-29 07-37-30](https://github.com/netbox-community/netbox/assets/99642/27aa4c92-a652-4268-a8d6-79055df48bac)

