### PR TITLE
Closes #17221: Extend ObjectEditView to support HTMX requests

### DIFF
--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -234,6 +234,8 @@ class ObjectEditView(GetReturnURLMixin, BaseObjectView):
         # If this is an HTMX request, return only the rendered form HTML
         if htmx_partial(request):
             return render(request, self.htmx_template_name, {
+                'model': model,
+                'object': obj,
                 'form': form,
             })
 
@@ -288,6 +290,7 @@ class ObjectEditView(GetReturnURLMixin, BaseObjectView):
                     msg = f'{msg} {obj}'
                 messages.success(request, msg)
 
+                # If adding another object, redirect back to the edit form
                 if '_addanother' in request.POST:
                     redirect_url = request.path
 
@@ -302,6 +305,12 @@ class ObjectEditView(GetReturnURLMixin, BaseObjectView):
                     return redirect(redirect_url)
 
                 return_url = self.get_return_url(request, obj)
+
+                # If the object has been created or edited via HTMX, return an HTMX redirect to the object view
+                if request.htmx:
+                    return HttpResponse(headers={
+                        'HX-Location': return_url,
+                    })
 
                 return redirect(return_url)
 


### PR DESCRIPTION
### Fixes: #17221

Extends `ObjectEditView` to return an `HX-Location` redirect in response to HTMX POST requests
