### PR TITLE
Fixes: #17498 - Avoid error in bulk import when non-unique identifying values are provided

### DIFF
--- a/netbox/netbox/forms/base.py
+++ b/netbox/netbox/forms/base.py
@@ -2,6 +2,7 @@ import json
 
 from django import forms
 from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import MultipleObjectsReturned
 from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
@@ -98,6 +99,12 @@ class NetBoxModelImportForm(CSVModelForm, NetBoxModelForm):
 
     def _get_form_field(self, customfield):
         return customfield.to_form_field(for_csv_import=True)
+
+    def _clean_fields(self):
+        try:
+            return super()._clean_fields()
+        except MultipleObjectsReturned as e:
+            self.add_error(None, f'A non-unique value was provided for one or more fields: {e}')
 
 
 class NetBoxModelBulkEditForm(CustomFieldsMixin, forms.Form):


### PR DESCRIPTION
### Fixes: #17498

Extends `_clean_fields` to catch `MultipleObjectsReturned` exceptions on any field where an ad-hoc accessor is used (for example `manufacturer.description` in `DeviceType`) and multiple matching records are found.

With this change, a toast is displayed which surfaces the model that caused the exception. Because this is a non-field clean method, the field's specific metadata is not available, but the general message from the exception (which contains the model name) is reflected in the toast which should lead the user to a solution.

Note that other extraneous toasts appear as well as a side effect; this is not ideal, but this solution avoids the much greater issue of an opaque 500 error.

<img width="905" alt="Screenshot 2024-09-23 at 8 05 13 PM" src="https://github.com/user-attachments/assets/95c3bbe2-45c0-48ed-8ab6-7445dcf30fad">
