### PR TITLE
Fixes #15548: Ignore many-to-many mappings when checking dependencies of an object being deleted

### DIFF
--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -339,10 +339,14 @@ class ObjectDeleteView(GetReturnURLMixin, BaseObjectView):
 
         # Compile a mapping of models to instances
         dependent_objects = defaultdict(list)
-        for model, instance in collector.instances_with_model():
+        for model, instances in collector.instances_with_model():
+            # Ignore relations to auto-created models (e.g. many-to-many mappings)
+            if model._meta.auto_created:
+                continue
             # Omit the root object
-            if instance != obj:
-                dependent_objects[model].append(instance)
+            if instances == obj:
+                continue
+            dependent_objects[model].append(instances)
 
         return dict(dependent_objects)
 


### PR DESCRIPTION
### Fixes: #15548

Ignore relations to auto-created models (e.g. many-to-many assignments) when determining the dependent objects for an object being deleted.