### PR TITLE
Use `provider_id` instead of `account_id` in url_params

### DIFF
--- a/netbox/circuits/tables/providers.py
+++ b/netbox/circuits/tables/providers.py
@@ -25,7 +25,7 @@ class ProviderTable(ContactsColumnMixin, NetBoxTable):
     account_count = columns.LinkedCountColumn(
         accessor=tables.A('accounts__count'),
         viewname='circuits:provideraccount_list',
-        url_params={'account_id': 'pk'},
+        url_params={'provider_id': 'pk'},
         verbose_name=_('Account Count')
     )
     asns = columns.ManyToManyColumn(


### PR DESCRIPTION

### Fixes: #16963

Use `provider_id` instead of `account_id` to properly filter Accounts belonging to a specific Provider when navigating Accounts from the Providers list view