### PR TITLE
Fixes #16454: Roll back django-debug-toolbar version to avoid DNS lookup bug

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -8,7 +8,9 @@ django-cors-headers
 
 # Runtime UI tool for debugging Django
 # https://github.com/jazzband/django-debug-toolbar/blob/main/docs/changes.rst
-django-debug-toolbar
+# Pinned for DNS looukp bug; see https://github.com/netbox-community/netbox/issues/16454
+# and https://github.com/jazzband/django-debug-toolbar/issues/1927
+django-debug-toolbar==4.3.0
 
 # Library for writing reusable URL query filters
 # https://github.com/carltongibson/django-filter/blob/main/CHANGES.rst

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==5.0.6
 django-cors-headers==4.3.1
-django-debug-toolbar==4.4.2
+django-debug-toolbar==4.3.0
 django-filter==24.2
 django-htmx==1.17.3
 django-graphiql-debug-toolbar==0.2.0


### PR DESCRIPTION
### Fixes: #16454

Pin `django-debug-toolbar` to v4.3.0 until jazzband/django-debug-toolbar#1927 is addressed