### PR TITLE
Fixes 16536 - Fix filtering of device component by device role

### DIFF
--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -1378,12 +1378,12 @@ class DeviceComponentFilterSet(django_filters.FilterSet):
         to_field_name='model',
         label=_('Device type (model)'),
     )
-    role_id = django_filters.ModelMultipleChoiceFilter(
+    device_role_id = django_filters.ModelMultipleChoiceFilter(
         field_name='device__role',
         queryset=DeviceRole.objects.all(),
         label=_('Device role (ID)'),
     )
-    role = django_filters.ModelMultipleChoiceFilter(
+    device_role = django_filters.ModelMultipleChoiceFilter(
         field_name='device__role__slug',
         queryset=DeviceRole.objects.all(),
         to_field_name='slug',

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -32,11 +32,11 @@ class DeviceComponentFilterSetTests:
         params = {'device_type': [device_types[0].model, device_types[1].model]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
-    def test_role(self):
+    def test_device_role(self):
         role = DeviceRole.objects.all()[:2]
-        params = {'role_id': [role[0].pk, role[1].pk]}
+        params = {'device_role_id': [role[0].pk, role[1].pk]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
-        params = {'role': [role[0].slug, role[1].slug]}
+        params = {'device_role': [role[0].slug, role[1].slug]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
@@ -4532,6 +4532,13 @@ class InventoryItemTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {'device_type_id': [device_types[0].pk, device_types[1].pk]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'device_type': [device_types[0].model, device_types[1].model]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
+
+    def test_device_role(self):
+        role = DeviceRole.objects.all()[:2]
+        params = {'device_role_id': [role[0].pk, role[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
+        params = {'device_role': [role[0].slug, role[1].slug]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
     def test_role(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #16536 

<!--
    Please include a summary of the proposed changes below.
-->

Fix the filtering of device components by device role by aligning the name of the fields from the DeviceComponentFilterForm and the DeviceComponentFilterSet.

I saw two solutions to implement the fix:
1. Rename the fields in the DeviceComponentFilterSet to `device_role_id` and `device_role` (that's the one I've implemented)
2. Rename the field in the DeviceComponentFilterForm to `role_id` but create an exception for InventoryItemFilterSet and InventoryItemFilterForm, which already have a field named `role` for the InventoryItemRole
 
I've chosen solution 1 because:
* We are not filtering according to the component's role but according to its parent device's role, so `device_role` makes more sense as `role` could be confused with the role of the component.
* It avoids creating an exception for InventoryItemFilterSet, which would have its `role` field override the role field from DeviceComponentFilterSet, and would have needed a `device_role` field or equivalent to preserve the feature. The role filter of DeviceComponent would have a different meaning between an Interface or a InventoryItem, which would have been more confusing.
* While the release note for 4.0 clearly states in breaking changes that the device_role field of devices has been removed after a depreciation period, there are no mentions of DeviceComponent in the notes or in #13342, so it may have been an undocumented or unintended change
* There is no equivalent filtering on VMInterface, it's not possible to filter them by their VM's role at the moment, so the reason behind the renaming of "device_role" to "role" is not currently present for DeviceComponent. However, if this feature is added, a more neutral field name such as "parent_role" or "parent_object_role" could be used instead.
* It's the least amount of changes required for this fix. Solution 2 would have required modifying InventoryItemFilterSet, InventoryItemFilterForm, DeviceComponentFilterForm and the fieldsets of all inheriting FilterForms.

However, solution 1 also changes the API to filter the device components by roles. This was an undocumented change in 4.0, so maybe that's acceptable.

Please let me know if you agree with that approach or if you prefer another solution.