### PR TITLE
Fixes #16871: Sanitize device ID when bulk editing components to prevent exception

### DIFF
--- a/netbox/dcim/forms/bulk_edit.py
+++ b/netbox/dcim/forms/bulk_edit.py
@@ -1188,12 +1188,17 @@ class ComponentBulkEditForm(NetBoxModelBulkEditForm):
         required=False
     )
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, *args, initial=None, **kwargs):
+        try:
+            self.device_id = int(initial.get('device'))
+        except (TypeError, ValueError):
+            self.device_id = None
+
+        super().__init__(*args, initial=initial, **kwargs)
 
         # Limit module queryset to Modules which belong to the parent Device
-        if 'device' in self.initial:
-            device = Device.objects.filter(pk=self.initial['device']).first()
+        if self.device_id:
+            device = Device.objects.filter(pk=self.device_id).first()
             self.fields['module'].queryset = Module.objects.filter(device=device)
         else:
             self.fields['module'].choices = ()
@@ -1201,8 +1206,8 @@ class ComponentBulkEditForm(NetBoxModelBulkEditForm):
 
 
 class ConsolePortBulkEditForm(
-    form_from_model(ConsolePort, ['label', 'type', 'speed', 'mark_connected', 'description']),
-    ComponentBulkEditForm
+    ComponentBulkEditForm,
+    form_from_model(ConsolePort, ['label', 'type', 'speed', 'mark_connected', 'description'])
 ):
     mark_connected = forms.NullBooleanField(
         label=_('Mark connected'),
@@ -1218,8 +1223,8 @@ class ConsolePortBulkEditForm(
 
 
 class ConsoleServerPortBulkEditForm(
-    form_from_model(ConsoleServerPort, ['label', 'type', 'speed', 'mark_connected', 'description']),
-    ComponentBulkEditForm
+    ComponentBulkEditForm,
+    form_from_model(ConsoleServerPort, ['label', 'type', 'speed', 'mark_connected', 'description'])
 ):
     mark_connected = forms.NullBooleanField(
         label=_('Mark connected'),
@@ -1235,8 +1240,8 @@ class ConsoleServerPortBulkEditForm(
 
 
 class PowerPortBulkEditForm(
-    form_from_model(PowerPort, ['label', 'type', 'maximum_draw', 'allocated_draw', 'mark_connected', 'description']),
-    ComponentBulkEditForm
+    ComponentBulkEditForm,
+    form_from_model(PowerPort, ['label', 'type', 'maximum_draw', 'allocated_draw', 'mark_connected', 'description'])
 ):
     mark_connected = forms.NullBooleanField(
         label=_('Mark connected'),
@@ -1253,8 +1258,8 @@ class PowerPortBulkEditForm(
 
 
 class PowerOutletBulkEditForm(
-    form_from_model(PowerOutlet, ['label', 'type', 'feed_leg', 'power_port', 'mark_connected', 'description']),
-    ComponentBulkEditForm
+    ComponentBulkEditForm,
+    form_from_model(PowerOutlet, ['label', 'type', 'feed_leg', 'power_port', 'mark_connected', 'description'])
 ):
     mark_connected = forms.NullBooleanField(
         label=_('Mark connected'),
@@ -1273,8 +1278,8 @@ class PowerOutletBulkEditForm(
         super().__init__(*args, **kwargs)
 
         # Limit power_port queryset to PowerPorts which belong to the parent Device
-        if 'device' in self.initial:
-            device = Device.objects.filter(pk=self.initial['device']).first()
+        if self.device_id:
+            device = Device.objects.filter(pk=self.device_id).first()
             self.fields['power_port'].queryset = PowerPort.objects.filter(device=device)
         else:
             self.fields['power_port'].choices = ()
@@ -1282,12 +1287,12 @@ class PowerOutletBulkEditForm(
 
 
 class InterfaceBulkEditForm(
+    ComponentBulkEditForm,
     form_from_model(Interface, [
         'label', 'type', 'parent', 'bridge', 'lag', 'speed', 'duplex', 'mac_address', 'wwn', 'mtu', 'mgmt_only',
         'mark_connected', 'description', 'mode', 'rf_role', 'rf_channel', 'rf_channel_frequency', 'rf_channel_width',
         'tx_power', 'wireless_lans'
-    ]),
-    ComponentBulkEditForm
+    ])
 ):
     enabled = forms.NullBooleanField(
         label=_('Enabled'),
@@ -1416,8 +1421,8 @@ class InterfaceBulkEditForm(
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if 'device' in self.initial:
-            device = Device.objects.filter(pk=self.initial['device']).first()
+        if self.device_id:
+            device = Device.objects.filter(pk=self.device_id).first()
 
             # Restrict parent/bridge/LAG interface assignment by device
             self.fields['parent'].widget.add_query_param('virtual_chassis_member_id', device.pk)
@@ -1480,8 +1485,8 @@ class InterfaceBulkEditForm(
 
 
 class FrontPortBulkEditForm(
-    form_from_model(FrontPort, ['label', 'type', 'color', 'mark_connected', 'description']),
-    ComponentBulkEditForm
+    ComponentBulkEditForm,
+    form_from_model(FrontPort, ['label', 'type', 'color', 'mark_connected', 'description'])
 ):
     mark_connected = forms.NullBooleanField(
         label=_('Mark connected'),
@@ -1497,8 +1502,8 @@ class FrontPortBulkEditForm(
 
 
 class RearPortBulkEditForm(
-    form_from_model(RearPort, ['label', 'type', 'color', 'mark_connected', 'description']),
-    ComponentBulkEditForm
+    ComponentBulkEditForm,
+    form_from_model(RearPort, ['label', 'type', 'color', 'mark_connected', 'description'])
 ):
     mark_connected = forms.NullBooleanField(
         label=_('Mark connected'),


### PR DESCRIPTION
### Fixes: #16871

Extend `ComponentBulkEditForm` to capture the device ID (if any) on initialization for context