### PR TITLE
Fixes #15899: Correct the view name for the tags column on L2VPNTerminationTable

### DIFF
--- a/netbox/vpn/tables/l2vpn.py
+++ b/netbox/vpn/tables/l2vpn.py
@@ -74,7 +74,7 @@ class L2VPNTerminationTable(NetBoxTable):
         verbose_name=_('Object Site')
     )
     tags = columns.TagColumn(
-        url_name='ipam:l2vpntermination_list'
+        url_name='vpn:l2vpntermination_list'
     )
 
     class Meta(NetBoxTable.Meta):


### PR DESCRIPTION
### Fixes: #15899
