### PR TITLE
Add EVPN-VPWS to L2VPNTypeChoices

### DIFF
--- a/docs/models/vpn/l2vpn.md
+++ b/docs/models/vpn/l2vpn.md
@@ -28,6 +28,7 @@ The technology employed in forming and operating the L2VPN. Choices include:
 * VXLAN-EVPN
 * MPLS-EVPN
 * PBB-EVPN
+* EVPN-VPWS
 
 !!! note
     Designating the type as VPWS, EPL, EP-LAN, EP-TREE will limit the L2VPN instance to two terminations.

--- a/netbox/vpn/choices.py
+++ b/netbox/vpn/choices.py
@@ -219,6 +219,7 @@ class L2VPNTypeChoices(ChoiceSet):
     TYPE_VXLAN_EVPN = 'vxlan-evpn'
     TYPE_MPLS_EVPN = 'mpls-evpn'
     TYPE_PBB_EVPN = 'pbb-evpn'
+    TYPE_EVPN_VPWS = 'evpn-vpws'
 
     CHOICES = (
         ('VPLS', (
@@ -232,6 +233,7 @@ class L2VPNTypeChoices(ChoiceSet):
         ('L2VPN E-VPN', (
             (TYPE_MPLS_EVPN, 'MPLS EVPN'),
             (TYPE_PBB_EVPN, 'PBB EVPN'),
+            (TYPE_EVPN_VPWS, 'EVPN VPWS')
         )),
         ('E-Line', (
             (TYPE_EPL, 'EPL'),


### PR DESCRIPTION
### Fixes: #17216

Updated L2VPNTypeChoices to include the EVPN-VPWS type but didn't include it in the P2P list so more than two interfaces can be assigned to it. 