### PR TITLE
Fixes #16232: Fix inclusion of bulk action checkboxes on dynamic tables

### DIFF
--- a/netbox/netbox/tables/tables.py
+++ b/netbox/netbox/tables/tables.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from functools import cached_property
 
 import django_tables2 as tables
 from django.contrib.auth.models import AnonymousUser
@@ -189,6 +190,7 @@ class NetBoxTable(BaseTable):
     actions = columns.ActionsColumn()
 
     exempt_columns = ('pk', 'actions')
+    embedded = False
 
     class Meta(BaseTable.Meta):
         pass
@@ -218,12 +220,12 @@ class NetBoxTable(BaseTable):
 
         super().__init__(*args, extra_columns=extra_columns, **kwargs)
 
-    @property
+    @cached_property
     def htmx_url(self):
         """
         Return the base HTML request URL for embedded tables.
         """
-        if getattr(self, 'embedded', False):
+        if self.embedded:
             viewname = get_viewname(self._meta.model, action='list')
             try:
                 return reverse(viewname)

--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -163,7 +163,7 @@ class ObjectListView(BaseMultiObjectView, ActionsMixin, TableMixin):
 
         # If this is an HTMX request, return only the rendered table HTML
         if htmx_partial(request):
-            if not request.htmx.target:
+            if request.GET.get('embedded', False):
                 table.embedded = True
                 # Hide selection checkboxes
                 if 'pk' in table.base_columns:

--- a/netbox/utilities/templates/builtins/htmx_table.html
+++ b/netbox/utilities/templates/builtins/htmx_table.html
@@ -1,5 +1,5 @@
 <div class="htmx-container table-responsive"
-  hx-get="{% url viewname %}{% if url_params %}?{{ url_params.urlencode }}{% endif %}"
+  hx-get="{% url viewname %}?embedded=True{% if url_params %}&{{ url_params.urlencode }}{% endif %}"
   hx-target="this"
   hx-trigger="load" hx-select=".htmx-container" hx-swap="outerHTML"
 ></div>


### PR DESCRIPTION
### Fixes: #16232

- Update the `htmx_table` template tag used to embed object tables so that it passes `embedded=True` as a URL parameter.
- Update the logic in ObjectListView to check for the presence of `embedded=True` rather than an HTMX target
- Misc cleanup of NetBoxTable
