### PR TITLE
16218 copy script on data-source sync

### DIFF
--- a/netbox/core/models/data.py
+++ b/netbox/core/models/data.py
@@ -217,7 +217,7 @@ class DataSource(JobsMixin, PrimaryModel):
             logger.debug(f"Updated {updated_count} files")
 
             # Bulk delete deleted files
-            deleted_count, _ = DataFile.objects.filter(pk__in=deleted_file_ids).delete()
+            deleted_count, _deleted_dict = DataFile.objects.filter(pk__in=deleted_file_ids).delete()
             logger.debug(f"Deleted {deleted_count} files")
 
             # Walk the local replication to find new files

--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -11,7 +11,8 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from core.choices import ManagedFileRootPathChoices
-from core.models import ManagedFile
+from core.models import DataSource, ManagedFile
+from core.signals import post_sync
 from extras.utils import is_script
 from netbox.models.features import JobsMixin, EventRulesMixin
 from utilities.querysets import RestrictedQuerySet
@@ -182,3 +183,10 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
 @receiver(post_save, sender=ScriptModule)
 def script_module_post_save_handler(instance, created, **kwargs):
     instance.sync_classes()
+
+
+@receiver(post_sync, sender=DataSource)
+def script_data_source_sync_handler(instance, **kwargs):
+    modules = ScriptModule.objects.filter(data_source=instance)
+    for module in modules:
+        module.sync_data()


### PR DESCRIPTION
### Fixes: #16218 

Script module needs sync_data called when data source is synced to make sure any updated file is copied over.  Also was an error in data.py where the underscore was used later so it was counted as a local variable which was causing RQ to crash.