### PR TITLE
Fixes: #17431 - Fix migration dependencies for 3.7->4.1 path

### DIFF
--- a/netbox/users/migrations/0005_alter_user_table.py
+++ b/netbox/users/migrations/0005_alter_user_table.py
@@ -22,6 +22,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('users', '0002_squashed_0004'),
+        ('extras', '0113_customfield_rename_object_type'),
     ]
 
     operations = [


### PR DESCRIPTION
### Fixes: #17431

Adjusts migration dependency path to ensure `CustomField.related_object_type` update comes before `users.0005_alter_user_table`

Fixes v3.7 -> v4.1 upgrade path.