### PR TITLE
Do not delete all search indexes when reindexing specific models

### DIFF
--- a/netbox/extras/management/commands/reindex.py
+++ b/netbox/extras/management/commands/reindex.py
@@ -67,8 +67,8 @@ class Command(BaseCommand):
         self.stdout.write(f'Reindexing {len(indexers)} models.')
 
         # Clear all cached values for the specified models (if not being lazy)
-        if not kwargs['lazy']:
-            self.stdout.write('Clearing cached values... ', ending='')
+        if not kwargs['lazy'] and not model_labels:
+            self.stdout.write('Clearing all cached values... ', ending='')
             self.stdout.flush()
             deleted_count = search_backend.clear()
             self.stdout.write(f'{deleted_count} entries deleted.')
@@ -81,11 +81,18 @@ class Command(BaseCommand):
             self.stdout.write(f'  {app_label}.{model_name}... ', ending='')
             self.stdout.flush()
 
-            if kwargs['lazy']:
-                content_type = ContentType.objects.get_for_model(model)
-                if cached_count := search_backend.count(object_types=[content_type]):
+            content_type = ContentType.objects.get_for_model(model)
+            cached_count = search_backend.count(object_types=[content_type])
+
+            if cached_count:
+                if kwargs['lazy']:
                     self.stdout.write(f'Skipping (found {cached_count} existing).')
                     continue
+
+                if model_labels:
+                    self.stdout.write(f'clearing {cached_count} cached values... ', ending='')
+                    self.stdout.flush()
+                    search_backend.clear(object_types=[content_type])
 
             i = search_backend.cache(model.objects.iterator(), remove_existing=False)
             if i:


### PR DESCRIPTION
* Clear all indexes only if neither `--lazy` nor a list of models are specified for "manage.py reindex"
* Otherwise, clear the index for a model immediately before rebuilding it

### Fixes: #16747
