### PR TITLE
Closes #14861: Standardize URL path for virtual disks

### DIFF
--- a/netbox/virtualization/urls.py
+++ b/netbox/virtualization/urls.py
@@ -1,4 +1,4 @@
-from django.urls import include, path
+from django.urls import include, path, re_path
 
 from utilities.urls import get_model_urls
 from . import views
@@ -49,12 +49,16 @@ urlpatterns = [
     path('virtual-machines/interfaces/add/', views.VirtualMachineBulkAddInterfaceView.as_view(), name='virtualmachine_bulk_add_vminterface'),
 
     # Virtual disks
-    path('disks/', views.VirtualDiskListView.as_view(), name='virtualdisk_list'),
-    path('disks/add/', views.VirtualDiskCreateView.as_view(), name='virtualdisk_add'),
-    path('disks/import/', views.VirtualDiskBulkImportView.as_view(), name='virtualdisk_import'),
-    path('disks/edit/', views.VirtualDiskBulkEditView.as_view(), name='virtualdisk_bulk_edit'),
-    path('disks/rename/', views.VirtualDiskBulkRenameView.as_view(), name='virtualdisk_bulk_rename'),
-    path('disks/delete/', views.VirtualDiskBulkDeleteView.as_view(), name='virtualdisk_bulk_delete'),
-    path('disks/<int:pk>/', include(get_model_urls('virtualization', 'virtualdisk'))),
+    path('virtual-disks/', views.VirtualDiskListView.as_view(), name='virtualdisk_list'),
+    path('virtual-disks/add/', views.VirtualDiskCreateView.as_view(), name='virtualdisk_add'),
+    path('virtual-disks/import/', views.VirtualDiskBulkImportView.as_view(), name='virtualdisk_import'),
+    path('virtual-disks/edit/', views.VirtualDiskBulkEditView.as_view(), name='virtualdisk_bulk_edit'),
+    path('virtual-disks/rename/', views.VirtualDiskBulkRenameView.as_view(), name='virtualdisk_bulk_rename'),
+    path('virtual-disks/delete/', views.VirtualDiskBulkDeleteView.as_view(), name='virtualdisk_bulk_delete'),
+    path('virtual-disks/<int:pk>/', include(get_model_urls('virtualization', 'virtualdisk'))),
     path('virtual-machines/disks/add/', views.VirtualMachineBulkAddVirtualDiskView.as_view(), name='virtualmachine_bulk_add_virtualdisk'),
+
+    # TODO: Remove in v4.2
+    # Redirect old (pre-v4.1) URLs for VirtualDisk views
+    re_path('disks/(?P<path>[a-z0-9/-]*)', views.VirtualDiskRedirectView.as_view()),
 ]

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -7,6 +7,7 @@ from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext as _
+from django.views.generic.base import RedirectView
 from jinja2.exceptions import TemplateError
 
 from dcim.filtersets import DeviceFilterSet
@@ -628,6 +629,15 @@ class VirtualDiskBulkDeleteView(generic.BulkDeleteView):
     queryset = VirtualDisk.objects.all()
     filterset = filtersets.VirtualDiskFilterSet
     table = tables.VirtualDiskTable
+
+
+# TODO: Remove in v4.2
+class VirtualDiskRedirectView(RedirectView):
+    """
+    Redirect old (pre-v4.1) URLs for VirtualDisk views.
+    """
+    def get_redirect_url(self, path):
+        return f"{reverse('virtualization:virtualdisk_list')}{path}"
 
 
 #


### PR DESCRIPTION
### Closes: #14861

- Change the base URL path for all virtual disk UI views from `/virtualization/disks/` to `/virtualization/virtual-disks/`
- Introduce a transitional view to automatically redirect requests to the old paths