### PR TITLE
Fixes #17098: Prevent automatic deletion of related notifications when deleting an object

### DIFF
--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -382,11 +382,6 @@ class NotificationsMixin(models.Model):
     """
     Enables support for user notifications.
     """
-    notifications = GenericRelation(
-        to='extras.Notification',
-        content_type_field='object_type',
-        object_id_field='object_id'
-    )
     subscriptions = GenericRelation(
         to='extras.Subscription',
         content_type_field='object_type',


### PR DESCRIPTION
### Fixes: #17098

Remove the GenericRelation on NotificationsMixin to avoid automatically deleting any notifications referencing an object being deleted.