### PR TITLE
17086 Fix exception on job details view

### DIFF
--- a/netbox/templates/core/job.html
+++ b/netbox/templates/core/job.html
@@ -6,14 +6,20 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  <li class="breadcrumb-item">
-    <a href="{% url 'core:job_list' %}?object_type={{ object.object_type_id }}">{{ object.object|meta:"verbose_name_plural"|bettertitle }}</a>
-  </li>
-  {% with parent_jobs_viewname=object.object|viewname:"jobs" %}
+  {% if object.object %}
     <li class="breadcrumb-item">
-      <a href="{% url parent_jobs_viewname pk=object.object.pk %}">{{ object.object }}</a>
+      <a href="{% url 'core:job_list' %}?object_type={{ object.object_type_id }}">{{ object.object|meta:"verbose_name_plural"|bettertitle }}</a>
     </li>
-  {% endwith %}
+    {% with parent_jobs_viewname=object.object|viewname:"jobs" %}
+      <li class="breadcrumb-item">
+        <a href="{% url parent_jobs_viewname pk=object.object.pk %}">{{ object.object }}</a>
+      </li>
+    {% endwith %}
+  {% else %}
+    <li class="breadcrumb-item">
+      <a href="{% url 'core:job_list' %}?name={{ object.name|urlencode }}">{{ object.name }}</a>
+    </li>
+  {% endif %}
 {% endblock breadcrumbs %}
 
 {% block control-buttons %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #17086

<!--
    Please include a summary of the proposed changes below.
-->

If a job is not bound to an object, the job name will be used for breadcrumbs on the job details view instead. Clicking the breadcrumb will lead to the list of jobs with the same name (i.e. the same `JobRunner`).