### PR TITLE
Fixes #17279: Do not regenerate key when updating a token via REST API

### DIFF
--- a/netbox/users/api/serializers_/tokens.py
+++ b/netbox/users/api/serializers_/tokens.py
@@ -40,7 +40,7 @@ class TokenSerializer(ValidatedModelSerializer):
         brief_fields = ('id', 'url', 'display', 'key', 'write_enabled', 'description')
 
     def to_internal_value(self, data):
-        if 'key' not in data:
+        if not getattr(self.instance, 'key', None) and 'key' not in data:
             data['key'] = Token.generate_key()
         return super().to_internal_value(data)
 


### PR DESCRIPTION
### Fixes: #17279

Do not overwrite the key of an existing Token when processing a `PATCH` or `PUT` REST API request.