### PR TITLE
Fixes: #17360 - Ensure model is defined when rendering bulk_edit_button

### DIFF
--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -129,6 +129,7 @@ class ObjectChildrenView(ObjectView, ActionsMixin, TableMixin):
         GET handler for rendering child objects.
         """
         instance = self.get_object(**kwargs)
+        model = self.queryset.model
         child_objects = self.get_children(request, instance)
 
         if self.filterset:
@@ -146,10 +147,12 @@ class ObjectChildrenView(ObjectView, ActionsMixin, TableMixin):
             return render(request, 'htmx/table.html', {
                 'object': instance,
                 'table': table,
+                'model': model,
             })
 
         return render(request, self.get_template_name(), {
             'object': instance,
+            'model': model,
             'child_model': self.child_model,
             'base_template': f'{instance._meta.app_label}/{instance._meta.model_name}.html',
             'table': table,

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -129,7 +129,6 @@ class ObjectChildrenView(ObjectView, ActionsMixin, TableMixin):
         GET handler for rendering child objects.
         """
         instance = self.get_object(**kwargs)
-        model = self.queryset.model
         child_objects = self.get_children(request, instance)
 
         if self.filterset:
@@ -147,12 +146,12 @@ class ObjectChildrenView(ObjectView, ActionsMixin, TableMixin):
             return render(request, 'htmx/table.html', {
                 'object': instance,
                 'table': table,
-                'model': model,
+                'model': self.child_model,
             })
 
         return render(request, self.get_template_name(), {
             'object': instance,
-            'model': model,
+            'model': self.child_model,
             'child_model': self.child_model,
             'base_template': f'{instance._meta.app_label}/{instance._meta.model_name}.html',
             'table': table,

--- a/netbox/templates/htmx/table.html
+++ b/netbox/templates/htmx/table.html
@@ -15,7 +15,7 @@
   {% endwith %}
 </div>
 
-{% if request.htmx %}
+{% if request.htmx and model %}
   {# Include the updated object count for display elsewhere on the page #}
   <div hx-swap-oob="innerHTML:.total-object-count">{{ table.rows|length }}</div>
 

--- a/netbox/templates/htmx/table.html
+++ b/netbox/templates/htmx/table.html
@@ -20,7 +20,7 @@
   <div hx-swap-oob="innerHTML:.total-object-count">{{ table.rows|length }}</div>
 
   {# Update the bulk action buttons with new query parameters #}
-  {% if actions and model %}
+  {% if actions %}
     <div class="bulk-action-buttons" hx-swap-oob="outerHTML:.bulk-action-buttons">
       {% if 'bulk_edit' in actions %}
         {% bulk_edit_button model query_params=request.GET %}

--- a/netbox/templates/htmx/table.html
+++ b/netbox/templates/htmx/table.html
@@ -15,12 +15,12 @@
   {% endwith %}
 </div>
 
-{% if request.htmx and model %}
+{% if request.htmx %}
   {# Include the updated object count for display elsewhere on the page #}
   <div hx-swap-oob="innerHTML:.total-object-count">{{ table.rows|length }}</div>
 
   {# Update the bulk action buttons with new query parameters #}
-  {% if actions %}
+  {% if actions and model %}
     <div class="bulk-action-buttons" hx-swap-oob="outerHTML:.bulk-action-buttons">
       {% if 'bulk_edit' in actions %}
         {% bulk_edit_button model query_params=request.GET %}


### PR DESCRIPTION
### Fixes: #17360

Addresses a common issue in HTMX navigation where the inclusion of a call to `bulk_edit_button` where the param `model` is a string raises an `AttributeError: 'str' object has no attribute '_meta'`.

This fix adds a check for truthiness of `model` before trying to render `{% bulk_edit_button %}` or `{% bulk_delete_button %}` in `table.py`.