### PR TITLE
Fixes: #17648 - Fix exception thrown in `Job.delete()` when no object_type specified

### DIFF
--- a/netbox/core/models/jobs.py
+++ b/netbox/core/models/jobs.py
@@ -13,8 +13,6 @@ from django.utils.translation import gettext as _
 from core.choices import JobStatusChoices
 from core.models import ObjectType
 from core.signals import job_end, job_start
-from netbox.config import get_config
-from netbox.constants import RQ_QUEUE_DEFAULT
 from utilities.querysets import RestrictedQuerySet
 from utilities.rqworker import get_queue_for_model
 

--- a/netbox/core/models/jobs.py
+++ b/netbox/core/models/jobs.py
@@ -118,9 +118,9 @@ class Job(models.Model):
 
     def get_absolute_url(self):
         # TODO: Employ dynamic registration
-        if self.object_type.model == 'reportmodule':
+        if self.object_type and self.object_type.model == 'reportmodule':
             return reverse(f'extras:report_result', kwargs={'job_pk': self.pk})
-        if self.object_type.model == 'scriptmodule':
+        elif self.object_type and self.object_type.model == 'scriptmodule':
             return reverse(f'extras:script_result', kwargs={'job_pk': self.pk})
         return reverse('core:job', args=[self.pk])
 
@@ -154,7 +154,7 @@ class Job(models.Model):
     def delete(self, *args, **kwargs):
         super().delete(*args, **kwargs)
 
-        rq_queue_name = get_config().QUEUE_MAPPINGS.get(self.object_type.model, RQ_QUEUE_DEFAULT)
+        rq_queue_name = get_queue_for_model(self.object_type.model if self.object_type else None)
         queue = django_rq.get_queue(rq_queue_name)
         job = queue.fetch_job(str(self.job_id))
 

--- a/netbox/core/models/jobs.py
+++ b/netbox/core/models/jobs.py
@@ -120,7 +120,7 @@ class Job(models.Model):
         # TODO: Employ dynamic registration
         if self.object_type.model == 'reportmodule':
             return reverse(f'extras:report_result', kwargs={'job_pk': self.pk})
-        elif self.object_type.model == 'scriptmodule':
+        if self.object_type.model == 'scriptmodule':
             return reverse(f'extras:script_result', kwargs={'job_pk': self.pk})
         return reverse('core:job', args=[self.pk])
 

--- a/netbox/core/models/jobs.py
+++ b/netbox/core/models/jobs.py
@@ -118,9 +118,9 @@ class Job(models.Model):
 
     def get_absolute_url(self):
         # TODO: Employ dynamic registration
-        if self.object_type and self.object_type.model == 'reportmodule':
+        if self.object_type.model == 'reportmodule':
             return reverse(f'extras:report_result', kwargs={'job_pk': self.pk})
-        elif self.object_type and self.object_type.model == 'scriptmodule':
+        elif self.object_type.model == 'scriptmodule':
             return reverse(f'extras:script_result', kwargs={'job_pk': self.pk})
         return reverse('core:job', args=[self.pk])
 


### PR DESCRIPTION
Fixes: #17648 - Fix exception thrown in `Job.delete()` when no object_type specified

* Change `Job.delete()` to use `get_queue_for_model`
* Fix related issue in `Job.get_absolute_url()`