### PR TITLE
17169 use config_name for matching in plugin catalog

### DIFF
--- a/netbox/core/plugins.py
+++ b/netbox/core/plugins.py
@@ -81,8 +81,9 @@ def get_local_plugins(plugins=None):
         plugin_config: PluginConfig = plugin.config
 
         local_plugins[plugin_config.name] = Plugin(
-            slug=plugin_config.name,
+            config_name=plugin_config.name,
             title_short=plugin_config.verbose_name,
+            title_long=plugin_config.verbose_name,
             tag_line=plugin_config.description,
             description_short=plugin_config.description,
             is_local=True,
@@ -181,7 +182,7 @@ def get_catalog_plugins():
                     author = None
 
                 # Populate plugin data
-                plugins[data['slug']] = Plugin(
+                plugins[data['config_name']] = Plugin(
                     id=data['id'],
                     status=data['status'],
                     title_short=data['title_short'],
@@ -204,6 +205,7 @@ def get_catalog_plugins():
         return plugins
 
     catalog_plugins = cache.get(CACHE_KEY_CATALOG_FEED, default={})
+    catalog_plugins = None
     if not catalog_plugins:
         try:
             catalog_plugins = make_plugin_dict()

--- a/netbox/core/plugins.py
+++ b/netbox/core/plugins.py
@@ -205,7 +205,6 @@ def get_catalog_plugins():
         return plugins
 
     catalog_plugins = cache.get(CACHE_KEY_CATALOG_FEED, default={})
-    catalog_plugins = None
     if not catalog_plugins:
         try:
             catalog_plugins = make_plugin_dict()

--- a/netbox/core/tables/plugins.py
+++ b/netbox/core/tables/plugins.py
@@ -39,8 +39,8 @@ class PluginVersionTable(BaseTable):
 
 
 class CatalogPluginTable(BaseTable):
-    title_short = tables.Column(
-        linkify=('core:plugin', [tables.A('slug')]),
+    title_long = tables.Column(
+        linkify=('core:plugin', [tables.A('config_name')]),
         verbose_name=_('Name')
     )
     author = tables.Column(
@@ -69,11 +69,11 @@ class CatalogPluginTable(BaseTable):
     class Meta(BaseTable.Meta):
         empty_text = _('No plugin data found')
         fields = (
-            'title_short', 'author', 'is_local', 'is_installed', 'is_certified', 'created_at', 'updated_at',
+            'title_long', 'author', 'is_local', 'is_installed', 'is_certified', 'created_at', 'updated_at',
             'installed_version',
         )
         default_columns = (
-            'title_short', 'author', 'is_local', 'is_installed', 'is_certified', 'created_at', 'updated_at',
+            'title_long', 'author', 'is_local', 'is_installed', 'is_certified', 'created_at', 'updated_at',
         )
         # List installed plugins first, then certified plugins, then
         # everything else (with each tranche ordered alphabetically)

--- a/netbox/templates/core/plugin.html
+++ b/netbox/templates/core/plugin.html
@@ -3,7 +3,7 @@
 {% load form_helpers %}
 {% load i18n %}
 
-{% block title %}{{ plugin.title_short }}{% endblock %}
+{% block title %}{{ plugin.title_long }}{% endblock %}
 
 {% block object_identifier %}
 {% endblock object_identifier %}
@@ -51,7 +51,7 @@
           <table class="table table-hover attr-table">
             <tr>
               <th scope="row">{% trans "Name" %}</th>
-              <td>{{ plugin.title_short }}</td>
+              <td>{{ plugin.title_long }}</td>
             </tr>
             <tr>
               <th scope="row">{% trans "Summary" %}</th>


### PR DESCRIPTION
### Fixes: #17169 

Per review of interfacing with Plugin Catalog - used config_name for matching of plugins and used title_long instead of title_short for the display name.