### PR TITLE
Fixes: #15408 - Add primary_ip4 and primary_ip6 to bulk import form for VDC

### DIFF
--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -1447,7 +1447,7 @@ class VirtualDeviceContextImportForm(NetBoxModelImportForm):
         queryset=IPAddress.objects.all(),
         required=False,
         to_field_name='address',
-        help_text=_('IPv6 address with prefix length, e.g. 1111:2222:3333:4444:5555:6666:7777:8888/64')
+        help_text=_('IPv6 address with prefix length, e.g. 2001:db8::1/64')
     )
 
     class Meta:

--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -1438,6 +1438,6 @@ class VirtualDeviceContextImportForm(NetBoxModelImportForm):
 
     class Meta:
         fields = [
-            'name', 'device', 'status', 'tenant', 'identifier', 'comments',
+            'name', 'device', 'status', 'tenant', 'identifier', 'comments', 'primary_ip4', 'primary_ip6',
         ]
         model = VirtualDeviceContext

--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -1447,7 +1447,7 @@ class VirtualDeviceContextImportForm(NetBoxModelImportForm):
         queryset=IPAddress.objects.all(),
         required=False,
         to_field_name='address',
-        help_text=_('IPv6 address')
+        help_text=_('IPv6 address with mask, e.g. 1111:2222:3333:4444:5555:6666:7777:8888/24')
     )
 
     class Meta:
@@ -1455,3 +1455,13 @@ class VirtualDeviceContextImportForm(NetBoxModelImportForm):
             'name', 'device', 'status', 'tenant', 'identifier', 'comments', 'primary_ip4', 'primary_ip6',
         ]
         model = VirtualDeviceContext
+
+    def __init__(self, data=None, *args, **kwargs):
+        super().__init__(data, *args, **kwargs)
+
+        if data:
+
+            # Limit primary_ip4/ip6 querysets by assigned site
+            params = {f"interface__device__{self.fields['device'].to_field_name}": data.get('device')}
+            self.fields['primary_ip4'].queryset = self.fields['primary_ip4'].queryset.filter(**params)
+            self.fields['primary_ip6'].queryset = self.fields['primary_ip6'].queryset.filter(**params)

--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -1461,7 +1461,7 @@ class VirtualDeviceContextImportForm(NetBoxModelImportForm):
 
         if data:
 
-            # Limit primary_ip4/ip6 querysets by assigned site
+            # Limit primary_ip4/ip6 querysets by assigned device
             params = {f"interface__device__{self.fields['device'].to_field_name}": data.get('device')}
             self.fields['primary_ip4'].queryset = self.fields['primary_ip4'].queryset.filter(**params)
             self.fields['primary_ip6'].queryset = self.fields['primary_ip6'].queryset.filter(**params)

--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -1447,7 +1447,7 @@ class VirtualDeviceContextImportForm(NetBoxModelImportForm):
         queryset=IPAddress.objects.all(),
         required=False,
         to_field_name='address',
-        help_text=_('IPv6 address with mask, e.g. 1111:2222:3333:4444:5555:6666:7777:8888/24')
+        help_text=_('IPv6 address with prefix length, e.g. 1111:2222:3333:4444:5555:6666:7777:8888/64')
     )
 
     class Meta:

--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -9,7 +9,7 @@ from dcim.choices import *
 from dcim.constants import *
 from dcim.models import *
 from extras.models import ConfigTemplate
-from ipam.models import VRF
+from ipam.models import VRF, IPAddress
 from netbox.forms import NetBoxModelImportForm
 from tenancy.models import Tenant
 from utilities.forms.fields import (
@@ -1434,6 +1434,20 @@ class VirtualDeviceContextImportForm(NetBoxModelImportForm):
     status = CSVChoiceField(
         label=_('Status'),
         choices=VirtualDeviceContextStatusChoices,
+    )
+    primary_ip4 = CSVModelChoiceField(
+        label=_('Primary IPv4'),
+        queryset=IPAddress.objects.all(),
+        required=False,
+        to_field_name='address',
+        help_text=_('IPv4 address with mask, e.g. 1.2.3.4/24')
+    )
+    primary_ip6 = CSVModelChoiceField(
+        label=_('Primary IPv6'),
+        queryset=IPAddress.objects.all(),
+        required=False,
+        to_field_name='address',
+        help_text=_('IPv6 address')
     )
 
     class Meta:


### PR DESCRIPTION
### Fixes: #15408

Adds `primary_ip4` and `primary_ip6` to VirtualDeviceContextImportForm.

Uses `address` as the accessor field.

<img width="945" alt="Screenshot 2024-09-16 at 2 49 04 PM" src="https://github.com/user-attachments/assets/c2dfa56e-2274-43d0-a6ea-cb22dcc1a7be">
