### PR TITLE
Fixes: #17072 - Make active links of phone and email in Contact Assignments table

### DIFF
--- a/netbox/tenancy/tables/contacts.py
+++ b/netbox/tenancy/tables/contacts.py
@@ -4,7 +4,7 @@ from django_tables2.utils import Accessor
 
 from netbox.tables import NetBoxTable, columns
 from tenancy.models import *
-from utilities.tables import linkify_phone, linkify_email
+from utilities.tables import linkify_phone
 
 __all__ = (
     'ContactAssignmentTable',
@@ -116,10 +116,9 @@ class ContactAssignmentTable(NetBoxTable):
         verbose_name=_('Contact Phone'),
         linkify=linkify_phone,
     )
-    contact_email = tables.Column(
+    contact_email = tables.EmailColumn(
         accessor=Accessor('contact__email'),
         verbose_name=_('Contact Email'),
-        linkify=linkify_email,
     )
     contact_address = tables.Column(
         accessor=Accessor('contact__address'),

--- a/netbox/tenancy/tables/contacts.py
+++ b/netbox/tenancy/tables/contacts.py
@@ -4,7 +4,7 @@ from django_tables2.utils import Accessor
 
 from netbox.tables import NetBoxTable, columns
 from tenancy.models import *
-from utilities.tables import linkify_phone
+from utilities.tables import linkify_phone, linkify_email
 
 __all__ = (
     'ContactAssignmentTable',
@@ -113,11 +113,13 @@ class ContactAssignmentTable(NetBoxTable):
     )
     contact_phone = tables.Column(
         accessor=Accessor('contact__phone'),
-        verbose_name=_('Contact Phone')
+        verbose_name=_('Contact Phone'),
+        linkify=linkify_phone,
     )
     contact_email = tables.Column(
         accessor=Accessor('contact__email'),
-        verbose_name=_('Contact Email')
+        verbose_name=_('Contact Email'),
+        linkify=linkify_email,
     )
     contact_address = tables.Column(
         accessor=Accessor('contact__address'),

--- a/netbox/utilities/tables.py
+++ b/netbox/utilities/tables.py
@@ -23,15 +23,6 @@ def get_table_ordering(request, table):
             return preference
 
 
-def linkify_email(value):
-    """
-    Render an email address as a hyperlink.
-    """
-    if value is None:
-        return None
-    return f"mailto:{value.replace(' ', '')}"
-
-
 def linkify_phone(value):
     """
     Render a telephone number as a hyperlink.

--- a/netbox/utilities/tables.py
+++ b/netbox/utilities/tables.py
@@ -23,6 +23,15 @@ def get_table_ordering(request, table):
             return preference
 
 
+def linkify_email(value):
+    """
+    Render an email address as a hyperlink.
+    """
+    if value is None:
+        return None
+    return f"mailto:{value.replace(' ', '')}"
+
+
 def linkify_phone(value):
     """
     Render a telephone number as a hyperlink.


### PR DESCRIPTION
### Fixes: #17072 - Make active links of phone and email in Contact Assignments table

Uses existing `linkify_phone` helper and `EmailColumn` from django-tables2 to activate links for the email and phone fields in the Contact Assignments table.
