### PR TITLE
Fixes: #17126 - Respect the weight unit of the DeviceType when displaying the Device detail

### DIFF
--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -324,7 +324,11 @@
                         <th scope="row">{% trans "Weight" %}</th>
                         <td>
                             {% if object.total_weight %}
-                                {{ object.total_weight|floatformat }} {% trans "Kilograms" %}
+                                {% if object.device_type.weight_unit == "lb" %}
+                                    {{ object.total_weight|kg_to_pounds|floatformat }} {% trans "Pounds" %}
+                                {% elif object.device_type.weight_unit == "kg" %}
+                                    {{ object.total_weight|floatformat }} {% trans "Kilograms" %}
+                                {% endif %}
                             {% else %}
                                 {{ ''|placeholder }}
                             {% endif %}

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -324,11 +324,8 @@
                         <th scope="row">{% trans "Weight" %}</th>
                         <td>
                             {% if object.total_weight %}
-                                {% if object.device_type.weight_unit == "lb" %}
-                                    {{ object.total_weight|kg_to_pounds|floatformat }} {% trans "Pounds" %}
-                                {% elif object.device_type.weight_unit == "kg" %}
-                                    {{ object.total_weight|floatformat }} {% trans "Kilograms" %}
-                                {% endif %}
+                                {{ object.total_weight|floatformat }} {% trans "Kilograms" %}
+                                ({{ object.total_weight|kg_to_pounds|floatformat }} {% trans "Pounds" %})
                             {% else %}
                                 {{ ''|placeholder }}
                             {% endif %}

--- a/netbox/templates/dcim/rack.html
+++ b/netbox/templates/dcim/rack.html
@@ -103,8 +103,12 @@
           <tr>
             <th scope="row">{% trans "Total Weight" %}</th>
             <td>
-              {{ object.total_weight|floatformat }} {% trans "Kilograms" %}
-              ({{ object.total_weight|kg_to_pounds|floatformat }} {% trans "Pounds" %})
+                {% if object.total_weight %}
+                    {{ object.total_weight|floatformat }} {% trans "Kilograms" %}
+                    ({{ object.total_weight|kg_to_pounds|floatformat }} {% trans "Pounds" %})
+                {% else %}
+                    {{ ''|placeholder }}
+                {% endif %}
             </td>
           </tr>
         </table>


### PR DESCRIPTION
### Fixes: #17126

Changes `device.html` to conditionally convert a device's `total_weight` to pounds if the DeviceType defines the weight in pounds in the `weight_unit`.

Note that this compares the `weight_unit` value to the literal string `'lb'` or `'kg'`, rather than to an enum value in the `WeightUnitChoiceSet`. It would be more DRY to pass the enum to the template context, but less elegant as the data construct does not seem to allow direct access to class attrs in the template, meaning the enum would need to be transformed or deconstructed to pass into the template properly.
