### PR TITLE
Fixes: #17732 - PNG background color in docs

### DIFF
--- a/docs/extra.css
+++ b/docs/extra.css
@@ -3,6 +3,7 @@ img {
     display: block;
     margin-left: auto;
     margin-right: auto;
+    background-color: rgba(255, 255, 255, 0.64);
 }
 
 /* Tables */


### PR DESCRIPTION
### Fixes: #17732

Adds a `background-color` property to the `img` CSS style for docs, to ensure that PNGs with transparent backgrounds and black text are still readable even on a dark-mode background.

<img width="953" alt="Screenshot 2024-10-16 at 2 18 10 PM" src="https://github.com/user-attachments/assets/86d6e945-a29e-4239-8f99-4344a43a3292">
