### PR TITLE
SSO: custom name for identity providers

### DIFF
--- a/docs/administration/authentication/overview.md
+++ b/docs/administration/authentication/overview.md
@@ -49,9 +49,9 @@ to an empty dictionary. This dictionary maps a `social_core` module's name (ie.
 `REMOTE_AUTH_BACKEND.name`) to a couple of parameters, `(display_name, icon)`.
 
 The `display_name` is the name displayed to the user on the login page. The
-icon refers to a [Material Design
-Icons](https://github.com/google/material-design-icons) icon's name, or `None`
-for no icon.
+icon may either be the URL of an icon; refer to a [Material Design
+Icons](https://github.com/google/material-design-icons) icon's name; or be
+`None` for no icon.
 
 For instance, the OIDC backend may be customized with
 ```python

--- a/docs/administration/authentication/overview.md
+++ b/docs/administration/authentication/overview.md
@@ -40,3 +40,22 @@ REMOTE_AUTH_BACKEND = 'social_core.backends.google.GoogleOAuth2'
 NetBox supports single sign-on authentication via the [python-social-auth](https://github.com/python-social-auth) library. To enable SSO, specify the path to the desired authentication backend within the `social_core` Python package. Please see the complete list of [supported authentication backends](https://github.com/python-social-auth/social-core/tree/master/social_core/backends) for the available options.
 
 Most remote authentication backends require some additional configuration through settings prefixed with `SOCIAL_AUTH_`. These will be automatically imported from NetBox's `configuration.py` file. Additionally, the [authentication pipeline](https://python-social-auth.readthedocs.io/en/latest/pipeline.html) can be customized via the `SOCIAL_AUTH_PIPELINE` parameter. (NetBox's default pipeline is defined in `netbox/settings.py` for your reference.)
+
+#### Configuring the SSO module's appearance
+
+The way a remote authentication backend is displayed to the user on the login
+page may be adjusted via the `SOCIAL_AUTH_BACKEND_ATTRS` parameter, defaulting
+to an empty dictionary. This dictionary maps a `social_core` module's name (ie.
+`REMOTE_AUTH_BACKEND.name`) to a couple of parameters, `(display_name, icon)`.
+
+The `display_name` is the name displayed to the user on the login page. The
+icon refers to a [Material Design
+Icons](https://github.com/google/material-design-icons) icon's name, or `None`
+for no icon.
+
+For instance, the OIDC backend may be customized with
+```python
+SOCIAL_AUTH_BACKEND_ATTRS = {
+    'oidc': ("My awesome SSO", "login"),
+}
+```

--- a/netbox/account/views.py
+++ b/netbox/account/views.py
@@ -44,10 +44,20 @@ class LoginView(View):
         return super().dispatch(*args, **kwargs)
 
     def gen_auth_data(self, name, url, params):
-        display_name, icon_name = get_auth_backend_display(name)
+        display_name, icon_source = get_auth_backend_display(name)
+
+        icon_name = None
+        icon_img = None
+        if icon_source:
+            if '://' in icon_source:
+                icon_img = icon_source
+            else:
+                icon_name = icon_source
+
         return {
             'display_name': display_name,
             'icon_name': icon_name,
+            'icon_img': icon_img,
             'url': f'{url}?{urlencode(params)}',
         }
 

--- a/netbox/netbox/authentication/__init__.py
+++ b/netbox/netbox/authentication/__init__.py
@@ -49,12 +49,15 @@ AUTH_BACKEND_ATTRS = {
     'okta-openidconnect': ('Okta (OIDC)', None),
     'salesforce-oauth2': ('Salesforce', 'salesforce'),
 }
+# Override with potential user configuration
+AUTH_BACKEND_ATTRS.update(getattr(settings, 'SOCIAL_AUTH_BACKEND_ATTRS', {}))
 
 
 def get_auth_backend_display(name):
     """
-    Return the user-friendly name and icon name for a remote authentication backend, if known. Defaults to the
-    raw backend name and no icon.
+    Return the user-friendly name and icon name for a remote authentication backend, if
+    known. Obtained from the defaults dictionary AUTH_BACKEND_ATTRS, overridden by the
+    setting `SOCIAL_AUTH_BACKEND_ATTRS`. Defaults to the raw backend name and no icon.
     """
     return AUTH_BACKEND_ATTRS.get(name, (name, None))
 

--- a/netbox/templates/login.html
+++ b/netbox/templates/login.html
@@ -78,7 +78,8 @@
               {% for backend in auth_backends %}
                 <div class="col">
                   <a href="{{ backend.url }}" class="btn w-100">
-                    {% if backend.icon_name %}<i class="mdi mdi-{{ backend.icon_name }}"></i>{% endif %}
+                    {% if backend.icon_name %}<i class="mdi mdi-{{ backend.icon_name }}"></i>
+                    {% elif backend.icon_img %}<img src="{{ backend.icon_img }}" height="24" class="me-2" />{% endif %}
                     {{ backend.display_name }}
                   </a>
                 </div>


### PR DESCRIPTION
Fixes:  #15375 -- allows a user to customize the display aspect of social login providers (SSO and such).

This PR is separated into two commits on purpose.

The first one fixes  #15375 and adds relevant documentation. Users may specify in their configuration `SOCIAL_AUTH_BACKEND_ATTRS`, which override the display name of a social login provider, based on the `name` attribute of the `REMOTE_AUTH_BACKEND` class.

The second one allows to use an arbitrary URL as the identity provider's image. Using mdi icons works well for eg. Github social auth, but does not allow for corporate branding of an internal SSO (which is often expected by users).