### PR TITLE
Add support for socks connection to Git backend

### DIFF
--- a/docs/features/synchronized-data.md
+++ b/docs/features/synchronized-data.md
@@ -13,6 +13,9 @@ To enable remote data synchronization, the NetBox administrator first designates
 !!! info
     Data backends which connect to external sources typically require the installation of one or more supporting Python libraries. The Git backend requires the [`dulwich`](https://www.dulwich.io/) package, and the S3 backend requires the [`boto3`](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) package. These must be installed within NetBox's environment to enable these backends.
 
+!!! info
+    If you are configuring Git and have HTTP_PROXIES set to use the SOCKS protocol, you will also need to install the [`python_socks`](https://pypi.org/project/python-socks/) package.
+
 Each type of remote source has its own configuration parameters. For instance, a git source will ask the user to specify a branch and authentication credentials. Once the source has been created, a synchronization job is run to automatically replicate remote files in the local database.
 
 The following NetBox models can be associated with replicated data files:

--- a/docs/features/synchronized-data.md
+++ b/docs/features/synchronized-data.md
@@ -14,7 +14,7 @@ To enable remote data synchronization, the NetBox administrator first designates
     Data backends which connect to external sources typically require the installation of one or more supporting Python libraries. The Git backend requires the [`dulwich`](https://www.dulwich.io/) package, and the S3 backend requires the [`boto3`](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) package. These must be installed within NetBox's environment to enable these backends.
 
 !!! info
-    If you are configuring Git and have HTTP_PROXIES set to use the SOCKS protocol, you will also need to install the [`python_socks`](https://pypi.org/project/python-socks/) package.
+    If you are configuring Git and have `HTTP_PROXIES` configured to use the SOCKS protocol, you will also need to install the [`python_socks`](https://pypi.org/project/python-socks/) Python library.
 
 Each type of remote source has its own configuration parameters. For instance, a git source will ask the user to specify a branch and authentication credentials. Once the source has been created, a synchronization job is run to automatically replicate remote files in the local database.
 

--- a/netbox/core/data_backends.py
+++ b/netbox/core/data_backends.py
@@ -79,7 +79,7 @@ class ProxyPoolManager(PoolManager):
         # python_socks uses rdns param to denote remote DNS parsing and
         # doesn't accept the 'h' or 'a' in the proxy URL
         cleaned_proxy_url = proxy_url
-        if use_rdns := urlparse(cleaned_proxy_url).scheme.lower() in ['socks4h', 'socks4a' 'socks5h', 'socks5a']:
+        if use_rdns := urlparse(cleaned_proxy_url).scheme in ['socks4h', 'socks4a' 'socks5h', 'socks5a']:
             cleaned_proxy_url = cleaned_proxy_url.replace('socks5h:', 'socks5:').replace('socks5a:', 'socks5:')
             cleaned_proxy_url = cleaned_proxy_url.replace('socks4h:', 'socks4:').replace('socks4a:', 'socks4:')
 
@@ -150,7 +150,7 @@ class GitBackend(DataBackend):
         if settings.HTTP_PROXIES and self.url_scheme in ('http', 'https'):
             if proxy := settings.HTTP_PROXIES.get(self.url_scheme):
                 config.set("http", "proxy", proxy)
-                if urlparse(proxy).scheme.lower() in ['socks4', 'socks4a', 'socks4h', 'socks5', 'socks5a', 'socks5h']:
+                if urlparse(proxy).scheme in ['socks4', 'socks4a', 'socks4h', 'socks5', 'socks5a', 'socks5h']:
                     self.use_socks = True
 
         return config

--- a/netbox/core/data_backends.py
+++ b/netbox/core/data_backends.py
@@ -8,10 +8,12 @@ from urllib.parse import urlparse
 
 from django import forms
 from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext as _
 
 from netbox.data_backends import DataBackend
 from netbox.utils import register_data_backend
+from utilities.constants import DATA_SOURCE_SUPPORTED_SCHEMAS, DATA_SOURCE_SUPPORTED_SOCK_SCHEMAS
 from utilities.socks import ProxyPoolManager
 from .exceptions import SyncError
 
@@ -71,11 +73,15 @@ class GitBackend(DataBackend):
         self.use_socks = False
 
         # Apply HTTP proxy (if configured)
-        if settings.HTTP_PROXIES and self.url_scheme in ('http', 'https'):
-            if proxy := settings.HTTP_PROXIES.get(self.url_scheme):
-                config.set("http", "proxy", proxy)
-                if urlparse(proxy).scheme in ['socks4', 'socks4a', 'socks4h', 'socks5', 'socks5a', 'socks5h']:
-                    self.use_socks = True
+        if settings.HTTP_PROXIES:
+            if proxy := settings.HTTP_PROXIES.get(self.url_scheme, None):
+                if urlparse(proxy).scheme not in DATA_SOURCE_SUPPORTED_SCHEMAS:
+                    raise ImproperlyConfigured(f"Unsupported Git DataSource proxy scheme: {urlparse(proxy).scheme}")
+
+                if self.url_scheme in ('http', 'https'):
+                    config.set("http", "proxy", proxy)
+                    if urlparse(proxy).scheme in DATA_SOURCE_SUPPORTED_SOCK_SCHEMAS:
+                        self.use_socks = True
 
         return config
 

--- a/netbox/core/data_backends.py
+++ b/netbox/core/data_backends.py
@@ -79,9 +79,9 @@ class ProxyPoolManager(PoolManager):
         # python_socks uses rdns param to denote remote DNS parsing and
         # doesn't accept the 'h' or 'a' in the proxy URL
         cleaned_proxy_url = proxy_url
-        if use_rdns := cleaned_proxy_url.startswith(('socks5h:', 'socks5a:')):
-            cleaned_proxy_url = cleaned_proxy_url.replace('socks5h:', 'socks5:')
-            cleaned_proxy_url = cleaned_proxy_url.replace('socks5a:', 'socks5:')
+        if use_rdns := urlparse(cleaned_proxy_url).scheme.lower() in ['socks4h', 'socks4a' 'socks5h', 'socks5a']:
+            cleaned_proxy_url = cleaned_proxy_url.replace('socks5h:', 'socks5:').replace('socks5a:', 'socks5:')
+            cleaned_proxy_url = cleaned_proxy_url.replace('socks4h:', 'socks4:').replace('socks4a:', 'socks4:')
 
         connection_pool_kw['_socks_options'] = {'proxy_url': cleaned_proxy_url}
         connection_pool_kw['timeout'] = timeout
@@ -150,7 +150,7 @@ class GitBackend(DataBackend):
         if settings.HTTP_PROXIES and self.url_scheme in ('http', 'https'):
             if proxy := settings.HTTP_PROXIES.get(self.url_scheme):
                 config.set("http", "proxy", proxy)
-                if proxy.startswith('socks'):
+                if urlparse(proxy).scheme.lower() in ['socks4', 'socks4a', 'socks4h', 'socks5', 'socks5a', 'socks5h']:
                     self.use_socks = True
 
         return config

--- a/netbox/core/data_backends.py
+++ b/netbox/core/data_backends.py
@@ -4,8 +4,6 @@ import re
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from urllib3 import PoolManager, HTTPConnectionPool, HTTPSConnectionPool
-from urllib3.connection import HTTPConnection, HTTPSConnection
 from urllib.parse import urlparse
 
 from django import forms
@@ -14,6 +12,7 @@ from django.utils.translation import gettext as _
 
 from netbox.data_backends import DataBackend
 from netbox.utils import register_data_backend
+from utilities.socks import ProxyPoolManager
 from .exceptions import SyncError
 
 __all__ = (
@@ -23,79 +22,6 @@ __all__ = (
 )
 
 logger = logging.getLogger('netbox.data_backends')
-
-
-# These Proxy Methods are for handling SOCKS connection proxy
-class ProxyHTTPConnection(HTTPConnection):
-    use_rdns = False
-
-    def __init__(self, *args, **kwargs):
-        socks_options = kwargs.pop('_socks_options')
-        self._proxy_url = socks_options['proxy_url']
-        super().__init__(*args, **kwargs)
-
-    def _new_conn(self):
-        from python_socks.sync import Proxy
-        proxy = Proxy.from_url(self._proxy_url, rdns=self.use_rdns)
-        return proxy.connect(
-            dest_host=self.host,
-            dest_port=self.port,
-            timeout=self.timeout
-        )
-
-
-class ProxyHTTPSConnection(ProxyHTTPConnection, HTTPSConnection):
-    pass
-
-
-class rdnsProxyHTTPConnection(ProxyHTTPConnection):
-    use_rdns = True
-
-
-class rdnsProxyHTTPSConnection(ProxyHTTPSConnection):
-    use_rdns = True
-
-
-class ProxyHTTPConnectionPool(HTTPConnectionPool):
-    ConnectionCls = ProxyHTTPConnection
-
-
-class ProxyHTTPSConnectionPool(HTTPSConnectionPool):
-    ConnectionCls = ProxyHTTPSConnection
-
-
-class rdnsProxyHTTPConnectionPool(HTTPConnectionPool):
-    ConnectionCls = rdnsProxyHTTPConnection
-
-
-class rdnsProxyHTTPSConnectionPool(HTTPSConnectionPool):
-    ConnectionCls = rdnsProxyHTTPSConnection
-
-
-class ProxyPoolManager(PoolManager):
-    def __init__(self, proxy_url, timeout=5, num_pools=10, headers=None, **connection_pool_kw):
-        # python_socks uses rdns param to denote remote DNS parsing and
-        # doesn't accept the 'h' or 'a' in the proxy URL
-        cleaned_proxy_url = proxy_url
-        if use_rdns := urlparse(cleaned_proxy_url).scheme in ['socks4h', 'socks4a' 'socks5h', 'socks5a']:
-            cleaned_proxy_url = cleaned_proxy_url.replace('socks5h:', 'socks5:').replace('socks5a:', 'socks5:')
-            cleaned_proxy_url = cleaned_proxy_url.replace('socks4h:', 'socks4:').replace('socks4a:', 'socks4:')
-
-        connection_pool_kw['_socks_options'] = {'proxy_url': cleaned_proxy_url}
-        connection_pool_kw['timeout'] = timeout
-
-        super().__init__(num_pools, headers, **connection_pool_kw)
-
-        if use_rdns:
-            self.pool_classes_by_scheme = {
-                'http': rdnsProxyHTTPConnectionPool,
-                'https': rdnsProxyHTTPSConnectionPool,
-            }
-        else:
-            self.pool_classes_by_scheme = {
-                'http': ProxyHTTPConnectionPool,
-                'https': ProxyHTTPSConnectionPool,
-            }
 
 
 @register_data_backend()

--- a/netbox/core/data_backends.py
+++ b/netbox/core/data_backends.py
@@ -25,7 +25,7 @@ __all__ = (
 logger = logging.getLogger('netbox.data_backends')
 
 
-# These Proxy Methods are for handling socks connection proxy
+# These Proxy Methods are for handling SOCKS connection proxy
 class ProxyHTTPConnection(HTTPConnection):
     use_rdns = False
 
@@ -73,9 +73,7 @@ class rdnsProxyHTTPSConnectionPool(HTTPSConnectionPool):
 
 
 class ProxyPoolManager(PoolManager):
-    def __init__(self, proxy_url, timeout=5, num_pools=10, headers=None,
-                 **connection_pool_kw):
-
+    def __init__(self, proxy_url, timeout=5, num_pools=10, headers=None, **connection_pool_kw):
         # python_socks uses rdns param to denote remote DNS parsing and
         # doesn't accept the 'h' or 'a' in the proxy URL
         cleaned_proxy_url = proxy_url

--- a/netbox/core/data_backends.py
+++ b/netbox/core/data_backends.py
@@ -13,7 +13,7 @@ from django.utils.translation import gettext as _
 
 from netbox.data_backends import DataBackend
 from netbox.utils import register_data_backend
-from utilities.constants import DATA_SOURCE_SUPPORTED_SCHEMAS, DATA_SOURCE_SUPPORTED_SOCK_SCHEMAS
+from utilities.constants import HTTP_PROXY_SUPPORTED_SCHEMAS, HTTP_PROXY_SUPPORTED_SOCK_SCHEMAS
 from utilities.socks import ProxyPoolManager
 from .exceptions import SyncError
 
@@ -75,12 +75,12 @@ class GitBackend(DataBackend):
         # Apply HTTP proxy (if configured)
         if settings.HTTP_PROXIES:
             if proxy := settings.HTTP_PROXIES.get(self.url_scheme, None):
-                if urlparse(proxy).scheme not in DATA_SOURCE_SUPPORTED_SCHEMAS:
+                if urlparse(proxy).scheme not in HTTP_PROXY_SUPPORTED_SCHEMAS:
                     raise ImproperlyConfigured(f"Unsupported Git DataSource proxy scheme: {urlparse(proxy).scheme}")
 
                 if self.url_scheme in ('http', 'https'):
                     config.set("http", "proxy", proxy)
-                    if urlparse(proxy).scheme in DATA_SOURCE_SUPPORTED_SOCK_SCHEMAS:
+                    if urlparse(proxy).scheme in HTTP_PROXY_SUPPORTED_SOCK_SCHEMAS:
                         self.use_socks = True
 
         return config

--- a/netbox/utilities/constants.py
+++ b/netbox/utilities/constants.py
@@ -94,6 +94,6 @@ HTML_ALLOWED_ATTRIBUTES = {
     "th": {"align"},
 }
 
-DATA_SOURCE_SUPPORTED_SOCK_SCHEMAS = ['socks4', 'socks4a', 'socks4h', 'socks5', 'socks5a', 'socks5h']
-DATA_SOURCE_SOCK_RDNS_SCHEMAS = ['socks4h', 'socks4a', 'socks5h', 'socks5a']
-DATA_SOURCE_SUPPORTED_SCHEMAS = ['http', 'https', 'socks4', 'socks4a', 'socks4h', 'socks5', 'socks5a', 'socks5h']
+HTTP_PROXY_SUPPORTED_SOCK_SCHEMAS = ['socks4', 'socks4a', 'socks4h', 'socks5', 'socks5a', 'socks5h']
+HTTP_PROXY_SOCK_RDNS_SCHEMAS = ['socks4h', 'socks4a', 'socks5h', 'socks5a']
+HTTP_PROXY_SUPPORTED_SCHEMAS = ['http', 'https', 'socks4', 'socks4a', 'socks4h', 'socks5', 'socks5a', 'socks5h']

--- a/netbox/utilities/constants.py
+++ b/netbox/utilities/constants.py
@@ -93,3 +93,7 @@ HTML_ALLOWED_ATTRIBUTES = {
     "td": {"align"},
     "th": {"align"},
 }
+
+DATA_SOURCE_SUPPORTED_SOCK_SCHEMAS = ['socks4', 'socks4a', 'socks4h', 'socks5', 'socks5a', 'socks5h']
+DATA_SOURCE_SOCK_RDNS_SCHEMAS = ['socks4h', 'socks4a', 'socks5h', 'socks5a']
+DATA_SOURCE_SUPPORTED_SCHEMAS = ['http', 'https', 'socks4', 'socks4a', 'socks4h', 'socks5', 'socks5a', 'socks5h']

--- a/netbox/utilities/socks.py
+++ b/netbox/utilities/socks.py
@@ -1,3 +1,4 @@
+from urllib.parse import urlparse
 from urllib3 import PoolManager, HTTPConnectionPool, HTTPSConnectionPool
 from urllib3.connection import HTTPConnection, HTTPSConnection
 

--- a/netbox/utilities/socks.py
+++ b/netbox/utilities/socks.py
@@ -1,0 +1,75 @@
+from urllib3 import PoolManager, HTTPConnectionPool, HTTPSConnectionPool
+from urllib3.connection import HTTPConnection, HTTPSConnection
+
+
+# These Proxy Methods are for handling SOCKS connection proxy
+class ProxyHTTPConnection(HTTPConnection):
+    use_rdns = False
+
+    def __init__(self, *args, **kwargs):
+        socks_options = kwargs.pop('_socks_options')
+        self._proxy_url = socks_options['proxy_url']
+        super().__init__(*args, **kwargs)
+
+    def _new_conn(self):
+        from python_socks.sync import Proxy
+        proxy = Proxy.from_url(self._proxy_url, rdns=self.use_rdns)
+        return proxy.connect(
+            dest_host=self.host,
+            dest_port=self.port,
+            timeout=self.timeout
+        )
+
+
+class ProxyHTTPSConnection(ProxyHTTPConnection, HTTPSConnection):
+    pass
+
+
+class RdnsProxyHTTPConnection(ProxyHTTPConnection):
+    use_rdns = True
+
+
+class RdnsProxyHTTPSConnection(ProxyHTTPSConnection):
+    use_rdns = True
+
+
+class ProxyHTTPConnectionPool(HTTPConnectionPool):
+    ConnectionCls = ProxyHTTPConnection
+
+
+class ProxyHTTPSConnectionPool(HTTPSConnectionPool):
+    ConnectionCls = ProxyHTTPSConnection
+
+
+class RdnsProxyHTTPConnectionPool(HTTPConnectionPool):
+    ConnectionCls = RdnsProxyHTTPConnection
+
+
+class RdnsProxyHTTPSConnectionPool(HTTPSConnectionPool):
+    ConnectionCls = RdnsProxyHTTPSConnection
+
+
+class ProxyPoolManager(PoolManager):
+    def __init__(self, proxy_url, timeout=5, num_pools=10, headers=None, **connection_pool_kw):
+        # python_socks uses rdns param to denote remote DNS parsing and
+        # doesn't accept the 'h' or 'a' in the proxy URL
+        cleaned_proxy_url = proxy_url
+        if use_rdns := urlparse(cleaned_proxy_url).scheme in ['socks4h', 'socks4a' 'socks5h', 'socks5a']:
+            cleaned_proxy_url = cleaned_proxy_url.replace('socks5h:', 'socks5:').replace('socks5a:', 'socks5:')
+            cleaned_proxy_url = cleaned_proxy_url.replace('socks4h:', 'socks4:').replace('socks4a:', 'socks4:')
+
+        connection_pool_kw['_socks_options'] = {'proxy_url': cleaned_proxy_url}
+        connection_pool_kw['timeout'] = timeout
+
+        super().__init__(num_pools, headers, **connection_pool_kw)
+
+        if use_rdns:
+            self.pool_classes_by_scheme = {
+                'http': RdnsProxyHTTPConnectionPool,
+                'https': RdnsProxyHTTPSConnectionPool,
+            }
+        else:
+            self.pool_classes_by_scheme = {
+                'http': ProxyHTTPConnectionPool,
+                'https': ProxyHTTPSConnectionPool,
+            }

--- a/netbox/utilities/socks.py
+++ b/netbox/utilities/socks.py
@@ -55,7 +55,7 @@ class ProxyPoolManager(PoolManager):
         # python_socks uses rdns param to denote remote DNS parsing and
         # doesn't accept the 'h' or 'a' in the proxy URL
         cleaned_proxy_url = proxy_url
-        if use_rdns := urlparse(cleaned_proxy_url).scheme in ['socks4h', 'socks4a' 'socks5h', 'socks5a']:
+        if use_rdns := urlparse(cleaned_proxy_url).scheme in ['socks4h', 'socks4a', 'socks5h', 'socks5a']:
             cleaned_proxy_url = cleaned_proxy_url.replace('socks5h:', 'socks5:').replace('socks5a:', 'socks5:')
             cleaned_proxy_url = cleaned_proxy_url.replace('socks4h:', 'socks4:').replace('socks4a:', 'socks4:')
 


### PR DESCRIPTION
### Fixes: #17639

**Note:** will also need to install the python_socks library along with the Dulwich library to use this:
```
pip install dulwich
pip install python_socks
```

To test locally, start a socks proxy in a docker container. Make a HTTP request and observe it using the proxy:

```
$ docker run -d --name socks5 -p 1080:1080 serjs/go-socks5-proxy
$ docker logs -f socks5
```

Specify the local proxy in Netbox configuration.py:
```
HTTP_PROXIES = {
   'http': 'socks5h://localhost:1080',
   'https': 'socks5h://localhost:1080',
}
```

Add a remote GIT datasource and you should see the traffic logs in the terminal. Setup a DataSource in Netbox, I was using the following in the form:

```
Name = GitSync
Type = Git
URL = https://github.com/bogdancordos/netbox_scripts.git
```
The URL just has a selection of scripts so you can see that it actually syncs the data source.  Press the [Sync] button and make sure it actually syncs.

For SOCKs auth scenario it can be setup as follows:

```
docker run -d --name socks5 -p 1080:1080 -e PROXY_USER=aaa -e PROXY_PASSWORD=bbb  serjs/go-socks5-proxy
```

Then in configuration.py:
```
HTTP_PROXIES = {
    'http': 'socks5h://aaa:bbb@localhost:1080',
    'https': 'socks5h://aaa:bbb@localhost:1080',
}
```