### PR TITLE
16725 - The admin section should always come last in the navigation menu

### DIFF
--- a/netbox/netbox/navigation/menu.py
+++ b/netbox/netbox/navigation/menu.py
@@ -470,7 +470,7 @@ MENUS = [
 #
 
 for menu in registry['plugins']['menus']:
-    MENUS.append(menu)
+    MENUS.insert(-1, menu)
 
 if registry['plugins']['menu_items']:
 
@@ -484,4 +484,4 @@ if registry['plugins']['menu_items']:
         icon_class="mdi mdi-puzzle",
         groups=groups
     )
-    MENUS.append(plugins_menu)
+    MENUS.insert(-1, plugins_menu)

--- a/netbox/netbox/navigation/menu.py
+++ b/netbox/netbox/navigation/menu.py
@@ -462,16 +462,13 @@ MENUS = [
     PROVISIONING_MENU,
     CUSTOMIZATION_MENU,
     OPERATIONS_MENU,
-    ADMIN_MENU,
 ]
 
-#
-# Add plugin menus
-#
-
+# Add top-level plugin menus
 for menu in registry['plugins']['menus']:
-    MENUS.insert(-1, menu)
+    MENUS.append(menu)
 
+# Add the default "plugins" menu
 if registry['plugins']['menu_items']:
 
     # Build the default plugins menu
@@ -484,4 +481,7 @@ if registry['plugins']['menu_items']:
         icon_class="mdi mdi-puzzle",
         groups=groups
     )
-    MENUS.insert(-1, plugins_menu)
+    MENUS.append(plugins_menu)
+
+# Add the admin menu last
+MENUS.append(ADMIN_MENU)


### PR DESCRIPTION

### Fixes: #16725

I replaced `append` with `insert` into menu.py to make the admin section appear last in the navigation menu.