### PR TITLE
14653 Add Inventory Item column to all Device components tables

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -358,6 +358,10 @@ class ConsolePortTable(ModularDeviceComponentTable, PathEndpointTable):
             'args': [Accessor('device_id')],
         }
     )
+    inventory_items = columns.ManyToManyColumn(
+        linkify_item=True,
+        verbose_name=_('Inventory Items'),
+    )
     tags = columns.TagColumn(
         url_name='dcim:consoleport_list'
     )
@@ -366,7 +370,7 @@ class ConsolePortTable(ModularDeviceComponentTable, PathEndpointTable):
         model = models.ConsolePort
         fields = (
             'pk', 'id', 'name', 'device', 'module_bay', 'module', 'label', 'type', 'speed', 'description',
-            'mark_connected', 'cable', 'cable_color', 'link_peer', 'connection', 'tags', 'created', 'last_updated',
+            'mark_connected', 'cable', 'cable_color', 'link_peer', 'connection', 'inventory_items', 'tags', 'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'device', 'label', 'type', 'speed', 'description')
 
@@ -402,6 +406,10 @@ class ConsoleServerPortTable(ModularDeviceComponentTable, PathEndpointTable):
             'args': [Accessor('device_id')],
         }
     )
+    inventory_items = columns.ManyToManyColumn(
+        linkify_item=True,
+        verbose_name=_('Inventory Items'),
+    )
     tags = columns.TagColumn(
         url_name='dcim:consoleserverport_list'
     )
@@ -410,7 +418,7 @@ class ConsoleServerPortTable(ModularDeviceComponentTable, PathEndpointTable):
         model = models.ConsoleServerPort
         fields = (
             'pk', 'id', 'name', 'device', 'module_bay', 'module', 'label', 'type', 'speed', 'description',
-            'mark_connected', 'cable', 'cable_color', 'link_peer', 'connection', 'tags', 'created', 'last_updated',
+            'mark_connected', 'cable', 'cable_color', 'link_peer', 'connection', 'inventory_items', 'tags', 'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'device', 'label', 'type', 'speed', 'description')
 
@@ -453,6 +461,10 @@ class PowerPortTable(ModularDeviceComponentTable, PathEndpointTable):
     allocated_draw = tables.Column(
         verbose_name=_('Allocated draw (W)')
     )
+    inventory_items = columns.ManyToManyColumn(
+        linkify_item=True,
+        verbose_name=_('Inventory Items'),
+    )
     tags = columns.TagColumn(
         url_name='dcim:powerport_list'
     )
@@ -461,8 +473,8 @@ class PowerPortTable(ModularDeviceComponentTable, PathEndpointTable):
         model = models.PowerPort
         fields = (
             'pk', 'id', 'name', 'device', 'module_bay', 'module', 'label', 'type', 'description', 'mark_connected',
-            'maximum_draw', 'allocated_draw', 'cable', 'cable_color', 'link_peer', 'connection', 'tags', 'created',
-            'last_updated',
+            'maximum_draw', 'allocated_draw', 'cable', 'cable_color', 'link_peer', 'connection', 'inventory_items',
+            'tags', 'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'device', 'label', 'type', 'maximum_draw', 'allocated_draw', 'description')
 
@@ -505,6 +517,10 @@ class PowerOutletTable(ModularDeviceComponentTable, PathEndpointTable):
         verbose_name=_('Power Port'),
         linkify=True
     )
+    inventory_items = columns.ManyToManyColumn(
+        linkify_item=True,
+        verbose_name=_('Inventory Items'),
+    )
     tags = columns.TagColumn(
         url_name='dcim:poweroutlet_list'
     )
@@ -513,8 +529,8 @@ class PowerOutletTable(ModularDeviceComponentTable, PathEndpointTable):
         model = models.PowerOutlet
         fields = (
             'pk', 'id', 'name', 'device', 'module_bay', 'module', 'label', 'type', 'description', 'power_port',
-            'feed_leg', 'mark_connected', 'cable', 'cable_color', 'link_peer', 'connection', 'tags', 'created',
-            'last_updated',
+            'feed_leg', 'mark_connected', 'cable', 'cable_color', 'link_peer', 'connection', 'inventory_items',
+            'tags', 'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'device', 'label', 'type', 'power_port', 'feed_leg', 'description')
 
@@ -705,6 +721,10 @@ class FrontPortTable(ModularDeviceComponentTable, CableTerminationTable):
         verbose_name=_('Rear Port'),
         linkify=True
     )
+    inventory_items = columns.ManyToManyColumn(
+        linkify_item=True,
+        verbose_name=_('Inventory Items'),
+    )
     tags = columns.TagColumn(
         url_name='dcim:frontport_list'
     )
@@ -713,8 +733,8 @@ class FrontPortTable(ModularDeviceComponentTable, CableTerminationTable):
         model = models.FrontPort
         fields = (
             'pk', 'id', 'name', 'device', 'module_bay', 'module', 'label', 'type', 'color', 'rear_port',
-            'rear_port_position', 'description', 'mark_connected', 'cable', 'cable_color', 'link_peer', 'tags',
-            'created', 'last_updated',
+            'rear_port_position', 'description', 'mark_connected', 'cable', 'cable_color', 'link_peer',
+            'inventory_items', 'tags', 'created', 'last_updated',
         )
         default_columns = (
             'pk', 'name', 'device', 'label', 'type', 'color', 'rear_port', 'rear_port_position', 'description',
@@ -758,6 +778,10 @@ class RearPortTable(ModularDeviceComponentTable, CableTerminationTable):
     color = columns.ColorColumn(
         verbose_name=_('Color'),
     )
+    inventory_items = columns.ManyToManyColumn(
+        linkify_item=True,
+        verbose_name=_('Inventory Items'),
+    )
     tags = columns.TagColumn(
         url_name='dcim:rearport_list'
     )
@@ -766,7 +790,7 @@ class RearPortTable(ModularDeviceComponentTable, CableTerminationTable):
         model = models.RearPort
         fields = (
             'pk', 'id', 'name', 'device', 'module_bay', 'module', 'label', 'type', 'color', 'positions', 'description',
-            'mark_connected', 'cable', 'cable_color', 'link_peer', 'tags', 'created', 'last_updated',
+            'mark_connected', 'cable', 'cable_color', 'link_peer', 'inventory_items', 'tags', 'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'device', 'label', 'type', 'color', 'description')
 

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -313,6 +313,10 @@ class ModularDeviceComponentTable(DeviceComponentTable):
         verbose_name=_('Module'),
         linkify=True
     )
+    inventory_items = columns.ManyToManyColumn(
+        linkify_item=True,
+        verbose_name=_('Inventory Items'),
+    )
 
 
 class CableTerminationTable(NetBoxTable):
@@ -358,10 +362,6 @@ class ConsolePortTable(ModularDeviceComponentTable, PathEndpointTable):
             'args': [Accessor('device_id')],
         }
     )
-    inventory_items = columns.ManyToManyColumn(
-        linkify_item=True,
-        verbose_name=_('Inventory Items'),
-    )
     tags = columns.TagColumn(
         url_name='dcim:consoleport_list'
     )
@@ -405,10 +405,6 @@ class ConsoleServerPortTable(ModularDeviceComponentTable, PathEndpointTable):
             'viewname': 'dcim:device_consoleserverports',
             'args': [Accessor('device_id')],
         }
-    )
-    inventory_items = columns.ManyToManyColumn(
-        linkify_item=True,
-        verbose_name=_('Inventory Items'),
     )
     tags = columns.TagColumn(
         url_name='dcim:consoleserverport_list'
@@ -461,10 +457,6 @@ class PowerPortTable(ModularDeviceComponentTable, PathEndpointTable):
     allocated_draw = tables.Column(
         verbose_name=_('Allocated draw (W)')
     )
-    inventory_items = columns.ManyToManyColumn(
-        linkify_item=True,
-        verbose_name=_('Inventory Items'),
-    )
     tags = columns.TagColumn(
         url_name='dcim:powerport_list'
     )
@@ -516,10 +508,6 @@ class PowerOutletTable(ModularDeviceComponentTable, PathEndpointTable):
     power_port = tables.Column(
         verbose_name=_('Power Port'),
         linkify=True
-    )
-    inventory_items = columns.ManyToManyColumn(
-        linkify_item=True,
-        verbose_name=_('Inventory Items'),
     )
     tags = columns.TagColumn(
         url_name='dcim:poweroutlet_list'
@@ -634,10 +622,6 @@ class InterfaceTable(ModularDeviceComponentTable, BaseInterfaceTable, PathEndpoi
         verbose_name=_('VRF'),
         linkify=True
     )
-    inventory_items = columns.ManyToManyColumn(
-        linkify_item=True,
-        verbose_name=_('Inventory Items'),
-    )
     tags = columns.TagColumn(
         url_name='dcim:interface_list'
     )
@@ -721,10 +705,6 @@ class FrontPortTable(ModularDeviceComponentTable, CableTerminationTable):
         verbose_name=_('Rear Port'),
         linkify=True
     )
-    inventory_items = columns.ManyToManyColumn(
-        linkify_item=True,
-        verbose_name=_('Inventory Items'),
-    )
     tags = columns.TagColumn(
         url_name='dcim:frontport_list'
     )
@@ -777,10 +757,6 @@ class RearPortTable(ModularDeviceComponentTable, CableTerminationTable):
     )
     color = columns.ColorColumn(
         verbose_name=_('Color'),
-    )
-    inventory_items = columns.ManyToManyColumn(
-        linkify_item=True,
-        verbose_name=_('Inventory Items'),
     )
     tags = columns.TagColumn(
         url_name='dcim:rearport_list'


### PR DESCRIPTION
### Fixes: #14653 

![Monosnap Power Outlets | NetBox 2024-05-20 14-35-25](https://github.com/netbox-community/netbox/assets/99642/059cf4a1-1b52-4507-a6ae-cb55f4ff7172)
![Monosnap Power Ports | NetBox 2024-05-20 14-34-21](https://github.com/netbox-community/netbox/assets/99642/a0d61980-a2d3-4643-9215-dd8388793013)
![Monosnap Rear Ports | NetBox 2024-05-20 14-33-23](https://github.com/netbox-community/netbox/assets/99642/d18b2571-9ebb-4c53-9774-d1dfc629eab0)
![Monosnap Console Server Ports | NetBox 2024-05-20 14-31-13](https://github.com/netbox-community/netbox/assets/99642/3b0ce0e9-093b-4226-a786-74dbd2513ead)
![Monosnap Console Ports | NetBox 2024-05-20 14-29-18](https://github.com/netbox-community/netbox/assets/99642/6e226610-8e4d-42fc-ba96-cb34ca933151)
![Monosnap Front Ports | NetBox 2024-05-20 14-27-48](https://github.com/netbox-community/netbox/assets/99642/eb5cd223-d972-45fc-888e-8ef80a48f1d0)
