### PR TITLE
Fixes #17362: Fix unicity of VRF returned by filter_present_in_vrf function

### DIFF
--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -458,7 +458,7 @@ class PrefixFilterSet(NetBoxModelFilterSet, TenancyFilterSet):
         return queryset.filter(
             Q(vrf=vrf) |
             Q(vrf__export_targets__in=vrf.import_targets.all())
-        )
+        ).distinct()
 
 
 class IPRangeFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
@@ -738,7 +738,7 @@ class IPAddressFilterSet(NetBoxModelFilterSet, TenancyFilterSet):
         return queryset.filter(
             Q(vrf=vrf) |
             Q(vrf__export_targets__in=vrf.import_targets.all())
-        )
+        ).distinct()
 
     def filter_device(self, queryset, name, value):
         devices = Device.objects.filter(**{'{}__in'.format(name): value})


### PR DESCRIPTION
### Fixes: #17362 

.distinct() permits to remove unnecessary duplicated returns of the VRF passed in parameter in the function.
This permits to have unique IP and Prefixes when using `present_in_vrf ` / `present_in_vrf_id` parameter, example :

For prefixes:
![image](https://github.com/user-attachments/assets/29c8a3bc-b0cf-4f55-98d8-4f0cc63fe36d)

For IP:
![image](https://github.com/user-attachments/assets/b46fa49d-aa7e-4391-a8b6-f2ab23c9a5ea)

