### PR TITLE
16995 Move language handling to Middleware

### DIFF
--- a/netbox/account/views.py
+++ b/netbox/account/views.py
@@ -121,10 +121,6 @@ class LoginView(View):
 
             response = self.redirect_to_next(request, logger)
 
-            # Set the user's preferred language (if any)
-            if language := request.user.config.get('locale.language'):
-                response.set_cookie(settings.LANGUAGE_COOKIE_NAME, language, max_age=request.session.get_expiry_age())
-
             return response
 
         else:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #16995

<!--
    Please include a summary of the proposed changes below.
-->
Decouples language activation from login form to have it handled by `CoreMiddleware` which will also trigger language activation on any type of login (e.g. SSO).