### PR TITLE
14948 add has_virtual_device_contexts filter to device

### DIFF
--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -1100,9 +1100,9 @@ class DeviceFilterSet(
         queryset=IPAddress.objects.all(),
         label=_('OOB IP (ID)'),
     )
-    has_virtual_device_contexts = django_filters.BooleanFilter(
-        method='_has_virtual_device_contexts',
-        label=_('Has virtual device contexts'),
+    has_virtual_device_context = django_filters.BooleanFilter(
+        method='_has_virtual_device_context',
+        label=_('Has virtual device context'),
     )
 
     class Meta:
@@ -1180,7 +1180,7 @@ class DeviceFilterSet(
     def _device_bays(self, queryset, name, value):
         return queryset.exclude(devicebays__isnull=value)
 
-    def _has_virtual_device_contexts(self, queryset, name, value):
+    def _has_virtual_device_context(self, queryset, name, value):
         params = Q(vdcs__isnull=False)
         if value:
             return queryset.filter(params).distinct()

--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -1100,6 +1100,10 @@ class DeviceFilterSet(
         queryset=IPAddress.objects.all(),
         label=_('OOB IP (ID)'),
     )
+    has_virtual_device_contexts = django_filters.BooleanFilter(
+        method='_has_virtual_device_contexts',
+        label=_('Has virtual device contexts'),
+    )
 
     class Meta:
         model = Device
@@ -1175,6 +1179,12 @@ class DeviceFilterSet(
 
     def _device_bays(self, queryset, name, value):
         return queryset.exclude(devicebays__isnull=value)
+
+    def _has_virtual_device_contexts(self, queryset, name, value):
+        params = Q(vdcs__isnull=False)
+        if value:
+            return queryset.filter(params).distinct()
+        return queryset.exclude(params)
 
 
 class VirtualDeviceContextFilterSet(NetBoxModelFilterSet, TenancyFilterSet, PrimaryIPFilterSet):

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -657,7 +657,7 @@ class DeviceFilterForm(
         ),
         FieldSet(
             'has_primary_ip', 'has_oob_ip', 'virtual_chassis_member', 'config_template_id', 'local_context_data',
-            'has_virtual_device_contexts',
+            'has_virtual_device_context',
             name=_('Miscellaneous')
         )
     )
@@ -814,7 +814,7 @@ class DeviceFilterForm(
             choices=BOOLEAN_WITH_BLANK_CHOICES
         )
     )
-    has_virtual_device_contexts = forms.NullBooleanField(
+    has_virtual_device_context = forms.NullBooleanField(
         required=False,
         label=_('Has virtual device contexts'),
         widget=forms.Select(

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -657,6 +657,7 @@ class DeviceFilterForm(
         ),
         FieldSet(
             'has_primary_ip', 'has_oob_ip', 'virtual_chassis_member', 'config_template_id', 'local_context_data',
+            'has_virtual_device_contexts',
             name=_('Miscellaneous')
         )
     )
@@ -809,6 +810,13 @@ class DeviceFilterForm(
     pass_through_ports = forms.NullBooleanField(
         required=False,
         label=_('Has pass-through ports'),
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        )
+    )
+    has_virtual_device_contexts = forms.NullBooleanField(
+        required=False,
+        label=_('Has virtual device contexts'),
         widget=forms.Select(
             choices=BOOLEAN_WITH_BLANK_CHOICES
         )

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -2103,6 +2103,9 @@ class DeviceTestCase(TestCase, ChangeLoggedFilterSetTests):
         Device.objects.filter(pk=devices[0].pk).update(virtual_chassis=virtual_chassis, vc_position=1, vc_priority=1)
         Device.objects.filter(pk=devices[1].pk).update(virtual_chassis=virtual_chassis, vc_position=2, vc_priority=2)
 
+        # VirtualDeviceContext assignment for filtering
+        VirtualDeviceContext.objects.create(device=devices[0], name="VDC 1", identifier=1, status='active')
+
     def test_q(self):
         params = {'q': 'foobar1'}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
@@ -2334,6 +2337,12 @@ class DeviceTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {'tenant_group_id': [tenant_groups[0].pk, tenant_groups[1].pk]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'tenant_group': [tenant_groups[0].slug, tenant_groups[1].slug]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_has_virtual_device_context(self):
+        params = {'has_virtual_device_context': 'true'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+        params = {'has_virtual_device_context': 'false'}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 


### PR DESCRIPTION
### Fixes: #14948 

Adds a has_virtual_device_contexts filter to devices.

![Monosnap Devices | NetBox 2024-05-20 13-45-04](https://github.com/netbox-community/netbox/assets/99642/34a0d7cd-9e53-4b3f-91eb-5067b5d72b4d)
