### PR TITLE
Fixes #15982: Restore the "assign IP" tab

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -781,6 +781,7 @@ class IPAddressView(generic.ObjectView):
 class IPAddressEditView(generic.ObjectEditView):
     queryset = IPAddress.objects.all()
     form = forms.IPAddressForm
+    template_name = 'ipam/ipaddress_edit.html'
 
     def alter_object(self, obj, request, url_args, url_kwargs):
 

--- a/netbox/templates/ipam/inc/ipaddress_edit_header.html
+++ b/netbox/templates/ipam/inc/ipaddress_edit_header.html
@@ -3,30 +3,21 @@
 
 <ul class="nav nav-tabs">
   <li class="nav-item">
-      <a
-          class="nav-link {% if active_tab == 'add' %}active{% endif %}"
-          href="{% url 'ipam:ipaddress_add' %}{% querystring request %}"
-      >
-          {% if obj.pk %}{% trans "Edit" %}{% else %}{% trans "Create" %}{% endif %}
-      </a>
+    <a href="{% url 'ipam:ipaddress_add' %}{% querystring request %}" class="nav-link {% if active_tab == 'add' %}active{% endif %}">
+      {% if object.pk %}{% trans "Edit" %}{% else %}{% trans "Create" %}{% endif %}
+    </a>
   </li>
   {% if 'interface' in request.GET or 'vminterface' in request.GET %}
-  <li class="nav-item">
-      <a
-          class="nav-link {% if active_tab == 'assign' %}active{% endif %}"
-          href="{% url 'ipam:ipaddress_assign' %}{% querystring request %}"
-      >
-          {% trans "Assign IP" %}
+    <li class="nav-item">
+      <a href="{% url 'ipam:ipaddress_assign' %}{% querystring request %}" class="nav-link {% if active_tab == 'assign' %}active{% endif %}">
+        {% trans "Assign IP" %}
       </a>
-  </li>
-  {% else %}
-  <li class="nav-item">
-      <a
-          class="nav-link {% if active_tab == 'bulk_add' %}active{% endif %}"
-          href="{% url 'ipam:ipaddress_bulk_add' %}{% querystring request %}"
-      >
-          {% trans "Bulk Create" %}
+    </li>
+  {% elif not object.pk %}
+    <li class="nav-item">
+      <a href="{% url 'ipam:ipaddress_bulk_add' %}{% querystring request %}" class="nav-link {% if active_tab == 'bulk_add' %}active{% endif %}">
+        {% trans "Bulk Create" %}
       </a>
-  </li>
+    </li>
   {% endif %}
 </ul>

--- a/netbox/templates/ipam/ipaddress_assign.html
+++ b/netbox/templates/ipam/ipaddress_assign.html
@@ -12,37 +12,33 @@
 {% endblock %}
 
 {% block form %}
-    <form action="{% querystring request %}" method="post" class="form form-horizontal">
-        {% csrf_token %}
-        {% for field in form.hidden_fields %}
-            {{ field }}
-        {% endfor %}
-        <div class="row mb-3">
-            <div class="col col-md-8 offset-md-2">
-                <div class="field-group">
-                    <h6>{% trans "Select IP Address" %}</h6>
-                    {% render_field form.vrf_id %}
-                    {% render_field form.q %}
-                </div>
-            </div>
+  <form action="{% querystring request %}" method="post" class="form form-horizontal">
+    {% csrf_token %}
+    {% for field in form.hidden_fields %}
+      {{ field }}
+    {% endfor %}
+    <div class="field-group my-5">
+      <div class="row">
+        <h5 class="col-9 offset-3">{% trans "Select IP Address" %}</h5>
+      </div>
+      {% render_field form.vrf_id %}
+      {% render_field form.q %}
+    </div>
+    <div class="text-end my-3">
+      <a href="{{ return_url }}" class="btn btn-outline-secondary">{% trans "Cancel" %}</a>
+      <button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
+    </div>
+  </form>
+  {% if table %}
+    <div class="row mb-3">
+      <div class="col col-md-12">
+        <h3>{% trans "Search Results" %}</h3>
+        <div class="table-responsive">
+          {% render_table table 'inc/table.html' %}
         </div>
-        <div class="row mb-3">
-            <div class="col col-md-8 offset-md-2 text-end">
-                <a href="{{ return_url }}" class="btn btn-outline-secondary">{% trans "Cancel" %}</a>
-                <button type="submit" class="btn btn-primary">{% trans "Search" %}</button>
-            </div>
-        </div>
-    </form>
-    {% if table %}
-        <div class="row mb-3">
-            <div class="col col-md-12">
-                <h3>{% trans "Search Results" %}</h3>
-                <div class="table-responsive">
-                  {% render_table table 'inc/table.html' %}
-                </div>
-            </div>
-        </div>
-    {% endif %}
+      </div>
+    </div>
+  {% endif %}
 {% endblock form %}
 
 {% block buttons %}

--- a/netbox/templates/ipam/ipaddress_edit.html
+++ b/netbox/templates/ipam/ipaddress_edit.html
@@ -1,0 +1,5 @@
+{% extends 'generic/object_edit.html' %}
+
+{% block tabs %}
+  {% include 'ipam/inc/ipaddress_edit_header.html' with active_tab='add' %}
+{% endblock %}


### PR DESCRIPTION
### Fixes: #15982

- Restore the `ipaddress_edit.html` template to render the "create/edit" and "assign" tabs
- General cleanup
