### PR TITLE
16173 - Fix pagination when `pagination.per_page` is `""`

### DIFF
--- a/netbox/utilities/paginator.py
+++ b/netbox/utilities/paginator.py
@@ -87,7 +87,7 @@ def get_paginate_count(request):
             pass
 
     if request.user.is_authenticated:
-        per_page = request.user.config.get('pagination.per_page', config.PAGINATE_COUNT)
+        per_page = request.user.config.get('pagination.per_page') or config.PAGINATE_COUNT
         return _max_allowed(per_page)
 
     return _max_allowed(config.PAGINATE_COUNT)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #16173

Fixes `TypeError` when `paginate.per_page` user preference is `""`.
This happens when the user clears the per page preference which sets it to the empty string, causing
`per_page` to be a string instead of an integer.

<!--
    Please include a summary of the proposed changes below.
-->
