### PR TITLE
Closes #16964: Validate password when creating a new user or updating password for an existing user

### DIFF
--- a/netbox/users/forms/model_forms.py
+++ b/netbox/users/forms/model_forms.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.conf import settings
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, password_validation
 from django.contrib.postgres.forms import SimpleArrayField
 from django.core.exceptions import FieldError
 from django.utils.safestring import mark_safe
@@ -226,6 +226,8 @@ class UserForm(forms.ModelForm):
         # Check that password confirmation matches if password is set
         if self.cleaned_data['password'] and self.cleaned_data['password'] != self.cleaned_data['confirm_password']:
             raise forms.ValidationError(_("Passwords do not match! Please check your input and try again."))
+        if self.cleaned_data['password'] and self.cleaned_data['confirm_password']:
+            password_validation.validate_password(self.cleaned_data['confirm_password'], self.instance)
 
 
 class GroupForm(forms.ModelForm):


### PR DESCRIPTION

### Fixes: #16964

- Call `validate_password()` on the configured password validators, while cleaning the `UserForm` data.
