### PR TITLE
Closes #16090: Show NetBox version if plugin validation fails

### DIFF
--- a/netbox/netbox/plugins/__init__.py
+++ b/netbox/netbox/plugins/__init__.py
@@ -138,13 +138,15 @@ class PluginConfig(AppConfig):
             min_version = version.parse(cls.min_version)
             if current_version < min_version:
                 raise ImproperlyConfigured(
-                    f"Plugin {cls.__module__} requires NetBox minimum version {cls.min_version}."
+                    f"Plugin {cls.__module__} requires NetBox minimum version {cls.min_version} but "
+                    f"this NetBox version is {netbox_version}."
                 )
         if cls.max_version is not None:
             max_version = version.parse(cls.max_version)
             if current_version > max_version:
                 raise ImproperlyConfigured(
-                    f"Plugin {cls.__module__} requires NetBox maximum version {cls.max_version}."
+                    f"Plugin {cls.__module__} requires NetBox maximum version {cls.max_version} but "
+                    f"this NetBox version is {netbox_version}."
                 )
 
         # Verify required configuration settings

--- a/netbox/netbox/plugins/__init__.py
+++ b/netbox/netbox/plugins/__init__.py
@@ -138,15 +138,15 @@ class PluginConfig(AppConfig):
             min_version = version.parse(cls.min_version)
             if current_version < min_version:
                 raise ImproperlyConfigured(
-                    f"Plugin {cls.__module__} requires NetBox minimum version {cls.min_version} but "
-                    f"this NetBox version is {netbox_version}."
+                    f"Plugin {cls.__module__} requires NetBox minimum version {cls.min_version} (current: "
+                    f"{netbox_version})."
                 )
         if cls.max_version is not None:
             max_version = version.parse(cls.max_version)
             if current_version > max_version:
                 raise ImproperlyConfigured(
-                    f"Plugin {cls.__module__} requires NetBox maximum version {cls.max_version} but "
-                    f"this NetBox version is {netbox_version}."
+                    f"Plugin {cls.__module__} requires NetBox maximum version {cls.max_version} (current: "
+                    f"{netbox_version})."
                 )
 
         # Verify required configuration settings


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #16090

<!--
    Please include a summary of the proposed changes below.
-->
