### PR TITLE
17006 Add Wi-Fi 7 IEEE 802.11be

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,3 @@ netbox.pid
 .coverage
 .vscode
 .python-version
-.devcontainer

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ netbox.pid
 .coverage
 .vscode
 .python-version
+.devcontainer

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -886,6 +886,7 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_80211AD = 'ieee802.11ad'
     TYPE_80211AX = 'ieee802.11ax'
     TYPE_80211AY = 'ieee802.11ay'
+    TYPE_80211BE = 'ieee802.11be'
     TYPE_802151 = 'ieee802.15.1'
     TYPE_OTHER_WIRELESS = 'other-wireless'
 
@@ -1057,6 +1058,7 @@ class InterfaceTypeChoices(ChoiceSet):
                 (TYPE_80211AD, 'IEEE 802.11ad'),
                 (TYPE_80211AX, 'IEEE 802.11ax'),
                 (TYPE_80211AY, 'IEEE 802.11ay'),
+                (TYPE_80211BE, 'IEEE 802.11be'),
                 (TYPE_802151, 'IEEE 802.15.1 (Bluetooth)'),
                 (TYPE_OTHER_WIRELESS, 'Other (Wireless)'),
             )

--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -49,6 +49,7 @@ WIRELESS_IFACE_TYPES = [
     InterfaceTypeChoices.TYPE_80211AD,
     InterfaceTypeChoices.TYPE_80211AX,
     InterfaceTypeChoices.TYPE_80211AY,
+    InterfaceTypeChoices.TYPE_80211BE,
     InterfaceTypeChoices.TYPE_802151,
     InterfaceTypeChoices.TYPE_OTHER_WIRELESS,
 ]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #17006

<!--
    Please include a summary of the proposed changes below.
-->

- Adds Wi-Fi 7 (IEEE 802.11be) to the list of wireless interface options.
- Adds `.devcontainer` to the `.gitignore` to prevent development container configurations being submitted to the NetBox repository.