### PR TITLE
16232 only remove checkbox on embedded tables

### DIFF
--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -112,6 +112,13 @@ class ObjectListView(BaseMultiObjectView, ActionsMixin, TableMixin):
             query_params.pop('export')
             return redirect(f'{request.path}?{query_params.urlencode()}')
 
+    def _is_embedded_path(self, request):
+        if 'return_url' in request.GET:
+            if request.GET['return_url'] != request.path:
+                return True
+
+        return False
+
     #
     # Request handlers
     #
@@ -163,7 +170,7 @@ class ObjectListView(BaseMultiObjectView, ActionsMixin, TableMixin):
 
         # If this is an HTMX request, return only the rendered table HTML
         if htmx_partial(request):
-            if not request.htmx.target:
+            if not request.htmx.target and self._is_embedded_path(request):
                 table.embedded = True
                 # Hide selection checkboxes
                 if 'pk' in table.base_columns:


### PR DESCRIPTION
### Fixes: #16232 

Not 100% sure of this solution, relies on the 'return_url' which will be for bulk operations not being the same as the request path.  As this routine tries to set if the table is embedded, I'm not sure if there is another flag to look at that would be different if it is a main table or embedded.