### PR TITLE
Fixes: 17177 - Add "facility" field to LocationFilterForm

### DIFF
--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -195,7 +195,7 @@ class LocationFilterForm(TenancyFilterForm, ContactModelFilterForm, NetBoxModelF
     model = Location
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('region_id', 'site_group_id', 'site_id', 'parent_id', 'status', name=_('Attributes')),
+        FieldSet('region_id', 'site_group_id', 'site_id', 'parent_id', 'status', 'facility', name=_('Attributes')),
         FieldSet('tenant_group_id', 'tenant_id', name=_('Tenant')),
         FieldSet('contact', 'contact_role', 'contact_group', name=_('Contacts')),
     )
@@ -230,6 +230,10 @@ class LocationFilterForm(TenancyFilterForm, ContactModelFilterForm, NetBoxModelF
     status = forms.MultipleChoiceField(
         label=_('Status'),
         choices=LocationStatusChoices,
+        required=False
+    )
+    facility = forms.CharField(
+        label=_('Facility'),
         required=False
     )
     tag = TagFilterField(model)


### PR DESCRIPTION
### Fixes: #17177 - Add "facility" field to LocationFilterForm

Adds a form field on the Locations filter form to allow filtering on the Facility field. This filtering behavior is already supported in the underlying mechanism, this just exposes the field in the UI.

Ordering of the Facility field (after Status in the Attributes fieldset) is open to comment; I put it at the end to match the placement in the default table column ordering.
