### PR TITLE
Closes: #11671 - Add position display to cable trace

### DIFF
--- a/netbox/dcim/svg/cables.py
+++ b/netbox/dcim/svg/cables.py
@@ -162,6 +162,9 @@ class CableTraceSVG:
                 location_label += f' / {instance.location}'
             if instance.rack:
                 location_label += f' / {instance.rack}'
+            if instance.position:
+                location_label += f' / {instance.get_face_display()}'
+                location_label += f' / U{instance.position}'
             labels.append(location_label)
         elif instance._meta.model_name == 'circuit':
             labels[0] = f'Circuit {instance}'


### PR DESCRIPTION
Closes: #11671 - Add position display to cable trace

* Alter `_get_labels()` to add rack face and position if position is set
