### PR TITLE
Fixes: #17070 - Make image_width and image_height read_only on REST API ImageAttachmentSerializer

### DIFF
--- a/netbox/extras/api/serializers_/attachments.py
+++ b/netbox/extras/api/serializers_/attachments.py
@@ -19,6 +19,8 @@ class ImageAttachmentSerializer(ValidatedModelSerializer):
         queryset=ObjectType.objects.all()
     )
     parent = serializers.SerializerMethodField(read_only=True)
+    image_width = serializers.IntegerField(read_only=True)
+    image_height = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = ImageAttachment


### PR DESCRIPTION
### Fixes: #17070 - Make image_width and image_height read_only on REST API ImageAttachmentSerializer

Sets the `image_width` and `image_height` fields on `ImageAttachmentSerializer` to read_only. This prevents redundant and cumbersome "field required" errors when submitting an Image Attachment via the REST API.

Tested to verify that submitting an image via the API without these fields in the payload is still handled correctly via Django and the fields are automatically populated.
