### PR TITLE
Fixes #15995: Permit nullable fields referenced by unique constraints to be omitted from REST API requests

### DIFF
--- a/netbox/circuits/api/serializers_/circuits.py
+++ b/netbox/circuits/api/serializers_/circuits.py
@@ -48,7 +48,7 @@ class CircuitCircuitTerminationSerializer(WritableNestedSerializer):
 class CircuitSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='circuits-api:circuit-detail')
     provider = ProviderSerializer(nested=True)
-    provider_account = ProviderAccountSerializer(nested=True, required=False, allow_null=True)
+    provider_account = ProviderAccountSerializer(nested=True, required=False, allow_null=True, default=None)
     status = ChoiceField(choices=CircuitStatusChoices, required=False)
     type = CircuitTypeSerializer(nested=True)
     tenant = TenantSerializer(nested=True, required=False, allow_null=True)

--- a/netbox/circuits/api/serializers_/providers.py
+++ b/netbox/circuits/api/serializers_/providers.py
@@ -45,6 +45,7 @@ class ProviderSerializer(NetBoxModelSerializer):
 class ProviderAccountSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='circuits-api:provideraccount-detail')
     provider = ProviderSerializer(nested=True)
+    name = serializers.CharField(allow_blank=True, max_length=100, required=False, default='')
 
     class Meta:
         model = ProviderAccount

--- a/netbox/circuits/tests/test_api.py
+++ b/netbox/circuits/tests/test_api.py
@@ -141,7 +141,7 @@ class CircuitTest(APIViewTestCases.APIViewTestCase):
             {
                 'cid': 'Circuit 6',
                 'provider': providers[1].pk,
-                'provider_account': provider_accounts[1].pk,
+                # Omit provider account to test uniqueness constraint
                 'type': circuit_types[1].pk,
             },
         ]
@@ -237,7 +237,7 @@ class ProviderAccountTest(APIViewTestCases.APIViewTestCase):
                 'account': '5678',
             },
             {
-                'name': 'Provider Account 6',
+                # Omit name to test uniqueness constraint
                 'provider': providers[0].pk,
                 'account': '6789',
             },

--- a/netbox/dcim/api/serializers_/devices.py
+++ b/netbox/dcim/api/serializers_/devices.py
@@ -122,6 +122,7 @@ class DeviceWithConfigContextSerializer(DeviceSerializer):
 class VirtualDeviceContextSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:virtualdevicecontext-detail')
     device = DeviceSerializer(nested=True)
+    identifier = serializers.IntegerField(allow_null=True, max_value=32767, min_value=0, required=False, default=None)
     tenant = TenantSerializer(nested=True, required=False, allow_null=True, default=None)
     primary_ip = IPAddressSerializer(nested=True, read_only=True, allow_null=True)
     primary_ip4 = IPAddressSerializer(nested=True, required=False, allow_null=True)

--- a/netbox/dcim/api/serializers_/sites.py
+++ b/netbox/dcim/api/serializers_/sites.py
@@ -83,7 +83,7 @@ class SiteSerializer(NetBoxModelSerializer):
 class LocationSerializer(NestedGroupModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:location-detail')
     site = SiteSerializer(nested=True)
-    parent = NestedLocationSerializer(required=False, allow_null=True)
+    parent = NestedLocationSerializer(required=False, allow_null=True, default=None)
     status = ChoiceField(choices=LocationStatusChoices, required=False)
     tenant = TenantSerializer(nested=True, required=False, allow_null=True)
     rack_count = serializers.IntegerField(read_only=True)

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -230,7 +230,7 @@ class LocationTest(APIViewTestCases.APIViewTestCase):
                 'name': 'Test Location 6',
                 'slug': 'test-location-6',
                 'site': sites[1].pk,
-                'parent': parent_locations[1].pk,
+                # Omit parent to test uniqueness constraint
                 'status': LocationStatusChoices.STATUS_PLANNED,
             },
         ]
@@ -2307,6 +2307,6 @@ class VirtualDeviceContextTest(APIViewTestCases.APIViewTestCase):
                 'device': devices[1].pk,
                 'status': 'active',
                 'name': 'VDC 3',
-                'identifier': 3,
+                # Omit identifier to test uniqueness constraint
             },
         ]

--- a/netbox/tenancy/api/serializers_/tenants.py
+++ b/netbox/tenancy/api/serializers_/tenants.py
@@ -27,7 +27,7 @@ class TenantGroupSerializer(NestedGroupModelSerializer):
 
 class TenantSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='tenancy-api:tenant-detail')
-    group = TenantGroupSerializer(nested=True, required=False, allow_null=True)
+    group = TenantGroupSerializer(nested=True, required=False, allow_null=True, default=None)
 
     # Related object counts
     circuit_count = RelatedObjectCountField('circuits')

--- a/netbox/virtualization/api/serializers_/virtualmachines.py
+++ b/netbox/virtualization/api/serializers_/virtualmachines.py
@@ -31,11 +31,11 @@ __all__ = (
 class VirtualMachineSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='virtualization-api:virtualmachine-detail')
     status = ChoiceField(choices=VirtualMachineStatusChoices, required=False)
-    site = SiteSerializer(nested=True, required=False, allow_null=True)
-    cluster = ClusterSerializer(nested=True, required=False, allow_null=True)
-    device = DeviceSerializer(nested=True, required=False, allow_null=True)
+    site = SiteSerializer(nested=True, required=False, allow_null=True, default=None)
+    cluster = ClusterSerializer(nested=True, required=False, allow_null=True, default=None)
+    device = DeviceSerializer(nested=True, required=False, allow_null=True, default=None)
     role = DeviceRoleSerializer(nested=True, required=False, allow_null=True)
-    tenant = TenantSerializer(nested=True, required=False, allow_null=True)
+    tenant = TenantSerializer(nested=True, required=False, allow_null=True, default=None)
     platform = PlatformSerializer(nested=True, required=False, allow_null=True)
     primary_ip = IPAddressSerializer(nested=True, read_only=True, allow_null=True)
     primary_ip4 = IPAddressSerializer(nested=True, required=False, allow_null=True)
@@ -55,7 +55,6 @@ class VirtualMachineSerializer(NetBoxModelSerializer):
             'interface_count', 'virtual_disk_count',
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'description')
-        validators = []
 
 
 class VirtualMachineWithConfigContextSerializer(VirtualMachineSerializer):


### PR DESCRIPTION
### Fixes: #15995

- Set a default value on each of the relevant fields in API serializers
- Modify tests to omit these fields in some object representations