### PR TITLE
Fixes #16032: Specify the WSGI module to load in uwsgi.ini

### DIFF
--- a/contrib/uwsgi.ini
+++ b/contrib/uwsgi.ini
@@ -16,3 +16,9 @@ need-app = true
 
 ; do not use multiple interpreters
 single-interpreter = true
+
+; change to the project directory
+chdir = netbox
+
+; specify the WSGI module to load
+module = netbox.wsgi


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #16032

`chdir` is needed for Python paths to work (see https://docs.djangoproject.com/en/5.0/howto/deployment/wsgi/uwsgi/). I used the relative path `netbox` because the NetBox-default systemd configuration file has `WorkingDirectory=/opt/netbox`, thus concentrating the possible NetBox install path customizations in the systemd configuration file.

I used the short `module = netbox.wsgi` syntax to specify the WSGI application to load. https://uwsgi-docs.readthedocs.io/en/latest/WSGIquickstart.html#deploying-django hints using `wsgi-file = netbox/wsgi.py`, but I figured maybe leaving any "netbox/xxx" path-looking strings out would help to avoid breaking this configuration accidentally, if someone tries to customize the NetBox installation path.
