### PR TITLE
Hide exception in ObjectCountsWidget for models without a `xxx_list` view function

### DIFF
--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -185,11 +185,11 @@ class ObjectCountsWidget(DashboardWidget):
             if request.user.has_perm(permission):
                 try:
                     url = reverse(get_viewname(model, 'list'))
-                except Exception:
-                    url = '#'
+                except NoReverseMatch:
+                    url = None
                 qs = model.objects.restrict(request.user, 'view')
                 # Apply any specified filters
-                if filters := self.config.get('filters'):
+                if url and (filters := self.config.get('filters')):
                     params = dict_to_querydict(filters)
                     filterset = getattr(resolve(url).func.view_class, 'filterset', None)
                     qs = filterset(params, qs).qs

--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -183,7 +183,10 @@ class ObjectCountsWidget(DashboardWidget):
         for model in get_models_from_content_types(self.config['models']):
             permission = get_permission_for_model(model, 'view')
             if request.user.has_perm(permission):
-                url = reverse(get_viewname(model, 'list'))
+                try:
+                    url = reverse(get_viewname(model, 'list'))
+                except Exception:
+                    url = '#'
                 qs = model.objects.restrict(request.user, 'view')
                 # Apply any specified filters
                 if filters := self.config.get('filters'):

--- a/netbox/templates/extras/dashboard/widgets/objectcounts.html
+++ b/netbox/templates/extras/dashboard/widgets/objectcounts.html
@@ -3,7 +3,7 @@
 {% if counts %}
   <div class="list-group list-group-flush">
     {% for model, count, url in counts %}
-      <a href="{{ url }}" class="list-group-item list-group-item-action px-1 py-2">
+      <a {% if url %}href="{{ url }}" {% endif %}class="list-group-item list-group-item-action px-1 py-2">
         <div class="d-flex w-100 justify-content-between align-items-center">
           {{ model|meta:"verbose_name_plural"|bettertitle }}
           {% if count is None %}


### PR DESCRIPTION
### Fixes #17341

This is a quick workaround specifically to stop ObjectCountsWidget raising an exception for models without a `xxx_list` view function.

(A better, more generally useful solution would be to catch exceptions raised by *any* widget, and allow the widget pane to be displayed with an error message. That would avoid Netbox becoming unusable for any widget problem, and would also allow the widget settings to be edited to correct the problem)