### PR TITLE
13764 Add contacts to IP views

### DIFF
--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -18,6 +18,7 @@ from ipam.querysets import PrefixQuerySet
 from ipam.validators import DNSValidator
 from netbox.config import get_config
 from netbox.models import OrganizationalModel, PrimaryModel
+from netbox.models.features import ContactsMixin
 
 __all__ = (
     'Aggregate',
@@ -74,7 +75,7 @@ class RIR(OrganizationalModel):
         return reverse('ipam:rir', args=[self.pk])
 
 
-class Aggregate(GetAvailablePrefixesMixin, PrimaryModel):
+class Aggregate(ContactsMixin, GetAvailablePrefixesMixin, PrimaryModel):
     """
     An aggregate exists at the root level of the IP address space hierarchy in NetBox. Aggregates are used to organize
     the hierarchy and track the overall utilization of available address space. Each Aggregate is assigned to a RIR.
@@ -206,7 +207,7 @@ class Role(OrganizationalModel):
         return reverse('ipam:role', args=[self.pk])
 
 
-class Prefix(GetAvailablePrefixesMixin, PrimaryModel):
+class Prefix(ContactsMixin, GetAvailablePrefixesMixin, PrimaryModel):
     """
     A Prefix represents an IPv4 or IPv6 network, including mask length. Prefixes can optionally be assigned to Sites and
     VRFs. A Prefix must be assigned a status and may optionally be assigned a used-define Role. A Prefix can also be
@@ -486,7 +487,7 @@ class Prefix(GetAvailablePrefixesMixin, PrimaryModel):
         return min(utilization, 100)
 
 
-class IPRange(PrimaryModel):
+class IPRange(ContactsMixin, PrimaryModel):
     """
     A range of IP addresses, defined by start and end addresses.
     """
@@ -695,7 +696,7 @@ class IPRange(PrimaryModel):
         return min(float(child_count) / self.size * 100, 100)
 
 
-class IPAddress(PrimaryModel):
+class IPAddress(ContactsMixin, PrimaryModel):
     """
     An IPAddress represents an individual IPv4 or IPv6 address and its mask. The mask length should match what is
     configured in the real world. (Typically, only loopback interfaces are configured with /32 or /128 masks.) Like

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -9,6 +9,7 @@ from circuits.models import Provider
 from dcim.filtersets import InterfaceFilterSet
 from dcim.models import Interface, Site
 from netbox.views import generic
+from tenancy.views import ObjectContactsView
 from utilities.query import count_related
 from utilities.tables import get_table_ordering
 from utilities.views import ViewTab, register_model_view
@@ -405,6 +406,11 @@ class AggregateBulkDeleteView(generic.BulkDeleteView):
     table = tables.AggregateTable
 
 
+@register_model_view(Aggregate, 'contacts')
+class AggregateContactsView(ObjectContactsView):
+    queryset = Aggregate.objects.all()
+
+
 #
 # Prefix/VLAN roles
 #
@@ -643,6 +649,11 @@ class PrefixBulkDeleteView(generic.BulkDeleteView):
     table = tables.PrefixTable
 
 
+@register_model_view(Prefix, 'contacts')
+class PrefixContactsView(ObjectContactsView):
+    queryset = Prefix.objects.all()
+
+
 #
 # IP Ranges
 #
@@ -724,6 +735,11 @@ class IPRangeBulkDeleteView(generic.BulkDeleteView):
     queryset = IPRange.objects.all()
     filterset = filtersets.IPRangeFilterSet
     table = tables.IPRangeTable
+
+
+@register_model_view(IPRange, 'contacts')
+class IPRangeContactsView(ObjectContactsView):
+    queryset = IPRange.objects.all()
 
 
 #
@@ -891,6 +907,11 @@ class IPAddressRelatedIPsView(generic.ObjectChildrenView):
 
     def get_children(self, request, parent):
         return parent.get_related_ips().restrict(request.user, 'view')
+
+
+@register_model_view(IPAddress, 'contacts')
+class IPAddressContactsView(ObjectContactsView):
+    queryset = IPAddress.objects.all()
 
 
 #


### PR DESCRIPTION
### Fixes: #13764 

Add contacts to Aggregates, Prefixes, IP ranges and IP addresses.

![Monosnap 192 168 1 0-49:22 | NetBox 2024-05-20 14-54-11](https://github.com/netbox-community/netbox/assets/99642/d6a095ba-7514-4b7b-9b92-9592aee8b5d1)
![Monosnap 10 112 128 0:17 | NetBox 2024-05-20 14-53-46](https://github.com/netbox-community/netbox/assets/99642/da8e2f43-bffb-4b30-86bc-988904e15c7e)
![Monosnap 10 0 0 0:8 | NetBox 2024-05-20 14-53-20](https://github.com/netbox-community/netbox/assets/99642/746dfd7d-58e1-4c30-84d2-3f31b3be19f9)
![Monosnap 1 1 1 1:24 | NetBox 2024-05-20 14-52-23](https://github.com/netbox-community/netbox/assets/99642/3438df1e-b13e-454b-aabe-cc232cfb835c)
