### PR TITLE
14606 add id to GenericObjectSerializer

### DIFF
--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -2005,10 +2005,12 @@ class CableTest(APIViewTestCases.APIViewTestCase):
         cls.create_data = [
             {
                 'a_terminations': [{
+                    'id': interfaces[4].pk,
                     'object_type': 'dcim.interface',
                     'object_id': interfaces[4].pk,
                 }],
                 'b_terminations': [{
+                    'id': interfaces[14].pk,
                     'object_type': 'dcim.interface',
                     'object_id': interfaces[14].pk,
                 }],
@@ -2016,10 +2018,12 @@ class CableTest(APIViewTestCases.APIViewTestCase):
             },
             {
                 'a_terminations': [{
+                    'id': interfaces[5].pk,
                     'object_type': 'dcim.interface',
                     'object_id': interfaces[5].pk,
                 }],
                 'b_terminations': [{
+                    'id': interfaces[15].pk,
                     'object_type': 'dcim.interface',
                     'object_id': interfaces[15].pk,
                 }],
@@ -2027,10 +2031,12 @@ class CableTest(APIViewTestCases.APIViewTestCase):
             },
             {
                 'a_terminations': [{
+                    'id': interfaces[6].pk,
                     'object_type': 'dcim.interface',
                     'object_id': interfaces[6].pk,
                 }],
                 'b_terminations': [{
+                    'id': interfaces[16].pk,
                     'object_type': 'dcim.interface',
                     'object_id': interfaces[16].pk,
                 }],

--- a/netbox/netbox/api/serializers/generic.py
+++ b/netbox/netbox/api/serializers/generic.py
@@ -16,7 +16,7 @@ class GenericObjectSerializer(serializers.Serializer):
     """
     Minimal representation of some generic object identified by ContentType and PK.
     """
-    id = serializers.IntegerField()
+    id = serializers.IntegerField(read_only=True, required=False)
     object_type = ContentTypeField(
         queryset=ContentType.objects.all()
     )

--- a/netbox/netbox/api/serializers/generic.py
+++ b/netbox/netbox/api/serializers/generic.py
@@ -16,6 +16,7 @@ class GenericObjectSerializer(serializers.Serializer):
     """
     Minimal representation of some generic object identified by ContentType and PK.
     """
+    id = serializers.IntegerField()
     object_type = ContentTypeField(
         queryset=ContentType.objects.all()
     )
@@ -30,6 +31,7 @@ class GenericObjectSerializer(serializers.Serializer):
     def to_representation(self, instance):
         object_type = ObjectType.objects.get_for_model(instance)
         data = {
+            'id': instance.pk,
             'object_type': object_type_identifier(object_type),
             'object_id': instance.pk,
         }


### PR DESCRIPTION
### Fixes: #14606 

@jeremystretch Not sure if this is the correct fix - just returning the Id which is the same as the object_id.  I think that is what is requested but seems like duplicated information.