### PR TITLE
#15981 - Make device description a clickable link

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -141,6 +141,10 @@ class DeviceTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
         template_code=DEVICE_LINK,
         linkify=True
     )
+    description = tables.Column(
+        verbose_name=_('Description'),
+        linkify=True
+    )
     status = columns.ChoiceFieldColumn(
         verbose_name=_('Status'),
     )


### PR DESCRIPTION
### Fixes: #15981

Added hyperlink to the Description field on the device page