### PR TITLE
17517 fix cable creation when switching device type

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -3253,10 +3253,10 @@ class CableEditView(generic.ObjectEditView):
         doesn't currently provide a hook for dynamic class resolution.
         """
         a_terminations_type = CABLE_TERMINATION_TYPES.get(
-            request.GET.get('a_terminations_type') or request.POST.get('a_terminations_type')
+            request.POST.get('a_terminations_type') or request.GET.get('a_terminations_type')
         )
         b_terminations_type = CABLE_TERMINATION_TYPES.get(
-            request.GET.get('b_terminations_type') or request.POST.get('b_terminations_type')
+            request.POST.get('b_terminations_type') or request.GET.get('b_terminations_type')
         )
 
         if obj.pk:


### PR DESCRIPTION
### Fixes: #17517 

On Cable Form submit the post data is updated but the request URL is referring to the initial (old) values, so need to use the POST data if available instead of the GET params.