### PR TITLE
DRAFT: 16224 add cursor pagin to interfaces and devices + offset paging to device roles

### DIFF
--- a/netbox/dcim/graphql/schema.py
+++ b/netbox/dcim/graphql/schema.py
@@ -38,6 +38,8 @@ class DCIMQuery:
     def device(self, id: int) -> DeviceType:
         return models.Device.objects.get(pk=id)
     device_list: List[DeviceType] = strawberry_django.field()
+    device_connection: strawberry.relay.ListConnection[DeviceType] = strawberry_django.connection()
+
 
     @strawberry.field
     def device_bay(self, id: int) -> DeviceBayType:
@@ -72,7 +74,7 @@ class DCIMQuery:
     @strawberry.field
     def interface(self, id: int) -> InterfaceType:
         return models.Interface.objects.get(pk=id)
-    interface_list: List[InterfaceType] = strawberry_django.field()
+    interface_list: strawberry.relay.ListConnection[InterfaceType] = strawberry_django.connection()
 
     @strawberry.field
     def interface_template(self, id: int) -> InterfaceTemplateType:

--- a/netbox/dcim/graphql/types.py
+++ b/netbox/dcim/graphql/types.py
@@ -210,7 +210,8 @@ class ConsoleServerPortTemplateType(ModularComponentTemplateType):
     fields='__all__',
     filters=DeviceFilter
 )
-class DeviceType(ConfigContextMixin, ImageAttachmentsMixin, ContactsMixin, NetBoxObjectType):
+class DeviceType(ConfigContextMixin, ImageAttachmentsMixin, ContactsMixin, NetBoxObjectType, strawberry.relay.Node):
+    id: strawberry.relay.GlobalID
     _name: str
     console_port_count: BigInt
     console_server_port_count: BigInt
@@ -308,7 +309,8 @@ class InventoryItemTemplateType(ComponentTemplateType):
 @strawberry_django.type(
     models.DeviceRole,
     fields='__all__',
-    filters=DeviceRoleFilter
+    filters=DeviceRoleFilter,
+    pagination=True
 )
 class DeviceRoleType(OrganizationalObjectType):
     color: str
@@ -378,7 +380,8 @@ class FrontPortTemplateType(ModularComponentTemplateType):
     exclude=('_path',),
     filters=InterfaceFilter
 )
-class InterfaceType(IPAddressesMixin, ModularComponentType, CabledObjectMixin, PathEndpointMixin):
+class InterfaceType(IPAddressesMixin, ModularComponentType, CabledObjectMixin, PathEndpointMixin, strawberry.relay.Node):
+    id: strawberry.relay.GlobalID
     mac_address: str | None
     wwn: str | None
     parent: Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')] | None


### PR DESCRIPTION
PR to show how `strawberry_django` allows for both offset based pagination with `pagination=True` and cursor based pagination by implementing the [Relay](https://relay.dev/graphql/connections.html) spec via `strawberry_django.connections()`



### Fixes: #16224 partially. 

