### PR TITLE
Fixes #17437: Fix exception when specifying a bridge relationship on an interface template

### DIFF
--- a/netbox/dcim/api/serializers_/nested.py
+++ b/netbox/dcim/api/serializers_/nested.py
@@ -72,7 +72,7 @@ class NestedInterfaceTemplateSerializer(WritableNestedSerializer):
 
     class Meta:
         model = models.InterfaceTemplate
-        fields = ['id', 'url', 'display_url', 'display', 'name']
+        fields = ['id', 'url', 'display', 'name']
 
 
 class NestedDeviceBaySerializer(WritableNestedSerializer):

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -975,8 +975,8 @@ class InterfaceTemplateForm(ModularComponentTemplateForm):
         queryset=InterfaceTemplate.objects.all(),
         required=False,
         query_params={
-            'devicetype_id': '$device_type',
-            'moduletype_id': '$module_type',
+            'device_type_id': '$device_type',
+            'module_type_id': '$module_type',
         }
     )
 


### PR DESCRIPTION
### Fixes: #17437

- Correct the filter names set on the `bridge` form field to ensure selections are limited to valid options
- Remove the `display_url` field from NestedInterfaceTemplateSerializer
