### PR TITLE
16460 remove spaces from telephone dialing

### DIFF
--- a/netbox/utilities/tables.py
+++ b/netbox/utilities/tables.py
@@ -29,7 +29,7 @@ def linkify_phone(value):
     """
     if value is None:
         return None
-    return f"tel:{value}"
+    return f"tel:{value.replace(' ', '')}"
 
 
 def register_table_column(column, name, *tables):


### PR DESCRIPTION
### Fixes: #16460 

Just remove spaces from link to dial phone number.  There is more to RFC3966 but removing any more characters can be country specific - we would probably want to use something like https://pypi.org/project/phonenumbers/ but removing space is safe and should fix most issues.