### PR TITLE
16164 - Displayed ID instead of name when None is selected on the Filters.

### DIFF
--- a/netbox/utilities/forms/fields/dynamic.py
+++ b/netbox/utilities/forms/fields/dynamic.py
@@ -197,6 +197,6 @@ class DynamicModelMultipleChoiceField(DynamicModelChoiceMixin, forms.ModelMultip
         # string 'null'.  This will check for that condition and gracefully handle the conversion to a NoneType.
         if self.null_option is not None and settings.FILTERS_NULL_CHOICE_VALUE in value:
             value = [v for v in value if v != settings.FILTERS_NULL_CHOICE_VALUE]
-            return [None, *value]
+            return [None, *super().clean(value)]
 
         return super().clean(value)


### PR DESCRIPTION
### Fixes: #16164
Updated `clean` method on `DynamicModelMultipleChoiceField` to return the name.