### PR TITLE
Fixes: #16022 - Fix Script and Report Migration

### DIFF
--- a/netbox/extras/migrations/0109_script_model.py
+++ b/netbox/extras/migrations/0109_script_model.py
@@ -60,7 +60,10 @@ def get_module_scripts(scriptmodule):
         return cls.full_name.split(".", maxsplit=1)[1]
 
     loader = SourceFileLoader(get_python_name(scriptmodule), get_full_path(scriptmodule))
-    module = loader.load_module()
+    try:
+        module = loader.load_module()
+    except FileNotFoundError:
+        return {}
 
     scripts = {}
     ordered = getattr(module, 'script_order', [])


### PR DESCRIPTION
### Fixes: #16022 - Fix Script and Report Migration

* Return an empty dict if import failes.  This results in no scripts being created (ScriptModule still exists until deleted)