### PR TITLE
Closes #17288: Limit the number of aliases within a GraphQL API requests to 10

### DIFF
--- a/docs/configuration/graphql-api.md
+++ b/docs/configuration/graphql-api.md
@@ -1,0 +1,17 @@
+# GraphQL API Parameters
+
+## GRAPHQL_ENABLED
+
+!!! tip "Dynamic Configuration Parameter"
+
+Default: True
+
+Setting this to False will disable the GraphQL API.
+
+---
+
+## GRAPHQL_MAX_ALIASES
+
+Default: 10
+
+The maximum number of queries that a GraphQL API request may contain.

--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -122,16 +122,6 @@ The maximum amount (in bytes) of uploaded data that will be held in memory befor
 
 ---
 
-## GRAPHQL_ENABLED
-
-!!! tip "Dynamic Configuration Parameter"
-
-Default: True
-
-Setting this to False will disable the GraphQL API.
-
----
-
 ## JOB_RETENTION
 
 !!! tip "Dynamic Configuration Parameter"

--- a/docs/integrations/graphql-api.md
+++ b/docs/integrations/graphql-api.md
@@ -112,4 +112,4 @@ Authorization: Token $TOKEN
 
 ## Disabling the GraphQL API
 
-If not needed, the GraphQL API can be disabled by setting the [`GRAPHQL_ENABLED`](../configuration/miscellaneous.md#graphql_enabled) configuration parameter to False and restarting NetBox.
+If not needed, the GraphQL API can be disabled by setting the [`GRAPHQL_ENABLED`](../configuration/graphql-api.md#graphql_enabled) configuration parameter to False and restarting NetBox.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -109,6 +109,7 @@ nav:
         - Required Parameters: 'configuration/required-parameters.md'
         - System: 'configuration/system.md'
         - Security: 'configuration/security.md'
+        - GraphQL API: 'configuration/graphql-api.md'
         - Remote Authentication: 'configuration/remote-authentication.md'
         - Data & Validation: 'configuration/data-validation.md'
         - Default Values: 'configuration/default-values.md'

--- a/netbox/netbox/graphql/schema.py
+++ b/netbox/netbox/graphql/schema.py
@@ -1,4 +1,5 @@
 import strawberry
+from django.conf import settings
 from strawberry_django.optimizer import DjangoOptimizerExtension
 from strawberry.extensions import MaxAliasesLimiter
 from strawberry.schema.config import StrawberryConfig
@@ -38,6 +39,6 @@ schema = strawberry.Schema(
     config=StrawberryConfig(auto_camel_case=False),
     extensions=[
         DjangoOptimizerExtension,
-        MaxAliasesLimiter(max_alias_count=10),
+        MaxAliasesLimiter(max_alias_count=settings.GRAPHQL_MAX_ALIASES),
     ]
 )

--- a/netbox/netbox/graphql/schema.py
+++ b/netbox/netbox/graphql/schema.py
@@ -1,5 +1,6 @@
 import strawberry
 from strawberry_django.optimizer import DjangoOptimizerExtension
+from strawberry.extensions import MaxAliasesLimiter
 from strawberry.schema.config import StrawberryConfig
 
 from circuits.graphql.schema import CircuitsQuery
@@ -37,5 +38,6 @@ schema = strawberry.Schema(
     config=StrawberryConfig(auto_camel_case=False),
     extensions=[
         DjangoOptimizerExtension,
+        MaxAliasesLimiter(max_alias_count=10),
     ]
 )

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -110,6 +110,7 @@ EVENTS_PIPELINE = getattr(configuration, 'EVENTS_PIPELINE', (
 EXEMPT_VIEW_PERMISSIONS = getattr(configuration, 'EXEMPT_VIEW_PERMISSIONS', [])
 FIELD_CHOICES = getattr(configuration, 'FIELD_CHOICES', {})
 FILE_UPLOAD_MAX_MEMORY_SIZE = getattr(configuration, 'FILE_UPLOAD_MAX_MEMORY_SIZE', 2621440)
+GRAPHQL_MAX_ALIASES = getattr(configuration, 'GRAPHQL_MAX_ALIASES', 10)
 HTTP_PROXIES = getattr(configuration, 'HTTP_PROXIES', None)
 INTERNAL_IPS = getattr(configuration, 'INTERNAL_IPS', ('127.0.0.1', '::1'))
 ISOLATED_DEPLOYMENT = getattr(configuration, 'ISOLATED_DEPLOYMENT', False)


### PR DESCRIPTION
### Closes: #17288

Limit a GraphQL API request to a maximum of 10 aliases.
