### PR TITLE
Fixes: #16973 - Resolve $user token to User.id for use in permissions based on custom fields

### DIFF
--- a/netbox/utilities/permissions.py
+++ b/netbox/utilities/permissions.py
@@ -97,7 +97,7 @@ def qs_filter_from_constraints(constraints, tokens=None):
         if type(value) is list:
             return list(map(lambda v: tokens.get(v, v), value))
         User = apps.get_model('users.User')
-        if value == CONSTRAINT_TOKEN_USER and type(tokens[CONSTRAINT_TOKEN_USER] is User):
+        if value == CONSTRAINT_TOKEN_USER and isinstance(tokens.get(CONSTRAINT_TOKEN_USER), User):
             return tokens[CONSTRAINT_TOKEN_USER].id
         return tokens.get(value, value)
 

--- a/netbox/utilities/permissions.py
+++ b/netbox/utilities/permissions.py
@@ -93,12 +93,14 @@ def qs_filter_from_constraints(constraints, tokens=None):
     if tokens is None:
         tokens = {}
 
+    User = apps.get_model('users.User')
+    for token, value in tokens.items():
+        if token == CONSTRAINT_TOKEN_USER and isinstance(value, User):
+            tokens[token] = value.id
+
     def _replace_tokens(value, tokens):
         if type(value) is list:
             return list(map(lambda v: tokens.get(v, v), value))
-        User = apps.get_model('users.User')
-        if value == CONSTRAINT_TOKEN_USER and isinstance(tokens.get(CONSTRAINT_TOKEN_USER), User):
-            return tokens[CONSTRAINT_TOKEN_USER].id
         return tokens.get(value, value)
 
     params = Q()

--- a/netbox/utilities/permissions.py
+++ b/netbox/utilities/permissions.py
@@ -1,6 +1,9 @@
 from django.conf import settings
+from django.apps import apps
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
+
+from users.constants import CONSTRAINT_TOKEN_USER
 
 __all__ = (
     'get_permission_for_model',
@@ -93,6 +96,9 @@ def qs_filter_from_constraints(constraints, tokens=None):
     def _replace_tokens(value, tokens):
         if type(value) is list:
             return list(map(lambda v: tokens.get(v, v), value))
+        User = apps.get_model('users.User')
+        if value == CONSTRAINT_TOKEN_USER and type(tokens[CONSTRAINT_TOKEN_USER] is User):
+            return tokens[CONSTRAINT_TOKEN_USER].id
         return tokens.get(value, value)
 
     params = Q()


### PR DESCRIPTION
### Fixes: #16973 - Resolve $user token to User.id for use in permissions based on custom fields

Adds special handling for `CONSTRAINT_TOKEN_USER` ("$user" token) when used in custom fields in object-based permissions.
