### PR TITLE
17522 enable localization of user preference form labels

### DIFF
--- a/netbox/netbox/preferences.py
+++ b/netbox/netbox/preferences.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from netbox.registry import registry
 from users.preferences import UserPreference


### PR DESCRIPTION
### Fixes: #17522 

The help text as still showing untranslated 
![Preferencias de usuario | NetBox 2024-09-17 13-17-20](https://github.com/user-attachments/assets/af26ee6e-9f22-4a0a-976d-867eafbb8ee7)
