### PR TITLE
Fixes #17131: Fix exception when creating object-type custom field without selecting related object type

### DIFF
--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -352,13 +352,11 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
         if self.type in (CustomFieldTypeChoices.TYPE_OBJECT, CustomFieldTypeChoices.TYPE_MULTIOBJECT):
             if not self.related_object_type:
                 raise ValidationError({
-                    'object_type': _("Object fields must define an object type.")
+                    'related_object_type': _("Object fields must define an object type.")
                 })
         elif self.related_object_type:
             raise ValidationError({
-                'object_type': _(
-                    "{type} fields may not define an object type.")
-                .format(type=self.get_type_display())
+                'type': _("{type} fields may not define an object type.") .format(type=self.get_type_display())
             })
 
     def serialize(self, value):


### PR DESCRIPTION
### Fixes: #17131

- Correct the field name with which relevant errors messages are associated