### PR TITLE
Fixes #16937: Don't generate final navbar on file import

### DIFF
--- a/netbox/netbox/navigation/menu.py
+++ b/netbox/netbox/navigation/menu.py
@@ -1,6 +1,5 @@
 from django.utils.translation import gettext_lazy as _
 
-from netbox.registry import registry
 from . import *
 
 #
@@ -464,24 +463,38 @@ MENUS = [
     OPERATIONS_MENU,
 ]
 
-# Add top-level plugin menus
-for menu in registry['plugins']['menus']:
-    MENUS.append(menu)
+has_initialized_function_menus = False
 
-# Add the default "plugins" menu
-if registry['plugins']['menu_items']:
 
-    # Build the default plugins menu
-    groups = [
-        MenuGroup(label=label, items=items)
-        for label, items in registry['plugins']['menu_items'].items()
-    ]
-    plugins_menu = Menu(
-        label=_("Plugins"),
-        icon_class="mdi mdi-puzzle",
-        groups=groups
-    )
-    MENUS.append(plugins_menu)
+def add_plugin_menus():
+    """
+    Build the plugin navigation menu and add plugin defined
+    menus to the global context.
+    """
 
-# Add the admin menu last
-MENUS.append(ADMIN_MENU)
+    global has_initialized_function_menus
+    if has_initialized_function_menus:
+        return
+    else:
+        has_initialized_function_menus = True
+
+    from netbox.registry import registry
+
+    for menu in registry['plugins']['menus']:
+        MENUS.append(menu)
+
+    if registry['plugins']['menu_items']:
+        # Build the default plugins menu
+        groups = [
+            MenuGroup(label=label, items=items)
+            for label, items in registry['plugins']['menu_items'].items()
+        ]
+        plugins_menu = Menu(
+            label=_("Plugins"),
+            icon_class="mdi mdi-puzzle",
+            groups=groups
+        )
+        MENUS.append(plugins_menu)
+
+    # Add the admin menu last
+    MENUS.append(ADMIN_MENU)

--- a/netbox/utilities/templatetags/navigation.py
+++ b/netbox/utilities/templatetags/navigation.py
@@ -1,7 +1,7 @@
 from django import template
 from django.utils.safestring import mark_safe
 
-from netbox.navigation.menu import MENUS
+from netbox.navigation.menu import MENUS, add_plugin_menus
 
 __all__ = (
     'nav',
@@ -14,6 +14,8 @@ register = template.Library()
 
 @register.inclusion_tag("navigation/menu.html", takes_context=True)
 def nav(context):
+    add_plugin_menus()
+
     """
     Render the navigation menu.
     """


### PR DESCRIPTION
### Fixes: #16937

- Instead of generating the final navigation bar, including plugins, when the menu module is imported, we lazy-generate it once, later before it's being used.

This has no breaking code impact, only visually and behaviorally, where a bug is fixed, that happens when trying to import *(from)* menu too early. See issue for more info.