### PR TITLE
Fixes #15960: Use internal ManyToManyColumn to ensure proper export behavior

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -618,7 +618,7 @@ class InterfaceTable(ModularDeviceComponentTable, BaseInterfaceTable, PathEndpoi
         verbose_name=_('VRF'),
         linkify=True
     )
-    inventory_items = tables.ManyToManyColumn(
+    inventory_items = columns.ManyToManyColumn(
         linkify_item=True,
         verbose_name=_('Inventory Items'),
     )

--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -378,7 +378,7 @@ class IPAddressTable(TenancyColumnsMixin, NetBoxTable):
         orderable=False,
         verbose_name=_('NAT (Inside)')
     )
-    nat_outside = tables.ManyToManyColumn(
+    nat_outside = columns.ManyToManyColumn(
         linkify_item=True,
         orderable=False,
         verbose_name=_('NAT (Outside)')

--- a/netbox/vpn/tables/crypto.py
+++ b/netbox/vpn/tables/crypto.py
@@ -63,7 +63,7 @@ class IKEPolicyTable(NetBoxTable):
     mode = tables.Column(
         verbose_name=_('Mode')
     )
-    proposals = tables.ManyToManyColumn(
+    proposals = columns.ManyToManyColumn(
         linkify_item=True,
         verbose_name=_('Proposals')
     )
@@ -129,7 +129,7 @@ class IPSecPolicyTable(NetBoxTable):
         verbose_name=_('Name'),
         linkify=True
     )
-    proposals = tables.ManyToManyColumn(
+    proposals = columns.ManyToManyColumn(
         linkify_item=True,
         verbose_name=_('Proposals')
     )

--- a/netbox/vpn/tables/tunnels.py
+++ b/netbox/vpn/tables/tunnels.py
@@ -91,7 +91,7 @@ class TunnelTerminationTable(TenancyColumnsMixin, NetBoxTable):
         verbose_name=_('Tunnel interface'),
         linkify=True
     )
-    ip_addresses = tables.ManyToManyColumn(
+    ip_addresses = columns.ManyToManyColumn(
         accessor=tables.A('termination__ip_addresses'),
         orderable=False,
         linkify_item=True,


### PR DESCRIPTION
### Fixes: #15960

Replace all uses of ManyToManyColumn from django-tables2 with our own modified column to ensure proper formatting of values on export.