### PR TITLE
Fixes: #17108 - Update isotime and isodate filters to be timezone-aware

### DIFF
--- a/netbox/extras/forms/reports.py
+++ b/netbox/extras/forms/reports.py
@@ -31,7 +31,7 @@ class ReportForm(forms.Form):
         super().__init__(*args, **kwargs)
 
         # Annotate the current system time for reference
-        now = local_now().strftime('%Y-%m-%d %H:%M:%S')
+        now = local_now().strftime('%Y-%m-%d %H:%M:%S %Z')
         self.fields['schedule_at'].help_text += _(' (current time: <strong>{now}</strong>)').format(now=now)
 
         # Remove scheduling fields if scheduling is disabled

--- a/netbox/extras/forms/scripts.py
+++ b/netbox/extras/forms/scripts.py
@@ -37,7 +37,7 @@ class ScriptForm(forms.Form):
         super().__init__(*args, **kwargs)
 
         # Annotate the current system time for reference
-        now = local_now().strftime('%Y-%m-%d %H:%M:%S')
+        now = local_now().strftime('%Y-%m-%d %H:%M:%S %Z')
         self.fields['_schedule_at'].help_text += _(' (current time: <strong>{now}</strong>)').format(now=now)
 
         # Remove scheduling fields if scheduling is disabled

--- a/netbox/utilities/templatetags/builtins/filters.py
+++ b/netbox/utilities/templatetags/builtins/filters.py
@@ -8,6 +8,7 @@ from django.contrib.contenttypes.models import ContentType
 from django.contrib.humanize.templatetags.humanize import naturalday, naturaltime
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
+from django.utils.timezone import localtime
 from markdown import markdown
 from markdown.extensions.tables import TableExtension
 
@@ -218,7 +219,7 @@ def isodate(value):
         text = value.isoformat()
         return mark_safe(f'<span title="{naturalday(value)}">{text}</span>')
     elif type(value) is datetime.datetime:
-        text = value.date().isoformat()
+        text = localtime(value).date().isoformat()
         return mark_safe(f'<span title="{naturaltime(value)}">{text}</span>')
     else:
         return ''
@@ -229,7 +230,7 @@ def isotime(value, spec='seconds'):
     if type(value) is datetime.time:
         return value.isoformat(timespec=spec)
     if type(value) is datetime.datetime:
-        return value.time().isoformat(timespec=spec)
+        return localtime(value).time().isoformat(timespec=spec)
     return ''
 
 

--- a/netbox/utilities/templatetags/builtins/filters.py
+++ b/netbox/utilities/templatetags/builtins/filters.py
@@ -219,7 +219,8 @@ def isodate(value):
         text = value.isoformat()
         return mark_safe(f'<span title="{naturalday(value)}">{text}</span>')
     elif type(value) is datetime.datetime:
-        text = localtime(value).date().isoformat()
+        local_value = localtime(value) if value.tzinfo else value
+        text = local_value.date().isoformat()
         return mark_safe(f'<span title="{naturaltime(value)}">{text}</span>')
     else:
         return ''
@@ -230,7 +231,8 @@ def isotime(value, spec='seconds'):
     if type(value) is datetime.time:
         return value.isoformat(timespec=spec)
     if type(value) is datetime.datetime:
-        return localtime(value).time().isoformat(timespec=spec)
+        local_value = localtime(value) if value.tzinfo else value
+        return local_value.time().isoformat(timespec=spec)
     return ''
 
 


### PR DESCRIPTION
### Fixes: #17108 - Update isotime and isodate filters to be timezone-aware

Wraps the logic of the `isodate` and `isotime` filters in the Django `localtime` util, with the (potentially widespread) effect that every appearance of a datetime in the UI will now respect the `TIME_ZONE` setting. This particularly fixes the job scheduling UI as seen below (note also that the "Current time" output also now reflects the timezone for added clarity):

<img width="831" alt="Screenshot 2024-08-26 at 11 14 19 AM" src="https://github.com/user-attachments/assets/9a1be422-de16-4a8e-9626-9db98d152ac8">

<img width="590" alt="Screenshot 2024-08-26 at 11 16 56 AM" src="https://github.com/user-attachments/assets/8daec8fe-6904-4dbd-a752-b4ad4a8397f4">

<img width="595" alt="Screenshot 2024-08-26 at 11 19 52 AM" src="https://github.com/user-attachments/assets/205d4760-6fbb-497f-886e-a94c62747573">
