### PR TITLE
Fixes #16825: Avoid NoReverseMatch exceptions when rendering related objects panel

### DIFF
--- a/netbox/templates/inc/panels/related_objects.html
+++ b/netbox/templates/inc/panels/related_objects.html
@@ -5,7 +5,8 @@
   <h5 class="card-header">{% trans "Related Objects" %}</h5>
   <ul class="list-group list-group-flush">
     {% for qs, filter_param in related_models %}
-      {% with viewname=qs.model|viewname:"list" %}
+      {% with viewname=qs.model|validated_viewname:"list" %}
+        {% if viewname is not None %}
         <a href="{% url viewname %}?{{ filter_param }}={{ object.pk }}" class="list-group-item list-group-item-action d-flex justify-content-between">
           {{ qs.model|meta:"verbose_name_plural"|bettertitle }}
           {% with count=qs.count %}
@@ -16,6 +17,7 @@
             {% endif %}
           {% endwith %}
         </a>
+        {% endif %}
       {% endwith %}
     {% endfor %}
   </ul>


### PR DESCRIPTION
### Fixes: #16825

When rendering the related objects panel, skip any objects for which a valid list view cannot be derived, avoiding a NoReverseMatch exception.

Thanks to @jsenecal for the fix!