### PR TITLE
17614 Disallow removal of virtual chassis from device if set as master

### DIFF
--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -983,7 +983,7 @@ class Device(
                 'vc_position': _("A device assigned to a virtual chassis must have its position defined.")
             })
 
-        if vc_master_for := getattr(self, 'vc_master_for', None) != self.virtual_chassis:
+        if hasattr(self, 'vc_master_for') and self.vc_master_for and self.vc_master_for != self.virtual_chassis:
             raise ValidationError({
                 'virtual_chassis': _('Device cannot be removed from virtual chassis {virtual_chassis} because it is currently designated as its master.').format(
                     virtual_chassis=self.vc_master_for

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -983,6 +983,13 @@ class Device(
                 'vc_position': _("A device assigned to a virtual chassis must have its position defined.")
             })
 
+        if hasattr(self, 'vc_master_for') and self.vc_master_for and self.vc_master_for != self.virtual_chassis:
+            raise ValidationError({
+                'virtual_chassis': _("Cannot change to a different virtual chassis when assigned as a master. Remove it as the master of {master} first.").format(
+                    master=self.vc_master_for
+                )
+            })
+
     def _instantiate_components(self, queryset, bulk_create=True):
         """
         Instantiate components for the device from the specified component templates.

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -983,10 +983,10 @@ class Device(
                 'vc_position': _("A device assigned to a virtual chassis must have its position defined.")
             })
 
-        if hasattr(self, 'vc_master_for') and self.vc_master_for and self.vc_master_for != self.virtual_chassis:
+        if vc_master_for := getattr(self, 'vc_master_for', None) != self.virtual_chassis:
             raise ValidationError({
-                'virtual_chassis': _("Cannot change to a different virtual chassis when assigned as a master. Remove it as the master of {master} first.").format(
-                    master=self.vc_master_for
+                'virtual_chassis': _('Device cannot be removed from virtual chassis {virtual_chassis} because it is currently designated as its master.').format(
+                    virtual_chassis=self.vc_master_for
                 )
             })
 


### PR DESCRIPTION
### Fixes: #17614 

Raise error if removing the virtual chassis from a device if it is set as master.  We could auto-remove it from master on the virtual-chassis, but it seems like in other places we disallow the removal so keeping it consistent.