### PR TITLE
17501 fix showing last run of script execution in list view

### DIFF
--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -410,12 +410,7 @@ class JobsMixin(models.Model):
         """
         Return a dictionary mapping of the most recent jobs for this instance.
         """
-        return {
-            job.name: job
-            for job in self.jobs.filter(
-                status__in=JobStatusChoices.TERMINAL_STATE_CHOICES
-            ).order_by('name', '-created').distinct('name').defer('data')
-        }
+        return self.jobs.filter(status__in=JobStatusChoices.TERMINAL_STATE_CHOICES).order_by('-created').defer('data')
 
 
 class JournalingMixin(models.Model):

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -408,7 +408,7 @@ class JobsMixin(models.Model):
 
     def get_latest_jobs(self):
         """
-        Return a dictionary mapping of the most recent jobs for this instance.
+        Return a list of the most recent jobs for this instance.
         """
         return self.jobs.filter(status__in=JobStatusChoices.TERMINAL_STATE_CHOICES).order_by('-created').defer('data')
 

--- a/netbox/templates/extras/script_list.html
+++ b/netbox/templates/extras/script_list.html
@@ -50,7 +50,7 @@
           </thead>
           <tbody>
             {% for script in module.scripts.all %}
-              {% with last_job=script.get_latest_jobs|get_key:script.name %}
+              {% with last_job=script.get_latest_jobs|first %}
                 <tr>
                   <td>
                     {% if script.is_executable %}


### PR DESCRIPTION
### Fixes: #17501 

Tested with single script and script with multiple methods.  The template is the only place get_latest_jobs is used.

![Scripts | NetBox 2024-09-23 13-06-11](https://github.com/user-attachments/assets/ddf2065d-f894-44ad-8ff1-82fe97333629)
