### PR TITLE
Fixes #16702: Fix validation of return_url query parameter

### DIFF
--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -4,6 +4,7 @@ from django.contrib.auth.mixins import AccessMixin
 from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext_lazy as _
 
 from netbox.plugins import PluginConfig
@@ -123,7 +124,7 @@ class GetReturnURLMixin:
         # First, see if `return_url` was specified as a query parameter or form data. Use this URL only if it's
         # considered safe.
         return_url = request.GET.get('return_url') or request.POST.get('return_url')
-        if return_url and return_url.startswith('/'):
+        if return_url and url_has_allowed_host_and_scheme(return_url, allowed_hosts=None):
             return return_url
 
         # Next, check if the object being modified (if any) has an absolute URL.


### PR DESCRIPTION
### Fixes: #16702

Use Django's aptly-named `url_has_allowed_host_and_scheme()` function to validate the return URL. (This is already being used by LoginView.)