### PR TITLE
Fixes #15977: Hide all admin menu items for non-authenticated users

### DIFF
--- a/netbox/netbox/navigation/__init__.py
+++ b/netbox/netbox/navigation/__init__.py
@@ -32,6 +32,7 @@ class MenuItem:
     link: str
     link_text: str
     permissions: Optional[Sequence[str]] = ()
+    auth_required: Optional[bool] = False
     staff_only: Optional[bool] = False
     buttons: Optional[Sequence[MenuItemButton]] = ()
 

--- a/netbox/netbox/navigation/menu.py
+++ b/netbox/netbox/navigation/menu.py
@@ -371,6 +371,7 @@ ADMIN_MENU = Menu(
                 MenuItem(
                     link=f'users:user_list',
                     link_text=_('Users'),
+                    auth_required=True,
                     permissions=[f'auth.view_user'],
                     buttons=(
                         MenuItemButton(
@@ -390,6 +391,7 @@ ADMIN_MENU = Menu(
                 MenuItem(
                     link=f'users:group_list',
                     link_text=_('Groups'),
+                    auth_required=True,
                     permissions=[f'auth.view_group'],
                     buttons=(
                         MenuItemButton(
@@ -409,12 +411,14 @@ ADMIN_MENU = Menu(
                 MenuItem(
                     link=f'users:token_list',
                     link_text=_('API Tokens'),
+                    auth_required=True,
                     permissions=[f'users.view_token'],
                     buttons=get_model_buttons('users', 'token')
                 ),
                 MenuItem(
                     link=f'users:objectpermission_list',
                     link_text=_('Permissions'),
+                    auth_required=True,
                     permissions=[f'users.view_objectpermission'],
                     buttons=get_model_buttons('users', 'objectpermission', actions=['add'])
                 ),
@@ -425,16 +429,19 @@ ADMIN_MENU = Menu(
             items=(
                 MenuItem(
                     link='core:system',
-                    link_text=_('System')
+                    link_text=_('System'),
+                    auth_required=True
                 ),
                 MenuItem(
                     link='core:configrevision_list',
                     link_text=_('Configuration History'),
+                    auth_required=True,
                     permissions=['core.view_configrevision']
                 ),
                 MenuItem(
                     link='core:background_queue_list',
-                    link_text=_('Background Tasks')
+                    link_text=_('Background Tasks'),
+                    auth_required=True
                 ),
             ),
         ),

--- a/netbox/utilities/templatetags/navigation.py
+++ b/netbox/utilities/templatetags/navigation.py
@@ -26,6 +26,8 @@ def nav(context):
         for group in menu.groups:
             items = []
             for item in group.items:
+                if item.auth_required and not user.is_authenticated:
+                    continue
                 if not user.has_perms(item.permissions):
                     continue
                 if item.staff_only and not user.is_staff:

--- a/netbox/utilities/templatetags/navigation.py
+++ b/netbox/utilities/templatetags/navigation.py
@@ -26,7 +26,7 @@ def nav(context):
         for group in menu.groups:
             items = []
             for item in group.items:
-                if item.auth_required and not user.is_authenticated:
+                if getattr(item, 'auth_required', False) and not user.is_authenticated:
                     continue
                 if not user.has_perms(item.permissions):
                     continue


### PR DESCRIPTION
### Fixes: #15977

- Extend PluginMenuItem with `auth_required` boolean attribute & enforce when rendering the navigation menu
- Set `auth_required=True` on _all_ menu items under the admin group as a sanity check