### PR TITLE
Fixes #15194: Prevent enqueuing duplicate events for an object

### DIFF
--- a/netbox/extras/context_managers.py
+++ b/netbox/extras/context_managers.py
@@ -13,13 +13,14 @@ def event_tracking(request):
     :param request: WSGIRequest object with a unique `id` set
     """
     current_request.set(request)
-    events_queue.set([])
+    events_queue.set({})
 
     yield
 
     # Flush queued webhooks to RQ
-    flush_events(events_queue.get())
+    if events := list(events_queue.get().values()):
+        flush_events(events)
 
     # Clear context vars
     current_request.set(None)
-    events_queue.set([])
+    events_queue.set({})

--- a/netbox/extras/tests/test_event_rules.py
+++ b/netbox/extras/tests/test_event_rules.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 
 import django_rq
 from django.http import HttpResponse
+from django.test import RequestFactory
 from django.urls import reverse
 from requests import Session
 from rest_framework import status
@@ -12,6 +13,7 @@ from core.models import ObjectType
 from dcim.choices import SiteStatusChoices
 from dcim.models import Site
 from extras.choices import EventRuleActionChoices, ObjectChangeActionChoices
+from extras.context_managers import event_tracking
 from extras.events import enqueue_object, flush_events, serialize_for_event
 from extras.models import EventRule, Tag, Webhook
 from extras.webhooks import generate_signature, send_webhook
@@ -360,7 +362,7 @@ class EventRuleTest(APITestCase):
             return HttpResponse()
 
         # Enqueue a webhook for processing
-        webhooks_queue = []
+        webhooks_queue = {}
         site = Site.objects.create(name='Site 1', slug='site-1')
         enqueue_object(
             webhooks_queue,
@@ -369,7 +371,7 @@ class EventRuleTest(APITestCase):
             request_id=request_id,
             action=ObjectChangeActionChoices.ACTION_CREATE
         )
-        flush_events(webhooks_queue)
+        flush_events(list(webhooks_queue.values()))
 
         # Retrieve the job from queue
         job = self.queue.jobs[0]
@@ -377,3 +379,24 @@ class EventRuleTest(APITestCase):
         # Patch the Session object with our dummy_send() method, then process the webhook for sending
         with patch.object(Session, 'send', dummy_send) as mock_send:
             send_webhook(**job.kwargs)
+
+    def test_duplicate_triggers(self):
+        """
+        Test for erroneous duplicate event triggers resulting from saving an object multiple times
+        within the span of a single request.
+        """
+        url = reverse('dcim:site_add')
+        request = RequestFactory().get(url)
+        request.id = uuid.uuid4()
+        request.user = self.user
+
+        self.assertEqual(self.queue.count, 0, msg="Unexpected jobs found in queue")
+
+        with event_tracking(request):
+            site = Site(name='Site 1', slug='site-1')
+            site.save()
+
+            # Save the site a second time
+            site.save()
+
+        self.assertEqual(self.queue.count, 1, msg="Duplicate jobs found in queue")

--- a/netbox/netbox/context.py
+++ b/netbox/netbox/context.py
@@ -7,4 +7,4 @@ __all__ = (
 
 
 current_request = ContextVar('current_request', default=None)
-events_queue = ContextVar('events_queue', default=[])
+events_queue = ContextVar('events_queue', default=dict())


### PR DESCRIPTION
### Fixes: #15194

- Change the `events_queue` context variable from a list to a dictionary, to enable identifying each object by a unique key.
- Modify the logic within `enqueue_object()` to designate a unique key for each object in the events queue, instead of comparing each new object to the previous entry.
- Remove the now-obsolete `is_same_object()` function.
- Add a test for duplicate event triggers.

A huge **thank you** to @peteeckel for his thorough research into this issue and his initial work on a solution under PR #15318!