### PR TITLE
16400 - Problem to restore configuration from history

### DIFF
--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -224,7 +224,7 @@ class ConfigRevisionRestoreView(ContentTypePermissionRequiredMixin, View):
         for param in PARAMS:
             params.append((
                 param.name,
-                current_config.data.get(param.name, None),
+                current_config.data.get(param.name, None) if current_config else None,
                 candidate_config.data.get(param.name, None)
             ))
 


### PR DESCRIPTION

### Fixes: #16400

Before accessing `data` in the `current_config`, check if `current_config` is `None.`
