### PR TITLE
16586 add .python-version to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ netbox.pid
 .idea
 .coverage
 .vscode
+.python-version


### PR DESCRIPTION
### Fixes: #16586 
