### PR TITLE
Fixes: #16039 - Fix row highlighting on device components and VM interfaces

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -390,7 +390,10 @@ class DeviceConsolePortTable(ConsolePortTable):
         )
         default_columns = ('pk', 'name', 'label', 'type', 'speed', 'description', 'cable', 'connection')
         row_attrs = {
-            'class': get_cabletermination_row_class
+            'data-name': lambda record: record.name,
+            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
+            'data-cable-status': lambda record: record.cable.status if record.cable else "",
+            'data-type': lambda record: record.type
         }
 
 
@@ -435,7 +438,10 @@ class DeviceConsoleServerPortTable(ConsoleServerPortTable):
         )
         default_columns = ('pk', 'name', 'label', 'type', 'speed', 'description', 'cable', 'connection')
         row_attrs = {
-            'class': get_cabletermination_row_class
+            'data-name': lambda record: record.name,
+            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
+            'data-cable-status': lambda record: record.cable.status if record.cable else "",
+            'data-type': lambda record: record.type
         }
 
 
@@ -489,7 +495,10 @@ class DevicePowerPortTable(PowerPortTable):
             'pk', 'name', 'label', 'type', 'maximum_draw', 'allocated_draw', 'description', 'cable', 'connection',
         )
         row_attrs = {
-            'class': get_cabletermination_row_class
+            'data-name': lambda record: record.name,
+            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
+            'data-cable-status': lambda record: record.cable.status if record.cable else "",
+            'data-type': lambda record: record.type
         }
 
 
@@ -540,7 +549,10 @@ class DevicePowerOutletTable(PowerOutletTable):
             'pk', 'name', 'label', 'type', 'power_port', 'feed_leg', 'description', 'cable', 'connection',
         )
         row_attrs = {
-            'class': get_cabletermination_row_class
+            'data-name': lambda record: record.name,
+            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
+            'data-cable-status': lambda record: record.cable.status if record.cable else "",
+            'data-type': lambda record: record.type
         }
 
 
@@ -743,7 +755,10 @@ class DeviceFrontPortTable(FrontPortTable):
             'pk', 'name', 'label', 'type', 'rear_port', 'rear_port_position', 'description', 'cable', 'link_peer',
         )
         row_attrs = {
-            'class': get_cabletermination_row_class
+            'data-name': lambda record: record.name,
+            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
+            'data-cable-status': lambda record: record.cable.status if record.cable else "",
+            'data-type': lambda record: record.type
         }
 
 
@@ -793,7 +808,10 @@ class DeviceRearPortTable(RearPortTable):
             'pk', 'name', 'label', 'type', 'positions', 'description', 'cable', 'link_peer',
         )
         row_attrs = {
-            'class': get_cabletermination_row_class
+            'data-name': lambda record: record.name,
+            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
+            'data-cable-status': lambda record: record.cable.status if record.cable else "",
+            'data-type': lambda record: record.type
         }
 
 

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -43,16 +43,6 @@ MODULEBAY_STATUS = """
 """
 
 
-class ConnectionDeviceComponentTableMixin:
-    class Meta:
-        row_attrs = {
-            'data-name': lambda record: record.name,
-            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
-            'data-cable-status': lambda record: record.cable.status if record.cable else "",
-            'data-type': lambda record: record.type
-        }
-
-
 #
 # Device roles
 #
@@ -337,6 +327,14 @@ class CableTerminationTable(NetBoxTable):
         verbose_name=_('Mark Connected'),
     )
 
+    class Meta:
+        row_attrs = {
+            'data-name': lambda record: record.name,
+            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
+            'data-cable-status': lambda record: record.cable.status if record.cable else "",
+            'data-type': lambda record: record.type
+        }
+
     def value_link_peer(self, value):
         return ', '.join([
             f"{termination.parent_object} > {termination}" for termination in value
@@ -384,7 +382,7 @@ class DeviceConsolePortTable(ConsolePortTable):
         extra_buttons=CONSOLEPORT_BUTTONS
     )
 
-    class Meta(ConnectionDeviceComponentTableMixin.Meta, DeviceComponentTable.Meta):
+    class Meta(CableTerminationTable.Meta, DeviceComponentTable.Meta):
         model = models.ConsolePort
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'type', 'speed', 'description', 'mark_connected',
@@ -426,7 +424,7 @@ class DeviceConsoleServerPortTable(ConsoleServerPortTable):
         extra_buttons=CONSOLESERVERPORT_BUTTONS
     )
 
-    class Meta(ConnectionDeviceComponentTableMixin.Meta, DeviceComponentTable.Meta):
+    class Meta(CableTerminationTable.Meta, DeviceComponentTable.Meta):
         model = models.ConsoleServerPort
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'type', 'speed', 'description', 'mark_connected',
@@ -475,7 +473,7 @@ class DevicePowerPortTable(PowerPortTable):
         extra_buttons=POWERPORT_BUTTONS
     )
 
-    class Meta(ConnectionDeviceComponentTableMixin.Meta, DeviceComponentTable.Meta):
+    class Meta(CableTerminationTable.Meta, DeviceComponentTable.Meta):
         model = models.PowerPort
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'type', 'maximum_draw', 'allocated_draw',
@@ -523,7 +521,7 @@ class DevicePowerOutletTable(PowerOutletTable):
         extra_buttons=POWEROUTLET_BUTTONS
     )
 
-    class Meta(ConnectionDeviceComponentTableMixin.Meta, DeviceComponentTable.Meta):
+    class Meta(CableTerminationTable.Meta, DeviceComponentTable.Meta):
         model = models.PowerOutlet
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'type', 'power_port', 'feed_leg', 'description',
@@ -723,7 +721,7 @@ class DeviceFrontPortTable(FrontPortTable):
         extra_buttons=FRONTPORT_BUTTONS
     )
 
-    class Meta(ConnectionDeviceComponentTableMixin.Meta, DeviceComponentTable.Meta):
+    class Meta(CableTerminationTable.Meta, DeviceComponentTable.Meta):
         model = models.FrontPort
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'type', 'rear_port', 'rear_port_position',
@@ -770,7 +768,7 @@ class DeviceRearPortTable(RearPortTable):
         extra_buttons=REARPORT_BUTTONS
     )
 
-    class Meta(ConnectionDeviceComponentTableMixin.Meta, DeviceComponentTable.Meta):
+    class Meta(CableTerminationTable.Meta, DeviceComponentTable.Meta):
         model = models.RearPort
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'type', 'positions', 'description', 'mark_connected',

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -43,12 +43,14 @@ MODULEBAY_STATUS = """
 """
 
 
-def get_cabletermination_row_class(record):
-    if record.mark_connected:
-        return 'success'
-    elif record.cable:
-        return record.cable.get_status_color()
-    return ''
+class ConnectionDeviceComponentTableMixin:
+    class Meta:
+        row_attrs = {
+            'data-name': lambda record: record.name,
+            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
+            'data-cable-status': lambda record: record.cable.status if record.cable else "",
+            'data-type': lambda record: record.type
+        }
 
 
 #
@@ -382,19 +384,13 @@ class DeviceConsolePortTable(ConsolePortTable):
         extra_buttons=CONSOLEPORT_BUTTONS
     )
 
-    class Meta(DeviceComponentTable.Meta):
+    class Meta(ConnectionDeviceComponentTableMixin.Meta, DeviceComponentTable.Meta):
         model = models.ConsolePort
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'type', 'speed', 'description', 'mark_connected',
             'cable', 'cable_color', 'link_peer', 'connection', 'tags', 'actions'
         )
         default_columns = ('pk', 'name', 'label', 'type', 'speed', 'description', 'cable', 'connection')
-        row_attrs = {
-            'data-name': lambda record: record.name,
-            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
-            'data-cable-status': lambda record: record.cable.status if record.cable else "",
-            'data-type': lambda record: record.type
-        }
 
 
 class ConsoleServerPortTable(ModularDeviceComponentTable, PathEndpointTable):
@@ -430,19 +426,13 @@ class DeviceConsoleServerPortTable(ConsoleServerPortTable):
         extra_buttons=CONSOLESERVERPORT_BUTTONS
     )
 
-    class Meta(DeviceComponentTable.Meta):
+    class Meta(ConnectionDeviceComponentTableMixin.Meta, DeviceComponentTable.Meta):
         model = models.ConsoleServerPort
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'type', 'speed', 'description', 'mark_connected',
             'cable', 'cable_color', 'link_peer', 'connection', 'tags', 'actions',
         )
         default_columns = ('pk', 'name', 'label', 'type', 'speed', 'description', 'cable', 'connection')
-        row_attrs = {
-            'data-name': lambda record: record.name,
-            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
-            'data-cable-status': lambda record: record.cable.status if record.cable else "",
-            'data-type': lambda record: record.type
-        }
 
 
 class PowerPortTable(ModularDeviceComponentTable, PathEndpointTable):
@@ -485,7 +475,7 @@ class DevicePowerPortTable(PowerPortTable):
         extra_buttons=POWERPORT_BUTTONS
     )
 
-    class Meta(DeviceComponentTable.Meta):
+    class Meta(ConnectionDeviceComponentTableMixin.Meta, DeviceComponentTable.Meta):
         model = models.PowerPort
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'type', 'maximum_draw', 'allocated_draw',
@@ -494,12 +484,6 @@ class DevicePowerPortTable(PowerPortTable):
         default_columns = (
             'pk', 'name', 'label', 'type', 'maximum_draw', 'allocated_draw', 'description', 'cable', 'connection',
         )
-        row_attrs = {
-            'data-name': lambda record: record.name,
-            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
-            'data-cable-status': lambda record: record.cable.status if record.cable else "",
-            'data-type': lambda record: record.type
-        }
 
 
 class PowerOutletTable(ModularDeviceComponentTable, PathEndpointTable):
@@ -539,7 +523,7 @@ class DevicePowerOutletTable(PowerOutletTable):
         extra_buttons=POWEROUTLET_BUTTONS
     )
 
-    class Meta(DeviceComponentTable.Meta):
+    class Meta(ConnectionDeviceComponentTableMixin.Meta, DeviceComponentTable.Meta):
         model = models.PowerOutlet
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'type', 'power_port', 'feed_leg', 'description',
@@ -548,12 +532,6 @@ class DevicePowerOutletTable(PowerOutletTable):
         default_columns = (
             'pk', 'name', 'label', 'type', 'power_port', 'feed_leg', 'description', 'cable', 'connection',
         )
-        row_attrs = {
-            'data-name': lambda record: record.name,
-            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
-            'data-cable-status': lambda record: record.cable.status if record.cable else "",
-            'data-type': lambda record: record.type
-        }
 
 
 class BaseInterfaceTable(NetBoxTable):
@@ -745,7 +723,7 @@ class DeviceFrontPortTable(FrontPortTable):
         extra_buttons=FRONTPORT_BUTTONS
     )
 
-    class Meta(DeviceComponentTable.Meta):
+    class Meta(ConnectionDeviceComponentTableMixin.Meta, DeviceComponentTable.Meta):
         model = models.FrontPort
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'type', 'rear_port', 'rear_port_position',
@@ -754,12 +732,6 @@ class DeviceFrontPortTable(FrontPortTable):
         default_columns = (
             'pk', 'name', 'label', 'type', 'rear_port', 'rear_port_position', 'description', 'cable', 'link_peer',
         )
-        row_attrs = {
-            'data-name': lambda record: record.name,
-            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
-            'data-cable-status': lambda record: record.cable.status if record.cable else "",
-            'data-type': lambda record: record.type
-        }
 
 
 class RearPortTable(ModularDeviceComponentTable, CableTerminationTable):
@@ -798,7 +770,7 @@ class DeviceRearPortTable(RearPortTable):
         extra_buttons=REARPORT_BUTTONS
     )
 
-    class Meta(DeviceComponentTable.Meta):
+    class Meta(ConnectionDeviceComponentTableMixin.Meta, DeviceComponentTable.Meta):
         model = models.RearPort
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'type', 'positions', 'description', 'mark_connected',
@@ -807,12 +779,6 @@ class DeviceRearPortTable(RearPortTable):
         default_columns = (
             'pk', 'name', 'label', 'type', 'positions', 'description', 'cable', 'link_peer',
         )
-        row_attrs = {
-            'data-name': lambda record: record.name,
-            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
-            'data-cable-status': lambda record: record.cable.status if record.cable else "",
-            'data-type': lambda record: record.type
-        }
 
 
 class DeviceBayTable(DeviceComponentTable):

--- a/netbox/virtualization/tables/virtualmachines.py
+++ b/netbox/virtualization/tables/virtualmachines.py
@@ -173,6 +173,8 @@ class VirtualMachineVMInterfaceTable(VMInterfaceTable):
         default_columns = ('pk', 'name', 'enabled', 'mac_address', 'mtu', 'mode', 'description', 'ip_addresses')
         row_attrs = {
             'data-name': lambda record: record.name,
+            'data-virtual': lambda record: "true" if record.is_virtual else "false",
+            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
         }
 
 

--- a/netbox/virtualization/tables/virtualmachines.py
+++ b/netbox/virtualization/tables/virtualmachines.py
@@ -173,8 +173,8 @@ class VirtualMachineVMInterfaceTable(VMInterfaceTable):
         default_columns = ('pk', 'name', 'enabled', 'mac_address', 'mtu', 'mode', 'description', 'ip_addresses')
         row_attrs = {
             'data-name': lambda record: record.name,
-            'data-virtual': lambda record: "true" if record.is_virtual else "false",
-            'data-mark-connected': lambda record: "true" if record.mark_connected else "false",
+            'data-virtual': lambda record: "true",
+            'data-enabled': lambda record: "true" if record.enabled else "false",
         }
 
 


### PR DESCRIPTION
Fixes: #16039 - Fix row highlighting on device components and VM interfaces

* Convert device component tables to utilize the same row highlighting technology that interfaces use
* Convert VMInterfaceTable to utilize the same row highlighting technology that device interfaces use