### PR TITLE
Fixes #16756: Fix table pagination for custom script results

### DIFF
--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1258,6 +1258,9 @@ class ScriptResultView(TableMixin, generic.ObjectView):
 
         # If this is an HTMX request, return only the result HTML
         if htmx_partial(request):
+            if request.GET.get('log'):
+                # If log=True, render only the log table
+                return render(request, 'htmx/table.html', context)
             response = render(request, 'extras/htmx/script_result.html', context)
             if job.completed or not job.started:
                 response.status_code = 286

--- a/netbox/templates/extras/htmx/script_result.html
+++ b/netbox/templates/extras/htmx/script_result.html
@@ -41,7 +41,11 @@
     <div class="card">
       <div class="table-responsive" id="object_list">
         <h5 class="card-header">{% trans "Log" %}</h5>
-        {% include 'htmx/table.html' %}
+        <div class="htmx-container table-responsive"
+          hx-get="{% url 'extras:script_result' job_pk=job.pk %}?embedded=True&log=True"
+          hx-target="this"
+          hx-trigger="load" hx-select=".htmx-container" hx-swap="outerHTML"
+        ></div>
       </div>
     </div>
     {% endif %}

--- a/netbox/templates/extras/script_result.html
+++ b/netbox/templates/extras/script_result.html
@@ -90,14 +90,6 @@
     </div>
     {# /Object list tab #}
 
-    {# Filters tab #}
-    {% if filter_form %}
-      <div class="tab-pane show" id="filters-form" role="tabpanel" aria-labelledby="filters-form-tab">
-        {% include 'inc/filter_list.html' %}
-      </div>
-    {% endif %}
-    {# /Filters tab #}
-
 {% endblock content %}
 
 {% block modals %}


### PR DESCRIPTION
### Fixes: #16756

Submitting this as an alternate to PR #17129.

- Provide a hook in `ScriptResultView` to return only the rendered table
- Load the log as an HTMX table (though not using the `{% htmx_table %}` tag due to a limitation concerning view name resolution)
- Cleanup: Remove obsolete code from `script_result.html`