### PR TITLE
Closes #17472: Deprecate the staged changes API

### DIFF
--- a/docs/models/extras/branch.md
+++ b/docs/models/extras/branch.md
@@ -1,5 +1,8 @@
 # Branches
 
+!!! danger "Deprecated Feature"
+    This feature has been deprecated in NetBox v4.2 and will be removed in a future release. Please consider using the [netbox-branching plugin](https://github.com/netboxlabs/netbox-branching), which provides much more robust functionality.
+
 A branch is a collection of related [staged changes](./stagedchange.md) that have been prepared for merging into the active database. A branch can be merged by executing its `commit()` method. Deleting a branch will delete all its related changes.
 
 ## Fields

--- a/docs/models/extras/stagedchange.md
+++ b/docs/models/extras/stagedchange.md
@@ -1,5 +1,8 @@
 # Staged Changes
 
+!!! danger "Deprecated Feature"
+    This feature has been deprecated in NetBox v4.2 and will be removed in a future release. Please consider using the [netbox-branching plugin](https://github.com/netboxlabs/netbox-branching), which provides much more robust functionality.
+
 A staged change represents the creation of a new object or the modification or deletion of an existing object to be performed at some future point. Each change must be assigned to a [branch](./branch.md).
 
 Changes can be applied individually via the `apply()` method, however it is recommended to apply changes in bulk using the parent branch's `commit()` method.

--- a/docs/plugins/development/staged-changes.md
+++ b/docs/plugins/development/staged-changes.md
@@ -1,7 +1,7 @@
 # Staged Changes
 
-!!! danger "Experimental Feature"
-    This feature is still under active development and considered experimental in nature. Its use in production is strongly discouraged at this time.
+!!! danger "Deprecated Feature"
+    This feature has been deprecated in NetBox v4.2 and will be removed in a future release. Please consider using the [netbox-branching plugin](https://github.com/netboxlabs/netbox-branching), which provides much more robust functionality.
 
 NetBox provides a programmatic API to stage the creation, modification, and deletion of objects without actually committing those changes to the active database. This can be useful for performing a "dry run" of bulk operations, or preparing a set of changes for administrative approval, for example.
 

--- a/netbox/extras/models/staging.py
+++ b/netbox/extras/models/staging.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.db import models, transaction
@@ -43,6 +44,13 @@ class Branch(ChangeLoggedModel):
         ordering = ('name',)
         verbose_name = _('branch')
         verbose_name_plural = _('branches')
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            'The staged changes functionality has been deprecated and will be removed in a future release.',
+            DeprecationWarning
+        )
+        super().__init__(*args, **kwargs)
 
     def __str__(self):
         return f'{self.name} ({self.pk})'
@@ -96,6 +104,13 @@ class StagedChange(CustomValidationMixin, EventRulesMixin, models.Model):
         )
         verbose_name = _('staged change')
         verbose_name_plural = _('staged changes')
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn(
+            'The staged changes functionality has been deprecated and will be removed in a future release.',
+            DeprecationWarning
+        )
+        super().__init__(*args, **kwargs)
 
     def __str__(self):
         action = self.get_action_display()


### PR DESCRIPTION
### Fixes: #17472

- Raise a deprecation warning when instantiating a Branch or StagedChange
- Add deprecation warnings to the documentation