### PR TITLE
Fixes #16624: Set allow_null=True on method fields that can return None

### DIFF
--- a/netbox/dcim/api/serializers_/base.py
+++ b/netbox/dcim/api/serializers_/base.py
@@ -13,7 +13,7 @@ class ConnectedEndpointsSerializer(serializers.ModelSerializer):
     """
     Legacy serializer for pre-v3.3 connections
     """
-    connected_endpoints_type = serializers.SerializerMethodField(read_only=True)
+    connected_endpoints_type = serializers.SerializerMethodField(read_only=True, allow_null=True)
     connected_endpoints = serializers.SerializerMethodField(read_only=True)
     connected_endpoints_reachable = serializers.SerializerMethodField(read_only=True)
 
@@ -22,7 +22,7 @@ class ConnectedEndpointsSerializer(serializers.ModelSerializer):
         if endpoints := obj.connected_endpoints:
             return f'{endpoints[0]._meta.app_label}.{endpoints[0]._meta.model_name}'
 
-    @extend_schema_field(serializers.ListField)
+    @extend_schema_field(serializers.ListField(allow_null=True))
     def get_connected_endpoints(self, obj):
         """
         Return the appropriate serializer for the type of connected object.

--- a/netbox/dcim/api/serializers_/cables.py
+++ b/netbox/dcim/api/serializers_/cables.py
@@ -91,7 +91,7 @@ class CablePathSerializer(serializers.ModelSerializer):
 class CabledObjectSerializer(serializers.ModelSerializer):
     cable = CableSerializer(nested=True, read_only=True, allow_null=True)
     cable_end = serializers.CharField(read_only=True)
-    link_peers_type = serializers.SerializerMethodField(read_only=True)
+    link_peers_type = serializers.SerializerMethodField(read_only=True, allow_null=True)
     link_peers = serializers.SerializerMethodField(read_only=True)
     _occupied = serializers.SerializerMethodField(read_only=True)
 

--- a/netbox/dcim/api/serializers_/devices.py
+++ b/netbox/dcim/api/serializers_/devices.py
@@ -88,7 +88,7 @@ class DeviceSerializer(NetBoxModelSerializer):
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'description')
 
-    @extend_schema_field(NestedDeviceSerializer)
+    @extend_schema_field(NestedDeviceSerializer(allow_null=True))
     def get_parent_device(self, obj):
         try:
             device_bay = obj.parent_bay

--- a/netbox/extras/api/serializers_/scripts.py
+++ b/netbox/extras/api/serializers_/scripts.py
@@ -39,7 +39,7 @@ class ScriptSerializer(ValidatedModelSerializer):
     def get_display(self, obj):
         return f'{obj.name} ({obj.module})'
 
-    @extend_schema_field(serializers.CharField())
+    @extend_schema_field(serializers.CharField(allow_null=True))
     def get_description(self, obj):
         if obj.python_class:
             return obj.python_class().description


### PR DESCRIPTION
### Fixes: #16624

Noticed that Device.parent_device was not marked as nullable in the swagger api docs. Went through all uses of `SerializerMethodField` and added `allow_null=True` if the method could return `None`.

I opted to add it to the `@extend_schema_field` decorator where possible because that's how `allow_null` was set on other methods that could return `None`.