### PR TITLE
Closes #16943: Expand navigation breadcrumbs on job view to include parent object

### DIFF
--- a/netbox/templates/core/job.html
+++ b/netbox/templates/core/job.html
@@ -4,6 +4,18 @@
 {% load perms %}
 {% load i18n %}
 
+{% block breadcrumbs %}
+  {{ block.super }}
+  <li class="breadcrumb-item">
+    <a href="{% url 'core:job_list' %}?object_type={{ object.object_type_id }}">{{ object.object|meta:"verbose_name_plural"|bettertitle }}</a>
+  </li>
+  {% with parent_jobs_viewname=object.object|viewname:"jobs" %}
+    <li class="breadcrumb-item">
+      <a href="{% url parent_jobs_viewname pk=object.object.pk %}">{{ object.object }}</a>
+    </li>
+  {% endwith %}
+{% endblock breadcrumbs %}
+
 {% block control-buttons %}
   {% if request.user|can_delete:object %}
     {% delete_button object %}


### PR DESCRIPTION
### Fixes: #16943

Adds links to:
- The jobs list, filtered by object type
- The parent object's "jobs" tab

![screenshot](https://github.com/user-attachments/assets/f6ab8d79-8f85-4e74-8808-4ec771ab2fa0)
