### PR TITLE
16357 clone tenant and type for cable

### DIFF
--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -88,6 +88,8 @@ class Cable(PrimaryModel):
         null=True
     )
 
+    clone_fields = ('tenant', 'type',)
+
     class Meta:
         ordering = ('pk',)
         verbose_name = _('cable')


### PR DESCRIPTION
### Fixes: #16357 

Clones tenant and type for cable when 'Create & Add Another'