### PR TITLE
Fixes: #16949 - Device count column on Sites table

### DIFF
--- a/netbox/dcim/tables/sites.py
+++ b/netbox/dcim/tables/sites.py
@@ -99,6 +99,11 @@ class SiteTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
         url_params={'site_id': 'pk'},
         verbose_name=_('ASN Count')
     )
+    device_count = columns.LinkedCountColumn(
+        viewname='dcim:device_list',
+        url_params={'site_id': 'pk'},
+        verbose_name=_('Devices')
+    )
     comments = columns.MarkdownColumn(
         verbose_name=_('Comments'),
     )

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -380,7 +380,9 @@ class SiteGroupContactsView(ObjectContactsView):
 #
 
 class SiteListView(generic.ObjectListView):
-    queryset = Site.objects.all()
+    queryset = Site.objects.annotate(
+        device_count=count_related(Device, 'site')
+    )
     filterset = filtersets.SiteFilterSet
     filterset_form = forms.SiteFilterForm
     table = tables.SiteTable


### PR DESCRIPTION
### Fixes: #16949 - Device count column on Sites table

Adds a Devices column with device_count hyperlink (via count_related) to the SiteListView table.

Tested with populated demo data and it seems acceptably performant.