### PR TITLE
17422 update custom field group display tag

### DIFF
--- a/netbox/utilities/templates/form_helpers/render_custom_fields.html
+++ b/netbox/utilities/templates/form_helpers/render_custom_fields.html
@@ -3,7 +3,7 @@
 {% for group, fields in form.custom_field_groups.items %}
   {% if group %}
   <div class="row">
-    <h6 class="offset-sm-3 mb-3">{{ group }}</h6>
+    <h3 class="offset-sm-3 mb-3">{{ group }}</h3>
   </div>
   {% endif %}
   {% for name in fields %}

--- a/netbox/utilities/templates/form_helpers/render_custom_fields.html
+++ b/netbox/utilities/templates/form_helpers/render_custom_fields.html
@@ -3,7 +3,7 @@
 {% for group, fields in form.custom_field_groups.items %}
   {% if group %}
   <div class="row">
-    <h3 class="offset-sm-3 mb-3">{{ group }}</h3>
+    <h3 class="col-9 offset-3 mb-3 h4">{{ group }}</h3>
   </div>
   {% endif %}
   {% for name in fields %}


### PR DESCRIPTION
### Fixes: #17422

Was set at h6 tag, but the "Custom Fields" header above is h2, so making it h3 as that is correct hierarchical wise and also displays at the correct size.

![Add a new site | NetBox 2024-09-10 09-46-55](https://github.com/user-attachments/assets/f043c6ca-bc12-4a8f-8498-63ed83714543)
