### PR TITLE
14201 allow searching for ASN with prefix AS

### DIFF
--- a/netbox/ipam/models/asns.py
+++ b/netbox/ipam/models/asns.py
@@ -149,3 +149,7 @@ class ASN(PrimaryModel):
             return f'{self.asn} ({self.asn // 65536}.{self.asn % 65536})'
         else:
             return self.asn
+
+    @property
+    def prefixed_name(self):
+        return f'AS{self.asn_with_asdot}'

--- a/netbox/ipam/search.py
+++ b/netbox/ipam/search.py
@@ -19,6 +19,7 @@ class ASNIndex(SearchIndex):
     model = models.ASN
     fields = (
         ('asn', 100),
+        ('prefixed_name', 110),
         ('description', 500),
     )
     display_attrs = ('rir', 'tenant', 'description')


### PR DESCRIPTION
### Fixes: #14201 

Search index will need to be rebuilt to search for existing ASNs, otherwise if you add or edit an ASN it will be searchable with the "AS"