### PR TITLE
15973 fix switch type on cable edit

### DIFF
--- a/netbox/dcim/forms/connections.py
+++ b/netbox/dcim/forms/connections.py
@@ -91,14 +91,13 @@ def get_cable_form(a_type, b_type):
 
         def __init__(self, *args, initial=None, **kwargs):
             initial = initial or {}
+
             if a_type:
                 a_ct = ContentType.objects.get_for_model(a_type)
                 initial['a_terminations_type'] = f'{a_ct.app_label}.{a_ct.model}'
-                initial.pop('a_terminations', None)
             if b_type:
                 b_ct = ContentType.objects.get_for_model(b_type)
                 initial['b_terminations_type'] = f'{b_ct.app_label}.{b_ct.model}'
-                initial.pop('b_terminations', None)
 
             # TODO: Temporary hack to work around list handling limitations with utils.normalize_querydict()
             for field_name in ('a_terminations', 'b_terminations'):
@@ -113,6 +112,13 @@ def get_cable_form(a_type, b_type):
                     self.initial['a_terminations'] = self.instance.a_terminations
                 if b_type and self.instance.b_terminations and b_ct == ContentType.objects.get_for_model(self.instance.b_terminations[0]):
                     self.initial['b_terminations'] = self.instance.b_terminations
+            else:
+                # Need to clear terminations if swapped type - but need to do it only
+                # if not from instance
+                if a_type:
+                    initial.pop('a_terminations', None)
+                if b_type:
+                    initial.pop('b_terminations', None)
 
         def clean(self):
             super().clean()


### PR DESCRIPTION
### Fixes: #15973 

A couple difference scenarios were causing issues with different fixes (now working):
1.  Have a Circuit Termination and switch to a Console Port and have IDs of termination and console port matching - would leave Console Port field with value
2. Was originally popping terminations above in the existing if a_type checks, but that caused a blank a_terminations if you add a cable from a device.

This also looks like it fixes #15783 and will also resolve #13278