### PR TITLE
Fixes: #17497 - Handle invalid accessor fields in bulk import forms

### DIFF
--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -367,13 +367,13 @@ class ManufacturerImportForm(NetBoxModelImportForm):
 
 
 class DeviceTypeImportForm(NetBoxModelImportForm):
-    manufacturer = forms.ModelChoiceField(
+    manufacturer = CSVModelChoiceField(
         label=_('Manufacturer'),
         queryset=Manufacturer.objects.all(),
         to_field_name='name',
         help_text=_('The manufacturer which produces this device type')
     )
-    default_platform = forms.ModelChoiceField(
+    default_platform = CSVModelChoiceField(
         label=_('Default platform'),
         queryset=Platform.objects.all(),
         to_field_name='name',

--- a/netbox/utilities/forms/fields/csv.py
+++ b/netbox/utilities/forms/fields/csv.py
@@ -66,7 +66,7 @@ class CSVModelChoiceField(forms.ModelChoiceField):
             )
         except FieldError:
             raise forms.ValidationError(
-                _(f'"{self.to_field_name}" is an invalid accessor field name.')
+                _('"{field_name}" is an invalid accessor field name.').format(field_name=self.to_field_name)
             )
 
 

--- a/netbox/utilities/forms/fields/csv.py
+++ b/netbox/utilities/forms/fields/csv.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
+from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist, FieldError
 from django.db.models import Q
 
 from utilities.choices import unpack_grouped_choices
@@ -63,6 +63,10 @@ class CSVModelChoiceField(forms.ModelChoiceField):
         except MultipleObjectsReturned:
             raise forms.ValidationError(
                 _('"{value}" is not a unique value for this field; multiple objects were found').format(value=value)
+            )
+        except FieldError:
+            raise forms.ValidationError(
+                _(f'"{self.to_field_name}" is an invalid accessor field name.')
             )
 
 


### PR DESCRIPTION
### Fixes: #17497

More generally solves the issue of invalid accessor field names in a `BulkImportForm` by adding `FieldError` handling to the `to_python` method of `CSVModelChoiceField`.

Note that this will only fix #17497 if https://github.com/netbox-community/netbox/pull/17593 is merged.

<img width="884" alt="Screenshot 2024-09-24 at 5 30 44 PM" src="https://github.com/user-attachments/assets/38755db7-883a-4b3c-bcef-532dd168ab4f">
