### PR TITLE
17289 enforce minimum password strength

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -76,7 +76,7 @@ AUTH_PASSWORD_VALIDATORS = getattr(configuration, 'AUTH_PASSWORD_VALIDATORS', [
         "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
     },
     {
-        "NAME": "utilities.password_validation.NumericAlphaPasswordValidator",
+        "NAME": "utilities.password_validation.AlphanumericPasswordValidator",
     },
 ])
 BASE_PATH = trailing_slash(getattr(configuration, 'BASE_PATH', ''))

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -64,9 +64,6 @@ ALLOW_TOKEN_RETRIEVAL = getattr(configuration, 'ALLOW_TOKEN_RETRIEVAL', True)
 ALLOWED_HOSTS = getattr(configuration, 'ALLOWED_HOSTS')  # Required
 AUTH_PASSWORD_VALIDATORS = getattr(configuration, 'AUTH_PASSWORD_VALIDATORS', [
     {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
-    },
-    {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
         "OPTIONS": {
             "min_length": 12,

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -21,7 +21,6 @@ from netbox.plugins import PluginConfig
 from utilities.release import load_release_data
 from utilities.string import trailing_slash
 
-
 #
 # Environment setup
 #
@@ -63,7 +62,23 @@ for parameter in ('ALLOWED_HOSTS', 'DATABASE', 'SECRET_KEY', 'REDIS'):
 ADMINS = getattr(configuration, 'ADMINS', [])
 ALLOW_TOKEN_RETRIEVAL = getattr(configuration, 'ALLOW_TOKEN_RETRIEVAL', True)
 ALLOWED_HOSTS = getattr(configuration, 'ALLOWED_HOSTS')  # Required
-AUTH_PASSWORD_VALIDATORS = getattr(configuration, 'AUTH_PASSWORD_VALIDATORS', [])
+AUTH_PASSWORD_VALIDATORS = getattr(configuration, 'AUTH_PASSWORD_VALIDATORS', [
+    {
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        "OPTIONS": {
+            "min_length": 12,
+        },
+    },
+    {
+        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+    },
+    {
+        "NAME": "utilities.password_validation.NumericAlphaPasswordValidator",
+    },
+])
 BASE_PATH = trailing_slash(getattr(configuration, 'BASE_PATH', ''))
 CHANGELOG_SKIP_EMPTY_CHANGES = getattr(configuration, 'CHANGELOG_SKIP_EMPTY_CHANGES', True)
 CENSUS_REPORTING_ENABLED = getattr(configuration, 'CENSUS_REPORTING_ENABLED', True)

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -73,9 +73,6 @@ AUTH_PASSWORD_VALIDATORS = getattr(configuration, 'AUTH_PASSWORD_VALIDATORS', [
         },
     },
     {
-        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
-    },
-    {
         "NAME": "utilities.password_validation.AlphanumericPasswordValidator",
     },
 ])

--- a/netbox/users/forms/model_forms.py
+++ b/netbox/users/forms/model_forms.py
@@ -2,7 +2,7 @@ from django import forms
 from django.conf import settings
 from django.contrib.auth import password_validation
 from django.contrib.postgres.forms import SimpleArrayField
-from django.core.exceptions import FieldError, ValidationError
+from django.core.exceptions import FieldError
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
@@ -221,20 +221,15 @@ class UserForm(forms.ModelForm):
 
         return instance
 
-    def _post_clean(self):
-        super()._post_clean()
-        # Validate the password after self.instance is updated with form data
-        if self.cleaned_data['password']:
-            try:
-                password_validation.validate_password(self.cleaned_data['password'], self.instance)
-            except ValidationError as error:
-                self.add_error('password', error)
-
     def clean(self):
 
         # Check that password confirmation matches if password is set
         if self.cleaned_data['password'] and self.cleaned_data['password'] != self.cleaned_data['confirm_password']:
             raise forms.ValidationError(_("Passwords do not match! Please check your input and try again."))
+
+        # Enforce password validation rules (if configured)
+        if self.cleaned_data['password']:
+            password_validation.validate_password(self.cleaned_data['password'], self.instance)
 
 
 class GroupForm(forms.ModelForm):

--- a/netbox/users/tests/test_api.py
+++ b/netbox/users/tests/test_api.py
@@ -38,26 +38,26 @@ class UserTest(APIViewTestCases.APIViewTestCase):
         permissions[2].object_types.add(ObjectType.objects.get_by_natural_key('dcim', 'rack'))
 
         users = (
-            User(username='User1', password='password1'),
-            User(username='User2', password='password2'),
-            User(username='User3', password='password3'),
+            User(username='User1', password='FooBarFooBar1'),
+            User(username='User2', password='FooBarFooBar2'),
+            User(username='User3', password='FooBarFooBar3'),
         )
         User.objects.bulk_create(users)
 
         cls.create_data = [
             {
                 'username': 'User4',
-                'password': 'password4',
+                'password': 'FooBarFooBar4',
                 'permissions': [permissions[0].pk],
             },
             {
                 'username': 'User5',
-                'password': 'password5',
+                'password': 'FooBarFooBar5',
                 'permissions': [permissions[1].pk],
             },
             {
                 'username': 'User6',
-                'password': 'password6',
+                'password': 'FooBarFooBar6',
                 'permissions': [permissions[2].pk],
             },
         ]
@@ -77,12 +77,12 @@ class UserTest(APIViewTestCases.APIViewTestCase):
 
         user_credentials = {
             'username': 'newuser',
-            'password': 'abc123',
+            'password': 'abc123FOO',
         }
         user = User.objects.create_user(**user_credentials)
 
         data = {
-            'password': 'newpassword'
+            'password': 'FooBarFooBar1'
         }
         url = reverse('users-api:user-detail', kwargs={'pk': user.id})
         response = self.client.patch(url, data, format='json', **self.header)
@@ -90,10 +90,23 @@ class UserTest(APIViewTestCases.APIViewTestCase):
         user.refresh_from_db()
         self.assertTrue(user.check_password(data['password']))
 
-    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-        'OPTIONS': {'min_length': 8}
-    }])
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[
+        {
+            "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
+        },
+        {
+            "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+            "OPTIONS": {
+                "min_length": 8,
+            },
+        },
+        {
+            "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
+        },
+        {
+            "NAME": "utilities.password_validation.NumericAlphaPasswordValidator",
+        },
+    ])
     def test_password_validation_enforced(self):
         """
         Test that any configured password validation rules (AUTH_PASSWORD_VALIDATORS) are enforced.
@@ -102,7 +115,7 @@ class UserTest(APIViewTestCases.APIViewTestCase):
 
         data = {
             'username': 'new_user',
-            'password': 'foo',
+            'password': 'f1A',
         }
         url = reverse('users-api:user-list')
 
@@ -111,9 +124,29 @@ class UserTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(response.status_code, 400)
 
         # Password long enough
-        data['password'] = 'foobar123'
+        data['password'] = 'FooBar123'
         response = self.client.post(url, data, format='json', **self.header)
         self.assertEqual(response.status_code, 201)
+
+        # Password no number
+        data['password'] = 'foobarFoo'
+        response = self.client.post(url, data, format='json', **self.header)
+        self.assertEqual(response.status_code, 400)
+
+        # Password no letter
+        data['password'] = '123456789012'
+        response = self.client.post(url, data, format='json', **self.header)
+        self.assertEqual(response.status_code, 400)
+
+        # Password no uppercase
+        data['password'] = 'foobarfoo1'
+        response = self.client.post(url, data, format='json', **self.header)
+        self.assertEqual(response.status_code, 400)
+
+        # Password no lowercase
+        data['password'] = 'FOOBARFOO1'
+        response = self.client.post(url, data, format='json', **self.header)
+        self.assertEqual(response.status_code, 400)
 
 
 class GroupTest(APIViewTestCases.APIViewTestCase):

--- a/netbox/users/tests/test_api.py
+++ b/netbox/users/tests/test_api.py
@@ -90,23 +90,10 @@ class UserTest(APIViewTestCases.APIViewTestCase):
         user.refresh_from_db()
         self.assertTrue(user.check_password(data['password']))
 
-    @override_settings(AUTH_PASSWORD_VALIDATORS=[
-        {
-            "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
-        },
-        {
-            "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
-            "OPTIONS": {
-                "min_length": 8,
-            },
-        },
-        {
-            "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
-        },
-        {
-            "NAME": "utilities.password_validation.NumericAlphaPasswordValidator",
-        },
-    ])
+    @override_settings(AUTH_PASSWORD_VALIDATORS=[{
+        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
+        'OPTIONS': {'min_length': 8}
+    }])
     def test_password_validation_enforced(self):
         """
         Test that any configured password validation rules (AUTH_PASSWORD_VALIDATORS) are enforced.

--- a/netbox/users/tests/test_views.py
+++ b/netbox/users/tests/test_views.py
@@ -60,23 +60,6 @@ class UserTestCase(
             'last_name': 'newlastname',
         }
 
-    @override_settings(AUTH_PASSWORD_VALIDATORS=[
-        {
-            "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
-        },
-        {
-            "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
-            "OPTIONS": {
-                "min_length": 8,
-            },
-        },
-        {
-            "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
-        },
-        {
-            "NAME": "utilities.password_validation.NumericAlphaPasswordValidator",
-        },
-    ])
     def test_password_validation_enforced(self):
         """
         Test that any configured password validation rules (AUTH_PASSWORD_VALIDATORS) are enforced.
@@ -97,8 +80,8 @@ class UserTestCase(
         self.assertHttpStatus(response, 200)
 
         # Password long enough
-        data['password'] = 'fooBar12'
-        data['confirm_password'] = 'fooBar12'
+        data['password'] = 'fooBarFoo123'
+        data['confirm_password'] = 'fooBarFoo123'
         self.assertHttpStatus(self.client.post(**request), 302)
 
         # Password no number

--- a/netbox/users/tests/test_views.py
+++ b/netbox/users/tests/test_views.py
@@ -38,8 +38,8 @@ class UserTestCase(
             'first_name': 'firstx',
             'last_name': 'lastx',
             'email': 'userx@foo.com',
-            'password': 'pass1xxx',
-            'confirm_password': 'pass1xxx',
+            'password': 'pass1xxxABCD',
+            'confirm_password': 'pass1xxxABCD',
         }
 
         cls.csv_data = (
@@ -84,8 +84,8 @@ class UserTestCase(
         self.assertHttpStatus(response, 200)
 
         # Password long enough
-        data['password'] = 'foobar123'
-        data['confirm_password'] = 'foobar123'
+        data['password'] = 'foobar123AD'
+        data['confirm_password'] = 'foobar123AD'
         self.assertHttpStatus(self.client.post(**request), 302)
 
 

--- a/netbox/utilities/password_validation.py
+++ b/netbox/utilities/password_validation.py
@@ -10,7 +10,7 @@ class NumericAlphaPasswordValidator:
     def validate(self, password, user=None):
         if not any(char.isdigit() for char in password):
             raise ValidationError(
-                _("Password should have at least one numeral"),
+                _("Password must have at least one numeral."),
             )
 
         if not any(char.isupper() for char in password):

--- a/netbox/utilities/password_validation.py
+++ b/netbox/utilities/password_validation.py
@@ -1,0 +1,27 @@
+from django.core.exceptions import ValidationError
+from django.utils.translation import gettext as _
+
+
+class NumericAlphaPasswordValidator:
+    """
+    Validate that the password has at least one numeral, one uppercase letter and one lowercase letter.
+    """
+
+    def validate(self, password, user=None):
+        if not any(char.isdigit() for char in password):
+            raise ValidationError(
+                _("Password should have at least one numeral"),
+            )
+
+        if not any(char.isupper() for char in password):
+            raise ValidationError(
+                _("Password should have at least one uppercase letter"),
+            )
+
+        if not any(char.islower() for char in password):
+            raise ValidationError(
+                _("Password should have at least one lowercase letter"),
+            )
+
+    def get_help_text(self):
+        return _("Your password must contain at least one numeral, one uppercase letter and one lowercase letter.")

--- a/netbox/utilities/password_validation.py
+++ b/netbox/utilities/password_validation.py
@@ -20,7 +20,7 @@ class NumericAlphaPasswordValidator:
 
         if not any(char.islower() for char in password):
             raise ValidationError(
-                _("Password should have at least one lowercase letter"),
+                _("Password must have at least one lowercase letter."),
             )
 
     def get_help_text(self):

--- a/netbox/utilities/password_validation.py
+++ b/netbox/utilities/password_validation.py
@@ -2,7 +2,7 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext as _
 
 
-class NumericAlphaPasswordValidator:
+class AlphanumericPasswordValidator:
     """
     Validate that the password has at least one numeral, one uppercase letter and one lowercase letter.
     """

--- a/netbox/utilities/password_validation.py
+++ b/netbox/utilities/password_validation.py
@@ -15,7 +15,7 @@ class NumericAlphaPasswordValidator:
 
         if not any(char.isupper() for char in password):
             raise ValidationError(
-                _("Password should have at least one uppercase letter"),
+                _("Password must have at least one uppercase letter."),
             )
 
         if not any(char.islower() for char in password):


### PR DESCRIPTION
### Fixes: #17289 

Enforce default minimum password strength:
* 12 characters minimum
* similarities to user attributes (first name, last name, email)
* common password check
* must contain one number, one upper-case letter and one lower-case letter.

![Change Password | NetBox 2024-08-29 08-58-46](https://github.com/user-attachments/assets/f027edd3-e521-45fc-96ff-01b8a90a026b)
