### PR TITLE
Fixes #17332: Restore pagination for object list dashboard widgets

### DIFF
--- a/netbox/templates/extras/dashboard/widgets/objectlist.html
+++ b/netbox/templates/extras/dashboard/widgets/objectlist.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 {% if htmx_url and has_permission %}
-  <div class="htmx-container" hx-get="{{ htmx_url }}" hx-trigger="load" hx-target="this" hx-select="table" hx-swap="innerHTML"></div>
+  <div class="htmx-container" hx-get="{{ htmx_url }}" hx-trigger="load" hx-target="this" hx-swap="innerHTML"></div>
 {% elif htmx_url %}
   <div class="text-muted text-center">
     <i class="mdi mdi-lock-outline"></i> {% trans "No permission to view this content" %}.

--- a/netbox/templates/home.html
+++ b/netbox/templates/home.html
@@ -28,7 +28,7 @@
 
 {% block page %}
   {# Render the user's customized dashboard #}
-  <div class="grid-stack m-2" id="dashboard">
+  <div class="grid-stack m-2" id="dashboard" hx-disinherit="*">
     {% for widget in dashboard %}
       {% include 'extras/dashboard/widget.html' %}
     {% endfor %}


### PR DESCRIPTION
### Fixes: #17332

- Set `hx-disinherit="*"` on the parent dashboard element to negate the `hx-select` attribute of the parent page element when HTMX navigation is enabled.
- Remove the now-obsolete `hx-select` attribute from the widget's HTMX container element.
