### PR TITLE
15831 monkeypatch LDAP _mirror_group function for NB4

### DIFF
--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -333,7 +333,6 @@ try:
         user's membership.
         """
         target_group_names = frozenset(self._get_groups().get_group_names())
-        target_group_names = frozenset("testgroup",)
         current_group_names = frozenset(
             self._user.groups.values_list("name", flat=True).iterator()
         )

--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -313,7 +313,8 @@ class RemoteUserBackend(_RemoteUserBackend):
 
 # Create a new instance of django-auth-ldap's LDAPBackend with our own ObjectPermissions
 try:
-    from django_auth_ldap.backend import LDAPBackend as LDAPBackend_
+    from django_auth_ldap.backend import _LDAPUser, LDAPBackend as LDAPBackend_
+    from users.models import Group
 
     class NBLDAPBackend(ObjectPermissionMixin, LDAPBackend_):
         def get_permission_filter(self, user_obj):
@@ -323,6 +324,50 @@ try:
                     hasattr(user_obj.ldap_user, "group_names")):
                 permission_filter = permission_filter | Q(groups__name__in=user_obj.ldap_user.group_names)
             return permission_filter
+
+    def _mirror_groups(self):
+        """
+        Mirrors the user's LDAP groups in the Django database and updates the
+        user's membership.
+        """
+        target_group_names = frozenset(self._get_groups().get_group_names())
+        target_group_names = frozenset("testgroup",)
+        current_group_names = frozenset(
+            self._user.groups.values_list("name", flat=True).iterator()
+        )
+
+        # These were normalized to sets above.
+        MIRROR_GROUPS_EXCEPT = self.settings.MIRROR_GROUPS_EXCEPT
+        MIRROR_GROUPS = self.settings.MIRROR_GROUPS
+
+        # If the settings are white- or black-listing groups, we'll update
+        # target_group_names such that we won't modify the membership of groups
+        # beyond our purview.
+        if isinstance(MIRROR_GROUPS_EXCEPT, (set, frozenset)):
+            target_group_names = (target_group_names - MIRROR_GROUPS_EXCEPT) | (
+                current_group_names & MIRROR_GROUPS_EXCEPT
+            )
+        elif isinstance(MIRROR_GROUPS, (set, frozenset)):
+            target_group_names = (target_group_names & MIRROR_GROUPS) | (
+                current_group_names - MIRROR_GROUPS
+            )
+
+        if target_group_names != current_group_names:
+            existing_groups = list(
+                Group.objects.filter(name__in=target_group_names).iterator()
+            )
+            existing_group_names = frozenset(group.name for group in existing_groups)
+
+            new_groups = [
+                Group.objects.get_or_create(name=name)[0]
+                for name in target_group_names
+                if name not in existing_group_names
+            ]
+
+            self._user.groups.set(existing_groups + new_groups)
+
+    _LDAPUser._mirror_groups = _mirror_groups
+
 except ModuleNotFoundError:
     pass
 

--- a/netbox/netbox/authentication.py
+++ b/netbox/netbox/authentication.py
@@ -325,6 +325,8 @@ try:
                 permission_filter = permission_filter | Q(groups__name__in=user_obj.ldap_user.group_names)
             return permission_filter
 
+    # Monkey-patch _mirror_groups, code is from django-auth-ldap.backends._LDAPUser
+    # There are no changes to this routine, the 'fix' is the import of Group above.
     def _mirror_groups(self):
         """
         Mirrors the user's LDAP groups in the Django database and updates the

--- a/netbox/netbox/authentication/__init__.py
+++ b/netbox/netbox/authentication/__init__.py
@@ -10,7 +10,7 @@ from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
 from users.constants import CONSTRAINT_TOKEN_USER
-from users.models import ObjectPermission
+from users.models import Group, ObjectPermission
 from utilities.permissions import (
     permission_is_exempt, qs_filter_from_constraints, resolve_permission, resolve_permission_type,
 )
@@ -315,7 +315,7 @@ class RemoteUserBackend(_RemoteUserBackend):
 # Create a new instance of django-auth-ldap's LDAPBackend with our own ObjectPermissions
 try:
     from django_auth_ldap.backend import _LDAPUser, LDAPBackend as LDAPBackend_
-    from users.models import Group
+    from .misc import _mirror_groups
 
     class NBLDAPBackend(ObjectPermissionMixin, LDAPBackend_):
         def get_permission_filter(self, user_obj):

--- a/netbox/netbox/authentication/__init__.py
+++ b/netbox/netbox/authentication/__init__.py
@@ -315,7 +315,6 @@ class RemoteUserBackend(_RemoteUserBackend):
 # Create a new instance of django-auth-ldap's LDAPBackend with our own ObjectPermissions
 try:
     from django_auth_ldap.backend import _LDAPUser, LDAPBackend as LDAPBackend_
-    from .misc import _mirror_groups
 
     class NBLDAPBackend(ObjectPermissionMixin, LDAPBackend_):
         def get_permission_filter(self, user_obj):

--- a/netbox/netbox/authentication/misc.py
+++ b/netbox/netbox/authentication/misc.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2009, Peter Sagerson
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# - Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+from users.models import Group
+
+
+# Copied from django_auth_ldap.backend._LDAPUser and modified to support our
+# custom Group model.
+def _mirror_groups(self):
+    """
+    Mirrors the user's LDAP groups in the Django database and updates the
+    user's membership.
+    """
+    target_group_names = frozenset(self._get_groups().get_group_names())
+    current_group_names = frozenset(
+        self._user.groups.values_list("name", flat=True).iterator()
+    )
+
+    # These were normalized to sets above.
+    MIRROR_GROUPS_EXCEPT = self.settings.MIRROR_GROUPS_EXCEPT
+    MIRROR_GROUPS = self.settings.MIRROR_GROUPS
+
+    # If the settings are white- or black-listing groups, we'll update
+    # target_group_names such that we won't modify the membership of groups
+    # beyond our purview.
+    if isinstance(MIRROR_GROUPS_EXCEPT, (set, frozenset)):
+        target_group_names = (target_group_names - MIRROR_GROUPS_EXCEPT) | (
+            current_group_names & MIRROR_GROUPS_EXCEPT
+        )
+    elif isinstance(MIRROR_GROUPS, (set, frozenset)):
+        target_group_names = (target_group_names & MIRROR_GROUPS) | (
+            current_group_names - MIRROR_GROUPS
+        )
+
+    if target_group_names != current_group_names:
+        existing_groups = list(
+            Group.objects.filter(name__in=target_group_names).iterator()
+        )
+        existing_group_names = frozenset(group.name for group in existing_groups)
+
+        new_groups = [
+            Group.objects.get_or_create(name=name)[0]
+            for name in target_group_names
+            if name not in existing_group_names
+        ]
+
+        self._user.groups.set(existing_groups + new_groups)


### PR DESCRIPTION
### Fixes: #15831 

Mokey-patches _mirror_groups from django-auth-ldap to use NetBox Group instead of the Django.auth one.  Code is directly from django-auth-ldap, no changes except for the import statement above the function definition.