### PR TITLE
Fixes #16312: Fix object list navigation for dashboard widgets

### DIFF
--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -265,6 +265,7 @@ class ObjectListWidget(DashboardWidget):
         parameters = self.config.get('url_params') or {}
         if page_size := self.config.get('page_size'):
             parameters['per_page'] = page_size
+        parameters['embedded'] = True
 
         if parameters:
             try:


### PR DESCRIPTION
### Fixes: #16312

Include the `embedded=True` URL query parameter when fetching the table