### PR TITLE
Fixes: #17498 - Handle "manufacturer" field with a validation error on non-unique values in DeviceTypeImportForm

### DIFF
--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -367,7 +367,7 @@ class ManufacturerImportForm(NetBoxModelImportForm):
 
 
 class DeviceTypeImportForm(NetBoxModelImportForm):
-    manufacturer = forms.ModelChoiceField(
+    manufacturer = CSVModelChoiceField(
         label=_('Manufacturer'),
         queryset=Manufacturer.objects.all(),
         to_field_name='name',


### PR DESCRIPTION
### Fixes: #17498

Changes `DeviceTypeImportForm.manufacturer` to a `CSVModelChoiceField`, ensuring that non-unique values will raise a validation error rather than crashing with an opaque 500.