### PR TITLE
#11969: Cleanup

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -129,12 +129,12 @@ class RackElevationDetailRenderChoices(ChoiceSet):
 
 class RackAirflowChoices(ChoiceSet):
 
-    AIRFLOW_FRONT_TO_REAR = 'front-to-rear'
-    AIRFLOW_REAR_TO_FRONT = 'rear-to-front'
+    FRONT_TO_REAR = 'front-to-rear'
+    REAR_TO_FRONT = 'rear-to-front'
 
     CHOICES = (
-        (AIRFLOW_FRONT_TO_REAR, _('Front to rear')),
-        (AIRFLOW_REAR_TO_FRONT, _('Rear to front')),
+        (FRONT_TO_REAR, _('Front to rear')),
+        (REAR_TO_FRONT, _('Rear to front')),
     )
 
 
@@ -237,20 +237,20 @@ class ModuleStatusChoices(ChoiceSet):
 
 class ModuleAirflowChoices(ChoiceSet):
 
-    AIRFLOW_FRONT_TO_REAR = 'front-to-rear'
-    AIRFLOW_REAR_TO_FRONT = 'rear-to-front'
-    AIRFLOW_LEFT_TO_RIGHT = 'left-to-right'
-    AIRFLOW_RIGHT_TO_LEFT = 'right-to-left'
-    AIRFLOW_SIDE_TO_REAR = 'side-to-rear'
-    AIRFLOW_PASSIVE = 'passive'
+    FRONT_TO_REAR = 'front-to-rear'
+    REAR_TO_FRONT = 'rear-to-front'
+    LEFT_TO_RIGHT = 'left-to-right'
+    RIGHT_TO_LEFT = 'right-to-left'
+    SIDE_TO_REAR = 'side-to-rear'
+    PASSIVE = 'passive'
 
     CHOICES = (
-        (AIRFLOW_FRONT_TO_REAR, _('Front to rear')),
-        (AIRFLOW_REAR_TO_FRONT, _('Rear to front')),
-        (AIRFLOW_LEFT_TO_RIGHT, _('Left to right')),
-        (AIRFLOW_RIGHT_TO_LEFT, _('Right to left')),
-        (AIRFLOW_SIDE_TO_REAR, _('Side to rear')),
-        (AIRFLOW_PASSIVE, _('Passive')),
+        (FRONT_TO_REAR, _('Front to rear')),
+        (REAR_TO_FRONT, _('Rear to front')),
+        (LEFT_TO_RIGHT, _('Left to right')),
+        (RIGHT_TO_LEFT, _('Right to left')),
+        (SIDE_TO_REAR, _('Side to rear')),
+        (PASSIVE, _('Passive')),
     )
 
 

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -500,7 +500,8 @@ class RackTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
                 weight=10,
                 max_weight=1000,
                 weight_unit=WeightUnitChoices.UNIT_POUND,
-                description='foobar1'
+                description='foobar1',
+                airflow=RackAirflowChoices.FRONT_TO_REAR
             ),
             RackType(
                 manufacturer=manufacturers[1],
@@ -518,7 +519,8 @@ class RackTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
                 weight=20,
                 max_weight=2000,
                 weight_unit=WeightUnitChoices.UNIT_POUND,
-                description='foobar2'
+                description='foobar2',
+                airflow=RackAirflowChoices.REAR_TO_FRONT
             ),
             RackType(
                 manufacturer=manufacturers[2],
@@ -614,6 +616,10 @@ class RackTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
     def test_weight_unit(self):
         params = {'weight_unit': WeightUnitChoices.UNIT_POUND}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_airflow(self):
+        params = {'airflow': RackAirflowChoices.REAR_TO_FRONT}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class RackTestCase(TestCase, ChangeLoggedFilterSetTests):
@@ -745,7 +751,8 @@ class RackTestCase(TestCase, ChangeLoggedFilterSetTests):
                 weight=10,
                 max_weight=1000,
                 weight_unit=WeightUnitChoices.UNIT_POUND,
-                description='foobar1'
+                description='foobar1',
+                airflow=RackAirflowChoices.FRONT_TO_REAR
             ),
             Rack(
                 name='Rack 2',
@@ -767,7 +774,8 @@ class RackTestCase(TestCase, ChangeLoggedFilterSetTests):
                 weight=20,
                 max_weight=2000,
                 weight_unit=WeightUnitChoices.UNIT_POUND,
-                description='foobar2'
+                description='foobar2',
+                airflow=RackAirflowChoices.REAR_TO_FRONT
             ),
             Rack(
                 name='Rack 3',
@@ -957,6 +965,10 @@ class RackTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'rack_type': [rack_types[0].slug, rack_types[1].slug]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_airflow(self):
+        params = {'airflow': RackAirflowChoices.FRONT_TO_REAR}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class RackReservationTestCase(TestCase, ChangeLoggedFilterSetTests):
@@ -1380,7 +1392,8 @@ class ModuleTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
                 part_number='Part Number 1',
                 weight=10,
                 weight_unit=WeightUnitChoices.UNIT_POUND,
-                description='foobar1'
+                description='foobar1',
+                airflow=ModuleAirflowChoices.FRONT_TO_REAR
             ),
             ModuleType(
                 manufacturer=manufacturers[1],
@@ -1388,7 +1401,8 @@ class ModuleTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
                 part_number='Part Number 2',
                 weight=20,
                 weight_unit=WeightUnitChoices.UNIT_POUND,
-                description='foobar2'
+                description='foobar2',
+                airflow=ModuleAirflowChoices.REAR_TO_FRONT
             ),
             ModuleType(
                 manufacturer=manufacturers[2],
@@ -1498,6 +1512,10 @@ class ModuleTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
     def test_weight_unit(self):
         params = {'weight_unit': WeightUnitChoices.UNIT_POUND}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_airflow(self):
+        params = {'airflow': RackAirflowChoices.FRONT_TO_REAR}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
 class ConsolePortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):


### PR DESCRIPTION
- Use shorter names for airflow choice constants
- Add filterset tests for `airflow` fields