### PR TITLE
15082 - Custom field with trailing white space unable to import

### DIFF
--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -122,7 +122,7 @@ class CustomFieldChoiceSetForm(forms.ModelForm):
                 label = label.replace('\\:', ':')
             except ValueError:
                 value, label = line, line
-            data.append((value, label))
+            data.append((value.strip(), label.strip()))
         return data
 
 


### PR DESCRIPTION

### Fixes: #15082

Changed "clean_extra_choices" in "CustomFieldChoiceSetForm" to strip the space for value and label.
