### PR TITLE
Fixed view permissions for ObjectChange

### DIFF
--- a/netbox/netbox/views/generic/feature_views.py
+++ b/netbox/netbox/views/generic/feature_views.py
@@ -38,7 +38,7 @@ class ObjectChangeLogView(ConditionalLoginRequiredMixin, View):
     base_template = None
     tab = ViewTab(
         label=_('Changelog'),
-        permission='extras.view_objectchange',
+        permission='core.view_objectchange',
         weight=10000
     )
 

--- a/netbox/templates/account/profile.html
+++ b/netbox/templates/account/profile.html
@@ -61,7 +61,7 @@
       </div>
     </div>
   </div>
-  {% if perms.extras.view_objectchange %}
+  {% if perms.core.view_objectchange %}
     <div class="row">
       <div class="col-md-12">
         <div class="card">

--- a/netbox/templates/users/user.html
+++ b/netbox/templates/users/user.html
@@ -71,7 +71,7 @@
       </div>
     </div>
   </div>
-  {% if perms.extras.view_objectchange %}
+  {% if perms.core.view_objectchange %}
     <div class="row">
       <div class="col-md-12">
         <div class="card">


### PR DESCRIPTION
### Fixes: #17387

When the `ObjectChange` class was moved from `extras` to `core`, some instances of the permission name were missed.

This PR fixes them by replacing the `extras.view_objectchange` permission with `core.view_objectchange`.
