### PR TITLE
runscript: use the previously defined "user"

### DIFF
--- a/netbox/extras/management/commands/runscript.py
+++ b/netbox/extras/management/commands/runscript.py
@@ -125,7 +125,7 @@ class Command(BaseCommand):
         job = Job.objects.create(
             object=module,
             name=script.class_name,
-            user=User.objects.filter(is_superuser=True).order_by('pk')[0],
+            user=user,
             job_id=uuid.uuid4()
         )
 


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
Oops, only seeing now that this might be closed automatically as the linked ticket is not triaged yet.

### Fixes: #17321

<!--
    Please include a summary of the proposed changes below.
-->
There is already a logic set earlier in the code to define "user" if --user is passed as parameter, and default to the user with the lowest ID no none is provided.
This patch uses this "user" to run the job instead of always applying the default.
