### PR TITLE
Closes #16669: Include a notice when rendering docs locally

### DIFF
--- a/docs/_theme/partials/copyright.html
+++ b/docs/_theme/partials/copyright.html
@@ -1,0 +1,18 @@
+<div class="md-copyright">
+  {% if config.copyright %}
+    <div class="md-copyright__highlight">
+      {{ config.copyright }}
+    </div>
+  {% endif %}
+  {% if not config.extra.generator == false %}
+    Made with
+    <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">
+      Material for MkDocs
+    </a>
+  {% endif %}
+</div>
+{% if not config.extra.build_public %}
+  <div class="md-copyright">
+    ℹ️ Documentation is being served locally
+  </div>
+{% endif %}


### PR DESCRIPTION
### Closes: #16669

To test a local build, run:

```
mkdocs serve
```

This should display a notification message in the footer. To emulate a public build, run:

```
BUILD_PUBLIC=1 mkdocs serve
```

The notification should not be present.