### PR TITLE
Update choices.py to add C39 Type outlets

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -684,6 +684,7 @@ class PowerOutletTypeChoices(ChoiceSet):
     # Direct current (DC)
     TYPE_DC = 'dc-terminal'
     # Proprietary
+    TYPE_EATON_C39 = 'eaton-c39'
     TYPE_HDOT_CX = 'hdot-cx'
     TYPE_SAF_D_GRID = 'saf-d-grid'
     TYPE_NEUTRIK_POWERCON_20A = 'neutrik-powercon-20a'
@@ -805,6 +806,7 @@ class PowerOutletTypeChoices(ChoiceSet):
             (TYPE_DC, 'DC Terminal'),
         )),
         (_('Proprietary'), (
+            (TYPE_EATON_C39, 'Eaton C39'),
             (TYPE_HDOT_CX, 'HDOT Cx'),
             (TYPE_SAF_D_GRID, 'Saf-D-Grid'),
             (TYPE_NEUTRIK_POWERCON_20A, 'Neutrik powerCON (20A)'),


### PR DESCRIPTION
### Fixes: #17471

[Eaton released a proprietary hybrid outlet type that is compatible with BOTH C14 and C20 male connectors.](https://www.eaton.com/ca/en-gb/catalog/backup-power-ups-surge-it-power-distribution/eaton-high-density-rack-pdu/c39-outlet.html)

This PR adds support for that new "C39" type.