### PR TITLE
16145 Use module.ScriptName to call Script API instead of PK

### DIFF
--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -241,7 +241,7 @@ class ScriptViewSet(ModelViewSet):
 
     def post(self, request, pk):
         """
-        Run a Script identified by the name and return the pending Job as the result
+        Run a Script identified by the name or pk and return the pending Job as the result
         """
 
         if not request.user.has_perm('extras.run_script'):

--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -1,3 +1,4 @@
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django_rq.queues import get_connection
 from rest_framework import status
@@ -13,7 +14,7 @@ from rq import Worker
 from core.models import Job, ObjectType
 from extras import filtersets
 from extras.models import *
-from extras.scripts import run_script
+from extras.scripts import get_module_and_script, run_script
 from netbox.api.authentication import IsAuthenticatedOrLoginNotRequired
 from netbox.api.features import SyncedDataMixin
 from netbox.api.metadata import ContentTypeMetadata
@@ -215,21 +216,33 @@ class ScriptViewSet(ModelViewSet):
     _ignore_model_permissions = True
     lookup_value_regex = '[^/]+'  # Allow dots
 
+    def _get_script(self, pk):
+        try:
+            module_name, script_name = pk.split('.', maxsplit=1)
+        except ValueError:
+            raise Http404
+
+        module, script = get_module_and_script(module_name, script_name)
+        if script is None:
+            raise Http404
+
+        return module, script
+
     def retrieve(self, request, pk):
-        script = get_object_or_404(self.queryset, pk=pk)
+        module, script = self._get_script(pk)
         serializer = serializers.ScriptDetailSerializer(script, context={'request': request})
 
         return Response(serializer.data)
 
     def post(self, request, pk):
         """
-        Run a Script identified by the id and return the pending Job as the result
+        Run a Script identified by the name and return the pending Job as the result
         """
 
         if not request.user.has_perm('extras.run_script'):
             raise PermissionDenied("This user does not have permission to run scripts.")
 
-        script = get_object_or_404(self.queryset, pk=pk)
+        module, script = self._get_script(pk)
         input_serializer = serializers.ScriptInputSerializer(
             data=request.data,
             context={'script': script}

--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -217,12 +217,17 @@ class ScriptViewSet(ModelViewSet):
     lookup_value_regex = '[^/]+'  # Allow dots
 
     def _get_script(self, pk):
-        try:
-            module_name, script_name = pk.split('.', maxsplit=1)
-        except ValueError:
-            raise Http404
+        if pk.isnumeric():
+            script = get_object_or_404(self.queryset, pk=pk)
+            module = script.module
+        else:
+            try:
+                module_name, script_name = pk.split('.', maxsplit=1)
+            except ValueError:
+                raise Http404
 
-        module, script = get_module_and_script(module_name, script_name)
+            module, script = get_module_and_script(module_name, script_name)
+
         if script is None:
             raise Http404
 

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -777,8 +777,10 @@ class ScriptTest(APITestCase):
             is_executable=True,
         )
 
-    def python_class(self):
-        return self.TestScriptClass
+    def get_vars(self, *args):
+        return {
+            k: v.__class__.__name__ for k, v in self.TestScriptClass._get_vars().items()
+        }
 
     def get_test_script(self, *args):
         module = ScriptModule.objects.first()
@@ -790,6 +792,8 @@ class ScriptTest(APITestCase):
         # Monkey-patch the Script model to return our TestScriptClass above
         from extras.api.views import ScriptViewSet
         ScriptViewSet._get_script = self.get_test_script
+        from extras.api.serializers_.scripts import ScriptSerializer
+        ScriptSerializer.get_vars = self.get_vars
 
     def test_get_script(self):
         module = ScriptModule.objects.get(

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -780,12 +780,16 @@ class ScriptTest(APITestCase):
     def python_class(self):
         return self.TestScriptClass
 
+    def get_test_script(self, *args):
+        module = ScriptModule.objects.first()
+        return module, module.scripts.first()
+
     def setUp(self):
         super().setUp()
 
         # Monkey-patch the Script model to return our TestScriptClass above
         from extras.api.views import ScriptViewSet
-        Script.python_class = self.python_class
+        ScriptViewSet._get_script = self.get_test_script
 
     def test_get_script(self):
         module = ScriptModule.objects.get(
@@ -793,7 +797,7 @@ class ScriptTest(APITestCase):
             file_path='/var/tmp/script.py'
         )
         script = module.scripts.all().first()
-        url = reverse('extras-api:script-detail', kwargs={'pk': script.pk})
+        url = reverse('extras-api:script-detail', kwargs={'pk': None})
         response = self.client.get(url, **self.header)
 
         self.assertEqual(response.data['name'], self.TestScriptClass.Meta.name)


### PR DESCRIPTION
### Fixes: #16145 

Changes the script api back to using the "module.ScriptName" instead of id (this is the way it was in NB3.x).  The test was a bit of a mess to fix, the issue is the get_vars function in the Script class calls the python_class property which calls module_scripts on on the module - this tries to load the module which fails as the script doesn't actually exist on disk.

```
curl -X 'GET' \
  'http://localhost:8000/api/extras/scripts/testscript.NewBranchScript/' \
  -H 'accept: application/json; indent=4' \
  -H 'Content-Type: application/json' \
  -H "Authorization: Token 6f22af1129a164f92e4abdfa716cb54df9684f5e"

{
    "id": 3,
    "url": "http://localhost:8000/api/extras/scripts/3/",
    "module": 7,
    "name": "NewBranchScript",
    "description": "Provision a new branch site",
    "vars": {
        "site_name": "StringVar",
        "switch_count": "IntegerVar",
        "switch_model": "ObjectVar",
        "manufacturer": "ObjectVar"
    },
    "result": {
        "object_id": null,
        "name": "",
        "scheduled": null,
        "interval": null,
        "started": null,
        "completed": null,
        "data": null,
        "job_id": null
    },
    "display": "NewBranchScript (testscript)",
    "is_executable": true
}
```