### PR TITLE
Fixes #17802 - Added opaque background to Rename buttons

### DIFF
--- a/netbox/templates/dcim/component_list.html
+++ b/netbox/templates/dcim/component_list.html
@@ -10,7 +10,7 @@
     {% endif %}
     {% if 'bulk_rename' in actions %}
       {% with bulk_rename_view=model|validated_viewname:"bulk_rename" %}
-        <button type="submit" name="_rename" {% formaction %}="{% url bulk_rename_view %}" class="btn btn-outline-warning">
+        <button type="submit" name="_rename" {% formaction %}="{% url bulk_rename_view %}" class="btn btn-outline-warning btn-float">
           <i class="mdi mdi-pencil-outline" aria-hidden="true"></i> {% trans "Rename Selected" %}
         </button>
       {% endwith %}

--- a/netbox/templates/dcim/device_list.html
+++ b/netbox/templates/dcim/device_list.html
@@ -78,7 +78,7 @@
   {% if 'bulk_edit' in actions %}
     <div class="btn-group" role="group">
       {% bulk_edit_button model query_params=request.GET %}
-      <button type="submit" name="_rename" {% formaction %}="{% url 'dcim:device_bulk_rename' %}?return_url={% url 'dcim:device_list' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-outline-warning">
+      <button type="submit" name="_rename" {% formaction %}="{% url 'dcim:device_bulk_rename' %}?return_url={% url 'dcim:device_list' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="btn btn-outline-warning btn-float">
         <i class="mdi mdi-pencil-outline" aria-hidden="true"></i> {% trans "Rename" %}
       </button>
     </div>


### PR DESCRIPTION
Fixes: #17802

Added the `btn-float` class to the Rename buttons in the corresponding templates.
