### PR TITLE
Closes #16905: Allow filtering of Inventory Items by Device Status

### DIFF
--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -1400,6 +1400,12 @@ class DeviceComponentFilterSet(django_filters.FilterSet):
         to_field_name='slug',
         label=_('Device role (slug)'),
     )
+    device_status = django_filters.ModelMultipleChoiceFilter(
+        field_name='device__status',
+        queryset=Device.objects.all(),
+        to_field_name='status',
+        label=_('Device (status)')
+    )
     virtual_chassis_id = django_filters.ModelMultipleChoiceFilter(
         field_name='device__virtual_chassis',
         queryset=VirtualChassis.objects.all(),

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -129,6 +129,11 @@ class DeviceComponentFilterForm(NetBoxModelFilterSetForm):
         },
         label=_('Device')
     )
+    device_status = forms.MultipleChoiceField(
+        choices=DeviceStatusChoices,
+        label=_('Device status'),
+        required=False
+    )
 
 
 class RegionFilterForm(ContactModelFilterForm, NetBoxModelFilterSetForm):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Closes: #16905

Added ability to filter inventory items by the device status field.

There's currently one issue where filtering by a device status that isn't assigned to a device returns all the inventory items. The same behavior occurs when selecting an unused device status with other assigned status'. I'm still trying to figure out the issue, but do you have any ideas? I've attached the SQL debugs which show the device status queries are working, but it appears the results are not being built when filtering by an unassigned device status. Any help or tips are appreciated!
<img width="1164" alt="device_status_filtering_broken" src="https://github.com/user-attachments/assets/8a9ffe18-278e-4b0d-a861-8b87ea78682f">
<img width="1169" alt="device_status_filtering_working" src="https://github.com/user-attachments/assets/9692e549-d7aa-4ddd-999f-5230ab3ddac0">
