### PR TITLE
Fixes: #17358 - Ensure correct comparison of overlapping IPRanges

### DIFF
--- a/netbox/ipam/fields.py
+++ b/netbox/ipam/fields.py
@@ -105,7 +105,8 @@ IPAddressField.register_lookup(lookups.NetIn)
 IPAddressField.register_lookup(lookups.NetHostContained)
 IPAddressField.register_lookup(lookups.NetFamily)
 IPAddressField.register_lookup(lookups.NetMaskLength)
-IPAddressField.register_lookup(lookups.HostAsInet)
+IPAddressField.register_lookup(lookups.Host)
+IPAddressField.register_lookup(lookups.Inet)
 
 
 class ASNField(models.BigIntegerField):

--- a/netbox/ipam/fields.py
+++ b/netbox/ipam/fields.py
@@ -105,10 +105,6 @@ IPAddressField.register_lookup(lookups.NetIn)
 IPAddressField.register_lookup(lookups.NetHostContained)
 IPAddressField.register_lookup(lookups.NetFamily)
 IPAddressField.register_lookup(lookups.NetMaskLength)
-IPAddressField.register_lookup(lookups.NetHostLessThan)
-IPAddressField.register_lookup(lookups.NetHostLessThanOrEqual)
-IPAddressField.register_lookup(lookups.NetHostGreaterThan)
-IPAddressField.register_lookup(lookups.NetHostGreaterThanOrEqual)
 IPAddressField.register_lookup(lookups.HostAsInet)
 
 

--- a/netbox/ipam/fields.py
+++ b/netbox/ipam/fields.py
@@ -105,6 +105,10 @@ IPAddressField.register_lookup(lookups.NetIn)
 IPAddressField.register_lookup(lookups.NetHostContained)
 IPAddressField.register_lookup(lookups.NetFamily)
 IPAddressField.register_lookup(lookups.NetMaskLength)
+IPAddressField.register_lookup(lookups.NetHostLessThan)
+IPAddressField.register_lookup(lookups.NetHostLessThanOrEqual)
+IPAddressField.register_lookup(lookups.NetHostGreaterThan)
+IPAddressField.register_lookup(lookups.NetHostGreaterThanOrEqual)
 
 
 class ASNField(models.BigIntegerField):

--- a/netbox/ipam/fields.py
+++ b/netbox/ipam/fields.py
@@ -109,6 +109,7 @@ IPAddressField.register_lookup(lookups.NetHostLessThan)
 IPAddressField.register_lookup(lookups.NetHostLessThanOrEqual)
 IPAddressField.register_lookup(lookups.NetHostGreaterThan)
 IPAddressField.register_lookup(lookups.NetHostGreaterThanOrEqual)
+IPAddressField.register_lookup(lookups.HostAsInet)
 
 
 class ASNField(models.BigIntegerField):

--- a/netbox/ipam/lookups.py
+++ b/netbox/ipam/lookups.py
@@ -207,6 +207,11 @@ class Host(Transform):
     lookup_name = 'host'
 
 
+class HostAsInet(Transform):
+    lookup_name = 'host_as_inet'
+    template = 'CAST(HOST( %(expressions)s ) AS INET)'
+
+
 class Inet(Transform):
     function = 'INET'
     lookup_name = 'inet'

--- a/netbox/ipam/lookups.py
+++ b/netbox/ipam/lookups.py
@@ -154,44 +154,49 @@ class NetHostContained(Lookup):
         return 'CAST(HOST(%s) AS INET) <<= %s' % (lhs, rhs), params
 
 
-class NetHostGreaterThan(Lookup):
+class NetHostComparison(Lookup):
+
+    @property
+    def comparison_sql(self):
+        raise NotImplementedError
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return self.comparison_sql % (lhs, rhs), params
+
+
+class NetHostGreaterThan(NetHostComparison):
     lookup_name = 'net_host_gt'
 
-    def as_sql(self, qn, connection):
-        lhs, lhs_params = self.process_lhs(qn, connection)
-        rhs, rhs_params = self.process_rhs(qn, connection)
-        params = lhs_params + rhs_params
-        return 'CAST(HOST(%s) AS INET) > INET %s' % (lhs, rhs), params
+    @property
+    def comparison_sql(self):
+        return 'CAST(HOST(%s) AS INET) > INET %s'
 
 
-class NetHostLessThan(Lookup):
+class NetHostLessThan(NetHostComparison):
     lookup_name = 'net_host_lt'
 
-    def as_sql(self, qn, connection):
-        lhs, lhs_params = self.process_lhs(qn, connection)
-        rhs, rhs_params = self.process_rhs(qn, connection)
-        params = lhs_params + rhs_params
-        return 'CAST(HOST(%s) AS INET) < INET %s' % (lhs, rhs), params
+    @property
+    def comparison_sql(self):
+        return 'CAST(HOST(%s) AS INET) < INET %s'
 
 
-class NetHostGreaterThanOrEqual(Lookup):
+class NetHostGreaterThanOrEqual(NetHostComparison):
     lookup_name = 'net_host_gte'
 
-    def as_sql(self, qn, connection):
-        lhs, lhs_params = self.process_lhs(qn, connection)
-        rhs, rhs_params = self.process_rhs(qn, connection)
-        params = lhs_params + rhs_params
-        return 'CAST(HOST(%s) AS INET) >= INET %s' % (lhs, rhs), params
+    @property
+    def comparison_sql(self):
+        return 'CAST(HOST(%s) AS INET) >= INET %s'
 
 
-class NetHostLessThanOrEqual(Lookup):
+class NetHostLessThanOrEqual(NetHostComparison):
     lookup_name = 'net_host_lte'
 
-    def as_sql(self, qn, connection):
-        lhs, lhs_params = self.process_lhs(qn, connection)
-        rhs, rhs_params = self.process_rhs(qn, connection)
-        params = lhs_params + rhs_params
-        return 'CAST(HOST(%s) AS INET) <= INET %s' % (lhs, rhs), params
+    @property
+    def comparison_sql(self):
+        return 'CAST(HOST(%s) AS INET) <= INET %s'
 
 
 class NetFamily(Transform):

--- a/netbox/ipam/lookups.py
+++ b/netbox/ipam/lookups.py
@@ -177,11 +177,6 @@ class Host(Transform):
     lookup_name = 'host'
 
 
-class HostAsInet(Transform):
-    lookup_name = 'host_as_inet'
-    template = 'CAST(HOST( %(expressions)s ) AS INET)'
-
-
 class Inet(Transform):
     function = 'INET'
     lookup_name = 'inet'

--- a/netbox/ipam/lookups.py
+++ b/netbox/ipam/lookups.py
@@ -155,10 +155,7 @@ class NetHostContained(Lookup):
 
 
 class NetHostComparison(Lookup):
-
-    @property
-    def comparison_sql(self):
-        raise NotImplementedError
+    comparison_sql = None
 
     def as_sql(self, qn, connection):
         lhs, lhs_params = self.process_lhs(qn, connection)
@@ -169,34 +166,22 @@ class NetHostComparison(Lookup):
 
 class NetHostGreaterThan(NetHostComparison):
     lookup_name = 'net_host_gt'
-
-    @property
-    def comparison_sql(self):
-        return 'CAST(HOST(%s) AS INET) > INET %s'
+    comparison_sql = 'CAST(HOST(%s) AS INET) > INET %s'
 
 
 class NetHostLessThan(NetHostComparison):
     lookup_name = 'net_host_lt'
-
-    @property
-    def comparison_sql(self):
-        return 'CAST(HOST(%s) AS INET) < INET %s'
+    comparison_sql = 'CAST(HOST(%s) AS INET) < INET %s'
 
 
 class NetHostGreaterThanOrEqual(NetHostComparison):
     lookup_name = 'net_host_gte'
-
-    @property
-    def comparison_sql(self):
-        return 'CAST(HOST(%s) AS INET) >= INET %s'
+    comparison_sql = 'CAST(HOST(%s) AS INET) >= INET %s'
 
 
 class NetHostLessThanOrEqual(NetHostComparison):
     lookup_name = 'net_host_lte'
-
-    @property
-    def comparison_sql(self):
-        return 'CAST(HOST(%s) AS INET) <= INET %s'
+    comparison_sql = 'CAST(HOST(%s) AS INET) <= INET %s'
 
 
 class NetFamily(Transform):

--- a/netbox/ipam/lookups.py
+++ b/netbox/ipam/lookups.py
@@ -154,36 +154,6 @@ class NetHostContained(Lookup):
         return 'CAST(HOST(%s) AS INET) <<= %s' % (lhs, rhs), params
 
 
-class NetHostComparison(Lookup):
-    comparison_sql = None
-
-    def as_sql(self, qn, connection):
-        lhs, lhs_params = self.process_lhs(qn, connection)
-        rhs, rhs_params = self.process_rhs(qn, connection)
-        params = lhs_params + rhs_params
-        return self.comparison_sql % (lhs, rhs), params
-
-
-class NetHostGreaterThan(NetHostComparison):
-    lookup_name = 'net_host_gt'
-    comparison_sql = 'CAST(HOST(%s) AS INET) > INET %s'
-
-
-class NetHostLessThan(NetHostComparison):
-    lookup_name = 'net_host_lt'
-    comparison_sql = 'CAST(HOST(%s) AS INET) < INET %s'
-
-
-class NetHostGreaterThanOrEqual(NetHostComparison):
-    lookup_name = 'net_host_gte'
-    comparison_sql = 'CAST(HOST(%s) AS INET) >= INET %s'
-
-
-class NetHostLessThanOrEqual(NetHostComparison):
-    lookup_name = 'net_host_lte'
-    comparison_sql = 'CAST(HOST(%s) AS INET) <= INET %s'
-
-
 class NetFamily(Transform):
     lookup_name = 'family'
     function = 'FAMILY'

--- a/netbox/ipam/lookups.py
+++ b/netbox/ipam/lookups.py
@@ -154,6 +154,46 @@ class NetHostContained(Lookup):
         return 'CAST(HOST(%s) AS INET) <<= %s' % (lhs, rhs), params
 
 
+class NetHostGreaterThan(Lookup):
+    lookup_name = 'net_host_gt'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return 'CAST(HOST(%s) AS INET) > INET %s' % (lhs, rhs), params
+
+
+class NetHostLessThan(Lookup):
+    lookup_name = 'net_host_lt'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return 'CAST(HOST(%s) AS INET) < INET %s' % (lhs, rhs), params
+
+
+class NetHostGreaterThanOrEqual(Lookup):
+    lookup_name = 'net_host_gte'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return 'CAST(HOST(%s) AS INET) >= INET %s' % (lhs, rhs), params
+
+
+class NetHostLessThanOrEqual(Lookup):
+    lookup_name = 'net_host_lte'
+
+    def as_sql(self, qn, connection):
+        lhs, lhs_params = self.process_lhs(qn, connection)
+        rhs, rhs_params = self.process_rhs(qn, connection)
+        params = lhs_params + rhs_params
+        return 'CAST(HOST(%s) AS INET) <= INET %s' % (lhs, rhs), params
+
+
 class NetFamily(Transform):
     lookup_name = 'family'
     function = 'FAMILY'

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -580,15 +580,15 @@ class IPRange(ContactsMixin, PrimaryModel):
                 })
 
             # Check for overlapping ranges
-            overlapping_range = IPRange.objects.exclude(pk=self.pk).filter(vrf=self.vrf).filter(
-                Q(start_address__gte=self.start_address, start_address__lte=self.end_address) |  # Starts inside
-                Q(end_address__gte=self.start_address, end_address__lte=self.end_address) |  # Ends inside
-                Q(start_address__lte=self.start_address, end_address__gte=self.end_address)  # Starts & ends outside
-            ).first()
-            if overlapping_range:
+            overlapping_ranges = IPRange.objects.exclude(pk=self.pk).filter(vrf=self.vrf).filter(
+                Q(start_address__net_host_gte=self.start_address.ip, start_address__net_host_lte=self.end_address.ip) |  # Starts inside
+                Q(end_address__net_host_gte=self.start_address.ip, end_address__net_host_lte=self.end_address.ip) |  # Ends inside
+                Q(start_address__net_host_lte=self.start_address.ip, end_address__net_host_gte=self.end_address.ip)  # Starts & ends outside
+            )
+            if overlapping_ranges.exists():
                 raise ValidationError(
                     _("Defined addresses overlap with range {overlapping_range} in VRF {vrf}").format(
-                        overlapping_range=overlapping_range,
+                        overlapping_range=overlapping_ranges.first(),
                         vrf=self.vrf
                     ))
 

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -581,9 +581,9 @@ class IPRange(ContactsMixin, PrimaryModel):
 
             # Check for overlapping ranges
             overlapping_ranges = IPRange.objects.exclude(pk=self.pk).filter(vrf=self.vrf).filter(
-                Q(start_address__host_as_inet__gte=self.start_address.ip, start_address__host_as_inet__lte=self.end_address.ip) |  # Starts inside
-                Q(end_address__host_as_inet__gte=self.start_address.ip, end_address__host_as_inet__lte=self.end_address.ip) |  # Ends inside
-                Q(start_address__host_as_inet__lte=self.start_address.ip, end_address__host_as_inet__gte=self.end_address.ip)  # Starts & ends outside
+                Q(start_address__host__inet__gte=self.start_address.ip, start_address__host__inet__lte=self.end_address.ip) |  # Starts inside
+                Q(end_address__host__inet__gte=self.start_address.ip, end_address__host__inet__lte=self.end_address.ip) |  # Ends inside
+                Q(start_address__host__inet__lte=self.start_address.ip, end_address__host__inet__gte=self.end_address.ip)  # Starts & ends outside
             )
             if overlapping_ranges.exists():
                 raise ValidationError(

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -581,9 +581,9 @@ class IPRange(ContactsMixin, PrimaryModel):
 
             # Check for overlapping ranges
             overlapping_ranges = IPRange.objects.exclude(pk=self.pk).filter(vrf=self.vrf).filter(
-                Q(start_address__net_host_gte=self.start_address.ip, start_address__net_host_lte=self.end_address.ip) |  # Starts inside
-                Q(end_address__net_host_gte=self.start_address.ip, end_address__net_host_lte=self.end_address.ip) |  # Ends inside
-                Q(start_address__net_host_lte=self.start_address.ip, end_address__net_host_gte=self.end_address.ip)  # Starts & ends outside
+                Q(start_address__host_as_inet__gte=self.start_address.ip, start_address__host_as_inet__lte=self.end_address.ip) |  # Starts inside
+                Q(end_address__host_as_inet__gte=self.start_address.ip, end_address__host_as_inet__lte=self.end_address.ip) |  # Ends inside
+                Q(start_address__host_as_inet__lte=self.start_address.ip, end_address__host_as_inet__gte=self.end_address.ip)  # Starts & ends outside
             )
             if overlapping_ranges.exists():
                 raise ValidationError(

--- a/netbox/ipam/tests/test_models.py
+++ b/netbox/ipam/tests/test_models.py
@@ -36,6 +36,35 @@ class TestAggregate(TestCase):
         self.assertEqual(aggregate.get_utilization(), 100)
 
 
+class TestIPRange(TestCase):
+
+    def test_overlapping_range(self):
+        iprange_192_168 = IPRange.objects.create(start_address=IPNetwork('192.168.0.1/22'), end_address=IPNetwork('192.168.0.49/22'))
+        iprange_192_168.clean()
+        iprange_3_1_99 = IPRange.objects.create(start_address=IPNetwork('1.2.3.1/24'), end_address=IPNetwork('1.2.3.99/24'))
+        iprange_3_1_99.clean()
+        iprange_3_100_199 = IPRange.objects.create(start_address=IPNetwork('1.2.3.100/24'), end_address=IPNetwork('1.2.3.199/24'))
+        iprange_3_100_199.clean()
+        iprange_3_200_255 = IPRange.objects.create(start_address=IPNetwork('1.2.3.200/24'), end_address=IPNetwork('1.2.3.255/24'))
+        iprange_3_200_255.clean()
+        iprange_4_1_99 = IPRange.objects.create(start_address=IPNetwork('1.2.4.1/24'), end_address=IPNetwork('1.2.4.99/24'))
+        iprange_4_1_99.clean()
+        iprange_4_200 = IPRange.objects.create(start_address=IPNetwork('1.2.4.200/24'), end_address=IPNetwork('1.2.4.255/24'))
+        iprange_4_200.clean()
+        # Overlapping range entirely within existing
+        with self.assertRaises(ValidationError):
+            iprange_3_123_124 = IPRange.objects.create(start_address=IPNetwork('1.2.3.123/26'), end_address=IPNetwork('1.2.3.124/26'))
+            iprange_3_123_124.clean()
+        # Overlapping range starting within existing
+        with self.assertRaises(ValidationError):
+            iprange_4_98_101 = IPRange.objects.create(start_address=IPNetwork('1.2.4.98/24'), end_address=IPNetwork('1.2.4.101/24'))
+            iprange_4_98_101.clean()
+        # Overlapping range ending within existing
+        with self.assertRaises(ValidationError):
+            iprange_4_198_201 = IPRange.objects.create(start_address=IPNetwork('1.2.4.198/24'), end_address=IPNetwork('1.2.4.201/24'))
+            iprange_4_198_201.clean()
+
+
 class TestPrefix(TestCase):
 
     def test_get_duplicates(self):


### PR DESCRIPTION
### Fixes: #17358

Adds new Lookup classes for `lt/gt/lte/gte` comparisons with INET objects, ignoring the mask. This enables correct comparison of adjacent IPRanges when looking for overlaps, and prevents acceptance of an invalid new IPRange where the entered start_address and end_address masks do not match the existing ranges.