### PR TITLE
Closes #16056: Add binary-path configuration in uwsgi.ini

### DIFF
--- a/contrib/uwsgi.ini
+++ b/contrib/uwsgi.ini
@@ -26,6 +26,9 @@ chdir = netbox
 ; specify the WSGI module to load
 module = netbox.wsgi
 
+; workaround to make uWSGI reloads work with pyuwsgi (not to be used if using uwsgi package instead)
+binary-path = venv/bin/python
+
 ; only log internal messages and errors (reverse proxy already logs the requests)
 disable-logging = true
 log-5xx = true


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #16056

I used relative path to ensure that changing the NetBox installation directory does not require changes in `uwsgi.ini`. Systemd configuration file has `WorkingDirectory` set.