### PR TITLE
Fixes: #17663 - Only remove extraneous attributes from extra if changing to a BooleanFilter

### DIFF
--- a/netbox/netbox/filtersets.py
+++ b/netbox/netbox/filtersets.py
@@ -183,8 +183,8 @@ class BaseFilterSet(django_filters.FilterSet):
                     filter_cls = type(existing_filter)
                     if lookup_expr == 'empty':
                         filter_cls = django_filters.BooleanFilter
-                        for field_to_remove in ('choices', 'null_value'):
-                            existing_filter_extra.pop(field_to_remove, None)
+                        for param_to_remove in ('choices', 'null_value'):
+                            existing_filter_extra.pop(param_to_remove, None)
                     new_filter = filter_cls(
                         field_name=field_name,
                         lookup_expr=lookup_expr,

--- a/netbox/netbox/filtersets.py
+++ b/netbox/netbox/filtersets.py
@@ -180,9 +180,11 @@ class BaseFilterSet(django_filters.FilterSet):
                     # create the new filter with the same type because there is no guarantee the defined type
                     # is the same as the default type for the field
                     resolve_field(field, lookup_expr)  # Will raise FieldLookupError if the lookup is invalid
-                    for field_to_remove in ('choices', 'null_value'):
-                        existing_filter_extra.pop(field_to_remove, None)
-                    filter_cls = django_filters.BooleanFilter if lookup_expr == 'empty' else type(existing_filter)
+                    filter_cls = type(existing_filter)
+                    if lookup_expr == 'empty':
+                        filter_cls = django_filters.BooleanFilter
+                        for field_to_remove in ('choices', 'null_value'):
+                            existing_filter_extra.pop(field_to_remove, None)
                     new_filter = filter_cls(
                         field_name=field_name,
                         lookup_expr=lookup_expr,

--- a/netbox/utilities/tests/test_filters.py
+++ b/netbox/utilities/tests/test_filters.py
@@ -408,9 +408,9 @@ class DynamicFilterLookupExpressionTest(TestCase):
             region.save()
 
         sites = (
-            Site(name='Site 1', slug='abc-site-1', region=regions[0], status='active'),
-            Site(name='Site 2', slug='def-site-2', region=regions[1], status='active'),
-            Site(name='Site 3', slug='ghi-site-3', region=regions[2], status='planned'),
+            Site(name='Site 1', slug='abc-site-1', region=regions[0], status=SiteStatusChoices.STATUS_ACTIVE),
+            Site(name='Site 2', slug='def-site-2', region=regions[1], status=SiteStatusChoices.STATUS_ACTIVE),
+            Site(name='Site 3', slug='ghi-site-3', region=regions[2], status=SiteStatusChoices.STATUS_PLANNED),
         )
         Site.objects.bulk_create(sites)
 

--- a/netbox/utilities/tests/test_filters.py
+++ b/netbox/utilities/tests/test_filters.py
@@ -446,16 +446,16 @@ class DynamicFilterLookupExpressionTest(TestCase):
         params = {'name__n': ['Site 1']}
         self.assertEqual(SiteFilterSet(params, Site.objects.all()).qs.count(), 2)
 
-    def test_site_slug_icontains(self):
-        params = {'slug__ic': ['-1']}
-        self.assertEqual(SiteFilterSet(params, Site.objects.all()).qs.count(), 1)
-
     def test_site_status_icontains(self):
         params = {'status__ic': [SiteStatusChoices.STATUS_ACTIVE]}
         self.assertEqual(SiteFilterSet(params, Site.objects.all()).qs.count(), 2)
 
     def test_site_status_icontains_negation(self):
         params = {'status__nic': [SiteStatusChoices.STATUS_ACTIVE]}
+        self.assertEqual(SiteFilterSet(params, Site.objects.all()).qs.count(), 1)
+
+    def test_site_slug_icontains(self):
+        params = {'slug__ic': ['-1']}
         self.assertEqual(SiteFilterSet(params, Site.objects.all()).qs.count(), 1)
 
     def test_site_slug_icontains_negation(self):

--- a/netbox/utilities/tests/test_filters.py
+++ b/netbox/utilities/tests/test_filters.py
@@ -563,7 +563,7 @@ class DynamicFilterLookupExpressionTest(TestCase):
         params = {'mac_address__nic': ['aa:', 'bb']}
         self.assertEqual(DeviceFilterSet(params, Device.objects.all()).qs.count(), 1)
 
-    def test_interface_wireless_role_empty(self):
+    def test_interface_rf_role_empty(self):
         params = {'rf_role__empty': 'true'}
         self.assertEqual(InterfaceFilterSet(params, Interface.objects.all()).qs.count(), 5)
         params = {'rf_role__empty': 'false'}

--- a/netbox/utilities/tests/test_filters.py
+++ b/netbox/utilities/tests/test_filters.py
@@ -408,9 +408,9 @@ class DynamicFilterLookupExpressionTest(TestCase):
             region.save()
 
         sites = (
-            Site(name='Site 1', slug='abc-site-1', region=regions[0]),
-            Site(name='Site 2', slug='def-site-2', region=regions[1]),
-            Site(name='Site 3', slug='ghi-site-3', region=regions[2]),
+            Site(name='Site 1', slug='abc-site-1', region=regions[0], status='active'),
+            Site(name='Site 2', slug='def-site-2', region=regions[1], status='active'),
+            Site(name='Site 3', slug='ghi-site-3', region=regions[2], status='planned'),
         )
         Site.objects.bulk_create(sites)
 
@@ -448,6 +448,14 @@ class DynamicFilterLookupExpressionTest(TestCase):
 
     def test_site_slug_icontains(self):
         params = {'slug__ic': ['-1']}
+        self.assertEqual(SiteFilterSet(params, Site.objects.all()).qs.count(), 1)
+
+    def test_site_status_icontains(self):
+        params = {'status__ic': [SiteStatusChoices.STATUS_ACTIVE]}
+        self.assertEqual(SiteFilterSet(params, Site.objects.all()).qs.count(), 2)
+
+    def test_site_status_icontains_negation(self):
+        params = {'status__nic': [SiteStatusChoices.STATUS_ACTIVE]}
         self.assertEqual(SiteFilterSet(params, Site.objects.all()).qs.count(), 1)
 
     def test_site_slug_icontains_negation(self):

--- a/netbox/utilities/tests/test_filters.py
+++ b/netbox/utilities/tests/test_filters.py
@@ -7,7 +7,7 @@ from taggit.managers import TaggableManager
 
 from dcim.choices import *
 from dcim.fields import MACAddressField
-from dcim.filtersets import DeviceFilterSet, SiteFilterSet
+from dcim.filtersets import DeviceFilterSet, SiteFilterSet, InterfaceFilterSet
 from dcim.models import (
     Device, DeviceRole, DeviceType, Interface, Manufacturer, Platform, Rack, Region, Site
 )
@@ -16,6 +16,7 @@ from extras.models import TaggedItem
 from ipam.filtersets import ASNFilterSet
 from ipam.models import RIR, ASN
 from netbox.filtersets import BaseFilterSet
+from wireless.choices import WirelessRoleChoices
 from utilities.filters import (
     MultiValueCharFilter, MultiValueDateFilter, MultiValueDateTimeFilter, MultiValueMACAddressFilter,
     MultiValueNumberFilter, MultiValueTimeFilter, TreeNodeMultipleChoiceFilter,
@@ -438,7 +439,7 @@ class DynamicFilterLookupExpressionTest(TestCase):
             Interface(device=devices[1], name='Interface 3', mac_address='00-00-00-00-00-02'),
             Interface(device=devices[1], name='Interface 4', mac_address='bb-00-00-00-00-02'),
             Interface(device=devices[2], name='Interface 5', mac_address='00-00-00-00-00-03'),
-            Interface(device=devices[2], name='Interface 6', mac_address='cc-00-00-00-00-03'),
+            Interface(device=devices[2], name='Interface 6', mac_address='cc-00-00-00-00-03', rf_role=WirelessRoleChoices.ROLE_AP),
         )
         Interface.objects.bulk_create(interfaces)
 
@@ -561,3 +562,9 @@ class DynamicFilterLookupExpressionTest(TestCase):
     def test_device_mac_address_icontains_negation(self):
         params = {'mac_address__nic': ['aa:', 'bb']}
         self.assertEqual(DeviceFilterSet(params, Device.objects.all()).qs.count(), 1)
+
+    def test_interface_wireless_role_empty(self):
+        params = {'rf_role__empty': 'true'}
+        self.assertEqual(InterfaceFilterSet(params, Interface.objects.all()).qs.count(), 5)
+        params = {'rf_role__empty': 'false'}
+        self.assertEqual(InterfaceFilterSet(params, Interface.objects.all()).qs.count(), 1)


### PR DESCRIPTION
### Fixes: #17663

Refines https://github.com/netbox-community/netbox/pull/17574 to ensure we only remove `choices` from the filter's `extra` attributes if we are artificially changing it to a `BooleanFilter` (i.e. if the lookup is `__empty`). This fixes an issue where `choices` was not being respected in the case of `MultipleChoiceField` where it should be allowed.

Also adds a test to ensure `MultipleChoiceField` character-based lookups are exercised.
Also adds tests for `__empty` lookup to the base filter lookup tests to exercise that behavior generically.