### PR TITLE
16202 fix mapit button for internationalized decimal seperator

### DIFF
--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -63,7 +63,7 @@
                         {% if object.latitude and object.longitude %}
                           {% if config.MAPS_URL %}
                             <div class="position-absolute top-50 end-0 translate-middle-y d-print-none">
-                              <a href="{{ config.MAPS_URL }}{{ object.latitude }},{{ object.longitude }}" target="_blank" class="btn btn-primary">
+                              <a href="{{ config.MAPS_URL }}{{ object.latitude|untranslate_decimal_separator }},{{ object.longitude|untranslate_decimal_separator }}" target="_blank" class="btn btn-primary">
                                 <i class="mdi mdi-map-marker"></i> {% trans "Map It" %}
                               </a>
                             </div>

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -5,6 +5,7 @@
 {% load helpers %}
 {% load plugins %}
 {% load i18n %}
+{% load l10n %}
 {% load mptt %}
 
 {% block content %}
@@ -63,7 +64,7 @@
                         {% if object.latitude and object.longitude %}
                           {% if config.MAPS_URL %}
                             <div class="position-absolute top-50 end-0 translate-middle-y d-print-none">
-                              <a href="{{ config.MAPS_URL }}{{ object.latitude|untranslate_decimal_separator }},{{ object.longitude|untranslate_decimal_separator }}" target="_blank" class="btn btn-primary">
+                              <a href="{{ config.MAPS_URL }}{{ object.latitude|unlocalize }},{{ object.longitude|unlocalize }}" target="_blank" class="btn btn-primary">
                                 <i class="mdi mdi-map-marker"></i> {% trans "Map It" %}
                               </a>
                             </div>

--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -3,6 +3,7 @@
 {% load plugins %}
 {% load tz %}
 {% load i18n %}
+{% load l10n %}
 {% load mptt %}
 
 {% block breadcrumbs %}
@@ -95,7 +96,7 @@
             {% if object.latitude and object.longitude %}
               {% if config.MAPS_URL %}
                 <div class="position-absolute top-50 end-0 translate-middle-y d-print-none">
-                  <a href="{{ config.MAPS_URL }}{{ object.latitude|untranslate_decimal_separator }},{{ object.longitude|untranslate_decimal_separator }}" target="_blank" class="btn btn-primary">
+                  <a href="{{ config.MAPS_URL }}{{ object.latitude|unlocalize }},{{ object.longitude|unlocalize }}" target="_blank" class="btn btn-primary">
                     <i class="mdi mdi-map-marker"></i> {% trans "Map It" %}
                   </a>
                 </div>

--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -95,7 +95,7 @@
             {% if object.latitude and object.longitude %}
               {% if config.MAPS_URL %}
                 <div class="position-absolute top-50 end-0 translate-middle-y d-print-none">
-                  <a href="{{ config.MAPS_URL }}{{ object.latitude }},{{ object.longitude }}" target="_blank" class="btn btn-primary">
+                  <a href="{{ config.MAPS_URL }}{{ object.latitude|untranslate_decimal_separator }},{{ object.longitude|untranslate_decimal_separator }}" target="_blank" class="btn btn-primary">
                     <i class="mdi mdi-map-marker"></i> {% trans "Map It" %}
                   </a>
                 </div>

--- a/netbox/utilities/templatetags/helpers.py
+++ b/netbox/utilities/templatetags/helpers.py
@@ -8,9 +8,7 @@ from django.conf import settings
 from django.template.defaultfilters import date
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
-from django.utils.formats import get_format
 from django.utils.safestring import mark_safe
-from django.utils.translation import get_language
 
 from core.models import ObjectType
 from utilities.forms import get_selected_values, TableConfigForm
@@ -32,7 +30,6 @@ __all__ = (
     'startswith',
     'status_from_tag',
     'table_config_form',
-    'untranslate_decimal_separator',
     'utilization_graph',
     'validated_viewname',
     'viewname',
@@ -304,9 +301,3 @@ def applied_filters(context, model, form, query_params):
         'applied_filters': applied_filters,
         'save_link': save_link,
     }
-
-
-@register.filter()
-def untranslate_decimal_separator(number: str):
-    decimal_seperator = get_format('DECIMAL_SEPARATOR', get_language())
-    return str(number).replace(decimal_seperator, ".")

--- a/netbox/utilities/templatetags/helpers.py
+++ b/netbox/utilities/templatetags/helpers.py
@@ -8,7 +8,9 @@ from django.conf import settings
 from django.template.defaultfilters import date
 from django.urls import NoReverseMatch, reverse
 from django.utils import timezone
+from django.utils.formats import get_format
 from django.utils.safestring import mark_safe
+from django.utils.translation import get_language
 
 from core.models import ObjectType
 from utilities.forms import get_selected_values, TableConfigForm
@@ -30,6 +32,7 @@ __all__ = (
     'startswith',
     'status_from_tag',
     'table_config_form',
+    'untranslate_decimal_separator',
     'utilization_graph',
     'validated_viewname',
     'viewname',
@@ -301,3 +304,9 @@ def applied_filters(context, model, form, query_params):
         'applied_filters': applied_filters,
         'save_link': save_link,
     }
+
+
+@register.filter()
+def untranslate_decimal_separator(number: str):
+    decimal_seperator = get_format('DECIMAL_SEPARATOR', get_language())
+    return str(number).replace(decimal_seperator, ".")


### PR DESCRIPTION
### Fixes: #16202 

Used a filter function to get DECIMAL_SEPARATOR from Django as it could be something other then a comma.