### PR TITLE
Fixes #17097: Record static object representation when calling `NotificationGroup.notify()`

### DIFF
--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -139,6 +139,7 @@ def process_event_rules(event_rules, object_type, event_type, data, username=Non
             event_rule.action_object.notify(
                 object_type=object_type,
                 object_id=data['id'],
+                object_repr=data.get('display'),
                 event_type=event_type
             )
 

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -424,11 +424,16 @@ class NotificationReadView(LoginRequiredMixin, View):
     Mark the Notification read and redirect the user to its attached object.
     """
     def get(self, request, pk):
+        # Mark the Notification as read
         notification = get_object_or_404(request.user.notifications, pk=pk)
         notification.read = timezone.now()
         notification.save()
 
-        return redirect(notification.object.get_absolute_url())
+        # Redirect to the object if it has a URL (deleted objects will not)
+        if hasattr(notification.object, 'get_absolute_url'):
+            return redirect(notification.object.get_absolute_url())
+
+        return redirect('account:notifications')
 
 
 @register_model_view(Notification, 'dismiss')

--- a/netbox/templates/htmx/notifications.html
+++ b/netbox/templates/htmx/notifications.html
@@ -7,7 +7,11 @@
           <i class="{{ notification.event.icon }}"></i>
         </div>
         <div class="col text-truncate">
-          <a href="{% url 'extras:notification_read' pk=notification.pk %}" class="text-body d-block">{{ notification.object_repr }}</a>
+          {% if not notification.event.destructive %}
+            <a href="{% url 'extras:notification_read' pk=notification.pk %}" class="text-body d-block">{{ notification.object_repr }}</a>
+          {% else %}
+            <span class="text-body d-block">{{ notification.object_repr }}</span>
+          {% endif %}
           <div class="d-block text-secondary fs-5">{{ notification.event }} {{ notification.created|timesince }} {% trans "ago" %}</div>
         </div>
         <div class="col-auto">


### PR DESCRIPTION
### Fixes: #17097

Pass the `display` string from the serialized object when bulk-creating notification for a group. This isn't ideal, but the event handling logic doesn't currently have access to the object instance.