### PR TITLE
14953 fix serializers when using add_related_count

### DIFF
--- a/netbox/dcim/api/serializers_/sites.py
+++ b/netbox/dcim/api/serializers_/sites.py
@@ -32,7 +32,7 @@ class RegionSerializer(NestedGroupModelSerializer):
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'site_count', '_depth')
 
     def create(self, request, *args, **kwargs):
-        # this is required as tenant_count is added in the view with add_related_count
+        # this is required as site_count is added in the view with add_related_count
         instance = super().create(request, *args, **kwargs)
         instance.site_count = 0
         return instance
@@ -52,7 +52,7 @@ class SiteGroupSerializer(NestedGroupModelSerializer):
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'site_count', '_depth')
 
     def create(self, request, *args, **kwargs):
-        # this is required as tenant_count is added in the view with add_related_count
+        # this is required as site_count is added in the view with add_related_count
         instance = super().create(request, *args, **kwargs)
         instance.site_count = 0
         return instance
@@ -110,7 +110,7 @@ class LocationSerializer(NestedGroupModelSerializer):
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'rack_count', '_depth')
 
     def create(self, request, *args, **kwargs):
-        # this is required as tenant_count is added in the view with add_related_count
+        # this is required as rack_count is added in the view with add_related_count
         instance = super().create(request, *args, **kwargs)
         instance.rack_count = 0
         return instance

--- a/netbox/dcim/api/serializers_/sites.py
+++ b/netbox/dcim/api/serializers_/sites.py
@@ -21,7 +21,7 @@ __all__ = (
 class RegionSerializer(NestedGroupModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:region-detail')
     parent = NestedRegionSerializer(required=False, allow_null=True, default=None)
-    site_count = serializers.IntegerField(read_only=True)
+    site_count = serializers.IntegerField(read_only=True, default=0)
 
     class Meta:
         model = Region
@@ -31,17 +31,11 @@ class RegionSerializer(NestedGroupModelSerializer):
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'site_count', '_depth')
 
-    def create(self, request, *args, **kwargs):
-        # this is required as site_count is added in the view with add_related_count
-        instance = super().create(request, *args, **kwargs)
-        instance.site_count = 0
-        return instance
-
 
 class SiteGroupSerializer(NestedGroupModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:sitegroup-detail')
     parent = NestedSiteGroupSerializer(required=False, allow_null=True, default=None)
-    site_count = serializers.IntegerField(read_only=True)
+    site_count = serializers.IntegerField(read_only=True, default=0)
 
     class Meta:
         model = SiteGroup
@@ -50,12 +44,6 @@ class SiteGroupSerializer(NestedGroupModelSerializer):
             'last_updated', 'site_count', '_depth',
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'site_count', '_depth')
-
-    def create(self, request, *args, **kwargs):
-        # this is required as site_count is added in the view with add_related_count
-        instance = super().create(request, *args, **kwargs)
-        instance.site_count = 0
-        return instance
 
 
 class SiteSerializer(NetBoxModelSerializer):
@@ -98,8 +86,8 @@ class LocationSerializer(NestedGroupModelSerializer):
     parent = NestedLocationSerializer(required=False, allow_null=True, default=None)
     status = ChoiceField(choices=LocationStatusChoices, required=False)
     tenant = TenantSerializer(nested=True, required=False, allow_null=True)
-    rack_count = serializers.IntegerField(read_only=True)
-    device_count = serializers.IntegerField(read_only=True)
+    rack_count = serializers.IntegerField(read_only=True, default=0)
+    device_count = serializers.IntegerField(read_only=True, default=0)
 
     class Meta:
         model = Location
@@ -108,9 +96,3 @@ class LocationSerializer(NestedGroupModelSerializer):
             'tags', 'custom_fields', 'created', 'last_updated', 'rack_count', 'device_count', '_depth',
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'rack_count', '_depth')
-
-    def create(self, request, *args, **kwargs):
-        # this is required as rack_count is added in the view with add_related_count
-        instance = super().create(request, *args, **kwargs)
-        instance.rack_count = 0
-        return instance

--- a/netbox/dcim/api/serializers_/sites.py
+++ b/netbox/dcim/api/serializers_/sites.py
@@ -31,6 +31,12 @@ class RegionSerializer(NestedGroupModelSerializer):
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'site_count', '_depth')
 
+    def create(self, request, *args, **kwargs):
+        # this is required as tenant_count is added in the view with add_related_count
+        instance = super().create(request, *args, **kwargs)
+        instance.site_count = 0
+        return instance
+
 
 class SiteGroupSerializer(NestedGroupModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='dcim-api:sitegroup-detail')
@@ -44,6 +50,12 @@ class SiteGroupSerializer(NestedGroupModelSerializer):
             'last_updated', 'site_count', '_depth',
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'site_count', '_depth')
+
+    def create(self, request, *args, **kwargs):
+        # this is required as tenant_count is added in the view with add_related_count
+        instance = super().create(request, *args, **kwargs)
+        instance.site_count = 0
+        return instance
 
 
 class SiteSerializer(NetBoxModelSerializer):
@@ -96,3 +108,9 @@ class LocationSerializer(NestedGroupModelSerializer):
             'tags', 'custom_fields', 'created', 'last_updated', 'rack_count', 'device_count', '_depth',
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'rack_count', '_depth')
+
+    def create(self, request, *args, **kwargs):
+        # this is required as tenant_count is added in the view with add_related_count
+        instance = super().create(request, *args, **kwargs)
+        instance.rack_count = 0
+        return instance

--- a/netbox/tenancy/api/serializers_/contacts.py
+++ b/netbox/tenancy/api/serializers_/contacts.py
@@ -31,6 +31,12 @@ class ContactGroupSerializer(NestedGroupModelSerializer):
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'contact_count', '_depth')
 
+    def create(self, request, *args, **kwargs):
+        # this is required as tenant_count is added in the view with add_related_count
+        instance = super().create(request, *args, **kwargs)
+        instance.contact_count = 0
+        return instance
+
 
 class ContactRoleSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='tenancy-api:contactrole-detail')

--- a/netbox/tenancy/api/serializers_/contacts.py
+++ b/netbox/tenancy/api/serializers_/contacts.py
@@ -21,7 +21,7 @@ __all__ = (
 class ContactGroupSerializer(NestedGroupModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='tenancy-api:contactgroup-detail')
     parent = NestedContactGroupSerializer(required=False, allow_null=True, default=None)
-    contact_count = serializers.IntegerField(read_only=True)
+    contact_count = serializers.IntegerField(read_only=True, default=0)
 
     class Meta:
         model = ContactGroup
@@ -30,12 +30,6 @@ class ContactGroupSerializer(NestedGroupModelSerializer):
             'last_updated', 'contact_count', '_depth',
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'contact_count', '_depth')
-
-    def create(self, request, *args, **kwargs):
-        # this is required as contact_count is added in the view with add_related_count
-        instance = super().create(request, *args, **kwargs)
-        instance.contact_count = 0
-        return instance
 
 
 class ContactRoleSerializer(NetBoxModelSerializer):

--- a/netbox/tenancy/api/serializers_/contacts.py
+++ b/netbox/tenancy/api/serializers_/contacts.py
@@ -32,7 +32,7 @@ class ContactGroupSerializer(NestedGroupModelSerializer):
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'contact_count', '_depth')
 
     def create(self, request, *args, **kwargs):
-        # this is required as tenant_count is added in the view with add_related_count
+        # this is required as contact_count is added in the view with add_related_count
         instance = super().create(request, *args, **kwargs)
         instance.contact_count = 0
         return instance

--- a/netbox/tenancy/api/serializers_/tenants.py
+++ b/netbox/tenancy/api/serializers_/tenants.py
@@ -14,7 +14,7 @@ __all__ = (
 class TenantGroupSerializer(NestedGroupModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='tenancy-api:tenantgroup-detail')
     parent = NestedTenantGroupSerializer(required=False, allow_null=True)
-    tenant_count = serializers.IntegerField(read_only=True)
+    tenant_count = serializers.IntegerField(read_only=True, default=0)
 
     class Meta:
         model = TenantGroup
@@ -23,12 +23,6 @@ class TenantGroupSerializer(NestedGroupModelSerializer):
             'last_updated', 'tenant_count', '_depth',
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'tenant_count', '_depth')
-
-    def create(self, request, *args, **kwargs):
-        # this is required as tenant_count is added in the view with add_related_count
-        instance = super().create(request, *args, **kwargs)
-        instance.tenant_count = 0
-        return instance
 
 
 class TenantSerializer(NetBoxModelSerializer):

--- a/netbox/tenancy/api/serializers_/tenants.py
+++ b/netbox/tenancy/api/serializers_/tenants.py
@@ -24,6 +24,12 @@ class TenantGroupSerializer(NestedGroupModelSerializer):
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'tenant_count', '_depth')
 
+    def create(self, request, *args, **kwargs):
+        # this is required as tenant_count is added in the view with add_related_count
+        instance = super().create(request, *args, **kwargs)
+        instance.tenant_count = 0
+        return instance
+
 
 class TenantSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='tenancy-api:tenant-detail')

--- a/netbox/wireless/api/serializers_/wirelesslans.py
+++ b/netbox/wireless/api/serializers_/wirelesslans.py
@@ -17,7 +17,7 @@ __all__ = (
 class WirelessLANGroupSerializer(NestedGroupModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='wireless-api:wirelesslangroup-detail')
     parent = NestedWirelessLANGroupSerializer(required=False, allow_null=True, default=None)
-    wirelesslan_count = serializers.IntegerField(read_only=True)
+    wirelesslan_count = serializers.IntegerField(read_only=True, default=0)
 
     class Meta:
         model = WirelessLANGroup
@@ -26,12 +26,6 @@ class WirelessLANGroupSerializer(NestedGroupModelSerializer):
             'last_updated', 'wirelesslan_count', '_depth',
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'wirelesslan_count', '_depth')
-
-    def create(self, request, *args, **kwargs):
-        # this is required as wirelesslan_count is added in the view with add_related_count
-        instance = super().create(request, *args, **kwargs)
-        instance.wirelesslan_count = 0
-        return instance
 
 
 class WirelessLANSerializer(NetBoxModelSerializer):

--- a/netbox/wireless/api/serializers_/wirelesslans.py
+++ b/netbox/wireless/api/serializers_/wirelesslans.py
@@ -28,7 +28,7 @@ class WirelessLANGroupSerializer(NestedGroupModelSerializer):
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'wirelesslan_count', '_depth')
 
     def create(self, request, *args, **kwargs):
-        # this is required as tenant_count is added in the view with add_related_count
+        # this is required as wirelesslan_count is added in the view with add_related_count
         instance = super().create(request, *args, **kwargs)
         instance.wirelesslan_count = 0
         return instance

--- a/netbox/wireless/api/serializers_/wirelesslans.py
+++ b/netbox/wireless/api/serializers_/wirelesslans.py
@@ -27,6 +27,12 @@ class WirelessLANGroupSerializer(NestedGroupModelSerializer):
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'wirelesslan_count', '_depth')
 
+    def create(self, request, *args, **kwargs):
+        # this is required as tenant_count is added in the view with add_related_count
+        instance = super().create(request, *args, **kwargs)
+        instance.wirelesslan_count = 0
+        return instance
+
 
 class WirelessLANSerializer(NetBoxModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='wireless-api:wirelesslan-detail')


### PR DESCRIPTION
### Fixes: #14953 

This happens as the count fields are set via add_related_count in the view queryset, in create there isn't a record, therefore no count field.  On create the count fields would always be zero so can just be set, obviating the need for any DB call.  This should only effect create as a PUT or PATCH will cause the field to get set via the queryset, and the counts shouldn't be changed from the PUT or PATCH call as they are for related objects.