### PR TITLE
16293 fix form data handler deleting checkbox data

### DIFF
--- a/netbox/project-static/src/netbox.ts
+++ b/netbox/project-static/src/netbox.ts
@@ -42,9 +42,15 @@ function initWindow(): void {
     if (documentForm.method.toUpperCase() == 'GET') {
       documentForm.addEventListener('formdata', function (event: FormDataEvent) {
         const formData: FormData = event.formData;
-        for (const [name, value] of Array.from(formData.entries())) {
-          if (value === '') formData.delete(name);
-        }
+        // formData may have multiple values associated with a given key
+        // (see netbox/templates/django/forms/widgets/checkbox.html).
+	for (const name of Array.from(new Set(formData.keys()))) {
+	  const values = formData.getAll(name);
+	  formData.delete(name);
+	  values.forEach(value => {
+	    if (value !== '') formData.append(name, value)
+	  });
+	}
       });
     }
   }


### PR DESCRIPTION
In NetBox, formData may have multiple values associated with a given key (see [netbox/templates/django/forms/widgets/checkbox.html](https://github.com/netbox-community/netbox/blob/8e48e939aab3b75a50c73cb46b2cc4c30f801ae8/netbox/templates/django/forms/widgets/checkbox.html)), however a handler that prunes empty form data before posting doesn't take this into account.

So instead of a for loop over all `formData.entries()`, retrieve all values using `formData.getAll()`, delete all keys from `formData`, then append all non-empty values back in.

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #16293

<!--
    Please include a summary of the proposed changes below.
-->

What is happening here?
1. Netbox uses checkboxes in Edit forms ([reference](https://github.com/netbox-community/netbox/blob/8e48e939aab3b75a50c73cb46b2cc4c30f801ae8/netbox/dcim/models/device_components.py#L512-L515))
2. NetBox uses HTMX in Edit forms ([reference](https://github.com/netbox-community/netbox/blob/8e48e939aab3b75a50c73cb46b2cc4c30f801ae8/netbox/templates/generic/object_edit.html#L64-L68))
3. HTMX breaks NetBox by filtering unchecked checkboxes from submit form data ([reference](https://github.com/bigskysoftware/htmx/blob/4eadc8f492bd90694455414d06f99801d950e94f/src/htmx.js#L2512C18-L2524)) ([bug report](https://github.com/netbox-community/netbox/issues/13064))
4. NetBox worked around this by adding in a hidden input with the same name, and an empty string value ([reference](https://github.com/netbox-community/netbox/blob/8e48e939aab3b75a50c73cb46b2cc4c30f801ae8/netbox/templates/django/forms/widgets/checkbox.html#L1-L6))
5. NetBox deletes all form data from Filter forms if any value is an empty string ([reference](https://github.com/netbox-community/netbox/blob/8e48e939aab3b75a50c73cb46b2cc4c30f801ae8/netbox/project-static/src/netbox.ts#L43-L48))
6. Some downstream NetBox plugins - looking specifically at Topology View - use checkboxes in Filter forms ([reference](https://github.com/netbox-community/netbox-topology-views/blob/8368ffa2fdc13b258be3c42ddc275054853fde85/netbox_topology_views/forms.py#L231-L270))
7. NetBox broke these plugins by filtering checked checkboxes - because of the introduced hidden input - from Filter submit form data ([bug report](https://github.com/netbox-community/netbox-topology-views/issues/407))
8. Downstream plugins worked around this by overriding/subverting NetBox's renderer to remove/revert this hidden input field within their plugin ([reference](https://github.com/netbox-community/netbox-topology-views/blob/develop/netbox_topology_views/forms.py#L32))

---

Honestly, there are so many wrongs here it's difficult to know at which level it should be "righted" (except that downstreams obviously override NetBox's django templates at their own peril).

- Should someone ask HTMX whether there's an alternative way to preserve checkbox values across page refreshes?
- Should downstream plugins stop using BooleanField in Filter forms?
- Should NetBox fix its logic bugs?

This change sits somewhere in the middle that keeps NetBox's workarounds for HTMX whilst at the same time not breaking downstreams.

Aside: This particular function looks suspiciously like it was copy-pasted from ([StackOverflow](https://stackoverflow.com/questions/8029532/how-to-prevent-submitting-the-html-forms-input-field-value-if-it-empty/64029534#64029534)) - ouch!. The fact that it doesn't work when form data has multiple values associated to the same key is also pointed out there.

I don't know idiomatic TypeScript, so someone more knowledgeable may have a cleaner way of doing this.