### PR TITLE
17096 Do not omit "False" values from the request URL for cloned fields

### DIFF
--- a/netbox/netbox/forms/base.py
+++ b/netbox/netbox/forms/base.py
@@ -1,6 +1,7 @@
 import json
 
 from django import forms
+from django.forms.fields import BooleanField, NullBooleanField
 from django.contrib.contenttypes.models import ContentType
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
@@ -30,6 +31,15 @@ class NetBoxModelForm(CheckLastUpdatedMixin, CustomFieldsMixin, TagsMixin, forms
             the rendered form (optional). If not defined, the all fields will be rendered as a single section.
     """
     fieldsets = ()
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        for key, value in self.initial.items():
+            if key not in self.fields:
+                continue
+            if isinstance(self.fields[key], (BooleanField, NullBooleanField)) and self.initial[key] == "False":
+                self.initial[key] = False
 
     def _get_content_type(self):
         return ContentType.objects.get_for_model(self._meta.model)

--- a/netbox/utilities/querydict.py
+++ b/netbox/utilities/querydict.py
@@ -55,7 +55,7 @@ def prepare_cloned_fields(instance):
     for key, value in attrs.items():
         if type(value) in (list, tuple):
             params.extend([(key, v) for v in value])
-        elif value is not None and (key.startswith('cf_') or value is not False):
+        elif value is not None:
             params.append((key, value))
         else:
             params.append((key, ''))

--- a/netbox/utilities/querydict.py
+++ b/netbox/utilities/querydict.py
@@ -55,7 +55,7 @@ def prepare_cloned_fields(instance):
     for key, value in attrs.items():
         if type(value) in (list, tuple):
             params.extend([(key, v) for v in value])
-        elif value is not False and value is not None:
+        elif value is not None:
             params.append((key, value))
         else:
             params.append((key, ''))

--- a/netbox/utilities/querydict.py
+++ b/netbox/utilities/querydict.py
@@ -55,7 +55,7 @@ def prepare_cloned_fields(instance):
     for key, value in attrs.items():
         if type(value) in (list, tuple):
             params.extend([(key, v) for v in value])
-        elif value is not None:
+        elif value is not None and (key.startswith('cf_') or value is not False):
             params.append((key, value))
         else:
             params.append((key, ''))


### PR DESCRIPTION
### Fixes: #17096

The current implementation leaves the URL parameters for boolean fields empty if their value is actually `False`, which leads to fields with `False` values not being cloned correctly.