### PR TITLE
Fix #15992: Removed integrations for sentry-sdk

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -522,7 +522,6 @@ if SENTRY_ENABLED:
     sentry_sdk.init(
         dsn=SENTRY_DSN,
         release=VERSION,
-        integrations=[sentry_sdk.integrations.django.DjangoIntegration()],
         sample_rate=SENTRY_SAMPLE_RATE,
         traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
         send_default_pii=True,


### PR DESCRIPTION
### Fixes: #15992

According to the Sentry Python SDK documentation setting the integrations manually is only needed when the integration configuration needs to be changed.

See: https://docs.sentry.io/platforms/python/integrations/django/#options
