### PR TITLE
Closes #16817: Added 200 & 400 Gbps selections for circuit commit rate

### DIFF
--- a/netbox/circuits/choices.py
+++ b/netbox/circuits/choices.py
@@ -38,6 +38,8 @@ class CircuitCommitRateChoices(ChoiceSet):
         (25000000, '25 Gbps'),
         (40000000, '40 Gbps'),
         (100000000, '100 Gbps'),
+        (200000000, '200 Gbps'),
+        (400000000, '400 Gbps'),
         (1544, 'T1 (1.544 Mbps)'),
         (2048, 'E1 (2.048 Mbps)'),
     ]


### PR DESCRIPTION
Closes #16817.

As #16791 added 200 and 400 GBPS circuit termination port speed, here I am adding 200 & 400 Gbps selections for circuit commit rate