### PR TITLE
Closes #8198: Custom field uniqueness

### DIFF
--- a/docs/models/extras/customfield.md
+++ b/docs/models/extras/customfield.md
@@ -107,3 +107,7 @@ For numeric custom fields only. The maximum valid value (optional).
 ### Validation Regex
 
 For string-based custom fields only. A regular expression used to validate the field's value (optional).
+
+### Uniqueness Validation
+
+If enabled, each object must have a unique value set for this custom field (per object type).

--- a/netbox/extras/api/customfields.py
+++ b/netbox/extras/api/customfields.py
@@ -6,6 +6,7 @@ from rest_framework.serializers import ValidationError
 
 from core.models import ObjectType
 from extras.choices import CustomFieldTypeChoices
+from extras.constants import CUSTOMFIELD_EMPTY_VALUES
 from extras.models import CustomField
 from utilities.api import get_serializer_for_model
 
@@ -75,7 +76,7 @@ class CustomFieldsDataField(Field):
 
         # Serialize object and multi-object values
         for cf in self._get_custom_fields():
-            if cf.name in data and data[cf.name] not in (None, []) and cf.type in (
+            if cf.name in data and data[cf.name] not in CUSTOMFIELD_EMPTY_VALUES and cf.type in (
                     CustomFieldTypeChoices.TYPE_OBJECT,
                     CustomFieldTypeChoices.TYPE_MULTIOBJECT
             ):

--- a/netbox/extras/api/serializers_/customfields.py
+++ b/netbox/extras/api/serializers_/customfields.py
@@ -65,7 +65,7 @@ class CustomFieldSerializer(ValidatedModelSerializer):
             'id', 'url', 'display', 'object_types', 'type', 'related_object_type', 'data_type', 'name', 'label',
             'group_name', 'description', 'required', 'search_weight', 'filter_logic', 'ui_visible', 'ui_editable',
             'is_cloneable', 'default', 'weight', 'validation_minimum', 'validation_maximum', 'validation_regex',
-            'choice_set', 'comments', 'created', 'last_updated',
+            'validation_unique', 'choice_set', 'comments', 'created', 'last_updated',
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'description')
 

--- a/netbox/extras/constants.py
+++ b/netbox/extras/constants.py
@@ -5,6 +5,8 @@ EVENT_DELETE = 'delete'
 EVENT_JOB_START = 'job_start'
 EVENT_JOB_END = 'job_end'
 
+# Custom fields
+CUSTOMFIELD_EMPTY_VALUES = (None, '', [])
 
 # Webhooks
 HTTP_CONTENT_TYPE_JSON = 'application/json'

--- a/netbox/extras/filtersets.py
+++ b/netbox/extras/filtersets.py
@@ -154,7 +154,7 @@ class CustomFieldFilterSet(ChangeLoggedModelFilterSet):
         fields = (
             'id', 'name', 'label', 'group_name', 'required', 'search_weight', 'filter_logic', 'ui_visible',
             'ui_editable', 'weight', 'is_cloneable', 'description', 'validation_minimum', 'validation_maximum',
-            'validation_regex',
+            'validation_regex', 'validation_unique',
         )
 
     def search(self, queryset, name, value):

--- a/netbox/extras/forms/bulk_edit.py
+++ b/netbox/extras/forms/bulk_edit.py
@@ -6,6 +6,7 @@ from extras.models import *
 from netbox.forms import NetBoxModelBulkEditForm
 from utilities.forms import BulkEditForm, add_blank_choice
 from utilities.forms.fields import ColorField, CommentField, DynamicModelChoiceField
+from utilities.forms.rendering import FieldSet
 from utilities.forms.widgets import BulkEditNullBooleanSelect
 
 __all__ = (
@@ -64,6 +65,18 @@ class CustomFieldBulkEditForm(BulkEditForm):
         required=False,
         widget=BulkEditNullBooleanSelect()
     )
+    validation_minimum = forms.IntegerField(
+        label=_('Minimum value'),
+        required=False,
+    )
+    validation_maximum = forms.IntegerField(
+        label=_('Maximum value'),
+        required=False,
+    )
+    validation_regex = forms.CharField(
+        label=_('Validation regex'),
+        required=False
+    )
     validation_unique = forms.NullBooleanField(
         label=_('Must be unique'),
         required=False,
@@ -71,6 +84,13 @@ class CustomFieldBulkEditForm(BulkEditForm):
     )
     comments = CommentField()
 
+    fieldsets = (
+        FieldSet('group_name', 'description', 'weight', 'choice_set', name=_('Attributes')),
+        FieldSet('ui_visible', 'ui_editable', 'is_cloneable', name=_('Behavior')),
+        FieldSet(
+            'validation_minimum', 'validation_maximum', 'validation_regex', 'validation_unique', name=_('Validation')
+        ),
+    )
     nullable_fields = ('group_name', 'description', 'choice_set')
 
 

--- a/netbox/extras/forms/bulk_edit.py
+++ b/netbox/extras/forms/bulk_edit.py
@@ -64,6 +64,11 @@ class CustomFieldBulkEditForm(BulkEditForm):
         required=False,
         widget=BulkEditNullBooleanSelect()
     )
+    validation_unique = forms.NullBooleanField(
+        label=_('Must be unique'),
+        required=False,
+        widget=BulkEditNullBooleanSelect()
+    )
     comments = CommentField()
 
     nullable_fields = ('group_name', 'description', 'choice_set')

--- a/netbox/extras/forms/bulk_import.py
+++ b/netbox/extras/forms/bulk_import.py
@@ -71,7 +71,8 @@ class CustomFieldImportForm(CSVModelForm):
         fields = (
             'name', 'label', 'group_name', 'type', 'object_types', 'related_object_type', 'required', 'description',
             'search_weight', 'filter_logic', 'default', 'choice_set', 'weight', 'validation_minimum',
-            'validation_maximum', 'validation_regex', 'ui_visible', 'ui_editable', 'is_cloneable', 'comments',
+            'validation_maximum', 'validation_regex', 'validation_unique', 'ui_visible', 'ui_editable', 'is_cloneable',
+            'comments',
         )
 
 

--- a/netbox/extras/forms/filtersets.py
+++ b/netbox/extras/forms/filtersets.py
@@ -41,7 +41,9 @@ class CustomFieldFilterForm(SavedFiltersMixin, FilterForm):
             'type', 'related_object_type_id', 'group_name', 'weight', 'required', 'choice_set_id', 'ui_visible',
             'ui_editable', 'is_cloneable', name=_('Attributes')
         ),
-        FieldSet('validation_unique', name=_('Validation')),
+        FieldSet(
+            'validation_minimum', 'validation_maximum', 'validation_regex', 'validation_unique', name=_('Validation')
+        ),
     )
     related_object_type_id = ContentTypeMultipleChoiceField(
         queryset=ObjectType.objects.with_feature('custom_fields'),
@@ -89,6 +91,18 @@ class CustomFieldFilterForm(SavedFiltersMixin, FilterForm):
         widget=forms.Select(
             choices=BOOLEAN_WITH_BLANK_CHOICES
         )
+    )
+    validation_minimum = forms.IntegerField(
+        label=_('Minimum value'),
+        required=False
+    )
+    validation_maximum = forms.IntegerField(
+        label=_('Maximum value'),
+        required=False
+    )
+    validation_regex = forms.CharField(
+        label=_('Validation regex'),
+        required=False
     )
     validation_unique = forms.NullBooleanField(
         label=_('Must be unique'),

--- a/netbox/extras/forms/filtersets.py
+++ b/netbox/extras/forms/filtersets.py
@@ -41,6 +41,7 @@ class CustomFieldFilterForm(SavedFiltersMixin, FilterForm):
             'type', 'related_object_type_id', 'group_name', 'weight', 'required', 'choice_set_id', 'ui_visible',
             'ui_editable', 'is_cloneable', name=_('Attributes')
         ),
+        FieldSet('validation_unique', name=_('Validation')),
     )
     related_object_type_id = ContentTypeMultipleChoiceField(
         queryset=ObjectType.objects.with_feature('custom_fields'),
@@ -84,6 +85,13 @@ class CustomFieldFilterForm(SavedFiltersMixin, FilterForm):
     )
     is_cloneable = forms.NullBooleanField(
         label=_('Is cloneable'),
+        required=False,
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        )
+    )
+    validation_unique = forms.NullBooleanField(
+        label=_('Must be unique'),
         required=False,
         widget=forms.Select(
             choices=BOOLEAN_WITH_BLANK_CHOICES

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -64,7 +64,9 @@ class CustomFieldForm(forms.ModelForm):
             'search_weight', 'filter_logic', 'ui_visible', 'ui_editable', 'weight', 'is_cloneable', name=_('Behavior')
         ),
         FieldSet('default', 'choice_set', name=_('Values')),
-        FieldSet('validation_minimum', 'validation_maximum', 'validation_regex', name=_('Validation')),
+        FieldSet(
+            'validation_minimum', 'validation_maximum', 'validation_regex', 'validation_unique', name=_('Validation')
+        ),
     )
 
     class Meta:

--- a/netbox/extras/migrations/0117_customfield_uniqueness.py
+++ b/netbox/extras/migrations/0117_customfield_uniqueness.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('extras', '0116_move_objectchange'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='customfield',
+            name='validation_unique',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -179,6 +179,11 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
             'example, <code>^[A-Z]{3}$</code> will limit values to exactly three uppercase letters.'
         )
     )
+    validation_unique = models.BooleanField(
+        verbose_name=_('must be unique'),
+        default=False,
+        help_text=_('The value of this field must be unique for the assigned object')
+    )
     choice_set = models.ForeignKey(
         to='CustomFieldChoiceSet',
         on_delete=models.PROTECT,
@@ -216,7 +221,7 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
     clone_fields = (
         'object_types', 'type', 'related_object_type', 'group_name', 'description', 'required', 'search_weight',
         'filter_logic', 'default', 'weight', 'validation_minimum', 'validation_maximum', 'validation_regex',
-        'choice_set', 'ui_visible', 'ui_editable', 'is_cloneable',
+        'validation_unique', 'choice_set', 'ui_visible', 'ui_editable', 'is_cloneable',
     )
 
     class Meta:
@@ -331,6 +336,12 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
         if self.validation_regex and self.type not in regex_types:
             raise ValidationError({
                 'validation_regex': _("Regular expression validation is supported only for text and URL fields")
+            })
+
+        # Uniqueness can not be enforced for boolean fields
+        if self.validation_unique and self.type == CustomFieldTypeChoices.TYPE_BOOLEAN:
+            raise ValidationError({
+                'validation_unique': _("Uniqueness cannot be enforced for boolean fields")
             })
 
         # Choice set must be set on selection fields, and *only* on selection fields

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -71,6 +71,15 @@ class CustomFieldTable(NetBoxTable):
     is_cloneable = columns.BooleanColumn(
         verbose_name=_('Is Cloneable'),
     )
+    validation_minimum = tables.Column(
+        verbose_name=_('Minimum Value'),
+    )
+    validation_maximum = tables.Column(
+        verbose_name=_('Maximum Value'),
+    )
+    validation_regex = tables.Column(
+        verbose_name=_('Validation Regex'),
+    )
     validation_unique = columns.BooleanColumn(
         verbose_name=_('Validate Uniqueness'),
     )
@@ -80,7 +89,8 @@ class CustomFieldTable(NetBoxTable):
         fields = (
             'pk', 'id', 'name', 'object_types', 'label', 'type', 'related_object_type', 'group_name', 'required',
             'default', 'description', 'search_weight', 'filter_logic', 'ui_visible', 'ui_editable', 'is_cloneable',
-            'weight', 'choice_set', 'choices', 'validation_unique', 'comments', 'created', 'last_updated',
+            'weight', 'choice_set', 'choices', 'validation_minimum', 'validation_maximum', 'validation_regex',
+            'validation_unique', 'comments', 'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'object_types', 'label', 'group_name', 'type', 'required', 'description')
 

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -6,7 +6,6 @@ from django.utils.translation import gettext_lazy as _
 from extras.models import *
 from netbox.constants import EMPTY_TABLE_TEXT
 from netbox.tables import BaseTable, NetBoxTable, columns
-from .template_code import *
 
 __all__ = (
     'BookmarkTable',

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -71,13 +71,16 @@ class CustomFieldTable(NetBoxTable):
     is_cloneable = columns.BooleanColumn(
         verbose_name=_('Is Cloneable'),
     )
+    validation_unique = columns.BooleanColumn(
+        verbose_name=_('Validate Uniqueness'),
+    )
 
     class Meta(NetBoxTable.Meta):
         model = CustomField
         fields = (
             'pk', 'id', 'name', 'object_types', 'label', 'type', 'related_object_type', 'group_name', 'required',
             'default', 'description', 'search_weight', 'filter_logic', 'ui_visible', 'ui_editable', 'is_cloneable',
-            'weight', 'choice_set', 'choices', 'comments', 'created', 'last_updated',
+            'weight', 'choice_set', 'choices', 'validation_unique', 'comments', 'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'object_types', 'label', 'group_name', 'type', 'required', 'description')
 

--- a/netbox/extras/tables/template_code.py
+++ b/netbox/extras/tables/template_code.py
@@ -1,8 +1,0 @@
-CONFIGCONTEXT_ACTIONS = """
-{% if perms.extras.change_configcontext %}
-    <a href="{% url 'extras:configcontext_edit' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="mdi mdi-pencil" aria-hidden="true"></i></a>
-{% endif %}
-{% if perms.extras.delete_configcontext %}
-    <a href="{% url 'extras:configcontext_delete' pk=record.pk %}" class="btn btn-sm btn-danger"><i class="mdi mdi-trash-can-outline" aria-hidden="true"></i></a>
-{% endif %}
-"""

--- a/netbox/templates/extras/customfield.html
+++ b/netbox/templates/extras/customfield.html
@@ -120,6 +120,10 @@
             {% endif %}
           </td>
         </tr>
+        <tr>
+          <th scope="row">{% trans "Must be Unique" %}</th>
+          <td>{% checkmark object.validation_unique %}</td>
+        </tr>
       </table>
     </div>
     <div class="card">


### PR DESCRIPTION
### Closes: #8198

- Introduce `CUSTOMFIELD_EMPTY_VALUES` to standardize the set of "empty" values for custom fields
- Add a `validation_unique` field  to CustomModel
- Extend CustomFieldsMixin to handle the uniquess validation
- Add missing form fields and table columns for other CF validation fields
- Add uniqueness validation test
- Remove obsolete table template code