### PR TITLE
17419 fix MPTT issue with migrations for nested module bays

### DIFF
--- a/netbox/dcim/migrations/0191_module_bay_rebuild.py
+++ b/netbox/dcim/migrations/0191_module_bay_rebuild.py
@@ -2,7 +2,7 @@ from django.db import migrations
 
 
 def rebuild_mptt(apps, schema_editor):
-    ModuleBay = apps.get_model('dcim', 'ModuleBay')
+    from dcim.models import ModuleBay
     ModuleBay.objects.rebuild()
 
 

--- a/netbox/dcim/migrations/0191_module_bay_rebuild.py
+++ b/netbox/dcim/migrations/0191_module_bay_rebuild.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+def rebuild_mptt(apps, schema_editor):
+    ModuleBay = apps.get_model('dcim', 'ModuleBay')
+    ModuleBay.objects.rebuild()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dcim', '0190_nested_modules'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=rebuild_mptt,
+            reverse_code=migrations.RunPython.noop
+        ),
+    ]

--- a/netbox/dcim/migrations/0191_module_bay_rebuild.py
+++ b/netbox/dcim/migrations/0191_module_bay_rebuild.py
@@ -1,9 +1,15 @@
 from django.db import migrations
+import mptt
+import mptt.managers
 
 
 def rebuild_mptt(apps, schema_editor):
-    from dcim.models import ModuleBay
-    ModuleBay.objects.rebuild()
+    manager = mptt.managers.TreeManager()
+    ModuleBay = apps.get_model('dcim', 'ModuleBay')
+    manager.model = ModuleBay
+    mptt.register(ModuleBay)
+    manager.contribute_to_class(ModuleBay, 'objects')
+    manager.rebuild()
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
### Fixes: #17419 

Note in the migration had to use the actual model and not `apps.get_model` as the manager for rebuild is needed.