### PR TITLE
Fixes #15891: Ensure deterministic ordering for scripts & reports

### DIFF
--- a/netbox/extras/migrations/0091_create_managedfiles.py
+++ b/netbox/extras/migrations/0091_create_managedfiles.py
@@ -50,6 +50,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'proxy': True,
+                'ordering': ('file_root', 'file_path'),
                 'indexes': [],
                 'constraints': [],
             },
@@ -61,6 +62,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'proxy': True,
+                'ordering': ('file_root', 'file_path'),
                 'indexes': [],
                 'constraints': [],
             },

--- a/netbox/extras/models/reports.py
+++ b/netbox/extras/models/reports.py
@@ -43,6 +43,7 @@ class ReportModule(PythonModuleMixin, JobsMixin, ManagedFile):
 
     class Meta:
         proxy = True
+        ordering = ('file_root', 'file_path')
         verbose_name = _('report module')
         verbose_name_plural = _('report modules')
 

--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -51,6 +51,7 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
 
     class Meta:
         proxy = True
+        ordering = ('file_root', 'file_path')
         verbose_name = _('script module')
         verbose_name_plural = _('script modules')
 

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1042,7 +1042,7 @@ class ReportListView(ContentTypePermissionRequiredMixin, View):
         return 'extras.view_report'
 
     def get(self, request):
-        report_modules = ReportModule.objects.restrict(request.user)
+        report_modules = ReportModule.objects.restrict(request.user).prefetch_related('data_source', 'data_file')
 
         return render(request, 'extras/report_list.html', {
             'model': ReportModule,
@@ -1217,7 +1217,7 @@ class ScriptListView(ContentTypePermissionRequiredMixin, View):
         return 'extras.view_script'
 
     def get(self, request):
-        script_modules = ScriptModule.objects.restrict(request.user)
+        script_modules = ScriptModule.objects.restrict(request.user).prefetch_related('data_source', 'data_file')
 
         return render(request, 'extras/script_list.html', {
             'model': ScriptModule,


### PR DESCRIPTION
### Fixes: #15891

- Set `ordering` on ReportModule & ScriptModule
- Prefetch related objects under the view
