### PR TITLE
#10500: Cleanup

### DIFF
--- a/docs/models/dcim/modulebay.md
+++ b/docs/models/dcim/modulebay.md
@@ -16,6 +16,8 @@ The device to which this module bay belongs.
 
 ### Module
 
+!!! info "This feature was introduced in NetBox v4.1."
+
 The module to which this bay belongs (optional).
 
 ### Name

--- a/netbox/dcim/api/serializers_/device_components.py
+++ b/netbox/dcim/api/serializers_/device_components.py
@@ -299,7 +299,7 @@ class ModuleBaySerializer(NetBoxModelSerializer):
     device = DeviceSerializer(nested=True)
     module = ModuleSerializer(
         nested=True,
-        fields=('id', 'url', 'display', 'module_bay'),
+        fields=('id', 'url', 'display'),
         required=False,
         allow_null=True,
         default=None

--- a/netbox/dcim/api/serializers_/nested.py
+++ b/netbox/dcim/api/serializers_/nested.py
@@ -91,8 +91,7 @@ class ModuleBayNestedModuleSerializer(WritableNestedSerializer):
 
 
 class NestedModuleBaySerializer(WritableNestedSerializer):
-    installed_module = ModuleBayNestedModuleSerializer(required=False, allow_null=True)
 
     class Meta:
         model = models.ModuleBay
-        fields = ['id', 'url', 'display_url', 'display', 'installed_module', 'name']
+        fields = ['id', 'url', 'display_url', 'display', 'name']

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -903,12 +903,10 @@ class ModuleBayTable(ModularDeviceComponentTable):
 
 
 class DeviceModuleBayTable(ModuleBayTable):
-    name = tables.TemplateColumn(
+    name = columns.MPTTColumn(
         verbose_name=_('Name'),
-        template_code='<a href="{{ record.get_absolute_url }}" style="padding-left: {{ record.level }}0px">'
-                      '{{ value }}</a>',
-        order_by=Accessor('_name'),
-        attrs={'td': {'class': 'text-nowrap'}}
+        linkify=True,
+        order_by=Accessor('_name')
     )
     actions = columns.ActionsColumn(
         extra_buttons=MODULEBAY_BUTTONS

--- a/netbox/templates/dcim/module.html
+++ b/netbox/templates/dcim/module.html
@@ -19,28 +19,28 @@
       </button>
       <ul class="dropdown-menu" aria-labeled-by="add-components">
         {% if perms.dcim.add_consoleport %}
-          <li><a class="dropdown-item" href="{% url 'dcim:consoleport_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={% url 'dcim:device_consoleports' pk=object.device.pk %}">{% trans "Console Ports" %}</a></li>
+          <li><a class="dropdown-item" href="{% url 'dcim:consoleport_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={{ object.get_absolute_url }}">{% trans "Console Ports" %}</a></li>
         {% endif %}
         {% if perms.dcim.add_consoleserverport %}
-          <li><a class="dropdown-item" href="{% url 'dcim:consoleserverport_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={% url 'dcim:device_consoleserverports' pk=object.device.pk %}">{% trans "Console Server Ports" %}</a></li>
+          <li><a class="dropdown-item" href="{% url 'dcim:consoleserverport_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={{ object.get_absolute_url }}">{% trans "Console Server Ports" %}</a></li>
         {% endif %}
         {% if perms.dcim.add_powerport %}
-          <li><a class="dropdown-item" href="{% url 'dcim:powerport_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={% url 'dcim:device_powerports' pk=object.device.pk %}">{% trans "Power Ports" %}</a></li>
+          <li><a class="dropdown-item" href="{% url 'dcim:powerport_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={{ object.get_absolute_url }}">{% trans "Power Ports" %}</a></li>
         {% endif %}
         {% if perms.dcim.add_poweroutlet %}
-          <li><a class="dropdown-item" href="{% url 'dcim:poweroutlet_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={% url 'dcim:device_poweroutlets' pk=object.device.pk %}">{% trans "Power Outlets" %}</a></li>
+          <li><a class="dropdown-item" href="{% url 'dcim:poweroutlet_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={{ object.get_absolute_url }}">{% trans "Power Outlets" %}</a></li>
         {% endif %}
         {% if perms.dcim.add_interface %}
-          <li><a class="dropdown-item" href="{% url 'dcim:interface_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={% url 'dcim:device_interfaces' pk=object.device.pk %}">{% trans "Interfaces" %}</a></li>
+          <li><a class="dropdown-item" href="{% url 'dcim:interface_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={{ object.get_absolute_url }}">{% trans "Interfaces" %}</a></li>
         {% endif %}
         {% if perms.dcim.add_frontport %}
-          <li><a class="dropdown-item" href="{% url 'dcim:frontport_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={% url 'dcim:device_frontports' pk=object.device.pk %}">{% trans "Front Ports" %}</a></li>
+          <li><a class="dropdown-item" href="{% url 'dcim:frontport_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={{ object.get_absolute_url }}">{% trans "Front Ports" %}</a></li>
         {% endif %}
         {% if perms.dcim.add_rearport %}
-          <li><a class="dropdown-item" href="{% url 'dcim:rearport_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={% url 'dcim:device_rearports' pk=object.device.pk %}">{% trans "Rear Ports" %}</a></li>
+          <li><a class="dropdown-item" href="{% url 'dcim:rearport_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={{ object.get_absolute_url }}">{% trans "Rear Ports" %}</a></li>
         {% endif %}
         {% if perms.dcim.add_modulebay %}
-          <li><a class="dropdown-item" href="{% url 'dcim:modulebay_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={% url 'dcim:device_modulebays' pk=object.pk %}">{% trans "Module Bays" %}</a></li>
+          <li><a class="dropdown-item" href="{% url 'dcim:modulebay_add' %}?device={{ object.device.pk }}&module={{ object.pk }}&return_url={{ object.get_absolute_url }}">{% trans "Module Bays" %}</a></li>
         {% endif %}
       </ul>
     </div>


### PR DESCRIPTION
- `DeviceModuleBayTable` should use an `MPTTColumn` for the module bay names
- Fix return URLs for "add component" links under module view
- Simplify REST API representation of module bays