### PR TITLE
Fixes #16228: Fix permissions enforcement for GraphQL queries of users & groups

### DIFF
--- a/netbox/users/graphql/types.py
+++ b/netbox/users/graphql/types.py
@@ -1,13 +1,10 @@
 from typing import List
 
-import strawberry
 import strawberry_django
 from django.contrib.auth import get_user_model
-from django.contrib.auth.models import Group
-from strawberry import auto
-from users import filtersets
+
+from netbox.graphql.types import BaseObjectType
 from users.models import Group
-from utilities.querysets import RestrictedQuerySet
 from .filters import *
 
 __all__ = (
@@ -21,17 +18,16 @@ __all__ = (
     fields=['id', 'name'],
     filters=GroupFilter
 )
-class GroupType:
+class GroupType(BaseObjectType):
     pass
 
 
 @strawberry_django.type(
     get_user_model(),
     fields=[
-        'id', 'username', 'password', 'first_name', 'last_name', 'email', 'is_staff',
-        'is_active', 'date_joined', 'groups',
+        'id', 'username', 'first_name', 'last_name', 'email', 'is_staff', 'is_active', 'date_joined', 'groups',
     ],
     filters=UserFilter
 )
-class UserType:
+class UserType(BaseObjectType):
     groups: List[GroupType]


### PR DESCRIPTION
### Fixes: #16228

- The User & Group types must inherit BaseObjectType
- Clean up unused imports