### PR TITLE
Fixes: #17740 - Add webp to the list of acceptable extensions for handling filenames in image_upload

### DIFF
--- a/netbox/extras/utils.py
+++ b/netbox/extras/utils.py
@@ -33,7 +33,7 @@ def image_upload(instance, filename):
 
     # Rename the file to the provided name, if any. Attempt to preserve the file extension.
     extension = filename.rsplit('.')[-1].lower()
-    if instance.name and extension in ['bmp', 'gif', 'jpeg', 'jpg', 'png']:
+    if instance.name and extension in ['bmp', 'gif', 'jpeg', 'jpg', 'png', 'webp']:
         filename = '.'.join([instance.name, extension])
     elif instance.name:
         filename = instance.name


### PR DESCRIPTION
### Fixes: #17740 

This ensures that image files with a `.webp` extension will be handled the same way as `png`, `jpg`, `jpeg`, etc. in that the appropriate extension will be appended to the saved file in `media`.

This addresses a knock-on issue raised in #17740 that a filename with multiple dots will have the rightmost dotted segment treated as the "extension", resulting in a (seemingly) unopenable file after download from NetBox.