### PR TITLE
Closes #17007: Center SSO if display name is an empty string

### DIFF
--- a/netbox/templates/login.html
+++ b/netbox/templates/login.html
@@ -79,7 +79,7 @@
                 <div class="col">
                   <a href="{{ backend.url }}" class="btn w-100">
                     {% if backend.icon_name %}<i class="mdi mdi-{{ backend.icon_name }}"></i>
-                    {% elif backend.icon_img %}<img src="{{ backend.icon_img }}" height="24" class="me-2" />{% endif %}
+                    {% elif backend.icon_img %}<img src="{{ backend.icon_img }}" height="24" {% if backend.display_name %}class="me-2" {% endif %}/>{% endif %}
                     {{ backend.display_name }}
                   </a>
                 </div>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #17007

<!--
    Please include a summary of the proposed changes below.
-->
- SSO icon will now be centered if the backend display name is an empty string