### PR TITLE
16416 enable dark/light toggle in mobile view

### DIFF
--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -35,15 +35,7 @@ Blocks:
 
         {# User menu (mobile view) #}
         <div class="navbar-nav flex-row d-lg-none">
-          <div class="d-flex">
-            <button class="btn color-mode-toggle hide-theme-dark" title="{% trans "Enable dark mode" %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
-              <i class="mdi mdi-lightbulb"></i>
-            </button>
-            <button class="btn color-mode-toggle hide-theme-light" title="{% trans "Enable light mode" %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
-              <i class="mdi mdi-lightbulb-on"></i>
-            </button>
-          </div>
-
+          {% include 'inc/light_toggle.html' %}
           {% include 'inc/user_menu.html' %}
         </div>
 
@@ -61,14 +53,7 @@ Blocks:
 
         <div class="navbar-nav flex-row align-items-center order-md-last">
           {# Dark/light mode toggle #}
-          <div class="d-none d-md-flex">
-            <button class="btn color-mode-toggle hide-theme-dark" title="{% trans "Enable dark mode" %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
-              <i class="mdi mdi-lightbulb"></i>
-            </button>
-            <button class="btn color-mode-toggle hide-theme-light" title="{% trans "Enable light mode" %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
-              <i class="mdi mdi-lightbulb-on"></i>
-            </button>
-          </div>
+          {% include 'inc/light_toggle.html' %}
 
           {# User menu #}
           {% include 'inc/user_menu.html' %}

--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -35,6 +35,15 @@ Blocks:
 
         {# User menu (mobile view) #}
         <div class="navbar-nav flex-row d-lg-none">
+          <div class="d-flex">
+            <button class="btn color-mode-toggle hide-theme-dark" title="{% trans "Enable dark mode" %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
+              <i class="mdi mdi-lightbulb"></i>
+            </button>
+            <button class="btn color-mode-toggle hide-theme-light" title="{% trans "Enable light mode" %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
+              <i class="mdi mdi-lightbulb-on"></i>
+            </button>
+          </div>
+
           {% include 'inc/user_menu.html' %}
         </div>
 

--- a/netbox/templates/inc/light_toggle.html
+++ b/netbox/templates/inc/light_toggle.html
@@ -1,0 +1,10 @@
+{% load i18n %}
+
+<div class="d-flex">
+  <button class="btn color-mode-toggle hide-theme-dark" title="{% trans "Enable dark mode" %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
+    <i class="mdi mdi-lightbulb"></i>
+  </button>
+  <button class="btn color-mode-toggle hide-theme-light" title="{% trans "Enable light mode" %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
+    <i class="mdi mdi-lightbulb-on"></i>
+  </button>
+</div>


### PR DESCRIPTION
### Fixes: #16416 

There is enough room in mobile to leave it displayed:

![Rack Elevations | NetBox 2024-06-17 09-26-59](https://github.com/netbox-community/netbox/assets/99642/4fb0078c-d4e5-4fe4-b929-3178bc0c06c7)
