### PR TITLE
17444 fix event rules jobs enqueue

### DIFF
--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -100,9 +100,7 @@ class JobRunner(ABC):
         This method is a wrapper of `Job.enqueue()` using `handle()` as function callback. See its documentation for
         parameters.
         """
-        name = kwargs.pop('name', None)
-        if not name:
-            name = cls.name
+        name = kwargs.pop('name', None) or cls.name
 
         return Job.enqueue(cls.handle, name=name, *args, **kwargs)
 

--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -93,14 +93,13 @@ class JobRunner(ABC):
         return jobs
 
     @classmethod
-    def enqueue(cls, *args, **kwargs):
+    def enqueue(cls, name=None, *args, **kwargs):
         """
         Enqueue a new `Job`.
 
         This method is a wrapper of `Job.enqueue()` using `handle()` as function callback. See its documentation for
         parameters.
         """
-        name = kwargs.pop('name', None)
         if not name:
             name = cls.name
 

--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -101,7 +101,6 @@ class JobRunner(ABC):
         parameters.
         """
         name = kwargs.pop('name', None) or cls.name
-
         return Job.enqueue(cls.handle, name=name, *args, **kwargs)
 
     @classmethod

--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -93,13 +93,14 @@ class JobRunner(ABC):
         return jobs
 
     @classmethod
-    def enqueue(cls, name=None, *args, **kwargs):
+    def enqueue(cls, *args, **kwargs):
         """
         Enqueue a new `Job`.
 
         This method is a wrapper of `Job.enqueue()` using `handle()` as function callback. See its documentation for
         parameters.
         """
+        name = kwargs.pop('name', None)
         if not name:
             name = cls.name
 

--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -100,7 +100,11 @@ class JobRunner(ABC):
         This method is a wrapper of `Job.enqueue()` using `handle()` as function callback. See its documentation for
         parameters.
         """
-        return Job.enqueue(cls.handle, name=cls.name, *args, **kwargs)
+        name = kwargs.pop('name', None)
+        if not name:
+            name = cls.name
+
+        return Job.enqueue(cls.handle, name=name, *args, **kwargs)
 
     @classmethod
     @advisory_lock(ADVISORY_LOCK_KEYS['job-schedules'])


### PR DESCRIPTION
### Fixes: #17444 

Scripts pass in a name param in extras.events.process_event_rules to the enqueue function resulting in duplicate name params as there will be a name in kwargs.