### PR TITLE
17333 don't prefetch jobs on script api call

### DIFF
--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -231,7 +231,7 @@ class ConfigTemplateViewSet(SyncedDataMixin, ConfigTemplateRenderMixin, NetBoxMo
 
 class ScriptViewSet(ModelViewSet):
     permission_classes = [IsAuthenticatedOrLoginNotRequired]
-    queryset = Script.objects.prefetch_related('jobs')
+    queryset = Script.objects.all()
     serializer_class = serializers.ScriptSerializer
     filterset_class = filtersets.ScriptFilterSet
 


### PR DESCRIPTION
### Fixes: #17333 

It doesn't look like the prefetch for jobs is used anywhere in this call and it is causing extra DB queries / data transfer.