### PR TITLE
12826 make RackType.form_factor required

### DIFF
--- a/netbox/dcim/migrations/0188_racktype.py
+++ b/netbox/dcim/migrations/0188_racktype.py
@@ -39,7 +39,7 @@ class Migration(migrations.Migration):
                 )),
                 ('model', models.CharField(max_length=100)),
                 ('slug', models.SlugField(max_length=100, unique=True)),
-                ('form_factor', models.CharField(blank=True, max_length=50)),
+                ('form_factor', models.CharField(max_length=50)),
                 ('width', models.PositiveSmallIntegerField(default=19)),
                 ('u_height', models.PositiveSmallIntegerField(
                     default=42,

--- a/netbox/dcim/models/racks.py
+++ b/netbox/dcim/models/racks.py
@@ -41,12 +41,6 @@ class RackBase(WeightMixin, PrimaryModel):
     """
     Base class for RackType & Rack. Holds
     """
-    form_factor = models.CharField(
-        choices=RackFormFactorChoices,
-        max_length=50,
-        blank=True,
-        verbose_name=_('form factor')
-    )
     width = models.PositiveSmallIntegerField(
         choices=RackWidthChoices,
         default=RackWidthChoices.WIDTH_19IN,
@@ -131,6 +125,11 @@ class RackType(RackBase):
     Devices are housed within Racks. Each rack has a defined height measured in rack units, and a front and rear face.
     Each Rack is assigned to a Site and (optionally) a Location.
     """
+    form_factor = models.CharField(
+        choices=RackFormFactorChoices,
+        max_length=50,
+        verbose_name=_('form factor')
+    )
     manufacturer = models.ForeignKey(
         to='dcim.Manufacturer',
         on_delete=models.PROTECT,
@@ -252,6 +251,12 @@ class Rack(ContactsMixin, ImageAttachmentsMixin, RackBase):
         'outer_unit', 'mounting_depth', 'weight', 'weight_unit', 'max_weight',
     )
 
+    form_factor = models.CharField(
+        choices=RackFormFactorChoices,
+        max_length=50,
+        blank=True,
+        verbose_name=_('form factor')
+    )
     rack_type = models.ForeignKey(
         to='dcim.RackType',
         on_delete=models.PROTECT,

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -287,9 +287,9 @@ class RackTypeTest(APIViewTestCases.APIViewTestCase):
         Manufacturer.objects.bulk_create(manufacturers)
 
         rack_types = (
-            RackType(manufacturer=manufacturers[0], model='Rack Type 1', slug='rack-type-1'),
-            RackType(manufacturer=manufacturers[0], model='Rack Type 2', slug='rack-type-2'),
-            RackType(manufacturer=manufacturers[0], model='Rack Type 3', slug='rack-type-3'),
+            RackType(manufacturer=manufacturers[0], model='Rack Type 1', slug='rack-type-1', form_factor=RackFormFactorChoices.TYPE_CABINET,),
+            RackType(manufacturer=manufacturers[0], model='Rack Type 2', slug='rack-type-2', form_factor=RackFormFactorChoices.TYPE_CABINET,),
+            RackType(manufacturer=manufacturers[0], model='Rack Type 3', slug='rack-type-3', form_factor=RackFormFactorChoices.TYPE_CABINET,),
         )
         RackType.objects.bulk_create(rack_types)
 
@@ -298,16 +298,19 @@ class RackTypeTest(APIViewTestCases.APIViewTestCase):
                 'manufacturer': manufacturers[1].pk,
                 'model': 'Rack Type 4',
                 'slug': 'rack-type-4',
+                'form_factor': RackFormFactorChoices.TYPE_CABINET,
             },
             {
                 'manufacturer': manufacturers[1].pk,
                 'model': 'Rack Type 5',
                 'slug': 'rack-type-5',
+                'form_factor': RackFormFactorChoices.TYPE_CABINET,
             },
             {
                 'manufacturer': manufacturers[1].pk,
                 'model': 'Rack Type 6',
                 'slug': 'rack-type-6',
+                'form_factor': RackFormFactorChoices.TYPE_CABINET,
             },
         ]
 

--- a/netbox/dcim/tests/test_views.py
+++ b/netbox/dcim/tests/test_views.py
@@ -346,9 +346,9 @@ class RackTypeTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         Manufacturer.objects.bulk_create(manufacturers)
 
         rack_types = (
-            RackType(manufacturer=manufacturers[0], model='RackType 1', slug='rack-type-1',),
-            RackType(manufacturer=manufacturers[0], model='RackType 2', slug='rack-type-2',),
-            RackType(manufacturer=manufacturers[0], model='RackType 3', slug='rack-type-3',),
+            RackType(manufacturer=manufacturers[0], model='RackType 1', slug='rack-type-1', form_factor=RackFormFactorChoices.TYPE_CABINET,),
+            RackType(manufacturer=manufacturers[0], model='RackType 2', slug='rack-type-2', form_factor=RackFormFactorChoices.TYPE_CABINET,),
+            RackType(manufacturer=manufacturers[0], model='RackType 3', slug='rack-type-3', form_factor=RackFormFactorChoices.TYPE_CABINET,),
         )
         RackType.objects.bulk_create(rack_types)
 
@@ -369,6 +369,7 @@ class RackTypeTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             'weight': 100,
             'max_weight': 2000,
             'weight_unit': WeightUnitChoices.UNIT_POUND,
+            'form_factor': RackFormFactorChoices.TYPE_CABINET,
             'comments': 'Some comments',
             'tags': [t.pk for t in tags],
         }


### PR DESCRIPTION
### Fixes: #12826 

Change RackType.form_factor to be unique.  Had to move the field out of RackBase, I looked at changing the field options in __init on RackType but that doesn't effect migrations and wanted to make it a database constraint. 