### PR TITLE
create 802.15.4 interface type

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -924,6 +924,7 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_80211AY = 'ieee802.11ay'
     TYPE_80211BE = 'ieee802.11be'
     TYPE_802151 = 'ieee802.15.1'
+    TYPE_802154 = 'ieee802.15.4'
     TYPE_OTHER_WIRELESS = 'other-wireless'
 
     # Cellular
@@ -1096,6 +1097,7 @@ class InterfaceTypeChoices(ChoiceSet):
                 (TYPE_80211AY, 'IEEE 802.11ay'),
                 (TYPE_80211BE, 'IEEE 802.11be'),
                 (TYPE_802151, 'IEEE 802.15.1 (Bluetooth)'),
+                (TYPE_802154, 'IEEE 802.15.4 (LR-WPAN)'),
                 (TYPE_OTHER_WIRELESS, 'Other (Wireless)'),
             )
         ),

--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -51,6 +51,7 @@ WIRELESS_IFACE_TYPES = [
     InterfaceTypeChoices.TYPE_80211AY,
     InterfaceTypeChoices.TYPE_80211BE,
     InterfaceTypeChoices.TYPE_802151,
+    InterfaceTypeChoices.TYPE_802154,
     InterfaceTypeChoices.TYPE_OTHER_WIRELESS,
 ]
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #17550 

<!--
    Please include a summary of the proposed changes below.
-->

Adds [IEEE 802.15.4](https://en.wikipedia.org/wiki/IEEE_802.15.4) (LR-WPAN --> basis for Zigbee, Thread, Matter, etc.) to the list of wireless interface types.