### PR TITLE
Closes #16786: Clone device location from rack

### DIFF
--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -829,22 +829,12 @@ class Device(
     def clean(self):
         super().clean()
 
-        # Validate site/location/rack combination
-        if self.rack and self.site != self.rack.site:
-            raise ValidationError({
-                'rack': _("Rack {rack} does not belong to site {site}.").format(rack=self.rack, site=self.site),
-            })
+        # Validate site/location combination
         if self.location and self.site != self.location.site:
             raise ValidationError({
                 'location': _(
                     "Location {location} does not belong to site {site}."
                 ).format(location=self.location, site=self.site)
-            })
-        if self.rack and self.location and self.rack.location != self.location:
-            raise ValidationError({
-                'rack': _(
-                    "Rack {rack} does not belong to location {location}."
-                ).format(rack=self.rack, location=self.location)
             })
 
         if self.rack is None:
@@ -1031,8 +1021,9 @@ class Device(
         if is_new and not self.platform:
             self.platform = self.device_type.default_platform
 
-        # Inherit location from Rack if not set
-        if self.rack and self.rack.location:
+        # Inherit site/location from Rack
+        if self.rack:
+            self.site = self.rack.site
             self.location = self.rack.location
 
         super().save(*args, **kwargs)

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -840,7 +840,7 @@ class Device(
                     "Location {location} does not belong to site {site}."
                 ).format(location=self.location, site=self.site)
             })
-        if self.rack and self.location and self.rack.location != self.location:
+        if self.rack and self.location and not self.location.get_descendants(True).contains(self.rack.location):
             raise ValidationError({
                 'rack': _(
                     "Rack {rack} does not belong to location {location}."

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -623,9 +623,8 @@ class DeviceTestCase(TestCase):
         device_type = DeviceType.objects.first()
         device_role = DeviceRole.objects.first()
 
-        # Device should use site and location from rack
-        device = Device.objects.create(name='device1', rack=rack, device_type=device_type, role=device_role)
-        self.assertEqual(device.site, site)
+        # Device should use location from rack
+        device = Device.objects.create(name='device1', site=site, rack=rack, device_type=device_type, role=device_role)
         self.assertEqual(device.location, location)
 
     def test_device_mismatched_site_cluster(self):

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -613,6 +613,25 @@ class DeviceTestCase(TestCase):
         with self.assertRaises(ValidationError):
             Device(name='device2', site=sites[0], location=locations[1], device_type=device_type, role=device_role).full_clean()
 
+    def test_device_mismatched_rack_location(self):
+        site = Site.objects.first()
+
+        locations = (
+            Location(name='Location 1', slug='location-1', site=site),
+            Location(name='Location 2', slug='location-2', site=site),
+        )
+        for location in locations:
+            location.save()
+
+        rack = Rack.objects.create(name='Rack 1', site=site, location=locations[0])
+
+        device_type = DeviceType.objects.first()
+        device_role = DeviceRole.objects.first()
+
+        # Device should use location from rack
+        with self.assertRaises(ValidationError):
+            Device(name='device1', site=site, location=locations[1], rack=rack, device_type=device_type, role=device_role).full_clean()
+
     def test_device_rack_clone_fields(self):
         site = Site.objects.first()
         location = Location(name='Location 1', slug='location-1', site=site)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #16786 

<!--
    Please include a summary of the proposed changes below.
-->

To fix errors when selecting a rack of a child location being not part of the parent location, the site and location are now always copied from the rack when a device is assigned to a rack.