### PR TITLE
Fixes #15896: Retain proper formatting for JSON custom field default values

### DIFF
--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -1,4 +1,5 @@
 import decimal
+import json
 import re
 from datetime import datetime, date
 
@@ -484,7 +485,7 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
 
         # JSON
         elif self.type == CustomFieldTypeChoices.TYPE_JSON:
-            field = JSONField(required=required, initial=initial)
+            field = JSONField(required=required, initial=json.dumps(initial) if initial else '')
 
         # Object
         elif self.type == CustomFieldTypeChoices.TYPE_OBJECT:

--- a/netbox/netbox/forms/base.py
+++ b/netbox/netbox/forms/base.py
@@ -1,3 +1,5 @@
+import json
+
 from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
@@ -34,7 +36,11 @@ class NetBoxModelForm(BootstrapMixin, CheckLastUpdatedMixin, CustomFieldsMixin, 
     def _get_form_field(self, customfield):
         if self.instance.pk:
             form_field = customfield.to_form_field(set_initial=False)
-            form_field.initial = self.instance.custom_field_data.get(customfield.name, None)
+            initial = self.instance.custom_field_data.get(customfield.name)
+            if customfield.type == CustomFieldTypeChoices.TYPE_JSON:
+                form_field.initial = json.dumps(initial)
+            else:
+                form_field.initial = initial
             return form_field
 
         return customfield.to_form_field()


### PR DESCRIPTION
### Fixes: #15896

Call `json.dumps()` on initial values to ensure strings are represented correctly.