### PR TITLE
Closes #16700: Audit usage of mark_safe() for consistent escaping

### DIFF
--- a/netbox/dcim/tables/cables.py
+++ b/netbox/dcim/tables/cables.py
@@ -1,6 +1,7 @@
 from django.utils.translation import gettext_lazy as _
 import django_tables2 as tables
 from django_tables2.utils import Accessor
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
 from dcim.models import Cable
@@ -35,7 +36,7 @@ class CableTerminationsColumn(tables.Column):
 
     def render(self, value):
         links = [
-            f'<a href="{term.get_absolute_url()}">{term}</a>' for term in self._get_terminations(value)
+            f'<a href="{term.get_absolute_url()}">{escape(term)}</a>' for term in self._get_terminations(value)
         ]
         return mark_safe('<br />'.join(links) or '&mdash;')
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -3410,8 +3410,9 @@ class VirtualChassisAddMemberView(ObjectPermissionRequiredMixin, GetReturnURLMix
             if membership_form.is_valid():
 
                 membership_form.save()
-                msg = f'Added member <a href="{device.get_absolute_url()}">{escape(device)}</a>'
-                messages.success(request, mark_safe(msg))
+                messages.success(request, mark_safe(
+                    f'Added member <a href="{device.get_absolute_url()}">{escape(device)}</a>'
+                ))
 
                 if '_addanother' in request.POST:
                     return redirect(request.get_full_path())

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -10,6 +10,7 @@ from django.contrib.postgres.fields import ArrayField
 from django.core.validators import RegexValidator, ValidationError
 from django.db import models
 from django.urls import reverse
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
@@ -520,7 +521,7 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
                     RegexValidator(
                         regex=self.validation_regex,
                         message=mark_safe(_("Values must match this regex: <code>{regex}</code>").format(
-                            regex=self.validation_regex
+                            regex=escape(self.validation_regex)
                         ))
                     )
                 ]

--- a/netbox/extras/templatetags/custom_links.py
+++ b/netbox/extras/templatetags/custom_links.py
@@ -1,4 +1,5 @@
 from django import template
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
 from core.models import ObjectType
@@ -59,8 +60,7 @@ def custom_links(context, obj):
         # Add non-grouped links
         else:
             try:
-                rendered = cl.render(link_context)
-                if rendered:
+                if rendered := cl.render(link_context):
                     template_code += LINK_BUTTON.format(
                         rendered['link'], rendered['link_target'], cl.button_class, rendered['text']
                     )
@@ -75,8 +75,7 @@ def custom_links(context, obj):
 
         for cl in links:
             try:
-                rendered = cl.render(link_context)
-                if rendered:
+                if rendered := cl.render(link_context):
                     links_rendered.append(
                         GROUP_LINK.format(rendered['link'], rendered['link_target'], rendered['text'])
                     )
@@ -88,7 +87,7 @@ def custom_links(context, obj):
 
         if links_rendered:
             template_code += GROUP_BUTTON.format(
-                links[0].button_class, group, ''.join(links_rendered)
+                links[0].button_class, escape(group), ''.join(links_rendered)
             )
 
     return mark_safe(template_code)

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -433,7 +433,7 @@ class LinkedCountColumn(tables.Column):
                     f'{k}={getattr(record, v) or settings.FILTERS_NULL_CHOICE_VALUE}'
                     for k, v in self.url_params.items()
                 ])
-            return mark_safe(f'<a href="{url}">{value}</a>')
+            return mark_safe(f'<a href="{url}">{escape(value)}</a>')
         return value
 
     def value(self, value):

--- a/netbox/utilities/error_handlers.py
+++ b/netbox/utilities/error_handlers.py
@@ -39,7 +39,7 @@ def handle_protectederror(obj_list, request, e):
         if hasattr(dependent, 'get_absolute_url'):
             dependent_objects.append(f'<a href="{dependent.get_absolute_url()}">{escape(dependent)}</a>')
         else:
-            dependent_objects.append(str(dependent))
+            dependent_objects.append(escape(str(dependent)))
     err_message += ', '.join(dependent_objects)
 
     messages.error(request, mark_safe(err_message))

--- a/netbox/utilities/templatetags/builtins/filters.py
+++ b/netbox/utilities/templatetags/builtins/filters.py
@@ -58,7 +58,7 @@ def linkify(instance, attr=None):
         url = instance.get_absolute_url()
         return mark_safe(f'<a href="{url}">{escape(text)}</a>')
     except (AttributeError, TypeError):
-        return text
+        return escape(text)
 
 
 @register.filter()

--- a/netbox/utilities/templatetags/mptt.py
+++ b/netbox/utilities/templatetags/mptt.py
@@ -1,4 +1,5 @@
 from django import template
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 
 register = template.Library()
@@ -15,6 +16,6 @@ def nested_tree(obj):
     nodes = obj.get_ancestors(include_self=True)
     return mark_safe(
         ' / '.join(
-            f'<a href="{node.get_absolute_url()}">{node}</a>' for node in nodes
+            f'<a href="{node.get_absolute_url()}">{escape(node)}</a>' for node in nodes
         )
     )


### PR DESCRIPTION
### Fixes: #16700

- Ensure any user-sourced data is passed through `escape()` first
- Miscellaneous cleanup