### PR TITLE
16261 fix graphql lookup for MultiValueCharFilter fields

### DIFF
--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -649,7 +649,7 @@ class IPAddressTest(APIViewTestCases.APIViewTestCase):
         'description': 'New description',
     }
     graphql_filter = {
-        'address': '192.168.0.1/24',
+        'address': {'lookup': 'i_exact', 'value': '192.168.0.1/24'},
     }
 
     @classmethod

--- a/netbox/netbox/graphql/filter_mixins.py
+++ b/netbox/netbox/graphql/filter_mixins.py
@@ -23,7 +23,6 @@ def map_strawberry_type(field):
     elif isinstance(field, MultiValueArrayFilter):
         pass
     elif isinstance(field, MultiValueCharFilter):
-        should_create_function = False
         # Note: Need to use the legacy FilterLookup from filters, not from
         # strawberry_django.FilterLookup as we currently have USE_DEPRECATED_FILTERS
         attr_type = strawberry_django.filters.FilterLookup[str] | None

--- a/netbox/netbox/graphql/filter_mixins.py
+++ b/netbox/netbox/graphql/filter_mixins.py
@@ -24,6 +24,8 @@ def map_strawberry_type(field):
         pass
     elif isinstance(field, MultiValueCharFilter):
         should_create_function = False
+        # Note: Need to use the legacy FilterLookup from filters, not from
+        # strawberry_django.FilterLookup as we currently have USE_DEPRECATED_FILTERS
         attr_type = strawberry_django.filters.FilterLookup[str] | None
     elif isinstance(field, MultiValueDateFilter):
         attr_type = auto

--- a/netbox/netbox/graphql/filter_mixins.py
+++ b/netbox/netbox/graphql/filter_mixins.py
@@ -23,8 +23,8 @@ def map_strawberry_type(field):
     elif isinstance(field, MultiValueArrayFilter):
         pass
     elif isinstance(field, MultiValueCharFilter):
-        should_create_function = True
-        attr_type = List[str] | None
+        should_create_function = False
+        attr_type = strawberry_django.filters.FilterLookup[str] | None
     elif isinstance(field, MultiValueDateFilter):
         attr_type = auto
     elif isinstance(field, MultiValueDateTimeFilter):

--- a/netbox/utilities/testing/api.py
+++ b/netbox/utilities/testing/api.py
@@ -496,7 +496,14 @@ class APIViewTestCases:
             Create a filtered query: i.e. ip_address_list(filters: {address: "1.1.1.1/24"}){.
             """
             if filters:
-                filter_string = ', '.join(f'{k}: "{v}"' for k, v in filters.items())
+                for field_name, params in filters.items():
+                    lookup = params['lookup']
+                    value = params['value']
+                    if lookup:
+                        query = f'{{{lookup}: "{value}"}}'
+                        filter_string = f'{field_name}: {query}'
+                    else:
+                        filter_string = f'{field_name}: "{value}"'
                 filter_string = f'(filters: {{{filter_string}}})'
             else:
                 filter_string = ''

--- a/netbox/utilities/testing/api.py
+++ b/netbox/utilities/testing/api.py
@@ -493,8 +493,9 @@ class APIViewTestCases:
 
         def _build_filtered_query(self, name, **filters):
             """
-            Create a filtered query: i.e. ip_address_list(filters: {address: "1.1.1.1/24"}){.
+            Create a filtered query: i.e. device_list(filters: {name: {i_contains: "akron"}}){.
             """
+            # TODO: This should be extended to support AND, OR multi-lookups
             if filters:
                 for field_name, params in filters.items():
                     lookup = params['lookup']


### PR DESCRIPTION
### Fixes: #16261 

**Note:** This requires lookups for string key filtering, for example you can't query `device_list(filters: {name: "akron"}) {` you have to do `device_list(filters: {name: {i_contains: "akron"}}) {`but this is consistent with the other string fields.

![Monosnap GraphiQL | NetBox 2024-05-29 11-49-48](https://github.com/netbox-community/netbox/assets/99642/61ce5897-add3-4441-941f-8bec9a9efb11)
