### PR TITLE
Closes #16574: Add last_synced time to REST API serializer for data sources

### DIFF
--- a/netbox/core/api/serializers_/data.py
+++ b/netbox/core/api/serializers_/data.py
@@ -1,5 +1,3 @@
-from rest_framework import serializers
-
 from core.choices import *
 from core.models import DataFile, DataSource
 from netbox.api.fields import ChoiceField, RelatedObjectCountField
@@ -27,8 +25,9 @@ class DataSourceSerializer(NetBoxModelSerializer):
     class Meta:
         model = DataSource
         fields = [
-            'id', 'url', 'display_url', 'display', 'name', 'type', 'source_url', 'enabled', 'status', 'description', 'comments',
-            'parameters', 'ignore_rules', 'custom_fields', 'created', 'last_updated', 'file_count',
+            'id', 'url', 'display_url', 'display', 'name', 'type', 'source_url', 'enabled', 'status', 'description',
+            'parameters', 'ignore_rules', 'comments', 'custom_fields', 'created', 'last_updated', 'last_synced',
+            'file_count',
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'description')
 


### PR DESCRIPTION
### Fixes: #16574

Add the `last_synced` field to the REST API serializer for the DataSource model.