### PR TITLE
Closes #16307: Enable calling log_* methods on Script without a log message

### DIFF
--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -138,11 +138,11 @@ These two methods will load data in YAML or JSON format, respectively, from file
 
 The Script object provides a set of convenient functions for recording messages at different severity levels:
 
-* `log_debug(message, obj=None)`
-* `log_success(message, obj=None)`
-* `log_info(message, obj=None)`
-* `log_warning(message, obj=None)`
-* `log_failure(message, obj=None)`
+* `log_debug(message=None, obj=None)`
+* `log_success(message=None, obj=None)`
+* `log_info(message=None, obj=None)`
+* `log_warning(message=None, obj=None)`
+* `log_failure(message=None, obj=None)`
 
 Log messages are returned to the user upon execution of the script. Markdown rendering is supported for log messages. A message may optionally be associated with a particular object by passing it as the second argument to the logging method.
 
@@ -151,6 +151,8 @@ Log messages are returned to the user upon execution of the script. Markdown ren
 A script can define one or more test methods to report on certain conditions. All test methods must have a name beginning with `test_` and accept no arguments beyond `self`.
 
 These methods are detected and run automatically when the script is executed, unless its `run()` method has been overridden. (When overriding `run()`, `run_tests()` can be called to run all test methods present in the script.)
+
+Calling any of these logging methods without a message will increment the relevant counter, but will not generate an output line in the script's log.
 
 !!! info
     This functionality was ported from [legacy reports](./reports.md) in NetBox v4.0.

--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -480,18 +480,20 @@ class BaseScript:
         # A test method is currently active, so log the message using legacy Report logging
         if self._current_test:
 
-            # TODO: Use a dataclass for test method logs
-            self.tests[self._current_test]['log'].append((
-                timezone.now().isoformat(),
-                level,
-                str(obj) if obj else None,
-                obj.get_absolute_url() if hasattr(obj, 'get_absolute_url') else None,
-                str(message),
-            ))
-
             # Increment the event counter for this level
             if level in self.tests[self._current_test]:
                 self.tests[self._current_test][level] += 1
+
+            # Record message (if any) to the report log
+            if message:
+                # TODO: Use a dataclass for test method logs
+                self.tests[self._current_test]['log'].append((
+                    timezone.now().isoformat(),
+                    level,
+                    str(obj) if obj else None,
+                    obj.get_absolute_url() if hasattr(obj, 'get_absolute_url') else None,
+                    str(message),
+                ))
 
         elif message:
 
@@ -509,19 +511,19 @@ class BaseScript:
                 message = f"{obj}: {message}"
             self.logger.log(LogLevelChoices.SYSTEM_LEVELS[level], message)
 
-    def log_debug(self, message, obj=None):
+    def log_debug(self, message=None, obj=None):
         self._log(message, obj, level=LogLevelChoices.LOG_DEBUG)
 
-    def log_success(self, message, obj=None):
+    def log_success(self, message=None, obj=None):
         self._log(message, obj, level=LogLevelChoices.LOG_SUCCESS)
 
-    def log_info(self, message, obj=None):
+    def log_info(self, message=None, obj=None):
         self._log(message, obj, level=LogLevelChoices.LOG_INFO)
 
-    def log_warning(self, message, obj=None):
+    def log_warning(self, message=None, obj=None):
         self._log(message, obj, level=LogLevelChoices.LOG_WARNING)
 
-    def log_failure(self, message, obj=None):
+    def log_failure(self, message=None, obj=None):
         self._log(message, obj, level=LogLevelChoices.LOG_FAILURE)
         self.failed = True
 


### PR DESCRIPTION
### Fixes: #16307

- Convert the `message` argument on all Script `log_*()` methods to an optional keyword argument
- Record test method logs only if `message` is not null/empty
- Update documentation