### PR TITLE
Fix parsing of extra_choices

### DIFF
--- a/netbox/extras/graphql/types.py
+++ b/netbox/extras/graphql/types.py
@@ -84,7 +84,7 @@ class CustomFieldType(ObjectType):
 class CustomFieldChoiceSetType(ObjectType):
 
     choices_for: List[Annotated["CustomFieldType", strawberry.lazy('extras.graphql.types')]]
-    extra_choices: List[str] | None
+    extra_choices: List[List[str]] | None
 
 
 @strawberry_django.type(

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -244,9 +244,18 @@ class CustomFieldChoiceSetTest(APIViewTestCases.APIViewTestCase):
     @classmethod
     def setUpTestData(cls):
         choice_sets = (
-            CustomFieldChoiceSet(name='Choice Set 1', extra_choices=['1A', '1B', '1C', '1D', '1E']),
-            CustomFieldChoiceSet(name='Choice Set 2', extra_choices=['2A', '2B', '2C', '2D', '2E']),
-            CustomFieldChoiceSet(name='Choice Set 3', extra_choices=['3A', '3B', '3C', '3D', '3E']),
+            CustomFieldChoiceSet(
+                name='Choice Set 1',
+                extra_choices=[['1A', '1A'], ['1B', '1B'], ['1C', '1C'], ['1D', '1D'], ['1E', '1E']],
+            ),
+            CustomFieldChoiceSet(
+                name='Choice Set 2',
+                extra_choices=[['2A', '2A'], ['2B', '2B'], ['2C', '2C'], ['2D', '2D'], ['2E', '2E']],
+            ),
+            CustomFieldChoiceSet(
+                name='Choice Set 3',
+                extra_choices=[['3A', '3A'], ['3B', '3B'], ['3C', '3C'], ['3D', '3D'], ['3E', '3E']],
+            ),
         )
         CustomFieldChoiceSet.objects.bulk_create(choice_sets)
 


### PR DESCRIPTION
Fixes: https://github.com/netbox-community/netbox/issues/17562

Updates extra_choices to be a list of a list of strings which is what Django reports as the relevant types at each level. In addition, it seems some of the test data for extra_choices was a list of strings instead of a nested list. 

The form code in CustomFieldChoiceSetForm automatically takes single-items and creates a label so there is a list of tuples being passed into the model. 