### PR TITLE
fixed #16853: accessibility issues

### DIFF
--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -275,7 +275,7 @@ class ActionsColumn(tables.Column):
                 if len(self.actions) == 1 or (self.split_actions and idx == 0):
                     dropdown_class = attrs.css_class
                     button = (
-                        f'<a class="btn btn-sm btn-{attrs.css_class}" href="{url}{url_appendix}" type="button">'
+                        f'<a class="btn btn-sm btn-{attrs.css_class}" href="{url}{url_appendix}" type="button" aria-label="{attrs.title}">'
                         f'<i class="mdi mdi-{attrs.icon}"></i></a>'
                     )
 

--- a/netbox/templates/base/base.html
+++ b/netbox/templates/base/base.html
@@ -11,7 +11,7 @@
   >
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="initial-scale=1, maximum-scale=1, user-scalable=no, width=device-width, viewport-fit=cover" />
+    <meta name="viewport" content="initial-scale=1, maximum-scale=5, width=device-width, viewport-fit=cover" />
     <meta name="htmx-config" content='{"scrollBehavior": "auto"}'>
 
     {# Page title #}

--- a/netbox/templates/dcim/rack_elevation_list.html
+++ b/netbox/templates/dcim/rack_elevation_list.html
@@ -11,7 +11,7 @@
       <a href="{% url 'dcim:rack_list' %}{% querystring request %}" class="btn btn-primary">
         <i class="mdi mdi-format-list-checkbox"></i> {% trans "View List" %}
       </a>
-      <select class="btn btn-outline-secondary no-ts rack-view">
+      <select class="btn btn-outline-secondary no-ts rack-view" aria-label="Select rack view">
         <option value="images-and-labels" selected="selected">{% trans "Images and Labels" %}</option>
         <option value="images-only">{% trans "Images only" %}</option>
         <option value="labels-only">{% trans "Labels only" %}</option>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #16853

<!--
    Please include a summary of the proposed changes below.
-->

- [x]  (Misc) Edit icon/combo box missing alt text [Multiple]
- [x]  (Racks) 'images and labels' button label is ambiguous [Multiple]
- [ ]  (Buttons) On rack elevation page front and rear toggle button missing focus state on active part [Multiple]
Leaving this one off as I've covered it in #16845 
- [x]  (Misc) user-scalable="no" in the meta tag [Global]
- [ ]  (User profile) Redundant link as both id and date link to the same place [Single]
I believe this is a non-issue. There is no error in Lighthouse and it only appears as a warning in WAVE. For me, it does not hinder the UX. Let me know if you disagree.