### PR TITLE
Fixes: #17083 - Wrap labels in a div to reduce inadvertently clickable area to their left in forms

### DIFF
--- a/netbox/utilities/templates/form_helpers/render_field.html
+++ b/netbox/utilities/templates/form_helpers/render_field.html
@@ -6,9 +6,11 @@
 
   {# Render the field label (if any), except for checkboxes #}
   {% if label and not field|widget_type == 'checkboxinput' %}
-    <label for="{{ field.id_for_label }}" class="col-sm-3 col-form-label text-lg-end{% if field.field.required %} required{% endif %}">
-      {{ label }}
-    </label>
+    <div class="col-sm-3">
+      <label for="{{ field.id_for_label }}" class="col-form-label text-lg-end{% if field.field.required %} required{% endif %}">
+        {{ label }}
+      </label>
+    </div>
   {% endif %}
 
   {# Render the field itself #}

--- a/netbox/utilities/templates/form_helpers/render_field.html
+++ b/netbox/utilities/templates/form_helpers/render_field.html
@@ -6,8 +6,8 @@
 
   {# Render the field label (if any), except for checkboxes #}
   {% if label and not field|widget_type == 'checkboxinput' %}
-    <div class="col-sm-3">
-      <label for="{{ field.id_for_label }}" class="col-form-label text-lg-end{% if field.field.required %} required{% endif %}">
+    <div class="col-sm-3 text-lg-end">
+      <label for="{{ field.id_for_label }}" class="col-form-label d-inline-block{% if field.field.required %} required{% endif %}">
         {{ label }}
       </label>
     </div>


### PR DESCRIPTION
### Fixes: #17083

Wraps all form labels in a `<div class="col-sm-3">` which ensures ample dead clickable space to their left in forms, while remaining responsive.

<img width="726" alt="Screenshot 2024-09-17 at 4 15 24 PM" src="https://github.com/user-attachments/assets/9e47c3d8-367f-4e90-9b01-583ed7853b6c">
