### PR TITLE
Closes #17577: Reference ModelState when determining whether an object is being created

### DIFF
--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -164,7 +164,7 @@ class Cable(PrimaryModel):
         if self.length is not None and not self.length_unit:
             raise ValidationError(_("Must specify a unit when setting a cable length"))
 
-        if self.pk is None and (not self.a_terminations or not self.b_terminations):
+        if self._state.adding and (not self.a_terminations or not self.b_terminations):
             raise ValidationError(_("Must define A and B terminations when creating a new cable."))
 
         if self._terminations_modified:

--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -98,7 +98,7 @@ class ComponentTemplateModel(ChangeLoggedModel, TrackingModelMixin):
     def clean(self):
         super().clean()
 
-        if self.pk is not None and self._original_device_type != self.device_type_id:
+        if not self._state.adding and self._original_device_type != self.device_type_id:
             raise ValidationError({
                 "device_type": _("Component templates cannot be moved to a different device type.")
             })

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -561,7 +561,7 @@ class BaseInterface(models.Model):
             self.untagged_vlan = None
 
         # Only "tagged" interfaces may have tagged VLANs assigned. ("tagged all" implies all VLANs are assigned.)
-        if self.pk and self.mode != InterfaceModeChoices.MODE_TAGGED:
+        if not self._state.adding and self.mode != InterfaceModeChoices.MODE_TAGGED:
             self.tagged_vlans.clear()
 
         return super().save(*args, **kwargs)
@@ -1072,7 +1072,7 @@ class RearPort(ModularComponentModel, CabledObjectModel, TrackingModelMixin):
         super().clean()
 
         # Check that positions count is greater than or equal to the number of associated FrontPorts
-        if self.pk:
+        if not self._state.adding:
             frontport_count = self.frontports.count()
             if self.positions < frontport_count:
                 raise ValidationError({
@@ -1314,7 +1314,7 @@ class InventoryItem(MPTTModel, ComponentModel, TrackingModelMixin):
             })
 
         # Validation for moving InventoryItems
-        if self.pk:
+        if not self._state.adding:
             # Cannot move an InventoryItem to another device if it has a parent
             if self.parent and self.parent.device != self.device:
                 raise ValidationError({

--- a/netbox/dcim/models/racks.py
+++ b/netbox/dcim/models/racks.py
@@ -382,7 +382,7 @@ class Rack(ContactsMixin, ImageAttachmentsMixin, RackBase):
         if self.max_weight and not self.weight_unit:
             raise ValidationError(_("Must specify a unit when setting a maximum weight"))
 
-        if self.pk:
+        if not self._state.adding:
             mounted_devices = Device.objects.filter(rack=self).exclude(position__isnull=True).order_by('position')
 
             # Validate that Rack is tall enough to house the highest mounted Device
@@ -468,7 +468,7 @@ class Rack(ContactsMixin, ImageAttachmentsMixin, RackBase):
             }
 
         # Add devices to rack units list
-        if self.pk:
+        if not self._state.adding:
 
             # Retrieve all devices installed within the rack
             devices = Device.objects.prefetch_related(

--- a/netbox/netbox/models/__init__.py
+++ b/netbox/netbox/models/__init__.py
@@ -162,7 +162,7 @@ class NestedGroupModel(NetBoxFeatureSet, MPTTModel):
         super().clean()
 
         # An MPTT model cannot be its own parent
-        if self.pk and self.parent and self.parent in self.get_descendants(include_self=True):
+        if not self._state.adding and self.parent and self.parent in self.get_descendants(include_self=True):
             raise ValidationError({
                 "parent": "Cannot assign self or child {type} as parent.".format(type=self._meta.verbose_name)
             })

--- a/netbox/virtualization/models/clusters.py
+++ b/netbox/virtualization/models/clusters.py
@@ -134,7 +134,7 @@ class Cluster(ContactsMixin, PrimaryModel):
         super().clean()
 
         # If the Cluster is assigned to a Site, verify that all host Devices belong to that Site.
-        if self.pk and self.site:
+        if not self._state.adding and self.site:
             if nonsite_devices := Device.objects.filter(cluster=self).exclude(site=self.site).count():
                 raise ValidationError({
                     'site': _(

--- a/netbox/virtualization/models/virtualmachines.py
+++ b/netbox/virtualization/models/virtualmachines.py
@@ -205,7 +205,7 @@ class VirtualMachine(ContactsMixin, ImageAttachmentsMixin, RenderConfigMixin, Co
             })
 
         # Validate aggregate disk size
-        if self.pk:
+        if not self._state.adding:
             total_disk = self.virtualdisks.aggregate(Sum('size', default=0))['size__sum']
             if total_disk and self.disk is None:
                 self.disk = total_disk


### PR DESCRIPTION
### Closes: #17577

For every instance where we're currently evaluating whether `self.pk` is null to determine if an object is being created or updated, instead reference its `_state` attribute.