### PR TITLE
Closes: #17575 - Add NullableMultipleChoiceFilter and filter form UI to match empty string

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from utilities.choices import ChoiceSet

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1482,6 +1482,7 @@ class CableTypeChoices(ChoiceSet):
     TYPE_AOC = 'aoc'
     TYPE_POWER = 'power'
     TYPE_USB = 'usb'
+    TYPE_EMPTY = 'EMPTY'
 
     CHOICES = (
         (
@@ -1514,8 +1515,13 @@ class CableTypeChoices(ChoiceSet):
                 (TYPE_AOC, 'Active Optical Cabling (AOC)'),
             ),
         ),
-        (TYPE_USB, _('USB')),
-        (TYPE_POWER, _('Power')),
+        (
+            _('Other'), (
+                (TYPE_USB, _('USB')),
+                (TYPE_POWER, _('Power')),
+                (TYPE_EMPTY, _('(unset)')),
+            )
+        )
     )
 
 

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1483,7 +1483,6 @@ class CableTypeChoices(ChoiceSet):
     TYPE_AOC = 'aoc'
     TYPE_POWER = 'power'
     TYPE_USB = 'usb'
-    TYPE_EMPTY = settings.FILTERS_NULL_CHOICE_VALUE
 
     CHOICES = (
         (
@@ -1520,7 +1519,6 @@ class CableTypeChoices(ChoiceSet):
             _('Other'), (
                 (TYPE_USB, _('USB')),
                 (TYPE_POWER, _('Power')),
-                (settings.FILTERS_NULL_CHOICE_VALUE, _('(unset)')),
             )
         )
     )

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from utilities.choices import ChoiceSet
@@ -1482,7 +1483,7 @@ class CableTypeChoices(ChoiceSet):
     TYPE_AOC = 'aoc'
     TYPE_POWER = 'power'
     TYPE_USB = 'usb'
-    TYPE_EMPTY = 'EMPTY'
+    TYPE_EMPTY = settings.FILTERS_NULL_CHOICE_VALUE
 
     CHOICES = (
         (
@@ -1519,7 +1520,7 @@ class CableTypeChoices(ChoiceSet):
             _('Other'), (
                 (TYPE_USB, _('USB')),
                 (TYPE_POWER, _('Power')),
-                (TYPE_EMPTY, _('(unset)')),
+                (settings.FILTERS_NULL_CHOICE_VALUE, _('(unset)')),
             )
         )
     )

--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -18,7 +18,7 @@ from tenancy.models import *
 from users.models import User
 from utilities.filters import (
     ContentTypeFilter, MultiValueCharFilter, MultiValueMACAddressFilter, MultiValueNumberFilter, MultiValueWWNFilter,
-    NumericArrayFilter, TreeNodeMultipleChoiceFilter, EmptyStringMultipleChoiceFilter,
+    NumericArrayFilter, TreeNodeMultipleChoiceFilter, NullableMultipleChoiceFilter,
 )
 from virtualization.models import Cluster, ClusterGroup
 from vpn.models import L2VPN
@@ -1980,7 +1980,7 @@ class CableFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
         method='_unterminated',
         label=_('Unterminated'),
     )
-    type = EmptyStringMultipleChoiceFilter(
+    type = NullableMultipleChoiceFilter(
         choices=CableTypeChoices
     )
     status = django_filters.MultipleChoiceFilter(

--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -18,7 +18,7 @@ from tenancy.models import *
 from users.models import User
 from utilities.filters import (
     ContentTypeFilter, MultiValueCharFilter, MultiValueMACAddressFilter, MultiValueNumberFilter, MultiValueWWNFilter,
-    NumericArrayFilter, TreeNodeMultipleChoiceFilter, EmptyStringFilter,
+    NumericArrayFilter, TreeNodeMultipleChoiceFilter, EmptyStringMultipleChoiceFilter,
 )
 from virtualization.models import Cluster, ClusterGroup
 from vpn.models import L2VPN
@@ -1980,11 +1980,8 @@ class CableFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
         method='_unterminated',
         label=_('Unterminated'),
     )
-    type = django_filters.MultipleChoiceFilter(
+    type = EmptyStringMultipleChoiceFilter(
         choices=CableTypeChoices
-    )
-    type__empty = EmptyStringFilter(
-        field_name='type'
     )
     status = django_filters.MultipleChoiceFilter(
         choices=LinkStatusChoices

--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -18,7 +18,7 @@ from tenancy.models import *
 from users.models import User
 from utilities.filters import (
     ContentTypeFilter, MultiValueCharFilter, MultiValueMACAddressFilter, MultiValueNumberFilter, MultiValueWWNFilter,
-    NumericArrayFilter, TreeNodeMultipleChoiceFilter,
+    NumericArrayFilter, TreeNodeMultipleChoiceFilter, EmptyStringFilter,
 )
 from virtualization.models import Cluster, ClusterGroup
 from vpn.models import L2VPN
@@ -1982,6 +1982,9 @@ class CableFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
     )
     type = django_filters.MultipleChoiceFilter(
         choices=CableTypeChoices
+    )
+    type__empty = EmptyStringFilter(
+        field_name='type'
     )
     status = django_filters.MultipleChoiceFilter(
         choices=LinkStatusChoices

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -10,7 +10,7 @@ from ipam.models import ASN, VRF
 from netbox.forms import NetBoxModelFilterSetForm
 from tenancy.forms import ContactModelFilterForm, TenancyFilterForm
 from users.models import User
-from utilities.forms import BOOLEAN_WITH_BLANK_CHOICES, FilterForm, add_blank_choice
+from utilities.forms import BOOLEAN_WITH_BLANK_CHOICES, FilterForm, add_blank_choice, add_empty_filtering_choice
 from utilities.forms.fields import ColorField, DynamicModelMultipleChoiceField, TagFilterField
 from utilities.forms.rendering import FieldSet
 from utilities.forms.widgets import NumberWithOptions
@@ -1052,7 +1052,7 @@ class CableFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
     )
     type = forms.MultipleChoiceField(
         label=_('Type'),
-        choices=add_blank_choice(CableTypeChoices),
+        choices=add_empty_filtering_choice(add_blank_choice(CableTypeChoices)),
         required=False
     )
     status = forms.MultipleChoiceField(

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -1,4 +1,5 @@
 from django.test import TestCase
+from django.conf import settings
 
 from circuits.models import Circuit, CircuitTermination, CircuitType, Provider
 from dcim.choices import *
@@ -5240,7 +5241,7 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
     def test_type(self):
         params = {'type': [CableTypeChoices.TYPE_CAT3, CableTypeChoices.TYPE_CAT5E]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
-        params = {'type': [CableTypeChoices.TYPE_EMPTY]}
+        params = {'type': [settings.FILTERS_NULL_CHOICE_VALUE]}
         params = {'type__empty': 'true'}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
         params = {'type__empty': 'false'}
@@ -5249,7 +5250,7 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
     def test_type_empty(self):
         params = {'type__empty': 'true'}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
-        params = {'type': [CableTypeChoices.TYPE_EMPTY, CableTypeChoices.TYPE_CAT3]}
+        params = {'type': [settings.FILTERS_NULL_CHOICE_VALUE, CableTypeChoices.TYPE_CAT3]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 10)
 
     def test_status(self):

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -5245,6 +5245,12 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {'type__empty': 'false'}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
 
+    def test_type_empty(self):
+        params = {'type__empty': 'true'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
+        params = {'type__empty': 'false'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+
     def test_status(self):
         params = {'status': [LinkStatusChoices.STATUS_CONNECTED]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 11)

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -5240,6 +5240,7 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
     def test_type(self):
         params = {'type': [CableTypeChoices.TYPE_CAT3, CableTypeChoices.TYPE_CAT5E]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
+        params = {'type': [CableTypeChoices.TYPE_EMPTY]}
         params = {'type__empty': 'true'}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
         params = {'type__empty': 'false'}
@@ -5248,8 +5249,8 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
     def test_type_empty(self):
         params = {'type__empty': 'true'}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
-        params = {'type__empty': 'false'}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+        params = {'type': [CableTypeChoices.TYPE_EMPTY, CableTypeChoices.TYPE_CAT3]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 10)
 
     def test_status(self):
         params = {'status': [LinkStatusChoices.STATUS_CONNECTED]}

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -5242,13 +5242,6 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {'type': [CableTypeChoices.TYPE_CAT3, CableTypeChoices.TYPE_CAT5E]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
         params = {'type': [settings.FILTERS_NULL_CHOICE_VALUE]}
-        params = {'type__empty': 'true'}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
-        params = {'type__empty': 'false'}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
-
-    def test_type_empty(self):
-        params = {'type__empty': 'true'}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
         params = {'type': [settings.FILTERS_NULL_CHOICE_VALUE, CableTypeChoices.TYPE_CAT3]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 10)

--- a/netbox/utilities/filters.py
+++ b/netbox/utilities/filters.py
@@ -173,12 +173,10 @@ class ContentTypeFilter(django_filters.CharFilter):
         )
 
 
-class EmptyStringFilter(django_filters.BooleanFilter):
+class EmptyStringMultipleChoiceFilter(django_filters.MultipleChoiceFilter):
+    empty_value = 'EMPTY'
+
     def filter(self, qs, value):
-        if value in EMPTY_VALUES:
-            return qs
-
-        exclude = self.exclude ^ (value is False)
-        method = qs.exclude if exclude else qs.filter
-
-        return method(**{self.field_name: ""})
+        if self.empty_value in value:
+            value.append('')
+        return super().filter(qs, value)

--- a/netbox/utilities/filters.py
+++ b/netbox/utilities/filters.py
@@ -143,6 +143,14 @@ class NullableCharFieldFilter(django_filters.CharFilter):
         return qs.distinct() if self.distinct else qs
 
 
+class NullableMultipleChoiceFilter(django_filters.MultipleChoiceFilter):
+
+    def filter(self, qs, value):
+        if settings.FILTERS_NULL_CHOICE_VALUE in value:
+            value.append('')
+        return super().filter(qs, value)
+
+
 class NumericArrayFilter(django_filters.NumberFilter):
     """
     Filter based on the presence of an integer within an ArrayField.
@@ -171,12 +179,3 @@ class ContentTypeFilter(django_filters.CharFilter):
                 f'{self.field_name}__model': model
             }
         )
-
-
-class EmptyStringMultipleChoiceFilter(django_filters.MultipleChoiceFilter):
-    empty_value = 'EMPTY'
-
-    def filter(self, qs, value):
-        if self.empty_value in value:
-            value.append('')
-        return super().filter(qs, value)

--- a/netbox/utilities/filters.py
+++ b/netbox/utilities/filters.py
@@ -18,6 +18,7 @@ __all__ = (
     'MultiValueTimeFilter',
     'MultiValueWWNFilter',
     'NullableCharFieldFilter',
+    'NullableMultipleChoiceFilter',
     'NumericArrayFilter',
     'TreeNodeMultipleChoiceFilter',
 )
@@ -144,7 +145,9 @@ class NullableCharFieldFilter(django_filters.CharFilter):
 
 
 class NullableMultipleChoiceFilter(django_filters.MultipleChoiceFilter):
-
+    """
+    Similar to NullableCharFieldFilter, but allows multiple values including the special NULL string.
+    """
     def filter(self, qs, value):
         if settings.FILTERS_NULL_CHOICE_VALUE in value:
             value.append('')

--- a/netbox/utilities/filters.py
+++ b/netbox/utilities/filters.py
@@ -171,3 +171,14 @@ class ContentTypeFilter(django_filters.CharFilter):
                 f'{self.field_name}__model': model
             }
         )
+
+
+class EmptyStringFilter(django_filters.BooleanFilter):
+    def filter(self, qs, value):
+        if value in EMPTY_VALUES:
+            return qs
+
+        exclude = self.exclude ^ (value is False)
+        method = qs.exclude if exclude else qs.filter
+
+        return method(**{self.field_name: ""})

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -1,6 +1,7 @@
 import re
 
 from django import forms
+from django.conf import settings
 from django.forms.models import fields_for_model
 from django.utils.translation import gettext as _
 
@@ -10,6 +11,7 @@ from .constants import *
 
 __all__ = (
     'add_blank_choice',
+    'add_empty_filtering_choice',
     'expand_alphanumeric_pattern',
     'expand_ipaddress_pattern',
     'form_from_model',
@@ -187,6 +189,14 @@ def add_blank_choice(choices):
     Add a blank choice to the beginning of a choices list.
     """
     return ((None, '---------'),) + tuple(choices)
+
+
+def add_empty_filtering_choice(choices):
+    """
+    Add an empty (null) choice to the end of a choices list, to be used in filtering classes
+    such as NullableMultipleChoiceFilter to match on an empty value.
+    """
+    return tuple(choices) + ((settings.FILTERS_NULL_CHOICE_VALUE, '(unset)'),)
 
 
 def form_from_model(model, fields):


### PR DESCRIPTION
### Closes: #17575

Adds a `NullableMultipleChoiceFilter` class (patterned on the existing `NullableCharFieldFilter`) which can be used in a multiple-choice FilterForm input to add the "(unset)" (`''`) value to a list of acceptable choices in the filter, evaluated in an OR fashion in a single query.
