### PR TITLE
Closes #17482: Ignore Branch & StagedChange in `nbshell`

### DIFF
--- a/netbox/core/management/commands/nbshell.py
+++ b/netbox/core/management/commands/nbshell.py
@@ -11,6 +11,10 @@ from core.models import ObjectType
 from users.models import User
 
 APPS = ('circuits', 'core', 'dcim', 'extras', 'ipam', 'tenancy', 'users', 'virtualization', 'vpn', 'wireless')
+EXCLUDE_MODELS = (
+    'extras.branch',
+    'extras.stagedchange',
+)
 
 BANNER_TEXT = """### NetBox interactive shell ({node})
 ### Python {python} | Django {django} | NetBox {netbox}
@@ -44,12 +48,16 @@ class Command(BaseCommand):
 
         # Gather Django models and constants from each app
         for app in APPS:
-            self.django_models[app] = []
+            models = []
 
             # Load models from each app
             for model in apps.get_app_config(app).get_models():
-                namespace[model.__name__] = model
-                self.django_models[app].append(model.__name__)
+                app_label = model._meta.app_label
+                model_name = model._meta.model_name
+                if f'{app_label}.{model_name}' not in EXCLUDE_MODELS:
+                    namespace[model.__name__] = model
+                    models.append(model.__name__)
+            self.django_models[app] = sorted(models)
 
             # Constants
             try:


### PR DESCRIPTION
### Closes: #17482

- Exclude extras.Branch and extras.StagedChange from automatically imported models when invoking the shell
- Alphabetically order the output of `lsmodels()`