### PR TITLE
Fixes #17884: Fix translation support for certain tab headings

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -11,7 +11,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
 from jinja2.exceptions import TemplateError
 

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -3,7 +3,7 @@ from django.db.models import Prefetch
 from django.db.models.expressions import RawSQL
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from circuits.models import Provider
 from dcim.filtersets import InterfaceFilterSet

--- a/netbox/netbox/views/generic/feature_views.py
+++ b/netbox/netbox/views/generic/feature_views.py
@@ -4,7 +4,7 @@ from django.contrib import messages
 from django.db import transaction
 from django.db.models import Q
 from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
 
 from core.models import Job, ObjectChange

--- a/netbox/tenancy/views.py
+++ b/netbox/tenancy/views.py
@@ -1,6 +1,6 @@
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from netbox.views import generic
 from utilities.query import count_related

--- a/netbox/translations/en/LC_MESSAGES/django.po
+++ b/netbox/translations/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-10-29 05:01+0000\n"
+"POT-Creation-Date: 2024-10-29 21:00+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -18,8056 +18,7536 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: netbox/account/tables.py:27 netbox/templates/account/token.html:22
-#: netbox/templates/users/token.html:17 netbox/users/forms/bulk_import.py:39
-#: netbox/users/forms/model_forms.py:112
+#: account/tables.py:27 templates/account/token.html:22
+#: templates/users/token.html:17 users/forms/bulk_import.py:39
+#: users/forms/model_forms.py:112
 msgid "Key"
 msgstr ""
 
-#: netbox/account/tables.py:31 netbox/users/forms/filtersets.py:132
+#: account/tables.py:31 users/forms/filtersets.py:132
 msgid "Write Enabled"
 msgstr ""
 
-#: netbox/account/tables.py:35 netbox/core/choices.py:86
-#: netbox/core/tables/jobs.py:29 netbox/core/tables/tasks.py:79
-#: netbox/extras/tables/tables.py:335 netbox/extras/tables/tables.py:566
-#: netbox/templates/account/token.html:43
-#: netbox/templates/core/configrevision.html:26
-#: netbox/templates/core/configrevision_restore.html:12
-#: netbox/templates/core/job.html:69 netbox/templates/core/rq_task.html:16
-#: netbox/templates/core/rq_task.html:73
-#: netbox/templates/core/rq_worker.html:14
-#: netbox/templates/extras/htmx/script_result.html:12
-#: netbox/templates/extras/journalentry.html:22
-#: netbox/templates/generic/object.html:58 netbox/templates/users/token.html:35
+#: account/tables.py:35 core/choices.py:86 core/tables/jobs.py:29
+#: core/tables/tasks.py:79 extras/tables/tables.py:335
+#: extras/tables/tables.py:566 templates/account/token.html:43
+#: templates/core/configrevision.html:26
+#: templates/core/configrevision_restore.html:12 templates/core/job.html:69
+#: templates/core/rq_task.html:16 templates/core/rq_task.html:73
+#: templates/core/rq_worker.html:14 templates/extras/htmx/script_result.html:12
+#: templates/extras/journalentry.html:22 templates/generic/object.html:58
+#: templates/users/token.html:35
 msgid "Created"
 msgstr ""
 
-#: netbox/account/tables.py:39 netbox/templates/account/token.html:47
-#: netbox/templates/users/token.html:39 netbox/users/forms/bulk_edit.py:117
-#: netbox/users/forms/filtersets.py:136
+#: account/tables.py:39 templates/account/token.html:47
+#: templates/users/token.html:39 users/forms/bulk_edit.py:117
+#: users/forms/filtersets.py:136
 msgid "Expires"
 msgstr ""
 
-#: netbox/account/tables.py:42 netbox/users/forms/filtersets.py:141
+#: account/tables.py:42 users/forms/filtersets.py:141
 msgid "Last Used"
 msgstr ""
 
-#: netbox/account/tables.py:45 netbox/templates/account/token.html:55
-#: netbox/templates/users/token.html:47 netbox/users/forms/bulk_edit.py:122
-#: netbox/users/forms/model_forms.py:124
+#: account/tables.py:45 templates/account/token.html:55
+#: templates/users/token.html:47 users/forms/bulk_edit.py:122
+#: users/forms/model_forms.py:124
 msgid "Allowed IPs"
 msgstr ""
 
-#: netbox/account/views.py:114
+#: account/views.py:114
 #, python-brace-format
 msgid "Logged in as {user}."
 msgstr ""
 
-#: netbox/account/views.py:164
+#: account/views.py:164
 msgid "You have logged out."
 msgstr ""
 
-#: netbox/account/views.py:216
+#: account/views.py:216
 msgid "Your preferences have been updated."
 msgstr ""
 
-#: netbox/account/views.py:239
+#: account/views.py:239
 msgid "LDAP-authenticated user credentials cannot be changed within NetBox."
 msgstr ""
 
-#: netbox/account/views.py:254
+#: account/views.py:254
 msgid "Your password has been changed successfully."
 msgstr ""
 
-#: netbox/circuits/choices.py:21 netbox/dcim/choices.py:20
-#: netbox/dcim/choices.py:102 netbox/dcim/choices.py:185
-#: netbox/dcim/choices.py:237 netbox/dcim/choices.py:1530
-#: netbox/dcim/choices.py:1606 netbox/dcim/choices.py:1656
-#: netbox/virtualization/choices.py:20 netbox/virtualization/choices.py:45
-#: netbox/vpn/choices.py:18
+#: circuits/choices.py:21 dcim/choices.py:20 dcim/choices.py:102
+#: dcim/choices.py:185 dcim/choices.py:237 dcim/choices.py:1530
+#: dcim/choices.py:1606 dcim/choices.py:1656 virtualization/choices.py:20
+#: virtualization/choices.py:45 vpn/choices.py:18
 msgid "Planned"
 msgstr ""
 
-#: netbox/circuits/choices.py:22 netbox/netbox/navigation/menu.py:305
+#: circuits/choices.py:22 netbox/navigation/menu.py:305
 msgid "Provisioning"
 msgstr ""
 
-#: netbox/circuits/choices.py:23 netbox/core/tables/tasks.py:22
-#: netbox/dcim/choices.py:22 netbox/dcim/choices.py:103
-#: netbox/dcim/choices.py:184 netbox/dcim/choices.py:236
-#: netbox/dcim/choices.py:1605 netbox/dcim/choices.py:1655
-#: netbox/extras/tables/tables.py:495 netbox/ipam/choices.py:31
-#: netbox/ipam/choices.py:49 netbox/ipam/choices.py:69
-#: netbox/ipam/choices.py:154 netbox/templates/extras/configcontext.html:25
-#: netbox/templates/users/user.html:37 netbox/users/forms/bulk_edit.py:38
-#: netbox/virtualization/choices.py:22 netbox/virtualization/choices.py:44
-#: netbox/vpn/choices.py:19 netbox/wireless/choices.py:25
+#: circuits/choices.py:23 core/tables/tasks.py:22 dcim/choices.py:22
+#: dcim/choices.py:103 dcim/choices.py:184 dcim/choices.py:236
+#: dcim/choices.py:1605 dcim/choices.py:1655 extras/tables/tables.py:495
+#: ipam/choices.py:31 ipam/choices.py:49 ipam/choices.py:69 ipam/choices.py:154
+#: templates/extras/configcontext.html:25 templates/users/user.html:37
+#: users/forms/bulk_edit.py:38 virtualization/choices.py:22
+#: virtualization/choices.py:44 vpn/choices.py:19 wireless/choices.py:25
 msgid "Active"
 msgstr ""
 
-#: netbox/circuits/choices.py:24 netbox/dcim/choices.py:183
-#: netbox/dcim/choices.py:235 netbox/dcim/choices.py:1604
-#: netbox/dcim/choices.py:1657 netbox/virtualization/choices.py:24
-#: netbox/virtualization/choices.py:43
+#: circuits/choices.py:24 dcim/choices.py:183 dcim/choices.py:235
+#: dcim/choices.py:1604 dcim/choices.py:1657 virtualization/choices.py:24
+#: virtualization/choices.py:43
 msgid "Offline"
 msgstr ""
 
-#: netbox/circuits/choices.py:25
+#: circuits/choices.py:25
 msgid "Deprovisioning"
 msgstr ""
 
-#: netbox/circuits/choices.py:26
+#: circuits/choices.py:26
 msgid "Decommissioned"
 msgstr ""
 
-#: netbox/circuits/choices.py:90 netbox/dcim/choices.py:1617
-#: netbox/tenancy/choices.py:17
+#: circuits/choices.py:90 dcim/choices.py:1617 tenancy/choices.py:17
 msgid "Primary"
 msgstr ""
 
-#: netbox/circuits/choices.py:91 netbox/ipam/choices.py:90
-#: netbox/tenancy/choices.py:18
+#: circuits/choices.py:91 ipam/choices.py:90 tenancy/choices.py:18
 msgid "Secondary"
 msgstr ""
 
-#: netbox/circuits/choices.py:92 netbox/tenancy/choices.py:19
+#: circuits/choices.py:92 tenancy/choices.py:19
 msgid "Tertiary"
 msgstr ""
 
-#: netbox/circuits/choices.py:93 netbox/tenancy/choices.py:20
+#: circuits/choices.py:93 tenancy/choices.py:20
 msgid "Inactive"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:31 netbox/circuits/filtersets.py:198
-#: netbox/dcim/filtersets.py:98 netbox/dcim/filtersets.py:152
-#: netbox/dcim/filtersets.py:212 netbox/dcim/filtersets.py:333
-#: netbox/dcim/filtersets.py:464 netbox/dcim/filtersets.py:1021
-#: netbox/dcim/filtersets.py:1368 netbox/dcim/filtersets.py:1903
-#: netbox/dcim/filtersets.py:2146 netbox/dcim/filtersets.py:2204
-#: netbox/ipam/filtersets.py:339 netbox/ipam/filtersets.py:959
-#: netbox/virtualization/filtersets.py:45
-#: netbox/virtualization/filtersets.py:173 netbox/vpn/filtersets.py:358
+#: circuits/filtersets.py:31 circuits/filtersets.py:198 dcim/filtersets.py:98
+#: dcim/filtersets.py:152 dcim/filtersets.py:212 dcim/filtersets.py:333
+#: dcim/filtersets.py:464 dcim/filtersets.py:1021 dcim/filtersets.py:1368
+#: dcim/filtersets.py:1903 dcim/filtersets.py:2146 dcim/filtersets.py:2204
+#: ipam/filtersets.py:339 ipam/filtersets.py:959
+#: virtualization/filtersets.py:45 virtualization/filtersets.py:173
+#: vpn/filtersets.py:358
 msgid "Region (ID)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:38 netbox/circuits/filtersets.py:205
-#: netbox/dcim/filtersets.py:105 netbox/dcim/filtersets.py:158
-#: netbox/dcim/filtersets.py:219 netbox/dcim/filtersets.py:340
-#: netbox/dcim/filtersets.py:471 netbox/dcim/filtersets.py:1028
-#: netbox/dcim/filtersets.py:1375 netbox/dcim/filtersets.py:1910
-#: netbox/dcim/filtersets.py:2153 netbox/dcim/filtersets.py:2211
-#: netbox/extras/filtersets.py:509 netbox/ipam/filtersets.py:346
-#: netbox/ipam/filtersets.py:966 netbox/virtualization/filtersets.py:52
-#: netbox/virtualization/filtersets.py:180 netbox/vpn/filtersets.py:353
+#: circuits/filtersets.py:38 circuits/filtersets.py:205 dcim/filtersets.py:105
+#: dcim/filtersets.py:158 dcim/filtersets.py:219 dcim/filtersets.py:340
+#: dcim/filtersets.py:471 dcim/filtersets.py:1028 dcim/filtersets.py:1375
+#: dcim/filtersets.py:1910 dcim/filtersets.py:2153 dcim/filtersets.py:2211
+#: extras/filtersets.py:509 ipam/filtersets.py:346 ipam/filtersets.py:966
+#: virtualization/filtersets.py:52 virtualization/filtersets.py:180
+#: vpn/filtersets.py:353
 msgid "Region (slug)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:44 netbox/circuits/filtersets.py:211
-#: netbox/dcim/filtersets.py:128 netbox/dcim/filtersets.py:225
-#: netbox/dcim/filtersets.py:346 netbox/dcim/filtersets.py:477
-#: netbox/dcim/filtersets.py:1034 netbox/dcim/filtersets.py:1381
-#: netbox/dcim/filtersets.py:1916 netbox/dcim/filtersets.py:2159
-#: netbox/dcim/filtersets.py:2217 netbox/ipam/filtersets.py:352
-#: netbox/ipam/filtersets.py:972 netbox/virtualization/filtersets.py:58
-#: netbox/virtualization/filtersets.py:186
+#: circuits/filtersets.py:44 circuits/filtersets.py:211 dcim/filtersets.py:128
+#: dcim/filtersets.py:225 dcim/filtersets.py:346 dcim/filtersets.py:477
+#: dcim/filtersets.py:1034 dcim/filtersets.py:1381 dcim/filtersets.py:1916
+#: dcim/filtersets.py:2159 dcim/filtersets.py:2217 ipam/filtersets.py:352
+#: ipam/filtersets.py:972 virtualization/filtersets.py:58
+#: virtualization/filtersets.py:186
 msgid "Site group (ID)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:51 netbox/circuits/filtersets.py:218
-#: netbox/dcim/filtersets.py:135 netbox/dcim/filtersets.py:232
-#: netbox/dcim/filtersets.py:353 netbox/dcim/filtersets.py:484
-#: netbox/dcim/filtersets.py:1041 netbox/dcim/filtersets.py:1388
-#: netbox/dcim/filtersets.py:1923 netbox/dcim/filtersets.py:2166
-#: netbox/dcim/filtersets.py:2224 netbox/extras/filtersets.py:515
-#: netbox/ipam/filtersets.py:359 netbox/ipam/filtersets.py:979
-#: netbox/virtualization/filtersets.py:65
-#: netbox/virtualization/filtersets.py:193
+#: circuits/filtersets.py:51 circuits/filtersets.py:218 dcim/filtersets.py:135
+#: dcim/filtersets.py:232 dcim/filtersets.py:353 dcim/filtersets.py:484
+#: dcim/filtersets.py:1041 dcim/filtersets.py:1388 dcim/filtersets.py:1923
+#: dcim/filtersets.py:2166 dcim/filtersets.py:2224 extras/filtersets.py:515
+#: ipam/filtersets.py:359 ipam/filtersets.py:979
+#: virtualization/filtersets.py:65 virtualization/filtersets.py:193
 msgid "Site group (slug)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:56 netbox/circuits/forms/bulk_edit.py:188
-#: netbox/circuits/forms/bulk_edit.py:216
-#: netbox/circuits/forms/bulk_import.py:124
-#: netbox/circuits/forms/filtersets.py:51
-#: netbox/circuits/forms/filtersets.py:171
-#: netbox/circuits/forms/filtersets.py:209
-#: netbox/circuits/forms/model_forms.py:138
-#: netbox/circuits/forms/model_forms.py:154
-#: netbox/circuits/tables/circuits.py:113 netbox/dcim/forms/bulk_edit.py:168
-#: netbox/dcim/forms/bulk_edit.py:329 netbox/dcim/forms/bulk_edit.py:677
-#: netbox/dcim/forms/bulk_edit.py:873 netbox/dcim/forms/bulk_import.py:131
-#: netbox/dcim/forms/bulk_import.py:230 netbox/dcim/forms/bulk_import.py:309
-#: netbox/dcim/forms/bulk_import.py:540 netbox/dcim/forms/bulk_import.py:1311
-#: netbox/dcim/forms/bulk_import.py:1339 netbox/dcim/forms/filtersets.py:87
-#: netbox/dcim/forms/filtersets.py:225 netbox/dcim/forms/filtersets.py:342
-#: netbox/dcim/forms/filtersets.py:439 netbox/dcim/forms/filtersets.py:753
-#: netbox/dcim/forms/filtersets.py:997 netbox/dcim/forms/filtersets.py:1021
-#: netbox/dcim/forms/filtersets.py:1111 netbox/dcim/forms/filtersets.py:1149
-#: netbox/dcim/forms/filtersets.py:1584 netbox/dcim/forms/filtersets.py:1608
-#: netbox/dcim/forms/filtersets.py:1632 netbox/dcim/forms/model_forms.py:137
-#: netbox/dcim/forms/model_forms.py:165 netbox/dcim/forms/model_forms.py:238
-#: netbox/dcim/forms/model_forms.py:463 netbox/dcim/forms/model_forms.py:723
-#: netbox/dcim/forms/object_create.py:391 netbox/dcim/tables/devices.py:153
-#: netbox/dcim/tables/power.py:26 netbox/dcim/tables/power.py:93
-#: netbox/dcim/tables/racks.py:122 netbox/dcim/tables/racks.py:207
-#: netbox/dcim/tables/sites.py:134 netbox/extras/filtersets.py:525
-#: netbox/ipam/forms/bulk_edit.py:218 netbox/ipam/forms/bulk_edit.py:285
-#: netbox/ipam/forms/bulk_edit.py:484 netbox/ipam/forms/bulk_import.py:171
-#: netbox/ipam/forms/bulk_import.py:429 netbox/ipam/forms/filtersets.py:153
-#: netbox/ipam/forms/filtersets.py:231 netbox/ipam/forms/filtersets.py:432
-#: netbox/ipam/forms/filtersets.py:489 netbox/ipam/forms/model_forms.py:205
-#: netbox/ipam/forms/model_forms.py:636 netbox/ipam/tables/ip.py:245
-#: netbox/ipam/tables/vlans.py:118 netbox/ipam/tables/vlans.py:221
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:6
-#: netbox/templates/dcim/device.html:22
-#: netbox/templates/dcim/inc/cable_termination.html:8
-#: netbox/templates/dcim/inc/cable_termination.html:33
-#: netbox/templates/dcim/location.html:37
-#: netbox/templates/dcim/powerpanel.html:22 netbox/templates/dcim/rack.html:20
-#: netbox/templates/dcim/rackreservation.html:28
-#: netbox/templates/dcim/site.html:28 netbox/templates/ipam/prefix.html:56
-#: netbox/templates/ipam/vlan.html:23 netbox/templates/ipam/vlan_edit.html:40
-#: netbox/templates/virtualization/cluster.html:42
-#: netbox/templates/virtualization/virtualmachine.html:95
-#: netbox/virtualization/forms/bulk_edit.py:91
-#: netbox/virtualization/forms/bulk_edit.py:109
-#: netbox/virtualization/forms/bulk_edit.py:124
-#: netbox/virtualization/forms/bulk_import.py:59
-#: netbox/virtualization/forms/bulk_import.py:85
-#: netbox/virtualization/forms/filtersets.py:79
-#: netbox/virtualization/forms/filtersets.py:148
-#: netbox/virtualization/forms/model_forms.py:71
-#: netbox/virtualization/forms/model_forms.py:104
-#: netbox/virtualization/forms/model_forms.py:171
-#: netbox/virtualization/tables/clusters.py:77
-#: netbox/virtualization/tables/virtualmachines.py:63
-#: netbox/vpn/forms/filtersets.py:266 netbox/wireless/forms/model_forms.py:76
-#: netbox/wireless/forms/model_forms.py:118
+#: circuits/filtersets.py:56 circuits/forms/bulk_edit.py:188
+#: circuits/forms/bulk_edit.py:216 circuits/forms/bulk_import.py:124
+#: circuits/forms/filtersets.py:51 circuits/forms/filtersets.py:171
+#: circuits/forms/filtersets.py:209 circuits/forms/model_forms.py:138
+#: circuits/forms/model_forms.py:154 circuits/tables/circuits.py:113
+#: dcim/forms/bulk_edit.py:168 dcim/forms/bulk_edit.py:329
+#: dcim/forms/bulk_edit.py:677 dcim/forms/bulk_edit.py:873
+#: dcim/forms/bulk_import.py:131 dcim/forms/bulk_import.py:230
+#: dcim/forms/bulk_import.py:309 dcim/forms/bulk_import.py:540
+#: dcim/forms/bulk_import.py:1311 dcim/forms/bulk_import.py:1339
+#: dcim/forms/filtersets.py:87 dcim/forms/filtersets.py:225
+#: dcim/forms/filtersets.py:342 dcim/forms/filtersets.py:439
+#: dcim/forms/filtersets.py:753 dcim/forms/filtersets.py:997
+#: dcim/forms/filtersets.py:1021 dcim/forms/filtersets.py:1111
+#: dcim/forms/filtersets.py:1149 dcim/forms/filtersets.py:1584
+#: dcim/forms/filtersets.py:1608 dcim/forms/filtersets.py:1632
+#: dcim/forms/model_forms.py:137 dcim/forms/model_forms.py:165
+#: dcim/forms/model_forms.py:238 dcim/forms/model_forms.py:463
+#: dcim/forms/model_forms.py:723 dcim/forms/object_create.py:391
+#: dcim/tables/devices.py:153 dcim/tables/power.py:26 dcim/tables/power.py:93
+#: dcim/tables/racks.py:122 dcim/tables/racks.py:207 dcim/tables/sites.py:134
+#: extras/filtersets.py:525 ipam/forms/bulk_edit.py:218
+#: ipam/forms/bulk_edit.py:285 ipam/forms/bulk_edit.py:484
+#: ipam/forms/bulk_import.py:171 ipam/forms/bulk_import.py:429
+#: ipam/forms/filtersets.py:153 ipam/forms/filtersets.py:231
+#: ipam/forms/filtersets.py:432 ipam/forms/filtersets.py:489
+#: ipam/forms/model_forms.py:205 ipam/forms/model_forms.py:636
+#: ipam/tables/ip.py:245 ipam/tables/vlans.py:118 ipam/tables/vlans.py:221
+#: templates/circuits/inc/circuit_termination_fields.html:6
+#: templates/dcim/device.html:22 templates/dcim/inc/cable_termination.html:8
+#: templates/dcim/inc/cable_termination.html:33 templates/dcim/location.html:37
+#: templates/dcim/powerpanel.html:22 templates/dcim/rack.html:20
+#: templates/dcim/rackreservation.html:28 templates/dcim/site.html:28
+#: templates/ipam/prefix.html:56 templates/ipam/vlan.html:23
+#: templates/ipam/vlan_edit.html:40 templates/virtualization/cluster.html:42
+#: templates/virtualization/virtualmachine.html:95
+#: virtualization/forms/bulk_edit.py:91 virtualization/forms/bulk_edit.py:109
+#: virtualization/forms/bulk_edit.py:124 virtualization/forms/bulk_import.py:59
+#: virtualization/forms/bulk_import.py:85 virtualization/forms/filtersets.py:79
+#: virtualization/forms/filtersets.py:148
+#: virtualization/forms/model_forms.py:71
+#: virtualization/forms/model_forms.py:104
+#: virtualization/forms/model_forms.py:171 virtualization/tables/clusters.py:77
+#: virtualization/tables/virtualmachines.py:63 vpn/forms/filtersets.py:266
+#: wireless/forms/model_forms.py:76 wireless/forms/model_forms.py:118
 msgid "Site"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:62 netbox/circuits/filtersets.py:229
-#: netbox/circuits/filtersets.py:274 netbox/dcim/filtersets.py:242
-#: netbox/dcim/filtersets.py:363 netbox/dcim/filtersets.py:458
-#: netbox/extras/filtersets.py:531 netbox/ipam/filtersets.py:238
-#: netbox/ipam/filtersets.py:369 netbox/ipam/filtersets.py:989
-#: netbox/virtualization/filtersets.py:75
-#: netbox/virtualization/filtersets.py:203 netbox/vpn/filtersets.py:363
+#: circuits/filtersets.py:62 circuits/filtersets.py:229
+#: circuits/filtersets.py:274 dcim/filtersets.py:242 dcim/filtersets.py:363
+#: dcim/filtersets.py:458 extras/filtersets.py:531 ipam/filtersets.py:238
+#: ipam/filtersets.py:369 ipam/filtersets.py:989
+#: virtualization/filtersets.py:75 virtualization/filtersets.py:203
+#: vpn/filtersets.py:363
 msgid "Site (slug)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:67
+#: circuits/filtersets.py:67
 msgid "ASN (ID)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:73 netbox/circuits/forms/filtersets.py:31
-#: netbox/ipam/forms/model_forms.py:159 netbox/ipam/models/asns.py:108
-#: netbox/ipam/models/asns.py:125 netbox/ipam/tables/asn.py:41
-#: netbox/templates/ipam/asn.html:20
+#: circuits/filtersets.py:73 circuits/forms/filtersets.py:31
+#: ipam/forms/model_forms.py:159 ipam/models/asns.py:108
+#: ipam/models/asns.py:125 ipam/tables/asn.py:41 templates/ipam/asn.html:20
 msgid "ASN"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:95 netbox/circuits/filtersets.py:122
-#: netbox/circuits/filtersets.py:156 netbox/circuits/filtersets.py:283
-#: netbox/circuits/filtersets.py:325 netbox/ipam/filtersets.py:243
+#: circuits/filtersets.py:95 circuits/filtersets.py:122
+#: circuits/filtersets.py:156 circuits/filtersets.py:283
+#: circuits/filtersets.py:325 ipam/filtersets.py:243
 msgid "Provider (ID)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:101 netbox/circuits/filtersets.py:128
-#: netbox/circuits/filtersets.py:162 netbox/circuits/filtersets.py:289
-#: netbox/circuits/filtersets.py:331 netbox/ipam/filtersets.py:249
+#: circuits/filtersets.py:101 circuits/filtersets.py:128
+#: circuits/filtersets.py:162 circuits/filtersets.py:289
+#: circuits/filtersets.py:331 ipam/filtersets.py:249
 msgid "Provider (slug)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:167
+#: circuits/filtersets.py:167
 msgid "Provider account (ID)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:173
+#: circuits/filtersets.py:173
 msgid "Provider account (account)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:178
+#: circuits/filtersets.py:178
 msgid "Provider network (ID)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:182
+#: circuits/filtersets.py:182
 msgid "Circuit type (ID)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:188
+#: circuits/filtersets.py:188
 msgid "Circuit type (slug)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:223 netbox/circuits/filtersets.py:268
-#: netbox/dcim/filtersets.py:236 netbox/dcim/filtersets.py:357
-#: netbox/dcim/filtersets.py:452 netbox/dcim/filtersets.py:1045
-#: netbox/dcim/filtersets.py:1393 netbox/dcim/filtersets.py:1928
-#: netbox/dcim/filtersets.py:2170 netbox/dcim/filtersets.py:2229
-#: netbox/ipam/filtersets.py:232 netbox/ipam/filtersets.py:363
-#: netbox/ipam/filtersets.py:983 netbox/virtualization/filtersets.py:69
-#: netbox/virtualization/filtersets.py:197 netbox/vpn/filtersets.py:368
+#: circuits/filtersets.py:223 circuits/filtersets.py:268 dcim/filtersets.py:236
+#: dcim/filtersets.py:357 dcim/filtersets.py:452 dcim/filtersets.py:1045
+#: dcim/filtersets.py:1393 dcim/filtersets.py:1928 dcim/filtersets.py:2170
+#: dcim/filtersets.py:2229 ipam/filtersets.py:232 ipam/filtersets.py:363
+#: ipam/filtersets.py:983 virtualization/filtersets.py:69
+#: virtualization/filtersets.py:197 vpn/filtersets.py:368
 msgid "Site (ID)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:233 netbox/circuits/filtersets.py:237
+#: circuits/filtersets.py:233 circuits/filtersets.py:237
 msgid "Termination A (ID)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:260 netbox/circuits/filtersets.py:320
-#: netbox/core/filtersets.py:77 netbox/core/filtersets.py:136
-#: netbox/core/filtersets.py:173 netbox/dcim/filtersets.py:751
-#: netbox/dcim/filtersets.py:1362 netbox/dcim/filtersets.py:2277
-#: netbox/extras/filtersets.py:41 netbox/extras/filtersets.py:63
-#: netbox/extras/filtersets.py:92 netbox/extras/filtersets.py:132
-#: netbox/extras/filtersets.py:181 netbox/extras/filtersets.py:209
-#: netbox/extras/filtersets.py:239 netbox/extras/filtersets.py:276
-#: netbox/extras/filtersets.py:348 netbox/extras/filtersets.py:391
-#: netbox/extras/filtersets.py:438 netbox/extras/filtersets.py:498
-#: netbox/extras/filtersets.py:657 netbox/extras/filtersets.py:703
-#: netbox/ipam/forms/model_forms.py:449 netbox/netbox/filtersets.py:282
-#: netbox/netbox/forms/__init__.py:22 netbox/netbox/forms/base.py:167
-#: netbox/templates/htmx/object_selector.html:28
-#: netbox/templates/inc/filter_list.html:46
-#: netbox/templates/ipam/ipaddress_assign.html:29
-#: netbox/templates/search.html:7 netbox/templates/search.html:26
-#: netbox/tenancy/filtersets.py:99 netbox/users/filtersets.py:23
-#: netbox/users/filtersets.py:57 netbox/users/filtersets.py:102
-#: netbox/users/filtersets.py:150 netbox/utilities/forms/forms.py:104
-#: netbox/utilities/templates/navigation/menu.html:16
+#: circuits/filtersets.py:260 circuits/filtersets.py:320 core/filtersets.py:77
+#: core/filtersets.py:136 core/filtersets.py:173 dcim/filtersets.py:751
+#: dcim/filtersets.py:1362 dcim/filtersets.py:2277 extras/filtersets.py:41
+#: extras/filtersets.py:63 extras/filtersets.py:92 extras/filtersets.py:132
+#: extras/filtersets.py:181 extras/filtersets.py:209 extras/filtersets.py:239
+#: extras/filtersets.py:276 extras/filtersets.py:348 extras/filtersets.py:391
+#: extras/filtersets.py:438 extras/filtersets.py:498 extras/filtersets.py:657
+#: extras/filtersets.py:703 ipam/forms/model_forms.py:449
+#: netbox/filtersets.py:282 netbox/forms/__init__.py:22
+#: netbox/forms/base.py:167 templates/htmx/object_selector.html:28
+#: templates/inc/filter_list.html:46 templates/ipam/ipaddress_assign.html:29
+#: templates/search.html:7 templates/search.html:26 tenancy/filtersets.py:99
+#: users/filtersets.py:23 users/filtersets.py:57 users/filtersets.py:102
+#: users/filtersets.py:150 utilities/forms/forms.py:104
+#: utilities/templates/navigation/menu.html:16
 msgid "Search"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:264 netbox/circuits/forms/bulk_edit.py:172
-#: netbox/circuits/forms/bulk_edit.py:246
-#: netbox/circuits/forms/bulk_import.py:115
-#: netbox/circuits/forms/filtersets.py:198
-#: netbox/circuits/forms/filtersets.py:214
-#: netbox/circuits/forms/filtersets.py:260
-#: netbox/circuits/forms/model_forms.py:111
-#: netbox/circuits/forms/model_forms.py:133
-#: netbox/circuits/forms/model_forms.py:199
-#: netbox/circuits/tables/circuits.py:104
-#: netbox/circuits/tables/circuits.py:164 netbox/dcim/forms/connections.py:73
-#: netbox/templates/circuits/circuit.html:15
-#: netbox/templates/circuits/circuitgroupassignment.html:26
-#: netbox/templates/circuits/circuittermination.html:19
-#: netbox/templates/dcim/inc/cable_termination.html:55
-#: netbox/templates/dcim/trace/circuit.html:4
+#: circuits/filtersets.py:264 circuits/forms/bulk_edit.py:172
+#: circuits/forms/bulk_edit.py:246 circuits/forms/bulk_import.py:115
+#: circuits/forms/filtersets.py:198 circuits/forms/filtersets.py:214
+#: circuits/forms/filtersets.py:260 circuits/forms/model_forms.py:111
+#: circuits/forms/model_forms.py:133 circuits/forms/model_forms.py:199
+#: circuits/tables/circuits.py:104 circuits/tables/circuits.py:164
+#: dcim/forms/connections.py:73 templates/circuits/circuit.html:15
+#: templates/circuits/circuitgroupassignment.html:26
+#: templates/circuits/circuittermination.html:19
+#: templates/dcim/inc/cable_termination.html:55
+#: templates/dcim/trace/circuit.html:4
 msgid "Circuit"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:278
+#: circuits/filtersets.py:278
 msgid "ProviderNetwork (ID)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:335
+#: circuits/filtersets.py:335
 msgid "Circuit (ID)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:341
+#: circuits/filtersets.py:341
 msgid "Circuit (CID)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:345
+#: circuits/filtersets.py:345
 msgid "Circuit group (ID)"
 msgstr ""
 
-#: netbox/circuits/filtersets.py:351
+#: circuits/filtersets.py:351
 msgid "Circuit group (slug)"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:30 netbox/circuits/forms/filtersets.py:56
-#: netbox/circuits/forms/model_forms.py:29
-#: netbox/circuits/tables/providers.py:33 netbox/dcim/forms/bulk_edit.py:128
-#: netbox/dcim/forms/filtersets.py:195 netbox/dcim/forms/model_forms.py:123
-#: netbox/dcim/tables/sites.py:94 netbox/ipam/models/asns.py:126
-#: netbox/ipam/tables/asn.py:27 netbox/ipam/views.py:213
-#: netbox/netbox/navigation/menu.py:172 netbox/netbox/navigation/menu.py:175
-#: netbox/templates/circuits/provider.html:23
+#: circuits/forms/bulk_edit.py:30 circuits/forms/filtersets.py:56
+#: circuits/forms/model_forms.py:29 circuits/tables/providers.py:33
+#: dcim/forms/bulk_edit.py:128 dcim/forms/filtersets.py:195
+#: dcim/forms/model_forms.py:123 dcim/tables/sites.py:94
+#: ipam/models/asns.py:126 ipam/tables/asn.py:27 ipam/views.py:213
+#: netbox/navigation/menu.py:172 netbox/navigation/menu.py:175
+#: templates/circuits/provider.html:23
 msgid "ASNs"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:34 netbox/circuits/forms/bulk_edit.py:56
-#: netbox/circuits/forms/bulk_edit.py:83 netbox/circuits/forms/bulk_edit.py:104
-#: netbox/circuits/forms/bulk_edit.py:164
-#: netbox/circuits/forms/bulk_edit.py:183
-#: netbox/circuits/forms/bulk_edit.py:228 netbox/core/forms/bulk_edit.py:28
-#: netbox/dcim/forms/bulk_create.py:35 netbox/dcim/forms/bulk_edit.py:73
-#: netbox/dcim/forms/bulk_edit.py:92 netbox/dcim/forms/bulk_edit.py:151
-#: netbox/dcim/forms/bulk_edit.py:192 netbox/dcim/forms/bulk_edit.py:210
-#: netbox/dcim/forms/bulk_edit.py:288 netbox/dcim/forms/bulk_edit.py:432
-#: netbox/dcim/forms/bulk_edit.py:466 netbox/dcim/forms/bulk_edit.py:481
-#: netbox/dcim/forms/bulk_edit.py:540 netbox/dcim/forms/bulk_edit.py:584
-#: netbox/dcim/forms/bulk_edit.py:618 netbox/dcim/forms/bulk_edit.py:642
-#: netbox/dcim/forms/bulk_edit.py:715 netbox/dcim/forms/bulk_edit.py:767
-#: netbox/dcim/forms/bulk_edit.py:819 netbox/dcim/forms/bulk_edit.py:842
-#: netbox/dcim/forms/bulk_edit.py:890 netbox/dcim/forms/bulk_edit.py:960
-#: netbox/dcim/forms/bulk_edit.py:1013 netbox/dcim/forms/bulk_edit.py:1048
-#: netbox/dcim/forms/bulk_edit.py:1088 netbox/dcim/forms/bulk_edit.py:1132
-#: netbox/dcim/forms/bulk_edit.py:1177 netbox/dcim/forms/bulk_edit.py:1204
-#: netbox/dcim/forms/bulk_edit.py:1222 netbox/dcim/forms/bulk_edit.py:1240
-#: netbox/dcim/forms/bulk_edit.py:1258 netbox/dcim/forms/bulk_edit.py:1682
-#: netbox/extras/forms/bulk_edit.py:39 netbox/extras/forms/bulk_edit.py:149
-#: netbox/extras/forms/bulk_edit.py:178 netbox/extras/forms/bulk_edit.py:208
-#: netbox/extras/forms/bulk_edit.py:256 netbox/extras/forms/bulk_edit.py:274
-#: netbox/extras/forms/bulk_edit.py:298 netbox/extras/forms/bulk_edit.py:312
-#: netbox/extras/forms/bulk_edit.py:339 netbox/extras/tables/tables.py:79
-#: netbox/ipam/forms/bulk_edit.py:53 netbox/ipam/forms/bulk_edit.py:73
-#: netbox/ipam/forms/bulk_edit.py:93 netbox/ipam/forms/bulk_edit.py:117
-#: netbox/ipam/forms/bulk_edit.py:146 netbox/ipam/forms/bulk_edit.py:175
-#: netbox/ipam/forms/bulk_edit.py:194 netbox/ipam/forms/bulk_edit.py:276
-#: netbox/ipam/forms/bulk_edit.py:321 netbox/ipam/forms/bulk_edit.py:369
-#: netbox/ipam/forms/bulk_edit.py:412 netbox/ipam/forms/bulk_edit.py:428
-#: netbox/ipam/forms/bulk_edit.py:516 netbox/ipam/forms/bulk_edit.py:547
-#: netbox/templates/account/token.html:35
-#: netbox/templates/circuits/circuit.html:59
-#: netbox/templates/circuits/circuitgroup.html:32
-#: netbox/templates/circuits/circuittype.html:26
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:88
-#: netbox/templates/circuits/provider.html:33
-#: netbox/templates/circuits/providernetwork.html:32
-#: netbox/templates/core/datasource.html:54
-#: netbox/templates/core/plugin.html:80 netbox/templates/dcim/cable.html:36
-#: netbox/templates/dcim/consoleport.html:44
-#: netbox/templates/dcim/consoleserverport.html:44
-#: netbox/templates/dcim/device.html:94 netbox/templates/dcim/devicebay.html:32
-#: netbox/templates/dcim/devicerole.html:30
-#: netbox/templates/dcim/devicetype.html:33
-#: netbox/templates/dcim/frontport.html:58
-#: netbox/templates/dcim/interface.html:69
-#: netbox/templates/dcim/inventoryitem.html:60
-#: netbox/templates/dcim/inventoryitemrole.html:22
-#: netbox/templates/dcim/location.html:33
-#: netbox/templates/dcim/manufacturer.html:40
-#: netbox/templates/dcim/module.html:73 netbox/templates/dcim/modulebay.html:42
-#: netbox/templates/dcim/moduletype.html:37
-#: netbox/templates/dcim/platform.html:33
-#: netbox/templates/dcim/powerfeed.html:40
-#: netbox/templates/dcim/poweroutlet.html:40
-#: netbox/templates/dcim/powerpanel.html:30
-#: netbox/templates/dcim/powerport.html:40 netbox/templates/dcim/rack.html:53
-#: netbox/templates/dcim/rackreservation.html:62
-#: netbox/templates/dcim/rackrole.html:26
-#: netbox/templates/dcim/racktype.html:24
-#: netbox/templates/dcim/rearport.html:54 netbox/templates/dcim/region.html:33
-#: netbox/templates/dcim/site.html:60 netbox/templates/dcim/sitegroup.html:33
-#: netbox/templates/dcim/virtualchassis.html:31
-#: netbox/templates/extras/configcontext.html:21
-#: netbox/templates/extras/configtemplate.html:17
-#: netbox/templates/extras/customfield.html:34
-#: netbox/templates/extras/dashboard/widget_add.html:14
-#: netbox/templates/extras/eventrule.html:21
-#: netbox/templates/extras/exporttemplate.html:19
-#: netbox/templates/extras/notificationgroup.html:20
-#: netbox/templates/extras/savedfilter.html:17
-#: netbox/templates/extras/script_list.html:45
-#: netbox/templates/extras/tag.html:20 netbox/templates/extras/webhook.html:17
-#: netbox/templates/generic/bulk_import.html:120
-#: netbox/templates/ipam/aggregate.html:43 netbox/templates/ipam/asn.html:42
-#: netbox/templates/ipam/asnrange.html:38
-#: netbox/templates/ipam/fhrpgroup.html:34
-#: netbox/templates/ipam/ipaddress.html:55
-#: netbox/templates/ipam/iprange.html:67 netbox/templates/ipam/prefix.html:81
-#: netbox/templates/ipam/rir.html:26 netbox/templates/ipam/role.html:26
-#: netbox/templates/ipam/routetarget.html:21
-#: netbox/templates/ipam/service.html:50
-#: netbox/templates/ipam/servicetemplate.html:27
-#: netbox/templates/ipam/vlan.html:62 netbox/templates/ipam/vlangroup.html:34
-#: netbox/templates/ipam/vrf.html:33 netbox/templates/tenancy/contact.html:67
-#: netbox/templates/tenancy/contactgroup.html:25
-#: netbox/templates/tenancy/contactrole.html:22
-#: netbox/templates/tenancy/tenant.html:24
-#: netbox/templates/tenancy/tenantgroup.html:33
-#: netbox/templates/users/group.html:21
-#: netbox/templates/users/objectpermission.html:21
-#: netbox/templates/users/token.html:27
-#: netbox/templates/virtualization/cluster.html:25
-#: netbox/templates/virtualization/clustergroup.html:26
-#: netbox/templates/virtualization/clustertype.html:26
-#: netbox/templates/virtualization/virtualdisk.html:39
-#: netbox/templates/virtualization/virtualmachine.html:31
-#: netbox/templates/virtualization/vminterface.html:51
-#: netbox/templates/vpn/ikepolicy.html:17
-#: netbox/templates/vpn/ikeproposal.html:17
-#: netbox/templates/vpn/ipsecpolicy.html:17
-#: netbox/templates/vpn/ipsecprofile.html:17
-#: netbox/templates/vpn/ipsecprofile.html:40
-#: netbox/templates/vpn/ipsecprofile.html:73
-#: netbox/templates/vpn/ipsecproposal.html:17
-#: netbox/templates/vpn/l2vpn.html:26 netbox/templates/vpn/tunnel.html:33
-#: netbox/templates/vpn/tunnelgroup.html:30
-#: netbox/templates/wireless/wirelesslan.html:26
-#: netbox/templates/wireless/wirelesslangroup.html:33
-#: netbox/templates/wireless/wirelesslink.html:34
-#: netbox/tenancy/forms/bulk_edit.py:32 netbox/tenancy/forms/bulk_edit.py:80
-#: netbox/tenancy/forms/bulk_edit.py:122 netbox/users/forms/bulk_edit.py:64
-#: netbox/users/forms/bulk_edit.py:82 netbox/users/forms/bulk_edit.py:112
-#: netbox/virtualization/forms/bulk_edit.py:32
-#: netbox/virtualization/forms/bulk_edit.py:46
-#: netbox/virtualization/forms/bulk_edit.py:100
-#: netbox/virtualization/forms/bulk_edit.py:177
-#: netbox/virtualization/forms/bulk_edit.py:228
-#: netbox/virtualization/forms/bulk_edit.py:337
-#: netbox/vpn/forms/bulk_edit.py:28 netbox/vpn/forms/bulk_edit.py:64
-#: netbox/vpn/forms/bulk_edit.py:121 netbox/vpn/forms/bulk_edit.py:155
-#: netbox/vpn/forms/bulk_edit.py:190 netbox/vpn/forms/bulk_edit.py:215
-#: netbox/vpn/forms/bulk_edit.py:247 netbox/vpn/forms/bulk_edit.py:274
-#: netbox/wireless/forms/bulk_edit.py:29 netbox/wireless/forms/bulk_edit.py:82
-#: netbox/wireless/forms/bulk_edit.py:140
+#: circuits/forms/bulk_edit.py:34 circuits/forms/bulk_edit.py:56
+#: circuits/forms/bulk_edit.py:83 circuits/forms/bulk_edit.py:104
+#: circuits/forms/bulk_edit.py:164 circuits/forms/bulk_edit.py:183
+#: circuits/forms/bulk_edit.py:228 core/forms/bulk_edit.py:28
+#: dcim/forms/bulk_create.py:35 dcim/forms/bulk_edit.py:73
+#: dcim/forms/bulk_edit.py:92 dcim/forms/bulk_edit.py:151
+#: dcim/forms/bulk_edit.py:192 dcim/forms/bulk_edit.py:210
+#: dcim/forms/bulk_edit.py:288 dcim/forms/bulk_edit.py:432
+#: dcim/forms/bulk_edit.py:466 dcim/forms/bulk_edit.py:481
+#: dcim/forms/bulk_edit.py:540 dcim/forms/bulk_edit.py:584
+#: dcim/forms/bulk_edit.py:618 dcim/forms/bulk_edit.py:642
+#: dcim/forms/bulk_edit.py:715 dcim/forms/bulk_edit.py:767
+#: dcim/forms/bulk_edit.py:819 dcim/forms/bulk_edit.py:842
+#: dcim/forms/bulk_edit.py:890 dcim/forms/bulk_edit.py:960
+#: dcim/forms/bulk_edit.py:1013 dcim/forms/bulk_edit.py:1048
+#: dcim/forms/bulk_edit.py:1088 dcim/forms/bulk_edit.py:1132
+#: dcim/forms/bulk_edit.py:1177 dcim/forms/bulk_edit.py:1204
+#: dcim/forms/bulk_edit.py:1222 dcim/forms/bulk_edit.py:1240
+#: dcim/forms/bulk_edit.py:1258 dcim/forms/bulk_edit.py:1682
+#: extras/forms/bulk_edit.py:39 extras/forms/bulk_edit.py:149
+#: extras/forms/bulk_edit.py:178 extras/forms/bulk_edit.py:208
+#: extras/forms/bulk_edit.py:256 extras/forms/bulk_edit.py:274
+#: extras/forms/bulk_edit.py:298 extras/forms/bulk_edit.py:312
+#: extras/forms/bulk_edit.py:339 extras/tables/tables.py:79
+#: ipam/forms/bulk_edit.py:53 ipam/forms/bulk_edit.py:73
+#: ipam/forms/bulk_edit.py:93 ipam/forms/bulk_edit.py:117
+#: ipam/forms/bulk_edit.py:146 ipam/forms/bulk_edit.py:175
+#: ipam/forms/bulk_edit.py:194 ipam/forms/bulk_edit.py:276
+#: ipam/forms/bulk_edit.py:321 ipam/forms/bulk_edit.py:369
+#: ipam/forms/bulk_edit.py:412 ipam/forms/bulk_edit.py:428
+#: ipam/forms/bulk_edit.py:516 ipam/forms/bulk_edit.py:547
+#: templates/account/token.html:35 templates/circuits/circuit.html:59
+#: templates/circuits/circuitgroup.html:32
+#: templates/circuits/circuittype.html:26
+#: templates/circuits/inc/circuit_termination_fields.html:88
+#: templates/circuits/provider.html:33
+#: templates/circuits/providernetwork.html:32 templates/core/datasource.html:54
+#: templates/core/plugin.html:80 templates/dcim/cable.html:36
+#: templates/dcim/consoleport.html:44 templates/dcim/consoleserverport.html:44
+#: templates/dcim/device.html:94 templates/dcim/devicebay.html:32
+#: templates/dcim/devicerole.html:30 templates/dcim/devicetype.html:33
+#: templates/dcim/frontport.html:58 templates/dcim/interface.html:69
+#: templates/dcim/inventoryitem.html:60
+#: templates/dcim/inventoryitemrole.html:22 templates/dcim/location.html:33
+#: templates/dcim/manufacturer.html:40 templates/dcim/module.html:73
+#: templates/dcim/modulebay.html:42 templates/dcim/moduletype.html:37
+#: templates/dcim/platform.html:33 templates/dcim/powerfeed.html:40
+#: templates/dcim/poweroutlet.html:40 templates/dcim/powerpanel.html:30
+#: templates/dcim/powerport.html:40 templates/dcim/rack.html:53
+#: templates/dcim/rackreservation.html:62 templates/dcim/rackrole.html:26
+#: templates/dcim/racktype.html:24 templates/dcim/rearport.html:54
+#: templates/dcim/region.html:33 templates/dcim/site.html:60
+#: templates/dcim/sitegroup.html:33 templates/dcim/virtualchassis.html:31
+#: templates/extras/configcontext.html:21
+#: templates/extras/configtemplate.html:17 templates/extras/customfield.html:34
+#: templates/extras/dashboard/widget_add.html:14
+#: templates/extras/eventrule.html:21 templates/extras/exporttemplate.html:19
+#: templates/extras/notificationgroup.html:20
+#: templates/extras/savedfilter.html:17 templates/extras/script_list.html:45
+#: templates/extras/tag.html:20 templates/extras/webhook.html:17
+#: templates/generic/bulk_import.html:120 templates/ipam/aggregate.html:43
+#: templates/ipam/asn.html:42 templates/ipam/asnrange.html:38
+#: templates/ipam/fhrpgroup.html:34 templates/ipam/ipaddress.html:55
+#: templates/ipam/iprange.html:67 templates/ipam/prefix.html:81
+#: templates/ipam/rir.html:26 templates/ipam/role.html:26
+#: templates/ipam/routetarget.html:21 templates/ipam/service.html:50
+#: templates/ipam/servicetemplate.html:27 templates/ipam/vlan.html:62
+#: templates/ipam/vlangroup.html:34 templates/ipam/vrf.html:33
+#: templates/tenancy/contact.html:67 templates/tenancy/contactgroup.html:25
+#: templates/tenancy/contactrole.html:22 templates/tenancy/tenant.html:24
+#: templates/tenancy/tenantgroup.html:33 templates/users/group.html:21
+#: templates/users/objectpermission.html:21 templates/users/token.html:27
+#: templates/virtualization/cluster.html:25
+#: templates/virtualization/clustergroup.html:26
+#: templates/virtualization/clustertype.html:26
+#: templates/virtualization/virtualdisk.html:39
+#: templates/virtualization/virtualmachine.html:31
+#: templates/virtualization/vminterface.html:51 templates/vpn/ikepolicy.html:17
+#: templates/vpn/ikeproposal.html:17 templates/vpn/ipsecpolicy.html:17
+#: templates/vpn/ipsecprofile.html:17 templates/vpn/ipsecprofile.html:40
+#: templates/vpn/ipsecprofile.html:73 templates/vpn/ipsecproposal.html:17
+#: templates/vpn/l2vpn.html:26 templates/vpn/tunnel.html:33
+#: templates/vpn/tunnelgroup.html:30 templates/wireless/wirelesslan.html:26
+#: templates/wireless/wirelesslangroup.html:33
+#: templates/wireless/wirelesslink.html:34 tenancy/forms/bulk_edit.py:32
+#: tenancy/forms/bulk_edit.py:80 tenancy/forms/bulk_edit.py:122
+#: users/forms/bulk_edit.py:64 users/forms/bulk_edit.py:82
+#: users/forms/bulk_edit.py:112 virtualization/forms/bulk_edit.py:32
+#: virtualization/forms/bulk_edit.py:46 virtualization/forms/bulk_edit.py:100
+#: virtualization/forms/bulk_edit.py:177 virtualization/forms/bulk_edit.py:228
+#: virtualization/forms/bulk_edit.py:337 vpn/forms/bulk_edit.py:28
+#: vpn/forms/bulk_edit.py:64 vpn/forms/bulk_edit.py:121
+#: vpn/forms/bulk_edit.py:155 vpn/forms/bulk_edit.py:190
+#: vpn/forms/bulk_edit.py:215 vpn/forms/bulk_edit.py:247
+#: vpn/forms/bulk_edit.py:274 wireless/forms/bulk_edit.py:29
+#: wireless/forms/bulk_edit.py:82 wireless/forms/bulk_edit.py:140
 msgid "Description"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:51 netbox/circuits/forms/bulk_edit.py:73
-#: netbox/circuits/forms/bulk_edit.py:123
-#: netbox/circuits/forms/bulk_import.py:36
-#: netbox/circuits/forms/bulk_import.py:51
-#: netbox/circuits/forms/bulk_import.py:74
-#: netbox/circuits/forms/filtersets.py:70
-#: netbox/circuits/forms/filtersets.py:88
-#: netbox/circuits/forms/filtersets.py:116
-#: netbox/circuits/forms/filtersets.py:131
-#: netbox/circuits/forms/filtersets.py:199
-#: netbox/circuits/forms/filtersets.py:232
-#: netbox/circuits/forms/filtersets.py:255
-#: netbox/circuits/forms/model_forms.py:47
-#: netbox/circuits/forms/model_forms.py:61
-#: netbox/circuits/forms/model_forms.py:93
-#: netbox/circuits/tables/circuits.py:58 netbox/circuits/tables/circuits.py:108
-#: netbox/circuits/tables/circuits.py:160
-#: netbox/circuits/tables/providers.py:72
-#: netbox/circuits/tables/providers.py:103
-#: netbox/templates/circuits/circuit.html:18
-#: netbox/templates/circuits/circuittermination.html:25
-#: netbox/templates/circuits/provider.html:20
-#: netbox/templates/circuits/provideraccount.html:20
-#: netbox/templates/circuits/providernetwork.html:20
-#: netbox/templates/dcim/inc/cable_termination.html:51
+#: circuits/forms/bulk_edit.py:51 circuits/forms/bulk_edit.py:73
+#: circuits/forms/bulk_edit.py:123 circuits/forms/bulk_import.py:36
+#: circuits/forms/bulk_import.py:51 circuits/forms/bulk_import.py:74
+#: circuits/forms/filtersets.py:70 circuits/forms/filtersets.py:88
+#: circuits/forms/filtersets.py:116 circuits/forms/filtersets.py:131
+#: circuits/forms/filtersets.py:199 circuits/forms/filtersets.py:232
+#: circuits/forms/filtersets.py:255 circuits/forms/model_forms.py:47
+#: circuits/forms/model_forms.py:61 circuits/forms/model_forms.py:93
+#: circuits/tables/circuits.py:58 circuits/tables/circuits.py:108
+#: circuits/tables/circuits.py:160 circuits/tables/providers.py:72
+#: circuits/tables/providers.py:103 templates/circuits/circuit.html:18
+#: templates/circuits/circuittermination.html:25
+#: templates/circuits/provider.html:20
+#: templates/circuits/provideraccount.html:20
+#: templates/circuits/providernetwork.html:20
+#: templates/dcim/inc/cable_termination.html:51
 msgid "Provider"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:80 netbox/circuits/forms/filtersets.py:91
-#: netbox/templates/circuits/providernetwork.html:28
+#: circuits/forms/bulk_edit.py:80 circuits/forms/filtersets.py:91
+#: templates/circuits/providernetwork.html:28
 msgid "Service ID"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:100
-#: netbox/circuits/forms/filtersets.py:107 netbox/dcim/forms/bulk_edit.py:206
-#: netbox/dcim/forms/bulk_edit.py:604 netbox/dcim/forms/bulk_edit.py:804
-#: netbox/dcim/forms/bulk_edit.py:1173 netbox/dcim/forms/bulk_edit.py:1200
-#: netbox/dcim/forms/bulk_edit.py:1678 netbox/dcim/forms/filtersets.py:1064
-#: netbox/dcim/forms/filtersets.py:1455 netbox/dcim/forms/filtersets.py:1479
-#: netbox/dcim/tables/devices.py:704 netbox/dcim/tables/devices.py:761
-#: netbox/dcim/tables/devices.py:1003 netbox/dcim/tables/devicetypes.py:249
-#: netbox/dcim/tables/devicetypes.py:264 netbox/dcim/tables/racks.py:33
-#: netbox/extras/forms/bulk_edit.py:270 netbox/extras/tables/tables.py:443
-#: netbox/templates/circuits/circuittype.html:30
-#: netbox/templates/dcim/cable.html:40 netbox/templates/dcim/devicerole.html:34
-#: netbox/templates/dcim/frontport.html:40
-#: netbox/templates/dcim/inventoryitemrole.html:26
-#: netbox/templates/dcim/rackrole.html:30
-#: netbox/templates/dcim/rearport.html:40 netbox/templates/extras/tag.html:26
+#: circuits/forms/bulk_edit.py:100 circuits/forms/filtersets.py:107
+#: dcim/forms/bulk_edit.py:206 dcim/forms/bulk_edit.py:604
+#: dcim/forms/bulk_edit.py:804 dcim/forms/bulk_edit.py:1173
+#: dcim/forms/bulk_edit.py:1200 dcim/forms/bulk_edit.py:1678
+#: dcim/forms/filtersets.py:1064 dcim/forms/filtersets.py:1455
+#: dcim/forms/filtersets.py:1479 dcim/tables/devices.py:704
+#: dcim/tables/devices.py:761 dcim/tables/devices.py:1003
+#: dcim/tables/devicetypes.py:249 dcim/tables/devicetypes.py:264
+#: dcim/tables/racks.py:33 extras/forms/bulk_edit.py:270
+#: extras/tables/tables.py:443 templates/circuits/circuittype.html:30
+#: templates/dcim/cable.html:40 templates/dcim/devicerole.html:34
+#: templates/dcim/frontport.html:40 templates/dcim/inventoryitemrole.html:26
+#: templates/dcim/rackrole.html:30 templates/dcim/rearport.html:40
+#: templates/extras/tag.html:26
 msgid "Color"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:118
-#: netbox/circuits/forms/bulk_import.py:87
-#: netbox/circuits/forms/filtersets.py:126 netbox/core/forms/bulk_edit.py:18
-#: netbox/core/forms/filtersets.py:33 netbox/core/tables/change_logging.py:32
-#: netbox/core/tables/data.py:20 netbox/core/tables/jobs.py:18
-#: netbox/dcim/forms/bulk_edit.py:782 netbox/dcim/forms/bulk_edit.py:921
-#: netbox/dcim/forms/bulk_edit.py:989 netbox/dcim/forms/bulk_edit.py:1008
-#: netbox/dcim/forms/bulk_edit.py:1031 netbox/dcim/forms/bulk_edit.py:1073
-#: netbox/dcim/forms/bulk_edit.py:1117 netbox/dcim/forms/bulk_edit.py:1168
-#: netbox/dcim/forms/bulk_edit.py:1195 netbox/dcim/forms/bulk_import.py:188
-#: netbox/dcim/forms/bulk_import.py:260 netbox/dcim/forms/bulk_import.py:708
-#: netbox/dcim/forms/bulk_import.py:734 netbox/dcim/forms/bulk_import.py:760
-#: netbox/dcim/forms/bulk_import.py:780 netbox/dcim/forms/bulk_import.py:863
-#: netbox/dcim/forms/bulk_import.py:957 netbox/dcim/forms/bulk_import.py:999
-#: netbox/dcim/forms/bulk_import.py:1213 netbox/dcim/forms/bulk_import.py:1376
-#: netbox/dcim/forms/filtersets.py:955 netbox/dcim/forms/filtersets.py:1054
-#: netbox/dcim/forms/filtersets.py:1175 netbox/dcim/forms/filtersets.py:1247
-#: netbox/dcim/forms/filtersets.py:1272 netbox/dcim/forms/filtersets.py:1296
-#: netbox/dcim/forms/filtersets.py:1316 netbox/dcim/forms/filtersets.py:1353
-#: netbox/dcim/forms/filtersets.py:1450 netbox/dcim/forms/filtersets.py:1474
-#: netbox/dcim/forms/model_forms.py:703 netbox/dcim/forms/model_forms.py:709
-#: netbox/dcim/forms/object_import.py:84 netbox/dcim/forms/object_import.py:113
-#: netbox/dcim/forms/object_import.py:145 netbox/dcim/tables/devices.py:178
-#: netbox/dcim/tables/devices.py:814 netbox/dcim/tables/power.py:77
-#: netbox/dcim/tables/racks.py:138 netbox/extras/forms/bulk_import.py:42
-#: netbox/extras/tables/tables.py:405 netbox/extras/tables/tables.py:465
-#: netbox/netbox/tables/tables.py:240 netbox/templates/circuits/circuit.html:30
-#: netbox/templates/core/datasource.html:38 netbox/templates/dcim/cable.html:15
-#: netbox/templates/dcim/consoleport.html:36
-#: netbox/templates/dcim/consoleserverport.html:36
-#: netbox/templates/dcim/frontport.html:36
-#: netbox/templates/dcim/interface.html:46
-#: netbox/templates/dcim/interface.html:169
-#: netbox/templates/dcim/interface.html:311
-#: netbox/templates/dcim/powerfeed.html:32
-#: netbox/templates/dcim/poweroutlet.html:36
-#: netbox/templates/dcim/powerport.html:36
-#: netbox/templates/dcim/rearport.html:36
-#: netbox/templates/extras/eventrule.html:74
-#: netbox/templates/virtualization/cluster.html:17
-#: netbox/templates/vpn/l2vpn.html:22
-#: netbox/templates/wireless/inc/authentication_attrs.html:8
-#: netbox/templates/wireless/inc/wirelesslink_interface.html:14
-#: netbox/virtualization/forms/bulk_edit.py:60
-#: netbox/virtualization/forms/bulk_import.py:41
-#: netbox/virtualization/forms/filtersets.py:54
-#: netbox/virtualization/forms/model_forms.py:62
-#: netbox/virtualization/tables/clusters.py:66
-#: netbox/vpn/forms/bulk_edit.py:264 netbox/vpn/forms/bulk_import.py:264
-#: netbox/vpn/forms/filtersets.py:217 netbox/vpn/forms/model_forms.py:84
-#: netbox/vpn/forms/model_forms.py:119 netbox/vpn/forms/model_forms.py:231
+#: circuits/forms/bulk_edit.py:118 circuits/forms/bulk_import.py:87
+#: circuits/forms/filtersets.py:126 core/forms/bulk_edit.py:18
+#: core/forms/filtersets.py:33 core/tables/change_logging.py:32
+#: core/tables/data.py:20 core/tables/jobs.py:18 dcim/forms/bulk_edit.py:782
+#: dcim/forms/bulk_edit.py:921 dcim/forms/bulk_edit.py:989
+#: dcim/forms/bulk_edit.py:1008 dcim/forms/bulk_edit.py:1031
+#: dcim/forms/bulk_edit.py:1073 dcim/forms/bulk_edit.py:1117
+#: dcim/forms/bulk_edit.py:1168 dcim/forms/bulk_edit.py:1195
+#: dcim/forms/bulk_import.py:188 dcim/forms/bulk_import.py:260
+#: dcim/forms/bulk_import.py:708 dcim/forms/bulk_import.py:734
+#: dcim/forms/bulk_import.py:760 dcim/forms/bulk_import.py:780
+#: dcim/forms/bulk_import.py:863 dcim/forms/bulk_import.py:957
+#: dcim/forms/bulk_import.py:999 dcim/forms/bulk_import.py:1213
+#: dcim/forms/bulk_import.py:1376 dcim/forms/filtersets.py:955
+#: dcim/forms/filtersets.py:1054 dcim/forms/filtersets.py:1175
+#: dcim/forms/filtersets.py:1247 dcim/forms/filtersets.py:1272
+#: dcim/forms/filtersets.py:1296 dcim/forms/filtersets.py:1316
+#: dcim/forms/filtersets.py:1353 dcim/forms/filtersets.py:1450
+#: dcim/forms/filtersets.py:1474 dcim/forms/model_forms.py:703
+#: dcim/forms/model_forms.py:709 dcim/forms/object_import.py:84
+#: dcim/forms/object_import.py:113 dcim/forms/object_import.py:145
+#: dcim/tables/devices.py:178 dcim/tables/devices.py:814
+#: dcim/tables/power.py:77 dcim/tables/racks.py:138
+#: extras/forms/bulk_import.py:42 extras/tables/tables.py:405
+#: extras/tables/tables.py:465 netbox/tables/tables.py:240
+#: templates/circuits/circuit.html:30 templates/core/datasource.html:38
+#: templates/dcim/cable.html:15 templates/dcim/consoleport.html:36
+#: templates/dcim/consoleserverport.html:36 templates/dcim/frontport.html:36
+#: templates/dcim/interface.html:46 templates/dcim/interface.html:169
+#: templates/dcim/interface.html:311 templates/dcim/powerfeed.html:32
+#: templates/dcim/poweroutlet.html:36 templates/dcim/powerport.html:36
+#: templates/dcim/rearport.html:36 templates/extras/eventrule.html:74
+#: templates/virtualization/cluster.html:17 templates/vpn/l2vpn.html:22
+#: templates/wireless/inc/authentication_attrs.html:8
+#: templates/wireless/inc/wirelesslink_interface.html:14
+#: virtualization/forms/bulk_edit.py:60 virtualization/forms/bulk_import.py:41
+#: virtualization/forms/filtersets.py:54 virtualization/forms/model_forms.py:62
+#: virtualization/tables/clusters.py:66 vpn/forms/bulk_edit.py:264
+#: vpn/forms/bulk_import.py:264 vpn/forms/filtersets.py:217
+#: vpn/forms/model_forms.py:84 vpn/forms/model_forms.py:119
+#: vpn/forms/model_forms.py:231
 msgid "Type"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:128
-#: netbox/circuits/forms/bulk_import.py:80
-#: netbox/circuits/forms/filtersets.py:139
-#: netbox/circuits/forms/model_forms.py:98
+#: circuits/forms/bulk_edit.py:128 circuits/forms/bulk_import.py:80
+#: circuits/forms/filtersets.py:139 circuits/forms/model_forms.py:98
 msgid "Provider account"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:136
-#: netbox/circuits/forms/bulk_import.py:93
-#: netbox/circuits/forms/filtersets.py:150 netbox/core/forms/filtersets.py:38
-#: netbox/core/forms/filtersets.py:79 netbox/core/tables/data.py:23
-#: netbox/core/tables/jobs.py:26 netbox/core/tables/tasks.py:88
-#: netbox/dcim/forms/bulk_edit.py:106 netbox/dcim/forms/bulk_edit.py:181
-#: netbox/dcim/forms/bulk_edit.py:351 netbox/dcim/forms/bulk_edit.py:700
-#: netbox/dcim/forms/bulk_edit.py:756 netbox/dcim/forms/bulk_edit.py:788
-#: netbox/dcim/forms/bulk_edit.py:915 netbox/dcim/forms/bulk_edit.py:1701
-#: netbox/dcim/forms/bulk_import.py:88 netbox/dcim/forms/bulk_import.py:147
-#: netbox/dcim/forms/bulk_import.py:248 netbox/dcim/forms/bulk_import.py:505
-#: netbox/dcim/forms/bulk_import.py:659 netbox/dcim/forms/bulk_import.py:1207
-#: netbox/dcim/forms/bulk_import.py:1371 netbox/dcim/forms/bulk_import.py:1435
-#: netbox/dcim/forms/filtersets.py:178 netbox/dcim/forms/filtersets.py:237
-#: netbox/dcim/forms/filtersets.py:359 netbox/dcim/forms/filtersets.py:799
-#: netbox/dcim/forms/filtersets.py:924 netbox/dcim/forms/filtersets.py:958
-#: netbox/dcim/forms/filtersets.py:1059 netbox/dcim/forms/filtersets.py:1170
-#: netbox/dcim/tables/devices.py:140 netbox/dcim/tables/devices.py:817
-#: netbox/dcim/tables/devices.py:1063 netbox/dcim/tables/modules.py:69
-#: netbox/dcim/tables/power.py:74 netbox/dcim/tables/racks.py:126
-#: netbox/dcim/tables/sites.py:82 netbox/dcim/tables/sites.py:138
-#: netbox/ipam/forms/bulk_edit.py:256 netbox/ipam/forms/bulk_edit.py:306
-#: netbox/ipam/forms/bulk_edit.py:354 netbox/ipam/forms/bulk_edit.py:506
-#: netbox/ipam/forms/bulk_import.py:192 netbox/ipam/forms/bulk_import.py:257
-#: netbox/ipam/forms/bulk_import.py:293 netbox/ipam/forms/bulk_import.py:450
-#: netbox/ipam/forms/filtersets.py:210 netbox/ipam/forms/filtersets.py:281
-#: netbox/ipam/forms/filtersets.py:355 netbox/ipam/forms/filtersets.py:501
-#: netbox/ipam/forms/model_forms.py:468 netbox/ipam/tables/ip.py:237
-#: netbox/ipam/tables/ip.py:312 netbox/ipam/tables/ip.py:363
-#: netbox/ipam/tables/ip.py:426 netbox/ipam/tables/ip.py:453
-#: netbox/ipam/tables/vlans.py:126 netbox/ipam/tables/vlans.py:232
-#: netbox/templates/circuits/circuit.html:34
-#: netbox/templates/core/datasource.html:46 netbox/templates/core/job.html:48
-#: netbox/templates/core/rq_task.html:81 netbox/templates/core/system.html:18
-#: netbox/templates/dcim/cable.html:19 netbox/templates/dcim/device.html:178
-#: netbox/templates/dcim/location.html:45 netbox/templates/dcim/module.html:69
-#: netbox/templates/dcim/powerfeed.html:36 netbox/templates/dcim/rack.html:41
-#: netbox/templates/dcim/site.html:43
-#: netbox/templates/extras/script_list.html:47
-#: netbox/templates/ipam/ipaddress.html:37
-#: netbox/templates/ipam/iprange.html:54 netbox/templates/ipam/prefix.html:73
-#: netbox/templates/ipam/vlan.html:48
-#: netbox/templates/virtualization/cluster.html:21
-#: netbox/templates/virtualization/virtualmachine.html:19
-#: netbox/templates/vpn/tunnel.html:25
-#: netbox/templates/wireless/wirelesslan.html:22
-#: netbox/templates/wireless/wirelesslink.html:17
-#: netbox/users/forms/filtersets.py:32 netbox/users/forms/model_forms.py:194
-#: netbox/virtualization/forms/bulk_edit.py:70
-#: netbox/virtualization/forms/bulk_edit.py:118
-#: netbox/virtualization/forms/bulk_import.py:54
-#: netbox/virtualization/forms/bulk_import.py:80
-#: netbox/virtualization/forms/filtersets.py:62
-#: netbox/virtualization/forms/filtersets.py:160
-#: netbox/virtualization/tables/clusters.py:74
-#: netbox/virtualization/tables/virtualmachines.py:60
-#: netbox/vpn/forms/bulk_edit.py:39 netbox/vpn/forms/bulk_import.py:37
-#: netbox/vpn/forms/filtersets.py:47 netbox/vpn/tables/tunnels.py:48
-#: netbox/wireless/forms/bulk_edit.py:43 netbox/wireless/forms/bulk_edit.py:105
-#: netbox/wireless/forms/bulk_import.py:43
-#: netbox/wireless/forms/bulk_import.py:84
-#: netbox/wireless/forms/filtersets.py:49
-#: netbox/wireless/forms/filtersets.py:83
-#: netbox/wireless/tables/wirelesslan.py:52
-#: netbox/wireless/tables/wirelesslink.py:20
+#: circuits/forms/bulk_edit.py:136 circuits/forms/bulk_import.py:93
+#: circuits/forms/filtersets.py:150 core/forms/filtersets.py:38
+#: core/forms/filtersets.py:79 core/tables/data.py:23 core/tables/jobs.py:26
+#: core/tables/tasks.py:88 dcim/forms/bulk_edit.py:106
+#: dcim/forms/bulk_edit.py:181 dcim/forms/bulk_edit.py:351
+#: dcim/forms/bulk_edit.py:700 dcim/forms/bulk_edit.py:756
+#: dcim/forms/bulk_edit.py:788 dcim/forms/bulk_edit.py:915
+#: dcim/forms/bulk_edit.py:1701 dcim/forms/bulk_import.py:88
+#: dcim/forms/bulk_import.py:147 dcim/forms/bulk_import.py:248
+#: dcim/forms/bulk_import.py:505 dcim/forms/bulk_import.py:659
+#: dcim/forms/bulk_import.py:1207 dcim/forms/bulk_import.py:1371
+#: dcim/forms/bulk_import.py:1435 dcim/forms/filtersets.py:178
+#: dcim/forms/filtersets.py:237 dcim/forms/filtersets.py:359
+#: dcim/forms/filtersets.py:799 dcim/forms/filtersets.py:924
+#: dcim/forms/filtersets.py:958 dcim/forms/filtersets.py:1059
+#: dcim/forms/filtersets.py:1170 dcim/tables/devices.py:140
+#: dcim/tables/devices.py:817 dcim/tables/devices.py:1063
+#: dcim/tables/modules.py:69 dcim/tables/power.py:74 dcim/tables/racks.py:126
+#: dcim/tables/sites.py:82 dcim/tables/sites.py:138 ipam/forms/bulk_edit.py:256
+#: ipam/forms/bulk_edit.py:306 ipam/forms/bulk_edit.py:354
+#: ipam/forms/bulk_edit.py:506 ipam/forms/bulk_import.py:192
+#: ipam/forms/bulk_import.py:257 ipam/forms/bulk_import.py:293
+#: ipam/forms/bulk_import.py:450 ipam/forms/filtersets.py:210
+#: ipam/forms/filtersets.py:281 ipam/forms/filtersets.py:355
+#: ipam/forms/filtersets.py:501 ipam/forms/model_forms.py:468
+#: ipam/tables/ip.py:237 ipam/tables/ip.py:312 ipam/tables/ip.py:363
+#: ipam/tables/ip.py:426 ipam/tables/ip.py:453 ipam/tables/vlans.py:126
+#: ipam/tables/vlans.py:232 templates/circuits/circuit.html:34
+#: templates/core/datasource.html:46 templates/core/job.html:48
+#: templates/core/rq_task.html:81 templates/core/system.html:18
+#: templates/dcim/cable.html:19 templates/dcim/device.html:178
+#: templates/dcim/location.html:45 templates/dcim/module.html:69
+#: templates/dcim/powerfeed.html:36 templates/dcim/rack.html:41
+#: templates/dcim/site.html:43 templates/extras/script_list.html:47
+#: templates/ipam/ipaddress.html:37 templates/ipam/iprange.html:54
+#: templates/ipam/prefix.html:73 templates/ipam/vlan.html:48
+#: templates/virtualization/cluster.html:21
+#: templates/virtualization/virtualmachine.html:19 templates/vpn/tunnel.html:25
+#: templates/wireless/wirelesslan.html:22
+#: templates/wireless/wirelesslink.html:17 users/forms/filtersets.py:32
+#: users/forms/model_forms.py:194 virtualization/forms/bulk_edit.py:70
+#: virtualization/forms/bulk_edit.py:118 virtualization/forms/bulk_import.py:54
+#: virtualization/forms/bulk_import.py:80 virtualization/forms/filtersets.py:62
+#: virtualization/forms/filtersets.py:160 virtualization/tables/clusters.py:74
+#: virtualization/tables/virtualmachines.py:60 vpn/forms/bulk_edit.py:39
+#: vpn/forms/bulk_import.py:37 vpn/forms/filtersets.py:47
+#: vpn/tables/tunnels.py:48 wireless/forms/bulk_edit.py:43
+#: wireless/forms/bulk_edit.py:105 wireless/forms/bulk_import.py:43
+#: wireless/forms/bulk_import.py:84 wireless/forms/filtersets.py:49
+#: wireless/forms/filtersets.py:83 wireless/tables/wirelesslan.py:52
+#: wireless/tables/wirelesslink.py:20
 msgid "Status"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:142
-#: netbox/circuits/forms/bulk_edit.py:233
-#: netbox/circuits/forms/bulk_import.py:98
-#: netbox/circuits/forms/bulk_import.py:158
-#: netbox/circuits/forms/filtersets.py:119
-#: netbox/circuits/forms/filtersets.py:241 netbox/dcim/forms/bulk_edit.py:122
-#: netbox/dcim/forms/bulk_edit.py:187 netbox/dcim/forms/bulk_edit.py:346
-#: netbox/dcim/forms/bulk_edit.py:461 netbox/dcim/forms/bulk_edit.py:690
-#: netbox/dcim/forms/bulk_edit.py:794 netbox/dcim/forms/bulk_edit.py:1706
-#: netbox/dcim/forms/bulk_import.py:107 netbox/dcim/forms/bulk_import.py:152
-#: netbox/dcim/forms/bulk_import.py:241 netbox/dcim/forms/bulk_import.py:334
-#: netbox/dcim/forms/bulk_import.py:479 netbox/dcim/forms/bulk_import.py:1219
-#: netbox/dcim/forms/bulk_import.py:1428 netbox/dcim/forms/filtersets.py:173
-#: netbox/dcim/forms/filtersets.py:205 netbox/dcim/forms/filtersets.py:323
-#: netbox/dcim/forms/filtersets.py:399 netbox/dcim/forms/filtersets.py:420
-#: netbox/dcim/forms/filtersets.py:722 netbox/dcim/forms/filtersets.py:916
-#: netbox/dcim/forms/filtersets.py:978 netbox/dcim/forms/filtersets.py:1008
-#: netbox/dcim/forms/filtersets.py:1130 netbox/dcim/tables/power.py:88
-#: netbox/extras/filtersets.py:612 netbox/extras/forms/filtersets.py:323
-#: netbox/extras/forms/filtersets.py:396 netbox/ipam/forms/bulk_edit.py:43
-#: netbox/ipam/forms/bulk_edit.py:68 netbox/ipam/forms/bulk_edit.py:112
-#: netbox/ipam/forms/bulk_edit.py:141 netbox/ipam/forms/bulk_edit.py:166
-#: netbox/ipam/forms/bulk_edit.py:251 netbox/ipam/forms/bulk_edit.py:301
-#: netbox/ipam/forms/bulk_edit.py:349 netbox/ipam/forms/bulk_edit.py:501
-#: netbox/ipam/forms/bulk_import.py:38 netbox/ipam/forms/bulk_import.py:67
-#: netbox/ipam/forms/bulk_import.py:95 netbox/ipam/forms/bulk_import.py:115
-#: netbox/ipam/forms/bulk_import.py:135 netbox/ipam/forms/bulk_import.py:164
-#: netbox/ipam/forms/bulk_import.py:250 netbox/ipam/forms/bulk_import.py:286
-#: netbox/ipam/forms/bulk_import.py:443 netbox/ipam/forms/filtersets.py:48
-#: netbox/ipam/forms/filtersets.py:68 netbox/ipam/forms/filtersets.py:100
-#: netbox/ipam/forms/filtersets.py:120 netbox/ipam/forms/filtersets.py:143
-#: netbox/ipam/forms/filtersets.py:174 netbox/ipam/forms/filtersets.py:267
-#: netbox/ipam/forms/filtersets.py:310 netbox/ipam/forms/filtersets.py:469
-#: netbox/ipam/tables/ip.py:456 netbox/ipam/tables/vlans.py:229
-#: netbox/templates/circuits/circuit.html:38
-#: netbox/templates/circuits/circuitgroup.html:36
-#: netbox/templates/dcim/cable.html:23 netbox/templates/dcim/device.html:79
-#: netbox/templates/dcim/location.html:49
-#: netbox/templates/dcim/powerfeed.html:44 netbox/templates/dcim/rack.html:32
-#: netbox/templates/dcim/rackreservation.html:49
-#: netbox/templates/dcim/site.html:47
-#: netbox/templates/dcim/virtualdevicecontext.html:52
-#: netbox/templates/ipam/aggregate.html:30 netbox/templates/ipam/asn.html:33
-#: netbox/templates/ipam/asnrange.html:29
-#: netbox/templates/ipam/ipaddress.html:28
-#: netbox/templates/ipam/iprange.html:58 netbox/templates/ipam/prefix.html:29
-#: netbox/templates/ipam/routetarget.html:17 netbox/templates/ipam/vlan.html:39
-#: netbox/templates/ipam/vrf.html:20 netbox/templates/tenancy/tenant.html:17
-#: netbox/templates/virtualization/cluster.html:33
-#: netbox/templates/virtualization/virtualmachine.html:39
-#: netbox/templates/vpn/l2vpn.html:30 netbox/templates/vpn/tunnel.html:49
-#: netbox/templates/wireless/wirelesslan.html:34
-#: netbox/templates/wireless/wirelesslink.html:25
-#: netbox/tenancy/forms/forms.py:25 netbox/tenancy/forms/forms.py:48
-#: netbox/tenancy/forms/model_forms.py:52 netbox/tenancy/tables/columns.py:64
-#: netbox/virtualization/forms/bulk_edit.py:76
-#: netbox/virtualization/forms/bulk_edit.py:155
-#: netbox/virtualization/forms/bulk_import.py:66
-#: netbox/virtualization/forms/bulk_import.py:115
-#: netbox/virtualization/forms/filtersets.py:47
-#: netbox/virtualization/forms/filtersets.py:105
-#: netbox/vpn/forms/bulk_edit.py:59 netbox/vpn/forms/bulk_edit.py:269
-#: netbox/vpn/forms/bulk_import.py:59 netbox/vpn/forms/bulk_import.py:258
-#: netbox/vpn/forms/filtersets.py:214 netbox/wireless/forms/bulk_edit.py:63
-#: netbox/wireless/forms/bulk_edit.py:110
-#: netbox/wireless/forms/bulk_import.py:55
-#: netbox/wireless/forms/bulk_import.py:97
-#: netbox/wireless/forms/filtersets.py:35
-#: netbox/wireless/forms/filtersets.py:75
+#: circuits/forms/bulk_edit.py:142 circuits/forms/bulk_edit.py:233
+#: circuits/forms/bulk_import.py:98 circuits/forms/bulk_import.py:158
+#: circuits/forms/filtersets.py:119 circuits/forms/filtersets.py:241
+#: dcim/forms/bulk_edit.py:122 dcim/forms/bulk_edit.py:187
+#: dcim/forms/bulk_edit.py:346 dcim/forms/bulk_edit.py:461
+#: dcim/forms/bulk_edit.py:690 dcim/forms/bulk_edit.py:794
+#: dcim/forms/bulk_edit.py:1706 dcim/forms/bulk_import.py:107
+#: dcim/forms/bulk_import.py:152 dcim/forms/bulk_import.py:241
+#: dcim/forms/bulk_import.py:334 dcim/forms/bulk_import.py:479
+#: dcim/forms/bulk_import.py:1219 dcim/forms/bulk_import.py:1428
+#: dcim/forms/filtersets.py:173 dcim/forms/filtersets.py:205
+#: dcim/forms/filtersets.py:323 dcim/forms/filtersets.py:399
+#: dcim/forms/filtersets.py:420 dcim/forms/filtersets.py:722
+#: dcim/forms/filtersets.py:916 dcim/forms/filtersets.py:978
+#: dcim/forms/filtersets.py:1008 dcim/forms/filtersets.py:1130
+#: dcim/tables/power.py:88 extras/filtersets.py:612
+#: extras/forms/filtersets.py:323 extras/forms/filtersets.py:396
+#: ipam/forms/bulk_edit.py:43 ipam/forms/bulk_edit.py:68
+#: ipam/forms/bulk_edit.py:112 ipam/forms/bulk_edit.py:141
+#: ipam/forms/bulk_edit.py:166 ipam/forms/bulk_edit.py:251
+#: ipam/forms/bulk_edit.py:301 ipam/forms/bulk_edit.py:349
+#: ipam/forms/bulk_edit.py:501 ipam/forms/bulk_import.py:38
+#: ipam/forms/bulk_import.py:67 ipam/forms/bulk_import.py:95
+#: ipam/forms/bulk_import.py:115 ipam/forms/bulk_import.py:135
+#: ipam/forms/bulk_import.py:164 ipam/forms/bulk_import.py:250
+#: ipam/forms/bulk_import.py:286 ipam/forms/bulk_import.py:443
+#: ipam/forms/filtersets.py:48 ipam/forms/filtersets.py:68
+#: ipam/forms/filtersets.py:100 ipam/forms/filtersets.py:120
+#: ipam/forms/filtersets.py:143 ipam/forms/filtersets.py:174
+#: ipam/forms/filtersets.py:267 ipam/forms/filtersets.py:310
+#: ipam/forms/filtersets.py:469 ipam/tables/ip.py:456 ipam/tables/vlans.py:229
+#: templates/circuits/circuit.html:38 templates/circuits/circuitgroup.html:36
+#: templates/dcim/cable.html:23 templates/dcim/device.html:79
+#: templates/dcim/location.html:49 templates/dcim/powerfeed.html:44
+#: templates/dcim/rack.html:32 templates/dcim/rackreservation.html:49
+#: templates/dcim/site.html:47 templates/dcim/virtualdevicecontext.html:52
+#: templates/ipam/aggregate.html:30 templates/ipam/asn.html:33
+#: templates/ipam/asnrange.html:29 templates/ipam/ipaddress.html:28
+#: templates/ipam/iprange.html:58 templates/ipam/prefix.html:29
+#: templates/ipam/routetarget.html:17 templates/ipam/vlan.html:39
+#: templates/ipam/vrf.html:20 templates/tenancy/tenant.html:17
+#: templates/virtualization/cluster.html:33
+#: templates/virtualization/virtualmachine.html:39 templates/vpn/l2vpn.html:30
+#: templates/vpn/tunnel.html:49 templates/wireless/wirelesslan.html:34
+#: templates/wireless/wirelesslink.html:25 tenancy/forms/forms.py:25
+#: tenancy/forms/forms.py:48 tenancy/forms/model_forms.py:52
+#: tenancy/tables/columns.py:64 virtualization/forms/bulk_edit.py:76
+#: virtualization/forms/bulk_edit.py:155 virtualization/forms/bulk_import.py:66
+#: virtualization/forms/bulk_import.py:115
+#: virtualization/forms/filtersets.py:47 virtualization/forms/filtersets.py:105
+#: vpn/forms/bulk_edit.py:59 vpn/forms/bulk_edit.py:269
+#: vpn/forms/bulk_import.py:59 vpn/forms/bulk_import.py:258
+#: vpn/forms/filtersets.py:214 wireless/forms/bulk_edit.py:63
+#: wireless/forms/bulk_edit.py:110 wireless/forms/bulk_import.py:55
+#: wireless/forms/bulk_import.py:97 wireless/forms/filtersets.py:35
+#: wireless/forms/filtersets.py:75
 msgid "Tenant"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:147
-#: netbox/circuits/forms/filtersets.py:174
+#: circuits/forms/bulk_edit.py:147 circuits/forms/filtersets.py:174
 msgid "Install date"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:152
-#: netbox/circuits/forms/filtersets.py:179
+#: circuits/forms/bulk_edit.py:152 circuits/forms/filtersets.py:179
 msgid "Termination date"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:158
-#: netbox/circuits/forms/filtersets.py:186
+#: circuits/forms/bulk_edit.py:158 circuits/forms/filtersets.py:186
 msgid "Commit rate (Kbps)"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:173
-#: netbox/circuits/forms/model_forms.py:112
+#: circuits/forms/bulk_edit.py:173 circuits/forms/model_forms.py:112
 msgid "Service Parameters"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:174
-#: netbox/circuits/forms/model_forms.py:113
-#: netbox/circuits/forms/model_forms.py:183
-#: netbox/dcim/forms/model_forms.py:139 netbox/dcim/forms/model_forms.py:181
-#: netbox/dcim/forms/model_forms.py:266 netbox/dcim/forms/model_forms.py:323
-#: netbox/dcim/forms/model_forms.py:768 netbox/dcim/forms/model_forms.py:1692
-#: netbox/ipam/forms/model_forms.py:64 netbox/ipam/forms/model_forms.py:81
-#: netbox/ipam/forms/model_forms.py:115 netbox/ipam/forms/model_forms.py:136
-#: netbox/ipam/forms/model_forms.py:160 netbox/ipam/forms/model_forms.py:232
-#: netbox/ipam/forms/model_forms.py:261 netbox/ipam/forms/model_forms.py:316
-#: netbox/netbox/navigation/menu.py:24
-#: netbox/templates/dcim/device_edit.html:85
-#: netbox/templates/dcim/htmx/cable_edit.html:72
-#: netbox/templates/ipam/ipaddress_bulk_add.html:27
-#: netbox/templates/ipam/vlan_edit.html:22
-#: netbox/virtualization/forms/model_forms.py:80
-#: netbox/virtualization/forms/model_forms.py:222
-#: netbox/vpn/forms/bulk_edit.py:78 netbox/vpn/forms/filtersets.py:44
-#: netbox/vpn/forms/model_forms.py:62 netbox/vpn/forms/model_forms.py:147
-#: netbox/vpn/forms/model_forms.py:411 netbox/wireless/forms/model_forms.py:54
-#: netbox/wireless/forms/model_forms.py:170
+#: circuits/forms/bulk_edit.py:174 circuits/forms/model_forms.py:113
+#: circuits/forms/model_forms.py:183 dcim/forms/model_forms.py:139
+#: dcim/forms/model_forms.py:181 dcim/forms/model_forms.py:266
+#: dcim/forms/model_forms.py:323 dcim/forms/model_forms.py:768
+#: dcim/forms/model_forms.py:1692 ipam/forms/model_forms.py:64
+#: ipam/forms/model_forms.py:81 ipam/forms/model_forms.py:115
+#: ipam/forms/model_forms.py:136 ipam/forms/model_forms.py:160
+#: ipam/forms/model_forms.py:232 ipam/forms/model_forms.py:261
+#: ipam/forms/model_forms.py:316 netbox/navigation/menu.py:24
+#: templates/dcim/device_edit.html:85 templates/dcim/htmx/cable_edit.html:72
+#: templates/ipam/ipaddress_bulk_add.html:27 templates/ipam/vlan_edit.html:22
+#: virtualization/forms/model_forms.py:80
+#: virtualization/forms/model_forms.py:222 vpn/forms/bulk_edit.py:78
+#: vpn/forms/filtersets.py:44 vpn/forms/model_forms.py:62
+#: vpn/forms/model_forms.py:147 vpn/forms/model_forms.py:411
+#: wireless/forms/model_forms.py:54 wireless/forms/model_forms.py:170
 msgid "Tenancy"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:193
-#: netbox/circuits/forms/bulk_edit.py:217
-#: netbox/circuits/forms/model_forms.py:155
-#: netbox/circuits/tables/circuits.py:117
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:62
-#: netbox/templates/circuits/providernetwork.html:17
+#: circuits/forms/bulk_edit.py:193 circuits/forms/bulk_edit.py:217
+#: circuits/forms/model_forms.py:155 circuits/tables/circuits.py:117
+#: templates/circuits/inc/circuit_termination_fields.html:62
+#: templates/circuits/providernetwork.html:17
 msgid "Provider Network"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:199
+#: circuits/forms/bulk_edit.py:199
 msgid "Port speed (Kbps)"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:203
+#: circuits/forms/bulk_edit.py:203
 msgid "Upstream speed (Kbps)"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:206 netbox/dcim/forms/bulk_edit.py:951
-#: netbox/dcim/forms/bulk_edit.py:1315 netbox/dcim/forms/bulk_edit.py:1332
-#: netbox/dcim/forms/bulk_edit.py:1349 netbox/dcim/forms/bulk_edit.py:1367
-#: netbox/dcim/forms/bulk_edit.py:1455 netbox/dcim/forms/bulk_edit.py:1594
-#: netbox/dcim/forms/bulk_edit.py:1611
+#: circuits/forms/bulk_edit.py:206 dcim/forms/bulk_edit.py:951
+#: dcim/forms/bulk_edit.py:1315 dcim/forms/bulk_edit.py:1332
+#: dcim/forms/bulk_edit.py:1349 dcim/forms/bulk_edit.py:1367
+#: dcim/forms/bulk_edit.py:1455 dcim/forms/bulk_edit.py:1594
+#: dcim/forms/bulk_edit.py:1611
 msgid "Mark connected"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:219
-#: netbox/circuits/forms/model_forms.py:157
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:54
-#: netbox/templates/dcim/frontport.html:121
-#: netbox/templates/dcim/interface.html:193
-#: netbox/templates/dcim/rearport.html:111
+#: circuits/forms/bulk_edit.py:219 circuits/forms/model_forms.py:157
+#: templates/circuits/inc/circuit_termination_fields.html:54
+#: templates/dcim/frontport.html:121 templates/dcim/interface.html:193
+#: templates/dcim/rearport.html:111
 msgid "Circuit Termination"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:221
-#: netbox/circuits/forms/model_forms.py:159
+#: circuits/forms/bulk_edit.py:221 circuits/forms/model_forms.py:159
 msgid "Termination Details"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_edit.py:251
-#: netbox/circuits/forms/filtersets.py:268
-#: netbox/circuits/tables/circuits.py:168 netbox/dcim/forms/model_forms.py:551
-#: netbox/templates/circuits/circuitgroupassignment.html:30
-#: netbox/templates/dcim/device.html:133
-#: netbox/templates/dcim/virtualchassis.html:68
-#: netbox/templates/dcim/virtualchassis_edit.html:56
-#: netbox/templates/ipam/inc/panels/fhrp_groups.html:26
-#: netbox/tenancy/forms/bulk_edit.py:147 netbox/tenancy/forms/filtersets.py:110
+#: circuits/forms/bulk_edit.py:251 circuits/forms/filtersets.py:268
+#: circuits/tables/circuits.py:168 dcim/forms/model_forms.py:551
+#: templates/circuits/circuitgroupassignment.html:30
+#: templates/dcim/device.html:133 templates/dcim/virtualchassis.html:68
+#: templates/dcim/virtualchassis_edit.html:56
+#: templates/ipam/inc/panels/fhrp_groups.html:26 tenancy/forms/bulk_edit.py:147
+#: tenancy/forms/filtersets.py:110
 msgid "Priority"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_import.py:39
-#: netbox/circuits/forms/bulk_import.py:54
-#: netbox/circuits/forms/bulk_import.py:77
+#: circuits/forms/bulk_import.py:39 circuits/forms/bulk_import.py:54
+#: circuits/forms/bulk_import.py:77
 msgid "Assigned provider"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_import.py:83
+#: circuits/forms/bulk_import.py:83
 msgid "Assigned provider account"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_import.py:90
+#: circuits/forms/bulk_import.py:90
 msgid "Type of circuit"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_import.py:95 netbox/dcim/forms/bulk_import.py:90
-#: netbox/dcim/forms/bulk_import.py:149 netbox/dcim/forms/bulk_import.py:250
-#: netbox/dcim/forms/bulk_import.py:507 netbox/dcim/forms/bulk_import.py:661
-#: netbox/dcim/forms/bulk_import.py:1373 netbox/ipam/forms/bulk_import.py:194
-#: netbox/ipam/forms/bulk_import.py:259 netbox/ipam/forms/bulk_import.py:295
-#: netbox/ipam/forms/bulk_import.py:452
-#: netbox/virtualization/forms/bulk_import.py:56
-#: netbox/virtualization/forms/bulk_import.py:82
-#: netbox/vpn/forms/bulk_import.py:39 netbox/wireless/forms/bulk_import.py:45
+#: circuits/forms/bulk_import.py:95 dcim/forms/bulk_import.py:90
+#: dcim/forms/bulk_import.py:149 dcim/forms/bulk_import.py:250
+#: dcim/forms/bulk_import.py:507 dcim/forms/bulk_import.py:661
+#: dcim/forms/bulk_import.py:1373 ipam/forms/bulk_import.py:194
+#: ipam/forms/bulk_import.py:259 ipam/forms/bulk_import.py:295
+#: ipam/forms/bulk_import.py:452 virtualization/forms/bulk_import.py:56
+#: virtualization/forms/bulk_import.py:82 vpn/forms/bulk_import.py:39
+#: wireless/forms/bulk_import.py:45
 msgid "Operational status"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_import.py:102
-#: netbox/circuits/forms/bulk_import.py:162
-#: netbox/dcim/forms/bulk_import.py:111 netbox/dcim/forms/bulk_import.py:156
-#: netbox/dcim/forms/bulk_import.py:338 netbox/dcim/forms/bulk_import.py:483
-#: netbox/dcim/forms/bulk_import.py:1223 netbox/dcim/forms/bulk_import.py:1368
-#: netbox/dcim/forms/bulk_import.py:1432 netbox/ipam/forms/bulk_import.py:42
-#: netbox/ipam/forms/bulk_import.py:71 netbox/ipam/forms/bulk_import.py:99
-#: netbox/ipam/forms/bulk_import.py:119 netbox/ipam/forms/bulk_import.py:139
-#: netbox/ipam/forms/bulk_import.py:168 netbox/ipam/forms/bulk_import.py:254
-#: netbox/ipam/forms/bulk_import.py:290 netbox/ipam/forms/bulk_import.py:447
-#: netbox/virtualization/forms/bulk_import.py:70
-#: netbox/virtualization/forms/bulk_import.py:119
-#: netbox/vpn/forms/bulk_import.py:63 netbox/wireless/forms/bulk_import.py:59
-#: netbox/wireless/forms/bulk_import.py:101
+#: circuits/forms/bulk_import.py:102 circuits/forms/bulk_import.py:162
+#: dcim/forms/bulk_import.py:111 dcim/forms/bulk_import.py:156
+#: dcim/forms/bulk_import.py:338 dcim/forms/bulk_import.py:483
+#: dcim/forms/bulk_import.py:1223 dcim/forms/bulk_import.py:1368
+#: dcim/forms/bulk_import.py:1432 ipam/forms/bulk_import.py:42
+#: ipam/forms/bulk_import.py:71 ipam/forms/bulk_import.py:99
+#: ipam/forms/bulk_import.py:119 ipam/forms/bulk_import.py:139
+#: ipam/forms/bulk_import.py:168 ipam/forms/bulk_import.py:254
+#: ipam/forms/bulk_import.py:290 ipam/forms/bulk_import.py:447
+#: virtualization/forms/bulk_import.py:70
+#: virtualization/forms/bulk_import.py:119 vpn/forms/bulk_import.py:63
+#: wireless/forms/bulk_import.py:59 wireless/forms/bulk_import.py:101
 msgid "Assigned tenant"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_import.py:120
-#: netbox/templates/circuits/inc/circuit_termination.html:6
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:15
-#: netbox/templates/dcim/cable.html:68 netbox/templates/dcim/cable.html:72
-#: netbox/vpn/forms/bulk_import.py:100 netbox/vpn/forms/filtersets.py:77
+#: circuits/forms/bulk_import.py:120
+#: templates/circuits/inc/circuit_termination.html:6
+#: templates/circuits/inc/circuit_termination_fields.html:15
+#: templates/dcim/cable.html:68 templates/dcim/cable.html:72
+#: vpn/forms/bulk_import.py:100 vpn/forms/filtersets.py:77
 msgid "Termination"
 msgstr ""
 
-#: netbox/circuits/forms/bulk_import.py:130
-#: netbox/circuits/forms/filtersets.py:147
-#: netbox/circuits/forms/filtersets.py:227
-#: netbox/circuits/forms/model_forms.py:144
+#: circuits/forms/bulk_import.py:130 circuits/forms/filtersets.py:147
+#: circuits/forms/filtersets.py:227 circuits/forms/model_forms.py:144
 msgid "Provider network"
 msgstr ""
 
-#: netbox/circuits/forms/filtersets.py:30
-#: netbox/circuits/forms/filtersets.py:118
-#: netbox/circuits/forms/filtersets.py:200 netbox/dcim/forms/bulk_edit.py:338
-#: netbox/dcim/forms/bulk_edit.py:441 netbox/dcim/forms/bulk_edit.py:682
-#: netbox/dcim/forms/bulk_edit.py:729 netbox/dcim/forms/bulk_edit.py:882
-#: netbox/dcim/forms/bulk_import.py:235 netbox/dcim/forms/bulk_import.py:315
-#: netbox/dcim/forms/bulk_import.py:546 netbox/dcim/forms/bulk_import.py:1317
-#: netbox/dcim/forms/bulk_import.py:1351 netbox/dcim/forms/filtersets.py:95
-#: netbox/dcim/forms/filtersets.py:322 netbox/dcim/forms/filtersets.py:356
-#: netbox/dcim/forms/filtersets.py:396 netbox/dcim/forms/filtersets.py:447
-#: netbox/dcim/forms/filtersets.py:719 netbox/dcim/forms/filtersets.py:762
-#: netbox/dcim/forms/filtersets.py:977 netbox/dcim/forms/filtersets.py:1006
-#: netbox/dcim/forms/filtersets.py:1026 netbox/dcim/forms/filtersets.py:1090
-#: netbox/dcim/forms/filtersets.py:1120 netbox/dcim/forms/filtersets.py:1129
-#: netbox/dcim/forms/filtersets.py:1240 netbox/dcim/forms/filtersets.py:1264
-#: netbox/dcim/forms/filtersets.py:1289 netbox/dcim/forms/filtersets.py:1308
-#: netbox/dcim/forms/filtersets.py:1331 netbox/dcim/forms/filtersets.py:1442
-#: netbox/dcim/forms/filtersets.py:1466 netbox/dcim/forms/filtersets.py:1490
-#: netbox/dcim/forms/filtersets.py:1508 netbox/dcim/forms/filtersets.py:1525
-#: netbox/dcim/forms/model_forms.py:180 netbox/dcim/forms/model_forms.py:243
-#: netbox/dcim/forms/model_forms.py:468 netbox/dcim/forms/model_forms.py:728
-#: netbox/dcim/tables/devices.py:157 netbox/dcim/tables/power.py:30
-#: netbox/dcim/tables/racks.py:118 netbox/dcim/tables/racks.py:212
-#: netbox/extras/filtersets.py:536 netbox/extras/forms/filtersets.py:320
-#: netbox/ipam/forms/filtersets.py:173 netbox/ipam/forms/filtersets.py:414
-#: netbox/ipam/forms/filtersets.py:437 netbox/ipam/forms/filtersets.py:467
-#: netbox/templates/dcim/device.html:26
-#: netbox/templates/dcim/device_edit.html:30
-#: netbox/templates/dcim/inc/cable_termination.html:12
-#: netbox/templates/dcim/location.html:26
-#: netbox/templates/dcim/powerpanel.html:26 netbox/templates/dcim/rack.html:24
-#: netbox/templates/dcim/rackreservation.html:32
-#: netbox/virtualization/forms/filtersets.py:46
-#: netbox/virtualization/forms/filtersets.py:100
-#: netbox/wireless/forms/model_forms.py:87
-#: netbox/wireless/forms/model_forms.py:129
+#: circuits/forms/filtersets.py:30 circuits/forms/filtersets.py:118
+#: circuits/forms/filtersets.py:200 dcim/forms/bulk_edit.py:338
+#: dcim/forms/bulk_edit.py:441 dcim/forms/bulk_edit.py:682
+#: dcim/forms/bulk_edit.py:729 dcim/forms/bulk_edit.py:882
+#: dcim/forms/bulk_import.py:235 dcim/forms/bulk_import.py:315
+#: dcim/forms/bulk_import.py:546 dcim/forms/bulk_import.py:1317
+#: dcim/forms/bulk_import.py:1351 dcim/forms/filtersets.py:95
+#: dcim/forms/filtersets.py:322 dcim/forms/filtersets.py:356
+#: dcim/forms/filtersets.py:396 dcim/forms/filtersets.py:447
+#: dcim/forms/filtersets.py:719 dcim/forms/filtersets.py:762
+#: dcim/forms/filtersets.py:977 dcim/forms/filtersets.py:1006
+#: dcim/forms/filtersets.py:1026 dcim/forms/filtersets.py:1090
+#: dcim/forms/filtersets.py:1120 dcim/forms/filtersets.py:1129
+#: dcim/forms/filtersets.py:1240 dcim/forms/filtersets.py:1264
+#: dcim/forms/filtersets.py:1289 dcim/forms/filtersets.py:1308
+#: dcim/forms/filtersets.py:1331 dcim/forms/filtersets.py:1442
+#: dcim/forms/filtersets.py:1466 dcim/forms/filtersets.py:1490
+#: dcim/forms/filtersets.py:1508 dcim/forms/filtersets.py:1525
+#: dcim/forms/model_forms.py:180 dcim/forms/model_forms.py:243
+#: dcim/forms/model_forms.py:468 dcim/forms/model_forms.py:728
+#: dcim/tables/devices.py:157 dcim/tables/power.py:30 dcim/tables/racks.py:118
+#: dcim/tables/racks.py:212 extras/filtersets.py:536
+#: extras/forms/filtersets.py:320 ipam/forms/filtersets.py:173
+#: ipam/forms/filtersets.py:414 ipam/forms/filtersets.py:437
+#: ipam/forms/filtersets.py:467 templates/dcim/device.html:26
+#: templates/dcim/device_edit.html:30
+#: templates/dcim/inc/cable_termination.html:12 templates/dcim/location.html:26
+#: templates/dcim/powerpanel.html:26 templates/dcim/rack.html:24
+#: templates/dcim/rackreservation.html:32 virtualization/forms/filtersets.py:46
+#: virtualization/forms/filtersets.py:100 wireless/forms/model_forms.py:87
+#: wireless/forms/model_forms.py:129
 msgid "Location"
 msgstr ""
 
-#: netbox/circuits/forms/filtersets.py:32
-#: netbox/circuits/forms/filtersets.py:120 netbox/dcim/forms/filtersets.py:144
-#: netbox/dcim/forms/filtersets.py:158 netbox/dcim/forms/filtersets.py:174
-#: netbox/dcim/forms/filtersets.py:206 netbox/dcim/forms/filtersets.py:328
-#: netbox/dcim/forms/filtersets.py:400 netbox/dcim/forms/filtersets.py:471
-#: netbox/dcim/forms/filtersets.py:723 netbox/dcim/forms/filtersets.py:1091
-#: netbox/netbox/navigation/menu.py:31 netbox/netbox/navigation/menu.py:33
-#: netbox/tenancy/forms/filtersets.py:42 netbox/tenancy/tables/columns.py:70
-#: netbox/tenancy/tables/contacts.py:25 netbox/tenancy/views.py:19
-#: netbox/virtualization/forms/filtersets.py:37
-#: netbox/virtualization/forms/filtersets.py:48
-#: netbox/virtualization/forms/filtersets.py:106
+#: circuits/forms/filtersets.py:32 circuits/forms/filtersets.py:120
+#: dcim/forms/filtersets.py:144 dcim/forms/filtersets.py:158
+#: dcim/forms/filtersets.py:174 dcim/forms/filtersets.py:206
+#: dcim/forms/filtersets.py:328 dcim/forms/filtersets.py:400
+#: dcim/forms/filtersets.py:471 dcim/forms/filtersets.py:723
+#: dcim/forms/filtersets.py:1091 netbox/navigation/menu.py:31
+#: netbox/navigation/menu.py:33 tenancy/forms/filtersets.py:42
+#: tenancy/tables/columns.py:70 tenancy/tables/contacts.py:25
+#: tenancy/views.py:19 virtualization/forms/filtersets.py:37
+#: virtualization/forms/filtersets.py:48 virtualization/forms/filtersets.py:106
 msgid "Contacts"
 msgstr ""
 
-#: netbox/circuits/forms/filtersets.py:37
-#: netbox/circuits/forms/filtersets.py:157 netbox/dcim/forms/bulk_edit.py:112
-#: netbox/dcim/forms/bulk_edit.py:313 netbox/dcim/forms/bulk_edit.py:857
-#: netbox/dcim/forms/bulk_import.py:93 netbox/dcim/forms/filtersets.py:73
-#: netbox/dcim/forms/filtersets.py:185 netbox/dcim/forms/filtersets.py:211
-#: netbox/dcim/forms/filtersets.py:334 netbox/dcim/forms/filtersets.py:425
-#: netbox/dcim/forms/filtersets.py:739 netbox/dcim/forms/filtersets.py:983
-#: netbox/dcim/forms/filtersets.py:1013 netbox/dcim/forms/filtersets.py:1097
-#: netbox/dcim/forms/filtersets.py:1136 netbox/dcim/forms/filtersets.py:1576
-#: netbox/dcim/forms/filtersets.py:1600 netbox/dcim/forms/filtersets.py:1624
-#: netbox/dcim/forms/model_forms.py:112 netbox/dcim/forms/object_create.py:375
-#: netbox/dcim/tables/devices.py:143 netbox/dcim/tables/sites.py:85
-#: netbox/extras/filtersets.py:503 netbox/ipam/forms/bulk_edit.py:208
-#: netbox/ipam/forms/bulk_edit.py:474 netbox/ipam/forms/filtersets.py:217
-#: netbox/ipam/forms/filtersets.py:422 netbox/ipam/forms/filtersets.py:475
-#: netbox/templates/dcim/device.html:18 netbox/templates/dcim/rack.html:16
-#: netbox/templates/dcim/rackreservation.html:22
-#: netbox/templates/dcim/region.html:26 netbox/templates/dcim/site.html:31
-#: netbox/templates/ipam/prefix.html:49 netbox/templates/ipam/vlan.html:16
-#: netbox/virtualization/forms/bulk_edit.py:81
-#: netbox/virtualization/forms/filtersets.py:59
-#: netbox/virtualization/forms/filtersets.py:133
-#: netbox/virtualization/forms/model_forms.py:92
-#: netbox/vpn/forms/filtersets.py:257
+#: circuits/forms/filtersets.py:37 circuits/forms/filtersets.py:157
+#: dcim/forms/bulk_edit.py:112 dcim/forms/bulk_edit.py:313
+#: dcim/forms/bulk_edit.py:857 dcim/forms/bulk_import.py:93
+#: dcim/forms/filtersets.py:73 dcim/forms/filtersets.py:185
+#: dcim/forms/filtersets.py:211 dcim/forms/filtersets.py:334
+#: dcim/forms/filtersets.py:425 dcim/forms/filtersets.py:739
+#: dcim/forms/filtersets.py:983 dcim/forms/filtersets.py:1013
+#: dcim/forms/filtersets.py:1097 dcim/forms/filtersets.py:1136
+#: dcim/forms/filtersets.py:1576 dcim/forms/filtersets.py:1600
+#: dcim/forms/filtersets.py:1624 dcim/forms/model_forms.py:112
+#: dcim/forms/object_create.py:375 dcim/tables/devices.py:143
+#: dcim/tables/sites.py:85 extras/filtersets.py:503 ipam/forms/bulk_edit.py:208
+#: ipam/forms/bulk_edit.py:474 ipam/forms/filtersets.py:217
+#: ipam/forms/filtersets.py:422 ipam/forms/filtersets.py:475
+#: templates/dcim/device.html:18 templates/dcim/rack.html:16
+#: templates/dcim/rackreservation.html:22 templates/dcim/region.html:26
+#: templates/dcim/site.html:31 templates/ipam/prefix.html:49
+#: templates/ipam/vlan.html:16 virtualization/forms/bulk_edit.py:81
+#: virtualization/forms/filtersets.py:59 virtualization/forms/filtersets.py:133
+#: virtualization/forms/model_forms.py:92 vpn/forms/filtersets.py:257
 msgid "Region"
 msgstr ""
 
-#: netbox/circuits/forms/filtersets.py:42
-#: netbox/circuits/forms/filtersets.py:162 netbox/dcim/forms/bulk_edit.py:321
-#: netbox/dcim/forms/bulk_edit.py:865 netbox/dcim/forms/filtersets.py:78
-#: netbox/dcim/forms/filtersets.py:190 netbox/dcim/forms/filtersets.py:216
-#: netbox/dcim/forms/filtersets.py:347 netbox/dcim/forms/filtersets.py:430
-#: netbox/dcim/forms/filtersets.py:744 netbox/dcim/forms/filtersets.py:988
-#: netbox/dcim/forms/filtersets.py:1102 netbox/dcim/forms/filtersets.py:1141
-#: netbox/dcim/forms/object_create.py:383 netbox/extras/filtersets.py:520
-#: netbox/ipam/forms/bulk_edit.py:213 netbox/ipam/forms/bulk_edit.py:479
-#: netbox/ipam/forms/filtersets.py:222 netbox/ipam/forms/filtersets.py:427
-#: netbox/ipam/forms/filtersets.py:480
-#: netbox/virtualization/forms/bulk_edit.py:86
-#: netbox/virtualization/forms/filtersets.py:69
-#: netbox/virtualization/forms/filtersets.py:138
-#: netbox/virtualization/forms/model_forms.py:98
+#: circuits/forms/filtersets.py:42 circuits/forms/filtersets.py:162
+#: dcim/forms/bulk_edit.py:321 dcim/forms/bulk_edit.py:865
+#: dcim/forms/filtersets.py:78 dcim/forms/filtersets.py:190
+#: dcim/forms/filtersets.py:216 dcim/forms/filtersets.py:347
+#: dcim/forms/filtersets.py:430 dcim/forms/filtersets.py:744
+#: dcim/forms/filtersets.py:988 dcim/forms/filtersets.py:1102
+#: dcim/forms/filtersets.py:1141 dcim/forms/object_create.py:383
+#: extras/filtersets.py:520 ipam/forms/bulk_edit.py:213
+#: ipam/forms/bulk_edit.py:479 ipam/forms/filtersets.py:222
+#: ipam/forms/filtersets.py:427 ipam/forms/filtersets.py:480
+#: virtualization/forms/bulk_edit.py:86 virtualization/forms/filtersets.py:69
+#: virtualization/forms/filtersets.py:138
+#: virtualization/forms/model_forms.py:98
 msgid "Site group"
 msgstr ""
 
-#: netbox/circuits/forms/filtersets.py:65
-#: netbox/circuits/forms/filtersets.py:83
-#: netbox/circuits/forms/filtersets.py:102
-#: netbox/circuits/forms/filtersets.py:117 netbox/core/forms/filtersets.py:67
-#: netbox/core/forms/filtersets.py:135 netbox/dcim/forms/bulk_edit.py:828
-#: netbox/dcim/forms/filtersets.py:172 netbox/dcim/forms/filtersets.py:204
-#: netbox/dcim/forms/filtersets.py:915 netbox/dcim/forms/filtersets.py:1007
-#: netbox/dcim/forms/filtersets.py:1131 netbox/dcim/forms/filtersets.py:1239
-#: netbox/dcim/forms/filtersets.py:1263 netbox/dcim/forms/filtersets.py:1288
-#: netbox/dcim/forms/filtersets.py:1307 netbox/dcim/forms/filtersets.py:1327
-#: netbox/dcim/forms/filtersets.py:1441 netbox/dcim/forms/filtersets.py:1465
-#: netbox/dcim/forms/filtersets.py:1489 netbox/dcim/forms/filtersets.py:1507
-#: netbox/dcim/forms/filtersets.py:1523 netbox/extras/forms/bulk_edit.py:90
-#: netbox/extras/forms/filtersets.py:44 netbox/extras/forms/filtersets.py:134
-#: netbox/extras/forms/filtersets.py:165 netbox/extras/forms/filtersets.py:205
-#: netbox/extras/forms/filtersets.py:221 netbox/extras/forms/filtersets.py:252
-#: netbox/extras/forms/filtersets.py:276 netbox/extras/forms/filtersets.py:441
-#: netbox/ipam/forms/filtersets.py:99 netbox/ipam/forms/filtersets.py:266
-#: netbox/ipam/forms/filtersets.py:307 netbox/ipam/forms/filtersets.py:382
-#: netbox/ipam/forms/filtersets.py:468 netbox/ipam/forms/filtersets.py:527
-#: netbox/ipam/forms/filtersets.py:545 netbox/netbox/tables/tables.py:256
-#: netbox/virtualization/forms/filtersets.py:45
-#: netbox/virtualization/forms/filtersets.py:103
-#: netbox/virtualization/forms/filtersets.py:198
-#: netbox/virtualization/forms/filtersets.py:243
-#: netbox/vpn/forms/filtersets.py:213 netbox/wireless/forms/bulk_edit.py:150
-#: netbox/wireless/forms/filtersets.py:34
-#: netbox/wireless/forms/filtersets.py:74
+#: circuits/forms/filtersets.py:65 circuits/forms/filtersets.py:83
+#: circuits/forms/filtersets.py:102 circuits/forms/filtersets.py:117
+#: core/forms/filtersets.py:67 core/forms/filtersets.py:135
+#: dcim/forms/bulk_edit.py:828 dcim/forms/filtersets.py:172
+#: dcim/forms/filtersets.py:204 dcim/forms/filtersets.py:915
+#: dcim/forms/filtersets.py:1007 dcim/forms/filtersets.py:1131
+#: dcim/forms/filtersets.py:1239 dcim/forms/filtersets.py:1263
+#: dcim/forms/filtersets.py:1288 dcim/forms/filtersets.py:1307
+#: dcim/forms/filtersets.py:1327 dcim/forms/filtersets.py:1441
+#: dcim/forms/filtersets.py:1465 dcim/forms/filtersets.py:1489
+#: dcim/forms/filtersets.py:1507 dcim/forms/filtersets.py:1523
+#: extras/forms/bulk_edit.py:90 extras/forms/filtersets.py:44
+#: extras/forms/filtersets.py:134 extras/forms/filtersets.py:165
+#: extras/forms/filtersets.py:205 extras/forms/filtersets.py:221
+#: extras/forms/filtersets.py:252 extras/forms/filtersets.py:276
+#: extras/forms/filtersets.py:441 ipam/forms/filtersets.py:99
+#: ipam/forms/filtersets.py:266 ipam/forms/filtersets.py:307
+#: ipam/forms/filtersets.py:382 ipam/forms/filtersets.py:468
+#: ipam/forms/filtersets.py:527 ipam/forms/filtersets.py:545
+#: netbox/tables/tables.py:256 virtualization/forms/filtersets.py:45
+#: virtualization/forms/filtersets.py:103
+#: virtualization/forms/filtersets.py:198
+#: virtualization/forms/filtersets.py:243 vpn/forms/filtersets.py:213
+#: wireless/forms/bulk_edit.py:150 wireless/forms/filtersets.py:34
+#: wireless/forms/filtersets.py:74
 msgid "Attributes"
 msgstr ""
 
-#: netbox/circuits/forms/filtersets.py:73 netbox/circuits/tables/circuits.py:63
-#: netbox/circuits/tables/providers.py:66
-#: netbox/templates/circuits/circuit.html:22
-#: netbox/templates/circuits/provideraccount.html:24
+#: circuits/forms/filtersets.py:73 circuits/tables/circuits.py:63
+#: circuits/tables/providers.py:66 templates/circuits/circuit.html:22
+#: templates/circuits/provideraccount.html:24
 msgid "Account"
 msgstr ""
 
-#: netbox/circuits/forms/filtersets.py:217
+#: circuits/forms/filtersets.py:217
 msgid "Term Side"
 msgstr ""
 
-#: netbox/circuits/forms/filtersets.py:250
-#: netbox/extras/forms/model_forms.py:582 netbox/ipam/forms/filtersets.py:142
-#: netbox/ipam/forms/filtersets.py:546 netbox/ipam/forms/model_forms.py:323
-#: netbox/templates/extras/configcontext.html:60
-#: netbox/templates/ipam/ipaddress.html:59
-#: netbox/templates/ipam/vlan_edit.html:30
-#: netbox/tenancy/forms/filtersets.py:87 netbox/users/forms/model_forms.py:314
+#: circuits/forms/filtersets.py:250 extras/forms/model_forms.py:582
+#: ipam/forms/filtersets.py:142 ipam/forms/filtersets.py:546
+#: ipam/forms/model_forms.py:323 templates/extras/configcontext.html:60
+#: templates/ipam/ipaddress.html:59 templates/ipam/vlan_edit.html:30
+#: tenancy/forms/filtersets.py:87 users/forms/model_forms.py:314
 msgid "Assignment"
 msgstr ""
 
-#: netbox/circuits/forms/filtersets.py:265
-#: netbox/circuits/forms/model_forms.py:195
-#: netbox/circuits/tables/circuits.py:155 netbox/dcim/forms/bulk_edit.py:117
-#: netbox/dcim/forms/bulk_import.py:100 netbox/dcim/forms/model_forms.py:117
-#: netbox/dcim/tables/sites.py:89 netbox/extras/forms/filtersets.py:480
-#: netbox/ipam/filtersets.py:999 netbox/ipam/forms/bulk_edit.py:493
-#: netbox/ipam/forms/bulk_import.py:436 netbox/ipam/forms/model_forms.py:528
-#: netbox/ipam/tables/fhrp.py:67 netbox/ipam/tables/vlans.py:122
-#: netbox/ipam/tables/vlans.py:226
-#: netbox/templates/circuits/circuitgroupassignment.html:22
-#: netbox/templates/dcim/interface.html:284 netbox/templates/dcim/site.html:37
-#: netbox/templates/ipam/inc/panels/fhrp_groups.html:23
-#: netbox/templates/ipam/vlan.html:27 netbox/templates/tenancy/contact.html:21
-#: netbox/templates/tenancy/tenant.html:20 netbox/templates/users/group.html:6
-#: netbox/templates/users/group.html:14
-#: netbox/templates/virtualization/cluster.html:29
-#: netbox/templates/vpn/tunnel.html:29
-#: netbox/templates/wireless/wirelesslan.html:18
-#: netbox/tenancy/forms/bulk_edit.py:43 netbox/tenancy/forms/bulk_edit.py:94
-#: netbox/tenancy/forms/bulk_import.py:40
-#: netbox/tenancy/forms/bulk_import.py:81 netbox/tenancy/forms/filtersets.py:48
-#: netbox/tenancy/forms/filtersets.py:78 netbox/tenancy/forms/filtersets.py:97
-#: netbox/tenancy/forms/model_forms.py:45
-#: netbox/tenancy/forms/model_forms.py:97
-#: netbox/tenancy/forms/model_forms.py:122 netbox/tenancy/tables/contacts.py:60
-#: netbox/tenancy/tables/contacts.py:107 netbox/tenancy/tables/tenants.py:42
-#: netbox/users/filtersets.py:62 netbox/users/filtersets.py:185
-#: netbox/users/forms/filtersets.py:31 netbox/users/forms/filtersets.py:37
-#: netbox/users/forms/filtersets.py:79
-#: netbox/virtualization/forms/bulk_edit.py:65
-#: netbox/virtualization/forms/bulk_import.py:47
-#: netbox/virtualization/forms/filtersets.py:85
-#: netbox/virtualization/forms/model_forms.py:66
-#: netbox/virtualization/tables/clusters.py:70
-#: netbox/vpn/forms/bulk_edit.py:112 netbox/vpn/forms/bulk_import.py:158
-#: netbox/vpn/forms/filtersets.py:116 netbox/vpn/tables/crypto.py:31
-#: netbox/vpn/tables/tunnels.py:44 netbox/wireless/forms/bulk_edit.py:48
-#: netbox/wireless/forms/bulk_import.py:36
-#: netbox/wireless/forms/filtersets.py:46
-#: netbox/wireless/forms/model_forms.py:40
-#: netbox/wireless/tables/wirelesslan.py:48
+#: circuits/forms/filtersets.py:265 circuits/forms/model_forms.py:195
+#: circuits/tables/circuits.py:155 dcim/forms/bulk_edit.py:117
+#: dcim/forms/bulk_import.py:100 dcim/forms/model_forms.py:117
+#: dcim/tables/sites.py:89 extras/forms/filtersets.py:480
+#: ipam/filtersets.py:999 ipam/forms/bulk_edit.py:493
+#: ipam/forms/bulk_import.py:436 ipam/forms/model_forms.py:528
+#: ipam/tables/fhrp.py:67 ipam/tables/vlans.py:122 ipam/tables/vlans.py:226
+#: templates/circuits/circuitgroupassignment.html:22
+#: templates/dcim/interface.html:284 templates/dcim/site.html:37
+#: templates/ipam/inc/panels/fhrp_groups.html:23 templates/ipam/vlan.html:27
+#: templates/tenancy/contact.html:21 templates/tenancy/tenant.html:20
+#: templates/users/group.html:6 templates/users/group.html:14
+#: templates/virtualization/cluster.html:29 templates/vpn/tunnel.html:29
+#: templates/wireless/wirelesslan.html:18 tenancy/forms/bulk_edit.py:43
+#: tenancy/forms/bulk_edit.py:94 tenancy/forms/bulk_import.py:40
+#: tenancy/forms/bulk_import.py:81 tenancy/forms/filtersets.py:48
+#: tenancy/forms/filtersets.py:78 tenancy/forms/filtersets.py:97
+#: tenancy/forms/model_forms.py:45 tenancy/forms/model_forms.py:97
+#: tenancy/forms/model_forms.py:122 tenancy/tables/contacts.py:60
+#: tenancy/tables/contacts.py:107 tenancy/tables/tenants.py:42
+#: users/filtersets.py:62 users/filtersets.py:185 users/forms/filtersets.py:31
+#: users/forms/filtersets.py:37 users/forms/filtersets.py:79
+#: virtualization/forms/bulk_edit.py:65 virtualization/forms/bulk_import.py:47
+#: virtualization/forms/filtersets.py:85 virtualization/forms/model_forms.py:66
+#: virtualization/tables/clusters.py:70 vpn/forms/bulk_edit.py:112
+#: vpn/forms/bulk_import.py:158 vpn/forms/filtersets.py:116
+#: vpn/tables/crypto.py:31 vpn/tables/tunnels.py:44
+#: wireless/forms/bulk_edit.py:48 wireless/forms/bulk_import.py:36
+#: wireless/forms/filtersets.py:46 wireless/forms/model_forms.py:40
+#: wireless/tables/wirelesslan.py:48
 msgid "Group"
 msgstr ""
 
-#: netbox/circuits/forms/model_forms.py:182
-#: netbox/templates/circuits/circuitgroup.html:25
+#: circuits/forms/model_forms.py:182 templates/circuits/circuitgroup.html:25
 msgid "Circuit Group"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:27 netbox/dcim/models/cables.py:67
-#: netbox/dcim/models/device_component_templates.py:517
-#: netbox/dcim/models/device_component_templates.py:617
-#: netbox/dcim/models/device_components.py:975
-#: netbox/dcim/models/device_components.py:1049
-#: netbox/dcim/models/device_components.py:1204
-#: netbox/dcim/models/devices.py:479 netbox/dcim/models/racks.py:224
-#: netbox/extras/models/tags.py:28
+#: circuits/models/circuits.py:27 dcim/models/cables.py:67
+#: dcim/models/device_component_templates.py:517
+#: dcim/models/device_component_templates.py:617
+#: dcim/models/device_components.py:975 dcim/models/device_components.py:1049
+#: dcim/models/device_components.py:1204 dcim/models/devices.py:479
+#: dcim/models/racks.py:224 extras/models/tags.py:28
 msgid "color"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:36
+#: circuits/models/circuits.py:36
 msgid "circuit type"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:37
+#: circuits/models/circuits.py:37
 msgid "circuit types"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:48
+#: circuits/models/circuits.py:48
 msgid "circuit ID"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:49
+#: circuits/models/circuits.py:49
 msgid "Unique circuit ID"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:69 netbox/core/models/data.py:52
-#: netbox/core/models/jobs.py:84 netbox/dcim/models/cables.py:49
-#: netbox/dcim/models/devices.py:653 netbox/dcim/models/devices.py:1173
-#: netbox/dcim/models/devices.py:1399 netbox/dcim/models/power.py:96
-#: netbox/dcim/models/racks.py:297 netbox/dcim/models/sites.py:154
-#: netbox/dcim/models/sites.py:266 netbox/ipam/models/ip.py:253
-#: netbox/ipam/models/ip.py:522 netbox/ipam/models/ip.py:730
-#: netbox/ipam/models/vlans.py:195 netbox/virtualization/models/clusters.py:74
-#: netbox/virtualization/models/virtualmachines.py:84
-#: netbox/vpn/models/tunnels.py:40 netbox/wireless/models.py:95
-#: netbox/wireless/models.py:159
+#: circuits/models/circuits.py:69 core/models/data.py:52 core/models/jobs.py:84
+#: dcim/models/cables.py:49 dcim/models/devices.py:653
+#: dcim/models/devices.py:1173 dcim/models/devices.py:1399
+#: dcim/models/power.py:96 dcim/models/racks.py:297 dcim/models/sites.py:154
+#: dcim/models/sites.py:266 ipam/models/ip.py:253 ipam/models/ip.py:522
+#: ipam/models/ip.py:730 ipam/models/vlans.py:195
+#: virtualization/models/clusters.py:74
+#: virtualization/models/virtualmachines.py:84 vpn/models/tunnels.py:40
+#: wireless/models.py:95 wireless/models.py:159
 msgid "status"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:84 netbox/templates/core/plugin.html:20
+#: circuits/models/circuits.py:84 templates/core/plugin.html:20
 msgid "installed"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:89
+#: circuits/models/circuits.py:89
 msgid "terminates"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:94
+#: circuits/models/circuits.py:94
 msgid "commit rate (Kbps)"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:95
+#: circuits/models/circuits.py:95
 msgid "Committed rate"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:137
+#: circuits/models/circuits.py:137
 msgid "circuit"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:138
+#: circuits/models/circuits.py:138
 msgid "circuits"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:170
+#: circuits/models/circuits.py:170
 msgid "circuit group"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:171
+#: circuits/models/circuits.py:171
 msgid "circuit groups"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:195 netbox/ipam/models/fhrp.py:93
-#: netbox/tenancy/models/contacts.py:134
+#: circuits/models/circuits.py:195 ipam/models/fhrp.py:93
+#: tenancy/models/contacts.py:134
 msgid "priority"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:213
+#: circuits/models/circuits.py:213
 msgid "Circuit group assignment"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:214
+#: circuits/models/circuits.py:214
 msgid "Circuit group assignments"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:240
+#: circuits/models/circuits.py:240
 msgid "termination"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:257
+#: circuits/models/circuits.py:257
 msgid "port speed (Kbps)"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:260
+#: circuits/models/circuits.py:260
 msgid "Physical circuit speed"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:265
+#: circuits/models/circuits.py:265
 msgid "upstream speed (Kbps)"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:266
+#: circuits/models/circuits.py:266
 msgid "Upstream speed, if different from port speed"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:271
+#: circuits/models/circuits.py:271
 msgid "cross-connect ID"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:272
+#: circuits/models/circuits.py:272
 msgid "ID of the local cross-connect"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:277
+#: circuits/models/circuits.py:277
 msgid "patch panel/port(s)"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:278
+#: circuits/models/circuits.py:278
 msgid "Patch panel ID and port number(s)"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:281
-#: netbox/dcim/models/device_component_templates.py:61
-#: netbox/dcim/models/device_components.py:68 netbox/dcim/models/racks.py:685
-#: netbox/extras/models/configs.py:45 netbox/extras/models/configs.py:219
-#: netbox/extras/models/customfields.py:125 netbox/extras/models/models.py:61
-#: netbox/extras/models/models.py:158 netbox/extras/models/models.py:396
-#: netbox/extras/models/models.py:511 netbox/extras/models/notifications.py:131
-#: netbox/extras/models/staging.py:31 netbox/extras/models/tags.py:32
-#: netbox/netbox/models/__init__.py:110 netbox/netbox/models/__init__.py:145
-#: netbox/netbox/models/__init__.py:191 netbox/users/models/permissions.py:24
-#: netbox/users/models/tokens.py:57 netbox/users/models/users.py:33
-#: netbox/virtualization/models/virtualmachines.py:289
+#: circuits/models/circuits.py:281 dcim/models/device_component_templates.py:61
+#: dcim/models/device_components.py:68 dcim/models/racks.py:685
+#: extras/models/configs.py:45 extras/models/configs.py:219
+#: extras/models/customfields.py:125 extras/models/models.py:61
+#: extras/models/models.py:158 extras/models/models.py:396
+#: extras/models/models.py:511 extras/models/notifications.py:131
+#: extras/models/staging.py:31 extras/models/tags.py:32
+#: netbox/models/__init__.py:110 netbox/models/__init__.py:145
+#: netbox/models/__init__.py:191 users/models/permissions.py:24
+#: users/models/tokens.py:57 users/models/users.py:33
+#: virtualization/models/virtualmachines.py:289
 msgid "description"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:294
+#: circuits/models/circuits.py:294
 msgid "circuit termination"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:295
+#: circuits/models/circuits.py:295
 msgid "circuit terminations"
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:308
+#: circuits/models/circuits.py:308
 msgid ""
 "A circuit termination must attach to either a site or a provider network."
 msgstr ""
 
-#: netbox/circuits/models/circuits.py:310
+#: circuits/models/circuits.py:310
 msgid ""
 "A circuit termination cannot attach to both a site and a provider network."
 msgstr ""
 
-#: netbox/circuits/models/providers.py:22
-#: netbox/circuits/models/providers.py:66
-#: netbox/circuits/models/providers.py:104 netbox/core/models/data.py:39
-#: netbox/core/models/jobs.py:45
-#: netbox/dcim/models/device_component_templates.py:43
-#: netbox/dcim/models/device_components.py:53 netbox/dcim/models/devices.py:593
-#: netbox/dcim/models/devices.py:1330 netbox/dcim/models/devices.py:1395
-#: netbox/dcim/models/power.py:39 netbox/dcim/models/power.py:92
-#: netbox/dcim/models/racks.py:262 netbox/dcim/models/sites.py:138
-#: netbox/extras/models/configs.py:36 netbox/extras/models/configs.py:215
-#: netbox/extras/models/customfields.py:92 netbox/extras/models/models.py:56
-#: netbox/extras/models/models.py:153 netbox/extras/models/models.py:296
-#: netbox/extras/models/models.py:392 netbox/extras/models/models.py:501
-#: netbox/extras/models/models.py:596 netbox/extras/models/notifications.py:126
-#: netbox/extras/models/scripts.py:30 netbox/extras/models/staging.py:26
-#: netbox/ipam/models/asns.py:18 netbox/ipam/models/fhrp.py:25
-#: netbox/ipam/models/services.py:52 netbox/ipam/models/services.py:88
-#: netbox/ipam/models/vlans.py:36 netbox/ipam/models/vlans.py:184
-#: netbox/ipam/models/vrfs.py:22 netbox/ipam/models/vrfs.py:79
-#: netbox/netbox/models/__init__.py:137 netbox/netbox/models/__init__.py:181
-#: netbox/tenancy/models/contacts.py:64 netbox/tenancy/models/tenants.py:20
-#: netbox/tenancy/models/tenants.py:45 netbox/users/models/permissions.py:20
-#: netbox/users/models/users.py:28 netbox/virtualization/models/clusters.py:57
-#: netbox/virtualization/models/virtualmachines.py:72
-#: netbox/virtualization/models/virtualmachines.py:279
-#: netbox/vpn/models/crypto.py:24 netbox/vpn/models/crypto.py:71
-#: netbox/vpn/models/crypto.py:131 netbox/vpn/models/crypto.py:183
-#: netbox/vpn/models/crypto.py:221 netbox/vpn/models/l2vpn.py:22
-#: netbox/vpn/models/tunnels.py:35 netbox/wireless/models.py:51
+#: circuits/models/providers.py:22 circuits/models/providers.py:66
+#: circuits/models/providers.py:104 core/models/data.py:39
+#: core/models/jobs.py:45 dcim/models/device_component_templates.py:43
+#: dcim/models/device_components.py:53 dcim/models/devices.py:593
+#: dcim/models/devices.py:1330 dcim/models/devices.py:1395
+#: dcim/models/power.py:39 dcim/models/power.py:92 dcim/models/racks.py:262
+#: dcim/models/sites.py:138 extras/models/configs.py:36
+#: extras/models/configs.py:215 extras/models/customfields.py:92
+#: extras/models/models.py:56 extras/models/models.py:153
+#: extras/models/models.py:296 extras/models/models.py:392
+#: extras/models/models.py:501 extras/models/models.py:596
+#: extras/models/notifications.py:126 extras/models/scripts.py:30
+#: extras/models/staging.py:26 ipam/models/asns.py:18 ipam/models/fhrp.py:25
+#: ipam/models/services.py:52 ipam/models/services.py:88
+#: ipam/models/vlans.py:36 ipam/models/vlans.py:184 ipam/models/vrfs.py:22
+#: ipam/models/vrfs.py:79 netbox/models/__init__.py:137
+#: netbox/models/__init__.py:181 tenancy/models/contacts.py:64
+#: tenancy/models/tenants.py:20 tenancy/models/tenants.py:45
+#: users/models/permissions.py:20 users/models/users.py:28
+#: virtualization/models/clusters.py:57
+#: virtualization/models/virtualmachines.py:72
+#: virtualization/models/virtualmachines.py:279 vpn/models/crypto.py:24
+#: vpn/models/crypto.py:71 vpn/models/crypto.py:131 vpn/models/crypto.py:183
+#: vpn/models/crypto.py:221 vpn/models/l2vpn.py:22 vpn/models/tunnels.py:35
+#: wireless/models.py:51
 msgid "name"
 msgstr ""
 
-#: netbox/circuits/models/providers.py:25
+#: circuits/models/providers.py:25
 msgid "Full name of the provider"
 msgstr ""
 
-#: netbox/circuits/models/providers.py:28 netbox/dcim/models/devices.py:86
-#: netbox/dcim/models/racks.py:137 netbox/dcim/models/sites.py:149
-#: netbox/extras/models/models.py:506 netbox/ipam/models/asns.py:23
-#: netbox/ipam/models/vlans.py:40 netbox/netbox/models/__init__.py:141
-#: netbox/netbox/models/__init__.py:186 netbox/tenancy/models/tenants.py:25
-#: netbox/tenancy/models/tenants.py:49 netbox/vpn/models/l2vpn.py:27
-#: netbox/wireless/models.py:56
+#: circuits/models/providers.py:28 dcim/models/devices.py:86
+#: dcim/models/racks.py:137 dcim/models/sites.py:149
+#: extras/models/models.py:506 ipam/models/asns.py:23 ipam/models/vlans.py:40
+#: netbox/models/__init__.py:141 netbox/models/__init__.py:186
+#: tenancy/models/tenants.py:25 tenancy/models/tenants.py:49
+#: vpn/models/l2vpn.py:27 wireless/models.py:56
 msgid "slug"
 msgstr ""
 
-#: netbox/circuits/models/providers.py:42
+#: circuits/models/providers.py:42
 msgid "provider"
 msgstr ""
 
-#: netbox/circuits/models/providers.py:43
+#: circuits/models/providers.py:43
 msgid "providers"
 msgstr ""
 
-#: netbox/circuits/models/providers.py:63
+#: circuits/models/providers.py:63
 msgid "account ID"
 msgstr ""
 
-#: netbox/circuits/models/providers.py:86
+#: circuits/models/providers.py:86
 msgid "provider account"
 msgstr ""
 
-#: netbox/circuits/models/providers.py:87
+#: circuits/models/providers.py:87
 msgid "provider accounts"
 msgstr ""
 
-#: netbox/circuits/models/providers.py:115
+#: circuits/models/providers.py:115
 msgid "service ID"
 msgstr ""
 
-#: netbox/circuits/models/providers.py:126
+#: circuits/models/providers.py:126
 msgid "provider network"
 msgstr ""
 
-#: netbox/circuits/models/providers.py:127
+#: circuits/models/providers.py:127
 msgid "provider networks"
 msgstr ""
 
-#: netbox/circuits/tables/circuits.py:32 netbox/circuits/tables/circuits.py:132
-#: netbox/circuits/tables/providers.py:18
-#: netbox/circuits/tables/providers.py:69
-#: netbox/circuits/tables/providers.py:99 netbox/core/tables/data.py:16
-#: netbox/core/tables/jobs.py:14 netbox/core/tables/plugins.py:44
-#: netbox/core/tables/tasks.py:11 netbox/core/tables/tasks.py:115
-#: netbox/dcim/forms/filtersets.py:63 netbox/dcim/forms/object_create.py:43
-#: netbox/dcim/tables/devices.py:52 netbox/dcim/tables/devices.py:92
-#: netbox/dcim/tables/devices.py:134 netbox/dcim/tables/devices.py:289
-#: netbox/dcim/tables/devices.py:392 netbox/dcim/tables/devices.py:433
-#: netbox/dcim/tables/devices.py:482 netbox/dcim/tables/devices.py:531
-#: netbox/dcim/tables/devices.py:648 netbox/dcim/tables/devices.py:731
-#: netbox/dcim/tables/devices.py:778 netbox/dcim/tables/devices.py:841
-#: netbox/dcim/tables/devices.py:911 netbox/dcim/tables/devices.py:974
-#: netbox/dcim/tables/devices.py:994 netbox/dcim/tables/devices.py:1023
-#: netbox/dcim/tables/devices.py:1053 netbox/dcim/tables/devicetypes.py:31
-#: netbox/dcim/tables/power.py:22 netbox/dcim/tables/power.py:62
-#: netbox/dcim/tables/racks.py:24 netbox/dcim/tables/racks.py:113
-#: netbox/dcim/tables/sites.py:24 netbox/dcim/tables/sites.py:51
-#: netbox/dcim/tables/sites.py:78 netbox/dcim/tables/sites.py:130
-#: netbox/extras/forms/filtersets.py:213 netbox/extras/tables/tables.py:58
-#: netbox/extras/tables/tables.py:122 netbox/extras/tables/tables.py:155
-#: netbox/extras/tables/tables.py:180 netbox/extras/tables/tables.py:246
-#: netbox/extras/tables/tables.py:361 netbox/extras/tables/tables.py:378
-#: netbox/extras/tables/tables.py:401 netbox/extras/tables/tables.py:439
-#: netbox/extras/tables/tables.py:491 netbox/extras/tables/tables.py:514
-#: netbox/ipam/forms/bulk_edit.py:407 netbox/ipam/forms/filtersets.py:386
-#: netbox/ipam/tables/asn.py:16 netbox/ipam/tables/ip.py:85
-#: netbox/ipam/tables/ip.py:160 netbox/ipam/tables/services.py:15
-#: netbox/ipam/tables/services.py:40 netbox/ipam/tables/vlans.py:64
-#: netbox/ipam/tables/vlans.py:114 netbox/ipam/tables/vrfs.py:26
-#: netbox/ipam/tables/vrfs.py:68 netbox/templates/circuits/circuitgroup.html:28
-#: netbox/templates/circuits/circuittype.html:22
-#: netbox/templates/circuits/provideraccount.html:28
-#: netbox/templates/circuits/providernetwork.html:24
-#: netbox/templates/core/datasource.html:34 netbox/templates/core/job.html:44
-#: netbox/templates/core/plugin.html:54 netbox/templates/core/rq_worker.html:43
-#: netbox/templates/dcim/consoleport.html:28
-#: netbox/templates/dcim/consoleserverport.html:28
-#: netbox/templates/dcim/devicebay.html:24
-#: netbox/templates/dcim/devicerole.html:26
-#: netbox/templates/dcim/frontport.html:28
-#: netbox/templates/dcim/inc/interface_vlans_table.html:5
-#: netbox/templates/dcim/inc/panels/inventory_items.html:18
-#: netbox/templates/dcim/interface.html:38
-#: netbox/templates/dcim/interface.html:165
-#: netbox/templates/dcim/inventoryitem.html:28
-#: netbox/templates/dcim/inventoryitemrole.html:18
-#: netbox/templates/dcim/location.html:29
-#: netbox/templates/dcim/manufacturer.html:36
-#: netbox/templates/dcim/modulebay.html:30
-#: netbox/templates/dcim/platform.html:29
-#: netbox/templates/dcim/poweroutlet.html:28
-#: netbox/templates/dcim/powerport.html:28
-#: netbox/templates/dcim/rackrole.html:22
-#: netbox/templates/dcim/rearport.html:28 netbox/templates/dcim/region.html:29
-#: netbox/templates/dcim/sitegroup.html:29
-#: netbox/templates/dcim/virtualdevicecontext.html:18
-#: netbox/templates/extras/configcontext.html:13
-#: netbox/templates/extras/configtemplate.html:13
-#: netbox/templates/extras/customfield.html:13
-#: netbox/templates/extras/customlink.html:13
-#: netbox/templates/extras/eventrule.html:13
-#: netbox/templates/extras/exporttemplate.html:15
-#: netbox/templates/extras/notificationgroup.html:14
-#: netbox/templates/extras/savedfilter.html:13
-#: netbox/templates/extras/script_list.html:44
-#: netbox/templates/extras/tag.html:14 netbox/templates/extras/webhook.html:13
-#: netbox/templates/ipam/asnrange.html:15
-#: netbox/templates/ipam/fhrpgroup.html:30 netbox/templates/ipam/rir.html:22
-#: netbox/templates/ipam/role.html:22 netbox/templates/ipam/routetarget.html:13
-#: netbox/templates/ipam/service.html:24
-#: netbox/templates/ipam/servicetemplate.html:15
-#: netbox/templates/ipam/vlan.html:35 netbox/templates/ipam/vlangroup.html:30
-#: netbox/templates/tenancy/contact.html:25
-#: netbox/templates/tenancy/contactgroup.html:21
-#: netbox/templates/tenancy/contactrole.html:18
-#: netbox/templates/tenancy/tenantgroup.html:29
-#: netbox/templates/users/group.html:17
-#: netbox/templates/users/objectpermission.html:17
-#: netbox/templates/virtualization/cluster.html:13
-#: netbox/templates/virtualization/clustergroup.html:22
-#: netbox/templates/virtualization/clustertype.html:22
-#: netbox/templates/virtualization/virtualdisk.html:25
-#: netbox/templates/virtualization/virtualmachine.html:15
-#: netbox/templates/virtualization/vminterface.html:25
-#: netbox/templates/vpn/ikepolicy.html:13
-#: netbox/templates/vpn/ikeproposal.html:13
-#: netbox/templates/vpn/ipsecpolicy.html:13
-#: netbox/templates/vpn/ipsecprofile.html:13
-#: netbox/templates/vpn/ipsecprofile.html:36
-#: netbox/templates/vpn/ipsecprofile.html:69
-#: netbox/templates/vpn/ipsecproposal.html:13
-#: netbox/templates/vpn/l2vpn.html:14 netbox/templates/vpn/tunnel.html:21
-#: netbox/templates/vpn/tunnelgroup.html:26
-#: netbox/templates/wireless/wirelesslangroup.html:29
-#: netbox/tenancy/tables/contacts.py:19 netbox/tenancy/tables/contacts.py:41
-#: netbox/tenancy/tables/contacts.py:56 netbox/tenancy/tables/tenants.py:16
-#: netbox/tenancy/tables/tenants.py:38 netbox/users/tables.py:62
-#: netbox/users/tables.py:76 netbox/virtualization/forms/bulk_create.py:20
-#: netbox/virtualization/forms/object_create.py:13
-#: netbox/virtualization/forms/object_create.py:23
-#: netbox/virtualization/tables/clusters.py:17
-#: netbox/virtualization/tables/clusters.py:39
-#: netbox/virtualization/tables/clusters.py:62
-#: netbox/virtualization/tables/virtualmachines.py:55
-#: netbox/virtualization/tables/virtualmachines.py:139
-#: netbox/virtualization/tables/virtualmachines.py:194
-#: netbox/vpn/tables/crypto.py:18 netbox/vpn/tables/crypto.py:57
-#: netbox/vpn/tables/crypto.py:93 netbox/vpn/tables/crypto.py:129
-#: netbox/vpn/tables/crypto.py:158 netbox/vpn/tables/l2vpn.py:23
-#: netbox/vpn/tables/tunnels.py:18 netbox/vpn/tables/tunnels.py:40
-#: netbox/wireless/tables/wirelesslan.py:18
-#: netbox/wireless/tables/wirelesslan.py:79
+#: circuits/tables/circuits.py:32 circuits/tables/circuits.py:132
+#: circuits/tables/providers.py:18 circuits/tables/providers.py:69
+#: circuits/tables/providers.py:99 core/tables/data.py:16
+#: core/tables/jobs.py:14 core/tables/plugins.py:44 core/tables/tasks.py:11
+#: core/tables/tasks.py:115 dcim/forms/filtersets.py:63
+#: dcim/forms/object_create.py:43 dcim/tables/devices.py:52
+#: dcim/tables/devices.py:92 dcim/tables/devices.py:134
+#: dcim/tables/devices.py:289 dcim/tables/devices.py:392
+#: dcim/tables/devices.py:433 dcim/tables/devices.py:482
+#: dcim/tables/devices.py:531 dcim/tables/devices.py:648
+#: dcim/tables/devices.py:731 dcim/tables/devices.py:778
+#: dcim/tables/devices.py:841 dcim/tables/devices.py:911
+#: dcim/tables/devices.py:974 dcim/tables/devices.py:994
+#: dcim/tables/devices.py:1023 dcim/tables/devices.py:1053
+#: dcim/tables/devicetypes.py:31 dcim/tables/power.py:22
+#: dcim/tables/power.py:62 dcim/tables/racks.py:24 dcim/tables/racks.py:113
+#: dcim/tables/sites.py:24 dcim/tables/sites.py:51 dcim/tables/sites.py:78
+#: dcim/tables/sites.py:130 extras/forms/filtersets.py:213
+#: extras/tables/tables.py:58 extras/tables/tables.py:122
+#: extras/tables/tables.py:155 extras/tables/tables.py:180
+#: extras/tables/tables.py:246 extras/tables/tables.py:361
+#: extras/tables/tables.py:378 extras/tables/tables.py:401
+#: extras/tables/tables.py:439 extras/tables/tables.py:491
+#: extras/tables/tables.py:514 ipam/forms/bulk_edit.py:407
+#: ipam/forms/filtersets.py:386 ipam/tables/asn.py:16 ipam/tables/ip.py:85
+#: ipam/tables/ip.py:160 ipam/tables/services.py:15 ipam/tables/services.py:40
+#: ipam/tables/vlans.py:64 ipam/tables/vlans.py:114 ipam/tables/vrfs.py:26
+#: ipam/tables/vrfs.py:68 templates/circuits/circuitgroup.html:28
+#: templates/circuits/circuittype.html:22
+#: templates/circuits/provideraccount.html:28
+#: templates/circuits/providernetwork.html:24 templates/core/datasource.html:34
+#: templates/core/job.html:44 templates/core/plugin.html:54
+#: templates/core/rq_worker.html:43 templates/dcim/consoleport.html:28
+#: templates/dcim/consoleserverport.html:28 templates/dcim/devicebay.html:24
+#: templates/dcim/devicerole.html:26 templates/dcim/frontport.html:28
+#: templates/dcim/inc/interface_vlans_table.html:5
+#: templates/dcim/inc/panels/inventory_items.html:18
+#: templates/dcim/interface.html:38 templates/dcim/interface.html:165
+#: templates/dcim/inventoryitem.html:28
+#: templates/dcim/inventoryitemrole.html:18 templates/dcim/location.html:29
+#: templates/dcim/manufacturer.html:36 templates/dcim/modulebay.html:30
+#: templates/dcim/platform.html:29 templates/dcim/poweroutlet.html:28
+#: templates/dcim/powerport.html:28 templates/dcim/rackrole.html:22
+#: templates/dcim/rearport.html:28 templates/dcim/region.html:29
+#: templates/dcim/sitegroup.html:29 templates/dcim/virtualdevicecontext.html:18
+#: templates/extras/configcontext.html:13
+#: templates/extras/configtemplate.html:13 templates/extras/customfield.html:13
+#: templates/extras/customlink.html:13 templates/extras/eventrule.html:13
+#: templates/extras/exporttemplate.html:15
+#: templates/extras/notificationgroup.html:14
+#: templates/extras/savedfilter.html:13 templates/extras/script_list.html:44
+#: templates/extras/tag.html:14 templates/extras/webhook.html:13
+#: templates/ipam/asnrange.html:15 templates/ipam/fhrpgroup.html:30
+#: templates/ipam/rir.html:22 templates/ipam/role.html:22
+#: templates/ipam/routetarget.html:13 templates/ipam/service.html:24
+#: templates/ipam/servicetemplate.html:15 templates/ipam/vlan.html:35
+#: templates/ipam/vlangroup.html:30 templates/tenancy/contact.html:25
+#: templates/tenancy/contactgroup.html:21 templates/tenancy/contactrole.html:18
+#: templates/tenancy/tenantgroup.html:29 templates/users/group.html:17
+#: templates/users/objectpermission.html:17
+#: templates/virtualization/cluster.html:13
+#: templates/virtualization/clustergroup.html:22
+#: templates/virtualization/clustertype.html:22
+#: templates/virtualization/virtualdisk.html:25
+#: templates/virtualization/virtualmachine.html:15
+#: templates/virtualization/vminterface.html:25 templates/vpn/ikepolicy.html:13
+#: templates/vpn/ikeproposal.html:13 templates/vpn/ipsecpolicy.html:13
+#: templates/vpn/ipsecprofile.html:13 templates/vpn/ipsecprofile.html:36
+#: templates/vpn/ipsecprofile.html:69 templates/vpn/ipsecproposal.html:13
+#: templates/vpn/l2vpn.html:14 templates/vpn/tunnel.html:21
+#: templates/vpn/tunnelgroup.html:26
+#: templates/wireless/wirelesslangroup.html:29 tenancy/tables/contacts.py:19
+#: tenancy/tables/contacts.py:41 tenancy/tables/contacts.py:56
+#: tenancy/tables/tenants.py:16 tenancy/tables/tenants.py:38 users/tables.py:62
+#: users/tables.py:76 virtualization/forms/bulk_create.py:20
+#: virtualization/forms/object_create.py:13
+#: virtualization/forms/object_create.py:23
+#: virtualization/tables/clusters.py:17 virtualization/tables/clusters.py:39
+#: virtualization/tables/clusters.py:62
+#: virtualization/tables/virtualmachines.py:55
+#: virtualization/tables/virtualmachines.py:139
+#: virtualization/tables/virtualmachines.py:194 vpn/tables/crypto.py:18
+#: vpn/tables/crypto.py:57 vpn/tables/crypto.py:93 vpn/tables/crypto.py:129
+#: vpn/tables/crypto.py:158 vpn/tables/l2vpn.py:23 vpn/tables/tunnels.py:18
+#: vpn/tables/tunnels.py:40 wireless/tables/wirelesslan.py:18
+#: wireless/tables/wirelesslan.py:79
 msgid "Name"
 msgstr ""
 
-#: netbox/circuits/tables/circuits.py:41 netbox/circuits/tables/circuits.py:138
-#: netbox/circuits/tables/providers.py:45
-#: netbox/circuits/tables/providers.py:79 netbox/netbox/navigation/menu.py:266
-#: netbox/netbox/navigation/menu.py:270 netbox/netbox/navigation/menu.py:272
-#: netbox/templates/circuits/provider.html:57
-#: netbox/templates/circuits/provideraccount.html:44
-#: netbox/templates/circuits/providernetwork.html:50
+#: circuits/tables/circuits.py:41 circuits/tables/circuits.py:138
+#: circuits/tables/providers.py:45 circuits/tables/providers.py:79
+#: netbox/navigation/menu.py:266 netbox/navigation/menu.py:270
+#: netbox/navigation/menu.py:272 templates/circuits/provider.html:57
+#: templates/circuits/provideraccount.html:44
+#: templates/circuits/providernetwork.html:50
 msgid "Circuits"
 msgstr ""
 
-#: netbox/circuits/tables/circuits.py:55
-#: netbox/templates/circuits/circuit.html:26
+#: circuits/tables/circuits.py:55 templates/circuits/circuit.html:26
 msgid "Circuit ID"
 msgstr ""
 
-#: netbox/circuits/tables/circuits.py:69
-#: netbox/wireless/forms/model_forms.py:160
+#: circuits/tables/circuits.py:69 wireless/forms/model_forms.py:160
 msgid "Side A"
 msgstr ""
 
-#: netbox/circuits/tables/circuits.py:74
+#: circuits/tables/circuits.py:74
 msgid "Side Z"
 msgstr ""
 
-#: netbox/circuits/tables/circuits.py:77
-#: netbox/templates/circuits/circuit.html:55
+#: circuits/tables/circuits.py:77 templates/circuits/circuit.html:55
 msgid "Commit Rate"
 msgstr ""
 
-#: netbox/circuits/tables/circuits.py:80 netbox/circuits/tables/providers.py:48
-#: netbox/circuits/tables/providers.py:82
-#: netbox/circuits/tables/providers.py:107 netbox/dcim/tables/devices.py:1036
-#: netbox/dcim/tables/devicetypes.py:92 netbox/dcim/tables/modules.py:29
-#: netbox/dcim/tables/modules.py:72 netbox/dcim/tables/power.py:39
-#: netbox/dcim/tables/power.py:96 netbox/dcim/tables/racks.py:84
-#: netbox/dcim/tables/racks.py:145 netbox/dcim/tables/racks.py:225
-#: netbox/dcim/tables/sites.py:108 netbox/extras/tables/tables.py:582
-#: netbox/ipam/tables/asn.py:69 netbox/ipam/tables/fhrp.py:34
-#: netbox/ipam/tables/ip.py:136 netbox/ipam/tables/ip.py:275
-#: netbox/ipam/tables/ip.py:329 netbox/ipam/tables/ip.py:397
-#: netbox/ipam/tables/services.py:24 netbox/ipam/tables/services.py:54
-#: netbox/ipam/tables/vlans.py:145 netbox/ipam/tables/vrfs.py:47
-#: netbox/ipam/tables/vrfs.py:72 netbox/templates/dcim/htmx/cable_edit.html:89
-#: netbox/templates/generic/bulk_edit.html:86
-#: netbox/templates/inc/panels/comments.html:5
-#: netbox/tenancy/tables/contacts.py:68 netbox/tenancy/tables/tenants.py:46
-#: netbox/utilities/forms/fields/fields.py:29
-#: netbox/virtualization/tables/clusters.py:91
-#: netbox/virtualization/tables/virtualmachines.py:82
-#: netbox/vpn/tables/crypto.py:37 netbox/vpn/tables/crypto.py:74
-#: netbox/vpn/tables/crypto.py:109 netbox/vpn/tables/crypto.py:140
-#: netbox/vpn/tables/crypto.py:173 netbox/vpn/tables/l2vpn.py:37
-#: netbox/vpn/tables/tunnels.py:61 netbox/wireless/tables/wirelesslan.py:27
-#: netbox/wireless/tables/wirelesslan.py:58
+#: circuits/tables/circuits.py:80 circuits/tables/providers.py:48
+#: circuits/tables/providers.py:82 circuits/tables/providers.py:107
+#: dcim/tables/devices.py:1036 dcim/tables/devicetypes.py:92
+#: dcim/tables/modules.py:29 dcim/tables/modules.py:72 dcim/tables/power.py:39
+#: dcim/tables/power.py:96 dcim/tables/racks.py:84 dcim/tables/racks.py:145
+#: dcim/tables/racks.py:225 dcim/tables/sites.py:108
+#: extras/tables/tables.py:582 ipam/tables/asn.py:69 ipam/tables/fhrp.py:34
+#: ipam/tables/ip.py:136 ipam/tables/ip.py:275 ipam/tables/ip.py:329
+#: ipam/tables/ip.py:397 ipam/tables/services.py:24 ipam/tables/services.py:54
+#: ipam/tables/vlans.py:145 ipam/tables/vrfs.py:47 ipam/tables/vrfs.py:72
+#: templates/dcim/htmx/cable_edit.html:89 templates/generic/bulk_edit.html:86
+#: templates/inc/panels/comments.html:5 tenancy/tables/contacts.py:68
+#: tenancy/tables/tenants.py:46 utilities/forms/fields/fields.py:29
+#: virtualization/tables/clusters.py:91
+#: virtualization/tables/virtualmachines.py:82 vpn/tables/crypto.py:37
+#: vpn/tables/crypto.py:74 vpn/tables/crypto.py:109 vpn/tables/crypto.py:140
+#: vpn/tables/crypto.py:173 vpn/tables/l2vpn.py:37 vpn/tables/tunnels.py:61
+#: wireless/tables/wirelesslan.py:27 wireless/tables/wirelesslan.py:58
 msgid "Comments"
 msgstr ""
 
-#: netbox/circuits/tables/circuits.py:86
-#: netbox/templates/tenancy/contact.html:84
-#: netbox/tenancy/tables/contacts.py:73
+#: circuits/tables/circuits.py:86 templates/tenancy/contact.html:84
+#: tenancy/tables/contacts.py:73
 msgid "Assignments"
 msgstr ""
 
-#: netbox/circuits/tables/providers.py:23
+#: circuits/tables/providers.py:23
 msgid "Accounts"
 msgstr ""
 
-#: netbox/circuits/tables/providers.py:29
+#: circuits/tables/providers.py:29
 msgid "Account Count"
 msgstr ""
 
-#: netbox/circuits/tables/providers.py:39 netbox/dcim/tables/sites.py:100
+#: circuits/tables/providers.py:39 dcim/tables/sites.py:100
 msgid "ASN Count"
 msgstr ""
 
-#: netbox/circuits/views.py:331
+#: circuits/views.py:331
 #, python-brace-format
 msgid "No terminations have been defined for circuit {circuit}."
 msgstr ""
 
-#: netbox/circuits/views.py:380
+#: circuits/views.py:380
 #, python-brace-format
 msgid "Swapped terminations for circuit {circuit}."
 msgstr ""
 
-#: netbox/core/api/views.py:39
+#: core/api/views.py:39
 msgid "This user does not have permission to synchronize this data source."
 msgstr ""
 
-#: netbox/core/choices.py:18
+#: core/choices.py:18
 msgid "New"
 msgstr ""
 
-#: netbox/core/choices.py:19 netbox/core/constants.py:18
-#: netbox/core/tables/tasks.py:15 netbox/templates/core/rq_task.html:77
+#: core/choices.py:19 core/constants.py:18 core/tables/tasks.py:15
+#: templates/core/rq_task.html:77
 msgid "Queued"
 msgstr ""
 
-#: netbox/core/choices.py:20
+#: core/choices.py:20
 msgid "Syncing"
 msgstr ""
 
-#: netbox/core/choices.py:21 netbox/core/choices.py:57
-#: netbox/core/tables/jobs.py:41 netbox/templates/core/job.html:86
+#: core/choices.py:21 core/choices.py:57 core/tables/jobs.py:41
+#: templates/core/job.html:86
 msgid "Completed"
 msgstr ""
 
-#: netbox/core/choices.py:22 netbox/core/choices.py:59
-#: netbox/core/constants.py:20 netbox/core/tables/tasks.py:34
-#: netbox/dcim/choices.py:187 netbox/dcim/choices.py:239
-#: netbox/dcim/choices.py:1607 netbox/virtualization/choices.py:47
+#: core/choices.py:22 core/choices.py:59 core/constants.py:20
+#: core/tables/tasks.py:34 dcim/choices.py:187 dcim/choices.py:239
+#: dcim/choices.py:1607 virtualization/choices.py:47
 msgid "Failed"
 msgstr ""
 
-#: netbox/core/choices.py:35 netbox/netbox/navigation/menu.py:335
-#: netbox/netbox/navigation/menu.py:339
-#: netbox/templates/extras/script/base.html:14
-#: netbox/templates/extras/script_list.html:7
-#: netbox/templates/extras/script_list.html:12
-#: netbox/templates/extras/script_result.html:17
+#: core/choices.py:35 netbox/navigation/menu.py:335
+#: netbox/navigation/menu.py:339 templates/extras/script/base.html:14
+#: templates/extras/script_list.html:7 templates/extras/script_list.html:12
+#: templates/extras/script_result.html:17
 msgid "Scripts"
 msgstr ""
 
-#: netbox/core/choices.py:36 netbox/templates/extras/report/base.html:13
+#: core/choices.py:36 templates/extras/report/base.html:13
 msgid "Reports"
 msgstr ""
 
-#: netbox/core/choices.py:54
+#: core/choices.py:54
 msgid "Pending"
 msgstr ""
 
-#: netbox/core/choices.py:55 netbox/core/constants.py:23
-#: netbox/core/tables/jobs.py:32 netbox/core/tables/tasks.py:38
-#: netbox/templates/core/job.html:73
+#: core/choices.py:55 core/constants.py:23 core/tables/jobs.py:32
+#: core/tables/tasks.py:38 templates/core/job.html:73
 msgid "Scheduled"
 msgstr ""
 
-#: netbox/core/choices.py:56
+#: core/choices.py:56
 msgid "Running"
 msgstr ""
 
-#: netbox/core/choices.py:58
+#: core/choices.py:58
 msgid "Errored"
 msgstr ""
 
-#: netbox/core/choices.py:87 netbox/core/tables/plugins.py:63
-#: netbox/templates/generic/object.html:61
+#: core/choices.py:87 core/tables/plugins.py:63
+#: templates/generic/object.html:61
 msgid "Updated"
 msgstr ""
 
-#: netbox/core/choices.py:88
+#: core/choices.py:88
 msgid "Deleted"
 msgstr ""
 
-#: netbox/core/constants.py:19 netbox/core/tables/tasks.py:30
+#: core/constants.py:19 core/tables/tasks.py:30
 msgid "Finished"
 msgstr ""
 
-#: netbox/core/constants.py:21 netbox/core/tables/jobs.py:38
-#: netbox/templates/core/job.html:82
-#: netbox/templates/extras/htmx/script_result.html:8
+#: core/constants.py:21 core/tables/jobs.py:38 templates/core/job.html:82
+#: templates/extras/htmx/script_result.html:8
 msgid "Started"
 msgstr ""
 
-#: netbox/core/constants.py:22 netbox/core/tables/tasks.py:26
+#: core/constants.py:22 core/tables/tasks.py:26
 msgid "Deferred"
 msgstr ""
 
-#: netbox/core/constants.py:24
+#: core/constants.py:24
 msgid "Stopped"
 msgstr ""
 
-#: netbox/core/constants.py:25
+#: core/constants.py:25
 msgid "Cancelled"
 msgstr ""
 
-#: netbox/core/data_backends.py:32 netbox/core/tables/plugins.py:51
-#: netbox/templates/core/plugin.html:88
-#: netbox/templates/dcim/interface.html:216
+#: core/data_backends.py:32 core/tables/plugins.py:51
+#: templates/core/plugin.html:88 templates/dcim/interface.html:216
 msgid "Local"
 msgstr ""
 
-#: netbox/core/data_backends.py:50 netbox/core/tables/change_logging.py:20
-#: netbox/templates/account/profile.html:15 netbox/templates/users/user.html:17
-#: netbox/users/tables.py:31
+#: core/data_backends.py:50 core/tables/change_logging.py:20
+#: templates/account/profile.html:15 templates/users/user.html:17
+#: users/tables.py:31
 msgid "Username"
 msgstr ""
 
-#: netbox/core/data_backends.py:52 netbox/core/data_backends.py:58
+#: core/data_backends.py:52 core/data_backends.py:58
 msgid "Only used for cloning with HTTP(S)"
 msgstr ""
 
-#: netbox/core/data_backends.py:56 netbox/templates/account/base.html:23
-#: netbox/templates/account/password.html:12
-#: netbox/users/forms/model_forms.py:170
+#: core/data_backends.py:56 templates/account/base.html:23
+#: templates/account/password.html:12 users/forms/model_forms.py:170
 msgid "Password"
 msgstr ""
 
-#: netbox/core/data_backends.py:62
+#: core/data_backends.py:62
 msgid "Branch"
 msgstr ""
 
-#: netbox/core/data_backends.py:120
+#: core/data_backends.py:120
 #, python-brace-format
 msgid "Fetching remote data failed ({name}): {error}"
 msgstr ""
 
-#: netbox/core/data_backends.py:133
+#: core/data_backends.py:133
 msgid "AWS access key ID"
 msgstr ""
 
-#: netbox/core/data_backends.py:137
+#: core/data_backends.py:137
 msgid "AWS secret access key"
 msgstr ""
 
-#: netbox/core/events.py:27
+#: core/events.py:27
 msgid "Object created"
 msgstr ""
 
-#: netbox/core/events.py:28
+#: core/events.py:28
 msgid "Object updated"
 msgstr ""
 
-#: netbox/core/events.py:29
+#: core/events.py:29
 msgid "Object deleted"
 msgstr ""
 
-#: netbox/core/events.py:30
+#: core/events.py:30
 msgid "Job started"
 msgstr ""
 
-#: netbox/core/events.py:31
+#: core/events.py:31
 msgid "Job completed"
 msgstr ""
 
-#: netbox/core/events.py:32
+#: core/events.py:32
 msgid "Job failed"
 msgstr ""
 
-#: netbox/core/events.py:33
+#: core/events.py:33
 msgid "Job errored"
 msgstr ""
 
-#: netbox/core/filtersets.py:53 netbox/extras/filtersets.py:250
-#: netbox/extras/filtersets.py:633 netbox/extras/filtersets.py:661
+#: core/filtersets.py:53 extras/filtersets.py:250 extras/filtersets.py:633
+#: extras/filtersets.py:661
 msgid "Data source (ID)"
 msgstr ""
 
-#: netbox/core/filtersets.py:59
+#: core/filtersets.py:59
 msgid "Data source (name)"
 msgstr ""
 
-#: netbox/core/filtersets.py:145 netbox/dcim/filtersets.py:501
-#: netbox/extras/filtersets.py:287 netbox/extras/filtersets.py:331
-#: netbox/extras/filtersets.py:353 netbox/extras/filtersets.py:413
-#: netbox/users/filtersets.py:28
+#: core/filtersets.py:145 dcim/filtersets.py:501 extras/filtersets.py:287
+#: extras/filtersets.py:331 extras/filtersets.py:353 extras/filtersets.py:413
+#: users/filtersets.py:28
 msgid "User (ID)"
 msgstr ""
 
-#: netbox/core/filtersets.py:151
+#: core/filtersets.py:151
 msgid "User name"
 msgstr ""
 
-#: netbox/core/forms/bulk_edit.py:25 netbox/core/forms/filtersets.py:43
-#: netbox/core/tables/data.py:26 netbox/dcim/forms/bulk_edit.py:1122
-#: netbox/dcim/forms/bulk_edit.py:1400 netbox/dcim/forms/filtersets.py:1370
-#: netbox/dcim/tables/devices.py:553 netbox/dcim/tables/devicetypes.py:224
-#: netbox/extras/forms/bulk_edit.py:123 netbox/extras/forms/bulk_edit.py:187
-#: netbox/extras/forms/bulk_edit.py:246 netbox/extras/forms/filtersets.py:142
-#: netbox/extras/forms/filtersets.py:229 netbox/extras/forms/filtersets.py:294
-#: netbox/extras/tables/tables.py:162 netbox/extras/tables/tables.py:253
-#: netbox/extras/tables/tables.py:415 netbox/netbox/preferences.py:22
-#: netbox/templates/core/datasource.html:42
-#: netbox/templates/dcim/interface.html:61
-#: netbox/templates/extras/customlink.html:17
-#: netbox/templates/extras/eventrule.html:17
-#: netbox/templates/extras/savedfilter.html:25
-#: netbox/templates/users/objectpermission.html:25
-#: netbox/templates/virtualization/vminterface.html:29
-#: netbox/users/forms/bulk_edit.py:89 netbox/users/forms/filtersets.py:70
-#: netbox/users/tables.py:83 netbox/virtualization/forms/bulk_edit.py:217
-#: netbox/virtualization/forms/filtersets.py:215
+#: core/forms/bulk_edit.py:25 core/forms/filtersets.py:43
+#: core/tables/data.py:26 dcim/forms/bulk_edit.py:1122
+#: dcim/forms/bulk_edit.py:1400 dcim/forms/filtersets.py:1370
+#: dcim/tables/devices.py:553 dcim/tables/devicetypes.py:224
+#: extras/forms/bulk_edit.py:123 extras/forms/bulk_edit.py:187
+#: extras/forms/bulk_edit.py:246 extras/forms/filtersets.py:142
+#: extras/forms/filtersets.py:229 extras/forms/filtersets.py:294
+#: extras/tables/tables.py:162 extras/tables/tables.py:253
+#: extras/tables/tables.py:415 netbox/preferences.py:22
+#: templates/core/datasource.html:42 templates/dcim/interface.html:61
+#: templates/extras/customlink.html:17 templates/extras/eventrule.html:17
+#: templates/extras/savedfilter.html:25
+#: templates/users/objectpermission.html:25
+#: templates/virtualization/vminterface.html:29 users/forms/bulk_edit.py:89
+#: users/forms/filtersets.py:70 users/tables.py:83
+#: virtualization/forms/bulk_edit.py:217 virtualization/forms/filtersets.py:215
 msgid "Enabled"
 msgstr ""
 
-#: netbox/core/forms/bulk_edit.py:34 netbox/extras/forms/model_forms.py:285
-#: netbox/templates/extras/savedfilter.html:52
-#: netbox/vpn/forms/filtersets.py:97 netbox/vpn/forms/filtersets.py:127
-#: netbox/vpn/forms/filtersets.py:151 netbox/vpn/forms/filtersets.py:170
-#: netbox/vpn/forms/model_forms.py:301 netbox/vpn/forms/model_forms.py:321
-#: netbox/vpn/forms/model_forms.py:337 netbox/vpn/forms/model_forms.py:357
-#: netbox/vpn/forms/model_forms.py:380
+#: core/forms/bulk_edit.py:34 extras/forms/model_forms.py:285
+#: templates/extras/savedfilter.html:52 vpn/forms/filtersets.py:97
+#: vpn/forms/filtersets.py:127 vpn/forms/filtersets.py:151
+#: vpn/forms/filtersets.py:170 vpn/forms/model_forms.py:301
+#: vpn/forms/model_forms.py:321 vpn/forms/model_forms.py:337
+#: vpn/forms/model_forms.py:357 vpn/forms/model_forms.py:380
 msgid "Parameters"
 msgstr ""
 
-#: netbox/core/forms/bulk_edit.py:38 netbox/templates/core/datasource.html:68
+#: core/forms/bulk_edit.py:38 templates/core/datasource.html:68
 msgid "Ignore rules"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:30 netbox/core/forms/model_forms.py:97
-#: netbox/extras/forms/model_forms.py:248
-#: netbox/extras/forms/model_forms.py:578
-#: netbox/extras/forms/model_forms.py:632 netbox/extras/tables/tables.py:191
-#: netbox/extras/tables/tables.py:483 netbox/extras/tables/tables.py:518
-#: netbox/templates/core/datasource.html:31
-#: netbox/templates/dcim/device/render_config.html:18
-#: netbox/templates/extras/configcontext.html:29
-#: netbox/templates/extras/configtemplate.html:21
-#: netbox/templates/extras/exporttemplate.html:35
-#: netbox/templates/virtualization/virtualmachine/render_config.html:18
+#: core/forms/filtersets.py:30 core/forms/model_forms.py:97
+#: extras/forms/model_forms.py:248 extras/forms/model_forms.py:578
+#: extras/forms/model_forms.py:632 extras/tables/tables.py:191
+#: extras/tables/tables.py:483 extras/tables/tables.py:518
+#: templates/core/datasource.html:31
+#: templates/dcim/device/render_config.html:18
+#: templates/extras/configcontext.html:29
+#: templates/extras/configtemplate.html:21
+#: templates/extras/exporttemplate.html:35
+#: templates/virtualization/virtualmachine/render_config.html:18
 msgid "Data Source"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:55 netbox/core/forms/mixins.py:21
+#: core/forms/filtersets.py:55 core/forms/mixins.py:21
 msgid "File"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:60 netbox/core/forms/mixins.py:16
-#: netbox/extras/forms/filtersets.py:170 netbox/extras/forms/filtersets.py:328
-#: netbox/extras/forms/filtersets.py:413
+#: core/forms/filtersets.py:60 core/forms/mixins.py:16
+#: extras/forms/filtersets.py:170 extras/forms/filtersets.py:328
+#: extras/forms/filtersets.py:413
 msgid "Data source"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:70 netbox/extras/forms/filtersets.py:440
+#: core/forms/filtersets.py:70 extras/forms/filtersets.py:440
 msgid "Creation"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:74 netbox/core/forms/filtersets.py:160
-#: netbox/extras/forms/filtersets.py:461 netbox/extras/tables/tables.py:220
-#: netbox/extras/tables/tables.py:294 netbox/extras/tables/tables.py:326
-#: netbox/extras/tables/tables.py:571 netbox/templates/core/job.html:38
-#: netbox/templates/core/objectchange.html:52
-#: netbox/tenancy/tables/contacts.py:90 netbox/vpn/tables/l2vpn.py:59
+#: core/forms/filtersets.py:74 core/forms/filtersets.py:160
+#: extras/forms/filtersets.py:461 extras/tables/tables.py:220
+#: extras/tables/tables.py:294 extras/tables/tables.py:326
+#: extras/tables/tables.py:571 templates/core/job.html:38
+#: templates/core/objectchange.html:52 tenancy/tables/contacts.py:90
+#: vpn/tables/l2vpn.py:59
 msgid "Object Type"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:84
+#: core/forms/filtersets.py:84
 msgid "Created after"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:89
+#: core/forms/filtersets.py:89
 msgid "Created before"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:94
+#: core/forms/filtersets.py:94
 msgid "Scheduled after"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:99
+#: core/forms/filtersets.py:99
 msgid "Scheduled before"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:104
+#: core/forms/filtersets.py:104
 msgid "Started after"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:109
+#: core/forms/filtersets.py:109
 msgid "Started before"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:114
+#: core/forms/filtersets.py:114
 msgid "Completed after"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:119
+#: core/forms/filtersets.py:119
 msgid "Completed before"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:126 netbox/core/forms/filtersets.py:155
-#: netbox/dcim/forms/bulk_edit.py:456 netbox/dcim/forms/filtersets.py:418
-#: netbox/dcim/forms/filtersets.py:462 netbox/dcim/forms/model_forms.py:316
-#: netbox/extras/forms/filtersets.py:456 netbox/extras/forms/filtersets.py:475
-#: netbox/extras/tables/tables.py:302 netbox/extras/tables/tables.py:342
-#: netbox/templates/core/objectchange.html:36
-#: netbox/templates/dcim/rackreservation.html:58
-#: netbox/templates/extras/savedfilter.html:21
-#: netbox/templates/inc/user_menu.html:33 netbox/templates/users/token.html:21
-#: netbox/templates/users/user.html:6 netbox/templates/users/user.html:14
-#: netbox/users/filtersets.py:107 netbox/users/filtersets.py:174
-#: netbox/users/forms/filtersets.py:84 netbox/users/forms/filtersets.py:125
-#: netbox/users/forms/model_forms.py:155 netbox/users/forms/model_forms.py:192
-#: netbox/users/tables.py:19
+#: core/forms/filtersets.py:126 core/forms/filtersets.py:155
+#: dcim/forms/bulk_edit.py:456 dcim/forms/filtersets.py:418
+#: dcim/forms/filtersets.py:462 dcim/forms/model_forms.py:316
+#: extras/forms/filtersets.py:456 extras/forms/filtersets.py:475
+#: extras/tables/tables.py:302 extras/tables/tables.py:342
+#: templates/core/objectchange.html:36 templates/dcim/rackreservation.html:58
+#: templates/extras/savedfilter.html:21 templates/inc/user_menu.html:33
+#: templates/users/token.html:21 templates/users/user.html:6
+#: templates/users/user.html:14 users/filtersets.py:107 users/filtersets.py:174
+#: users/forms/filtersets.py:84 users/forms/filtersets.py:125
+#: users/forms/model_forms.py:155 users/forms/model_forms.py:192
+#: users/tables.py:19
 msgid "User"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:134 netbox/core/tables/change_logging.py:15
-#: netbox/extras/tables/tables.py:609 netbox/extras/tables/tables.py:646
-#: netbox/templates/core/objectchange.html:32
+#: core/forms/filtersets.py:134 core/tables/change_logging.py:15
+#: extras/tables/tables.py:609 extras/tables/tables.py:646
+#: templates/core/objectchange.html:32
 msgid "Time"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:139 netbox/extras/forms/filtersets.py:445
+#: core/forms/filtersets.py:139 extras/forms/filtersets.py:445
 msgid "After"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:144 netbox/extras/forms/filtersets.py:450
+#: core/forms/filtersets.py:144 extras/forms/filtersets.py:450
 msgid "Before"
 msgstr ""
 
-#: netbox/core/forms/filtersets.py:148 netbox/core/tables/change_logging.py:29
-#: netbox/extras/forms/model_forms.py:396
-#: netbox/templates/core/objectchange.html:46
-#: netbox/templates/extras/eventrule.html:71
+#: core/forms/filtersets.py:148 core/tables/change_logging.py:29
+#: extras/forms/model_forms.py:396 templates/core/objectchange.html:46
+#: templates/extras/eventrule.html:71
 msgid "Action"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:54 netbox/core/tables/data.py:46
-#: netbox/templates/core/datafile.html:27
-#: netbox/templates/extras/report/base.html:33
-#: netbox/templates/extras/script/base.html:32
+#: core/forms/model_forms.py:54 core/tables/data.py:46
+#: templates/core/datafile.html:27 templates/extras/report/base.html:33
+#: templates/extras/script/base.html:32
 msgid "Source"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:58
+#: core/forms/model_forms.py:58
 msgid "Backend Parameters"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:96
+#: core/forms/model_forms.py:96
 msgid "File Upload"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:108
+#: core/forms/model_forms.py:108
 msgid "Cannot upload a file and sync from an existing file"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:110
+#: core/forms/model_forms.py:110
 msgid "Must upload a file or select a data file to sync"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:153
-#: netbox/templates/dcim/rack_elevation_list.html:6
+#: core/forms/model_forms.py:153 templates/dcim/rack_elevation_list.html:6
 msgid "Rack Elevations"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:157 netbox/dcim/choices.py:1518
-#: netbox/dcim/forms/bulk_edit.py:969 netbox/dcim/forms/bulk_edit.py:1357
-#: netbox/dcim/forms/bulk_edit.py:1375 netbox/dcim/tables/racks.py:158
-#: netbox/netbox/navigation/menu.py:291 netbox/netbox/navigation/menu.py:295
+#: core/forms/model_forms.py:157 dcim/choices.py:1518
+#: dcim/forms/bulk_edit.py:969 dcim/forms/bulk_edit.py:1357
+#: dcim/forms/bulk_edit.py:1375 dcim/tables/racks.py:158
+#: netbox/navigation/menu.py:291 netbox/navigation/menu.py:295
 msgid "Power"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:159 netbox/netbox/navigation/menu.py:154
-#: netbox/templates/core/inc/config_data.html:37
+#: core/forms/model_forms.py:159 netbox/navigation/menu.py:154
+#: templates/core/inc/config_data.html:37
 msgid "IPAM"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:160 netbox/netbox/navigation/menu.py:230
-#: netbox/templates/core/inc/config_data.html:50
-#: netbox/vpn/forms/bulk_edit.py:77 netbox/vpn/forms/filtersets.py:43
-#: netbox/vpn/forms/model_forms.py:61 netbox/vpn/forms/model_forms.py:146
+#: core/forms/model_forms.py:160 netbox/navigation/menu.py:230
+#: templates/core/inc/config_data.html:50 vpn/forms/bulk_edit.py:77
+#: vpn/forms/filtersets.py:43 vpn/forms/model_forms.py:61
+#: vpn/forms/model_forms.py:146
 msgid "Security"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:161
-#: netbox/templates/core/inc/config_data.html:59
+#: core/forms/model_forms.py:161 templates/core/inc/config_data.html:59
 msgid "Banners"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:162
-#: netbox/templates/core/inc/config_data.html:80
+#: core/forms/model_forms.py:162 templates/core/inc/config_data.html:80
 msgid "Pagination"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:163 netbox/extras/forms/bulk_edit.py:92
-#: netbox/extras/forms/filtersets.py:47 netbox/extras/forms/model_forms.py:116
-#: netbox/extras/forms/model_forms.py:129
-#: netbox/templates/core/inc/config_data.html:93
+#: core/forms/model_forms.py:163 extras/forms/bulk_edit.py:92
+#: extras/forms/filtersets.py:47 extras/forms/model_forms.py:116
+#: extras/forms/model_forms.py:129 templates/core/inc/config_data.html:93
 msgid "Validation"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:164
-#: netbox/templates/account/preferences.html:6
+#: core/forms/model_forms.py:164 templates/account/preferences.html:6
 msgid "User Preferences"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:167 netbox/dcim/forms/filtersets.py:732
-#: netbox/templates/core/inc/config_data.html:127
-#: netbox/users/forms/model_forms.py:64
+#: core/forms/model_forms.py:167 dcim/forms/filtersets.py:732
+#: templates/core/inc/config_data.html:127 users/forms/model_forms.py:64
 msgid "Miscellaneous"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:169
+#: core/forms/model_forms.py:169
 msgid "Config Revision"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:208
+#: core/forms/model_forms.py:208
 msgid "This parameter has been defined statically and cannot be modified."
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:216
+#: core/forms/model_forms.py:216
 #, python-brace-format
 msgid "Current value: <strong>{value}</strong>"
 msgstr ""
 
-#: netbox/core/forms/model_forms.py:218
+#: core/forms/model_forms.py:218
 msgid " (default)"
 msgstr ""
 
-#: netbox/core/models/change_logging.py:29
+#: core/models/change_logging.py:29
 msgid "time"
 msgstr ""
 
-#: netbox/core/models/change_logging.py:42
+#: core/models/change_logging.py:42
 msgid "user name"
 msgstr ""
 
-#: netbox/core/models/change_logging.py:47
+#: core/models/change_logging.py:47
 msgid "request ID"
 msgstr ""
 
-#: netbox/core/models/change_logging.py:52 netbox/extras/models/staging.py:69
+#: core/models/change_logging.py:52 extras/models/staging.py:69
 msgid "action"
 msgstr ""
 
-#: netbox/core/models/change_logging.py:86
+#: core/models/change_logging.py:86
 msgid "pre-change data"
 msgstr ""
 
-#: netbox/core/models/change_logging.py:92
+#: core/models/change_logging.py:92
 msgid "post-change data"
 msgstr ""
 
-#: netbox/core/models/change_logging.py:106
+#: core/models/change_logging.py:106
 msgid "object change"
 msgstr ""
 
-#: netbox/core/models/change_logging.py:107
+#: core/models/change_logging.py:107
 msgid "object changes"
 msgstr ""
 
-#: netbox/core/models/change_logging.py:123
+#: core/models/change_logging.py:123
 #, python-brace-format
 msgid "Change logging is not supported for this object type ({type})."
 msgstr ""
 
-#: netbox/core/models/config.py:18 netbox/core/models/data.py:266
-#: netbox/core/models/files.py:27 netbox/core/models/jobs.py:49
-#: netbox/extras/models/models.py:730 netbox/extras/models/notifications.py:39
-#: netbox/extras/models/notifications.py:186
-#: netbox/netbox/models/features.py:53 netbox/users/models/tokens.py:32
+#: core/models/config.py:18 core/models/data.py:266 core/models/files.py:27
+#: core/models/jobs.py:49 extras/models/models.py:730
+#: extras/models/notifications.py:39 extras/models/notifications.py:186
+#: netbox/models/features.py:53 users/models/tokens.py:32
 msgid "created"
 msgstr ""
 
-#: netbox/core/models/config.py:22
+#: core/models/config.py:22
 msgid "comment"
 msgstr ""
 
-#: netbox/core/models/config.py:29
+#: core/models/config.py:29
 msgid "configuration data"
 msgstr ""
 
-#: netbox/core/models/config.py:36
+#: core/models/config.py:36
 msgid "config revision"
 msgstr ""
 
-#: netbox/core/models/config.py:37
+#: core/models/config.py:37
 msgid "config revisions"
 msgstr ""
 
-#: netbox/core/models/config.py:41
+#: core/models/config.py:41
 msgid "Default configuration"
 msgstr ""
 
-#: netbox/core/models/config.py:43
+#: core/models/config.py:43
 msgid "Current configuration"
 msgstr ""
 
-#: netbox/core/models/config.py:44
+#: core/models/config.py:44
 #, python-brace-format
 msgid "Config revision #{id}"
 msgstr ""
 
-#: netbox/core/models/data.py:44 netbox/dcim/models/cables.py:43
-#: netbox/dcim/models/device_component_templates.py:203
-#: netbox/dcim/models/device_component_templates.py:237
-#: netbox/dcim/models/device_component_templates.py:272
-#: netbox/dcim/models/device_component_templates.py:334
-#: netbox/dcim/models/device_component_templates.py:413
-#: netbox/dcim/models/device_component_templates.py:512
-#: netbox/dcim/models/device_component_templates.py:612
-#: netbox/dcim/models/device_components.py:283
-#: netbox/dcim/models/device_components.py:312
-#: netbox/dcim/models/device_components.py:345
-#: netbox/dcim/models/device_components.py:463
-#: netbox/dcim/models/device_components.py:605
-#: netbox/dcim/models/device_components.py:970
-#: netbox/dcim/models/device_components.py:1044 netbox/dcim/models/power.py:102
-#: netbox/extras/models/customfields.py:78 netbox/extras/models/search.py:41
-#: netbox/virtualization/models/clusters.py:61 netbox/vpn/models/l2vpn.py:32
+#: core/models/data.py:44 dcim/models/cables.py:43
+#: dcim/models/device_component_templates.py:203
+#: dcim/models/device_component_templates.py:237
+#: dcim/models/device_component_templates.py:272
+#: dcim/models/device_component_templates.py:334
+#: dcim/models/device_component_templates.py:413
+#: dcim/models/device_component_templates.py:512
+#: dcim/models/device_component_templates.py:612
+#: dcim/models/device_components.py:283 dcim/models/device_components.py:312
+#: dcim/models/device_components.py:345 dcim/models/device_components.py:463
+#: dcim/models/device_components.py:605 dcim/models/device_components.py:970
+#: dcim/models/device_components.py:1044 dcim/models/power.py:102
+#: extras/models/customfields.py:78 extras/models/search.py:41
+#: virtualization/models/clusters.py:61 vpn/models/l2vpn.py:32
 msgid "type"
 msgstr ""
 
-#: netbox/core/models/data.py:49 netbox/extras/choices.py:37
-#: netbox/extras/models/models.py:164 netbox/extras/tables/tables.py:656
-#: netbox/templates/core/datasource.html:58
-#: netbox/templates/core/plugin.html:66
+#: core/models/data.py:49 extras/choices.py:37 extras/models/models.py:164
+#: extras/tables/tables.py:656 templates/core/datasource.html:58
+#: templates/core/plugin.html:66
 msgid "URL"
 msgstr ""
 
-#: netbox/core/models/data.py:59
-#: netbox/dcim/models/device_component_templates.py:418
-#: netbox/dcim/models/device_components.py:512
-#: netbox/extras/models/models.py:70 netbox/extras/models/models.py:301
-#: netbox/extras/models/models.py:526 netbox/users/models/permissions.py:29
+#: core/models/data.py:59 dcim/models/device_component_templates.py:418
+#: dcim/models/device_components.py:512 extras/models/models.py:70
+#: extras/models/models.py:301 extras/models/models.py:526
+#: users/models/permissions.py:29
 msgid "enabled"
 msgstr ""
 
-#: netbox/core/models/data.py:63
+#: core/models/data.py:63
 msgid "ignore rules"
 msgstr ""
 
-#: netbox/core/models/data.py:65
+#: core/models/data.py:65
 msgid "Patterns (one per line) matching files to ignore when syncing"
 msgstr ""
 
-#: netbox/core/models/data.py:68 netbox/extras/models/models.py:534
+#: core/models/data.py:68 extras/models/models.py:534
 msgid "parameters"
 msgstr ""
 
-#: netbox/core/models/data.py:73
+#: core/models/data.py:73
 msgid "last synced"
 msgstr ""
 
-#: netbox/core/models/data.py:81
+#: core/models/data.py:81
 msgid "data source"
 msgstr ""
 
-#: netbox/core/models/data.py:82
+#: core/models/data.py:82
 msgid "data sources"
 msgstr ""
 
-#: netbox/core/models/data.py:122
+#: core/models/data.py:122
 #, python-brace-format
 msgid "Unknown backend type: {type}"
 msgstr ""
 
-#: netbox/core/models/data.py:164
+#: core/models/data.py:164
 msgid "Cannot initiate sync; syncing already in progress."
 msgstr ""
 
-#: netbox/core/models/data.py:177
+#: core/models/data.py:177
 msgid ""
 "There was an error initializing the backend. A dependency needs to be "
 "installed: "
 msgstr ""
 
-#: netbox/core/models/data.py:270 netbox/core/models/files.py:31
-#: netbox/netbox/models/features.py:59
+#: core/models/data.py:270 core/models/files.py:31 netbox/models/features.py:59
 msgid "last updated"
 msgstr ""
 
-#: netbox/core/models/data.py:280 netbox/dcim/models/cables.py:444
+#: core/models/data.py:280 dcim/models/cables.py:444
 msgid "path"
 msgstr ""
 
-#: netbox/core/models/data.py:283
+#: core/models/data.py:283
 msgid "File path relative to the data source's root"
 msgstr ""
 
-#: netbox/core/models/data.py:287 netbox/ipam/models/ip.py:503
+#: core/models/data.py:287 ipam/models/ip.py:503
 msgid "size"
 msgstr ""
 
-#: netbox/core/models/data.py:290
+#: core/models/data.py:290
 msgid "hash"
 msgstr ""
 
-#: netbox/core/models/data.py:294
+#: core/models/data.py:294
 msgid "Length must be 64 hexadecimal characters."
 msgstr ""
 
-#: netbox/core/models/data.py:296
+#: core/models/data.py:296
 msgid "SHA256 hash of the file data"
 msgstr ""
 
-#: netbox/core/models/data.py:313
+#: core/models/data.py:313
 msgid "data file"
 msgstr ""
 
-#: netbox/core/models/data.py:314
+#: core/models/data.py:314
 msgid "data files"
 msgstr ""
 
-#: netbox/core/models/data.py:401
+#: core/models/data.py:401
 msgid "auto sync record"
 msgstr ""
 
-#: netbox/core/models/data.py:402
+#: core/models/data.py:402
 msgid "auto sync records"
 msgstr ""
 
-#: netbox/core/models/files.py:37
+#: core/models/files.py:37
 msgid "file root"
 msgstr ""
 
-#: netbox/core/models/files.py:42
+#: core/models/files.py:42
 msgid "file path"
 msgstr ""
 
-#: netbox/core/models/files.py:44
+#: core/models/files.py:44
 msgid "File path relative to the designated root path"
 msgstr ""
 
-#: netbox/core/models/files.py:61
+#: core/models/files.py:61
 msgid "managed file"
 msgstr ""
 
-#: netbox/core/models/files.py:62
+#: core/models/files.py:62
 msgid "managed files"
 msgstr ""
 
-#: netbox/core/models/jobs.py:53
+#: core/models/jobs.py:53
 msgid "scheduled"
 msgstr ""
 
-#: netbox/core/models/jobs.py:58
+#: core/models/jobs.py:58
 msgid "interval"
 msgstr ""
 
-#: netbox/core/models/jobs.py:64
+#: core/models/jobs.py:64
 msgid "Recurrence interval (in minutes)"
 msgstr ""
 
-#: netbox/core/models/jobs.py:67
+#: core/models/jobs.py:67
 msgid "started"
 msgstr ""
 
-#: netbox/core/models/jobs.py:72
+#: core/models/jobs.py:72
 msgid "completed"
 msgstr ""
 
-#: netbox/core/models/jobs.py:90 netbox/extras/models/models.py:101
-#: netbox/extras/models/staging.py:87
+#: core/models/jobs.py:90 extras/models/models.py:101
+#: extras/models/staging.py:87
 msgid "data"
 msgstr ""
 
-#: netbox/core/models/jobs.py:95
+#: core/models/jobs.py:95
 msgid "error"
 msgstr ""
 
-#: netbox/core/models/jobs.py:100
+#: core/models/jobs.py:100
 msgid "job ID"
 msgstr ""
 
-#: netbox/core/models/jobs.py:111
+#: core/models/jobs.py:111
 msgid "job"
 msgstr ""
 
-#: netbox/core/models/jobs.py:112
+#: core/models/jobs.py:112
 msgid "jobs"
 msgstr ""
 
-#: netbox/core/models/jobs.py:135
+#: core/models/jobs.py:135
 #, python-brace-format
 msgid "Jobs cannot be assigned to this object type ({type})."
 msgstr ""
 
-#: netbox/core/models/jobs.py:185
+#: core/models/jobs.py:185
 #, python-brace-format
 msgid "Invalid status for job termination. Choices are: {choices}"
 msgstr ""
 
-#: netbox/core/models/jobs.py:216
+#: core/models/jobs.py:216
 msgid ""
 "enqueue() cannot be called with values for both schedule_at and immediate."
 msgstr ""
 
-#: netbox/core/signals.py:126
+#: core/signals.py:126
 #, python-brace-format
 msgid "Deletion is prevented by a protection rule: {message}"
 msgstr ""
 
-#: netbox/core/tables/change_logging.py:25
-#: netbox/templates/account/profile.html:19 netbox/templates/users/user.html:21
+#: core/tables/change_logging.py:25 templates/account/profile.html:19
+#: templates/users/user.html:21
 msgid "Full Name"
 msgstr ""
 
-#: netbox/core/tables/change_logging.py:37 netbox/core/tables/jobs.py:21
-#: netbox/extras/choices.py:41 netbox/extras/tables/tables.py:279
-#: netbox/extras/tables/tables.py:297 netbox/extras/tables/tables.py:329
-#: netbox/extras/tables/tables.py:409 netbox/extras/tables/tables.py:470
-#: netbox/extras/tables/tables.py:576 netbox/extras/tables/tables.py:616
-#: netbox/extras/tables/tables.py:653 netbox/netbox/tables/tables.py:244
-#: netbox/templates/core/objectchange.html:58
-#: netbox/templates/extras/eventrule.html:78
-#: netbox/templates/extras/journalentry.html:18
-#: netbox/tenancy/tables/contacts.py:93 netbox/vpn/tables/l2vpn.py:64
+#: core/tables/change_logging.py:37 core/tables/jobs.py:21 extras/choices.py:41
+#: extras/tables/tables.py:279 extras/tables/tables.py:297
+#: extras/tables/tables.py:329 extras/tables/tables.py:409
+#: extras/tables/tables.py:470 extras/tables/tables.py:576
+#: extras/tables/tables.py:616 extras/tables/tables.py:653
+#: netbox/tables/tables.py:244 templates/core/objectchange.html:58
+#: templates/extras/eventrule.html:78 templates/extras/journalentry.html:18
+#: tenancy/tables/contacts.py:93 vpn/tables/l2vpn.py:64
 msgid "Object"
 msgstr ""
 
-#: netbox/core/tables/change_logging.py:42
-#: netbox/templates/core/objectchange.html:68
+#: core/tables/change_logging.py:42 templates/core/objectchange.html:68
 msgid "Request ID"
 msgstr ""
 
-#: netbox/core/tables/config.py:21 netbox/users/forms/filtersets.py:44
-#: netbox/users/tables.py:39
+#: core/tables/config.py:21 users/forms/filtersets.py:44 users/tables.py:39
 msgid "Is Active"
 msgstr ""
 
-#: netbox/core/tables/data.py:50 netbox/templates/core/datafile.html:31
+#: core/tables/data.py:50 templates/core/datafile.html:31
 msgid "Path"
 msgstr ""
 
-#: netbox/core/tables/data.py:54
-#: netbox/templates/extras/inc/result_pending.html:7
+#: core/tables/data.py:54 templates/extras/inc/result_pending.html:7
 msgid "Last updated"
 msgstr ""
 
-#: netbox/core/tables/jobs.py:10 netbox/core/tables/tasks.py:76
-#: netbox/dcim/tables/devicetypes.py:164 netbox/extras/tables/tables.py:216
-#: netbox/extras/tables/tables.py:460 netbox/netbox/tables/tables.py:189
-#: netbox/templates/dcim/virtualchassis_edit.html:52
-#: netbox/utilities/forms/forms.py:73 netbox/wireless/tables/wirelesslink.py:17
+#: core/tables/jobs.py:10 core/tables/tasks.py:76
+#: dcim/tables/devicetypes.py:164 extras/tables/tables.py:216
+#: extras/tables/tables.py:460 netbox/tables/tables.py:189
+#: templates/dcim/virtualchassis_edit.html:52 utilities/forms/forms.py:73
+#: wireless/tables/wirelesslink.py:17
 msgid "ID"
 msgstr ""
 
-#: netbox/core/tables/jobs.py:35
+#: core/tables/jobs.py:35
 msgid "Interval"
 msgstr ""
 
-#: netbox/core/tables/plugins.py:14 netbox/templates/vpn/ipsecprofile.html:44
-#: netbox/vpn/forms/bulk_edit.py:141 netbox/vpn/forms/bulk_import.py:172
-#: netbox/vpn/tables/crypto.py:61
+#: core/tables/plugins.py:14 templates/vpn/ipsecprofile.html:44
+#: vpn/forms/bulk_edit.py:141 vpn/forms/bulk_import.py:172
+#: vpn/tables/crypto.py:61
 msgid "Version"
 msgstr ""
 
-#: netbox/core/tables/plugins.py:19 netbox/templates/core/datafile.html:38
+#: core/tables/plugins.py:19 templates/core/datafile.html:38
 msgid "Last Updated"
 msgstr ""
 
-#: netbox/core/tables/plugins.py:23
+#: core/tables/plugins.py:23
 msgid "Minimum NetBox Version"
 msgstr ""
 
-#: netbox/core/tables/plugins.py:27
+#: core/tables/plugins.py:27
 msgid "Maximum NetBox Version"
 msgstr ""
 
-#: netbox/core/tables/plugins.py:31 netbox/core/tables/plugins.py:74
+#: core/tables/plugins.py:31 core/tables/plugins.py:74
 msgid "No plugin data found"
 msgstr ""
 
-#: netbox/core/tables/plugins.py:48 netbox/templates/core/plugin.html:62
+#: core/tables/plugins.py:48 templates/core/plugin.html:62
 msgid "Author"
 msgstr ""
 
-#: netbox/core/tables/plugins.py:54
+#: core/tables/plugins.py:54
 msgid "Installed"
 msgstr ""
 
-#: netbox/core/tables/plugins.py:57 netbox/templates/core/plugin.html:84
+#: core/tables/plugins.py:57 templates/core/plugin.html:84
 msgid "Certified"
 msgstr ""
 
-#: netbox/core/tables/plugins.py:60
+#: core/tables/plugins.py:60
 msgid "Published"
 msgstr ""
 
-#: netbox/core/tables/plugins.py:66
+#: core/tables/plugins.py:66
 msgid "Installed Version"
 msgstr ""
 
-#: netbox/core/tables/plugins.py:70
+#: core/tables/plugins.py:70
 msgid "Latest Version"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:18
+#: core/tables/tasks.py:18
 msgid "Oldest Task"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:42 netbox/templates/core/rq_worker_list.html:39
+#: core/tables/tasks.py:42 templates/core/rq_worker_list.html:39
 msgid "Workers"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:46 netbox/vpn/tables/tunnels.py:88
+#: core/tables/tasks.py:46 vpn/tables/tunnels.py:88
 msgid "Host"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:50 netbox/ipam/forms/filtersets.py:535
+#: core/tables/tasks.py:50 ipam/forms/filtersets.py:535
 msgid "Port"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:54
+#: core/tables/tasks.py:54
 msgid "DB"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:58
+#: core/tables/tasks.py:58
 msgid "Scheduler PID"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:62
+#: core/tables/tasks.py:62
 msgid "No queues found"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:82
+#: core/tables/tasks.py:82
 msgid "Enqueued"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:85
+#: core/tables/tasks.py:85
 msgid "Ended"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:93 netbox/templates/core/rq_task.html:85
+#: core/tables/tasks.py:93 templates/core/rq_task.html:85
 msgid "Callable"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:97
+#: core/tables/tasks.py:97
 msgid "No tasks found"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:118 netbox/templates/core/rq_worker.html:47
+#: core/tables/tasks.py:118 templates/core/rq_worker.html:47
 msgid "State"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:121 netbox/templates/core/rq_worker.html:51
+#: core/tables/tasks.py:121 templates/core/rq_worker.html:51
 msgid "Birth"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:124 netbox/templates/core/rq_worker.html:59
+#: core/tables/tasks.py:124 templates/core/rq_worker.html:59
 msgid "PID"
 msgstr ""
 
-#: netbox/core/tables/tasks.py:128
+#: core/tables/tasks.py:128
 msgid "No workers found"
 msgstr ""
 
-#: netbox/core/views.py:90
+#: core/views.py:90
 #, python-brace-format
 msgid "Queued job #{id} to sync {datasource}"
 msgstr ""
 
-#: netbox/core/views.py:319
+#: core/views.py:319
 #, python-brace-format
 msgid "Restored configuration revision #{id}"
 msgstr ""
 
-#: netbox/core/views.py:412 netbox/core/views.py:455 netbox/core/views.py:531
+#: core/views.py:412 core/views.py:455 core/views.py:531
 #, python-brace-format
 msgid "Job {job_id} not found"
 msgstr ""
 
-#: netbox/core/views.py:463
+#: core/views.py:463
 #, python-brace-format
 msgid "Job {id} has been deleted."
 msgstr ""
 
-#: netbox/core/views.py:465
+#: core/views.py:465
 #, python-brace-format
 msgid "Error deleting job {id}: {error}"
 msgstr ""
 
-#: netbox/core/views.py:478 netbox/core/views.py:496
+#: core/views.py:478 core/views.py:496
 #, python-brace-format
 msgid "Job {id} not found."
 msgstr ""
 
-#: netbox/core/views.py:484
+#: core/views.py:484
 #, python-brace-format
 msgid "Job {id} has been re-enqueued."
 msgstr ""
 
-#: netbox/core/views.py:519
+#: core/views.py:519
 #, python-brace-format
 msgid "Job {id} has been enqueued."
 msgstr ""
 
-#: netbox/core/views.py:538
+#: core/views.py:538
 #, python-brace-format
 msgid "Job {id} has been stopped."
 msgstr ""
 
-#: netbox/core/views.py:540
+#: core/views.py:540
 #, python-brace-format
 msgid "Failed to stop job {id}"
 msgstr ""
 
-#: netbox/core/views.py:678
+#: core/views.py:678
 msgid "Plugins catalog could not be loaded"
 msgstr ""
 
-#: netbox/core/views.py:712
+#: core/views.py:712
 #, python-brace-format
 msgid "Plugin {name} not found"
 msgstr ""
 
-#: netbox/dcim/api/serializers_/devices.py:49
-#: netbox/dcim/api/serializers_/devicetypes.py:25
+#: dcim/api/serializers_/devices.py:49 dcim/api/serializers_/devicetypes.py:25
 msgid "Position (U)"
 msgstr ""
 
-#: netbox/dcim/api/serializers_/racks.py:112 netbox/templates/dcim/rack.html:28
+#: dcim/api/serializers_/racks.py:112 templates/dcim/rack.html:28
 msgid "Facility ID"
 msgstr ""
 
-#: netbox/dcim/choices.py:21 netbox/virtualization/choices.py:21
+#: dcim/choices.py:21 virtualization/choices.py:21
 msgid "Staging"
 msgstr ""
 
-#: netbox/dcim/choices.py:23 netbox/dcim/choices.py:189
-#: netbox/dcim/choices.py:240 netbox/dcim/choices.py:1531
-#: netbox/virtualization/choices.py:23 netbox/virtualization/choices.py:48
+#: dcim/choices.py:23 dcim/choices.py:189 dcim/choices.py:240
+#: dcim/choices.py:1531 virtualization/choices.py:23
+#: virtualization/choices.py:48
 msgid "Decommissioning"
 msgstr ""
 
-#: netbox/dcim/choices.py:24
+#: dcim/choices.py:24
 msgid "Retired"
 msgstr ""
 
-#: netbox/dcim/choices.py:65
+#: dcim/choices.py:65
 msgid "2-post frame"
 msgstr ""
 
-#: netbox/dcim/choices.py:66
+#: dcim/choices.py:66
 msgid "4-post frame"
 msgstr ""
 
-#: netbox/dcim/choices.py:67
+#: dcim/choices.py:67
 msgid "4-post cabinet"
 msgstr ""
 
-#: netbox/dcim/choices.py:68
+#: dcim/choices.py:68
 msgid "Wall-mounted frame"
 msgstr ""
 
-#: netbox/dcim/choices.py:69
+#: dcim/choices.py:69
 msgid "Wall-mounted frame (vertical)"
 msgstr ""
 
-#: netbox/dcim/choices.py:70
+#: dcim/choices.py:70
 msgid "Wall-mounted cabinet"
 msgstr ""
 
-#: netbox/dcim/choices.py:71
+#: dcim/choices.py:71
 msgid "Wall-mounted cabinet (vertical)"
 msgstr ""
 
-#: netbox/dcim/choices.py:83 netbox/dcim/choices.py:84
-#: netbox/dcim/choices.py:85 netbox/dcim/choices.py:86
+#: dcim/choices.py:83 dcim/choices.py:84 dcim/choices.py:85 dcim/choices.py:86
 #, python-brace-format
 msgid "{n} inches"
 msgstr ""
 
-#: netbox/dcim/choices.py:100 netbox/ipam/choices.py:32
-#: netbox/ipam/choices.py:50 netbox/ipam/choices.py:70
-#: netbox/ipam/choices.py:155 netbox/wireless/choices.py:26
+#: dcim/choices.py:100 ipam/choices.py:32 ipam/choices.py:50 ipam/choices.py:70
+#: ipam/choices.py:155 wireless/choices.py:26
 msgid "Reserved"
 msgstr ""
 
-#: netbox/dcim/choices.py:101 netbox/templates/dcim/device.html:259
+#: dcim/choices.py:101 templates/dcim/device.html:259
 msgid "Available"
 msgstr ""
 
-#: netbox/dcim/choices.py:104 netbox/ipam/choices.py:33
-#: netbox/ipam/choices.py:51 netbox/ipam/choices.py:71
-#: netbox/ipam/choices.py:156 netbox/wireless/choices.py:28
+#: dcim/choices.py:104 ipam/choices.py:33 ipam/choices.py:51 ipam/choices.py:71
+#: ipam/choices.py:156 wireless/choices.py:28
 msgid "Deprecated"
 msgstr ""
 
-#: netbox/dcim/choices.py:114
-#: netbox/templates/dcim/inc/panels/racktype_dimensions.html:41
+#: dcim/choices.py:114 templates/dcim/inc/panels/racktype_dimensions.html:41
 msgid "Millimeters"
 msgstr ""
 
-#: netbox/dcim/choices.py:115 netbox/dcim/choices.py:1553
+#: dcim/choices.py:115 dcim/choices.py:1553
 msgid "Inches"
 msgstr ""
 
-#: netbox/dcim/choices.py:136 netbox/dcim/choices.py:207
-#: netbox/dcim/choices.py:254
+#: dcim/choices.py:136 dcim/choices.py:207 dcim/choices.py:254
 msgid "Front to rear"
 msgstr ""
 
-#: netbox/dcim/choices.py:137 netbox/dcim/choices.py:208
-#: netbox/dcim/choices.py:255
+#: dcim/choices.py:137 dcim/choices.py:208 dcim/choices.py:255
 msgid "Rear to front"
 msgstr ""
 
-#: netbox/dcim/choices.py:151 netbox/dcim/forms/bulk_edit.py:68
-#: netbox/dcim/forms/bulk_edit.py:87 netbox/dcim/forms/bulk_edit.py:173
-#: netbox/dcim/forms/bulk_edit.py:1405 netbox/dcim/forms/bulk_import.py:60
-#: netbox/dcim/forms/bulk_import.py:74 netbox/dcim/forms/bulk_import.py:137
-#: netbox/dcim/forms/bulk_import.py:566 netbox/dcim/forms/bulk_import.py:833
-#: netbox/dcim/forms/bulk_import.py:1088 netbox/dcim/forms/filtersets.py:234
-#: netbox/dcim/forms/model_forms.py:74 netbox/dcim/forms/model_forms.py:93
-#: netbox/dcim/forms/model_forms.py:170 netbox/dcim/forms/model_forms.py:1062
-#: netbox/dcim/forms/model_forms.py:1502 netbox/dcim/forms/object_import.py:176
-#: netbox/dcim/tables/devices.py:656 netbox/dcim/tables/devices.py:869
-#: netbox/dcim/tables/devices.py:954 netbox/extras/tables/tables.py:223
-#: netbox/ipam/tables/fhrp.py:59 netbox/ipam/tables/ip.py:378
-#: netbox/ipam/tables/services.py:44 netbox/templates/dcim/interface.html:102
-#: netbox/templates/dcim/interface.html:309
-#: netbox/templates/dcim/location.html:41 netbox/templates/dcim/region.html:37
-#: netbox/templates/dcim/sitegroup.html:37
-#: netbox/templates/ipam/service.html:28
-#: netbox/templates/tenancy/contactgroup.html:29
-#: netbox/templates/tenancy/tenantgroup.html:37
-#: netbox/templates/virtualization/vminterface.html:39
-#: netbox/templates/wireless/wirelesslangroup.html:37
-#: netbox/tenancy/forms/bulk_edit.py:27 netbox/tenancy/forms/bulk_edit.py:61
-#: netbox/tenancy/forms/bulk_import.py:24
-#: netbox/tenancy/forms/bulk_import.py:58
-#: netbox/tenancy/forms/model_forms.py:25
-#: netbox/tenancy/forms/model_forms.py:68
-#: netbox/virtualization/forms/bulk_edit.py:207
-#: netbox/virtualization/forms/bulk_import.py:151
-#: netbox/virtualization/tables/virtualmachines.py:162
-#: netbox/wireless/forms/bulk_edit.py:24
-#: netbox/wireless/forms/bulk_import.py:21
-#: netbox/wireless/forms/model_forms.py:21
+#: dcim/choices.py:151 dcim/forms/bulk_edit.py:68 dcim/forms/bulk_edit.py:87
+#: dcim/forms/bulk_edit.py:173 dcim/forms/bulk_edit.py:1405
+#: dcim/forms/bulk_import.py:60 dcim/forms/bulk_import.py:74
+#: dcim/forms/bulk_import.py:137 dcim/forms/bulk_import.py:566
+#: dcim/forms/bulk_import.py:833 dcim/forms/bulk_import.py:1088
+#: dcim/forms/filtersets.py:234 dcim/forms/model_forms.py:74
+#: dcim/forms/model_forms.py:93 dcim/forms/model_forms.py:170
+#: dcim/forms/model_forms.py:1062 dcim/forms/model_forms.py:1502
+#: dcim/forms/object_import.py:176 dcim/tables/devices.py:656
+#: dcim/tables/devices.py:869 dcim/tables/devices.py:954
+#: extras/tables/tables.py:223 ipam/tables/fhrp.py:59 ipam/tables/ip.py:378
+#: ipam/tables/services.py:44 templates/dcim/interface.html:102
+#: templates/dcim/interface.html:309 templates/dcim/location.html:41
+#: templates/dcim/region.html:37 templates/dcim/sitegroup.html:37
+#: templates/ipam/service.html:28 templates/tenancy/contactgroup.html:29
+#: templates/tenancy/tenantgroup.html:37
+#: templates/virtualization/vminterface.html:39
+#: templates/wireless/wirelesslangroup.html:37 tenancy/forms/bulk_edit.py:27
+#: tenancy/forms/bulk_edit.py:61 tenancy/forms/bulk_import.py:24
+#: tenancy/forms/bulk_import.py:58 tenancy/forms/model_forms.py:25
+#: tenancy/forms/model_forms.py:68 virtualization/forms/bulk_edit.py:207
+#: virtualization/forms/bulk_import.py:151
+#: virtualization/tables/virtualmachines.py:162 wireless/forms/bulk_edit.py:24
+#: wireless/forms/bulk_import.py:21 wireless/forms/model_forms.py:21
 msgid "Parent"
 msgstr ""
 
-#: netbox/dcim/choices.py:152
+#: dcim/choices.py:152
 msgid "Child"
 msgstr ""
 
-#: netbox/dcim/choices.py:166 netbox/templates/dcim/device.html:340
-#: netbox/templates/dcim/rack.html:133
-#: netbox/templates/dcim/rack_elevation_list.html:20
-#: netbox/templates/dcim/rackreservation.html:76
+#: dcim/choices.py:166 templates/dcim/device.html:340
+#: templates/dcim/rack.html:133 templates/dcim/rack_elevation_list.html:20
+#: templates/dcim/rackreservation.html:76
 msgid "Front"
 msgstr ""
 
-#: netbox/dcim/choices.py:167 netbox/templates/dcim/device.html:346
-#: netbox/templates/dcim/rack.html:139
-#: netbox/templates/dcim/rack_elevation_list.html:21
-#: netbox/templates/dcim/rackreservation.html:82
+#: dcim/choices.py:167 templates/dcim/device.html:346
+#: templates/dcim/rack.html:139 templates/dcim/rack_elevation_list.html:21
+#: templates/dcim/rackreservation.html:82
 msgid "Rear"
 msgstr ""
 
-#: netbox/dcim/choices.py:186 netbox/dcim/choices.py:238
-#: netbox/virtualization/choices.py:46
+#: dcim/choices.py:186 dcim/choices.py:238 virtualization/choices.py:46
 msgid "Staged"
 msgstr ""
 
-#: netbox/dcim/choices.py:188
+#: dcim/choices.py:188
 msgid "Inventory"
 msgstr ""
 
-#: netbox/dcim/choices.py:209 netbox/dcim/choices.py:256
+#: dcim/choices.py:209 dcim/choices.py:256
 msgid "Left to right"
 msgstr ""
 
-#: netbox/dcim/choices.py:210 netbox/dcim/choices.py:257
+#: dcim/choices.py:210 dcim/choices.py:257
 msgid "Right to left"
 msgstr ""
 
-#: netbox/dcim/choices.py:211 netbox/dcim/choices.py:258
+#: dcim/choices.py:211 dcim/choices.py:258
 msgid "Side to rear"
 msgstr ""
 
-#: netbox/dcim/choices.py:212
+#: dcim/choices.py:212
 msgid "Rear to side"
 msgstr ""
 
-#: netbox/dcim/choices.py:213
+#: dcim/choices.py:213
 msgid "Bottom to top"
 msgstr ""
 
-#: netbox/dcim/choices.py:214
+#: dcim/choices.py:214
 msgid "Top to bottom"
 msgstr ""
 
-#: netbox/dcim/choices.py:215 netbox/dcim/choices.py:259
-#: netbox/dcim/choices.py:1303
+#: dcim/choices.py:215 dcim/choices.py:259 dcim/choices.py:1303
 msgid "Passive"
 msgstr ""
 
-#: netbox/dcim/choices.py:216
+#: dcim/choices.py:216
 msgid "Mixed"
 msgstr ""
 
-#: netbox/dcim/choices.py:484 netbox/dcim/choices.py:733
+#: dcim/choices.py:484 dcim/choices.py:733
 msgid "NEMA (Non-locking)"
 msgstr ""
 
-#: netbox/dcim/choices.py:506 netbox/dcim/choices.py:755
+#: dcim/choices.py:506 dcim/choices.py:755
 msgid "NEMA (Locking)"
 msgstr ""
 
-#: netbox/dcim/choices.py:530 netbox/dcim/choices.py:779
+#: dcim/choices.py:530 dcim/choices.py:779
 msgid "California Style"
 msgstr ""
 
-#: netbox/dcim/choices.py:538
+#: dcim/choices.py:538
 msgid "International/ITA"
 msgstr ""
 
-#: netbox/dcim/choices.py:573 netbox/dcim/choices.py:814
+#: dcim/choices.py:573 dcim/choices.py:814
 msgid "Proprietary"
 msgstr ""
 
-#: netbox/dcim/choices.py:581 netbox/dcim/choices.py:824
-#: netbox/dcim/choices.py:1219 netbox/dcim/choices.py:1221
-#: netbox/dcim/choices.py:1447 netbox/dcim/choices.py:1449
-#: netbox/netbox/navigation/menu.py:200
+#: dcim/choices.py:581 dcim/choices.py:824 dcim/choices.py:1219
+#: dcim/choices.py:1221 dcim/choices.py:1447 dcim/choices.py:1449
+#: netbox/navigation/menu.py:200
 msgid "Other"
 msgstr ""
 
-#: netbox/dcim/choices.py:787
+#: dcim/choices.py:787
 msgid "ITA/International"
 msgstr ""
 
-#: netbox/dcim/choices.py:854
+#: dcim/choices.py:854
 msgid "Physical"
 msgstr ""
 
-#: netbox/dcim/choices.py:855 netbox/dcim/choices.py:1023
+#: dcim/choices.py:855 dcim/choices.py:1023
 msgid "Virtual"
 msgstr ""
 
-#: netbox/dcim/choices.py:856 netbox/dcim/choices.py:1097
-#: netbox/dcim/forms/bulk_edit.py:1515 netbox/dcim/forms/filtersets.py:1330
-#: netbox/dcim/forms/model_forms.py:988 netbox/dcim/forms/model_forms.py:1397
-#: netbox/netbox/navigation/menu.py:140 netbox/netbox/navigation/menu.py:144
-#: netbox/templates/dcim/interface.html:210
+#: dcim/choices.py:856 dcim/choices.py:1097 dcim/forms/bulk_edit.py:1515
+#: dcim/forms/filtersets.py:1330 dcim/forms/model_forms.py:988
+#: dcim/forms/model_forms.py:1397 netbox/navigation/menu.py:140
+#: netbox/navigation/menu.py:144 templates/dcim/interface.html:210
 msgid "Wireless"
 msgstr ""
 
-#: netbox/dcim/choices.py:1021
+#: dcim/choices.py:1021
 msgid "Virtual interfaces"
 msgstr ""
 
-#: netbox/dcim/choices.py:1024 netbox/dcim/forms/bulk_edit.py:1410
-#: netbox/dcim/forms/bulk_import.py:840 netbox/dcim/forms/model_forms.py:974
-#: netbox/dcim/tables/devices.py:660 netbox/templates/dcim/interface.html:106
-#: netbox/templates/virtualization/vminterface.html:43
-#: netbox/virtualization/forms/bulk_edit.py:212
-#: netbox/virtualization/forms/bulk_import.py:158
-#: netbox/virtualization/tables/virtualmachines.py:166
+#: dcim/choices.py:1024 dcim/forms/bulk_edit.py:1410
+#: dcim/forms/bulk_import.py:840 dcim/forms/model_forms.py:974
+#: dcim/tables/devices.py:660 templates/dcim/interface.html:106
+#: templates/virtualization/vminterface.html:43
+#: virtualization/forms/bulk_edit.py:212
+#: virtualization/forms/bulk_import.py:158
+#: virtualization/tables/virtualmachines.py:166
 msgid "Bridge"
 msgstr ""
 
-#: netbox/dcim/choices.py:1025
+#: dcim/choices.py:1025
 msgid "Link Aggregation Group (LAG)"
 msgstr ""
 
-#: netbox/dcim/choices.py:1029
+#: dcim/choices.py:1029
 msgid "Ethernet (fixed)"
 msgstr ""
 
-#: netbox/dcim/choices.py:1044
+#: dcim/choices.py:1044
 msgid "Ethernet (modular)"
 msgstr ""
 
-#: netbox/dcim/choices.py:1081
+#: dcim/choices.py:1081
 msgid "Ethernet (backplane)"
 msgstr ""
 
-#: netbox/dcim/choices.py:1113
+#: dcim/choices.py:1113
 msgid "Cellular"
 msgstr ""
 
-#: netbox/dcim/choices.py:1165 netbox/dcim/forms/filtersets.py:383
-#: netbox/dcim/forms/filtersets.py:809 netbox/dcim/forms/filtersets.py:963
-#: netbox/dcim/forms/filtersets.py:1542
-#: netbox/templates/dcim/inventoryitem.html:52
-#: netbox/templates/dcim/virtualchassis_edit.html:54
+#: dcim/choices.py:1165 dcim/forms/filtersets.py:383
+#: dcim/forms/filtersets.py:809 dcim/forms/filtersets.py:963
+#: dcim/forms/filtersets.py:1542 templates/dcim/inventoryitem.html:52
+#: templates/dcim/virtualchassis_edit.html:54
 msgid "Serial"
 msgstr ""
 
-#: netbox/dcim/choices.py:1180
+#: dcim/choices.py:1180
 msgid "Coaxial"
 msgstr ""
 
-#: netbox/dcim/choices.py:1200
+#: dcim/choices.py:1200
 msgid "Stacking"
 msgstr ""
 
-#: netbox/dcim/choices.py:1250
+#: dcim/choices.py:1250
 msgid "Half"
 msgstr ""
 
-#: netbox/dcim/choices.py:1251
+#: dcim/choices.py:1251
 msgid "Full"
 msgstr ""
 
-#: netbox/dcim/choices.py:1252 netbox/netbox/preferences.py:31
-#: netbox/wireless/choices.py:480
+#: dcim/choices.py:1252 netbox/preferences.py:31 wireless/choices.py:480
 msgid "Auto"
 msgstr ""
 
-#: netbox/dcim/choices.py:1263
+#: dcim/choices.py:1263
 msgid "Access"
 msgstr ""
 
-#: netbox/dcim/choices.py:1264 netbox/ipam/tables/vlans.py:172
-#: netbox/ipam/tables/vlans.py:217
-#: netbox/templates/dcim/inc/interface_vlans_table.html:7
+#: dcim/choices.py:1264 ipam/tables/vlans.py:172 ipam/tables/vlans.py:217
+#: templates/dcim/inc/interface_vlans_table.html:7
 msgid "Tagged"
 msgstr ""
 
-#: netbox/dcim/choices.py:1265
+#: dcim/choices.py:1265
 msgid "Tagged (All)"
 msgstr ""
 
-#: netbox/dcim/choices.py:1294
+#: dcim/choices.py:1294
 msgid "IEEE Standard"
 msgstr ""
 
-#: netbox/dcim/choices.py:1305
+#: dcim/choices.py:1305
 msgid "Passive 24V (2-pair)"
 msgstr ""
 
-#: netbox/dcim/choices.py:1306
+#: dcim/choices.py:1306
 msgid "Passive 24V (4-pair)"
 msgstr ""
 
-#: netbox/dcim/choices.py:1307
+#: dcim/choices.py:1307
 msgid "Passive 48V (2-pair)"
 msgstr ""
 
-#: netbox/dcim/choices.py:1308
+#: dcim/choices.py:1308
 msgid "Passive 48V (4-pair)"
 msgstr ""
 
-#: netbox/dcim/choices.py:1378 netbox/dcim/choices.py:1488
+#: dcim/choices.py:1378 dcim/choices.py:1488
 msgid "Copper"
 msgstr ""
 
-#: netbox/dcim/choices.py:1401
+#: dcim/choices.py:1401
 msgid "Fiber Optic"
 msgstr ""
 
-#: netbox/dcim/choices.py:1434 netbox/dcim/choices.py:1517
+#: dcim/choices.py:1434 dcim/choices.py:1517
 msgid "USB"
 msgstr ""
 
-#: netbox/dcim/choices.py:1504
+#: dcim/choices.py:1504
 msgid "Fiber"
 msgstr ""
 
-#: netbox/dcim/choices.py:1529 netbox/dcim/forms/filtersets.py:1227
+#: dcim/choices.py:1529 dcim/forms/filtersets.py:1227
 msgid "Connected"
 msgstr ""
 
-#: netbox/dcim/choices.py:1548 netbox/wireless/choices.py:497
+#: dcim/choices.py:1548 wireless/choices.py:497
 msgid "Kilometers"
 msgstr ""
 
-#: netbox/dcim/choices.py:1549 netbox/templates/dcim/cable_trace.html:65
-#: netbox/wireless/choices.py:498
+#: dcim/choices.py:1549 templates/dcim/cable_trace.html:65
+#: wireless/choices.py:498
 msgid "Meters"
 msgstr ""
 
-#: netbox/dcim/choices.py:1550
+#: dcim/choices.py:1550
 msgid "Centimeters"
 msgstr ""
 
-#: netbox/dcim/choices.py:1551 netbox/wireless/choices.py:499
+#: dcim/choices.py:1551 wireless/choices.py:499
 msgid "Miles"
 msgstr ""
 
-#: netbox/dcim/choices.py:1552 netbox/templates/dcim/cable_trace.html:66
-#: netbox/wireless/choices.py:500
+#: dcim/choices.py:1552 templates/dcim/cable_trace.html:66
+#: wireless/choices.py:500
 msgid "Feet"
 msgstr ""
 
-#: netbox/dcim/choices.py:1568 netbox/templates/dcim/device.html:327
-#: netbox/templates/dcim/rack.html:107
+#: dcim/choices.py:1568 templates/dcim/device.html:327
+#: templates/dcim/rack.html:107
 msgid "Kilograms"
 msgstr ""
 
-#: netbox/dcim/choices.py:1569
+#: dcim/choices.py:1569
 msgid "Grams"
 msgstr ""
 
-#: netbox/dcim/choices.py:1570 netbox/templates/dcim/device.html:328
-#: netbox/templates/dcim/rack.html:108
+#: dcim/choices.py:1570 templates/dcim/device.html:328
+#: templates/dcim/rack.html:108
 msgid "Pounds"
 msgstr ""
 
-#: netbox/dcim/choices.py:1571
+#: dcim/choices.py:1571
 msgid "Ounces"
 msgstr ""
 
-#: netbox/dcim/choices.py:1618
+#: dcim/choices.py:1618
 msgid "Redundant"
 msgstr ""
 
-#: netbox/dcim/choices.py:1639
+#: dcim/choices.py:1639
 msgid "Single phase"
 msgstr ""
 
-#: netbox/dcim/choices.py:1640
+#: dcim/choices.py:1640
 msgid "Three-phase"
 msgstr ""
 
-#: netbox/dcim/fields.py:45
+#: dcim/fields.py:45
 #, python-brace-format
 msgid "Invalid MAC address format: {value}"
 msgstr ""
 
-#: netbox/dcim/fields.py:71
+#: dcim/fields.py:71
 #, python-brace-format
 msgid "Invalid WWN format: {value}"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:86
+#: dcim/filtersets.py:86
 msgid "Parent region (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:92
+#: dcim/filtersets.py:92
 msgid "Parent region (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:116
+#: dcim/filtersets.py:116
 msgid "Parent site group (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:122
+#: dcim/filtersets.py:122
 msgid "Parent site group (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:164 netbox/extras/filtersets.py:364
-#: netbox/ipam/filtersets.py:841 netbox/ipam/filtersets.py:993
+#: dcim/filtersets.py:164 extras/filtersets.py:364 ipam/filtersets.py:841
+#: ipam/filtersets.py:993
 msgid "Group (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:170
+#: dcim/filtersets.py:170
 msgid "Group (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:176 netbox/dcim/filtersets.py:181
+#: dcim/filtersets.py:176 dcim/filtersets.py:181
 msgid "AS (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:246
+#: dcim/filtersets.py:246
 msgid "Parent location (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:252
+#: dcim/filtersets.py:252
 msgid "Parent location (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:258 netbox/dcim/filtersets.py:369
-#: netbox/dcim/filtersets.py:490 netbox/dcim/filtersets.py:1057
-#: netbox/dcim/filtersets.py:1404 netbox/dcim/filtersets.py:2182
+#: dcim/filtersets.py:258 dcim/filtersets.py:369 dcim/filtersets.py:490
+#: dcim/filtersets.py:1057 dcim/filtersets.py:1404 dcim/filtersets.py:2182
 msgid "Location (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:265 netbox/dcim/filtersets.py:376
-#: netbox/dcim/filtersets.py:497 netbox/dcim/filtersets.py:1410
-#: netbox/extras/filtersets.py:542
+#: dcim/filtersets.py:265 dcim/filtersets.py:376 dcim/filtersets.py:497
+#: dcim/filtersets.py:1410 extras/filtersets.py:542
 msgid "Location (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:296 netbox/dcim/filtersets.py:381
-#: netbox/dcim/filtersets.py:539 netbox/dcim/filtersets.py:678
-#: netbox/dcim/filtersets.py:882 netbox/dcim/filtersets.py:933
-#: netbox/dcim/filtersets.py:973 netbox/dcim/filtersets.py:1306
-#: netbox/dcim/filtersets.py:1840
+#: dcim/filtersets.py:296 dcim/filtersets.py:381 dcim/filtersets.py:539
+#: dcim/filtersets.py:678 dcim/filtersets.py:882 dcim/filtersets.py:933
+#: dcim/filtersets.py:973 dcim/filtersets.py:1306 dcim/filtersets.py:1840
 msgid "Manufacturer (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:302 netbox/dcim/filtersets.py:387
-#: netbox/dcim/filtersets.py:545 netbox/dcim/filtersets.py:684
-#: netbox/dcim/filtersets.py:888 netbox/dcim/filtersets.py:939
-#: netbox/dcim/filtersets.py:979 netbox/dcim/filtersets.py:1312
-#: netbox/dcim/filtersets.py:1846
+#: dcim/filtersets.py:302 dcim/filtersets.py:387 dcim/filtersets.py:545
+#: dcim/filtersets.py:684 dcim/filtersets.py:888 dcim/filtersets.py:939
+#: dcim/filtersets.py:979 dcim/filtersets.py:1312 dcim/filtersets.py:1846
 msgid "Manufacturer (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:393
+#: dcim/filtersets.py:393
 msgid "Rack type (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:397
+#: dcim/filtersets.py:397
 msgid "Rack type (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:411 netbox/dcim/filtersets.py:892
-#: netbox/dcim/filtersets.py:994 netbox/dcim/filtersets.py:1850
-#: netbox/ipam/filtersets.py:381 netbox/ipam/filtersets.py:493
-#: netbox/ipam/filtersets.py:1003 netbox/virtualization/filtersets.py:210
+#: dcim/filtersets.py:411 dcim/filtersets.py:892 dcim/filtersets.py:994
+#: dcim/filtersets.py:1850 ipam/filtersets.py:381 ipam/filtersets.py:493
+#: ipam/filtersets.py:1003 virtualization/filtersets.py:210
 msgid "Role (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:417 netbox/dcim/filtersets.py:898
-#: netbox/dcim/filtersets.py:1000 netbox/dcim/filtersets.py:1856
-#: netbox/extras/filtersets.py:558 netbox/ipam/filtersets.py:387
-#: netbox/ipam/filtersets.py:499 netbox/ipam/filtersets.py:1009
-#: netbox/virtualization/filtersets.py:216
+#: dcim/filtersets.py:417 dcim/filtersets.py:898 dcim/filtersets.py:1000
+#: dcim/filtersets.py:1856 extras/filtersets.py:558 ipam/filtersets.py:387
+#: ipam/filtersets.py:499 ipam/filtersets.py:1009
+#: virtualization/filtersets.py:216
 msgid "Role (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:447 netbox/dcim/filtersets.py:1062
-#: netbox/dcim/filtersets.py:1415 netbox/dcim/filtersets.py:2244
+#: dcim/filtersets.py:447 dcim/filtersets.py:1062 dcim/filtersets.py:1415
+#: dcim/filtersets.py:2244
 msgid "Rack (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:507 netbox/extras/filtersets.py:293
-#: netbox/extras/filtersets.py:337 netbox/extras/filtersets.py:359
-#: netbox/extras/filtersets.py:419 netbox/users/filtersets.py:113
-#: netbox/users/filtersets.py:180
+#: dcim/filtersets.py:507 extras/filtersets.py:293 extras/filtersets.py:337
+#: extras/filtersets.py:359 extras/filtersets.py:419 users/filtersets.py:113
+#: users/filtersets.py:180
 msgid "User (name)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:549
+#: dcim/filtersets.py:549
 msgid "Default platform (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:555
+#: dcim/filtersets.py:555
 msgid "Default platform (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:558 netbox/dcim/forms/filtersets.py:517
+#: dcim/filtersets.py:558 dcim/forms/filtersets.py:517
 msgid "Has a front image"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:562 netbox/dcim/forms/filtersets.py:524
+#: dcim/filtersets.py:562 dcim/forms/filtersets.py:524
 msgid "Has a rear image"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:567 netbox/dcim/filtersets.py:688
-#: netbox/dcim/filtersets.py:1131 netbox/dcim/forms/filtersets.py:531
-#: netbox/dcim/forms/filtersets.py:627 netbox/dcim/forms/filtersets.py:848
+#: dcim/filtersets.py:567 dcim/filtersets.py:688 dcim/filtersets.py:1131
+#: dcim/forms/filtersets.py:531 dcim/forms/filtersets.py:627
+#: dcim/forms/filtersets.py:848
 msgid "Has console ports"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:571 netbox/dcim/filtersets.py:692
-#: netbox/dcim/filtersets.py:1135 netbox/dcim/forms/filtersets.py:538
-#: netbox/dcim/forms/filtersets.py:634 netbox/dcim/forms/filtersets.py:855
+#: dcim/filtersets.py:571 dcim/filtersets.py:692 dcim/filtersets.py:1135
+#: dcim/forms/filtersets.py:538 dcim/forms/filtersets.py:634
+#: dcim/forms/filtersets.py:855
 msgid "Has console server ports"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:575 netbox/dcim/filtersets.py:696
-#: netbox/dcim/filtersets.py:1139 netbox/dcim/forms/filtersets.py:545
-#: netbox/dcim/forms/filtersets.py:641 netbox/dcim/forms/filtersets.py:862
+#: dcim/filtersets.py:575 dcim/filtersets.py:696 dcim/filtersets.py:1139
+#: dcim/forms/filtersets.py:545 dcim/forms/filtersets.py:641
+#: dcim/forms/filtersets.py:862
 msgid "Has power ports"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:579 netbox/dcim/filtersets.py:700
-#: netbox/dcim/filtersets.py:1143 netbox/dcim/forms/filtersets.py:552
-#: netbox/dcim/forms/filtersets.py:648 netbox/dcim/forms/filtersets.py:869
+#: dcim/filtersets.py:579 dcim/filtersets.py:700 dcim/filtersets.py:1143
+#: dcim/forms/filtersets.py:552 dcim/forms/filtersets.py:648
+#: dcim/forms/filtersets.py:869
 msgid "Has power outlets"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:583 netbox/dcim/filtersets.py:704
-#: netbox/dcim/filtersets.py:1147 netbox/dcim/forms/filtersets.py:559
-#: netbox/dcim/forms/filtersets.py:655 netbox/dcim/forms/filtersets.py:876
+#: dcim/filtersets.py:583 dcim/filtersets.py:704 dcim/filtersets.py:1147
+#: dcim/forms/filtersets.py:559 dcim/forms/filtersets.py:655
+#: dcim/forms/filtersets.py:876
 msgid "Has interfaces"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:587 netbox/dcim/filtersets.py:708
-#: netbox/dcim/filtersets.py:1151 netbox/dcim/forms/filtersets.py:566
-#: netbox/dcim/forms/filtersets.py:662 netbox/dcim/forms/filtersets.py:883
+#: dcim/filtersets.py:587 dcim/filtersets.py:708 dcim/filtersets.py:1151
+#: dcim/forms/filtersets.py:566 dcim/forms/filtersets.py:662
+#: dcim/forms/filtersets.py:883
 msgid "Has pass-through ports"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:591 netbox/dcim/filtersets.py:1155
-#: netbox/dcim/forms/filtersets.py:580
+#: dcim/filtersets.py:591 dcim/filtersets.py:1155 dcim/forms/filtersets.py:580
 msgid "Has module bays"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:595 netbox/dcim/filtersets.py:1159
-#: netbox/dcim/forms/filtersets.py:573
+#: dcim/filtersets.py:595 dcim/filtersets.py:1159 dcim/forms/filtersets.py:573
 msgid "Has device bays"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:599 netbox/dcim/forms/filtersets.py:587
+#: dcim/filtersets.py:599 dcim/forms/filtersets.py:587
 msgid "Has inventory items"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:756 netbox/dcim/filtersets.py:989
-#: netbox/dcim/filtersets.py:1436
+#: dcim/filtersets.py:756 dcim/filtersets.py:989 dcim/filtersets.py:1436
 msgid "Device type (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:772 netbox/dcim/filtersets.py:1317
+#: dcim/filtersets.py:772 dcim/filtersets.py:1317
 msgid "Module type (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:804 netbox/dcim/filtersets.py:1591
+#: dcim/filtersets.py:804 dcim/filtersets.py:1591
 msgid "Power port (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:878 netbox/dcim/filtersets.py:1836
+#: dcim/filtersets.py:878 dcim/filtersets.py:1836
 msgid "Parent inventory item (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:921 netbox/dcim/filtersets.py:947
-#: netbox/dcim/filtersets.py:1127 netbox/virtualization/filtersets.py:238
+#: dcim/filtersets.py:921 dcim/filtersets.py:947 dcim/filtersets.py:1127
+#: virtualization/filtersets.py:238
 msgid "Config template (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:985
+#: dcim/filtersets.py:985
 msgid "Device type (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1005
+#: dcim/filtersets.py:1005
 msgid "Parent Device (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1009 netbox/virtualization/filtersets.py:220
+#: dcim/filtersets.py:1009 virtualization/filtersets.py:220
 msgid "Platform (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1015 netbox/extras/filtersets.py:569
-#: netbox/virtualization/filtersets.py:226
+#: dcim/filtersets.py:1015 extras/filtersets.py:569
+#: virtualization/filtersets.py:226
 msgid "Platform (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1051 netbox/dcim/filtersets.py:1399
-#: netbox/dcim/filtersets.py:1934 netbox/dcim/filtersets.py:2176
-#: netbox/dcim/filtersets.py:2235
+#: dcim/filtersets.py:1051 dcim/filtersets.py:1399 dcim/filtersets.py:1934
+#: dcim/filtersets.py:2176 dcim/filtersets.py:2235
 msgid "Site name (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1067
+#: dcim/filtersets.py:1067
 msgid "Parent bay (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1071
+#: dcim/filtersets.py:1071
 msgid "VM cluster (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1077 netbox/extras/filtersets.py:591
-#: netbox/virtualization/filtersets.py:136
+#: dcim/filtersets.py:1077 extras/filtersets.py:591
+#: virtualization/filtersets.py:136
 msgid "Cluster group (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1082 netbox/virtualization/filtersets.py:130
+#: dcim/filtersets.py:1082 virtualization/filtersets.py:130
 msgid "Cluster group (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1088
+#: dcim/filtersets.py:1088
 msgid "Device model (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1099 netbox/dcim/forms/bulk_edit.py:516
+#: dcim/filtersets.py:1099 dcim/forms/bulk_edit.py:516
 msgid "Is full depth"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1103 netbox/dcim/forms/common.py:18
-#: netbox/dcim/forms/filtersets.py:818 netbox/dcim/forms/filtersets.py:1385
-#: netbox/dcim/models/device_components.py:518
-#: netbox/virtualization/filtersets.py:230
-#: netbox/virtualization/filtersets.py:301
-#: netbox/virtualization/forms/filtersets.py:172
-#: netbox/virtualization/forms/filtersets.py:223
+#: dcim/filtersets.py:1103 dcim/forms/common.py:18 dcim/forms/filtersets.py:818
+#: dcim/forms/filtersets.py:1385 dcim/models/device_components.py:518
+#: virtualization/filtersets.py:230 virtualization/filtersets.py:301
+#: virtualization/forms/filtersets.py:172
+#: virtualization/forms/filtersets.py:223
 msgid "MAC address"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1110 netbox/dcim/filtersets.py:1274
-#: netbox/dcim/forms/filtersets.py:827 netbox/dcim/forms/filtersets.py:930
-#: netbox/virtualization/filtersets.py:234
-#: netbox/virtualization/forms/filtersets.py:176
+#: dcim/filtersets.py:1110 dcim/filtersets.py:1274 dcim/forms/filtersets.py:827
+#: dcim/forms/filtersets.py:930 virtualization/filtersets.py:234
+#: virtualization/forms/filtersets.py:176
 msgid "Has a primary IP"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1114
+#: dcim/filtersets.py:1114
 msgid "Has an out-of-band IP"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1119
+#: dcim/filtersets.py:1119
 msgid "Virtual chassis (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1123
+#: dcim/filtersets.py:1123
 msgid "Is a virtual chassis member"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1164
+#: dcim/filtersets.py:1164
 msgid "OOB IP (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1168
+#: dcim/filtersets.py:1168
 msgid "Has virtual device context"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1257
+#: dcim/filtersets.py:1257
 msgid "VDC (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1262
+#: dcim/filtersets.py:1262
 msgid "Device model"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1267 netbox/ipam/filtersets.py:632
-#: netbox/vpn/filtersets.py:102 netbox/vpn/filtersets.py:401
+#: dcim/filtersets.py:1267 ipam/filtersets.py:632 vpn/filtersets.py:102
+#: vpn/filtersets.py:401
 msgid "Interface (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1323
+#: dcim/filtersets.py:1323
 msgid "Module type (model)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1329
+#: dcim/filtersets.py:1329
 msgid "Module bay (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1333 netbox/dcim/filtersets.py:1425
-#: netbox/ipam/filtersets.py:611 netbox/ipam/filtersets.py:851
-#: netbox/ipam/filtersets.py:1115 netbox/virtualization/filtersets.py:161
-#: netbox/vpn/filtersets.py:379
+#: dcim/filtersets.py:1333 dcim/filtersets.py:1425 ipam/filtersets.py:611
+#: ipam/filtersets.py:851 ipam/filtersets.py:1115
+#: virtualization/filtersets.py:161 vpn/filtersets.py:379
 msgid "Device (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1421
+#: dcim/filtersets.py:1421
 msgid "Rack (name)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1431 netbox/ipam/filtersets.py:606
-#: netbox/ipam/filtersets.py:846 netbox/ipam/filtersets.py:1121
-#: netbox/vpn/filtersets.py:374
+#: dcim/filtersets.py:1431 ipam/filtersets.py:606 ipam/filtersets.py:846
+#: ipam/filtersets.py:1121 vpn/filtersets.py:374
 msgid "Device (name)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1442
+#: dcim/filtersets.py:1442
 msgid "Device type (model)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1447
+#: dcim/filtersets.py:1447
 msgid "Device role (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1453
+#: dcim/filtersets.py:1453
 msgid "Device role (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1458
+#: dcim/filtersets.py:1458
 msgid "Virtual Chassis (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1464 netbox/dcim/forms/filtersets.py:109
-#: netbox/dcim/tables/devices.py:206 netbox/netbox/navigation/menu.py:79
-#: netbox/templates/dcim/device.html:120
-#: netbox/templates/dcim/device_edit.html:93
-#: netbox/templates/dcim/virtualchassis.html:20
-#: netbox/templates/dcim/virtualchassis_add.html:8
-#: netbox/templates/dcim/virtualchassis_edit.html:24
+#: dcim/filtersets.py:1464 dcim/forms/filtersets.py:109
+#: dcim/tables/devices.py:206 netbox/navigation/menu.py:79
+#: templates/dcim/device.html:120 templates/dcim/device_edit.html:93
+#: templates/dcim/virtualchassis.html:20
+#: templates/dcim/virtualchassis_add.html:8
+#: templates/dcim/virtualchassis_edit.html:24
 msgid "Virtual Chassis"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1488
+#: dcim/filtersets.py:1488
 msgid "Module (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1495
+#: dcim/filtersets.py:1495
 msgid "Cable (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1604 netbox/ipam/forms/bulk_import.py:189
-#: netbox/vpn/forms/bulk_import.py:308
+#: dcim/filtersets.py:1604 ipam/forms/bulk_import.py:189
+#: vpn/forms/bulk_import.py:308
 msgid "Assigned VLAN"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1608
+#: dcim/filtersets.py:1608
 msgid "Assigned VID"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1613 netbox/dcim/forms/bulk_edit.py:1489
-#: netbox/dcim/forms/bulk_import.py:891 netbox/dcim/forms/filtersets.py:1428
-#: netbox/dcim/forms/model_forms.py:1378
-#: netbox/dcim/models/device_components.py:711
-#: netbox/dcim/tables/devices.py:626 netbox/ipam/filtersets.py:316
-#: netbox/ipam/filtersets.py:327 netbox/ipam/filtersets.py:483
-#: netbox/ipam/filtersets.py:584 netbox/ipam/filtersets.py:595
-#: netbox/ipam/forms/bulk_edit.py:242 netbox/ipam/forms/bulk_edit.py:298
-#: netbox/ipam/forms/bulk_edit.py:340 netbox/ipam/forms/bulk_import.py:157
-#: netbox/ipam/forms/bulk_import.py:243 netbox/ipam/forms/bulk_import.py:279
-#: netbox/ipam/forms/filtersets.py:67 netbox/ipam/forms/filtersets.py:172
-#: netbox/ipam/forms/filtersets.py:309 netbox/ipam/forms/model_forms.py:62
-#: netbox/ipam/forms/model_forms.py:202 netbox/ipam/forms/model_forms.py:247
-#: netbox/ipam/forms/model_forms.py:300 netbox/ipam/forms/model_forms.py:431
-#: netbox/ipam/forms/model_forms.py:445 netbox/ipam/forms/model_forms.py:459
-#: netbox/ipam/models/ip.py:233 netbox/ipam/models/ip.py:512
-#: netbox/ipam/models/ip.py:720 netbox/ipam/models/vrfs.py:62
-#: netbox/ipam/tables/ip.py:242 netbox/ipam/tables/ip.py:309
-#: netbox/ipam/tables/ip.py:360 netbox/ipam/tables/ip.py:450
-#: netbox/templates/dcim/interface.html:133
-#: netbox/templates/ipam/ipaddress.html:18
-#: netbox/templates/ipam/iprange.html:40 netbox/templates/ipam/prefix.html:19
-#: netbox/templates/ipam/vrf.html:7 netbox/templates/ipam/vrf.html:13
-#: netbox/templates/virtualization/vminterface.html:47
-#: netbox/virtualization/forms/bulk_edit.py:261
-#: netbox/virtualization/forms/bulk_import.py:171
-#: netbox/virtualization/forms/filtersets.py:228
-#: netbox/virtualization/forms/model_forms.py:344
-#: netbox/virtualization/models/virtualmachines.py:355
-#: netbox/virtualization/tables/virtualmachines.py:143
+#: dcim/filtersets.py:1613 dcim/forms/bulk_edit.py:1489
+#: dcim/forms/bulk_import.py:891 dcim/forms/filtersets.py:1428
+#: dcim/forms/model_forms.py:1378 dcim/models/device_components.py:711
+#: dcim/tables/devices.py:626 ipam/filtersets.py:316 ipam/filtersets.py:327
+#: ipam/filtersets.py:483 ipam/filtersets.py:584 ipam/filtersets.py:595
+#: ipam/forms/bulk_edit.py:242 ipam/forms/bulk_edit.py:298
+#: ipam/forms/bulk_edit.py:340 ipam/forms/bulk_import.py:157
+#: ipam/forms/bulk_import.py:243 ipam/forms/bulk_import.py:279
+#: ipam/forms/filtersets.py:67 ipam/forms/filtersets.py:172
+#: ipam/forms/filtersets.py:309 ipam/forms/model_forms.py:62
+#: ipam/forms/model_forms.py:202 ipam/forms/model_forms.py:247
+#: ipam/forms/model_forms.py:300 ipam/forms/model_forms.py:431
+#: ipam/forms/model_forms.py:445 ipam/forms/model_forms.py:459
+#: ipam/models/ip.py:233 ipam/models/ip.py:512 ipam/models/ip.py:720
+#: ipam/models/vrfs.py:62 ipam/tables/ip.py:242 ipam/tables/ip.py:309
+#: ipam/tables/ip.py:360 ipam/tables/ip.py:450
+#: templates/dcim/interface.html:133 templates/ipam/ipaddress.html:18
+#: templates/ipam/iprange.html:40 templates/ipam/prefix.html:19
+#: templates/ipam/vrf.html:7 templates/ipam/vrf.html:13
+#: templates/virtualization/vminterface.html:47
+#: virtualization/forms/bulk_edit.py:261
+#: virtualization/forms/bulk_import.py:171
+#: virtualization/forms/filtersets.py:228
+#: virtualization/forms/model_forms.py:344
+#: virtualization/models/virtualmachines.py:355
+#: virtualization/tables/virtualmachines.py:143
 msgid "VRF"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1619 netbox/ipam/filtersets.py:322
-#: netbox/ipam/filtersets.py:333 netbox/ipam/filtersets.py:489
-#: netbox/ipam/filtersets.py:590 netbox/ipam/filtersets.py:601
+#: dcim/filtersets.py:1619 ipam/filtersets.py:322 ipam/filtersets.py:333
+#: ipam/filtersets.py:489 ipam/filtersets.py:590 ipam/filtersets.py:601
 msgid "VRF (RD)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1624 netbox/ipam/filtersets.py:1030
-#: netbox/vpn/filtersets.py:342
+#: dcim/filtersets.py:1624 ipam/filtersets.py:1030 vpn/filtersets.py:342
 msgid "L2VPN (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1630 netbox/dcim/forms/filtersets.py:1433
-#: netbox/dcim/tables/devices.py:570 netbox/ipam/filtersets.py:1036
-#: netbox/ipam/forms/filtersets.py:518 netbox/ipam/tables/vlans.py:137
-#: netbox/templates/dcim/interface.html:93 netbox/templates/ipam/vlan.html:66
-#: netbox/templates/vpn/l2vpntermination.html:12
-#: netbox/virtualization/forms/filtersets.py:233
-#: netbox/vpn/forms/bulk_import.py:280 netbox/vpn/forms/filtersets.py:246
-#: netbox/vpn/forms/model_forms.py:409 netbox/vpn/forms/model_forms.py:427
-#: netbox/vpn/models/l2vpn.py:63 netbox/vpn/tables/l2vpn.py:55
+#: dcim/filtersets.py:1630 dcim/forms/filtersets.py:1433
+#: dcim/tables/devices.py:570 ipam/filtersets.py:1036
+#: ipam/forms/filtersets.py:518 ipam/tables/vlans.py:137
+#: templates/dcim/interface.html:93 templates/ipam/vlan.html:66
+#: templates/vpn/l2vpntermination.html:12
+#: virtualization/forms/filtersets.py:233 vpn/forms/bulk_import.py:280
+#: vpn/forms/filtersets.py:246 vpn/forms/model_forms.py:409
+#: vpn/forms/model_forms.py:427 vpn/models/l2vpn.py:63 vpn/tables/l2vpn.py:55
 msgid "L2VPN"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1662
+#: dcim/filtersets.py:1662
 msgid "Virtual Chassis Interfaces for Device"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1667
+#: dcim/filtersets.py:1667
 msgid "Virtual Chassis Interfaces for Device (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1671
+#: dcim/filtersets.py:1671
 msgid "Kind of interface"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1676 netbox/virtualization/filtersets.py:293
+#: dcim/filtersets.py:1676 virtualization/filtersets.py:293
 msgid "Parent interface (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1681 netbox/virtualization/filtersets.py:298
+#: dcim/filtersets.py:1681 virtualization/filtersets.py:298
 msgid "Bridged interface (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1686
+#: dcim/filtersets.py:1686
 msgid "LAG interface (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1713 netbox/dcim/filtersets.py:1725
-#: netbox/dcim/forms/filtersets.py:1345 netbox/dcim/forms/model_forms.py:1690
-#: netbox/templates/dcim/virtualdevicecontext.html:15
+#: dcim/filtersets.py:1713 dcim/filtersets.py:1725
+#: dcim/forms/filtersets.py:1345 dcim/forms/model_forms.py:1690
+#: templates/dcim/virtualdevicecontext.html:15
 msgid "Virtual Device Context"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1719
+#: dcim/filtersets.py:1719
 msgid "Virtual Device Context (Identifier)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1730 netbox/templates/wireless/wirelesslan.html:11
-#: netbox/wireless/forms/model_forms.py:53
+#: dcim/filtersets.py:1730 templates/wireless/wirelesslan.html:11
+#: wireless/forms/model_forms.py:53
 msgid "Wireless LAN"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1734 netbox/dcim/tables/devices.py:613
+#: dcim/filtersets.py:1734 dcim/tables/devices.py:613
 msgid "Wireless link"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1803
+#: dcim/filtersets.py:1803
 msgid "Parent module bay (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1808
+#: dcim/filtersets.py:1808
 msgid "Installed module (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1819
+#: dcim/filtersets.py:1819
 msgid "Installed device (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1825
+#: dcim/filtersets.py:1825
 msgid "Installed device (name)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1891
+#: dcim/filtersets.py:1891
 msgid "Master (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1897
+#: dcim/filtersets.py:1897
 msgid "Master (name)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1939 netbox/tenancy/filtersets.py:245
+#: dcim/filtersets.py:1939 tenancy/filtersets.py:245
 msgid "Tenant (ID)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1945 netbox/extras/filtersets.py:618
-#: netbox/tenancy/filtersets.py:251
+#: dcim/filtersets.py:1945 extras/filtersets.py:618 tenancy/filtersets.py:251
 msgid "Tenant (slug)"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:1981 netbox/dcim/forms/filtersets.py:1077
+#: dcim/filtersets.py:1981 dcim/forms/filtersets.py:1077
 msgid "Unterminated"
 msgstr ""
 
-#: netbox/dcim/filtersets.py:2239
+#: dcim/filtersets.py:2239
 msgid "Power panel (ID)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_create.py:40 netbox/extras/forms/filtersets.py:401
-#: netbox/extras/forms/model_forms.py:567
-#: netbox/extras/forms/model_forms.py:619 netbox/netbox/forms/base.py:86
-#: netbox/netbox/forms/mixins.py:81 netbox/netbox/tables/columns.py:478
-#: netbox/templates/circuits/inc/circuit_termination.html:32
-#: netbox/templates/generic/bulk_edit.html:65
-#: netbox/templates/inc/panels/tags.html:5
-#: netbox/utilities/forms/fields/fields.py:81
+#: dcim/forms/bulk_create.py:40 extras/forms/filtersets.py:401
+#: extras/forms/model_forms.py:567 extras/forms/model_forms.py:619
+#: netbox/forms/base.py:86 netbox/forms/mixins.py:81
+#: netbox/tables/columns.py:478
+#: templates/circuits/inc/circuit_termination.html:32
+#: templates/generic/bulk_edit.html:65 templates/inc/panels/tags.html:5
+#: utilities/forms/fields/fields.py:81
 msgid "Tags"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_create.py:112 netbox/dcim/forms/filtersets.py:1498
-#: netbox/dcim/forms/model_forms.py:488 netbox/dcim/forms/model_forms.py:546
-#: netbox/dcim/forms/object_create.py:197
-#: netbox/dcim/forms/object_create.py:353 netbox/dcim/tables/devices.py:165
-#: netbox/dcim/tables/devices.py:707 netbox/dcim/tables/devicetypes.py:246
-#: netbox/templates/dcim/device.html:43 netbox/templates/dcim/device.html:131
-#: netbox/templates/dcim/modulebay.html:38
-#: netbox/templates/dcim/virtualchassis.html:66
-#: netbox/templates/dcim/virtualchassis_edit.html:55
+#: dcim/forms/bulk_create.py:112 dcim/forms/filtersets.py:1498
+#: dcim/forms/model_forms.py:488 dcim/forms/model_forms.py:546
+#: dcim/forms/object_create.py:197 dcim/forms/object_create.py:353
+#: dcim/tables/devices.py:165 dcim/tables/devices.py:707
+#: dcim/tables/devicetypes.py:246 templates/dcim/device.html:43
+#: templates/dcim/device.html:131 templates/dcim/modulebay.html:38
+#: templates/dcim/virtualchassis.html:66
+#: templates/dcim/virtualchassis_edit.html:55
 msgid "Position"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_create.py:114
+#: dcim/forms/bulk_create.py:114
 msgid ""
 "Alphanumeric ranges are supported. (Must match the number of names being "
 "created.)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:132
+#: dcim/forms/bulk_edit.py:132
 msgid "Contact name"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:137
+#: dcim/forms/bulk_edit.py:137
 msgid "Contact phone"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:143
+#: dcim/forms/bulk_edit.py:143
 msgid "Contact E-mail"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:146 netbox/dcim/forms/bulk_import.py:123
-#: netbox/dcim/forms/model_forms.py:128
+#: dcim/forms/bulk_edit.py:146 dcim/forms/bulk_import.py:123
+#: dcim/forms/model_forms.py:128
 msgid "Time zone"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:224 netbox/dcim/forms/bulk_edit.py:495
-#: netbox/dcim/forms/bulk_edit.py:559 netbox/dcim/forms/bulk_edit.py:632
-#: netbox/dcim/forms/bulk_edit.py:656 netbox/dcim/forms/bulk_edit.py:740
-#: netbox/dcim/forms/bulk_edit.py:1267 netbox/dcim/forms/bulk_edit.py:1660
-#: netbox/dcim/forms/bulk_import.py:182 netbox/dcim/forms/bulk_import.py:371
-#: netbox/dcim/forms/bulk_import.py:405 netbox/dcim/forms/bulk_import.py:450
-#: netbox/dcim/forms/bulk_import.py:486 netbox/dcim/forms/bulk_import.py:1082
-#: netbox/dcim/forms/filtersets.py:313 netbox/dcim/forms/filtersets.py:372
-#: netbox/dcim/forms/filtersets.py:494 netbox/dcim/forms/filtersets.py:619
-#: netbox/dcim/forms/filtersets.py:700 netbox/dcim/forms/filtersets.py:782
-#: netbox/dcim/forms/filtersets.py:947 netbox/dcim/forms/filtersets.py:1539
-#: netbox/dcim/forms/model_forms.py:207 netbox/dcim/forms/model_forms.py:337
-#: netbox/dcim/forms/model_forms.py:349 netbox/dcim/forms/model_forms.py:395
-#: netbox/dcim/forms/model_forms.py:436 netbox/dcim/forms/model_forms.py:1075
-#: netbox/dcim/forms/model_forms.py:1515 netbox/dcim/forms/object_import.py:187
-#: netbox/dcim/tables/devices.py:96 netbox/dcim/tables/devices.py:172
-#: netbox/dcim/tables/devices.py:940 netbox/dcim/tables/devicetypes.py:80
-#: netbox/dcim/tables/devicetypes.py:308 netbox/dcim/tables/modules.py:20
-#: netbox/dcim/tables/modules.py:60 netbox/dcim/tables/racks.py:58
-#: netbox/dcim/tables/racks.py:132 netbox/templates/dcim/devicetype.html:14
-#: netbox/templates/dcim/inventoryitem.html:44
-#: netbox/templates/dcim/manufacturer.html:33
-#: netbox/templates/dcim/modulebay.html:62
-#: netbox/templates/dcim/moduletype.html:25
-#: netbox/templates/dcim/platform.html:37
-#: netbox/templates/dcim/racktype.html:16
+#: dcim/forms/bulk_edit.py:224 dcim/forms/bulk_edit.py:495
+#: dcim/forms/bulk_edit.py:559 dcim/forms/bulk_edit.py:632
+#: dcim/forms/bulk_edit.py:656 dcim/forms/bulk_edit.py:740
+#: dcim/forms/bulk_edit.py:1267 dcim/forms/bulk_edit.py:1660
+#: dcim/forms/bulk_import.py:182 dcim/forms/bulk_import.py:371
+#: dcim/forms/bulk_import.py:405 dcim/forms/bulk_import.py:450
+#: dcim/forms/bulk_import.py:486 dcim/forms/bulk_import.py:1082
+#: dcim/forms/filtersets.py:313 dcim/forms/filtersets.py:372
+#: dcim/forms/filtersets.py:494 dcim/forms/filtersets.py:619
+#: dcim/forms/filtersets.py:700 dcim/forms/filtersets.py:782
+#: dcim/forms/filtersets.py:947 dcim/forms/filtersets.py:1539
+#: dcim/forms/model_forms.py:207 dcim/forms/model_forms.py:337
+#: dcim/forms/model_forms.py:349 dcim/forms/model_forms.py:395
+#: dcim/forms/model_forms.py:436 dcim/forms/model_forms.py:1075
+#: dcim/forms/model_forms.py:1515 dcim/forms/object_import.py:187
+#: dcim/tables/devices.py:96 dcim/tables/devices.py:172
+#: dcim/tables/devices.py:940 dcim/tables/devicetypes.py:80
+#: dcim/tables/devicetypes.py:308 dcim/tables/modules.py:20
+#: dcim/tables/modules.py:60 dcim/tables/racks.py:58 dcim/tables/racks.py:132
+#: templates/dcim/devicetype.html:14 templates/dcim/inventoryitem.html:44
+#: templates/dcim/manufacturer.html:33 templates/dcim/modulebay.html:62
+#: templates/dcim/moduletype.html:25 templates/dcim/platform.html:37
+#: templates/dcim/racktype.html:16
 msgid "Manufacturer"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:229 netbox/dcim/forms/bulk_edit.py:372
-#: netbox/dcim/forms/bulk_import.py:191 netbox/dcim/forms/bulk_import.py:263
-#: netbox/dcim/forms/filtersets.py:255
-#: netbox/templates/dcim/inc/panels/racktype_dimensions.html:6
+#: dcim/forms/bulk_edit.py:229 dcim/forms/bulk_edit.py:372
+#: dcim/forms/bulk_import.py:191 dcim/forms/bulk_import.py:263
+#: dcim/forms/filtersets.py:255
+#: templates/dcim/inc/panels/racktype_dimensions.html:6
 msgid "Form factor"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:234 netbox/dcim/forms/bulk_edit.py:377
-#: netbox/dcim/forms/bulk_import.py:199 netbox/dcim/forms/bulk_import.py:266
-#: netbox/dcim/forms/filtersets.py:260
-#: netbox/templates/dcim/inc/panels/racktype_dimensions.html:10
+#: dcim/forms/bulk_edit.py:234 dcim/forms/bulk_edit.py:377
+#: dcim/forms/bulk_import.py:199 dcim/forms/bulk_import.py:266
+#: dcim/forms/filtersets.py:260
+#: templates/dcim/inc/panels/racktype_dimensions.html:10
 msgid "Width"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:240 netbox/dcim/forms/bulk_edit.py:383
-#: netbox/templates/dcim/devicetype.html:37
+#: dcim/forms/bulk_edit.py:240 dcim/forms/bulk_edit.py:383
+#: templates/dcim/devicetype.html:37
 msgid "Height (U)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:249 netbox/dcim/forms/bulk_edit.py:388
-#: netbox/dcim/forms/filtersets.py:274
+#: dcim/forms/bulk_edit.py:249 dcim/forms/bulk_edit.py:388
+#: dcim/forms/filtersets.py:274
 msgid "Descending units"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:252 netbox/dcim/forms/bulk_edit.py:391
+#: dcim/forms/bulk_edit.py:252 dcim/forms/bulk_edit.py:391
 msgid "Outer width"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:257 netbox/dcim/forms/bulk_edit.py:396
+#: dcim/forms/bulk_edit.py:257 dcim/forms/bulk_edit.py:396
 msgid "Outer depth"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:262 netbox/dcim/forms/bulk_edit.py:401
-#: netbox/dcim/forms/bulk_import.py:204 netbox/dcim/forms/bulk_import.py:271
+#: dcim/forms/bulk_edit.py:262 dcim/forms/bulk_edit.py:401
+#: dcim/forms/bulk_import.py:204 dcim/forms/bulk_import.py:271
 msgid "Outer unit"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:267 netbox/dcim/forms/bulk_edit.py:406
+#: dcim/forms/bulk_edit.py:267 dcim/forms/bulk_edit.py:406
 msgid "Mounting depth"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:272 netbox/dcim/forms/bulk_edit.py:299
-#: netbox/dcim/forms/bulk_edit.py:416 netbox/dcim/forms/bulk_edit.py:446
-#: netbox/dcim/forms/bulk_edit.py:529 netbox/dcim/forms/bulk_edit.py:552
-#: netbox/dcim/forms/bulk_edit.py:573 netbox/dcim/forms/bulk_edit.py:595
-#: netbox/dcim/forms/bulk_import.py:384 netbox/dcim/forms/bulk_import.py:416
-#: netbox/dcim/forms/filtersets.py:285 netbox/dcim/forms/filtersets.py:307
-#: netbox/dcim/forms/filtersets.py:327 netbox/dcim/forms/filtersets.py:401
-#: netbox/dcim/forms/filtersets.py:488 netbox/dcim/forms/filtersets.py:594
-#: netbox/dcim/forms/filtersets.py:613 netbox/dcim/forms/filtersets.py:674
-#: netbox/dcim/forms/model_forms.py:221 netbox/dcim/forms/model_forms.py:298
-#: netbox/dcim/tables/devicetypes.py:106 netbox/dcim/tables/modules.py:35
-#: netbox/dcim/tables/racks.py:74 netbox/dcim/tables/racks.py:172
-#: netbox/extras/forms/bulk_edit.py:53 netbox/extras/forms/bulk_edit.py:133
-#: netbox/extras/forms/bulk_edit.py:183 netbox/extras/forms/bulk_edit.py:288
-#: netbox/extras/forms/filtersets.py:64 netbox/extras/forms/filtersets.py:156
-#: netbox/extras/forms/filtersets.py:243 netbox/ipam/forms/bulk_edit.py:190
-#: netbox/templates/dcim/device.html:324
-#: netbox/templates/dcim/devicetype.html:49
-#: netbox/templates/dcim/moduletype.html:45 netbox/templates/dcim/rack.html:81
-#: netbox/templates/dcim/racktype.html:41
-#: netbox/templates/extras/configcontext.html:17
-#: netbox/templates/extras/customlink.html:25
-#: netbox/templates/extras/savedfilter.html:33
-#: netbox/templates/ipam/role.html:30
+#: dcim/forms/bulk_edit.py:272 dcim/forms/bulk_edit.py:299
+#: dcim/forms/bulk_edit.py:416 dcim/forms/bulk_edit.py:446
+#: dcim/forms/bulk_edit.py:529 dcim/forms/bulk_edit.py:552
+#: dcim/forms/bulk_edit.py:573 dcim/forms/bulk_edit.py:595
+#: dcim/forms/bulk_import.py:384 dcim/forms/bulk_import.py:416
+#: dcim/forms/filtersets.py:285 dcim/forms/filtersets.py:307
+#: dcim/forms/filtersets.py:327 dcim/forms/filtersets.py:401
+#: dcim/forms/filtersets.py:488 dcim/forms/filtersets.py:594
+#: dcim/forms/filtersets.py:613 dcim/forms/filtersets.py:674
+#: dcim/forms/model_forms.py:221 dcim/forms/model_forms.py:298
+#: dcim/tables/devicetypes.py:106 dcim/tables/modules.py:35
+#: dcim/tables/racks.py:74 dcim/tables/racks.py:172
+#: extras/forms/bulk_edit.py:53 extras/forms/bulk_edit.py:133
+#: extras/forms/bulk_edit.py:183 extras/forms/bulk_edit.py:288
+#: extras/forms/filtersets.py:64 extras/forms/filtersets.py:156
+#: extras/forms/filtersets.py:243 ipam/forms/bulk_edit.py:190
+#: templates/dcim/device.html:324 templates/dcim/devicetype.html:49
+#: templates/dcim/moduletype.html:45 templates/dcim/rack.html:81
+#: templates/dcim/racktype.html:41 templates/extras/configcontext.html:17
+#: templates/extras/customlink.html:25 templates/extras/savedfilter.html:33
+#: templates/ipam/role.html:30
 msgid "Weight"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:277 netbox/dcim/forms/bulk_edit.py:421
-#: netbox/dcim/forms/filtersets.py:290
+#: dcim/forms/bulk_edit.py:277 dcim/forms/bulk_edit.py:421
+#: dcim/forms/filtersets.py:290
 msgid "Max weight"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:282 netbox/dcim/forms/bulk_edit.py:426
-#: netbox/dcim/forms/bulk_edit.py:534 netbox/dcim/forms/bulk_edit.py:578
-#: netbox/dcim/forms/bulk_import.py:210 netbox/dcim/forms/bulk_import.py:283
-#: netbox/dcim/forms/bulk_import.py:389 netbox/dcim/forms/bulk_import.py:421
-#: netbox/dcim/forms/filtersets.py:295 netbox/dcim/forms/filtersets.py:598
-#: netbox/dcim/forms/filtersets.py:678
+#: dcim/forms/bulk_edit.py:282 dcim/forms/bulk_edit.py:426
+#: dcim/forms/bulk_edit.py:534 dcim/forms/bulk_edit.py:578
+#: dcim/forms/bulk_import.py:210 dcim/forms/bulk_import.py:283
+#: dcim/forms/bulk_import.py:389 dcim/forms/bulk_import.py:421
+#: dcim/forms/filtersets.py:295 dcim/forms/filtersets.py:598
+#: dcim/forms/filtersets.py:678
 msgid "Weight unit"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:296 netbox/dcim/forms/filtersets.py:305
-#: netbox/dcim/forms/model_forms.py:217 netbox/dcim/forms/model_forms.py:256
-#: netbox/templates/dcim/rack.html:45 netbox/templates/dcim/racktype.html:13
+#: dcim/forms/bulk_edit.py:296 dcim/forms/filtersets.py:305
+#: dcim/forms/model_forms.py:217 dcim/forms/model_forms.py:256
+#: templates/dcim/rack.html:45 templates/dcim/racktype.html:13
 msgid "Rack Type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:298 netbox/dcim/forms/model_forms.py:220
-#: netbox/dcim/forms/model_forms.py:297
+#: dcim/forms/bulk_edit.py:298 dcim/forms/model_forms.py:220
+#: dcim/forms/model_forms.py:297
 msgid "Outer Dimensions"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:301 netbox/dcim/forms/model_forms.py:222
-#: netbox/dcim/forms/model_forms.py:299 netbox/templates/dcim/device.html:315
-#: netbox/templates/dcim/inc/panels/racktype_dimensions.html:3
+#: dcim/forms/bulk_edit.py:301 dcim/forms/model_forms.py:222
+#: dcim/forms/model_forms.py:299 templates/dcim/device.html:315
+#: templates/dcim/inc/panels/racktype_dimensions.html:3
 msgid "Dimensions"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:303 netbox/dcim/forms/filtersets.py:306
-#: netbox/dcim/forms/filtersets.py:326 netbox/dcim/forms/model_forms.py:224
-#: netbox/templates/dcim/inc/panels/racktype_numbering.html:3
+#: dcim/forms/bulk_edit.py:303 dcim/forms/filtersets.py:306
+#: dcim/forms/filtersets.py:326 dcim/forms/model_forms.py:224
+#: templates/dcim/inc/panels/racktype_numbering.html:3
 msgid "Numbering"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:357 netbox/dcim/forms/bulk_edit.py:1262
-#: netbox/dcim/forms/bulk_edit.py:1655 netbox/dcim/forms/bulk_import.py:253
-#: netbox/dcim/forms/bulk_import.py:1076 netbox/dcim/forms/filtersets.py:367
-#: netbox/dcim/forms/filtersets.py:777 netbox/dcim/forms/filtersets.py:1534
-#: netbox/dcim/forms/model_forms.py:251 netbox/dcim/forms/model_forms.py:1070
-#: netbox/dcim/forms/model_forms.py:1510 netbox/dcim/forms/object_import.py:181
-#: netbox/dcim/tables/devices.py:169 netbox/dcim/tables/devices.py:809
-#: netbox/dcim/tables/devices.py:937 netbox/dcim/tables/devicetypes.py:304
-#: netbox/dcim/tables/racks.py:129 netbox/extras/filtersets.py:552
-#: netbox/ipam/forms/bulk_edit.py:261 netbox/ipam/forms/bulk_edit.py:311
-#: netbox/ipam/forms/bulk_edit.py:359 netbox/ipam/forms/bulk_edit.py:511
-#: netbox/ipam/forms/bulk_import.py:197 netbox/ipam/forms/bulk_import.py:262
-#: netbox/ipam/forms/bulk_import.py:298 netbox/ipam/forms/bulk_import.py:455
-#: netbox/ipam/forms/filtersets.py:237 netbox/ipam/forms/filtersets.py:289
-#: netbox/ipam/forms/filtersets.py:360 netbox/ipam/forms/filtersets.py:509
-#: netbox/ipam/forms/model_forms.py:188 netbox/ipam/forms/model_forms.py:221
-#: netbox/ipam/forms/model_forms.py:250 netbox/ipam/forms/model_forms.py:643
-#: netbox/ipam/tables/ip.py:258 netbox/ipam/tables/ip.py:316
-#: netbox/ipam/tables/ip.py:367 netbox/ipam/tables/vlans.py:130
-#: netbox/ipam/tables/vlans.py:235 netbox/templates/dcim/device.html:182
-#: netbox/templates/dcim/inc/panels/inventory_items.html:20
-#: netbox/templates/dcim/interface.html:223
-#: netbox/templates/dcim/inventoryitem.html:36
-#: netbox/templates/dcim/rack.html:49 netbox/templates/ipam/ipaddress.html:41
-#: netbox/templates/ipam/iprange.html:50 netbox/templates/ipam/prefix.html:77
-#: netbox/templates/ipam/role.html:19 netbox/templates/ipam/vlan.html:52
-#: netbox/templates/virtualization/virtualmachine.html:23
-#: netbox/templates/vpn/tunneltermination.html:17
-#: netbox/templates/wireless/inc/wirelesslink_interface.html:20
-#: netbox/tenancy/forms/bulk_edit.py:142 netbox/tenancy/forms/filtersets.py:107
-#: netbox/tenancy/forms/model_forms.py:137
-#: netbox/tenancy/tables/contacts.py:102
-#: netbox/virtualization/forms/bulk_edit.py:145
-#: netbox/virtualization/forms/bulk_import.py:106
-#: netbox/virtualization/forms/filtersets.py:157
-#: netbox/virtualization/forms/model_forms.py:195
-#: netbox/virtualization/tables/virtualmachines.py:75
-#: netbox/vpn/forms/bulk_edit.py:87 netbox/vpn/forms/bulk_import.py:81
-#: netbox/vpn/forms/filtersets.py:85 netbox/vpn/forms/model_forms.py:78
-#: netbox/vpn/forms/model_forms.py:113 netbox/vpn/tables/tunnels.py:82
+#: dcim/forms/bulk_edit.py:357 dcim/forms/bulk_edit.py:1262
+#: dcim/forms/bulk_edit.py:1655 dcim/forms/bulk_import.py:253
+#: dcim/forms/bulk_import.py:1076 dcim/forms/filtersets.py:367
+#: dcim/forms/filtersets.py:777 dcim/forms/filtersets.py:1534
+#: dcim/forms/model_forms.py:251 dcim/forms/model_forms.py:1070
+#: dcim/forms/model_forms.py:1510 dcim/forms/object_import.py:181
+#: dcim/tables/devices.py:169 dcim/tables/devices.py:809
+#: dcim/tables/devices.py:937 dcim/tables/devicetypes.py:304
+#: dcim/tables/racks.py:129 extras/filtersets.py:552
+#: ipam/forms/bulk_edit.py:261 ipam/forms/bulk_edit.py:311
+#: ipam/forms/bulk_edit.py:359 ipam/forms/bulk_edit.py:511
+#: ipam/forms/bulk_import.py:197 ipam/forms/bulk_import.py:262
+#: ipam/forms/bulk_import.py:298 ipam/forms/bulk_import.py:455
+#: ipam/forms/filtersets.py:237 ipam/forms/filtersets.py:289
+#: ipam/forms/filtersets.py:360 ipam/forms/filtersets.py:509
+#: ipam/forms/model_forms.py:188 ipam/forms/model_forms.py:221
+#: ipam/forms/model_forms.py:250 ipam/forms/model_forms.py:643
+#: ipam/tables/ip.py:258 ipam/tables/ip.py:316 ipam/tables/ip.py:367
+#: ipam/tables/vlans.py:130 ipam/tables/vlans.py:235
+#: templates/dcim/device.html:182
+#: templates/dcim/inc/panels/inventory_items.html:20
+#: templates/dcim/interface.html:223 templates/dcim/inventoryitem.html:36
+#: templates/dcim/rack.html:49 templates/ipam/ipaddress.html:41
+#: templates/ipam/iprange.html:50 templates/ipam/prefix.html:77
+#: templates/ipam/role.html:19 templates/ipam/vlan.html:52
+#: templates/virtualization/virtualmachine.html:23
+#: templates/vpn/tunneltermination.html:17
+#: templates/wireless/inc/wirelesslink_interface.html:20
+#: tenancy/forms/bulk_edit.py:142 tenancy/forms/filtersets.py:107
+#: tenancy/forms/model_forms.py:137 tenancy/tables/contacts.py:102
+#: virtualization/forms/bulk_edit.py:145
+#: virtualization/forms/bulk_import.py:106
+#: virtualization/forms/filtersets.py:157
+#: virtualization/forms/model_forms.py:195
+#: virtualization/tables/virtualmachines.py:75 vpn/forms/bulk_edit.py:87
+#: vpn/forms/bulk_import.py:81 vpn/forms/filtersets.py:85
+#: vpn/forms/model_forms.py:78 vpn/forms/model_forms.py:113
+#: vpn/tables/tunnels.py:82
 msgid "Role"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:364 netbox/dcim/forms/bulk_edit.py:712
-#: netbox/dcim/forms/bulk_edit.py:764 netbox/templates/dcim/device.html:104
-#: netbox/templates/dcim/module.html:77 netbox/templates/dcim/modulebay.html:70
-#: netbox/templates/dcim/rack.html:57
-#: netbox/templates/virtualization/virtualmachine.html:35
+#: dcim/forms/bulk_edit.py:364 dcim/forms/bulk_edit.py:712
+#: dcim/forms/bulk_edit.py:764 templates/dcim/device.html:104
+#: templates/dcim/module.html:77 templates/dcim/modulebay.html:70
+#: templates/dcim/rack.html:57 templates/virtualization/virtualmachine.html:35
 msgid "Serial Number"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:367 netbox/dcim/forms/filtersets.py:387
-#: netbox/dcim/forms/filtersets.py:813 netbox/dcim/forms/filtersets.py:967
-#: netbox/dcim/forms/filtersets.py:1546
+#: dcim/forms/bulk_edit.py:367 dcim/forms/filtersets.py:387
+#: dcim/forms/filtersets.py:813 dcim/forms/filtersets.py:967
+#: dcim/forms/filtersets.py:1546
 msgid "Asset tag"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:411 netbox/dcim/forms/bulk_edit.py:524
-#: netbox/dcim/forms/bulk_edit.py:568 netbox/dcim/forms/bulk_edit.py:705
-#: netbox/dcim/forms/bulk_import.py:277 netbox/dcim/forms/bulk_import.py:410
-#: netbox/dcim/forms/bulk_import.py:580 netbox/dcim/forms/filtersets.py:280
-#: netbox/dcim/forms/filtersets.py:511 netbox/dcim/forms/filtersets.py:669
-#: netbox/dcim/forms/filtersets.py:804 netbox/templates/dcim/device.html:98
-#: netbox/templates/dcim/devicetype.html:65
-#: netbox/templates/dcim/moduletype.html:41 netbox/templates/dcim/rack.html:65
-#: netbox/templates/dcim/racktype.html:28
+#: dcim/forms/bulk_edit.py:411 dcim/forms/bulk_edit.py:524
+#: dcim/forms/bulk_edit.py:568 dcim/forms/bulk_edit.py:705
+#: dcim/forms/bulk_import.py:277 dcim/forms/bulk_import.py:410
+#: dcim/forms/bulk_import.py:580 dcim/forms/filtersets.py:280
+#: dcim/forms/filtersets.py:511 dcim/forms/filtersets.py:669
+#: dcim/forms/filtersets.py:804 templates/dcim/device.html:98
+#: templates/dcim/devicetype.html:65 templates/dcim/moduletype.html:41
+#: templates/dcim/rack.html:65 templates/dcim/racktype.html:28
 msgid "Airflow"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:440 netbox/dcim/forms/bulk_edit.py:910
-#: netbox/dcim/forms/bulk_import.py:322 netbox/dcim/forms/bulk_import.py:325
-#: netbox/dcim/forms/bulk_import.py:553 netbox/dcim/forms/bulk_import.py:1358
-#: netbox/dcim/forms/bulk_import.py:1362 netbox/dcim/forms/filtersets.py:104
-#: netbox/dcim/forms/filtersets.py:324 netbox/dcim/forms/filtersets.py:405
-#: netbox/dcim/forms/filtersets.py:419 netbox/dcim/forms/filtersets.py:457
-#: netbox/dcim/forms/filtersets.py:772 netbox/dcim/forms/filtersets.py:1035
-#: netbox/dcim/forms/filtersets.py:1167 netbox/dcim/forms/model_forms.py:264
-#: netbox/dcim/forms/model_forms.py:306 netbox/dcim/forms/model_forms.py:479
-#: netbox/dcim/forms/model_forms.py:755 netbox/dcim/forms/object_create.py:400
-#: netbox/dcim/tables/devices.py:161 netbox/dcim/tables/power.py:70
-#: netbox/dcim/tables/racks.py:217 netbox/ipam/forms/filtersets.py:442
-#: netbox/templates/dcim/device.html:30
-#: netbox/templates/dcim/inc/cable_termination.html:16
-#: netbox/templates/dcim/powerfeed.html:28 netbox/templates/dcim/rack.html:13
-#: netbox/templates/dcim/rack/base.html:4
-#: netbox/templates/dcim/rackreservation.html:19
-#: netbox/templates/dcim/rackreservation.html:36
-#: netbox/virtualization/forms/model_forms.py:113
+#: dcim/forms/bulk_edit.py:440 dcim/forms/bulk_edit.py:910
+#: dcim/forms/bulk_import.py:322 dcim/forms/bulk_import.py:325
+#: dcim/forms/bulk_import.py:553 dcim/forms/bulk_import.py:1358
+#: dcim/forms/bulk_import.py:1362 dcim/forms/filtersets.py:104
+#: dcim/forms/filtersets.py:324 dcim/forms/filtersets.py:405
+#: dcim/forms/filtersets.py:419 dcim/forms/filtersets.py:457
+#: dcim/forms/filtersets.py:772 dcim/forms/filtersets.py:1035
+#: dcim/forms/filtersets.py:1167 dcim/forms/model_forms.py:264
+#: dcim/forms/model_forms.py:306 dcim/forms/model_forms.py:479
+#: dcim/forms/model_forms.py:755 dcim/forms/object_create.py:400
+#: dcim/tables/devices.py:161 dcim/tables/power.py:70 dcim/tables/racks.py:217
+#: ipam/forms/filtersets.py:442 templates/dcim/device.html:30
+#: templates/dcim/inc/cable_termination.html:16
+#: templates/dcim/powerfeed.html:28 templates/dcim/rack.html:13
+#: templates/dcim/rack/base.html:4 templates/dcim/rackreservation.html:19
+#: templates/dcim/rackreservation.html:36
+#: virtualization/forms/model_forms.py:113
 msgid "Rack"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:444 netbox/dcim/forms/bulk_edit.py:730
-#: netbox/dcim/forms/filtersets.py:325 netbox/dcim/forms/filtersets.py:398
-#: netbox/dcim/forms/filtersets.py:481 netbox/dcim/forms/filtersets.py:608
-#: netbox/dcim/forms/filtersets.py:721 netbox/dcim/forms/filtersets.py:942
-#: netbox/dcim/forms/model_forms.py:670 netbox/dcim/forms/model_forms.py:1580
-#: netbox/templates/dcim/device_edit.html:20
+#: dcim/forms/bulk_edit.py:444 dcim/forms/bulk_edit.py:730
+#: dcim/forms/filtersets.py:325 dcim/forms/filtersets.py:398
+#: dcim/forms/filtersets.py:481 dcim/forms/filtersets.py:608
+#: dcim/forms/filtersets.py:721 dcim/forms/filtersets.py:942
+#: dcim/forms/model_forms.py:670 dcim/forms/model_forms.py:1580
+#: templates/dcim/device_edit.html:20
 msgid "Hardware"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:500 netbox/dcim/forms/bulk_import.py:377
-#: netbox/dcim/forms/filtersets.py:499 netbox/dcim/forms/model_forms.py:353
+#: dcim/forms/bulk_edit.py:500 dcim/forms/bulk_import.py:377
+#: dcim/forms/filtersets.py:499 dcim/forms/model_forms.py:353
 msgid "Default platform"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:505 netbox/dcim/forms/bulk_edit.py:564
-#: netbox/dcim/forms/filtersets.py:502 netbox/dcim/forms/filtersets.py:622
+#: dcim/forms/bulk_edit.py:505 dcim/forms/bulk_edit.py:564
+#: dcim/forms/filtersets.py:502 dcim/forms/filtersets.py:622
 msgid "Part number"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:509
+#: dcim/forms/bulk_edit.py:509
 msgid "U height"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:521 netbox/dcim/tables/devicetypes.py:102
+#: dcim/forms/bulk_edit.py:521 dcim/tables/devicetypes.py:102
 msgid "Exclude from utilization"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:550 netbox/dcim/forms/model_forms.py:368
-#: netbox/dcim/tables/devicetypes.py:77 netbox/templates/dcim/device.html:88
-#: netbox/templates/dcim/devicebay.html:52 netbox/templates/dcim/module.html:61
+#: dcim/forms/bulk_edit.py:550 dcim/forms/model_forms.py:368
+#: dcim/tables/devicetypes.py:77 templates/dcim/device.html:88
+#: templates/dcim/devicebay.html:52 templates/dcim/module.html:61
 msgid "Device Type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:592 netbox/dcim/forms/model_forms.py:401
-#: netbox/dcim/tables/modules.py:17 netbox/dcim/tables/modules.py:65
-#: netbox/templates/dcim/module.html:65 netbox/templates/dcim/modulebay.html:66
-#: netbox/templates/dcim/moduletype.html:22
+#: dcim/forms/bulk_edit.py:592 dcim/forms/model_forms.py:401
+#: dcim/tables/modules.py:17 dcim/tables/modules.py:65
+#: templates/dcim/module.html:65 templates/dcim/modulebay.html:66
+#: templates/dcim/moduletype.html:22
 msgid "Module Type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:596 netbox/dcim/forms/model_forms.py:371
-#: netbox/dcim/forms/model_forms.py:402
-#: netbox/templates/dcim/devicetype.html:11
+#: dcim/forms/bulk_edit.py:596 dcim/forms/model_forms.py:371
+#: dcim/forms/model_forms.py:402 templates/dcim/devicetype.html:11
 msgid "Chassis"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:610 netbox/dcim/models/devices.py:484
-#: netbox/dcim/tables/devices.py:67
+#: dcim/forms/bulk_edit.py:610 dcim/models/devices.py:484
+#: dcim/tables/devices.py:67
 msgid "VM role"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:613 netbox/dcim/forms/bulk_edit.py:637
-#: netbox/dcim/forms/bulk_edit.py:720 netbox/dcim/forms/bulk_import.py:434
-#: netbox/dcim/forms/bulk_import.py:438 netbox/dcim/forms/bulk_import.py:457
-#: netbox/dcim/forms/bulk_import.py:461 netbox/dcim/forms/bulk_import.py:586
-#: netbox/dcim/forms/bulk_import.py:590 netbox/dcim/forms/filtersets.py:689
-#: netbox/dcim/forms/filtersets.py:705 netbox/dcim/forms/filtersets.py:823
-#: netbox/dcim/forms/model_forms.py:415 netbox/dcim/forms/model_forms.py:441
-#: netbox/dcim/forms/model_forms.py:555
-#: netbox/virtualization/forms/bulk_import.py:132
-#: netbox/virtualization/forms/bulk_import.py:133
-#: netbox/virtualization/forms/filtersets.py:188
-#: netbox/virtualization/forms/model_forms.py:215
+#: dcim/forms/bulk_edit.py:613 dcim/forms/bulk_edit.py:637
+#: dcim/forms/bulk_edit.py:720 dcim/forms/bulk_import.py:434
+#: dcim/forms/bulk_import.py:438 dcim/forms/bulk_import.py:457
+#: dcim/forms/bulk_import.py:461 dcim/forms/bulk_import.py:586
+#: dcim/forms/bulk_import.py:590 dcim/forms/filtersets.py:689
+#: dcim/forms/filtersets.py:705 dcim/forms/filtersets.py:823
+#: dcim/forms/model_forms.py:415 dcim/forms/model_forms.py:441
+#: dcim/forms/model_forms.py:555 virtualization/forms/bulk_import.py:132
+#: virtualization/forms/bulk_import.py:133
+#: virtualization/forms/filtersets.py:188
+#: virtualization/forms/model_forms.py:215
 msgid "Config template"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:661 netbox/dcim/forms/bulk_edit.py:1061
-#: netbox/dcim/forms/bulk_import.py:492 netbox/dcim/forms/filtersets.py:114
-#: netbox/dcim/forms/model_forms.py:501 netbox/dcim/forms/model_forms.py:872
-#: netbox/dcim/forms/model_forms.py:889 netbox/extras/filtersets.py:547
+#: dcim/forms/bulk_edit.py:661 dcim/forms/bulk_edit.py:1061
+#: dcim/forms/bulk_import.py:492 dcim/forms/filtersets.py:114
+#: dcim/forms/model_forms.py:501 dcim/forms/model_forms.py:872
+#: dcim/forms/model_forms.py:889 extras/filtersets.py:547
 msgid "Device type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:672 netbox/dcim/forms/bulk_import.py:473
-#: netbox/dcim/forms/filtersets.py:119 netbox/dcim/forms/model_forms.py:509
+#: dcim/forms/bulk_edit.py:672 dcim/forms/bulk_import.py:473
+#: dcim/forms/filtersets.py:119 dcim/forms/model_forms.py:509
 msgid "Device role"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:695 netbox/dcim/forms/bulk_import.py:498
-#: netbox/dcim/forms/filtersets.py:796 netbox/dcim/forms/model_forms.py:451
-#: netbox/dcim/forms/model_forms.py:513 netbox/dcim/tables/devices.py:182
-#: netbox/extras/filtersets.py:563 netbox/templates/dcim/device.html:186
-#: netbox/templates/dcim/platform.html:26
-#: netbox/templates/virtualization/virtualmachine.html:27
-#: netbox/virtualization/forms/bulk_edit.py:160
-#: netbox/virtualization/forms/bulk_import.py:122
-#: netbox/virtualization/forms/filtersets.py:168
-#: netbox/virtualization/forms/model_forms.py:203
-#: netbox/virtualization/tables/virtualmachines.py:79
+#: dcim/forms/bulk_edit.py:695 dcim/forms/bulk_import.py:498
+#: dcim/forms/filtersets.py:796 dcim/forms/model_forms.py:451
+#: dcim/forms/model_forms.py:513 dcim/tables/devices.py:182
+#: extras/filtersets.py:563 templates/dcim/device.html:186
+#: templates/dcim/platform.html:26
+#: templates/virtualization/virtualmachine.html:27
+#: virtualization/forms/bulk_edit.py:160
+#: virtualization/forms/bulk_import.py:122
+#: virtualization/forms/filtersets.py:168
+#: virtualization/forms/model_forms.py:203
+#: virtualization/tables/virtualmachines.py:79
 msgid "Platform"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:728 netbox/dcim/forms/bulk_edit.py:1281
-#: netbox/dcim/forms/bulk_edit.py:1650 netbox/dcim/forms/bulk_edit.py:1696
-#: netbox/dcim/forms/bulk_import.py:641 netbox/dcim/forms/bulk_import.py:703
-#: netbox/dcim/forms/bulk_import.py:729 netbox/dcim/forms/bulk_import.py:755
-#: netbox/dcim/forms/bulk_import.py:775 netbox/dcim/forms/bulk_import.py:828
-#: netbox/dcim/forms/bulk_import.py:946 netbox/dcim/forms/bulk_import.py:994
-#: netbox/dcim/forms/bulk_import.py:1011 netbox/dcim/forms/bulk_import.py:1023
-#: netbox/dcim/forms/bulk_import.py:1071 netbox/dcim/forms/bulk_import.py:1422
-#: netbox/dcim/forms/connections.py:24 netbox/dcim/forms/filtersets.py:131
-#: netbox/dcim/forms/filtersets.py:921 netbox/dcim/forms/filtersets.py:1051
-#: netbox/dcim/forms/filtersets.py:1242 netbox/dcim/forms/filtersets.py:1267
-#: netbox/dcim/forms/filtersets.py:1291 netbox/dcim/forms/filtersets.py:1311
-#: netbox/dcim/forms/filtersets.py:1334 netbox/dcim/forms/filtersets.py:1444
-#: netbox/dcim/forms/filtersets.py:1469 netbox/dcim/forms/filtersets.py:1493
-#: netbox/dcim/forms/filtersets.py:1511 netbox/dcim/forms/filtersets.py:1528
-#: netbox/dcim/forms/filtersets.py:1592 netbox/dcim/forms/filtersets.py:1616
-#: netbox/dcim/forms/filtersets.py:1640 netbox/dcim/forms/model_forms.py:633
-#: netbox/dcim/forms/model_forms.py:849 netbox/dcim/forms/model_forms.py:1208
-#: netbox/dcim/forms/model_forms.py:1664 netbox/dcim/forms/object_create.py:257
-#: netbox/dcim/tables/connections.py:22 netbox/dcim/tables/connections.py:41
-#: netbox/dcim/tables/connections.py:60 netbox/dcim/tables/devices.py:285
-#: netbox/dcim/tables/devices.py:371 netbox/dcim/tables/devices.py:412
-#: netbox/dcim/tables/devices.py:454 netbox/dcim/tables/devices.py:505
-#: netbox/dcim/tables/devices.py:597 netbox/dcim/tables/devices.py:697
-#: netbox/dcim/tables/devices.py:754 netbox/dcim/tables/devices.py:801
-#: netbox/dcim/tables/devices.py:861 netbox/dcim/tables/devices.py:930
-#: netbox/dcim/tables/devices.py:1057 netbox/dcim/tables/modules.py:52
-#: netbox/extras/forms/filtersets.py:321 netbox/ipam/forms/bulk_import.py:304
-#: netbox/ipam/forms/bulk_import.py:481 netbox/ipam/forms/filtersets.py:551
-#: netbox/ipam/forms/model_forms.py:319 netbox/ipam/forms/model_forms.py:679
-#: netbox/ipam/forms/model_forms.py:712 netbox/ipam/forms/model_forms.py:738
-#: netbox/ipam/tables/vlans.py:180 netbox/templates/dcim/consoleport.html:20
-#: netbox/templates/dcim/consoleserverport.html:20
-#: netbox/templates/dcim/device.html:15 netbox/templates/dcim/device.html:130
-#: netbox/templates/dcim/device_edit.html:10
-#: netbox/templates/dcim/devicebay.html:20
-#: netbox/templates/dcim/devicebay.html:48
-#: netbox/templates/dcim/frontport.html:20
-#: netbox/templates/dcim/interface.html:30
-#: netbox/templates/dcim/interface.html:161
-#: netbox/templates/dcim/inventoryitem.html:20
-#: netbox/templates/dcim/module.html:57 netbox/templates/dcim/modulebay.html:20
-#: netbox/templates/dcim/poweroutlet.html:20
-#: netbox/templates/dcim/powerport.html:20
-#: netbox/templates/dcim/rearport.html:20
-#: netbox/templates/dcim/virtualchassis.html:65
-#: netbox/templates/dcim/virtualchassis_edit.html:51
-#: netbox/templates/dcim/virtualdevicecontext.html:22
-#: netbox/templates/virtualization/virtualmachine.html:114
-#: netbox/templates/vpn/tunneltermination.html:23
-#: netbox/templates/wireless/inc/wirelesslink_interface.html:6
-#: netbox/virtualization/filtersets.py:167
-#: netbox/virtualization/forms/bulk_edit.py:137
-#: netbox/virtualization/forms/bulk_import.py:99
-#: netbox/virtualization/forms/filtersets.py:128
-#: netbox/virtualization/forms/model_forms.py:185
-#: netbox/virtualization/tables/virtualmachines.py:71 netbox/vpn/choices.py:44
-#: netbox/vpn/forms/bulk_import.py:86 netbox/vpn/forms/bulk_import.py:283
-#: netbox/vpn/forms/filtersets.py:275 netbox/vpn/forms/model_forms.py:90
-#: netbox/vpn/forms/model_forms.py:125 netbox/vpn/forms/model_forms.py:236
-#: netbox/vpn/forms/model_forms.py:453 netbox/wireless/forms/model_forms.py:99
-#: netbox/wireless/forms/model_forms.py:141
-#: netbox/wireless/tables/wirelesslan.py:75
+#: dcim/forms/bulk_edit.py:728 dcim/forms/bulk_edit.py:1281
+#: dcim/forms/bulk_edit.py:1650 dcim/forms/bulk_edit.py:1696
+#: dcim/forms/bulk_import.py:641 dcim/forms/bulk_import.py:703
+#: dcim/forms/bulk_import.py:729 dcim/forms/bulk_import.py:755
+#: dcim/forms/bulk_import.py:775 dcim/forms/bulk_import.py:828
+#: dcim/forms/bulk_import.py:946 dcim/forms/bulk_import.py:994
+#: dcim/forms/bulk_import.py:1011 dcim/forms/bulk_import.py:1023
+#: dcim/forms/bulk_import.py:1071 dcim/forms/bulk_import.py:1422
+#: dcim/forms/connections.py:24 dcim/forms/filtersets.py:131
+#: dcim/forms/filtersets.py:921 dcim/forms/filtersets.py:1051
+#: dcim/forms/filtersets.py:1242 dcim/forms/filtersets.py:1267
+#: dcim/forms/filtersets.py:1291 dcim/forms/filtersets.py:1311
+#: dcim/forms/filtersets.py:1334 dcim/forms/filtersets.py:1444
+#: dcim/forms/filtersets.py:1469 dcim/forms/filtersets.py:1493
+#: dcim/forms/filtersets.py:1511 dcim/forms/filtersets.py:1528
+#: dcim/forms/filtersets.py:1592 dcim/forms/filtersets.py:1616
+#: dcim/forms/filtersets.py:1640 dcim/forms/model_forms.py:633
+#: dcim/forms/model_forms.py:849 dcim/forms/model_forms.py:1208
+#: dcim/forms/model_forms.py:1664 dcim/forms/object_create.py:257
+#: dcim/tables/connections.py:22 dcim/tables/connections.py:41
+#: dcim/tables/connections.py:60 dcim/tables/devices.py:285
+#: dcim/tables/devices.py:371 dcim/tables/devices.py:412
+#: dcim/tables/devices.py:454 dcim/tables/devices.py:505
+#: dcim/tables/devices.py:597 dcim/tables/devices.py:697
+#: dcim/tables/devices.py:754 dcim/tables/devices.py:801
+#: dcim/tables/devices.py:861 dcim/tables/devices.py:930
+#: dcim/tables/devices.py:1057 dcim/tables/modules.py:52
+#: extras/forms/filtersets.py:321 ipam/forms/bulk_import.py:304
+#: ipam/forms/bulk_import.py:481 ipam/forms/filtersets.py:551
+#: ipam/forms/model_forms.py:319 ipam/forms/model_forms.py:679
+#: ipam/forms/model_forms.py:712 ipam/forms/model_forms.py:738
+#: ipam/tables/vlans.py:180 templates/dcim/consoleport.html:20
+#: templates/dcim/consoleserverport.html:20 templates/dcim/device.html:15
+#: templates/dcim/device.html:130 templates/dcim/device_edit.html:10
+#: templates/dcim/devicebay.html:20 templates/dcim/devicebay.html:48
+#: templates/dcim/frontport.html:20 templates/dcim/interface.html:30
+#: templates/dcim/interface.html:161 templates/dcim/inventoryitem.html:20
+#: templates/dcim/module.html:57 templates/dcim/modulebay.html:20
+#: templates/dcim/poweroutlet.html:20 templates/dcim/powerport.html:20
+#: templates/dcim/rearport.html:20 templates/dcim/virtualchassis.html:65
+#: templates/dcim/virtualchassis_edit.html:51
+#: templates/dcim/virtualdevicecontext.html:22
+#: templates/virtualization/virtualmachine.html:114
+#: templates/vpn/tunneltermination.html:23
+#: templates/wireless/inc/wirelesslink_interface.html:6
+#: virtualization/filtersets.py:167 virtualization/forms/bulk_edit.py:137
+#: virtualization/forms/bulk_import.py:99
+#: virtualization/forms/filtersets.py:128
+#: virtualization/forms/model_forms.py:185
+#: virtualization/tables/virtualmachines.py:71 vpn/choices.py:44
+#: vpn/forms/bulk_import.py:86 vpn/forms/bulk_import.py:283
+#: vpn/forms/filtersets.py:275 vpn/forms/model_forms.py:90
+#: vpn/forms/model_forms.py:125 vpn/forms/model_forms.py:236
+#: vpn/forms/model_forms.py:453 wireless/forms/model_forms.py:99
+#: wireless/forms/model_forms.py:141 wireless/tables/wirelesslan.py:75
 msgid "Device"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:731
-#: netbox/templates/extras/dashboard/widget_config.html:7
-#: netbox/virtualization/forms/bulk_edit.py:191
+#: dcim/forms/bulk_edit.py:731 templates/extras/dashboard/widget_config.html:7
+#: virtualization/forms/bulk_edit.py:191
 msgid "Configuration"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:745 netbox/dcim/forms/bulk_import.py:653
-#: netbox/dcim/forms/model_forms.py:647 netbox/dcim/forms/model_forms.py:897
+#: dcim/forms/bulk_edit.py:745 dcim/forms/bulk_import.py:653
+#: dcim/forms/model_forms.py:647 dcim/forms/model_forms.py:897
 msgid "Module type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:799 netbox/dcim/forms/bulk_edit.py:984
-#: netbox/dcim/forms/bulk_edit.py:1003 netbox/dcim/forms/bulk_edit.py:1026
-#: netbox/dcim/forms/bulk_edit.py:1068 netbox/dcim/forms/bulk_edit.py:1112
-#: netbox/dcim/forms/bulk_edit.py:1163 netbox/dcim/forms/bulk_edit.py:1190
-#: netbox/dcim/forms/bulk_edit.py:1217 netbox/dcim/forms/bulk_edit.py:1235
-#: netbox/dcim/forms/bulk_edit.py:1253 netbox/dcim/forms/filtersets.py:67
-#: netbox/dcim/forms/object_create.py:46 netbox/templates/dcim/cable.html:32
-#: netbox/templates/dcim/consoleport.html:32
-#: netbox/templates/dcim/consoleserverport.html:32
-#: netbox/templates/dcim/devicebay.html:28
-#: netbox/templates/dcim/frontport.html:32
-#: netbox/templates/dcim/inc/panels/inventory_items.html:19
-#: netbox/templates/dcim/interface.html:42
-#: netbox/templates/dcim/inventoryitem.html:32
-#: netbox/templates/dcim/modulebay.html:34
-#: netbox/templates/dcim/poweroutlet.html:32
-#: netbox/templates/dcim/powerport.html:32
-#: netbox/templates/dcim/rearport.html:32
-#: netbox/templates/extras/customfield.html:26
-#: netbox/templates/generic/bulk_import.html:162
+#: dcim/forms/bulk_edit.py:799 dcim/forms/bulk_edit.py:984
+#: dcim/forms/bulk_edit.py:1003 dcim/forms/bulk_edit.py:1026
+#: dcim/forms/bulk_edit.py:1068 dcim/forms/bulk_edit.py:1112
+#: dcim/forms/bulk_edit.py:1163 dcim/forms/bulk_edit.py:1190
+#: dcim/forms/bulk_edit.py:1217 dcim/forms/bulk_edit.py:1235
+#: dcim/forms/bulk_edit.py:1253 dcim/forms/filtersets.py:67
+#: dcim/forms/object_create.py:46 templates/dcim/cable.html:32
+#: templates/dcim/consoleport.html:32 templates/dcim/consoleserverport.html:32
+#: templates/dcim/devicebay.html:28 templates/dcim/frontport.html:32
+#: templates/dcim/inc/panels/inventory_items.html:19
+#: templates/dcim/interface.html:42 templates/dcim/inventoryitem.html:32
+#: templates/dcim/modulebay.html:34 templates/dcim/poweroutlet.html:32
+#: templates/dcim/powerport.html:32 templates/dcim/rearport.html:32
+#: templates/extras/customfield.html:26 templates/generic/bulk_import.html:162
 msgid "Label"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:808 netbox/dcim/forms/filtersets.py:1068
-#: netbox/templates/dcim/cable.html:50
+#: dcim/forms/bulk_edit.py:808 dcim/forms/filtersets.py:1068
+#: templates/dcim/cable.html:50
 msgid "Length"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:813 netbox/dcim/forms/bulk_import.py:1226
-#: netbox/dcim/forms/bulk_import.py:1229 netbox/dcim/forms/filtersets.py:1072
+#: dcim/forms/bulk_edit.py:813 dcim/forms/bulk_import.py:1226
+#: dcim/forms/bulk_import.py:1229 dcim/forms/filtersets.py:1072
 msgid "Length unit"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:837
-#: netbox/templates/dcim/virtualchassis.html:23
+#: dcim/forms/bulk_edit.py:837 templates/dcim/virtualchassis.html:23
 msgid "Domain"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:905 netbox/dcim/forms/bulk_import.py:1345
-#: netbox/dcim/forms/filtersets.py:1158 netbox/dcim/forms/model_forms.py:750
+#: dcim/forms/bulk_edit.py:905 dcim/forms/bulk_import.py:1345
+#: dcim/forms/filtersets.py:1158 dcim/forms/model_forms.py:750
 msgid "Power panel"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:927 netbox/dcim/forms/bulk_import.py:1381
-#: netbox/dcim/forms/filtersets.py:1180 netbox/templates/dcim/powerfeed.html:83
+#: dcim/forms/bulk_edit.py:927 dcim/forms/bulk_import.py:1381
+#: dcim/forms/filtersets.py:1180 templates/dcim/powerfeed.html:83
 msgid "Supply"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:933 netbox/dcim/forms/bulk_import.py:1386
-#: netbox/dcim/forms/filtersets.py:1185 netbox/templates/dcim/powerfeed.html:95
+#: dcim/forms/bulk_edit.py:933 dcim/forms/bulk_import.py:1386
+#: dcim/forms/filtersets.py:1185 templates/dcim/powerfeed.html:95
 msgid "Phase"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:939 netbox/dcim/forms/filtersets.py:1190
-#: netbox/templates/dcim/powerfeed.html:87
+#: dcim/forms/bulk_edit.py:939 dcim/forms/filtersets.py:1190
+#: templates/dcim/powerfeed.html:87
 msgid "Voltage"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:943 netbox/dcim/forms/filtersets.py:1194
-#: netbox/templates/dcim/powerfeed.html:91
+#: dcim/forms/bulk_edit.py:943 dcim/forms/filtersets.py:1194
+#: templates/dcim/powerfeed.html:91
 msgid "Amperage"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:947 netbox/dcim/forms/filtersets.py:1198
+#: dcim/forms/bulk_edit.py:947 dcim/forms/filtersets.py:1198
 msgid "Max utilization"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1036
+#: dcim/forms/bulk_edit.py:1036
 msgid "Maximum draw"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1039
-#: netbox/dcim/models/device_component_templates.py:282
-#: netbox/dcim/models/device_components.py:356
+#: dcim/forms/bulk_edit.py:1039 dcim/models/device_component_templates.py:282
+#: dcim/models/device_components.py:356
 msgid "Maximum power draw (watts)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1042
+#: dcim/forms/bulk_edit.py:1042
 msgid "Allocated draw"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1045
-#: netbox/dcim/models/device_component_templates.py:289
-#: netbox/dcim/models/device_components.py:363
+#: dcim/forms/bulk_edit.py:1045 dcim/models/device_component_templates.py:289
+#: dcim/models/device_components.py:363
 msgid "Allocated power draw (watts)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1078 netbox/dcim/forms/bulk_import.py:786
-#: netbox/dcim/forms/model_forms.py:953 netbox/dcim/forms/model_forms.py:1278
-#: netbox/dcim/forms/model_forms.py:1567 netbox/dcim/forms/object_import.py:55
+#: dcim/forms/bulk_edit.py:1078 dcim/forms/bulk_import.py:786
+#: dcim/forms/model_forms.py:953 dcim/forms/model_forms.py:1278
+#: dcim/forms/model_forms.py:1567 dcim/forms/object_import.py:55
 msgid "Power port"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1083 netbox/dcim/forms/bulk_import.py:793
+#: dcim/forms/bulk_edit.py:1083 dcim/forms/bulk_import.py:793
 msgid "Feed leg"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1129 netbox/dcim/forms/bulk_edit.py:1440
+#: dcim/forms/bulk_edit.py:1129 dcim/forms/bulk_edit.py:1440
 msgid "Management only"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1139 netbox/dcim/forms/bulk_edit.py:1446
-#: netbox/dcim/forms/bulk_import.py:876 netbox/dcim/forms/filtersets.py:1394
-#: netbox/dcim/forms/object_import.py:90
-#: netbox/dcim/models/device_component_templates.py:437
-#: netbox/dcim/models/device_components.py:670
+#: dcim/forms/bulk_edit.py:1139 dcim/forms/bulk_edit.py:1446
+#: dcim/forms/bulk_import.py:876 dcim/forms/filtersets.py:1394
+#: dcim/forms/object_import.py:90 dcim/models/device_component_templates.py:437
+#: dcim/models/device_components.py:670
 msgid "PoE mode"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1145 netbox/dcim/forms/bulk_edit.py:1452
-#: netbox/dcim/forms/bulk_import.py:882 netbox/dcim/forms/filtersets.py:1399
-#: netbox/dcim/forms/object_import.py:95
-#: netbox/dcim/models/device_component_templates.py:443
-#: netbox/dcim/models/device_components.py:676
+#: dcim/forms/bulk_edit.py:1145 dcim/forms/bulk_edit.py:1452
+#: dcim/forms/bulk_import.py:882 dcim/forms/filtersets.py:1399
+#: dcim/forms/object_import.py:95 dcim/models/device_component_templates.py:443
+#: dcim/models/device_components.py:676
 msgid "PoE type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1151 netbox/dcim/forms/filtersets.py:1404
-#: netbox/dcim/forms/object_import.py:100
+#: dcim/forms/bulk_edit.py:1151 dcim/forms/filtersets.py:1404
+#: dcim/forms/object_import.py:100
 msgid "Wireless role"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1288 netbox/dcim/forms/model_forms.py:669
-#: netbox/dcim/forms/model_forms.py:1223 netbox/dcim/tables/devices.py:313
-#: netbox/templates/dcim/consoleport.html:24
-#: netbox/templates/dcim/consoleserverport.html:24
-#: netbox/templates/dcim/frontport.html:24
-#: netbox/templates/dcim/interface.html:34 netbox/templates/dcim/module.html:54
-#: netbox/templates/dcim/modulebay.html:26
-#: netbox/templates/dcim/modulebay.html:58
-#: netbox/templates/dcim/poweroutlet.html:24
-#: netbox/templates/dcim/powerport.html:24
-#: netbox/templates/dcim/rearport.html:24
+#: dcim/forms/bulk_edit.py:1288 dcim/forms/model_forms.py:669
+#: dcim/forms/model_forms.py:1223 dcim/tables/devices.py:313
+#: templates/dcim/consoleport.html:24 templates/dcim/consoleserverport.html:24
+#: templates/dcim/frontport.html:24 templates/dcim/interface.html:34
+#: templates/dcim/module.html:54 templates/dcim/modulebay.html:26
+#: templates/dcim/modulebay.html:58 templates/dcim/poweroutlet.html:24
+#: templates/dcim/powerport.html:24 templates/dcim/rearport.html:24
 msgid "Module"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1420 netbox/dcim/tables/devices.py:665
-#: netbox/templates/dcim/interface.html:110
+#: dcim/forms/bulk_edit.py:1420 dcim/tables/devices.py:665
+#: templates/dcim/interface.html:110
 msgid "LAG"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1425 netbox/dcim/forms/model_forms.py:1305
+#: dcim/forms/bulk_edit.py:1425 dcim/forms/model_forms.py:1305
 msgid "Virtual device contexts"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1431 netbox/dcim/forms/bulk_import.py:714
-#: netbox/dcim/forms/bulk_import.py:740 netbox/dcim/forms/filtersets.py:1252
-#: netbox/dcim/forms/filtersets.py:1277 netbox/dcim/forms/filtersets.py:1358
-#: netbox/dcim/tables/devices.py:610
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:67
-#: netbox/templates/dcim/consoleport.html:40
-#: netbox/templates/dcim/consoleserverport.html:40
+#: dcim/forms/bulk_edit.py:1431 dcim/forms/bulk_import.py:714
+#: dcim/forms/bulk_import.py:740 dcim/forms/filtersets.py:1252
+#: dcim/forms/filtersets.py:1277 dcim/forms/filtersets.py:1358
+#: dcim/tables/devices.py:610
+#: templates/circuits/inc/circuit_termination_fields.html:67
+#: templates/dcim/consoleport.html:40 templates/dcim/consoleserverport.html:40
 msgid "Speed"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1460 netbox/dcim/forms/bulk_import.py:885
-#: netbox/templates/vpn/ikepolicy.html:25
-#: netbox/templates/vpn/ipsecprofile.html:21
-#: netbox/templates/vpn/ipsecprofile.html:48
-#: netbox/virtualization/forms/bulk_edit.py:233
-#: netbox/virtualization/forms/bulk_import.py:165
-#: netbox/vpn/forms/bulk_edit.py:146 netbox/vpn/forms/bulk_edit.py:232
-#: netbox/vpn/forms/bulk_import.py:176 netbox/vpn/forms/bulk_import.py:234
-#: netbox/vpn/forms/filtersets.py:135 netbox/vpn/forms/filtersets.py:178
-#: netbox/vpn/forms/filtersets.py:192 netbox/vpn/tables/crypto.py:64
-#: netbox/vpn/tables/crypto.py:162
+#: dcim/forms/bulk_edit.py:1460 dcim/forms/bulk_import.py:885
+#: templates/vpn/ikepolicy.html:25 templates/vpn/ipsecprofile.html:21
+#: templates/vpn/ipsecprofile.html:48 virtualization/forms/bulk_edit.py:233
+#: virtualization/forms/bulk_import.py:165 vpn/forms/bulk_edit.py:146
+#: vpn/forms/bulk_edit.py:232 vpn/forms/bulk_import.py:176
+#: vpn/forms/bulk_import.py:234 vpn/forms/filtersets.py:135
+#: vpn/forms/filtersets.py:178 vpn/forms/filtersets.py:192
+#: vpn/tables/crypto.py:64 vpn/tables/crypto.py:162
 msgid "Mode"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1468 netbox/dcim/forms/model_forms.py:1354
-#: netbox/ipam/forms/bulk_import.py:178 netbox/ipam/forms/filtersets.py:498
-#: netbox/ipam/models/vlans.py:84 netbox/virtualization/forms/bulk_edit.py:240
-#: netbox/virtualization/forms/model_forms.py:321
+#: dcim/forms/bulk_edit.py:1468 dcim/forms/model_forms.py:1354
+#: ipam/forms/bulk_import.py:178 ipam/forms/filtersets.py:498
+#: ipam/models/vlans.py:84 virtualization/forms/bulk_edit.py:240
+#: virtualization/forms/model_forms.py:321
 msgid "VLAN group"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1476 netbox/dcim/forms/model_forms.py:1360
-#: netbox/dcim/tables/devices.py:579
-#: netbox/virtualization/forms/bulk_edit.py:248
-#: netbox/virtualization/forms/model_forms.py:326
+#: dcim/forms/bulk_edit.py:1476 dcim/forms/model_forms.py:1360
+#: dcim/tables/devices.py:579 virtualization/forms/bulk_edit.py:248
+#: virtualization/forms/model_forms.py:326
 msgid "Untagged VLAN"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1484 netbox/dcim/forms/model_forms.py:1369
-#: netbox/dcim/tables/devices.py:585
-#: netbox/virtualization/forms/bulk_edit.py:256
-#: netbox/virtualization/forms/model_forms.py:335
+#: dcim/forms/bulk_edit.py:1484 dcim/forms/model_forms.py:1369
+#: dcim/tables/devices.py:585 virtualization/forms/bulk_edit.py:256
+#: virtualization/forms/model_forms.py:335
 msgid "Tagged VLANs"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1494 netbox/dcim/forms/model_forms.py:1341
+#: dcim/forms/bulk_edit.py:1494 dcim/forms/model_forms.py:1341
 msgid "Wireless LAN group"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1499 netbox/dcim/forms/model_forms.py:1346
-#: netbox/dcim/tables/devices.py:619 netbox/netbox/navigation/menu.py:146
-#: netbox/templates/dcim/interface.html:280
-#: netbox/wireless/tables/wirelesslan.py:24
+#: dcim/forms/bulk_edit.py:1499 dcim/forms/model_forms.py:1346
+#: dcim/tables/devices.py:619 netbox/navigation/menu.py:146
+#: templates/dcim/interface.html:280 wireless/tables/wirelesslan.py:24
 msgid "Wireless LANs"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1508 netbox/dcim/forms/filtersets.py:1328
-#: netbox/dcim/forms/model_forms.py:1390 netbox/ipam/forms/bulk_edit.py:286
-#: netbox/ipam/forms/bulk_edit.py:378 netbox/ipam/forms/filtersets.py:169
-#: netbox/templates/dcim/interface.html:122
-#: netbox/templates/ipam/prefix.html:95
-#: netbox/virtualization/forms/model_forms.py:349
+#: dcim/forms/bulk_edit.py:1508 dcim/forms/filtersets.py:1328
+#: dcim/forms/model_forms.py:1390 ipam/forms/bulk_edit.py:286
+#: ipam/forms/bulk_edit.py:378 ipam/forms/filtersets.py:169
+#: templates/dcim/interface.html:122 templates/ipam/prefix.html:95
+#: virtualization/forms/model_forms.py:349
 msgid "Addressing"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1509 netbox/dcim/forms/filtersets.py:720
-#: netbox/dcim/forms/model_forms.py:1391
-#: netbox/virtualization/forms/model_forms.py:350
+#: dcim/forms/bulk_edit.py:1509 dcim/forms/filtersets.py:720
+#: dcim/forms/model_forms.py:1391 virtualization/forms/model_forms.py:350
 msgid "Operation"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1510 netbox/dcim/forms/filtersets.py:1329
-#: netbox/dcim/forms/model_forms.py:987 netbox/dcim/forms/model_forms.py:1393
+#: dcim/forms/bulk_edit.py:1510 dcim/forms/filtersets.py:1329
+#: dcim/forms/model_forms.py:987 dcim/forms/model_forms.py:1393
 msgid "PoE"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1511 netbox/dcim/forms/model_forms.py:1392
-#: netbox/templates/dcim/interface.html:99
-#: netbox/virtualization/forms/bulk_edit.py:267
-#: netbox/virtualization/forms/model_forms.py:351
+#: dcim/forms/bulk_edit.py:1511 dcim/forms/model_forms.py:1392
+#: templates/dcim/interface.html:99 virtualization/forms/bulk_edit.py:267
+#: virtualization/forms/model_forms.py:351
 msgid "Related Interfaces"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1512 netbox/dcim/forms/model_forms.py:1394
-#: netbox/virtualization/forms/bulk_edit.py:268
-#: netbox/virtualization/forms/model_forms.py:352
+#: dcim/forms/bulk_edit.py:1512 dcim/forms/model_forms.py:1394
+#: virtualization/forms/bulk_edit.py:268
+#: virtualization/forms/model_forms.py:352
 msgid "802.1Q Switching"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1574 netbox/dcim/forms/bulk_edit.py:1576
+#: dcim/forms/bulk_edit.py:1574 dcim/forms/bulk_edit.py:1576
 msgid "Interface mode must be specified to assign VLANs"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_edit.py:1581 netbox/dcim/forms/common.py:50
+#: dcim/forms/bulk_edit.py:1581 dcim/forms/common.py:50
 msgid "An access interface cannot have tagged VLANs assigned."
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:64
+#: dcim/forms/bulk_import.py:64
 msgid "Name of parent region"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:78
+#: dcim/forms/bulk_import.py:78
 msgid "Name of parent site group"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:97
+#: dcim/forms/bulk_import.py:97
 msgid "Assigned region"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:104 netbox/tenancy/forms/bulk_import.py:44
-#: netbox/tenancy/forms/bulk_import.py:85
-#: netbox/wireless/forms/bulk_import.py:40
+#: dcim/forms/bulk_import.py:104 tenancy/forms/bulk_import.py:44
+#: tenancy/forms/bulk_import.py:85 wireless/forms/bulk_import.py:40
 msgid "Assigned group"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:123
+#: dcim/forms/bulk_import.py:123
 msgid "available options"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:134 netbox/dcim/forms/bulk_import.py:543
-#: netbox/dcim/forms/bulk_import.py:1342 netbox/ipam/forms/bulk_import.py:175
-#: netbox/ipam/forms/bulk_import.py:433
-#: netbox/virtualization/forms/bulk_import.py:63
-#: netbox/virtualization/forms/bulk_import.py:89
+#: dcim/forms/bulk_import.py:134 dcim/forms/bulk_import.py:543
+#: dcim/forms/bulk_import.py:1342 ipam/forms/bulk_import.py:175
+#: ipam/forms/bulk_import.py:433 virtualization/forms/bulk_import.py:63
+#: virtualization/forms/bulk_import.py:89
 msgid "Assigned site"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:141
+#: dcim/forms/bulk_import.py:141
 msgid "Parent location"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:143
+#: dcim/forms/bulk_import.py:143
 msgid "Location not found."
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:185
+#: dcim/forms/bulk_import.py:185
 msgid "The manufacturer of this rack type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:196
+#: dcim/forms/bulk_import.py:196
 msgid "The lowest-numbered position in the rack"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:201 netbox/dcim/forms/bulk_import.py:268
+#: dcim/forms/bulk_import.py:201 dcim/forms/bulk_import.py:268
 msgid "Rail-to-rail width (in inches)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:207 netbox/dcim/forms/bulk_import.py:274
+#: dcim/forms/bulk_import.py:207 dcim/forms/bulk_import.py:274
 msgid "Unit for outer dimensions"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:213 netbox/dcim/forms/bulk_import.py:286
+#: dcim/forms/bulk_import.py:213 dcim/forms/bulk_import.py:286
 msgid "Unit for rack weights"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:245
+#: dcim/forms/bulk_import.py:245
 msgid "Name of assigned tenant"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:257
+#: dcim/forms/bulk_import.py:257
 msgid "Name of assigned role"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:280 netbox/dcim/forms/bulk_import.py:413
-#: netbox/dcim/forms/bulk_import.py:583
+#: dcim/forms/bulk_import.py:280 dcim/forms/bulk_import.py:413
+#: dcim/forms/bulk_import.py:583
 msgid "Airflow direction"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:312
+#: dcim/forms/bulk_import.py:312
 msgid "Parent site"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:319 netbox/dcim/forms/bulk_import.py:1355
+#: dcim/forms/bulk_import.py:319 dcim/forms/bulk_import.py:1355
 msgid "Rack's location (if any)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:328 netbox/dcim/forms/model_forms.py:311
-#: netbox/dcim/tables/racks.py:222
-#: netbox/templates/dcim/rackreservation.html:12
-#: netbox/templates/dcim/rackreservation.html:45
+#: dcim/forms/bulk_import.py:328 dcim/forms/model_forms.py:311
+#: dcim/tables/racks.py:222 templates/dcim/rackreservation.html:12
+#: templates/dcim/rackreservation.html:45
 msgid "Units"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:331
+#: dcim/forms/bulk_import.py:331
 msgid "Comma-separated list of individual unit numbers"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:374
+#: dcim/forms/bulk_import.py:374
 msgid "The manufacturer which produces this device type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:381
+#: dcim/forms/bulk_import.py:381
 msgid "The default platform for devices of this type (optional)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:386
+#: dcim/forms/bulk_import.py:386
 msgid "Device weight"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:392
+#: dcim/forms/bulk_import.py:392
 msgid "Unit for device weight"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:418
+#: dcim/forms/bulk_import.py:418
 msgid "Module weight"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:424
+#: dcim/forms/bulk_import.py:424
 msgid "Unit for module weight"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:454
+#: dcim/forms/bulk_import.py:454
 msgid "Limit platform assignments to this manufacturer"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:476 netbox/dcim/forms/bulk_import.py:1425
-#: netbox/tenancy/forms/bulk_import.py:106
+#: dcim/forms/bulk_import.py:476 dcim/forms/bulk_import.py:1425
+#: tenancy/forms/bulk_import.py:106
 msgid "Assigned role"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:489
+#: dcim/forms/bulk_import.py:489
 msgid "Device type manufacturer"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:495
+#: dcim/forms/bulk_import.py:495
 msgid "Device type model"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:502
-#: netbox/virtualization/forms/bulk_import.py:126
+#: dcim/forms/bulk_import.py:502 virtualization/forms/bulk_import.py:126
 msgid "Assigned platform"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:510 netbox/dcim/forms/bulk_import.py:514
-#: netbox/dcim/forms/model_forms.py:536
+#: dcim/forms/bulk_import.py:510 dcim/forms/bulk_import.py:514
+#: dcim/forms/model_forms.py:536
 msgid "Virtual chassis"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:517 netbox/dcim/forms/filtersets.py:728
-#: netbox/dcim/forms/filtersets.py:898 netbox/dcim/forms/model_forms.py:522
-#: netbox/dcim/tables/devices.py:202 netbox/extras/filtersets.py:596
-#: netbox/extras/forms/filtersets.py:322 netbox/ipam/forms/filtersets.py:415
-#: netbox/ipam/forms/filtersets.py:447 netbox/templates/dcim/device.html:239
-#: netbox/templates/virtualization/cluster.html:10
-#: netbox/templates/virtualization/virtualmachine.html:92
-#: netbox/templates/virtualization/virtualmachine.html:101
-#: netbox/virtualization/filtersets.py:157
-#: netbox/virtualization/filtersets.py:277
-#: netbox/virtualization/forms/bulk_edit.py:129
-#: netbox/virtualization/forms/bulk_import.py:92
-#: netbox/virtualization/forms/filtersets.py:99
-#: netbox/virtualization/forms/filtersets.py:123
-#: netbox/virtualization/forms/filtersets.py:204
-#: netbox/virtualization/forms/model_forms.py:79
-#: netbox/virtualization/forms/model_forms.py:176
-#: netbox/virtualization/tables/virtualmachines.py:67
+#: dcim/forms/bulk_import.py:517 dcim/forms/filtersets.py:728
+#: dcim/forms/filtersets.py:898 dcim/forms/model_forms.py:522
+#: dcim/tables/devices.py:202 extras/filtersets.py:596
+#: extras/forms/filtersets.py:322 ipam/forms/filtersets.py:415
+#: ipam/forms/filtersets.py:447 templates/dcim/device.html:239
+#: templates/virtualization/cluster.html:10
+#: templates/virtualization/virtualmachine.html:92
+#: templates/virtualization/virtualmachine.html:101
+#: virtualization/filtersets.py:157 virtualization/filtersets.py:277
+#: virtualization/forms/bulk_edit.py:129 virtualization/forms/bulk_import.py:92
+#: virtualization/forms/filtersets.py:99 virtualization/forms/filtersets.py:123
+#: virtualization/forms/filtersets.py:204
+#: virtualization/forms/model_forms.py:79
+#: virtualization/forms/model_forms.py:176
+#: virtualization/tables/virtualmachines.py:67
 msgid "Cluster"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:521
+#: dcim/forms/bulk_import.py:521
 msgid "Virtualization cluster"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:550
+#: dcim/forms/bulk_import.py:550
 msgid "Assigned location (if any)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:557
+#: dcim/forms/bulk_import.py:557
 msgid "Assigned rack (if any)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:560
+#: dcim/forms/bulk_import.py:560
 msgid "Face"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:563
+#: dcim/forms/bulk_import.py:563
 msgid "Mounted rack face"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:570
+#: dcim/forms/bulk_import.py:570
 msgid "Parent device (for child devices)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:573
+#: dcim/forms/bulk_import.py:573
 msgid "Device bay"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:577
+#: dcim/forms/bulk_import.py:577
 msgid "Device bay in which this device is installed (for child devices)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:644
+#: dcim/forms/bulk_import.py:644
 msgid "The device in which this module is installed"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:647 netbox/dcim/forms/model_forms.py:640
+#: dcim/forms/bulk_import.py:647 dcim/forms/model_forms.py:640
 msgid "Module bay"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:650
+#: dcim/forms/bulk_import.py:650
 msgid "The module bay in which this module is installed"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:656
+#: dcim/forms/bulk_import.py:656
 msgid "The type of module"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:664 netbox/dcim/forms/model_forms.py:656
+#: dcim/forms/bulk_import.py:664 dcim/forms/model_forms.py:656
 msgid "Replicate components"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:666
+#: dcim/forms/bulk_import.py:666
 msgid ""
 "Automatically populate components associated with this module type (enabled "
 "by default)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:669 netbox/dcim/forms/model_forms.py:662
+#: dcim/forms/bulk_import.py:669 dcim/forms/model_forms.py:662
 msgid "Adopt components"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:671 netbox/dcim/forms/model_forms.py:665
+#: dcim/forms/bulk_import.py:671 dcim/forms/model_forms.py:665
 msgid "Adopt already existing components"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:711 netbox/dcim/forms/bulk_import.py:737
-#: netbox/dcim/forms/bulk_import.py:763
+#: dcim/forms/bulk_import.py:711 dcim/forms/bulk_import.py:737
+#: dcim/forms/bulk_import.py:763
 msgid "Port type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:719 netbox/dcim/forms/bulk_import.py:745
+#: dcim/forms/bulk_import.py:719 dcim/forms/bulk_import.py:745
 msgid "Port speed in bps"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:783
+#: dcim/forms/bulk_import.py:783
 msgid "Outlet type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:790
+#: dcim/forms/bulk_import.py:790
 msgid "Local power port which feeds this outlet"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:796
+#: dcim/forms/bulk_import.py:796
 msgid "Electrical phase (for three-phase circuits)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:837 netbox/dcim/forms/model_forms.py:1316
-#: netbox/virtualization/forms/bulk_import.py:155
-#: netbox/virtualization/forms/model_forms.py:305
+#: dcim/forms/bulk_import.py:837 dcim/forms/model_forms.py:1316
+#: virtualization/forms/bulk_import.py:155
+#: virtualization/forms/model_forms.py:305
 msgid "Parent interface"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:844 netbox/dcim/forms/model_forms.py:1324
-#: netbox/virtualization/forms/bulk_import.py:162
-#: netbox/virtualization/forms/model_forms.py:313
+#: dcim/forms/bulk_import.py:844 dcim/forms/model_forms.py:1324
+#: virtualization/forms/bulk_import.py:162
+#: virtualization/forms/model_forms.py:313
 msgid "Bridged interface"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:847
+#: dcim/forms/bulk_import.py:847
 msgid "Lag"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:851
+#: dcim/forms/bulk_import.py:851
 msgid "Parent LAG interface"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:854
+#: dcim/forms/bulk_import.py:854
 msgid "Vdcs"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:859
+#: dcim/forms/bulk_import.py:859
 msgid "VDC names separated by commas, encased with double quotes. Example:"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:865
+#: dcim/forms/bulk_import.py:865
 msgid "Physical medium"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:868 netbox/dcim/forms/filtersets.py:1365
+#: dcim/forms/bulk_import.py:868 dcim/forms/filtersets.py:1365
 msgid "Duplex"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:873
+#: dcim/forms/bulk_import.py:873
 msgid "Poe mode"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:879
+#: dcim/forms/bulk_import.py:879
 msgid "Poe type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:888
-#: netbox/virtualization/forms/bulk_import.py:168
+#: dcim/forms/bulk_import.py:888 virtualization/forms/bulk_import.py:168
 msgid "IEEE 802.1Q operational mode (for L2 interfaces)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:895 netbox/ipam/forms/bulk_import.py:161
-#: netbox/ipam/forms/bulk_import.py:247 netbox/ipam/forms/bulk_import.py:283
-#: netbox/ipam/forms/filtersets.py:201 netbox/ipam/forms/filtersets.py:277
-#: netbox/ipam/forms/filtersets.py:336
-#: netbox/virtualization/forms/bulk_import.py:175
+#: dcim/forms/bulk_import.py:895 ipam/forms/bulk_import.py:161
+#: ipam/forms/bulk_import.py:247 ipam/forms/bulk_import.py:283
+#: ipam/forms/filtersets.py:201 ipam/forms/filtersets.py:277
+#: ipam/forms/filtersets.py:336 virtualization/forms/bulk_import.py:175
 msgid "Assigned VRF"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:898
+#: dcim/forms/bulk_import.py:898
 msgid "Rf role"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:901
+#: dcim/forms/bulk_import.py:901
 msgid "Wireless role (AP/station)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:937
+#: dcim/forms/bulk_import.py:937
 #, python-brace-format
 msgid "VDC {vdc} is not assigned to device {device}"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:951 netbox/dcim/forms/model_forms.py:1000
-#: netbox/dcim/forms/model_forms.py:1575 netbox/dcim/forms/object_import.py:117
+#: dcim/forms/bulk_import.py:951 dcim/forms/model_forms.py:1000
+#: dcim/forms/model_forms.py:1575 dcim/forms/object_import.py:117
 msgid "Rear port"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:954
+#: dcim/forms/bulk_import.py:954
 msgid "Corresponding rear port"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:959 netbox/dcim/forms/bulk_import.py:1000
-#: netbox/dcim/forms/bulk_import.py:1216
+#: dcim/forms/bulk_import.py:959 dcim/forms/bulk_import.py:1000
+#: dcim/forms/bulk_import.py:1216
 msgid "Physical medium classification"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1028 netbox/dcim/tables/devices.py:822
+#: dcim/forms/bulk_import.py:1028 dcim/tables/devices.py:822
 msgid "Installed device"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1032
+#: dcim/forms/bulk_import.py:1032
 msgid "Child device installed within this bay"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1034
+#: dcim/forms/bulk_import.py:1034
 msgid "Child device not found."
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1092
+#: dcim/forms/bulk_import.py:1092
 msgid "Parent inventory item"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1095
+#: dcim/forms/bulk_import.py:1095
 msgid "Component type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1099
+#: dcim/forms/bulk_import.py:1099
 msgid "Component Type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1102
+#: dcim/forms/bulk_import.py:1102
 msgid "Compnent name"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1104
+#: dcim/forms/bulk_import.py:1104
 msgid "Component Name"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1146
+#: dcim/forms/bulk_import.py:1146
 #, python-brace-format
 msgid "Component not found: {device} - {component_name}"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1171
+#: dcim/forms/bulk_import.py:1171
 msgid "Side A device"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1174 netbox/dcim/forms/bulk_import.py:1192
+#: dcim/forms/bulk_import.py:1174 dcim/forms/bulk_import.py:1192
 msgid "Device name"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1177
+#: dcim/forms/bulk_import.py:1177
 msgid "Side A type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1180 netbox/dcim/forms/bulk_import.py:1198
+#: dcim/forms/bulk_import.py:1180 dcim/forms/bulk_import.py:1198
 msgid "Termination type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1183
+#: dcim/forms/bulk_import.py:1183
 msgid "Side A name"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1184 netbox/dcim/forms/bulk_import.py:1202
+#: dcim/forms/bulk_import.py:1184 dcim/forms/bulk_import.py:1202
 msgid "Termination name"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1189
+#: dcim/forms/bulk_import.py:1189
 msgid "Side B device"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1195
+#: dcim/forms/bulk_import.py:1195
 msgid "Side B type"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1201
+#: dcim/forms/bulk_import.py:1201
 msgid "Side B name"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1210
-#: netbox/wireless/forms/bulk_import.py:86
+#: dcim/forms/bulk_import.py:1210 wireless/forms/bulk_import.py:86
 msgid "Connection status"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1262
+#: dcim/forms/bulk_import.py:1262
 #, python-brace-format
 msgid "Side {side_upper}: {device} {termination_object} is already connected"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1268
+#: dcim/forms/bulk_import.py:1268
 #, python-brace-format
 msgid "{side_upper} side termination not found: {device} {name}"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1293 netbox/dcim/forms/model_forms.py:785
-#: netbox/dcim/tables/devices.py:1027 netbox/templates/dcim/device.html:132
-#: netbox/templates/dcim/virtualchassis.html:27
-#: netbox/templates/dcim/virtualchassis.html:67
+#: dcim/forms/bulk_import.py:1293 dcim/forms/model_forms.py:785
+#: dcim/tables/devices.py:1027 templates/dcim/device.html:132
+#: templates/dcim/virtualchassis.html:27 templates/dcim/virtualchassis.html:67
 msgid "Master"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1297
+#: dcim/forms/bulk_import.py:1297
 msgid "Master device"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1314
+#: dcim/forms/bulk_import.py:1314
 msgid "Name of parent site"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1348
+#: dcim/forms/bulk_import.py:1348
 msgid "Upstream power panel"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1378
+#: dcim/forms/bulk_import.py:1378
 msgid "Primary or redundant"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1383
+#: dcim/forms/bulk_import.py:1383
 msgid "Supply type (AC/DC)"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1388
+#: dcim/forms/bulk_import.py:1388
 msgid "Single or three-phase"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1439 netbox/dcim/forms/model_forms.py:1670
-#: netbox/templates/dcim/device.html:190
-#: netbox/templates/dcim/virtualdevicecontext.html:30
-#: netbox/templates/virtualization/virtualmachine.html:52
+#: dcim/forms/bulk_import.py:1439 dcim/forms/model_forms.py:1670
+#: templates/dcim/device.html:190 templates/dcim/virtualdevicecontext.html:30
+#: templates/virtualization/virtualmachine.html:52
 msgid "Primary IPv4"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1443
+#: dcim/forms/bulk_import.py:1443
 msgid "IPv4 address with mask, e.g. 1.2.3.4/24"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1446 netbox/dcim/forms/model_forms.py:1679
-#: netbox/templates/dcim/device.html:206
-#: netbox/templates/dcim/virtualdevicecontext.html:41
-#: netbox/templates/virtualization/virtualmachine.html:68
+#: dcim/forms/bulk_import.py:1446 dcim/forms/model_forms.py:1679
+#: templates/dcim/device.html:206 templates/dcim/virtualdevicecontext.html:41
+#: templates/virtualization/virtualmachine.html:68
 msgid "Primary IPv6"
 msgstr ""
 
-#: netbox/dcim/forms/bulk_import.py:1450
+#: dcim/forms/bulk_import.py:1450
 msgid "IPv6 address with prefix length, e.g. 2001:db8::1/64"
 msgstr ""
 
-#: netbox/dcim/forms/common.py:24 netbox/dcim/models/device_components.py:527
-#: netbox/templates/dcim/interface.html:57
-#: netbox/templates/virtualization/vminterface.html:55
-#: netbox/virtualization/forms/bulk_edit.py:225
+#: dcim/forms/common.py:24 dcim/models/device_components.py:527
+#: templates/dcim/interface.html:57
+#: templates/virtualization/vminterface.html:55
+#: virtualization/forms/bulk_edit.py:225
 msgid "MTU"
 msgstr ""
 
-#: netbox/dcim/forms/common.py:65
+#: dcim/forms/common.py:65
 #, python-brace-format
 msgid ""
 "The tagged VLANs ({vlans}) must belong to the same site as the interface's "
 "parent device/VM, or they must be global"
 msgstr ""
 
-#: netbox/dcim/forms/common.py:126
+#: dcim/forms/common.py:126
 msgid ""
 "Cannot install module with placeholder values in a module bay with no "
 "position defined."
 msgstr ""
 
-#: netbox/dcim/forms/common.py:131
+#: dcim/forms/common.py:131
 #, python-brace-format
 msgid ""
 "Cannot install module with placeholder values in a module bay tree {level} "
 "in tree but {tokens} placeholders given."
 msgstr ""
 
-#: netbox/dcim/forms/common.py:144
+#: dcim/forms/common.py:144
 #, python-brace-format
 msgid "Cannot adopt {model} {name} as it already belongs to a module"
 msgstr ""
 
-#: netbox/dcim/forms/common.py:153
+#: dcim/forms/common.py:153
 #, python-brace-format
 msgid "A {model} named {name} already exists"
 msgstr ""
 
-#: netbox/dcim/forms/connections.py:49 netbox/dcim/forms/model_forms.py:738
-#: netbox/dcim/tables/power.py:66
-#: netbox/templates/dcim/inc/cable_termination.html:37
-#: netbox/templates/dcim/powerfeed.html:24
-#: netbox/templates/dcim/powerpanel.html:19
-#: netbox/templates/dcim/trace/powerpanel.html:4
+#: dcim/forms/connections.py:49 dcim/forms/model_forms.py:738
+#: dcim/tables/power.py:66 templates/dcim/inc/cable_termination.html:37
+#: templates/dcim/powerfeed.html:24 templates/dcim/powerpanel.html:19
+#: templates/dcim/trace/powerpanel.html:4
 msgid "Power Panel"
 msgstr ""
 
-#: netbox/dcim/forms/connections.py:58 netbox/dcim/forms/model_forms.py:765
-#: netbox/templates/dcim/powerfeed.html:21
-#: netbox/templates/dcim/powerport.html:80
+#: dcim/forms/connections.py:58 dcim/forms/model_forms.py:765
+#: templates/dcim/powerfeed.html:21 templates/dcim/powerport.html:80
 msgid "Power Feed"
 msgstr ""
 
-#: netbox/dcim/forms/connections.py:81
+#: dcim/forms/connections.py:81
 msgid "Side"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:136 netbox/dcim/tables/devices.py:295
+#: dcim/forms/filtersets.py:136 dcim/tables/devices.py:295
 msgid "Device Status"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:149
+#: dcim/forms/filtersets.py:149
 msgid "Parent region"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:163 netbox/tenancy/forms/bulk_import.py:28
-#: netbox/tenancy/forms/bulk_import.py:62 netbox/tenancy/forms/filtersets.py:33
-#: netbox/tenancy/forms/filtersets.py:62
-#: netbox/wireless/forms/bulk_import.py:25
-#: netbox/wireless/forms/filtersets.py:25
+#: dcim/forms/filtersets.py:163 tenancy/forms/bulk_import.py:28
+#: tenancy/forms/bulk_import.py:62 tenancy/forms/filtersets.py:33
+#: tenancy/forms/filtersets.py:62 wireless/forms/bulk_import.py:25
+#: wireless/forms/filtersets.py:25
 msgid "Parent group"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:242 netbox/templates/dcim/location.html:58
-#: netbox/templates/dcim/site.html:56
+#: dcim/forms/filtersets.py:242 templates/dcim/location.html:58
+#: templates/dcim/site.html:56
 msgid "Facility"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:380
+#: dcim/forms/filtersets.py:380
 msgid "Rack type"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:397
+#: dcim/forms/filtersets.py:397
 msgid "Function"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:483 netbox/dcim/forms/model_forms.py:373
-#: netbox/templates/inc/panels/image_attachments.html:6
+#: dcim/forms/filtersets.py:483 dcim/forms/model_forms.py:373
+#: templates/inc/panels/image_attachments.html:6
 msgid "Images"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:486 netbox/dcim/forms/filtersets.py:611
-#: netbox/dcim/forms/filtersets.py:726
+#: dcim/forms/filtersets.py:486 dcim/forms/filtersets.py:611
+#: dcim/forms/filtersets.py:726
 msgid "Components"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:506
+#: dcim/forms/filtersets.py:506
 msgid "Subdevice role"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:790 netbox/dcim/tables/racks.py:54
-#: netbox/templates/dcim/racktype.html:20
+#: dcim/forms/filtersets.py:790 dcim/tables/racks.py:54
+#: templates/dcim/racktype.html:20
 msgid "Model"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:834
+#: dcim/forms/filtersets.py:834
 msgid "Has an OOB IP"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:841
+#: dcim/forms/filtersets.py:841
 msgid "Virtual chassis member"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:890
+#: dcim/forms/filtersets.py:890
 msgid "Has virtual device contexts"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:903 netbox/extras/filtersets.py:585
-#: netbox/ipam/forms/filtersets.py:452
-#: netbox/virtualization/forms/filtersets.py:112
+#: dcim/forms/filtersets.py:903 extras/filtersets.py:585
+#: ipam/forms/filtersets.py:452 virtualization/forms/filtersets.py:112
 msgid "Cluster group"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:1210
+#: dcim/forms/filtersets.py:1210
 msgid "Cabled"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:1217
+#: dcim/forms/filtersets.py:1217
 msgid "Occupied"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:1244 netbox/dcim/forms/filtersets.py:1269
-#: netbox/dcim/forms/filtersets.py:1293 netbox/dcim/forms/filtersets.py:1313
-#: netbox/dcim/forms/filtersets.py:1336 netbox/dcim/tables/devices.py:364
-#: netbox/templates/dcim/consoleport.html:55
-#: netbox/templates/dcim/consoleserverport.html:55
-#: netbox/templates/dcim/frontport.html:69
-#: netbox/templates/dcim/interface.html:140
-#: netbox/templates/dcim/powerfeed.html:110
-#: netbox/templates/dcim/poweroutlet.html:59
-#: netbox/templates/dcim/powerport.html:59
-#: netbox/templates/dcim/rearport.html:65
+#: dcim/forms/filtersets.py:1244 dcim/forms/filtersets.py:1269
+#: dcim/forms/filtersets.py:1293 dcim/forms/filtersets.py:1313
+#: dcim/forms/filtersets.py:1336 dcim/tables/devices.py:364
+#: templates/dcim/consoleport.html:55 templates/dcim/consoleserverport.html:55
+#: templates/dcim/frontport.html:69 templates/dcim/interface.html:140
+#: templates/dcim/powerfeed.html:110 templates/dcim/poweroutlet.html:59
+#: templates/dcim/powerport.html:59 templates/dcim/rearport.html:65
 msgid "Connection"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:1348 netbox/extras/forms/bulk_edit.py:326
-#: netbox/extras/forms/bulk_import.py:247 netbox/extras/forms/filtersets.py:464
-#: netbox/extras/forms/model_forms.py:675 netbox/extras/tables/tables.py:579
-#: netbox/templates/extras/journalentry.html:30
+#: dcim/forms/filtersets.py:1348 extras/forms/bulk_edit.py:326
+#: extras/forms/bulk_import.py:247 extras/forms/filtersets.py:464
+#: extras/forms/model_forms.py:675 extras/tables/tables.py:579
+#: templates/extras/journalentry.html:30
 msgid "Kind"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:1377
+#: dcim/forms/filtersets.py:1377
 msgid "Mgmt only"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:1389 netbox/dcim/forms/model_forms.py:1383
-#: netbox/dcim/models/device_components.py:629
-#: netbox/templates/dcim/interface.html:129
+#: dcim/forms/filtersets.py:1389 dcim/forms/model_forms.py:1383
+#: dcim/models/device_components.py:629 templates/dcim/interface.html:129
 msgid "WWN"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:1409
+#: dcim/forms/filtersets.py:1409
 msgid "Wireless channel"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:1413
+#: dcim/forms/filtersets.py:1413
 msgid "Channel frequency (MHz)"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:1417
+#: dcim/forms/filtersets.py:1417
 msgid "Channel width (MHz)"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:1421 netbox/templates/dcim/interface.html:85
+#: dcim/forms/filtersets.py:1421 templates/dcim/interface.html:85
 msgid "Transmit power (dBm)"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:1446 netbox/dcim/forms/filtersets.py:1471
-#: netbox/dcim/tables/devices.py:327 netbox/templates/dcim/cable.html:12
-#: netbox/templates/dcim/cable_trace.html:46
-#: netbox/templates/dcim/frontport.html:77
-#: netbox/templates/dcim/htmx/cable_edit.html:50
-#: netbox/templates/dcim/inc/connection_endpoints.html:4
-#: netbox/templates/dcim/rearport.html:73
-#: netbox/templates/dcim/trace/cable.html:7
+#: dcim/forms/filtersets.py:1446 dcim/forms/filtersets.py:1471
+#: dcim/tables/devices.py:327 templates/dcim/cable.html:12
+#: templates/dcim/cable_trace.html:46 templates/dcim/frontport.html:77
+#: templates/dcim/htmx/cable_edit.html:50
+#: templates/dcim/inc/connection_endpoints.html:4
+#: templates/dcim/rearport.html:73 templates/dcim/trace/cable.html:7
 msgid "Cable"
 msgstr ""
 
-#: netbox/dcim/forms/filtersets.py:1550 netbox/dcim/tables/devices.py:949
+#: dcim/forms/filtersets.py:1550 dcim/tables/devices.py:949
 msgid "Discovered"
 msgstr ""
 
-#: netbox/dcim/forms/formsets.py:20
+#: dcim/forms/formsets.py:20
 #, python-brace-format
 msgid "A virtual chassis member already exists in position {vc_position}."
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:140
+#: dcim/forms/model_forms.py:140
 msgid "Contact Info"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:195 netbox/templates/dcim/rackrole.html:19
+#: dcim/forms/model_forms.py:195 templates/dcim/rackrole.html:19
 msgid "Rack Role"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:212 netbox/dcim/forms/model_forms.py:362
-#: netbox/dcim/forms/model_forms.py:446
-#: netbox/utilities/forms/fields/fields.py:47
+#: dcim/forms/model_forms.py:212 dcim/forms/model_forms.py:362
+#: dcim/forms/model_forms.py:446 utilities/forms/fields/fields.py:47
 msgid "Slug"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:259
+#: dcim/forms/model_forms.py:259
 msgid "Select a pre-defined rack type, or set physical characteristics below."
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:265
+#: dcim/forms/model_forms.py:265
 msgid "Inventory Control"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:313
+#: dcim/forms/model_forms.py:313
 msgid ""
 "Comma-separated list of numeric unit IDs. A range may be specified using a "
 "hyphen."
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:322 netbox/dcim/tables/racks.py:202
+#: dcim/forms/model_forms.py:322 dcim/tables/racks.py:202
 msgid "Reservation"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:423
-#: netbox/templates/dcim/devicerole.html:23
+#: dcim/forms/model_forms.py:423 templates/dcim/devicerole.html:23
 msgid "Device Role"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:490 netbox/dcim/models/devices.py:644
+#: dcim/forms/model_forms.py:490 dcim/models/devices.py:644
 msgid "The lowest-numbered unit occupied by the device"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:547
+#: dcim/forms/model_forms.py:547
 msgid "The position in the virtual chassis this device is identified by"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:552
+#: dcim/forms/model_forms.py:552
 msgid "The priority of the device in the virtual chassis"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:659
+#: dcim/forms/model_forms.py:659
 msgid "Automatically populate components associated with this module type"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:767
+#: dcim/forms/model_forms.py:767
 msgid "Characteristics"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1087
+#: dcim/forms/model_forms.py:1087
 msgid "Console port template"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1095
+#: dcim/forms/model_forms.py:1095
 msgid "Console server port template"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1103
+#: dcim/forms/model_forms.py:1103
 msgid "Front port template"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1111
+#: dcim/forms/model_forms.py:1111
 msgid "Interface template"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1119
+#: dcim/forms/model_forms.py:1119
 msgid "Power outlet template"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1127
+#: dcim/forms/model_forms.py:1127
 msgid "Power port template"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1135
+#: dcim/forms/model_forms.py:1135
 msgid "Rear port template"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1144 netbox/dcim/forms/model_forms.py:1388
-#: netbox/dcim/forms/model_forms.py:1551 netbox/dcim/forms/model_forms.py:1583
-#: netbox/dcim/tables/connections.py:65 netbox/ipam/forms/bulk_import.py:318
-#: netbox/ipam/forms/model_forms.py:280 netbox/ipam/forms/model_forms.py:289
-#: netbox/ipam/tables/fhrp.py:64 netbox/ipam/tables/ip.py:372
-#: netbox/ipam/tables/vlans.py:169
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:51
-#: netbox/templates/dcim/frontport.html:106
-#: netbox/templates/dcim/interface.html:27
-#: netbox/templates/dcim/interface.html:184
-#: netbox/templates/dcim/interface.html:310
-#: netbox/templates/dcim/rearport.html:102
-#: netbox/templates/virtualization/vminterface.html:18
-#: netbox/templates/vpn/tunneltermination.html:31
-#: netbox/templates/wireless/inc/wirelesslink_interface.html:10
-#: netbox/templates/wireless/wirelesslink.html:10
-#: netbox/templates/wireless/wirelesslink.html:55
-#: netbox/virtualization/forms/model_forms.py:348
-#: netbox/vpn/forms/bulk_import.py:297 netbox/vpn/forms/model_forms.py:436
-#: netbox/vpn/forms/model_forms.py:445 netbox/wireless/forms/model_forms.py:113
-#: netbox/wireless/forms/model_forms.py:155
+#: dcim/forms/model_forms.py:1144 dcim/forms/model_forms.py:1388
+#: dcim/forms/model_forms.py:1551 dcim/forms/model_forms.py:1583
+#: dcim/tables/connections.py:65 ipam/forms/bulk_import.py:318
+#: ipam/forms/model_forms.py:280 ipam/forms/model_forms.py:289
+#: ipam/tables/fhrp.py:64 ipam/tables/ip.py:372 ipam/tables/vlans.py:169
+#: templates/circuits/inc/circuit_termination_fields.html:51
+#: templates/dcim/frontport.html:106 templates/dcim/interface.html:27
+#: templates/dcim/interface.html:184 templates/dcim/interface.html:310
+#: templates/dcim/rearport.html:102
+#: templates/virtualization/vminterface.html:18
+#: templates/vpn/tunneltermination.html:31
+#: templates/wireless/inc/wirelesslink_interface.html:10
+#: templates/wireless/wirelesslink.html:10
+#: templates/wireless/wirelesslink.html:55
+#: virtualization/forms/model_forms.py:348 vpn/forms/bulk_import.py:297
+#: vpn/forms/model_forms.py:436 vpn/forms/model_forms.py:445
+#: wireless/forms/model_forms.py:113 wireless/forms/model_forms.py:155
 msgid "Interface"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1145 netbox/dcim/forms/model_forms.py:1584
-#: netbox/dcim/tables/connections.py:27
-#: netbox/templates/dcim/consoleport.html:17
-#: netbox/templates/dcim/consoleserverport.html:74
-#: netbox/templates/dcim/frontport.html:112
+#: dcim/forms/model_forms.py:1145 dcim/forms/model_forms.py:1584
+#: dcim/tables/connections.py:27 templates/dcim/consoleport.html:17
+#: templates/dcim/consoleserverport.html:74 templates/dcim/frontport.html:112
 msgid "Console Port"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1146 netbox/dcim/forms/model_forms.py:1585
-#: netbox/templates/dcim/consoleport.html:73
-#: netbox/templates/dcim/consoleserverport.html:17
-#: netbox/templates/dcim/frontport.html:109
+#: dcim/forms/model_forms.py:1146 dcim/forms/model_forms.py:1585
+#: templates/dcim/consoleport.html:73 templates/dcim/consoleserverport.html:17
+#: templates/dcim/frontport.html:109
 msgid "Console Server Port"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1147 netbox/dcim/forms/model_forms.py:1586
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:52
-#: netbox/templates/dcim/consoleport.html:76
-#: netbox/templates/dcim/consoleserverport.html:77
-#: netbox/templates/dcim/frontport.html:17
-#: netbox/templates/dcim/frontport.html:115
-#: netbox/templates/dcim/interface.html:187
-#: netbox/templates/dcim/rearport.html:105
+#: dcim/forms/model_forms.py:1147 dcim/forms/model_forms.py:1586
+#: templates/circuits/inc/circuit_termination_fields.html:52
+#: templates/dcim/consoleport.html:76 templates/dcim/consoleserverport.html:77
+#: templates/dcim/frontport.html:17 templates/dcim/frontport.html:115
+#: templates/dcim/interface.html:187 templates/dcim/rearport.html:105
 msgid "Front Port"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1148 netbox/dcim/forms/model_forms.py:1587
-#: netbox/dcim/tables/devices.py:710
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:53
-#: netbox/templates/dcim/consoleport.html:79
-#: netbox/templates/dcim/consoleserverport.html:80
-#: netbox/templates/dcim/frontport.html:50
-#: netbox/templates/dcim/frontport.html:118
-#: netbox/templates/dcim/interface.html:190
-#: netbox/templates/dcim/rearport.html:17
-#: netbox/templates/dcim/rearport.html:108
+#: dcim/forms/model_forms.py:1148 dcim/forms/model_forms.py:1587
+#: dcim/tables/devices.py:710
+#: templates/circuits/inc/circuit_termination_fields.html:53
+#: templates/dcim/consoleport.html:79 templates/dcim/consoleserverport.html:80
+#: templates/dcim/frontport.html:50 templates/dcim/frontport.html:118
+#: templates/dcim/interface.html:190 templates/dcim/rearport.html:17
+#: templates/dcim/rearport.html:108
 msgid "Rear Port"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1149 netbox/dcim/forms/model_forms.py:1588
-#: netbox/dcim/tables/connections.py:46 netbox/dcim/tables/devices.py:512
-#: netbox/templates/dcim/poweroutlet.html:44
-#: netbox/templates/dcim/powerport.html:17
+#: dcim/forms/model_forms.py:1149 dcim/forms/model_forms.py:1588
+#: dcim/tables/connections.py:46 dcim/tables/devices.py:512
+#: templates/dcim/poweroutlet.html:44 templates/dcim/powerport.html:17
 msgid "Power Port"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1150 netbox/dcim/forms/model_forms.py:1589
-#: netbox/templates/dcim/poweroutlet.html:17
-#: netbox/templates/dcim/powerport.html:77
+#: dcim/forms/model_forms.py:1150 dcim/forms/model_forms.py:1589
+#: templates/dcim/poweroutlet.html:17 templates/dcim/powerport.html:77
 msgid "Power Outlet"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1152 netbox/dcim/forms/model_forms.py:1591
+#: dcim/forms/model_forms.py:1152 dcim/forms/model_forms.py:1591
 msgid "Component Assignment"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1195 netbox/dcim/forms/model_forms.py:1638
+#: dcim/forms/model_forms.py:1195 dcim/forms/model_forms.py:1638
 msgid "An InventoryItem can only be assigned to a single component."
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1332
+#: dcim/forms/model_forms.py:1332
 msgid "LAG interface"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1355
+#: dcim/forms/model_forms.py:1355
 msgid "Filter VLANs available for assignment by group."
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1484
+#: dcim/forms/model_forms.py:1484
 msgid "Child Device"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1485
+#: dcim/forms/model_forms.py:1485
 msgid ""
 "Child devices must first be created and assigned to the site and rack of the "
 "parent device."
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1527
+#: dcim/forms/model_forms.py:1527
 msgid "Console port"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1535
+#: dcim/forms/model_forms.py:1535
 msgid "Console server port"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1543
+#: dcim/forms/model_forms.py:1543
 msgid "Front port"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1559
+#: dcim/forms/model_forms.py:1559
 msgid "Power outlet"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1579
-#: netbox/templates/dcim/inventoryitem.html:17
+#: dcim/forms/model_forms.py:1579 templates/dcim/inventoryitem.html:17
 msgid "Inventory Item"
 msgstr ""
 
-#: netbox/dcim/forms/model_forms.py:1652
-#: netbox/templates/dcim/inventoryitemrole.html:15
+#: dcim/forms/model_forms.py:1652 templates/dcim/inventoryitemrole.html:15
 msgid "Inventory Item Role"
 msgstr ""
 
-#: netbox/dcim/forms/object_create.py:48 netbox/dcim/forms/object_create.py:199
-#: netbox/dcim/forms/object_create.py:355
+#: dcim/forms/object_create.py:48 dcim/forms/object_create.py:199
+#: dcim/forms/object_create.py:355
 msgid ""
 "Alphanumeric ranges are supported. (Must match the number of objects being "
 "created.)"
 msgstr ""
 
-#: netbox/dcim/forms/object_create.py:68
+#: dcim/forms/object_create.py:68
 #, python-brace-format
 msgid ""
 "The provided pattern specifies {value_count} values, but {pattern_count} are "
 "expected."
 msgstr ""
 
-#: netbox/dcim/forms/object_create.py:110
-#: netbox/dcim/forms/object_create.py:271 netbox/dcim/tables/devices.py:252
+#: dcim/forms/object_create.py:110 dcim/forms/object_create.py:271
+#: dcim/tables/devices.py:252
 msgid "Rear ports"
 msgstr ""
 
-#: netbox/dcim/forms/object_create.py:111
-#: netbox/dcim/forms/object_create.py:272
+#: dcim/forms/object_create.py:111 dcim/forms/object_create.py:272
 msgid "Select one rear port assignment for each front port being created."
 msgstr ""
 
-#: netbox/dcim/forms/object_create.py:164
+#: dcim/forms/object_create.py:164
 #, python-brace-format
 msgid ""
 "The number of front port templates to be created ({frontport_count}) must "
 "match the selected number of rear port positions ({rearport_count})."
 msgstr ""
 
-#: netbox/dcim/forms/object_create.py:251
+#: dcim/forms/object_create.py:251
 #, python-brace-format
 msgid ""
 "The string <code>{module}</code> will be replaced with the position of the "
 "assigned module, if any."
 msgstr ""
 
-#: netbox/dcim/forms/object_create.py:320
+#: dcim/forms/object_create.py:320
 #, python-brace-format
 msgid ""
 "The number of front ports to be created ({frontport_count}) must match the "
 "selected number of rear port positions ({rearport_count})."
 msgstr ""
 
-#: netbox/dcim/forms/object_create.py:409 netbox/dcim/tables/devices.py:1033
-#: netbox/ipam/tables/fhrp.py:31 netbox/templates/dcim/virtualchassis.html:53
-#: netbox/templates/dcim/virtualchassis_edit.html:47
-#: netbox/templates/ipam/fhrpgroup.html:38
+#: dcim/forms/object_create.py:409 dcim/tables/devices.py:1033
+#: ipam/tables/fhrp.py:31 templates/dcim/virtualchassis.html:53
+#: templates/dcim/virtualchassis_edit.html:47 templates/ipam/fhrpgroup.html:38
 msgid "Members"
 msgstr ""
 
-#: netbox/dcim/forms/object_create.py:418
+#: dcim/forms/object_create.py:418
 msgid "Initial position"
 msgstr ""
 
-#: netbox/dcim/forms/object_create.py:421
+#: dcim/forms/object_create.py:421
 msgid ""
 "Position of the first member device. Increases by one for each additional "
 "member."
 msgstr ""
 
-#: netbox/dcim/forms/object_create.py:435
+#: dcim/forms/object_create.py:435
 msgid "A position must be specified for the first VC member."
 msgstr ""
 
-#: netbox/dcim/models/cables.py:62
-#: netbox/dcim/models/device_component_templates.py:55
-#: netbox/dcim/models/device_components.py:62
-#: netbox/extras/models/customfields.py:111
+#: dcim/models/cables.py:62 dcim/models/device_component_templates.py:55
+#: dcim/models/device_components.py:62 extras/models/customfields.py:111
 msgid "label"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:71
+#: dcim/models/cables.py:71
 msgid "length"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:78
+#: dcim/models/cables.py:78
 msgid "length unit"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:95
+#: dcim/models/cables.py:95
 msgid "cable"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:96
+#: dcim/models/cables.py:96
 msgid "cables"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:165
+#: dcim/models/cables.py:165
 msgid "Must specify a unit when setting a cable length"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:168
+#: dcim/models/cables.py:168
 msgid "Must define A and B terminations when creating a new cable."
 msgstr ""
 
-#: netbox/dcim/models/cables.py:175
+#: dcim/models/cables.py:175
 msgid "Cannot connect different termination types to same end of cable."
 msgstr ""
 
-#: netbox/dcim/models/cables.py:183
+#: dcim/models/cables.py:183
 #, python-brace-format
 msgid "Incompatible termination types: {type_a} and {type_b}"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:193
+#: dcim/models/cables.py:193
 msgid "A and B terminations cannot connect to the same object."
 msgstr ""
 
-#: netbox/dcim/models/cables.py:260 netbox/ipam/models/asns.py:37
+#: dcim/models/cables.py:260 ipam/models/asns.py:37
 msgid "end"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:313
+#: dcim/models/cables.py:313
 msgid "cable termination"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:314
+#: dcim/models/cables.py:314
 msgid "cable terminations"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:333
+#: dcim/models/cables.py:333
 #, python-brace-format
 msgid ""
 "Duplicate termination found for {app_label}.{model} {termination_id}: cable "
 "{cable_pk}"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:343
+#: dcim/models/cables.py:343
 #, python-brace-format
 msgid "Cables cannot be terminated to {type_display} interfaces"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:350
+#: dcim/models/cables.py:350
 msgid "Circuit terminations attached to a provider network may not be cabled."
 msgstr ""
 
-#: netbox/dcim/models/cables.py:448 netbox/extras/models/configs.py:50
+#: dcim/models/cables.py:448 extras/models/configs.py:50
 msgid "is active"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:452
+#: dcim/models/cables.py:452
 msgid "is complete"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:456
+#: dcim/models/cables.py:456
 msgid "is split"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:464
+#: dcim/models/cables.py:464
 msgid "cable path"
 msgstr ""
 
-#: netbox/dcim/models/cables.py:465
+#: dcim/models/cables.py:465
 msgid "cable paths"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:46
+#: dcim/models/device_component_templates.py:46
 #, python-brace-format
 msgid ""
 "{module} is accepted as a substitution for the module bay position when "
 "attached to a module type."
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:58
-#: netbox/dcim/models/device_components.py:65
+#: dcim/models/device_component_templates.py:58
+#: dcim/models/device_components.py:65
 msgid "Physical label"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:103
+#: dcim/models/device_component_templates.py:103
 msgid "Component templates cannot be moved to a different device type."
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:154
+#: dcim/models/device_component_templates.py:154
 msgid ""
 "A component template cannot be associated with both a device type and a "
 "module type."
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:158
+#: dcim/models/device_component_templates.py:158
 msgid ""
 "A component template must be associated with either a device type or a "
 "module type."
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:212
+#: dcim/models/device_component_templates.py:212
 msgid "console port template"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:213
+#: dcim/models/device_component_templates.py:213
 msgid "console port templates"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:246
+#: dcim/models/device_component_templates.py:246
 msgid "console server port template"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:247
+#: dcim/models/device_component_templates.py:247
 msgid "console server port templates"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:278
-#: netbox/dcim/models/device_components.py:352
+#: dcim/models/device_component_templates.py:278
+#: dcim/models/device_components.py:352
 msgid "maximum draw"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:285
-#: netbox/dcim/models/device_components.py:359
+#: dcim/models/device_component_templates.py:285
+#: dcim/models/device_components.py:359
 msgid "allocated draw"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:295
+#: dcim/models/device_component_templates.py:295
 msgid "power port template"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:296
+#: dcim/models/device_component_templates.py:296
 msgid "power port templates"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:315
-#: netbox/dcim/models/device_components.py:382
+#: dcim/models/device_component_templates.py:315
+#: dcim/models/device_components.py:382
 #, python-brace-format
 msgid "Allocated draw cannot exceed the maximum draw ({maximum_draw}W)."
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:347
-#: netbox/dcim/models/device_components.py:477
+#: dcim/models/device_component_templates.py:347
+#: dcim/models/device_components.py:477
 msgid "feed leg"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:351
-#: netbox/dcim/models/device_components.py:481
+#: dcim/models/device_component_templates.py:351
+#: dcim/models/device_components.py:481
 msgid "Phase (for three-phase feeds)"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:357
+#: dcim/models/device_component_templates.py:357
 msgid "power outlet template"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:358
+#: dcim/models/device_component_templates.py:358
 msgid "power outlet templates"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:367
+#: dcim/models/device_component_templates.py:367
 #, python-brace-format
 msgid "Parent power port ({power_port}) must belong to the same device type"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:371
+#: dcim/models/device_component_templates.py:371
 #, python-brace-format
 msgid "Parent power port ({power_port}) must belong to the same module type"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:423
-#: netbox/dcim/models/device_components.py:611
+#: dcim/models/device_component_templates.py:423
+#: dcim/models/device_components.py:611
 msgid "management only"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:431
-#: netbox/dcim/models/device_components.py:550
+#: dcim/models/device_component_templates.py:431
+#: dcim/models/device_components.py:550
 msgid "bridge interface"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:449
-#: netbox/dcim/models/device_components.py:636
+#: dcim/models/device_component_templates.py:449
+#: dcim/models/device_components.py:636
 msgid "wireless role"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:455
+#: dcim/models/device_component_templates.py:455
 msgid "interface template"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:456
+#: dcim/models/device_component_templates.py:456
 msgid "interface templates"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:463
-#: netbox/dcim/models/device_components.py:804
-#: netbox/virtualization/models/virtualmachines.py:405
+#: dcim/models/device_component_templates.py:463
+#: dcim/models/device_components.py:804
+#: virtualization/models/virtualmachines.py:405
 msgid "An interface cannot be bridged to itself."
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:466
+#: dcim/models/device_component_templates.py:466
 #, python-brace-format
 msgid "Bridge interface ({bridge}) must belong to the same device type"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:470
+#: dcim/models/device_component_templates.py:470
 #, python-brace-format
 msgid "Bridge interface ({bridge}) must belong to the same module type"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:526
-#: netbox/dcim/models/device_components.py:984
+#: dcim/models/device_component_templates.py:526
+#: dcim/models/device_components.py:984
 msgid "rear port position"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:551
+#: dcim/models/device_component_templates.py:551
 msgid "front port template"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:552
+#: dcim/models/device_component_templates.py:552
 msgid "front port templates"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:562
+#: dcim/models/device_component_templates.py:562
 #, python-brace-format
 msgid "Rear port ({name}) must belong to the same device type"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:568
+#: dcim/models/device_component_templates.py:568
 #, python-brace-format
 msgid ""
 "Invalid rear port position ({position}); rear port {name} has only {count} "
 "positions"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:621
-#: netbox/dcim/models/device_components.py:1053
+#: dcim/models/device_component_templates.py:621
+#: dcim/models/device_components.py:1053
 msgid "positions"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:632
+#: dcim/models/device_component_templates.py:632
 msgid "rear port template"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:633
+#: dcim/models/device_component_templates.py:633
 msgid "rear port templates"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:662
-#: netbox/dcim/models/device_components.py:1103
+#: dcim/models/device_component_templates.py:662
+#: dcim/models/device_components.py:1103
 msgid "position"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:665
-#: netbox/dcim/models/device_components.py:1106
+#: dcim/models/device_component_templates.py:665
+#: dcim/models/device_components.py:1106
 msgid "Identifier to reference when renaming installed components"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:671
+#: dcim/models/device_component_templates.py:671
 msgid "module bay template"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:672
+#: dcim/models/device_component_templates.py:672
 msgid "module bay templates"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:699
+#: dcim/models/device_component_templates.py:699
 msgid "device bay template"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:700
+#: dcim/models/device_component_templates.py:700
 msgid "device bay templates"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:713
+#: dcim/models/device_component_templates.py:713
 #, python-brace-format
 msgid ""
 "Subdevice role of device type ({device_type}) must be set to \"parent\" to "
 "allow device bays."
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:768
-#: netbox/dcim/models/device_components.py:1262
+#: dcim/models/device_component_templates.py:768
+#: dcim/models/device_components.py:1262
 msgid "part ID"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:770
-#: netbox/dcim/models/device_components.py:1264
+#: dcim/models/device_component_templates.py:770
+#: dcim/models/device_components.py:1264
 msgid "Manufacturer-assigned part identifier"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:787
+#: dcim/models/device_component_templates.py:787
 msgid "inventory item template"
 msgstr ""
 
-#: netbox/dcim/models/device_component_templates.py:788
+#: dcim/models/device_component_templates.py:788
 msgid "inventory item templates"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:105
+#: dcim/models/device_components.py:105
 msgid "Components cannot be moved to a different device."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:144
+#: dcim/models/device_components.py:144
 msgid "cable end"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:150
+#: dcim/models/device_components.py:150
 msgid "mark connected"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:152
+#: dcim/models/device_components.py:152
 msgid "Treat as if a cable is connected"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:170
+#: dcim/models/device_components.py:170
 msgid "Must specify cable end (A or B) when attaching a cable."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:174
+#: dcim/models/device_components.py:174
 msgid "Cable end must not be set without a cable."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:178
+#: dcim/models/device_components.py:178
 msgid "Cannot mark as connected with a cable attached."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:202
+#: dcim/models/device_components.py:202
 #, python-brace-format
 msgid "{class_name} models must declare a parent_object property"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:287
-#: netbox/dcim/models/device_components.py:316
-#: netbox/dcim/models/device_components.py:349
-#: netbox/dcim/models/device_components.py:467
+#: dcim/models/device_components.py:287 dcim/models/device_components.py:316
+#: dcim/models/device_components.py:349 dcim/models/device_components.py:467
 msgid "Physical port type"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:290
-#: netbox/dcim/models/device_components.py:319
+#: dcim/models/device_components.py:290 dcim/models/device_components.py:319
 msgid "speed"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:294
-#: netbox/dcim/models/device_components.py:323
+#: dcim/models/device_components.py:294 dcim/models/device_components.py:323
 msgid "Port speed in bits per second"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:300
+#: dcim/models/device_components.py:300
 msgid "console port"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:301
+#: dcim/models/device_components.py:301
 msgid "console ports"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:329
+#: dcim/models/device_components.py:329
 msgid "console server port"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:330
+#: dcim/models/device_components.py:330
 msgid "console server ports"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:369
+#: dcim/models/device_components.py:369
 msgid "power port"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:370
+#: dcim/models/device_components.py:370
 msgid "power ports"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:487
+#: dcim/models/device_components.py:487
 msgid "power outlet"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:488
+#: dcim/models/device_components.py:488
 msgid "power outlets"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:499
+#: dcim/models/device_components.py:499
 #, python-brace-format
 msgid "Parent power port ({power_port}) must belong to the same device"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:530 netbox/vpn/models/crypto.py:81
-#: netbox/vpn/models/crypto.py:226
+#: dcim/models/device_components.py:530 vpn/models/crypto.py:81
+#: vpn/models/crypto.py:226
 msgid "mode"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:534
+#: dcim/models/device_components.py:534
 msgid "IEEE 802.1Q tagging strategy"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:542
+#: dcim/models/device_components.py:542
 msgid "parent interface"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:602
+#: dcim/models/device_components.py:602
 msgid "parent LAG"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:612
+#: dcim/models/device_components.py:612
 msgid "This interface is used only for out-of-band management"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:617
+#: dcim/models/device_components.py:617
 msgid "speed (Kbps)"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:620
+#: dcim/models/device_components.py:620
 msgid "duplex"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:630
+#: dcim/models/device_components.py:630
 msgid "64-bit World Wide Name"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:642
+#: dcim/models/device_components.py:642
 msgid "wireless channel"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:649
+#: dcim/models/device_components.py:649
 msgid "channel frequency (MHz)"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:650
-#: netbox/dcim/models/device_components.py:658
+#: dcim/models/device_components.py:650 dcim/models/device_components.py:658
 msgid "Populated by selected channel (if set)"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:664
+#: dcim/models/device_components.py:664
 msgid "transmit power (dBm)"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:689 netbox/wireless/models.py:117
+#: dcim/models/device_components.py:689 wireless/models.py:117
 msgid "wireless LANs"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:697
-#: netbox/virtualization/models/virtualmachines.py:335
+#: dcim/models/device_components.py:697
+#: virtualization/models/virtualmachines.py:335
 msgid "untagged VLAN"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:703
-#: netbox/virtualization/models/virtualmachines.py:341
+#: dcim/models/device_components.py:703
+#: virtualization/models/virtualmachines.py:341
 msgid "tagged VLANs"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:745
-#: netbox/virtualization/models/virtualmachines.py:377
+#: dcim/models/device_components.py:745
+#: virtualization/models/virtualmachines.py:377
 msgid "interface"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:746
-#: netbox/virtualization/models/virtualmachines.py:378
+#: dcim/models/device_components.py:746
+#: virtualization/models/virtualmachines.py:378
 msgid "interfaces"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:757
+#: dcim/models/device_components.py:757
 #, python-brace-format
 msgid "{display_type} interfaces cannot have a cable attached."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:765
+#: dcim/models/device_components.py:765
 #, python-brace-format
 msgid "{display_type} interfaces cannot be marked as connected."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:774
-#: netbox/virtualization/models/virtualmachines.py:390
+#: dcim/models/device_components.py:774
+#: virtualization/models/virtualmachines.py:390
 msgid "An interface cannot be its own parent."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:778
+#: dcim/models/device_components.py:778
 msgid "Only virtual interfaces may be assigned to a parent interface."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:785
+#: dcim/models/device_components.py:785
 #, python-brace-format
 msgid ""
 "The selected parent interface ({interface}) belongs to a different device "
 "({device})"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:791
+#: dcim/models/device_components.py:791
 #, python-brace-format
 msgid ""
 "The selected parent interface ({interface}) belongs to {device}, which is "
 "not part of virtual chassis {virtual_chassis}."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:811
+#: dcim/models/device_components.py:811
 #, python-brace-format
 msgid ""
 "The selected bridge interface ({bridge}) belongs to a different device "
 "({device})."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:817
+#: dcim/models/device_components.py:817
 #, python-brace-format
 msgid ""
 "The selected bridge interface ({interface}) belongs to {device}, which is "
 "not part of virtual chassis {virtual_chassis}."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:828
+#: dcim/models/device_components.py:828
 msgid "Virtual interfaces cannot have a parent LAG interface."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:832
+#: dcim/models/device_components.py:832
 msgid "A LAG interface cannot be its own parent."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:839
+#: dcim/models/device_components.py:839
 #, python-brace-format
 msgid ""
 "The selected LAG interface ({lag}) belongs to a different device ({device})."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:845
+#: dcim/models/device_components.py:845
 #, python-brace-format
 msgid ""
 "The selected LAG interface ({lag}) belongs to {device}, which is not part of "
 "virtual chassis {virtual_chassis}."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:856
+#: dcim/models/device_components.py:856
 msgid "Virtual interfaces cannot have a PoE mode."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:860
+#: dcim/models/device_components.py:860
 msgid "Virtual interfaces cannot have a PoE type."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:866
+#: dcim/models/device_components.py:866
 msgid "Must specify PoE mode when designating a PoE type."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:873
+#: dcim/models/device_components.py:873
 msgid "Wireless role may be set only on wireless interfaces."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:875
+#: dcim/models/device_components.py:875
 msgid "Channel may be set only on wireless interfaces."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:881
+#: dcim/models/device_components.py:881
 msgid "Channel frequency may be set only on wireless interfaces."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:885
+#: dcim/models/device_components.py:885
 msgid "Cannot specify custom frequency with channel selected."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:891
+#: dcim/models/device_components.py:891
 msgid "Channel width may be set only on wireless interfaces."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:893
+#: dcim/models/device_components.py:893
 msgid "Cannot specify custom width with channel selected."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:901
+#: dcim/models/device_components.py:901
 #, python-brace-format
 msgid ""
 "The untagged VLAN ({untagged_vlan}) must belong to the same site as the "
 "interface's parent device, or it must be global."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:990
+#: dcim/models/device_components.py:990
 msgid "Mapped position on corresponding rear port"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1006
+#: dcim/models/device_components.py:1006
 msgid "front port"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1007
+#: dcim/models/device_components.py:1007
 msgid "front ports"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1021
+#: dcim/models/device_components.py:1021
 #, python-brace-format
 msgid "Rear port ({rear_port}) must belong to the same device"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1029
+#: dcim/models/device_components.py:1029
 #, python-brace-format
 msgid ""
 "Invalid rear port position ({rear_port_position}): Rear port {name} has only "
 "{positions} positions."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1059
+#: dcim/models/device_components.py:1059
 msgid "Number of front ports which may be mapped"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1064
+#: dcim/models/device_components.py:1064
 msgid "rear port"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1065
+#: dcim/models/device_components.py:1065
 msgid "rear ports"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1079
+#: dcim/models/device_components.py:1079
 #, python-brace-format
 msgid ""
 "The number of positions cannot be less than the number of mapped front ports "
 "({frontport_count})"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1120
+#: dcim/models/device_components.py:1120
 msgid "module bay"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1121
+#: dcim/models/device_components.py:1121
 msgid "module bays"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1138
-#: netbox/dcim/models/devices.py:1224
+#: dcim/models/device_components.py:1138 dcim/models/devices.py:1224
 msgid "A module bay cannot belong to a module installed within it."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1164
+#: dcim/models/device_components.py:1164
 msgid "device bay"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1165
+#: dcim/models/device_components.py:1165
 msgid "device bays"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1175
+#: dcim/models/device_components.py:1175
 #, python-brace-format
 msgid "This type of device ({device_type}) does not support device bays."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1181
+#: dcim/models/device_components.py:1181
 msgid "Cannot install a device into itself."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1189
+#: dcim/models/device_components.py:1189
 #, python-brace-format
 msgid ""
 "Cannot install the specified device; device is already installed in {bay}."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1210
+#: dcim/models/device_components.py:1210
 msgid "inventory item role"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1211
+#: dcim/models/device_components.py:1211
 msgid "inventory item roles"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1268
-#: netbox/dcim/models/devices.py:607 netbox/dcim/models/devices.py:1181
-#: netbox/dcim/models/racks.py:313
-#: netbox/virtualization/models/virtualmachines.py:131
+#: dcim/models/device_components.py:1268 dcim/models/devices.py:607
+#: dcim/models/devices.py:1181 dcim/models/racks.py:313
+#: virtualization/models/virtualmachines.py:131
 msgid "serial number"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1276
-#: netbox/dcim/models/devices.py:615 netbox/dcim/models/devices.py:1188
-#: netbox/dcim/models/racks.py:320
+#: dcim/models/device_components.py:1276 dcim/models/devices.py:615
+#: dcim/models/devices.py:1188 dcim/models/racks.py:320
 msgid "asset tag"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1277
+#: dcim/models/device_components.py:1277
 msgid "A unique tag used to identify this item"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1280
+#: dcim/models/device_components.py:1280
 msgid "discovered"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1282
+#: dcim/models/device_components.py:1282
 msgid "This item was automatically discovered"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1300
+#: dcim/models/device_components.py:1300
 msgid "inventory item"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1301
+#: dcim/models/device_components.py:1301
 msgid "inventory items"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1312
+#: dcim/models/device_components.py:1312
 msgid "Cannot assign self as parent."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1320
+#: dcim/models/device_components.py:1320
 msgid "Parent inventory item does not belong to the same device."
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1326
+#: dcim/models/device_components.py:1326
 msgid "Cannot move an inventory item with dependent children"
 msgstr ""
 
-#: netbox/dcim/models/device_components.py:1334
+#: dcim/models/device_components.py:1334
 msgid "Cannot assign inventory item to component on another device"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:54
+#: dcim/models/devices.py:54
 msgid "manufacturer"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:55
+#: dcim/models/devices.py:55
 msgid "manufacturers"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:82 netbox/dcim/models/devices.py:382
-#: netbox/dcim/models/racks.py:133
+#: dcim/models/devices.py:82 dcim/models/devices.py:382
+#: dcim/models/racks.py:133
 msgid "model"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:95
+#: dcim/models/devices.py:95
 msgid "default platform"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:98 netbox/dcim/models/devices.py:386
+#: dcim/models/devices.py:98 dcim/models/devices.py:386
 msgid "part number"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:101 netbox/dcim/models/devices.py:389
+#: dcim/models/devices.py:101 dcim/models/devices.py:389
 msgid "Discrete part number (optional)"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:107 netbox/dcim/models/racks.py:54
+#: dcim/models/devices.py:107 dcim/models/racks.py:54
 msgid "height (U)"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:111
+#: dcim/models/devices.py:111
 msgid "exclude from utilization"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:112
+#: dcim/models/devices.py:112
 msgid "Devices of this type are excluded when calculating rack utilization."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:116
+#: dcim/models/devices.py:116
 msgid "is full depth"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:117
+#: dcim/models/devices.py:117
 msgid "Device consumes both front and rear rack faces."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:123
+#: dcim/models/devices.py:123
 msgid "parent/child status"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:124
+#: dcim/models/devices.py:124
 msgid ""
 "Parent devices house child devices in device bays. Leave blank if this "
 "device type is neither a parent nor a child."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:128 netbox/dcim/models/devices.py:392
-#: netbox/dcim/models/devices.py:659 netbox/dcim/models/racks.py:324
+#: dcim/models/devices.py:128 dcim/models/devices.py:392
+#: dcim/models/devices.py:659 dcim/models/racks.py:324
 msgid "airflow"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:204
+#: dcim/models/devices.py:204
 msgid "device type"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:205
+#: dcim/models/devices.py:205
 msgid "device types"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:290
+#: dcim/models/devices.py:290
 msgid "U height must be in increments of 0.5 rack units."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:307
+#: dcim/models/devices.py:307
 #, python-brace-format
 msgid ""
 "Device {device} in rack {rack} does not have sufficient space to accommodate "
 "a height of {height}U"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:322
+#: dcim/models/devices.py:322
 #, python-brace-format
 msgid ""
 "Unable to set 0U height: Found <a href=\"{url}\">{racked_instance_count} "
 "instances</a> already mounted within racks."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:331
+#: dcim/models/devices.py:331
 msgid ""
 "Must delete all device bay templates associated with this device before "
 "declassifying it as a parent device."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:337
+#: dcim/models/devices.py:337
 msgid "Child device types must be 0U."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:411
+#: dcim/models/devices.py:411
 msgid "module type"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:412
+#: dcim/models/devices.py:412
 msgid "module types"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:485
+#: dcim/models/devices.py:485
 msgid "Virtual machines may be assigned to this role"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:497
+#: dcim/models/devices.py:497
 msgid "device role"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:498
+#: dcim/models/devices.py:498
 msgid "device roles"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:515
+#: dcim/models/devices.py:515
 msgid "Optionally limit this platform to devices of a certain manufacturer"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:527
+#: dcim/models/devices.py:527
 msgid "platform"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:528
+#: dcim/models/devices.py:528
 msgid "platforms"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:576
+#: dcim/models/devices.py:576
 msgid "The function this device serves"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:608
+#: dcim/models/devices.py:608
 msgid "Chassis serial number, assigned by the manufacturer"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:616 netbox/dcim/models/devices.py:1189
+#: dcim/models/devices.py:616 dcim/models/devices.py:1189
 msgid "A unique tag used to identify this device"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:643
+#: dcim/models/devices.py:643
 msgid "position (U)"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:650
+#: dcim/models/devices.py:650
 msgid "rack face"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:670 netbox/dcim/models/devices.py:1415
-#: netbox/virtualization/models/virtualmachines.py:100
+#: dcim/models/devices.py:670 dcim/models/devices.py:1415
+#: virtualization/models/virtualmachines.py:100
 msgid "primary IPv4"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:678 netbox/dcim/models/devices.py:1423
-#: netbox/virtualization/models/virtualmachines.py:108
+#: dcim/models/devices.py:678 dcim/models/devices.py:1423
+#: virtualization/models/virtualmachines.py:108
 msgid "primary IPv6"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:686
+#: dcim/models/devices.py:686
 msgid "out-of-band IP"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:703
+#: dcim/models/devices.py:703
 msgid "VC position"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:706
+#: dcim/models/devices.py:706
 msgid "Virtual chassis position"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:709
+#: dcim/models/devices.py:709
 msgid "VC priority"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:713
+#: dcim/models/devices.py:713
 msgid "Virtual chassis master election priority"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:716 netbox/dcim/models/sites.py:207
+#: dcim/models/devices.py:716 dcim/models/sites.py:207
 msgid "latitude"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:721 netbox/dcim/models/devices.py:729
-#: netbox/dcim/models/sites.py:212 netbox/dcim/models/sites.py:220
+#: dcim/models/devices.py:721 dcim/models/devices.py:729
+#: dcim/models/sites.py:212 dcim/models/sites.py:220
 msgid "GPS coordinate in decimal format (xx.yyyyyy)"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:724 netbox/dcim/models/sites.py:215
+#: dcim/models/devices.py:724 dcim/models/sites.py:215
 msgid "longitude"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:797
+#: dcim/models/devices.py:797
 msgid "Device name must be unique per site."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:808 netbox/ipam/models/services.py:75
+#: dcim/models/devices.py:808 ipam/models/services.py:75
 msgid "device"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:809
+#: dcim/models/devices.py:809
 msgid "devices"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:835
+#: dcim/models/devices.py:835
 #, python-brace-format
 msgid "Rack {rack} does not belong to site {site}."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:840
+#: dcim/models/devices.py:840
 #, python-brace-format
 msgid "Location {location} does not belong to site {site}."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:846
+#: dcim/models/devices.py:846
 #, python-brace-format
 msgid "Rack {rack} does not belong to location {location}."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:853
+#: dcim/models/devices.py:853
 msgid "Cannot select a rack face without assigning a rack."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:857
+#: dcim/models/devices.py:857
 msgid "Cannot select a rack position without assigning a rack."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:863
+#: dcim/models/devices.py:863
 msgid "Position must be in increments of 0.5 rack units."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:867
+#: dcim/models/devices.py:867
 msgid "Must specify rack face when defining rack position."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:875
+#: dcim/models/devices.py:875
 #, python-brace-format
 msgid "A 0U device type ({device_type}) cannot be assigned to a rack position."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:886
+#: dcim/models/devices.py:886
 msgid ""
 "Child device types cannot be assigned to a rack face. This is an attribute "
 "of the parent device."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:893
+#: dcim/models/devices.py:893
 msgid ""
 "Child device types cannot be assigned to a rack position. This is an "
 "attribute of the parent device."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:907
+#: dcim/models/devices.py:907
 #, python-brace-format
 msgid ""
 "U{position} is already occupied or does not have sufficient space to "
 "accommodate this device type: {device_type} ({u_height}U)"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:922
+#: dcim/models/devices.py:922
 #, python-brace-format
 msgid "{ip} is not an IPv4 address."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:931 netbox/dcim/models/devices.py:946
+#: dcim/models/devices.py:931 dcim/models/devices.py:946
 #, python-brace-format
 msgid "The specified IP address ({ip}) is not assigned to this device."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:937
+#: dcim/models/devices.py:937
 #, python-brace-format
 msgid "{ip} is not an IPv6 address."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:964
+#: dcim/models/devices.py:964
 #, python-brace-format
 msgid ""
 "The assigned platform is limited to {platform_manufacturer} device types, "
 "but this device's type belongs to {devicetype_manufacturer}."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:975
+#: dcim/models/devices.py:975
 #, python-brace-format
 msgid "The assigned cluster belongs to a different site ({site})"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:983
+#: dcim/models/devices.py:983
 msgid "A device assigned to a virtual chassis must have its position defined."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:988
+#: dcim/models/devices.py:988
 #, python-brace-format
 msgid ""
 "Device cannot be removed from virtual chassis {virtual_chassis} because it "
 "is currently designated as its master."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1196
+#: dcim/models/devices.py:1196
 msgid "module"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1197
+#: dcim/models/devices.py:1197
 msgid "modules"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1213
+#: dcim/models/devices.py:1213
 #, python-brace-format
 msgid ""
 "Module must be installed within a module bay belonging to the assigned "
 "device ({device})."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1334
+#: dcim/models/devices.py:1334
 msgid "domain"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1347 netbox/dcim/models/devices.py:1348
+#: dcim/models/devices.py:1347 dcim/models/devices.py:1348
 msgid "virtual chassis"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1363
+#: dcim/models/devices.py:1363
 #, python-brace-format
 msgid "The selected master ({master}) is not assigned to this virtual chassis."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1379
+#: dcim/models/devices.py:1379
 #, python-brace-format
 msgid ""
 "Unable to delete virtual chassis {self}. There are member interfaces which "
 "form a cross-chassis LAG interfaces."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1404 netbox/vpn/models/l2vpn.py:37
+#: dcim/models/devices.py:1404 vpn/models/l2vpn.py:37
 msgid "identifier"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1405
+#: dcim/models/devices.py:1405
 msgid "Numeric identifier unique to the parent device"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1433 netbox/extras/models/customfields.py:225
-#: netbox/extras/models/models.py:107 netbox/extras/models/models.py:694
-#: netbox/netbox/models/__init__.py:115
+#: dcim/models/devices.py:1433 extras/models/customfields.py:225
+#: extras/models/models.py:107 extras/models/models.py:694
+#: netbox/models/__init__.py:115
 msgid "comments"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1449
+#: dcim/models/devices.py:1449
 msgid "virtual device context"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1450
+#: dcim/models/devices.py:1450
 msgid "virtual device contexts"
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1482
+#: dcim/models/devices.py:1482
 #, python-brace-format
 msgid "{ip} is not an IPv{family} address."
 msgstr ""
 
-#: netbox/dcim/models/devices.py:1488
+#: dcim/models/devices.py:1488
 msgid "Primary IP address must belong to an interface on the assigned device."
 msgstr ""
 
-#: netbox/dcim/models/mixins.py:15 netbox/extras/models/configs.py:41
-#: netbox/extras/models/models.py:313 netbox/extras/models/models.py:522
-#: netbox/extras/models/search.py:48 netbox/ipam/models/ip.py:194
+#: dcim/models/mixins.py:15 extras/models/configs.py:41
+#: extras/models/models.py:313 extras/models/models.py:522
+#: extras/models/search.py:48 ipam/models/ip.py:194
 msgid "weight"
 msgstr ""
 
-#: netbox/dcim/models/mixins.py:22
+#: dcim/models/mixins.py:22
 msgid "weight unit"
 msgstr ""
 
-#: netbox/dcim/models/mixins.py:51
+#: dcim/models/mixins.py:51
 msgid "Must specify a unit when setting a weight"
 msgstr ""
 
-#: netbox/dcim/models/power.py:55
+#: dcim/models/power.py:55
 msgid "power panel"
 msgstr ""
 
-#: netbox/dcim/models/power.py:56
+#: dcim/models/power.py:56
 msgid "power panels"
 msgstr ""
 
-#: netbox/dcim/models/power.py:70
+#: dcim/models/power.py:70
 #, python-brace-format
 msgid ""
 "Location {location} ({location_site}) is in a different site than {site}"
 msgstr ""
 
-#: netbox/dcim/models/power.py:108
+#: dcim/models/power.py:108
 msgid "supply"
 msgstr ""
 
-#: netbox/dcim/models/power.py:114
+#: dcim/models/power.py:114
 msgid "phase"
 msgstr ""
 
-#: netbox/dcim/models/power.py:120
+#: dcim/models/power.py:120
 msgid "voltage"
 msgstr ""
 
-#: netbox/dcim/models/power.py:125
+#: dcim/models/power.py:125
 msgid "amperage"
 msgstr ""
 
-#: netbox/dcim/models/power.py:130
+#: dcim/models/power.py:130
 msgid "max utilization"
 msgstr ""
 
-#: netbox/dcim/models/power.py:133
+#: dcim/models/power.py:133
 msgid "Maximum permissible draw (percentage)"
 msgstr ""
 
-#: netbox/dcim/models/power.py:136
+#: dcim/models/power.py:136
 msgid "available power"
 msgstr ""
 
-#: netbox/dcim/models/power.py:164
+#: dcim/models/power.py:164
 msgid "power feed"
 msgstr ""
 
-#: netbox/dcim/models/power.py:165
+#: dcim/models/power.py:165
 msgid "power feeds"
 msgstr ""
 
-#: netbox/dcim/models/power.py:179
+#: dcim/models/power.py:179
 #, python-brace-format
 msgid ""
 "Rack {rack} ({rack_site}) and power panel {powerpanel} ({powerpanel_site}) "
 "are in different sites."
 msgstr ""
 
-#: netbox/dcim/models/power.py:190
+#: dcim/models/power.py:190
 msgid "Voltage cannot be negative for AC supply"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:47
+#: dcim/models/racks.py:47
 msgid "width"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:48
+#: dcim/models/racks.py:48
 msgid "Rail-to-rail width"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:56
+#: dcim/models/racks.py:56
 msgid "Height in rack units"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:60
+#: dcim/models/racks.py:60
 msgid "starting unit"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:62
+#: dcim/models/racks.py:62
 msgid "Starting unit for rack"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:66
+#: dcim/models/racks.py:66
 msgid "descending units"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:67
+#: dcim/models/racks.py:67
 msgid "Units are numbered top-to-bottom"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:72
+#: dcim/models/racks.py:72
 msgid "outer width"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:75
+#: dcim/models/racks.py:75
 msgid "Outer dimension of rack (width)"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:78
+#: dcim/models/racks.py:78
 msgid "outer depth"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:81
+#: dcim/models/racks.py:81
 msgid "Outer dimension of rack (depth)"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:84
+#: dcim/models/racks.py:84
 msgid "outer unit"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:90
+#: dcim/models/racks.py:90
 msgid "mounting depth"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:94
+#: dcim/models/racks.py:94
 msgid ""
 "Maximum depth of a mounted device, in millimeters. For four-post racks, this "
 "is the distance between the front and rear rails."
 msgstr ""
 
-#: netbox/dcim/models/racks.py:102
+#: dcim/models/racks.py:102
 msgid "max weight"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:105
+#: dcim/models/racks.py:105
 msgid "Maximum load capacity for the rack"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:125 netbox/dcim/models/racks.py:252
+#: dcim/models/racks.py:125 dcim/models/racks.py:252
 msgid "form factor"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:162
+#: dcim/models/racks.py:162
 msgid "rack type"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:163
+#: dcim/models/racks.py:163
 msgid "rack types"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:180 netbox/dcim/models/racks.py:379
+#: dcim/models/racks.py:180 dcim/models/racks.py:379
 msgid "Must specify a unit when setting an outer width/depth"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:184 netbox/dcim/models/racks.py:383
+#: dcim/models/racks.py:184 dcim/models/racks.py:383
 msgid "Must specify a unit when setting a maximum weight"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:230
+#: dcim/models/racks.py:230
 msgid "rack role"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:231
+#: dcim/models/racks.py:231
 msgid "rack roles"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:274
+#: dcim/models/racks.py:274
 msgid "facility ID"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:275
+#: dcim/models/racks.py:275
 msgid "Locally-assigned identifier"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:308 netbox/ipam/forms/bulk_import.py:201
-#: netbox/ipam/forms/bulk_import.py:266 netbox/ipam/forms/bulk_import.py:301
-#: netbox/ipam/forms/bulk_import.py:459
-#: netbox/virtualization/forms/bulk_import.py:112
+#: dcim/models/racks.py:308 ipam/forms/bulk_import.py:201
+#: ipam/forms/bulk_import.py:266 ipam/forms/bulk_import.py:301
+#: ipam/forms/bulk_import.py:459 virtualization/forms/bulk_import.py:112
 msgid "Functional role"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:321
+#: dcim/models/racks.py:321
 msgid "A unique tag used to identify this rack"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:359
+#: dcim/models/racks.py:359
 msgid "rack"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:360
+#: dcim/models/racks.py:360
 msgid "racks"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:375
+#: dcim/models/racks.py:375
 #, python-brace-format
 msgid "Assigned location must belong to parent site ({site})."
 msgstr ""
 
-#: netbox/dcim/models/racks.py:393
+#: dcim/models/racks.py:393
 #, python-brace-format
 msgid ""
 "Rack must be at least {min_height}U tall to house currently installed "
 "devices."
 msgstr ""
 
-#: netbox/dcim/models/racks.py:400
+#: dcim/models/racks.py:400
 #, python-brace-format
 msgid ""
 "Rack unit numbering must begin at {position} or less to house currently "
 "installed devices."
 msgstr ""
 
-#: netbox/dcim/models/racks.py:408
+#: dcim/models/racks.py:408
 #, python-brace-format
 msgid "Location must be from the same site, {site}."
 msgstr ""
 
-#: netbox/dcim/models/racks.py:670
+#: dcim/models/racks.py:670
 msgid "units"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:696
+#: dcim/models/racks.py:696
 msgid "rack reservation"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:697
+#: dcim/models/racks.py:697
 msgid "rack reservations"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:714
+#: dcim/models/racks.py:714
 #, python-brace-format
 msgid "Invalid unit(s) for {height}U rack: {unit_list}"
 msgstr ""
 
-#: netbox/dcim/models/racks.py:727
+#: dcim/models/racks.py:727
 #, python-brace-format
 msgid "The following units have already been reserved: {unit_list}"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:49
+#: dcim/models/sites.py:49
 msgid "A top-level region with this name already exists."
 msgstr ""
 
-#: netbox/dcim/models/sites.py:59
+#: dcim/models/sites.py:59
 msgid "A top-level region with this slug already exists."
 msgstr ""
 
-#: netbox/dcim/models/sites.py:62
+#: dcim/models/sites.py:62
 msgid "region"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:63
+#: dcim/models/sites.py:63
 msgid "regions"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:102
+#: dcim/models/sites.py:102
 msgid "A top-level site group with this name already exists."
 msgstr ""
 
-#: netbox/dcim/models/sites.py:112
+#: dcim/models/sites.py:112
 msgid "A top-level site group with this slug already exists."
 msgstr ""
 
-#: netbox/dcim/models/sites.py:115
+#: dcim/models/sites.py:115
 msgid "site group"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:116
+#: dcim/models/sites.py:116
 msgid "site groups"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:141
+#: dcim/models/sites.py:141
 msgid "Full name of the site"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:181 netbox/dcim/models/sites.py:279
+#: dcim/models/sites.py:181 dcim/models/sites.py:279
 msgid "facility"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:184 netbox/dcim/models/sites.py:282
+#: dcim/models/sites.py:184 dcim/models/sites.py:282
 msgid "Local facility ID or description"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:195
+#: dcim/models/sites.py:195
 msgid "physical address"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:198
+#: dcim/models/sites.py:198
 msgid "Physical location of the building"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:201
+#: dcim/models/sites.py:201
 msgid "shipping address"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:204
+#: dcim/models/sites.py:204
 msgid "If different from the physical address"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:238
+#: dcim/models/sites.py:238
 msgid "site"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:239
+#: dcim/models/sites.py:239
 msgid "sites"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:309
+#: dcim/models/sites.py:309
 msgid "A location with this name already exists within the specified site."
 msgstr ""
 
-#: netbox/dcim/models/sites.py:319
+#: dcim/models/sites.py:319
 msgid "A location with this slug already exists within the specified site."
 msgstr ""
 
-#: netbox/dcim/models/sites.py:322
+#: dcim/models/sites.py:322
 msgid "location"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:323
+#: dcim/models/sites.py:323
 msgid "locations"
 msgstr ""
 
-#: netbox/dcim/models/sites.py:337
+#: dcim/models/sites.py:337
 #, python-brace-format
 msgid "Parent location ({parent}) must belong to the same site ({site})."
 msgstr ""
 
-#: netbox/dcim/tables/cables.py:55
+#: dcim/tables/cables.py:55
 msgid "Termination A"
 msgstr ""
 
-#: netbox/dcim/tables/cables.py:60
+#: dcim/tables/cables.py:60
 msgid "Termination B"
 msgstr ""
 
-#: netbox/dcim/tables/cables.py:66 netbox/wireless/tables/wirelesslink.py:23
+#: dcim/tables/cables.py:66 wireless/tables/wirelesslink.py:23
 msgid "Device A"
 msgstr ""
 
-#: netbox/dcim/tables/cables.py:72 netbox/wireless/tables/wirelesslink.py:32
+#: dcim/tables/cables.py:72 wireless/tables/wirelesslink.py:32
 msgid "Device B"
 msgstr ""
 
-#: netbox/dcim/tables/cables.py:78
+#: dcim/tables/cables.py:78
 msgid "Location A"
 msgstr ""
 
-#: netbox/dcim/tables/cables.py:84
+#: dcim/tables/cables.py:84
 msgid "Location B"
 msgstr ""
 
-#: netbox/dcim/tables/cables.py:90
+#: dcim/tables/cables.py:90
 msgid "Rack A"
 msgstr ""
 
-#: netbox/dcim/tables/cables.py:96
+#: dcim/tables/cables.py:96
 msgid "Rack B"
 msgstr ""
 
-#: netbox/dcim/tables/cables.py:102
+#: dcim/tables/cables.py:102
 msgid "Site A"
 msgstr ""
 
-#: netbox/dcim/tables/cables.py:108
+#: dcim/tables/cables.py:108
 msgid "Site B"
 msgstr ""
 
-#: netbox/dcim/tables/connections.py:31 netbox/dcim/tables/connections.py:50
-#: netbox/dcim/tables/connections.py:71
-#: netbox/templates/dcim/inc/connection_endpoints.html:16
+#: dcim/tables/connections.py:31 dcim/tables/connections.py:50
+#: dcim/tables/connections.py:71
+#: templates/dcim/inc/connection_endpoints.html:16
 msgid "Reachable"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:58 netbox/dcim/tables/devices.py:106
-#: netbox/dcim/tables/racks.py:150 netbox/dcim/tables/sites.py:105
-#: netbox/dcim/tables/sites.py:148 netbox/extras/tables/tables.py:545
-#: netbox/netbox/navigation/menu.py:69 netbox/netbox/navigation/menu.py:73
-#: netbox/netbox/navigation/menu.py:75
-#: netbox/virtualization/forms/model_forms.py:122
-#: netbox/virtualization/tables/clusters.py:83
-#: netbox/virtualization/views.py:206
+#: dcim/tables/devices.py:58 dcim/tables/devices.py:106
+#: dcim/tables/racks.py:150 dcim/tables/sites.py:105 dcim/tables/sites.py:148
+#: extras/tables/tables.py:545 netbox/navigation/menu.py:69
+#: netbox/navigation/menu.py:73 netbox/navigation/menu.py:75
+#: virtualization/forms/model_forms.py:122 virtualization/tables/clusters.py:83
+#: virtualization/views.py:206
 msgid "Devices"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:63 netbox/dcim/tables/devices.py:111
-#: netbox/virtualization/tables/clusters.py:88
+#: dcim/tables/devices.py:63 dcim/tables/devices.py:111
+#: virtualization/tables/clusters.py:88
 msgid "VMs"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:100 netbox/dcim/tables/devices.py:216
-#: netbox/extras/forms/model_forms.py:630 netbox/templates/dcim/device.html:112
-#: netbox/templates/dcim/device/render_config.html:11
-#: netbox/templates/dcim/device/render_config.html:14
-#: netbox/templates/dcim/devicerole.html:44
-#: netbox/templates/dcim/platform.html:41
-#: netbox/templates/extras/configtemplate.html:10
-#: netbox/templates/virtualization/virtualmachine.html:48
-#: netbox/templates/virtualization/virtualmachine/render_config.html:11
-#: netbox/templates/virtualization/virtualmachine/render_config.html:14
-#: netbox/virtualization/tables/virtualmachines.py:107
+#: dcim/tables/devices.py:100 dcim/tables/devices.py:216
+#: extras/forms/model_forms.py:630 templates/dcim/device.html:112
+#: templates/dcim/device/render_config.html:11
+#: templates/dcim/device/render_config.html:14
+#: templates/dcim/devicerole.html:44 templates/dcim/platform.html:41
+#: templates/extras/configtemplate.html:10
+#: templates/virtualization/virtualmachine.html:48
+#: templates/virtualization/virtualmachine/render_config.html:11
+#: templates/virtualization/virtualmachine/render_config.html:14
+#: virtualization/tables/virtualmachines.py:107
 msgid "Config Template"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:150 netbox/templates/dcim/sitegroup.html:26
+#: dcim/tables/devices.py:150 templates/dcim/sitegroup.html:26
 msgid "Site Group"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:187 netbox/dcim/tables/devices.py:1068
-#: netbox/ipam/forms/bulk_import.py:503 netbox/ipam/forms/model_forms.py:306
-#: netbox/ipam/forms/model_forms.py:315 netbox/ipam/tables/ip.py:356
-#: netbox/ipam/tables/ip.py:423 netbox/ipam/tables/ip.py:446
-#: netbox/templates/ipam/ipaddress.html:11
-#: netbox/virtualization/tables/virtualmachines.py:95
+#: dcim/tables/devices.py:187 dcim/tables/devices.py:1068
+#: ipam/forms/bulk_import.py:503 ipam/forms/model_forms.py:306
+#: ipam/forms/model_forms.py:315 ipam/tables/ip.py:356 ipam/tables/ip.py:423
+#: ipam/tables/ip.py:446 templates/ipam/ipaddress.html:11
+#: virtualization/tables/virtualmachines.py:95
 msgid "IP Address"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:191 netbox/dcim/tables/devices.py:1072
-#: netbox/virtualization/tables/virtualmachines.py:86
+#: dcim/tables/devices.py:191 dcim/tables/devices.py:1072
+#: virtualization/tables/virtualmachines.py:86
 msgid "IPv4 Address"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:195 netbox/dcim/tables/devices.py:1076
-#: netbox/virtualization/tables/virtualmachines.py:90
+#: dcim/tables/devices.py:195 dcim/tables/devices.py:1076
+#: virtualization/tables/virtualmachines.py:90
 msgid "IPv6 Address"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:210
+#: dcim/tables/devices.py:210
 msgid "VC Position"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:213
+#: dcim/tables/devices.py:213
 msgid "VC Priority"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:220 netbox/templates/dcim/device_edit.html:38
-#: netbox/templates/dcim/devicebay_populate.html:16
+#: dcim/tables/devices.py:220 templates/dcim/device_edit.html:38
+#: templates/dcim/devicebay_populate.html:16
 msgid "Parent Device"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:225
+#: dcim/tables/devices.py:225
 msgid "Position (Device Bay)"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:234
+#: dcim/tables/devices.py:234
 msgid "Console ports"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:237
+#: dcim/tables/devices.py:237
 msgid "Console server ports"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:240
+#: dcim/tables/devices.py:240
 msgid "Power ports"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:243
+#: dcim/tables/devices.py:243
 msgid "Power outlets"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:246 netbox/dcim/tables/devices.py:1081
-#: netbox/dcim/tables/devicetypes.py:128 netbox/dcim/views.py:1042
-#: netbox/dcim/views.py:1281 netbox/dcim/views.py:1977
-#: netbox/netbox/navigation/menu.py:94 netbox/netbox/navigation/menu.py:250
-#: netbox/templates/dcim/device/base.html:37
-#: netbox/templates/dcim/device_list.html:43
-#: netbox/templates/dcim/devicetype/base.html:34
-#: netbox/templates/dcim/inc/moduletype_buttons.html:25
-#: netbox/templates/dcim/module.html:34
-#: netbox/templates/dcim/virtualdevicecontext.html:61
-#: netbox/templates/dcim/virtualdevicecontext.html:81
-#: netbox/templates/virtualization/virtualmachine/base.html:27
-#: netbox/templates/virtualization/virtualmachine_list.html:14
-#: netbox/virtualization/tables/virtualmachines.py:101
-#: netbox/virtualization/views.py:366 netbox/wireless/tables/wirelesslan.py:55
+#: dcim/tables/devices.py:246 dcim/tables/devices.py:1081
+#: dcim/tables/devicetypes.py:128 dcim/views.py:1042 dcim/views.py:1281
+#: dcim/views.py:1977 netbox/navigation/menu.py:94
+#: netbox/navigation/menu.py:250 templates/dcim/device/base.html:37
+#: templates/dcim/device_list.html:43 templates/dcim/devicetype/base.html:34
+#: templates/dcim/inc/moduletype_buttons.html:25 templates/dcim/module.html:34
+#: templates/dcim/virtualdevicecontext.html:61
+#: templates/dcim/virtualdevicecontext.html:81
+#: templates/virtualization/virtualmachine/base.html:27
+#: templates/virtualization/virtualmachine_list.html:14
+#: virtualization/tables/virtualmachines.py:101 virtualization/views.py:366
+#: wireless/tables/wirelesslan.py:55
 msgid "Interfaces"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:249
+#: dcim/tables/devices.py:249
 msgid "Front ports"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:255
+#: dcim/tables/devices.py:255
 msgid "Device bays"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:258
+#: dcim/tables/devices.py:258
 msgid "Module bays"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:261
+#: dcim/tables/devices.py:261
 msgid "Inventory items"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:305 netbox/dcim/tables/modules.py:56
-#: netbox/templates/dcim/modulebay.html:17
+#: dcim/tables/devices.py:305 dcim/tables/modules.py:56
+#: templates/dcim/modulebay.html:17
 msgid "Module Bay"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:318 netbox/dcim/tables/devicetypes.py:47
-#: netbox/dcim/tables/devicetypes.py:143 netbox/dcim/views.py:1117
-#: netbox/dcim/views.py:2075 netbox/netbox/navigation/menu.py:103
-#: netbox/templates/dcim/device/base.html:52
-#: netbox/templates/dcim/device_list.html:71
-#: netbox/templates/dcim/devicetype/base.html:49
-#: netbox/templates/dcim/inc/panels/inventory_items.html:6
-#: netbox/templates/dcim/inventoryitemrole.html:32
+#: dcim/tables/devices.py:318 dcim/tables/devicetypes.py:47
+#: dcim/tables/devicetypes.py:143 dcim/views.py:1117 dcim/views.py:2075
+#: netbox/navigation/menu.py:103 templates/dcim/device/base.html:52
+#: templates/dcim/device_list.html:71 templates/dcim/devicetype/base.html:49
+#: templates/dcim/inc/panels/inventory_items.html:6
+#: templates/dcim/inventoryitemrole.html:32
 msgid "Inventory Items"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:333
+#: dcim/tables/devices.py:333
 msgid "Cable Color"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:339
+#: dcim/tables/devices.py:339
 msgid "Link Peers"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:342
+#: dcim/tables/devices.py:342
 msgid "Mark Connected"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:461
+#: dcim/tables/devices.py:461
 msgid "Maximum draw (W)"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:464
+#: dcim/tables/devices.py:464
 msgid "Allocated draw (W)"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:558 netbox/ipam/forms/model_forms.py:701
-#: netbox/ipam/tables/fhrp.py:28 netbox/ipam/views.py:596
-#: netbox/ipam/views.py:696 netbox/netbox/navigation/menu.py:158
-#: netbox/netbox/navigation/menu.py:160
-#: netbox/templates/dcim/interface.html:339
-#: netbox/templates/ipam/ipaddress_bulk_add.html:15
-#: netbox/templates/ipam/service.html:40
-#: netbox/templates/virtualization/vminterface.html:85
-#: netbox/vpn/tables/tunnels.py:98
+#: dcim/tables/devices.py:558 ipam/forms/model_forms.py:701
+#: ipam/tables/fhrp.py:28 ipam/views.py:596 ipam/views.py:696
+#: netbox/navigation/menu.py:158 netbox/navigation/menu.py:160
+#: templates/dcim/interface.html:339 templates/ipam/ipaddress_bulk_add.html:15
+#: templates/ipam/service.html:40 templates/virtualization/vminterface.html:85
+#: vpn/tables/tunnels.py:98
 msgid "IP Addresses"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:564 netbox/netbox/navigation/menu.py:202
-#: netbox/templates/ipam/inc/panels/fhrp_groups.html:6
+#: dcim/tables/devices.py:564 netbox/navigation/menu.py:202
+#: templates/ipam/inc/panels/fhrp_groups.html:6
 msgid "FHRP Groups"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:576 netbox/templates/dcim/interface.html:89
-#: netbox/templates/virtualization/vminterface.html:67
-#: netbox/templates/vpn/tunnel.html:18
-#: netbox/templates/vpn/tunneltermination.html:13
-#: netbox/vpn/forms/bulk_edit.py:76 netbox/vpn/forms/bulk_import.py:76
-#: netbox/vpn/forms/filtersets.py:42 netbox/vpn/forms/filtersets.py:82
-#: netbox/vpn/forms/model_forms.py:60 netbox/vpn/forms/model_forms.py:145
-#: netbox/vpn/tables/tunnels.py:78
+#: dcim/tables/devices.py:576 templates/dcim/interface.html:89
+#: templates/virtualization/vminterface.html:67 templates/vpn/tunnel.html:18
+#: templates/vpn/tunneltermination.html:13 vpn/forms/bulk_edit.py:76
+#: vpn/forms/bulk_import.py:76 vpn/forms/filtersets.py:42
+#: vpn/forms/filtersets.py:82 vpn/forms/model_forms.py:60
+#: vpn/forms/model_forms.py:145 vpn/tables/tunnels.py:78
 msgid "Tunnel"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:604 netbox/dcim/tables/devicetypes.py:227
-#: netbox/templates/dcim/interface.html:65
+#: dcim/tables/devices.py:604 dcim/tables/devicetypes.py:227
+#: templates/dcim/interface.html:65
 msgid "Management Only"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:623
+#: dcim/tables/devices.py:623
 msgid "VDCs"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:873 netbox/templates/dcim/modulebay.html:53
+#: dcim/tables/devices.py:873 templates/dcim/modulebay.html:53
 msgid "Installed Module"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:876
+#: dcim/tables/devices.py:876
 msgid "Module Serial"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:880
+#: dcim/tables/devices.py:880
 msgid "Module Asset Tag"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:889
+#: dcim/tables/devices.py:889
 msgid "Module Status"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:944 netbox/dcim/tables/devicetypes.py:312
-#: netbox/templates/dcim/inventoryitem.html:40
+#: dcim/tables/devices.py:944 dcim/tables/devicetypes.py:312
+#: templates/dcim/inventoryitem.html:40
 msgid "Component"
 msgstr ""
 
-#: netbox/dcim/tables/devices.py:1000
+#: dcim/tables/devices.py:1000
 msgid "Items"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:37 netbox/netbox/navigation/menu.py:84
-#: netbox/netbox/navigation/menu.py:86
+#: dcim/tables/devicetypes.py:37 netbox/navigation/menu.py:84
+#: netbox/navigation/menu.py:86
 msgid "Device Types"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:42 netbox/netbox/navigation/menu.py:87
+#: dcim/tables/devicetypes.py:42 netbox/navigation/menu.py:87
 msgid "Module Types"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:52 netbox/extras/forms/filtersets.py:371
-#: netbox/extras/forms/model_forms.py:537 netbox/extras/tables/tables.py:540
-#: netbox/netbox/navigation/menu.py:78
+#: dcim/tables/devicetypes.py:52 extras/forms/filtersets.py:371
+#: extras/forms/model_forms.py:537 extras/tables/tables.py:540
+#: netbox/navigation/menu.py:78
 msgid "Platforms"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:84
-#: netbox/templates/dcim/devicetype.html:29
+#: dcim/tables/devicetypes.py:84 templates/dcim/devicetype.html:29
 msgid "Default Platform"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:88
-#: netbox/templates/dcim/devicetype.html:45
+#: dcim/tables/devicetypes.py:88 templates/dcim/devicetype.html:45
 msgid "Full Depth"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:98
+#: dcim/tables/devicetypes.py:98
 msgid "U Height"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:113 netbox/dcim/tables/modules.py:26
-#: netbox/dcim/tables/racks.py:89
+#: dcim/tables/devicetypes.py:113 dcim/tables/modules.py:26
+#: dcim/tables/racks.py:89
 msgid "Instances"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:116 netbox/dcim/views.py:982
-#: netbox/dcim/views.py:1221 netbox/dcim/views.py:1913
-#: netbox/netbox/navigation/menu.py:97
-#: netbox/templates/dcim/device/base.html:25
-#: netbox/templates/dcim/device_list.html:15
-#: netbox/templates/dcim/devicetype/base.html:22
-#: netbox/templates/dcim/inc/moduletype_buttons.html:13
-#: netbox/templates/dcim/module.html:22
+#: dcim/tables/devicetypes.py:116 dcim/views.py:982 dcim/views.py:1221
+#: dcim/views.py:1913 netbox/navigation/menu.py:97
+#: templates/dcim/device/base.html:25 templates/dcim/device_list.html:15
+#: templates/dcim/devicetype/base.html:22
+#: templates/dcim/inc/moduletype_buttons.html:13 templates/dcim/module.html:22
 msgid "Console Ports"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:119 netbox/dcim/views.py:997
-#: netbox/dcim/views.py:1236 netbox/dcim/views.py:1929
-#: netbox/netbox/navigation/menu.py:98
-#: netbox/templates/dcim/device/base.html:28
-#: netbox/templates/dcim/device_list.html:22
-#: netbox/templates/dcim/devicetype/base.html:25
-#: netbox/templates/dcim/inc/moduletype_buttons.html:16
-#: netbox/templates/dcim/module.html:25
+#: dcim/tables/devicetypes.py:119 dcim/views.py:997 dcim/views.py:1236
+#: dcim/views.py:1929 netbox/navigation/menu.py:98
+#: templates/dcim/device/base.html:28 templates/dcim/device_list.html:22
+#: templates/dcim/devicetype/base.html:25
+#: templates/dcim/inc/moduletype_buttons.html:16 templates/dcim/module.html:25
 msgid "Console Server Ports"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:122 netbox/dcim/views.py:1012
-#: netbox/dcim/views.py:1251 netbox/dcim/views.py:1945
-#: netbox/netbox/navigation/menu.py:99
-#: netbox/templates/dcim/device/base.html:31
-#: netbox/templates/dcim/device_list.html:29
-#: netbox/templates/dcim/devicetype/base.html:28
-#: netbox/templates/dcim/inc/moduletype_buttons.html:19
-#: netbox/templates/dcim/module.html:28
+#: dcim/tables/devicetypes.py:122 dcim/views.py:1012 dcim/views.py:1251
+#: dcim/views.py:1945 netbox/navigation/menu.py:99
+#: templates/dcim/device/base.html:31 templates/dcim/device_list.html:29
+#: templates/dcim/devicetype/base.html:28
+#: templates/dcim/inc/moduletype_buttons.html:19 templates/dcim/module.html:28
 msgid "Power Ports"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:125 netbox/dcim/views.py:1027
-#: netbox/dcim/views.py:1266 netbox/dcim/views.py:1961
-#: netbox/netbox/navigation/menu.py:100
-#: netbox/templates/dcim/device/base.html:34
-#: netbox/templates/dcim/device_list.html:36
-#: netbox/templates/dcim/devicetype/base.html:31
-#: netbox/templates/dcim/inc/moduletype_buttons.html:22
-#: netbox/templates/dcim/module.html:31
+#: dcim/tables/devicetypes.py:125 dcim/views.py:1027 dcim/views.py:1266
+#: dcim/views.py:1961 netbox/navigation/menu.py:100
+#: templates/dcim/device/base.html:34 templates/dcim/device_list.html:36
+#: templates/dcim/devicetype/base.html:31
+#: templates/dcim/inc/moduletype_buttons.html:22 templates/dcim/module.html:31
 msgid "Power Outlets"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:131 netbox/dcim/views.py:1057
-#: netbox/dcim/views.py:1296 netbox/dcim/views.py:1999
-#: netbox/netbox/navigation/menu.py:95
-#: netbox/templates/dcim/device/base.html:40
-#: netbox/templates/dcim/devicetype/base.html:37
-#: netbox/templates/dcim/inc/moduletype_buttons.html:28
-#: netbox/templates/dcim/module.html:37
+#: dcim/tables/devicetypes.py:131 dcim/views.py:1057 dcim/views.py:1296
+#: dcim/views.py:1999 netbox/navigation/menu.py:95
+#: templates/dcim/device/base.html:40 templates/dcim/devicetype/base.html:37
+#: templates/dcim/inc/moduletype_buttons.html:28 templates/dcim/module.html:37
 msgid "Front Ports"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:134 netbox/dcim/views.py:1072
-#: netbox/dcim/views.py:1311 netbox/dcim/views.py:2015
-#: netbox/netbox/navigation/menu.py:96
-#: netbox/templates/dcim/device/base.html:43
-#: netbox/templates/dcim/device_list.html:50
-#: netbox/templates/dcim/devicetype/base.html:40
-#: netbox/templates/dcim/inc/moduletype_buttons.html:31
-#: netbox/templates/dcim/module.html:40
+#: dcim/tables/devicetypes.py:134 dcim/views.py:1072 dcim/views.py:1311
+#: dcim/views.py:2015 netbox/navigation/menu.py:96
+#: templates/dcim/device/base.html:43 templates/dcim/device_list.html:50
+#: templates/dcim/devicetype/base.html:40
+#: templates/dcim/inc/moduletype_buttons.html:31 templates/dcim/module.html:40
 msgid "Rear Ports"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:137 netbox/dcim/views.py:1102
-#: netbox/dcim/views.py:2055 netbox/netbox/navigation/menu.py:102
-#: netbox/templates/dcim/device/base.html:49
-#: netbox/templates/dcim/device_list.html:57
-#: netbox/templates/dcim/devicetype/base.html:46
+#: dcim/tables/devicetypes.py:137 dcim/views.py:1102 dcim/views.py:2055
+#: netbox/navigation/menu.py:102 templates/dcim/device/base.html:49
+#: templates/dcim/device_list.html:57 templates/dcim/devicetype/base.html:46
 msgid "Device Bays"
 msgstr ""
 
-#: netbox/dcim/tables/devicetypes.py:140 netbox/dcim/views.py:1087
-#: netbox/dcim/views.py:1326 netbox/dcim/views.py:2035
-#: netbox/netbox/navigation/menu.py:101
-#: netbox/templates/dcim/device/base.html:46
-#: netbox/templates/dcim/device_list.html:64
-#: netbox/templates/dcim/devicetype/base.html:43
-#: netbox/templates/dcim/inc/moduletype_buttons.html:34
-#: netbox/templates/dcim/module.html:43
+#: dcim/tables/devicetypes.py:140 dcim/views.py:1087 dcim/views.py:1326
+#: dcim/views.py:2035 netbox/navigation/menu.py:101
+#: templates/dcim/device/base.html:46 templates/dcim/device_list.html:64
+#: templates/dcim/devicetype/base.html:43
+#: templates/dcim/inc/moduletype_buttons.html:34 templates/dcim/module.html:43
 msgid "Module Bays"
 msgstr ""
 
-#: netbox/dcim/tables/power.py:36 netbox/netbox/navigation/menu.py:297
-#: netbox/templates/dcim/powerpanel.html:51
+#: dcim/tables/power.py:36 netbox/navigation/menu.py:297
+#: templates/dcim/powerpanel.html:51
 msgid "Power Feeds"
 msgstr ""
 
-#: netbox/dcim/tables/power.py:80 netbox/templates/dcim/powerfeed.html:99
+#: dcim/tables/power.py:80 templates/dcim/powerfeed.html:99
 msgid "Max Utilization"
 msgstr ""
 
-#: netbox/dcim/tables/power.py:84
+#: dcim/tables/power.py:84
 msgid "Available Power (VA)"
 msgstr ""
 
-#: netbox/dcim/tables/racks.py:30 netbox/dcim/tables/sites.py:143
-#: netbox/netbox/navigation/menu.py:43 netbox/netbox/navigation/menu.py:47
-#: netbox/netbox/navigation/menu.py:49
+#: dcim/tables/racks.py:30 dcim/tables/sites.py:143
+#: netbox/navigation/menu.py:43 netbox/navigation/menu.py:47
+#: netbox/navigation/menu.py:49
 msgid "Racks"
 msgstr ""
 
-#: netbox/dcim/tables/racks.py:63 netbox/dcim/tables/racks.py:142
-#: netbox/templates/dcim/device.html:318
-#: netbox/templates/dcim/inc/panels/racktype_dimensions.html:14
+#: dcim/tables/racks.py:63 dcim/tables/racks.py:142
+#: templates/dcim/device.html:318
+#: templates/dcim/inc/panels/racktype_dimensions.html:14
 msgid "Height"
 msgstr ""
 
-#: netbox/dcim/tables/racks.py:67 netbox/dcim/tables/racks.py:165
-#: netbox/templates/dcim/inc/panels/racktype_dimensions.html:18
+#: dcim/tables/racks.py:67 dcim/tables/racks.py:165
+#: templates/dcim/inc/panels/racktype_dimensions.html:18
 msgid "Outer Width"
 msgstr ""
 
-#: netbox/dcim/tables/racks.py:71 netbox/dcim/tables/racks.py:169
-#: netbox/templates/dcim/inc/panels/racktype_dimensions.html:28
+#: dcim/tables/racks.py:71 dcim/tables/racks.py:169
+#: templates/dcim/inc/panels/racktype_dimensions.html:28
 msgid "Outer Depth"
 msgstr ""
 
-#: netbox/dcim/tables/racks.py:79 netbox/dcim/tables/racks.py:177
+#: dcim/tables/racks.py:79 dcim/tables/racks.py:177
 msgid "Max Weight"
 msgstr ""
 
-#: netbox/dcim/tables/racks.py:154
+#: dcim/tables/racks.py:154
 msgid "Space"
 msgstr ""
 
-#: netbox/dcim/tables/sites.py:30 netbox/dcim/tables/sites.py:57
-#: netbox/extras/forms/filtersets.py:351 netbox/extras/forms/model_forms.py:517
-#: netbox/ipam/forms/bulk_edit.py:131 netbox/ipam/forms/model_forms.py:153
-#: netbox/ipam/tables/asn.py:66 netbox/netbox/navigation/menu.py:15
-#: netbox/netbox/navigation/menu.py:17
+#: dcim/tables/sites.py:30 dcim/tables/sites.py:57
+#: extras/forms/filtersets.py:351 extras/forms/model_forms.py:517
+#: ipam/forms/bulk_edit.py:131 ipam/forms/model_forms.py:153
+#: ipam/tables/asn.py:66 netbox/navigation/menu.py:15
+#: netbox/navigation/menu.py:17
 msgid "Sites"
 msgstr ""
 
-#: netbox/dcim/tests/test_api.py:47
+#: dcim/tests/test_api.py:47
 msgid "Test case must set peer_termination_type"
 msgstr ""
 
-#: netbox/dcim/views.py:140
+#: dcim/views.py:140
 #, python-brace-format
 msgid "Disconnected {count} {type}"
 msgstr ""
 
-#: netbox/dcim/views.py:740 netbox/netbox/navigation/menu.py:51
+#: dcim/views.py:740 netbox/navigation/menu.py:51
 msgid "Reservations"
 msgstr ""
 
-#: netbox/dcim/views.py:759 netbox/templates/dcim/location.html:90
-#: netbox/templates/dcim/site.html:140
+#: dcim/views.py:759 templates/dcim/location.html:90
+#: templates/dcim/site.html:140
 msgid "Non-Racked Devices"
 msgstr ""
 
-#: netbox/dcim/views.py:2088 netbox/extras/forms/model_forms.py:577
-#: netbox/templates/extras/configcontext.html:10
-#: netbox/virtualization/forms/model_forms.py:225
-#: netbox/virtualization/views.py:407
+#: dcim/views.py:2088 extras/forms/model_forms.py:577
+#: templates/extras/configcontext.html:10
+#: virtualization/forms/model_forms.py:225 virtualization/views.py:407
 msgid "Config Context"
 msgstr ""
 
-#: netbox/dcim/views.py:2098 netbox/virtualization/views.py:417
+#: dcim/views.py:2098 virtualization/views.py:417
 msgid "Render Config"
 msgstr ""
 
-#: netbox/dcim/views.py:2131 netbox/virtualization/views.py:450
+#: dcim/views.py:2131 virtualization/views.py:450
 #, python-brace-format
 msgid "An error occurred while rendering the template: {error}"
 msgstr ""
 
-#: netbox/dcim/views.py:2149 netbox/extras/tables/tables.py:550
-#: netbox/netbox/navigation/menu.py:247 netbox/netbox/navigation/menu.py:249
-#: netbox/virtualization/views.py:180
+#: dcim/views.py:2149 extras/tables/tables.py:550 netbox/navigation/menu.py:247
+#: netbox/navigation/menu.py:249 virtualization/views.py:180
 msgid "Virtual Machines"
 msgstr ""
 
-#: netbox/dcim/views.py:2897
+#: dcim/views.py:2897
 #, python-brace-format
 msgid "Installed device {device} in bay {device_bay}."
 msgstr ""
 
-#: netbox/dcim/views.py:2938
+#: dcim/views.py:2938
 #, python-brace-format
 msgid "Removed device {device} from bay {device_bay}."
 msgstr ""
 
-#: netbox/dcim/views.py:3044 netbox/ipam/tables/ip.py:234
+#: dcim/views.py:3044 ipam/tables/ip.py:234
 msgid "Children"
 msgstr ""
 
-#: netbox/dcim/views.py:3510
+#: dcim/views.py:3510
 #, python-brace-format
 msgid "Added member <a href=\"{url}\">{device}</a>"
 msgstr ""
 
-#: netbox/dcim/views.py:3557
+#: dcim/views.py:3557
 #, python-brace-format
 msgid "Unable to remove master device {device} from the virtual chassis."
 msgstr ""
 
-#: netbox/dcim/views.py:3570
+#: dcim/views.py:3570
 #, python-brace-format
 msgid "Removed {device} from virtual chassis {chassis}"
 msgstr ""
 
-#: netbox/extras/api/customfields.py:89
+#: extras/api/customfields.py:89
 #, python-brace-format
 msgid "Unknown related object(s): {name}"
 msgstr ""
 
-#: netbox/extras/api/serializers_/customfields.py:73
+#: extras/api/serializers_/customfields.py:73
 msgid "Changing the type of custom fields is not supported."
 msgstr ""
 
-#: netbox/extras/api/serializers_/scripts.py:70
-#: netbox/extras/api/serializers_/scripts.py:75
+#: extras/api/serializers_/scripts.py:70 extras/api/serializers_/scripts.py:75
 msgid "Scheduling is not enabled for this script."
 msgstr ""
 
-#: netbox/extras/choices.py:30 netbox/extras/forms/misc.py:14
+#: extras/choices.py:30 extras/forms/misc.py:14
 msgid "Text"
 msgstr ""
 
-#: netbox/extras/choices.py:31
+#: extras/choices.py:31
 msgid "Text (long)"
 msgstr ""
 
-#: netbox/extras/choices.py:32
+#: extras/choices.py:32
 msgid "Integer"
 msgstr ""
 
-#: netbox/extras/choices.py:33
+#: extras/choices.py:33
 msgid "Decimal"
 msgstr ""
 
-#: netbox/extras/choices.py:34
+#: extras/choices.py:34
 msgid "Boolean (true/false)"
 msgstr ""
 
-#: netbox/extras/choices.py:35
+#: extras/choices.py:35
 msgid "Date"
 msgstr ""
 
-#: netbox/extras/choices.py:36
+#: extras/choices.py:36
 msgid "Date & time"
 msgstr ""
 
-#: netbox/extras/choices.py:38
+#: extras/choices.py:38
 msgid "JSON"
 msgstr ""
 
-#: netbox/extras/choices.py:39
+#: extras/choices.py:39
 msgid "Selection"
 msgstr ""
 
-#: netbox/extras/choices.py:40
+#: extras/choices.py:40
 msgid "Multiple selection"
 msgstr ""
 
-#: netbox/extras/choices.py:42
+#: extras/choices.py:42
 msgid "Multiple objects"
 msgstr ""
 
-#: netbox/extras/choices.py:53 netbox/netbox/preferences.py:21
-#: netbox/templates/extras/customfield.html:78 netbox/vpn/choices.py:20
-#: netbox/wireless/choices.py:27
+#: extras/choices.py:53 netbox/preferences.py:21
+#: templates/extras/customfield.html:78 vpn/choices.py:20
+#: wireless/choices.py:27
 msgid "Disabled"
 msgstr ""
 
-#: netbox/extras/choices.py:54
+#: extras/choices.py:54
 msgid "Loose"
 msgstr ""
 
-#: netbox/extras/choices.py:55
+#: extras/choices.py:55
 msgid "Exact"
 msgstr ""
 
-#: netbox/extras/choices.py:66
+#: extras/choices.py:66
 msgid "Always"
 msgstr ""
 
-#: netbox/extras/choices.py:67
+#: extras/choices.py:67
 msgid "If set"
 msgstr ""
 
-#: netbox/extras/choices.py:68 netbox/extras/choices.py:81
+#: extras/choices.py:68 extras/choices.py:81
 msgid "Hidden"
 msgstr ""
 
-#: netbox/extras/choices.py:79
+#: extras/choices.py:79
 msgid "Yes"
 msgstr ""
 
-#: netbox/extras/choices.py:80
+#: extras/choices.py:80
 msgid "No"
 msgstr ""
 
-#: netbox/extras/choices.py:108 netbox/templates/tenancy/contact.html:57
-#: netbox/tenancy/forms/bulk_edit.py:118
-#: netbox/wireless/forms/model_forms.py:168
+#: extras/choices.py:108 templates/tenancy/contact.html:57
+#: tenancy/forms/bulk_edit.py:118 wireless/forms/model_forms.py:168
 msgid "Link"
 msgstr ""
 
-#: netbox/extras/choices.py:124
+#: extras/choices.py:124
 msgid "Newest"
 msgstr ""
 
-#: netbox/extras/choices.py:125
+#: extras/choices.py:125
 msgid "Oldest"
 msgstr ""
 
-#: netbox/extras/choices.py:126
+#: extras/choices.py:126
 msgid "Alphabetical (A-Z)"
 msgstr ""
 
-#: netbox/extras/choices.py:127
+#: extras/choices.py:127
 msgid "Alphabetical (Z-A)"
 msgstr ""
 
-#: netbox/extras/choices.py:144 netbox/extras/choices.py:167
+#: extras/choices.py:144 extras/choices.py:167
 msgid "Info"
 msgstr ""
 
-#: netbox/extras/choices.py:145 netbox/extras/choices.py:168
+#: extras/choices.py:145 extras/choices.py:168
 msgid "Success"
 msgstr ""
 
-#: netbox/extras/choices.py:146 netbox/extras/choices.py:169
+#: extras/choices.py:146 extras/choices.py:169
 msgid "Warning"
 msgstr ""
 
-#: netbox/extras/choices.py:147
+#: extras/choices.py:147
 msgid "Danger"
 msgstr ""
 
-#: netbox/extras/choices.py:165
+#: extras/choices.py:165
 msgid "Debug"
 msgstr ""
 
-#: netbox/extras/choices.py:166 netbox/netbox/choices.py:101
+#: extras/choices.py:166 netbox/choices.py:101
 msgid "Default"
 msgstr ""
 
-#: netbox/extras/choices.py:170
+#: extras/choices.py:170
 msgid "Failure"
 msgstr ""
 
-#: netbox/extras/choices.py:186
+#: extras/choices.py:186
 msgid "Hourly"
 msgstr ""
 
-#: netbox/extras/choices.py:187
+#: extras/choices.py:187
 msgid "12 hours"
 msgstr ""
 
-#: netbox/extras/choices.py:188
+#: extras/choices.py:188
 msgid "Daily"
 msgstr ""
 
-#: netbox/extras/choices.py:189
+#: extras/choices.py:189
 msgid "Weekly"
 msgstr ""
 
-#: netbox/extras/choices.py:190
+#: extras/choices.py:190
 msgid "30 days"
 msgstr ""
 
-#: netbox/extras/choices.py:226
-#: netbox/templates/dcim/virtualchassis_edit.html:107
-#: netbox/templates/generic/bulk_add_component.html:68
-#: netbox/templates/generic/object_edit.html:47
-#: netbox/templates/generic/object_edit.html:80
-#: netbox/templates/ipam/inc/ipaddress_edit_header.html:7
+#: extras/choices.py:226 templates/dcim/virtualchassis_edit.html:107
+#: templates/generic/bulk_add_component.html:68
+#: templates/generic/object_edit.html:47 templates/generic/object_edit.html:80
+#: templates/ipam/inc/ipaddress_edit_header.html:7
 msgid "Create"
 msgstr ""
 
-#: netbox/extras/choices.py:227
+#: extras/choices.py:227
 msgid "Update"
 msgstr ""
 
-#: netbox/extras/choices.py:228
-#: netbox/templates/circuits/inc/circuit_termination.html:23
-#: netbox/templates/dcim/inc/panels/inventory_items.html:37
-#: netbox/templates/dcim/powerpanel.html:66
-#: netbox/templates/extras/script_list.html:35
-#: netbox/templates/generic/bulk_delete.html:20
-#: netbox/templates/generic/bulk_delete.html:66
-#: netbox/templates/generic/object_delete.html:19
-#: netbox/templates/htmx/delete_form.html:57
-#: netbox/templates/ipam/inc/panels/fhrp_groups.html:48
-#: netbox/templates/users/objectpermission.html:46
-#: netbox/utilities/templates/buttons/delete.html:11
+#: extras/choices.py:228 templates/circuits/inc/circuit_termination.html:23
+#: templates/dcim/inc/panels/inventory_items.html:37
+#: templates/dcim/powerpanel.html:66 templates/extras/script_list.html:35
+#: templates/generic/bulk_delete.html:20 templates/generic/bulk_delete.html:66
+#: templates/generic/object_delete.html:19 templates/htmx/delete_form.html:57
+#: templates/ipam/inc/panels/fhrp_groups.html:48
+#: templates/users/objectpermission.html:46
+#: utilities/templates/buttons/delete.html:11
 msgid "Delete"
 msgstr ""
 
-#: netbox/extras/choices.py:252 netbox/netbox/choices.py:57
-#: netbox/netbox/choices.py:102
+#: extras/choices.py:252 netbox/choices.py:57 netbox/choices.py:102
 msgid "Blue"
 msgstr ""
 
-#: netbox/extras/choices.py:253 netbox/netbox/choices.py:56
-#: netbox/netbox/choices.py:103
+#: extras/choices.py:253 netbox/choices.py:56 netbox/choices.py:103
 msgid "Indigo"
 msgstr ""
 
-#: netbox/extras/choices.py:254 netbox/netbox/choices.py:54
-#: netbox/netbox/choices.py:104
+#: extras/choices.py:254 netbox/choices.py:54 netbox/choices.py:104
 msgid "Purple"
 msgstr ""
 
-#: netbox/extras/choices.py:255 netbox/netbox/choices.py:51
-#: netbox/netbox/choices.py:105
+#: extras/choices.py:255 netbox/choices.py:51 netbox/choices.py:105
 msgid "Pink"
 msgstr ""
 
-#: netbox/extras/choices.py:256 netbox/netbox/choices.py:50
-#: netbox/netbox/choices.py:106
+#: extras/choices.py:256 netbox/choices.py:50 netbox/choices.py:106
 msgid "Red"
 msgstr ""
 
-#: netbox/extras/choices.py:257 netbox/netbox/choices.py:68
-#: netbox/netbox/choices.py:107
+#: extras/choices.py:257 netbox/choices.py:68 netbox/choices.py:107
 msgid "Orange"
 msgstr ""
 
-#: netbox/extras/choices.py:258 netbox/netbox/choices.py:66
-#: netbox/netbox/choices.py:108
+#: extras/choices.py:258 netbox/choices.py:66 netbox/choices.py:108
 msgid "Yellow"
 msgstr ""
 
-#: netbox/extras/choices.py:259 netbox/netbox/choices.py:63
-#: netbox/netbox/choices.py:109
+#: extras/choices.py:259 netbox/choices.py:63 netbox/choices.py:109
 msgid "Green"
 msgstr ""
 
-#: netbox/extras/choices.py:260 netbox/netbox/choices.py:60
-#: netbox/netbox/choices.py:110
+#: extras/choices.py:260 netbox/choices.py:60 netbox/choices.py:110
 msgid "Teal"
 msgstr ""
 
-#: netbox/extras/choices.py:261 netbox/netbox/choices.py:59
-#: netbox/netbox/choices.py:111
+#: extras/choices.py:261 netbox/choices.py:59 netbox/choices.py:111
 msgid "Cyan"
 msgstr ""
 
-#: netbox/extras/choices.py:262 netbox/netbox/choices.py:112
+#: extras/choices.py:262 netbox/choices.py:112
 msgid "Gray"
 msgstr ""
 
-#: netbox/extras/choices.py:263 netbox/netbox/choices.py:74
-#: netbox/netbox/choices.py:113
+#: extras/choices.py:263 netbox/choices.py:74 netbox/choices.py:113
 msgid "Black"
 msgstr ""
 
-#: netbox/extras/choices.py:264 netbox/netbox/choices.py:75
-#: netbox/netbox/choices.py:114
+#: extras/choices.py:264 netbox/choices.py:75 netbox/choices.py:114
 msgid "White"
 msgstr ""
 
-#: netbox/extras/choices.py:279 netbox/extras/forms/model_forms.py:353
-#: netbox/extras/forms/model_forms.py:430
-#: netbox/templates/extras/webhook.html:10
+#: extras/choices.py:279 extras/forms/model_forms.py:353
+#: extras/forms/model_forms.py:430 templates/extras/webhook.html:10
 msgid "Webhook"
 msgstr ""
 
-#: netbox/extras/choices.py:280 netbox/extras/forms/model_forms.py:418
-#: netbox/templates/extras/script/base.html:29
+#: extras/choices.py:280 extras/forms/model_forms.py:418
+#: templates/extras/script/base.html:29
 msgid "Script"
 msgstr ""
 
-#: netbox/extras/choices.py:281
+#: extras/choices.py:281
 msgid "Notification"
 msgstr ""
 
-#: netbox/extras/conditions.py:54
+#: extras/conditions.py:54
 #, python-brace-format
 msgid "Unknown operator: {op}. Must be one of: {operators}"
 msgstr ""
 
-#: netbox/extras/conditions.py:58
+#: extras/conditions.py:58
 #, python-brace-format
 msgid "Unsupported value type: {value}"
 msgstr ""
 
-#: netbox/extras/conditions.py:60
+#: extras/conditions.py:60
 #, python-brace-format
 msgid "Invalid type for {op} operation: {value}"
 msgstr ""
 
-#: netbox/extras/conditions.py:137
+#: extras/conditions.py:137
 #, python-brace-format
 msgid "Ruleset must be a dictionary, not {ruleset}."
 msgstr ""
 
-#: netbox/extras/conditions.py:142
+#: extras/conditions.py:142
 msgid "Invalid logic type: must be 'AND' or 'OR'. Please check documentation."
 msgstr ""
 
-#: netbox/extras/conditions.py:154
+#: extras/conditions.py:154
 msgid "Incorrect key(s) informed. Please check documentation."
 msgstr ""
 
-#: netbox/extras/dashboard/forms.py:38
+#: extras/dashboard/forms.py:38
 msgid "Widget type"
 msgstr ""
 
-#: netbox/extras/dashboard/utils.py:36
+#: extras/dashboard/utils.py:36
 #, python-brace-format
 msgid "Unregistered widget class: {name}"
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:125
+#: extras/dashboard/widgets.py:125
 #, python-brace-format
 msgid "{class_name} must define a render() method."
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:144
+#: extras/dashboard/widgets.py:144
 msgid "Note"
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:145
+#: extras/dashboard/widgets.py:145
 msgid "Display some arbitrary custom content. Markdown is supported."
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:158
+#: extras/dashboard/widgets.py:158
 msgid "Object Counts"
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:159
+#: extras/dashboard/widgets.py:159
 msgid ""
 "Display a set of NetBox models and the number of objects created for each "
 "type."
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:169
+#: extras/dashboard/widgets.py:169
 msgid "Filters to apply when counting the number of objects"
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:177
+#: extras/dashboard/widgets.py:177
 msgid "Invalid format. Object filters must be passed as a dictionary."
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:208
+#: extras/dashboard/widgets.py:208
 msgid "Object List"
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:209
+#: extras/dashboard/widgets.py:209
 msgid "Display an arbitrary list of objects."
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:222
+#: extras/dashboard/widgets.py:222
 msgid "The default number of objects to display"
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:234
+#: extras/dashboard/widgets.py:234
 msgid "Invalid format. URL parameters must be passed as a dictionary."
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:274
+#: extras/dashboard/widgets.py:274
 msgid "RSS Feed"
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:279
+#: extras/dashboard/widgets.py:279
 msgid "Embed an RSS feed from an external website."
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:286
+#: extras/dashboard/widgets.py:286
 msgid "Feed URL"
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:291
+#: extras/dashboard/widgets.py:291
 msgid "The maximum number of objects to display"
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:296
+#: extras/dashboard/widgets.py:296
 msgid "How long to stored the cached content (in seconds)"
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:348 netbox/templates/account/base.html:10
-#: netbox/templates/account/bookmarks.html:7
-#: netbox/templates/inc/user_menu.html:48
+#: extras/dashboard/widgets.py:348 templates/account/base.html:10
+#: templates/account/bookmarks.html:7 templates/inc/user_menu.html:48
 msgid "Bookmarks"
 msgstr ""
 
-#: netbox/extras/dashboard/widgets.py:352
+#: extras/dashboard/widgets.py:352
 msgid "Show your personal bookmarks"
 msgstr ""
 
-#: netbox/extras/events.py:147
+#: extras/events.py:147
 #, python-brace-format
 msgid "Unknown action type for an event rule: {action_type}"
 msgstr ""
 
-#: netbox/extras/events.py:192
+#: extras/events.py:192
 #, python-brace-format
 msgid "Cannot import events pipeline {name} error: {error}"
 msgstr ""
 
-#: netbox/extras/filtersets.py:45
+#: extras/filtersets.py:45
 msgid "Script module (ID)"
 msgstr ""
 
-#: netbox/extras/filtersets.py:254 netbox/extras/filtersets.py:637
-#: netbox/extras/filtersets.py:665
+#: extras/filtersets.py:254 extras/filtersets.py:637 extras/filtersets.py:665
 msgid "Data file (ID)"
 msgstr ""
 
-#: netbox/extras/filtersets.py:370 netbox/users/filtersets.py:68
-#: netbox/users/filtersets.py:191
+#: extras/filtersets.py:370 users/filtersets.py:68 users/filtersets.py:191
 msgid "Group (name)"
 msgstr ""
 
-#: netbox/extras/filtersets.py:574
-#: netbox/virtualization/forms/filtersets.py:118
+#: extras/filtersets.py:574 virtualization/forms/filtersets.py:118
 msgid "Cluster type"
 msgstr ""
 
-#: netbox/extras/filtersets.py:580 netbox/virtualization/filtersets.py:95
-#: netbox/virtualization/filtersets.py:147
+#: extras/filtersets.py:580 virtualization/filtersets.py:95
+#: virtualization/filtersets.py:147
 msgid "Cluster type (slug)"
 msgstr ""
 
-#: netbox/extras/filtersets.py:601 netbox/tenancy/forms/forms.py:16
-#: netbox/tenancy/forms/forms.py:39
+#: extras/filtersets.py:601 tenancy/forms/forms.py:16 tenancy/forms/forms.py:39
 msgid "Tenant group"
 msgstr ""
 
-#: netbox/extras/filtersets.py:607 netbox/tenancy/filtersets.py:188
-#: netbox/tenancy/filtersets.py:208
+#: extras/filtersets.py:607 tenancy/filtersets.py:188 tenancy/filtersets.py:208
 msgid "Tenant group (slug)"
 msgstr ""
 
-#: netbox/extras/filtersets.py:623 netbox/extras/forms/model_forms.py:495
-#: netbox/templates/extras/tag.html:11
+#: extras/filtersets.py:623 extras/forms/model_forms.py:495
+#: templates/extras/tag.html:11
 msgid "Tag"
 msgstr ""
 
-#: netbox/extras/filtersets.py:629
+#: extras/filtersets.py:629
 msgid "Tag (slug)"
 msgstr ""
 
-#: netbox/extras/filtersets.py:689 netbox/extras/forms/filtersets.py:429
+#: extras/filtersets.py:689 extras/forms/filtersets.py:429
 msgid "Has local config context data"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:35 netbox/extras/forms/filtersets.py:60
+#: extras/forms/bulk_edit.py:35 extras/forms/filtersets.py:60
 msgid "Group name"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:43 netbox/extras/forms/filtersets.py:68
-#: netbox/extras/tables/tables.py:65
-#: netbox/templates/extras/customfield.html:38
-#: netbox/templates/generic/bulk_import.html:118
+#: extras/forms/bulk_edit.py:43 extras/forms/filtersets.py:68
+#: extras/tables/tables.py:65 templates/extras/customfield.html:38
+#: templates/generic/bulk_import.html:118
 msgid "Required"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:48 netbox/extras/forms/filtersets.py:75
+#: extras/forms/bulk_edit.py:48 extras/forms/filtersets.py:75
 msgid "Must be unique"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:61 netbox/extras/forms/bulk_import.py:60
-#: netbox/extras/forms/filtersets.py:89
-#: netbox/extras/models/customfields.py:209
+#: extras/forms/bulk_edit.py:61 extras/forms/bulk_import.py:60
+#: extras/forms/filtersets.py:89 extras/models/customfields.py:209
 msgid "UI visible"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:66 netbox/extras/forms/bulk_import.py:66
-#: netbox/extras/forms/filtersets.py:94
-#: netbox/extras/models/customfields.py:216
+#: extras/forms/bulk_edit.py:66 extras/forms/bulk_import.py:66
+#: extras/forms/filtersets.py:94 extras/models/customfields.py:216
 msgid "UI editable"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:71 netbox/extras/forms/filtersets.py:97
+#: extras/forms/bulk_edit.py:71 extras/forms/filtersets.py:97
 msgid "Is cloneable"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:76 netbox/extras/forms/filtersets.py:104
+#: extras/forms/bulk_edit.py:76 extras/forms/filtersets.py:104
 msgid "Minimum value"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:80 netbox/extras/forms/filtersets.py:108
+#: extras/forms/bulk_edit.py:80 extras/forms/filtersets.py:108
 msgid "Maximum value"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:84 netbox/extras/forms/filtersets.py:112
+#: extras/forms/bulk_edit.py:84 extras/forms/filtersets.py:112
 msgid "Validation regex"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:91 netbox/extras/forms/filtersets.py:46
-#: netbox/extras/forms/model_forms.py:76
-#: netbox/templates/extras/customfield.html:70
+#: extras/forms/bulk_edit.py:91 extras/forms/filtersets.py:46
+#: extras/forms/model_forms.py:76 templates/extras/customfield.html:70
 msgid "Behavior"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:128 netbox/extras/forms/filtersets.py:149
+#: extras/forms/bulk_edit.py:128 extras/forms/filtersets.py:149
 msgid "New window"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:137
+#: extras/forms/bulk_edit.py:137
 msgid "Button class"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:154 netbox/extras/forms/filtersets.py:187
-#: netbox/extras/models/models.py:409
+#: extras/forms/bulk_edit.py:154 extras/forms/filtersets.py:187
+#: extras/models/models.py:409
 msgid "MIME type"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:159 netbox/extras/forms/filtersets.py:190
+#: extras/forms/bulk_edit.py:159 extras/forms/filtersets.py:190
 msgid "File extension"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:164 netbox/extras/forms/filtersets.py:194
+#: extras/forms/bulk_edit.py:164 extras/forms/filtersets.py:194
 msgid "As attachment"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:192 netbox/extras/forms/filtersets.py:236
-#: netbox/extras/tables/tables.py:256
-#: netbox/templates/extras/savedfilter.html:29
+#: extras/forms/bulk_edit.py:192 extras/forms/filtersets.py:236
+#: extras/tables/tables.py:256 templates/extras/savedfilter.html:29
 msgid "Shared"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:215 netbox/extras/forms/filtersets.py:265
-#: netbox/extras/models/models.py:174
+#: extras/forms/bulk_edit.py:215 extras/forms/filtersets.py:265
+#: extras/models/models.py:174
 msgid "HTTP method"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:219 netbox/extras/forms/filtersets.py:259
-#: netbox/templates/extras/webhook.html:30
+#: extras/forms/bulk_edit.py:219 extras/forms/filtersets.py:259
+#: templates/extras/webhook.html:30
 msgid "Payload URL"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:224 netbox/extras/models/models.py:214
+#: extras/forms/bulk_edit.py:224 extras/models/models.py:214
 msgid "SSL verification"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:227 netbox/templates/extras/webhook.html:38
+#: extras/forms/bulk_edit.py:227 templates/extras/webhook.html:38
 msgid "Secret"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:232
+#: extras/forms/bulk_edit.py:232
 msgid "CA file path"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:253 netbox/extras/forms/bulk_import.py:192
-#: netbox/extras/forms/model_forms.py:377
+#: extras/forms/bulk_edit.py:253 extras/forms/bulk_import.py:192
+#: extras/forms/model_forms.py:377
 msgid "Event types"
 msgstr ""
 
-#: netbox/extras/forms/bulk_edit.py:293
+#: extras/forms/bulk_edit.py:293
 msgid "Is active"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:37 netbox/extras/forms/bulk_import.py:118
-#: netbox/extras/forms/bulk_import.py:139
-#: netbox/extras/forms/bulk_import.py:162
-#: netbox/extras/forms/bulk_import.py:186 netbox/extras/forms/filtersets.py:137
-#: netbox/extras/forms/filtersets.py:224 netbox/extras/forms/model_forms.py:47
-#: netbox/extras/forms/model_forms.py:205
-#: netbox/extras/forms/model_forms.py:237
-#: netbox/extras/forms/model_forms.py:278
-#: netbox/extras/forms/model_forms.py:372
-#: netbox/extras/forms/model_forms.py:489 netbox/users/forms/model_forms.py:276
+#: extras/forms/bulk_import.py:37 extras/forms/bulk_import.py:118
+#: extras/forms/bulk_import.py:139 extras/forms/bulk_import.py:162
+#: extras/forms/bulk_import.py:186 extras/forms/filtersets.py:137
+#: extras/forms/filtersets.py:224 extras/forms/model_forms.py:47
+#: extras/forms/model_forms.py:205 extras/forms/model_forms.py:237
+#: extras/forms/model_forms.py:278 extras/forms/model_forms.py:372
+#: extras/forms/model_forms.py:489 users/forms/model_forms.py:276
 msgid "Object types"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:39 netbox/extras/forms/bulk_import.py:120
-#: netbox/extras/forms/bulk_import.py:141
-#: netbox/extras/forms/bulk_import.py:164
-#: netbox/extras/forms/bulk_import.py:188
-#: netbox/tenancy/forms/bulk_import.py:96
+#: extras/forms/bulk_import.py:39 extras/forms/bulk_import.py:120
+#: extras/forms/bulk_import.py:141 extras/forms/bulk_import.py:164
+#: extras/forms/bulk_import.py:188 tenancy/forms/bulk_import.py:96
 msgid "One or more assigned object types"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:44
+#: extras/forms/bulk_import.py:44
 msgid "Field data type (e.g. text, integer, etc.)"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:47 netbox/extras/forms/filtersets.py:208
-#: netbox/extras/forms/filtersets.py:281 netbox/extras/forms/model_forms.py:304
-#: netbox/extras/forms/model_forms.py:341 netbox/tenancy/forms/filtersets.py:92
+#: extras/forms/bulk_import.py:47 extras/forms/filtersets.py:208
+#: extras/forms/filtersets.py:281 extras/forms/model_forms.py:304
+#: extras/forms/model_forms.py:341 tenancy/forms/filtersets.py:92
 msgid "Object type"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:50
+#: extras/forms/bulk_import.py:50
 msgid "Object type (for object or multi-object fields)"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:53 netbox/extras/forms/filtersets.py:84
+#: extras/forms/bulk_import.py:53 extras/forms/filtersets.py:84
 msgid "Choice set"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:57
+#: extras/forms/bulk_import.py:57
 msgid "Choice set (for selection fields)"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:63
+#: extras/forms/bulk_import.py:63
 msgid "Whether the custom field is displayed in the UI"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:69
+#: extras/forms/bulk_import.py:69
 msgid "Whether the custom field is editable in the UI"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:85
+#: extras/forms/bulk_import.py:85
 msgid "The base set of predefined choices to use (if any)"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:91
+#: extras/forms/bulk_import.py:91
 msgid ""
 "Quoted string of comma-separated field choices with optional labels "
 "separated by colon: \"choice1:First Choice,choice2:Second Choice\""
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:123 netbox/extras/models/models.py:323
+#: extras/forms/bulk_import.py:123 extras/models/models.py:323
 msgid "button class"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:126 netbox/extras/models/models.py:327
+#: extras/forms/bulk_import.py:126 extras/models/models.py:327
 msgid ""
 "The class of the first link in a group will be used for the dropdown button"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:193
+#: extras/forms/bulk_import.py:193
 msgid "The event type(s) which will trigger this rule"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:196
+#: extras/forms/bulk_import.py:196
 msgid "Action object"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:198
+#: extras/forms/bulk_import.py:198
 msgid "Webhook name or script as dotted path module.Class"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:219
+#: extras/forms/bulk_import.py:219
 #, python-brace-format
 msgid "Webhook {name} not found"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:228
+#: extras/forms/bulk_import.py:228
 #, python-brace-format
 msgid "Script {name} not found"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:244
+#: extras/forms/bulk_import.py:244
 msgid "Assigned object type"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:249
+#: extras/forms/bulk_import.py:249
 msgid "The classification of entry"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:261
-#: netbox/extras/forms/model_forms.py:320 netbox/netbox/navigation/menu.py:390
-#: netbox/templates/extras/notificationgroup.html:41
-#: netbox/templates/users/group.html:29 netbox/users/forms/model_forms.py:236
-#: netbox/users/forms/model_forms.py:248 netbox/users/forms/model_forms.py:300
-#: netbox/users/tables.py:102
+#: extras/forms/bulk_import.py:261 extras/forms/model_forms.py:320
+#: netbox/navigation/menu.py:390 templates/extras/notificationgroup.html:41
+#: templates/users/group.html:29 users/forms/model_forms.py:236
+#: users/forms/model_forms.py:248 users/forms/model_forms.py:300
+#: users/tables.py:102
 msgid "Users"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:265
+#: extras/forms/bulk_import.py:265
 msgid "User names separated by commas, encased with double quotes"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:268
-#: netbox/extras/forms/model_forms.py:315 netbox/netbox/navigation/menu.py:410
-#: netbox/templates/extras/notificationgroup.html:31
-#: netbox/users/forms/model_forms.py:181 netbox/users/forms/model_forms.py:193
-#: netbox/users/forms/model_forms.py:305 netbox/users/tables.py:35
-#: netbox/users/tables.py:106
+#: extras/forms/bulk_import.py:268 extras/forms/model_forms.py:315
+#: netbox/navigation/menu.py:410 templates/extras/notificationgroup.html:31
+#: users/forms/model_forms.py:181 users/forms/model_forms.py:193
+#: users/forms/model_forms.py:305 users/tables.py:35 users/tables.py:106
 msgid "Groups"
 msgstr ""
 
-#: netbox/extras/forms/bulk_import.py:272
+#: extras/forms/bulk_import.py:272
 msgid "Group names separated by commas, encased with double quotes"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:52 netbox/extras/forms/model_forms.py:56
+#: extras/forms/filtersets.py:52 extras/forms/model_forms.py:56
 msgid "Related object type"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:57
+#: extras/forms/filtersets.py:57
 msgid "Field type"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:120 netbox/extras/forms/model_forms.py:157
-#: netbox/extras/tables/tables.py:91
-#: netbox/templates/generic/bulk_import.html:154
+#: extras/forms/filtersets.py:120 extras/forms/model_forms.py:157
+#: extras/tables/tables.py:91 templates/generic/bulk_import.html:154
 msgid "Choices"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:164 netbox/extras/forms/filtersets.py:319
-#: netbox/extras/forms/filtersets.py:408 netbox/extras/forms/model_forms.py:572
-#: netbox/templates/core/job.html:96 netbox/templates/extras/eventrule.html:84
+#: extras/forms/filtersets.py:164 extras/forms/filtersets.py:319
+#: extras/forms/filtersets.py:408 extras/forms/model_forms.py:572
+#: templates/core/job.html:96 templates/extras/eventrule.html:84
 msgid "Data"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:175 netbox/extras/forms/filtersets.py:333
-#: netbox/extras/forms/filtersets.py:418 netbox/netbox/choices.py:130
-#: netbox/utilities/forms/bulk_import.py:26
+#: extras/forms/filtersets.py:175 extras/forms/filtersets.py:333
+#: extras/forms/filtersets.py:418 netbox/choices.py:130
+#: utilities/forms/bulk_import.py:26
 msgid "Data file"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:183
+#: extras/forms/filtersets.py:183
 msgid "Content types"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:255 netbox/extras/models/models.py:179
+#: extras/forms/filtersets.py:255 extras/models/models.py:179
 msgid "HTTP content type"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:286
+#: extras/forms/filtersets.py:286
 msgid "Event type"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:291
+#: extras/forms/filtersets.py:291
 msgid "Action type"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:307
+#: extras/forms/filtersets.py:307
 msgid "Tagged object type"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:312
+#: extras/forms/filtersets.py:312
 msgid "Allowed object type"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:341 netbox/extras/forms/model_forms.py:507
-#: netbox/netbox/navigation/menu.py:18
+#: extras/forms/filtersets.py:341 extras/forms/model_forms.py:507
+#: netbox/navigation/menu.py:18
 msgid "Regions"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:346 netbox/extras/forms/model_forms.py:512
+#: extras/forms/filtersets.py:346 extras/forms/model_forms.py:512
 msgid "Site groups"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:356 netbox/extras/forms/model_forms.py:522
-#: netbox/netbox/navigation/menu.py:20 netbox/templates/dcim/site.html:127
+#: extras/forms/filtersets.py:356 extras/forms/model_forms.py:522
+#: netbox/navigation/menu.py:20 templates/dcim/site.html:127
 msgid "Locations"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:361 netbox/extras/forms/model_forms.py:527
+#: extras/forms/filtersets.py:361 extras/forms/model_forms.py:527
 msgid "Device types"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:366 netbox/extras/forms/model_forms.py:532
+#: extras/forms/filtersets.py:366 extras/forms/model_forms.py:532
 msgid "Roles"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:376 netbox/extras/forms/model_forms.py:542
+#: extras/forms/filtersets.py:376 extras/forms/model_forms.py:542
 msgid "Cluster types"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:381 netbox/extras/forms/model_forms.py:547
+#: extras/forms/filtersets.py:381 extras/forms/model_forms.py:547
 msgid "Cluster groups"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:386 netbox/extras/forms/model_forms.py:552
-#: netbox/netbox/navigation/menu.py:255 netbox/netbox/navigation/menu.py:257
-#: netbox/templates/virtualization/clustertype.html:30
-#: netbox/virtualization/tables/clusters.py:23
-#: netbox/virtualization/tables/clusters.py:45
+#: extras/forms/filtersets.py:386 extras/forms/model_forms.py:552
+#: netbox/navigation/menu.py:255 netbox/navigation/menu.py:257
+#: templates/virtualization/clustertype.html:30
+#: virtualization/tables/clusters.py:23 virtualization/tables/clusters.py:45
 msgid "Clusters"
 msgstr ""
 
-#: netbox/extras/forms/filtersets.py:391 netbox/extras/forms/model_forms.py:557
+#: extras/forms/filtersets.py:391 extras/forms/model_forms.py:557
 msgid "Tenant groups"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:49
+#: extras/forms/model_forms.py:49
 msgid "The type(s) of object that have this custom field"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:52
+#: extras/forms/model_forms.py:52
 msgid "Default value"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:58
+#: extras/forms/model_forms.py:58
 msgid "Type of the related object (for object/multi-object fields only)"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:61
-#: netbox/templates/extras/customfield.html:60
+#: extras/forms/model_forms.py:61 templates/extras/customfield.html:60
 msgid "Related object filter"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:63
+#: extras/forms/model_forms.py:63
 msgid "Specify query parameters as a JSON object."
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:73
-#: netbox/templates/extras/customfield.html:10
+#: extras/forms/model_forms.py:73 templates/extras/customfield.html:10
 msgid "Custom Field"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:85
+#: extras/forms/model_forms.py:85
 msgid ""
 "The type of data stored in this field. For object/multi-object fields, "
 "select the related object type below."
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:88
+#: extras/forms/model_forms.py:88
 msgid ""
 "This will be displayed as help text for the form field. Markdown is "
 "supported."
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:143
+#: extras/forms/model_forms.py:143
 msgid "Related Object"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:169
+#: extras/forms/model_forms.py:169
 msgid ""
 "Enter one choice per line. An optional label may be specified for each "
 "choice by appending it with a colon. Example:"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:212
-#: netbox/templates/extras/customlink.html:10
+#: extras/forms/model_forms.py:212 templates/extras/customlink.html:10
 msgid "Custom Link"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:214
+#: extras/forms/model_forms.py:214
 msgid "Templates"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:226
+#: extras/forms/model_forms.py:226
 #, python-brace-format
 msgid ""
 "Jinja2 template code for the link text. Reference the object as {example}. "
 "Links which render as empty text will not be displayed."
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:230
+#: extras/forms/model_forms.py:230
 #, python-brace-format
 msgid ""
 "Jinja2 template code for the link URL. Reference the object as {example}."
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:241
-#: netbox/extras/forms/model_forms.py:624
+#: extras/forms/model_forms.py:241 extras/forms/model_forms.py:624
 msgid "Template code"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:247
-#: netbox/templates/extras/exporttemplate.html:12
+#: extras/forms/model_forms.py:247 templates/extras/exporttemplate.html:12
 msgid "Export Template"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:249
+#: extras/forms/model_forms.py:249
 msgid "Rendering"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:263
-#: netbox/extras/forms/model_forms.py:649
+#: extras/forms/model_forms.py:263 extras/forms/model_forms.py:649
 msgid "Template content is populated from the remote source selected below."
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:270
-#: netbox/extras/forms/model_forms.py:656
+#: extras/forms/model_forms.py:270 extras/forms/model_forms.py:656
 msgid "Must specify either local content or a data file"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:284 netbox/netbox/forms/mixins.py:70
-#: netbox/templates/extras/savedfilter.html:10
+#: extras/forms/model_forms.py:284 netbox/forms/mixins.py:70
+#: templates/extras/savedfilter.html:10
 msgid "Saved Filter"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:334
+#: extras/forms/model_forms.py:334
 msgid "A notification group specify at least one user or group."
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:356
-#: netbox/templates/extras/webhook.html:23
+#: extras/forms/model_forms.py:356 templates/extras/webhook.html:23
 msgid "HTTP Request"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:358
-#: netbox/templates/extras/webhook.html:44
+#: extras/forms/model_forms.py:358 templates/extras/webhook.html:44
 msgid "SSL"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:380
+#: extras/forms/model_forms.py:380
 msgid "Action choice"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:385
+#: extras/forms/model_forms.py:385
 msgid "Enter conditions in <a href=\"https://json.org/\">JSON</a> format."
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:389
+#: extras/forms/model_forms.py:389
 msgid ""
 "Enter parameters to pass to the action in <a href=\"https://json.org/"
 "\">JSON</a> format."
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:394
-#: netbox/templates/extras/eventrule.html:10
+#: extras/forms/model_forms.py:394 templates/extras/eventrule.html:10
 msgid "Event Rule"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:395
+#: extras/forms/model_forms.py:395
 msgid "Triggers"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:442
+#: extras/forms/model_forms.py:442
 msgid "Notification group"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:562 netbox/netbox/navigation/menu.py:26
-#: netbox/tenancy/tables/tenants.py:22
+#: extras/forms/model_forms.py:562 netbox/navigation/menu.py:26
+#: tenancy/tables/tenants.py:22
 msgid "Tenants"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:606
+#: extras/forms/model_forms.py:606
 msgid "Data is populated from the remote source selected below."
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:612
+#: extras/forms/model_forms.py:612
 msgid "Must specify either local data or a data file"
 msgstr ""
 
-#: netbox/extras/forms/model_forms.py:631
-#: netbox/templates/core/datafile.html:55
+#: extras/forms/model_forms.py:631 templates/core/datafile.html:55
 msgid "Content"
 msgstr ""
 
-#: netbox/extras/forms/reports.py:17 netbox/extras/forms/scripts.py:23
+#: extras/forms/reports.py:17 extras/forms/scripts.py:23
 msgid "Schedule at"
 msgstr ""
 
-#: netbox/extras/forms/reports.py:18
+#: extras/forms/reports.py:18
 msgid "Schedule execution of report to a set time"
 msgstr ""
 
-#: netbox/extras/forms/reports.py:23 netbox/extras/forms/scripts.py:29
+#: extras/forms/reports.py:23 extras/forms/scripts.py:29
 msgid "Recurs every"
 msgstr ""
 
-#: netbox/extras/forms/reports.py:27
+#: extras/forms/reports.py:27
 msgid "Interval at which this report is re-run (in minutes)"
 msgstr ""
 
-#: netbox/extras/forms/reports.py:35 netbox/extras/forms/scripts.py:41
+#: extras/forms/reports.py:35 extras/forms/scripts.py:41
 #, python-brace-format
 msgid " (current time: <strong>{now}</strong>)"
 msgstr ""
 
-#: netbox/extras/forms/reports.py:45 netbox/extras/forms/scripts.py:51
+#: extras/forms/reports.py:45 extras/forms/scripts.py:51
 msgid "Scheduled time must be in the future."
 msgstr ""
 
-#: netbox/extras/forms/scripts.py:17
+#: extras/forms/scripts.py:17
 msgid "Commit changes"
 msgstr ""
 
-#: netbox/extras/forms/scripts.py:18
+#: extras/forms/scripts.py:18
 msgid "Commit changes to the database (uncheck for a dry-run)"
 msgstr ""
 
-#: netbox/extras/forms/scripts.py:24
+#: extras/forms/scripts.py:24
 msgid "Schedule execution of script to a set time"
 msgstr ""
 
-#: netbox/extras/forms/scripts.py:33
+#: extras/forms/scripts.py:33
 msgid "Interval at which this script is re-run (in minutes)"
 msgstr ""
 
-#: netbox/extras/jobs.py:49
+#: extras/jobs.py:49
 msgid "Database changes have been reverted automatically."
 msgstr ""
 
-#: netbox/extras/jobs.py:55
+#: extras/jobs.py:55
 msgid "Script aborted with error: "
 msgstr ""
 
-#: netbox/extras/jobs.py:65
+#: extras/jobs.py:65
 msgid "An exception occurred: "
 msgstr ""
 
-#: netbox/extras/jobs.py:70
+#: extras/jobs.py:70
 msgid "Database changes have been reverted due to error."
 msgstr ""
 
-#: netbox/extras/management/commands/reindex.py:66
+#: extras/management/commands/reindex.py:66
 msgid "No indexers found!"
 msgstr ""
 
-#: netbox/extras/models/configs.py:130
+#: extras/models/configs.py:130
 msgid "config context"
 msgstr ""
 
-#: netbox/extras/models/configs.py:131
+#: extras/models/configs.py:131
 msgid "config contexts"
 msgstr ""
 
-#: netbox/extras/models/configs.py:149 netbox/extras/models/configs.py:205
+#: extras/models/configs.py:149 extras/models/configs.py:205
 msgid "JSON data must be in object form. Example:"
 msgstr ""
 
-#: netbox/extras/models/configs.py:169
+#: extras/models/configs.py:169
 msgid ""
 "Local config context data takes precedence over source contexts in the final "
 "rendered config context"
 msgstr ""
 
-#: netbox/extras/models/configs.py:224
+#: extras/models/configs.py:224
 msgid "template code"
 msgstr ""
 
-#: netbox/extras/models/configs.py:225
+#: extras/models/configs.py:225
 msgid "Jinja2 template code."
 msgstr ""
 
-#: netbox/extras/models/configs.py:228
+#: extras/models/configs.py:228
 msgid "environment parameters"
 msgstr ""
 
-#: netbox/extras/models/configs.py:233
+#: extras/models/configs.py:233
 msgid ""
 "Any <a href=\"https://jinja.palletsprojects.com/en/3.1.x/api/#jinja2."
 "Environment\">additional parameters</a> to pass when constructing the Jinja2 "
 "environment."
 msgstr ""
 
-#: netbox/extras/models/configs.py:240
+#: extras/models/configs.py:240
 msgid "config template"
 msgstr ""
 
-#: netbox/extras/models/configs.py:241
+#: extras/models/configs.py:241
 msgid "config templates"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:75
+#: extras/models/customfields.py:75
 msgid "The object(s) to which this field applies."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:82
+#: extras/models/customfields.py:82
 msgid "The type of data this custom field holds"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:89
+#: extras/models/customfields.py:89
 msgid "The type of NetBox object this field maps to (for object fields)"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:95
+#: extras/models/customfields.py:95
 msgid "Internal field name"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:99
+#: extras/models/customfields.py:99
 msgid "Only alphanumeric characters and underscores are allowed."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:104
+#: extras/models/customfields.py:104
 msgid "Double underscores are not permitted in custom field names."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:115
+#: extras/models/customfields.py:115
 msgid ""
 "Name of the field as displayed to users (if not provided, 'the field's name "
 "will be used)"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:119 netbox/extras/models/models.py:317
+#: extras/models/customfields.py:119 extras/models/models.py:317
 msgid "group name"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:122
+#: extras/models/customfields.py:122
 msgid "Custom fields within the same group will be displayed together"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:130
+#: extras/models/customfields.py:130
 msgid "required"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:132
+#: extras/models/customfields.py:132
 msgid ""
 "This field is required when creating new objects or editing an existing "
 "object."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:135
+#: extras/models/customfields.py:135
 msgid "must be unique"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:137
+#: extras/models/customfields.py:137
 msgid "The value of this field must be unique for the assigned object"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:140
+#: extras/models/customfields.py:140
 msgid "search weight"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:143
+#: extras/models/customfields.py:143
 msgid ""
 "Weighting for search. Lower values are considered more important. Fields "
 "with a search weight of zero will be ignored."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:148
+#: extras/models/customfields.py:148
 msgid "filter logic"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:152
+#: extras/models/customfields.py:152
 msgid ""
 "Loose matches any instance of a given string; exact matches the entire field."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:155
+#: extras/models/customfields.py:155
 msgid "default"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:159
+#: extras/models/customfields.py:159
 msgid ""
 "Default value for the field (must be a JSON value). Encapsulate strings with "
 "double quotes (e.g. \"Foo\")."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:166
+#: extras/models/customfields.py:166
 msgid ""
 "Filter the object selection choices using a query_params dict (must be a "
 "JSON value).Encapsulate strings with double quotes (e.g. \"Foo\")."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:172
+#: extras/models/customfields.py:172
 msgid "display weight"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:173
+#: extras/models/customfields.py:173
 msgid "Fields with higher weights appear lower in a form."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:178
+#: extras/models/customfields.py:178
 msgid "minimum value"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:179
+#: extras/models/customfields.py:179
 msgid "Minimum allowed value (for numeric fields)"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:184
+#: extras/models/customfields.py:184
 msgid "maximum value"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:185
+#: extras/models/customfields.py:185
 msgid "Maximum allowed value (for numeric fields)"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:191
+#: extras/models/customfields.py:191
 msgid "validation regex"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:193
+#: extras/models/customfields.py:193
 #, python-brace-format
 msgid ""
 "Regular expression to enforce on text field values. Use ^ and $ to force "
@@ -8075,261 +7555,259 @@ msgid ""
 "values to exactly three uppercase letters."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:201
+#: extras/models/customfields.py:201
 msgid "choice set"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:210
+#: extras/models/customfields.py:210
 msgid "Specifies whether the custom field is displayed in the UI"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:217
+#: extras/models/customfields.py:217
 msgid "Specifies whether the custom field value can be edited in the UI"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:221
+#: extras/models/customfields.py:221
 msgid "is cloneable"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:222
+#: extras/models/customfields.py:222
 msgid "Replicate this value when cloning objects"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:239
+#: extras/models/customfields.py:239
 msgid "custom field"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:240
+#: extras/models/customfields.py:240
 msgid "custom fields"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:329
+#: extras/models/customfields.py:329
 #, python-brace-format
 msgid "Invalid default value \"{value}\": {error}"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:336
+#: extras/models/customfields.py:336
 msgid "A minimum value may be set only for numeric fields"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:338
+#: extras/models/customfields.py:338
 msgid "A maximum value may be set only for numeric fields"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:348
+#: extras/models/customfields.py:348
 msgid "Regular expression validation is supported only for text and URL fields"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:354
+#: extras/models/customfields.py:354
 msgid "Uniqueness cannot be enforced for boolean fields"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:364
+#: extras/models/customfields.py:364
 msgid "Selection fields must specify a set of choices."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:368
+#: extras/models/customfields.py:368
 msgid "Choices may be set only on selection fields."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:375
+#: extras/models/customfields.py:375
 msgid "Object fields must define an object type."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:379
+#: extras/models/customfields.py:379
 #, python-brace-format
 msgid "{type} fields may not define an object type."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:386
+#: extras/models/customfields.py:386
 msgid "A related object filter can be defined only for object fields."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:390
+#: extras/models/customfields.py:390
 msgid "Filter must be defined as a dictionary mapping attributes to values."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:469
+#: extras/models/customfields.py:469
 msgid "True"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:470
+#: extras/models/customfields.py:470
 msgid "False"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:560
+#: extras/models/customfields.py:560
 #, python-brace-format
 msgid "Values must match this regex: <code>{regex}</code>"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:654
+#: extras/models/customfields.py:654
 msgid "Value must be a string."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:656
+#: extras/models/customfields.py:656
 #, python-brace-format
 msgid "Value must match regex '{regex}'"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:661
+#: extras/models/customfields.py:661
 msgid "Value must be an integer."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:664
-#: netbox/extras/models/customfields.py:679
+#: extras/models/customfields.py:664 extras/models/customfields.py:679
 #, python-brace-format
 msgid "Value must be at least {minimum}"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:668
-#: netbox/extras/models/customfields.py:683
+#: extras/models/customfields.py:668 extras/models/customfields.py:683
 #, python-brace-format
 msgid "Value must not exceed {maximum}"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:676
+#: extras/models/customfields.py:676
 msgid "Value must be a decimal."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:688
+#: extras/models/customfields.py:688
 msgid "Value must be true or false."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:696
+#: extras/models/customfields.py:696
 msgid "Date values must be in ISO 8601 format (YYYY-MM-DD)."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:705
+#: extras/models/customfields.py:705
 msgid "Date and time values must be in ISO 8601 format (YYYY-MM-DD HH:MM:SS)."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:712
+#: extras/models/customfields.py:712
 #, python-brace-format
 msgid "Invalid choice ({value}) for choice set {choiceset}."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:722
+#: extras/models/customfields.py:722
 #, python-brace-format
 msgid "Invalid choice(s) ({value}) for choice set {choiceset}."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:731
+#: extras/models/customfields.py:731
 #, python-brace-format
 msgid "Value must be an object ID, not {type}"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:737
+#: extras/models/customfields.py:737
 #, python-brace-format
 msgid "Value must be a list of object IDs, not {type}"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:741
+#: extras/models/customfields.py:741
 #, python-brace-format
 msgid "Found invalid object ID: {id}"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:744
+#: extras/models/customfields.py:744
 msgid "Required field cannot be empty."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:763
+#: extras/models/customfields.py:763
 msgid "Base set of predefined choices (optional)"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:775
+#: extras/models/customfields.py:775
 msgid "Choices are automatically ordered alphabetically"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:782
+#: extras/models/customfields.py:782
 msgid "custom field choice set"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:783
+#: extras/models/customfields.py:783
 msgid "custom field choice sets"
 msgstr ""
 
-#: netbox/extras/models/customfields.py:825
+#: extras/models/customfields.py:825
 msgid "Must define base or extra choices."
 msgstr ""
 
-#: netbox/extras/models/customfields.py:849
+#: extras/models/customfields.py:849
 #, python-brace-format
 msgid ""
 "Cannot remove choice {choice} as there are {model} objects which reference "
 "it."
 msgstr ""
 
-#: netbox/extras/models/dashboard.py:18
+#: extras/models/dashboard.py:18
 msgid "layout"
 msgstr ""
 
-#: netbox/extras/models/dashboard.py:22
+#: extras/models/dashboard.py:22
 msgid "config"
 msgstr ""
 
-#: netbox/extras/models/dashboard.py:27
+#: extras/models/dashboard.py:27
 msgid "dashboard"
 msgstr ""
 
-#: netbox/extras/models/dashboard.py:28
+#: extras/models/dashboard.py:28
 msgid "dashboards"
 msgstr ""
 
-#: netbox/extras/models/models.py:52
+#: extras/models/models.py:52
 msgid "object types"
 msgstr ""
 
-#: netbox/extras/models/models.py:53
+#: extras/models/models.py:53
 msgid "The object(s) to which this rule applies."
 msgstr ""
 
-#: netbox/extras/models/models.py:67
+#: extras/models/models.py:67
 msgid "The types of event which will trigger this rule."
 msgstr ""
 
-#: netbox/extras/models/models.py:74
+#: extras/models/models.py:74
 msgid "conditions"
 msgstr ""
 
-#: netbox/extras/models/models.py:77
+#: extras/models/models.py:77
 msgid ""
 "A set of conditions which determine whether the event will be generated."
 msgstr ""
 
-#: netbox/extras/models/models.py:85
+#: extras/models/models.py:85
 msgid "action type"
 msgstr ""
 
-#: netbox/extras/models/models.py:104
+#: extras/models/models.py:104
 msgid "Additional data to pass to the action object"
 msgstr ""
 
-#: netbox/extras/models/models.py:116
+#: extras/models/models.py:116
 msgid "event rule"
 msgstr ""
 
-#: netbox/extras/models/models.py:117
+#: extras/models/models.py:117
 msgid "event rules"
 msgstr ""
 
-#: netbox/extras/models/models.py:166
+#: extras/models/models.py:166
 msgid ""
 "This URL will be called using the HTTP method defined when the webhook is "
 "called. Jinja2 template processing is supported with the same context as the "
 "request body."
 msgstr ""
 
-#: netbox/extras/models/models.py:181
+#: extras/models/models.py:181
 msgid ""
 "The complete list of official content types is available <a href=\"https://"
 "www.iana.org/assignments/media-types/media-types.xhtml\">here</a>."
 msgstr ""
 
-#: netbox/extras/models/models.py:186
+#: extras/models/models.py:186
 msgid "additional headers"
 msgstr ""
 
-#: netbox/extras/models/models.py:189
+#: extras/models/models.py:189
 msgid ""
 "User-supplied HTTP headers to be sent with the request in addition to the "
 "HTTP content type. Headers should be defined in the format <code>Name: "
@@ -8337,11 +7815,11 @@ msgid ""
 "as the request body (below)."
 msgstr ""
 
-#: netbox/extras/models/models.py:195
+#: extras/models/models.py:195
 msgid "body template"
 msgstr ""
 
-#: netbox/extras/models/models.py:198
+#: extras/models/models.py:198
 msgid ""
 "Jinja2 template for a custom request body. If blank, a JSON object "
 "representing the change will be included. Available context data includes: "
@@ -8349,4386 +7827,4253 @@ msgid ""
 "<code>username</code>, <code>request_id</code>, and <code>data</code>."
 msgstr ""
 
-#: netbox/extras/models/models.py:204
+#: extras/models/models.py:204
 msgid "secret"
 msgstr ""
 
-#: netbox/extras/models/models.py:208
+#: extras/models/models.py:208
 msgid ""
 "When provided, the request will include a <code>X-Hook-Signature</code> "
 "header containing a HMAC hex digest of the payload body using the secret as "
 "the key. The secret is not transmitted in the request."
 msgstr ""
 
-#: netbox/extras/models/models.py:215
+#: extras/models/models.py:215
 msgid "Enable SSL certificate verification. Disable with caution!"
 msgstr ""
 
-#: netbox/extras/models/models.py:221 netbox/templates/extras/webhook.html:51
+#: extras/models/models.py:221 templates/extras/webhook.html:51
 msgid "CA File Path"
 msgstr ""
 
-#: netbox/extras/models/models.py:223
+#: extras/models/models.py:223
 msgid ""
 "The specific CA certificate file to use for SSL verification. Leave blank to "
 "use the system defaults."
 msgstr ""
 
-#: netbox/extras/models/models.py:234
+#: extras/models/models.py:234
 msgid "webhook"
 msgstr ""
 
-#: netbox/extras/models/models.py:235
+#: extras/models/models.py:235
 msgid "webhooks"
 msgstr ""
 
-#: netbox/extras/models/models.py:253
+#: extras/models/models.py:253
 msgid "Do not specify a CA certificate file if SSL verification is disabled."
 msgstr ""
 
-#: netbox/extras/models/models.py:293
+#: extras/models/models.py:293
 msgid "The object type(s) to which this link applies."
 msgstr ""
 
-#: netbox/extras/models/models.py:305
+#: extras/models/models.py:305
 msgid "link text"
 msgstr ""
 
-#: netbox/extras/models/models.py:306
+#: extras/models/models.py:306
 msgid "Jinja2 template code for link text"
 msgstr ""
 
-#: netbox/extras/models/models.py:309
+#: extras/models/models.py:309
 msgid "link URL"
 msgstr ""
 
-#: netbox/extras/models/models.py:310
+#: extras/models/models.py:310
 msgid "Jinja2 template code for link URL"
 msgstr ""
 
-#: netbox/extras/models/models.py:320
+#: extras/models/models.py:320
 msgid "Links with the same group will appear as a dropdown menu"
 msgstr ""
 
-#: netbox/extras/models/models.py:330
+#: extras/models/models.py:330
 msgid "new window"
 msgstr ""
 
-#: netbox/extras/models/models.py:332
+#: extras/models/models.py:332
 msgid "Force link to open in a new window"
 msgstr ""
 
-#: netbox/extras/models/models.py:341
+#: extras/models/models.py:341
 msgid "custom link"
 msgstr ""
 
-#: netbox/extras/models/models.py:342
+#: extras/models/models.py:342
 msgid "custom links"
 msgstr ""
 
-#: netbox/extras/models/models.py:389
+#: extras/models/models.py:389
 msgid "The object type(s) to which this template applies."
 msgstr ""
 
-#: netbox/extras/models/models.py:402
+#: extras/models/models.py:402
 msgid ""
 "Jinja2 template code. The list of objects being exported is passed as a "
 "context variable named <code>queryset</code>."
 msgstr ""
 
-#: netbox/extras/models/models.py:410
+#: extras/models/models.py:410
 msgid "Defaults to <code>text/plain; charset=utf-8</code>"
 msgstr ""
 
-#: netbox/extras/models/models.py:413
+#: extras/models/models.py:413
 msgid "file extension"
 msgstr ""
 
-#: netbox/extras/models/models.py:416
+#: extras/models/models.py:416
 msgid "Extension to append to the rendered filename"
 msgstr ""
 
-#: netbox/extras/models/models.py:419
+#: extras/models/models.py:419
 msgid "as attachment"
 msgstr ""
 
-#: netbox/extras/models/models.py:421
+#: extras/models/models.py:421
 msgid "Download file as attachment"
 msgstr ""
 
-#: netbox/extras/models/models.py:430
+#: extras/models/models.py:430
 msgid "export template"
 msgstr ""
 
-#: netbox/extras/models/models.py:431
+#: extras/models/models.py:431
 msgid "export templates"
 msgstr ""
 
-#: netbox/extras/models/models.py:448
+#: extras/models/models.py:448
 #, python-brace-format
 msgid "\"{name}\" is a reserved name. Please choose a different name."
 msgstr ""
 
-#: netbox/extras/models/models.py:498
+#: extras/models/models.py:498
 msgid "The object type(s) to which this filter applies."
 msgstr ""
 
-#: netbox/extras/models/models.py:530
+#: extras/models/models.py:530
 msgid "shared"
 msgstr ""
 
-#: netbox/extras/models/models.py:543
+#: extras/models/models.py:543
 msgid "saved filter"
 msgstr ""
 
-#: netbox/extras/models/models.py:544
+#: extras/models/models.py:544
 msgid "saved filters"
 msgstr ""
 
-#: netbox/extras/models/models.py:562
+#: extras/models/models.py:562
 msgid "Filter parameters must be stored as a dictionary of keyword arguments."
 msgstr ""
 
-#: netbox/extras/models/models.py:590
+#: extras/models/models.py:590
 msgid "image height"
 msgstr ""
 
-#: netbox/extras/models/models.py:593
+#: extras/models/models.py:593
 msgid "image width"
 msgstr ""
 
-#: netbox/extras/models/models.py:610
+#: extras/models/models.py:610
 msgid "image attachment"
 msgstr ""
 
-#: netbox/extras/models/models.py:611
+#: extras/models/models.py:611
 msgid "image attachments"
 msgstr ""
 
-#: netbox/extras/models/models.py:625
+#: extras/models/models.py:625
 #, python-brace-format
 msgid "Image attachments cannot be assigned to this object type ({type})."
 msgstr ""
 
-#: netbox/extras/models/models.py:688
+#: extras/models/models.py:688
 msgid "kind"
 msgstr ""
 
-#: netbox/extras/models/models.py:702
+#: extras/models/models.py:702
 msgid "journal entry"
 msgstr ""
 
-#: netbox/extras/models/models.py:703
+#: extras/models/models.py:703
 msgid "journal entries"
 msgstr ""
 
-#: netbox/extras/models/models.py:718
+#: extras/models/models.py:718
 #, python-brace-format
 msgid "Journaling is not supported for this object type ({type})."
 msgstr ""
 
-#: netbox/extras/models/models.py:760
+#: extras/models/models.py:760
 msgid "bookmark"
 msgstr ""
 
-#: netbox/extras/models/models.py:761
+#: extras/models/models.py:761
 msgid "bookmarks"
 msgstr ""
 
-#: netbox/extras/models/models.py:774
+#: extras/models/models.py:774
 #, python-brace-format
 msgid "Bookmarks cannot be assigned to this object type ({type})."
 msgstr ""
 
-#: netbox/extras/models/notifications.py:43
+#: extras/models/notifications.py:43
 msgid "read"
 msgstr ""
 
-#: netbox/extras/models/notifications.py:66
+#: extras/models/notifications.py:66
 msgid "event"
 msgstr ""
 
-#: netbox/extras/models/notifications.py:84
+#: extras/models/notifications.py:84
 msgid "notification"
 msgstr ""
 
-#: netbox/extras/models/notifications.py:85
+#: extras/models/notifications.py:85
 msgid "notifications"
 msgstr ""
 
-#: netbox/extras/models/notifications.py:99
-#: netbox/extras/models/notifications.py:234
+#: extras/models/notifications.py:99 extras/models/notifications.py:234
 #, python-brace-format
 msgid "Objects of this type ({type}) do not support notifications."
 msgstr ""
 
-#: netbox/extras/models/notifications.py:137 netbox/users/models/users.py:58
-#: netbox/users/models/users.py:77
+#: extras/models/notifications.py:137 users/models/users.py:58
+#: users/models/users.py:77
 msgid "groups"
 msgstr ""
 
-#: netbox/extras/models/notifications.py:143 netbox/users/models/users.py:93
+#: extras/models/notifications.py:143 users/models/users.py:93
 msgid "users"
 msgstr ""
 
-#: netbox/extras/models/notifications.py:152
+#: extras/models/notifications.py:152
 msgid "notification group"
 msgstr ""
 
-#: netbox/extras/models/notifications.py:153
+#: extras/models/notifications.py:153
 msgid "notification groups"
 msgstr ""
 
-#: netbox/extras/models/notifications.py:217
+#: extras/models/notifications.py:217
 msgid "subscription"
 msgstr ""
 
-#: netbox/extras/models/notifications.py:218
+#: extras/models/notifications.py:218
 msgid "subscriptions"
 msgstr ""
 
-#: netbox/extras/models/scripts.py:42
+#: extras/models/scripts.py:42
 msgid "is executable"
 msgstr ""
 
-#: netbox/extras/models/scripts.py:64
+#: extras/models/scripts.py:64
 msgid "script"
 msgstr ""
 
-#: netbox/extras/models/scripts.py:65
+#: extras/models/scripts.py:65
 msgid "scripts"
 msgstr ""
 
-#: netbox/extras/models/scripts.py:111
+#: extras/models/scripts.py:111
 msgid "script module"
 msgstr ""
 
-#: netbox/extras/models/scripts.py:112
+#: extras/models/scripts.py:112
 msgid "script modules"
 msgstr ""
 
-#: netbox/extras/models/search.py:22
+#: extras/models/search.py:22
 msgid "timestamp"
 msgstr ""
 
-#: netbox/extras/models/search.py:37
+#: extras/models/search.py:37
 msgid "field"
 msgstr ""
 
-#: netbox/extras/models/search.py:45
+#: extras/models/search.py:45
 msgid "value"
 msgstr ""
 
-#: netbox/extras/models/search.py:56
+#: extras/models/search.py:56
 msgid "cached value"
 msgstr ""
 
-#: netbox/extras/models/search.py:57
+#: extras/models/search.py:57
 msgid "cached values"
 msgstr ""
 
-#: netbox/extras/models/staging.py:44
+#: extras/models/staging.py:44
 msgid "branch"
 msgstr ""
 
-#: netbox/extras/models/staging.py:45
+#: extras/models/staging.py:45
 msgid "branches"
 msgstr ""
 
-#: netbox/extras/models/staging.py:97
+#: extras/models/staging.py:97
 msgid "staged change"
 msgstr ""
 
-#: netbox/extras/models/staging.py:98
+#: extras/models/staging.py:98
 msgid "staged changes"
 msgstr ""
 
-#: netbox/extras/models/tags.py:40
+#: extras/models/tags.py:40
 msgid "The object type(s) to which this tag can be applied."
 msgstr ""
 
-#: netbox/extras/models/tags.py:49
+#: extras/models/tags.py:49
 msgid "tag"
 msgstr ""
 
-#: netbox/extras/models/tags.py:50
+#: extras/models/tags.py:50
 msgid "tags"
 msgstr ""
 
-#: netbox/extras/models/tags.py:78
+#: extras/models/tags.py:78
 msgid "tagged item"
 msgstr ""
 
-#: netbox/extras/models/tags.py:79
+#: extras/models/tags.py:79
 msgid "tagged items"
 msgstr ""
 
-#: netbox/extras/scripts.py:429
+#: extras/scripts.py:429
 msgid "Script Data"
 msgstr ""
 
-#: netbox/extras/scripts.py:433
+#: extras/scripts.py:433
 msgid "Script Execution Parameters"
 msgstr ""
 
-#: netbox/extras/tables/columns.py:12
-#: netbox/templates/htmx/notifications.html:18
+#: extras/tables/columns.py:12 templates/htmx/notifications.html:18
 msgid "Dismiss"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:62 netbox/extras/tables/tables.py:159
-#: netbox/extras/tables/tables.py:184 netbox/extras/tables/tables.py:250
-#: netbox/extras/tables/tables.py:276 netbox/extras/tables/tables.py:412
-#: netbox/extras/tables/tables.py:446
-#: netbox/templates/extras/customfield.html:105
-#: netbox/templates/extras/eventrule.html:27
-#: netbox/templates/users/objectpermission.html:64 netbox/users/tables.py:80
+#: extras/tables/tables.py:62 extras/tables/tables.py:159
+#: extras/tables/tables.py:184 extras/tables/tables.py:250
+#: extras/tables/tables.py:276 extras/tables/tables.py:412
+#: extras/tables/tables.py:446 templates/extras/customfield.html:105
+#: templates/extras/eventrule.html:27 templates/users/objectpermission.html:64
+#: users/tables.py:80
 msgid "Object Types"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:69
+#: extras/tables/tables.py:69
 msgid "Validate Uniqueness"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:73
+#: extras/tables/tables.py:73
 msgid "Visible"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:76
+#: extras/tables/tables.py:76
 msgid "Editable"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:82
+#: extras/tables/tables.py:82
 msgid "Related Object Type"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:86
-#: netbox/templates/extras/customfield.html:51
+#: extras/tables/tables.py:86 templates/extras/customfield.html:51
 msgid "Choice Set"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:94
+#: extras/tables/tables.py:94
 msgid "Is Cloneable"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:98
-#: netbox/templates/extras/customfield.html:118
+#: extras/tables/tables.py:98 templates/extras/customfield.html:118
 msgid "Minimum Value"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:101
-#: netbox/templates/extras/customfield.html:122
+#: extras/tables/tables.py:101 templates/extras/customfield.html:122
 msgid "Maximum Value"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:104
+#: extras/tables/tables.py:104
 msgid "Validation Regex"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:137
+#: extras/tables/tables.py:137
 msgid "Count"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:140
+#: extras/tables/tables.py:140
 msgid "Order Alphabetically"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:165
-#: netbox/templates/extras/customlink.html:33
+#: extras/tables/tables.py:165 templates/extras/customlink.html:33
 msgid "New Window"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:187
+#: extras/tables/tables.py:187
 msgid "As Attachment"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:195 netbox/extras/tables/tables.py:487
-#: netbox/extras/tables/tables.py:522 netbox/templates/core/datafile.html:24
-#: netbox/templates/dcim/device/render_config.html:22
-#: netbox/templates/extras/configcontext.html:39
-#: netbox/templates/extras/configtemplate.html:31
-#: netbox/templates/extras/exporttemplate.html:45
-#: netbox/templates/generic/bulk_import.html:35
-#: netbox/templates/virtualization/virtualmachine/render_config.html:22
+#: extras/tables/tables.py:195 extras/tables/tables.py:487
+#: extras/tables/tables.py:522 templates/core/datafile.html:24
+#: templates/dcim/device/render_config.html:22
+#: templates/extras/configcontext.html:39
+#: templates/extras/configtemplate.html:31
+#: templates/extras/exporttemplate.html:45
+#: templates/generic/bulk_import.html:35
+#: templates/virtualization/virtualmachine/render_config.html:22
 msgid "Data File"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:200 netbox/extras/tables/tables.py:499
-#: netbox/extras/tables/tables.py:527
+#: extras/tables/tables.py:200 extras/tables/tables.py:499
+#: extras/tables/tables.py:527
 msgid "Synced"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:227
+#: extras/tables/tables.py:227
 msgid "Image"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:232
+#: extras/tables/tables.py:232
 msgid "Size (Bytes)"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:339
+#: extras/tables/tables.py:339
 msgid "Read"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:382
+#: extras/tables/tables.py:382
 msgid "SSL Validation"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:418 netbox/templates/extras/eventrule.html:37
+#: extras/tables/tables.py:418 templates/extras/eventrule.html:37
 msgid "Event Types"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:535 netbox/netbox/navigation/menu.py:77
-#: netbox/templates/dcim/devicerole.html:8
+#: extras/tables/tables.py:535 netbox/navigation/menu.py:77
+#: templates/dcim/devicerole.html:8
 msgid "Device Roles"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:587
+#: extras/tables/tables.py:587
 msgid "Comments (Short)"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:606 netbox/extras/tables/tables.py:640
+#: extras/tables/tables.py:606 extras/tables/tables.py:640
 msgid "Line"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:613 netbox/extras/tables/tables.py:650
+#: extras/tables/tables.py:613 extras/tables/tables.py:650
 msgid "Level"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:619 netbox/extras/tables/tables.py:659
+#: extras/tables/tables.py:619 extras/tables/tables.py:659
 msgid "Message"
 msgstr ""
 
-#: netbox/extras/tables/tables.py:643
+#: extras/tables/tables.py:643
 msgid "Method"
 msgstr ""
 
-#: netbox/extras/validators.py:15
+#: extras/validators.py:15
 #, python-format
 msgid "Ensure this value is equal to %(limit_value)s."
 msgstr ""
 
-#: netbox/extras/validators.py:26
+#: extras/validators.py:26
 #, python-format
 msgid "Ensure this value does not equal %(limit_value)s."
 msgstr ""
 
-#: netbox/extras/validators.py:37
+#: extras/validators.py:37
 msgid "This field must be empty."
 msgstr ""
 
-#: netbox/extras/validators.py:52
+#: extras/validators.py:52
 msgid "This field must not be empty."
 msgstr ""
 
-#: netbox/extras/validators.py:94
+#: extras/validators.py:94
 msgid "Validation rules must be passed as a dictionary"
 msgstr ""
 
-#: netbox/extras/validators.py:119
+#: extras/validators.py:119
 #, python-brace-format
 msgid "Custom validation failed for {attribute}: {exception}"
 msgstr ""
 
-#: netbox/extras/validators.py:133
+#: extras/validators.py:133
 #, python-brace-format
 msgid "Invalid attribute \"{name}\" for request"
 msgstr ""
 
-#: netbox/extras/validators.py:150
+#: extras/validators.py:150
 #, python-brace-format
 msgid "Invalid attribute \"{name}\" for {model}"
 msgstr ""
 
-#: netbox/extras/views.py:960
+#: extras/views.py:960
 msgid "Your dashboard has been reset."
 msgstr ""
 
-#: netbox/extras/views.py:1006
+#: extras/views.py:1006
 msgid "Added widget: "
 msgstr ""
 
-#: netbox/extras/views.py:1047
+#: extras/views.py:1047
 msgid "Updated widget: "
 msgstr ""
 
-#: netbox/extras/views.py:1083
+#: extras/views.py:1083
 msgid "Deleted widget: "
 msgstr ""
 
-#: netbox/extras/views.py:1085
+#: extras/views.py:1085
 msgid "Error deleting widget: "
 msgstr ""
 
-#: netbox/extras/views.py:1172
+#: extras/views.py:1172
 msgid "Unable to run script: RQ worker process not running."
 msgstr ""
 
-#: netbox/ipam/api/field_serializers.py:17
+#: ipam/api/field_serializers.py:17
 msgid "Enter a valid IPv4 or IPv6 address with optional mask."
 msgstr ""
 
-#: netbox/ipam/api/field_serializers.py:24
+#: ipam/api/field_serializers.py:24
 #, python-brace-format
 msgid "Invalid IP address format: {data}"
 msgstr ""
 
-#: netbox/ipam/api/field_serializers.py:37
+#: ipam/api/field_serializers.py:37
 msgid "Enter a valid IPv4 or IPv6 prefix and mask in CIDR notation."
 msgstr ""
 
-#: netbox/ipam/api/field_serializers.py:44
+#: ipam/api/field_serializers.py:44
 #, python-brace-format
 msgid "Invalid IP prefix format: {data}"
 msgstr ""
 
-#: netbox/ipam/api/views.py:358
+#: ipam/api/views.py:358
 msgid ""
 "Insufficient space is available to accommodate the requested prefix size(s)"
 msgstr ""
 
-#: netbox/ipam/choices.py:30
+#: ipam/choices.py:30
 msgid "Container"
 msgstr ""
 
-#: netbox/ipam/choices.py:72
+#: ipam/choices.py:72
 msgid "DHCP"
 msgstr ""
 
-#: netbox/ipam/choices.py:73
+#: ipam/choices.py:73
 msgid "SLAAC"
 msgstr ""
 
-#: netbox/ipam/choices.py:89
+#: ipam/choices.py:89
 msgid "Loopback"
 msgstr ""
 
-#: netbox/ipam/choices.py:91
+#: ipam/choices.py:91
 msgid "Anycast"
 msgstr ""
 
-#: netbox/ipam/choices.py:115
+#: ipam/choices.py:115
 msgid "Standard"
 msgstr ""
 
-#: netbox/ipam/choices.py:120
+#: ipam/choices.py:120
 msgid "CheckPoint"
 msgstr ""
 
-#: netbox/ipam/choices.py:123
+#: ipam/choices.py:123
 msgid "Cisco"
 msgstr ""
 
-#: netbox/ipam/choices.py:137
+#: ipam/choices.py:137
 msgid "Plaintext"
 msgstr ""
 
-#: netbox/ipam/fields.py:36
+#: ipam/fields.py:36
 #, python-brace-format
 msgid "Invalid IP address format: {address}"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:48 netbox/vpn/filtersets.py:304
+#: ipam/filtersets.py:48 vpn/filtersets.py:304
 msgid "Import target"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:54 netbox/vpn/filtersets.py:310
+#: ipam/filtersets.py:54 vpn/filtersets.py:310
 msgid "Import target (name)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:59 netbox/vpn/filtersets.py:315
+#: ipam/filtersets.py:59 vpn/filtersets.py:315
 msgid "Export target"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:65 netbox/vpn/filtersets.py:321
+#: ipam/filtersets.py:65 vpn/filtersets.py:321
 msgid "Export target (name)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:86
+#: ipam/filtersets.py:86
 msgid "Importing VRF"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:92
+#: ipam/filtersets.py:92
 msgid "Import VRF (RD)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:97
+#: ipam/filtersets.py:97
 msgid "Exporting VRF"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:103
+#: ipam/filtersets.py:103
 msgid "Export VRF (RD)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:108
+#: ipam/filtersets.py:108
 msgid "Importing L2VPN"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:114
+#: ipam/filtersets.py:114
 msgid "Importing L2VPN (identifier)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:119
+#: ipam/filtersets.py:119
 msgid "Exporting L2VPN"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:125
+#: ipam/filtersets.py:125
 msgid "Exporting L2VPN (identifier)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:155 netbox/ipam/filtersets.py:281
-#: netbox/ipam/forms/model_forms.py:229 netbox/ipam/tables/ip.py:212
-#: netbox/templates/ipam/prefix.html:12
+#: ipam/filtersets.py:155 ipam/filtersets.py:281 ipam/forms/model_forms.py:229
+#: ipam/tables/ip.py:212 templates/ipam/prefix.html:12
 msgid "Prefix"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:159 netbox/ipam/filtersets.py:198
-#: netbox/ipam/filtersets.py:221
+#: ipam/filtersets.py:159 ipam/filtersets.py:198 ipam/filtersets.py:221
 msgid "RIR (ID)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:165 netbox/ipam/filtersets.py:204
-#: netbox/ipam/filtersets.py:227
+#: ipam/filtersets.py:165 ipam/filtersets.py:204 ipam/filtersets.py:227
 msgid "RIR (slug)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:285
+#: ipam/filtersets.py:285
 msgid "Within prefix"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:289
+#: ipam/filtersets.py:289
 msgid "Within and including prefix"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:293
+#: ipam/filtersets.py:293
 msgid "Prefixes which contain this prefix or IP"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:304 netbox/ipam/filtersets.py:572
-#: netbox/ipam/forms/bulk_edit.py:343 netbox/ipam/forms/filtersets.py:196
-#: netbox/ipam/forms/filtersets.py:331
+#: ipam/filtersets.py:304 ipam/filtersets.py:572 ipam/forms/bulk_edit.py:343
+#: ipam/forms/filtersets.py:196 ipam/forms/filtersets.py:331
 msgid "Mask length"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:373 netbox/vpn/filtersets.py:427
+#: ipam/filtersets.py:373 vpn/filtersets.py:427
 msgid "VLAN (ID)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:377 netbox/vpn/filtersets.py:422
+#: ipam/filtersets.py:377 vpn/filtersets.py:422
 msgid "VLAN number (1-4094)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:471 netbox/ipam/filtersets.py:475
-#: netbox/ipam/filtersets.py:567 netbox/ipam/forms/model_forms.py:463
-#: netbox/templates/tenancy/contact.html:53
-#: netbox/tenancy/forms/bulk_edit.py:113
+#: ipam/filtersets.py:471 ipam/filtersets.py:475 ipam/filtersets.py:567
+#: ipam/forms/model_forms.py:463 templates/tenancy/contact.html:53
+#: tenancy/forms/bulk_edit.py:113
 msgid "Address"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:479
+#: ipam/filtersets.py:479
 msgid "Ranges which contain this prefix or IP"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:507 netbox/ipam/filtersets.py:563
+#: ipam/filtersets.py:507 ipam/filtersets.py:563
 msgid "Parent prefix"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:616 netbox/ipam/filtersets.py:856
-#: netbox/ipam/filtersets.py:1131 netbox/vpn/filtersets.py:385
+#: ipam/filtersets.py:616 ipam/filtersets.py:856 ipam/filtersets.py:1131
+#: vpn/filtersets.py:385
 msgid "Virtual machine (name)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:621 netbox/ipam/filtersets.py:861
-#: netbox/ipam/filtersets.py:1125 netbox/virtualization/filtersets.py:282
-#: netbox/virtualization/filtersets.py:321 netbox/vpn/filtersets.py:390
+#: ipam/filtersets.py:621 ipam/filtersets.py:861 ipam/filtersets.py:1125
+#: virtualization/filtersets.py:282 virtualization/filtersets.py:321
+#: vpn/filtersets.py:390
 msgid "Virtual machine (ID)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:627 netbox/vpn/filtersets.py:97
-#: netbox/vpn/filtersets.py:396
+#: ipam/filtersets.py:627 vpn/filtersets.py:97 vpn/filtersets.py:396
 msgid "Interface (name)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:638 netbox/vpn/filtersets.py:108
-#: netbox/vpn/filtersets.py:407
+#: ipam/filtersets.py:638 vpn/filtersets.py:108 vpn/filtersets.py:407
 msgid "VM interface (name)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:643 netbox/vpn/filtersets.py:113
+#: ipam/filtersets.py:643 vpn/filtersets.py:113
 msgid "VM interface (ID)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:648
+#: ipam/filtersets.py:648
 msgid "FHRP group (ID)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:652
+#: ipam/filtersets.py:652
 msgid "Is assigned to an interface"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:656
+#: ipam/filtersets.py:656
 msgid "Is assigned"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:668
+#: ipam/filtersets.py:668
 msgid "Service (ID)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:673
+#: ipam/filtersets.py:673
 msgid "NAT inside IP address (ID)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:1041 netbox/ipam/forms/bulk_import.py:322
+#: ipam/filtersets.py:1041 ipam/forms/bulk_import.py:322
 msgid "Assigned interface"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:1046
+#: ipam/filtersets.py:1046
 msgid "Assigned VM interface"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:1136
+#: ipam/filtersets.py:1136
 msgid "IP address (ID)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:1142 netbox/ipam/models/ip.py:788
+#: ipam/filtersets.py:1142 ipam/models/ip.py:788
 msgid "IP address"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:1167
+#: ipam/filtersets.py:1167
 msgid "Primary IPv4 (ID)"
 msgstr ""
 
-#: netbox/ipam/filtersets.py:1172
+#: ipam/filtersets.py:1172
 msgid "Primary IPv6 (ID)"
 msgstr ""
 
-#: netbox/ipam/formfields.py:14
+#: ipam/formfields.py:14
 msgid "Enter a valid IPv4 or IPv6 address (without a mask)."
 msgstr ""
 
-#: netbox/ipam/formfields.py:32
+#: ipam/formfields.py:32
 #, python-brace-format
 msgid "Invalid IPv4/IPv6 address format: {address}"
 msgstr ""
 
-#: netbox/ipam/formfields.py:37
+#: ipam/formfields.py:37
 msgid "This field requires an IP address without a mask."
 msgstr ""
 
-#: netbox/ipam/formfields.py:39 netbox/ipam/formfields.py:61
+#: ipam/formfields.py:39 ipam/formfields.py:61
 msgid "Please specify a valid IPv4 or IPv6 address."
 msgstr ""
 
-#: netbox/ipam/formfields.py:44
+#: ipam/formfields.py:44
 msgid "Enter a valid IPv4 or IPv6 address (with CIDR mask)."
 msgstr ""
 
-#: netbox/ipam/formfields.py:56
+#: ipam/formfields.py:56
 msgid "CIDR mask (e.g. /24) is required."
 msgstr ""
 
-#: netbox/ipam/forms/bulk_create.py:13
+#: ipam/forms/bulk_create.py:13
 msgid "Address pattern"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:50
+#: ipam/forms/bulk_edit.py:50
 msgid "Enforce unique space"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:88
+#: ipam/forms/bulk_edit.py:88
 msgid "Is private"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:109 netbox/ipam/forms/bulk_edit.py:138
-#: netbox/ipam/forms/bulk_edit.py:163 netbox/ipam/forms/bulk_import.py:89
-#: netbox/ipam/forms/bulk_import.py:109 netbox/ipam/forms/bulk_import.py:129
-#: netbox/ipam/forms/filtersets.py:110 netbox/ipam/forms/filtersets.py:125
-#: netbox/ipam/forms/filtersets.py:148 netbox/ipam/forms/model_forms.py:96
-#: netbox/ipam/forms/model_forms.py:109 netbox/ipam/forms/model_forms.py:131
-#: netbox/ipam/forms/model_forms.py:149 netbox/ipam/models/asns.py:31
-#: netbox/ipam/models/asns.py:103 netbox/ipam/models/ip.py:71
-#: netbox/ipam/models/ip.py:90 netbox/ipam/tables/asn.py:20
-#: netbox/ipam/tables/asn.py:45 netbox/templates/ipam/aggregate.html:18
-#: netbox/templates/ipam/asn.html:27 netbox/templates/ipam/asnrange.html:19
-#: netbox/templates/ipam/rir.html:19
+#: ipam/forms/bulk_edit.py:109 ipam/forms/bulk_edit.py:138
+#: ipam/forms/bulk_edit.py:163 ipam/forms/bulk_import.py:89
+#: ipam/forms/bulk_import.py:109 ipam/forms/bulk_import.py:129
+#: ipam/forms/filtersets.py:110 ipam/forms/filtersets.py:125
+#: ipam/forms/filtersets.py:148 ipam/forms/model_forms.py:96
+#: ipam/forms/model_forms.py:109 ipam/forms/model_forms.py:131
+#: ipam/forms/model_forms.py:149 ipam/models/asns.py:31 ipam/models/asns.py:103
+#: ipam/models/ip.py:71 ipam/models/ip.py:90 ipam/tables/asn.py:20
+#: ipam/tables/asn.py:45 templates/ipam/aggregate.html:18
+#: templates/ipam/asn.html:27 templates/ipam/asnrange.html:19
+#: templates/ipam/rir.html:19
 msgid "RIR"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:171
+#: ipam/forms/bulk_edit.py:171
 msgid "Date added"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:229 netbox/ipam/forms/model_forms.py:586
-#: netbox/ipam/forms/model_forms.py:633 netbox/ipam/tables/ip.py:251
-#: netbox/templates/ipam/vlan_edit.html:37
-#: netbox/templates/ipam/vlangroup.html:27
+#: ipam/forms/bulk_edit.py:229 ipam/forms/model_forms.py:586
+#: ipam/forms/model_forms.py:633 ipam/tables/ip.py:251
+#: templates/ipam/vlan_edit.html:37 templates/ipam/vlangroup.html:27
 msgid "VLAN Group"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:234 netbox/ipam/forms/bulk_import.py:185
-#: netbox/ipam/forms/filtersets.py:256 netbox/ipam/forms/model_forms.py:218
-#: netbox/ipam/models/vlans.py:234 netbox/ipam/tables/ip.py:255
-#: netbox/templates/ipam/prefix.html:60 netbox/templates/ipam/vlan.html:12
-#: netbox/templates/ipam/vlan/base.html:6
-#: netbox/templates/ipam/vlan_edit.html:10
-#: netbox/templates/wireless/wirelesslan.html:30
-#: netbox/vpn/forms/bulk_import.py:304 netbox/vpn/forms/filtersets.py:284
-#: netbox/vpn/forms/model_forms.py:433 netbox/vpn/forms/model_forms.py:452
-#: netbox/wireless/forms/bulk_edit.py:55
-#: netbox/wireless/forms/bulk_import.py:48
-#: netbox/wireless/forms/model_forms.py:48 netbox/wireless/models.py:102
+#: ipam/forms/bulk_edit.py:234 ipam/forms/bulk_import.py:185
+#: ipam/forms/filtersets.py:256 ipam/forms/model_forms.py:218
+#: ipam/models/vlans.py:234 ipam/tables/ip.py:255 templates/ipam/prefix.html:60
+#: templates/ipam/vlan.html:12 templates/ipam/vlan/base.html:6
+#: templates/ipam/vlan_edit.html:10 templates/wireless/wirelesslan.html:30
+#: vpn/forms/bulk_import.py:304 vpn/forms/filtersets.py:284
+#: vpn/forms/model_forms.py:433 vpn/forms/model_forms.py:452
+#: wireless/forms/bulk_edit.py:55 wireless/forms/bulk_import.py:48
+#: wireless/forms/model_forms.py:48 wireless/models.py:102
 msgid "VLAN"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:245
+#: ipam/forms/bulk_edit.py:245
 msgid "Prefix length"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:268 netbox/ipam/forms/filtersets.py:241
-#: netbox/templates/ipam/prefix.html:85
+#: ipam/forms/bulk_edit.py:268 ipam/forms/filtersets.py:241
+#: templates/ipam/prefix.html:85
 msgid "Is a pool"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:273 netbox/ipam/forms/bulk_edit.py:318
-#: netbox/ipam/forms/filtersets.py:248 netbox/ipam/forms/filtersets.py:293
-#: netbox/ipam/models/ip.py:272 netbox/ipam/models/ip.py:539
+#: ipam/forms/bulk_edit.py:273 ipam/forms/bulk_edit.py:318
+#: ipam/forms/filtersets.py:248 ipam/forms/filtersets.py:293
+#: ipam/models/ip.py:272 ipam/models/ip.py:539
 msgid "Treat as fully utilized"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:287 netbox/ipam/forms/filtersets.py:171
+#: ipam/forms/bulk_edit.py:287 ipam/forms/filtersets.py:171
 msgid "VLAN Assignment"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:366 netbox/ipam/models/ip.py:772
+#: ipam/forms/bulk_edit.py:366 ipam/models/ip.py:772
 msgid "DNS name"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:387 netbox/ipam/forms/bulk_edit.py:534
-#: netbox/ipam/forms/bulk_import.py:394 netbox/ipam/forms/bulk_import.py:469
-#: netbox/ipam/forms/bulk_import.py:495 netbox/ipam/forms/filtersets.py:390
-#: netbox/ipam/forms/filtersets.py:530 netbox/templates/ipam/fhrpgroup.html:22
-#: netbox/templates/ipam/inc/panels/fhrp_groups.html:24
-#: netbox/templates/ipam/service.html:32
-#: netbox/templates/ipam/servicetemplate.html:19
+#: ipam/forms/bulk_edit.py:387 ipam/forms/bulk_edit.py:534
+#: ipam/forms/bulk_import.py:394 ipam/forms/bulk_import.py:469
+#: ipam/forms/bulk_import.py:495 ipam/forms/filtersets.py:390
+#: ipam/forms/filtersets.py:530 templates/ipam/fhrpgroup.html:22
+#: templates/ipam/inc/panels/fhrp_groups.html:24 templates/ipam/service.html:32
+#: templates/ipam/servicetemplate.html:19
 msgid "Protocol"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:394 netbox/ipam/forms/filtersets.py:397
-#: netbox/ipam/tables/fhrp.py:22 netbox/templates/ipam/fhrpgroup.html:26
+#: ipam/forms/bulk_edit.py:394 ipam/forms/filtersets.py:397
+#: ipam/tables/fhrp.py:22 templates/ipam/fhrpgroup.html:26
 msgid "Group ID"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:399 netbox/ipam/forms/filtersets.py:402
-#: netbox/wireless/forms/bulk_edit.py:68 netbox/wireless/forms/bulk_edit.py:115
-#: netbox/wireless/forms/bulk_import.py:62
-#: netbox/wireless/forms/bulk_import.py:65
-#: netbox/wireless/forms/bulk_import.py:104
-#: netbox/wireless/forms/bulk_import.py:107
-#: netbox/wireless/forms/filtersets.py:54
-#: netbox/wireless/forms/filtersets.py:88
+#: ipam/forms/bulk_edit.py:399 ipam/forms/filtersets.py:402
+#: wireless/forms/bulk_edit.py:68 wireless/forms/bulk_edit.py:115
+#: wireless/forms/bulk_import.py:62 wireless/forms/bulk_import.py:65
+#: wireless/forms/bulk_import.py:104 wireless/forms/bulk_import.py:107
+#: wireless/forms/filtersets.py:54 wireless/forms/filtersets.py:88
 msgid "Authentication type"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:404 netbox/ipam/forms/filtersets.py:406
+#: ipam/forms/bulk_edit.py:404 ipam/forms/filtersets.py:406
 msgid "Authentication key"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:421 netbox/ipam/forms/filtersets.py:383
-#: netbox/ipam/forms/model_forms.py:474 netbox/netbox/navigation/menu.py:386
-#: netbox/templates/ipam/fhrpgroup.html:49
-#: netbox/templates/wireless/inc/authentication_attrs.html:5
-#: netbox/wireless/forms/bulk_edit.py:91 netbox/wireless/forms/bulk_edit.py:149
-#: netbox/wireless/forms/filtersets.py:36
-#: netbox/wireless/forms/filtersets.py:76
-#: netbox/wireless/forms/model_forms.py:55
-#: netbox/wireless/forms/model_forms.py:171
+#: ipam/forms/bulk_edit.py:421 ipam/forms/filtersets.py:383
+#: ipam/forms/model_forms.py:474 netbox/navigation/menu.py:386
+#: templates/ipam/fhrpgroup.html:49
+#: templates/wireless/inc/authentication_attrs.html:5
+#: wireless/forms/bulk_edit.py:91 wireless/forms/bulk_edit.py:149
+#: wireless/forms/filtersets.py:36 wireless/forms/filtersets.py:76
+#: wireless/forms/model_forms.py:55 wireless/forms/model_forms.py:171
 msgid "Authentication"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:436 netbox/ipam/forms/model_forms.py:575
+#: ipam/forms/bulk_edit.py:436 ipam/forms/model_forms.py:575
 msgid "Scope type"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:439 netbox/ipam/forms/bulk_edit.py:453
-#: netbox/ipam/forms/model_forms.py:578 netbox/ipam/forms/model_forms.py:588
-#: netbox/ipam/tables/vlans.py:71 netbox/templates/ipam/vlangroup.html:38
+#: ipam/forms/bulk_edit.py:439 ipam/forms/bulk_edit.py:453
+#: ipam/forms/model_forms.py:578 ipam/forms/model_forms.py:588
+#: ipam/tables/vlans.py:71 templates/ipam/vlangroup.html:38
 msgid "Scope"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:446 netbox/ipam/models/vlans.py:60
+#: ipam/forms/bulk_edit.py:446 ipam/models/vlans.py:60
 msgid "VLAN ID ranges"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:525
+#: ipam/forms/bulk_edit.py:525
 msgid "Site & Group"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_edit.py:539 netbox/ipam/forms/model_forms.py:659
-#: netbox/ipam/forms/model_forms.py:691 netbox/ipam/tables/services.py:19
-#: netbox/ipam/tables/services.py:49 netbox/templates/ipam/service.html:36
-#: netbox/templates/ipam/servicetemplate.html:23
+#: ipam/forms/bulk_edit.py:539 ipam/forms/model_forms.py:659
+#: ipam/forms/model_forms.py:691 ipam/tables/services.py:19
+#: ipam/tables/services.py:49 templates/ipam/service.html:36
+#: templates/ipam/servicetemplate.html:23
 msgid "Ports"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:48
+#: ipam/forms/bulk_import.py:48
 msgid "Import route targets"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:54
+#: ipam/forms/bulk_import.py:54
 msgid "Export route targets"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:92 netbox/ipam/forms/bulk_import.py:112
-#: netbox/ipam/forms/bulk_import.py:132
+#: ipam/forms/bulk_import.py:92 ipam/forms/bulk_import.py:112
+#: ipam/forms/bulk_import.py:132
 msgid "Assigned RIR"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:182
+#: ipam/forms/bulk_import.py:182
 msgid "VLAN's group (if any)"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:308
+#: ipam/forms/bulk_import.py:308
 msgid "Parent device of assigned interface (if any)"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:311 netbox/ipam/forms/bulk_import.py:488
-#: netbox/ipam/forms/model_forms.py:685 netbox/virtualization/filtersets.py:288
-#: netbox/virtualization/filtersets.py:327
-#: netbox/virtualization/forms/bulk_edit.py:200
-#: netbox/virtualization/forms/bulk_edit.py:326
-#: netbox/virtualization/forms/bulk_import.py:146
-#: netbox/virtualization/forms/bulk_import.py:207
-#: netbox/virtualization/forms/filtersets.py:212
-#: netbox/virtualization/forms/filtersets.py:248
-#: netbox/virtualization/forms/model_forms.py:288
-#: netbox/vpn/forms/bulk_import.py:93 netbox/vpn/forms/bulk_import.py:290
+#: ipam/forms/bulk_import.py:311 ipam/forms/bulk_import.py:488
+#: ipam/forms/model_forms.py:685 virtualization/filtersets.py:288
+#: virtualization/filtersets.py:327 virtualization/forms/bulk_edit.py:200
+#: virtualization/forms/bulk_edit.py:326
+#: virtualization/forms/bulk_import.py:146
+#: virtualization/forms/bulk_import.py:207
+#: virtualization/forms/filtersets.py:212
+#: virtualization/forms/filtersets.py:248
+#: virtualization/forms/model_forms.py:288 vpn/forms/bulk_import.py:93
+#: vpn/forms/bulk_import.py:290
 msgid "Virtual machine"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:315
+#: ipam/forms/bulk_import.py:315
 msgid "Parent VM of assigned interface (if any)"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:325
+#: ipam/forms/bulk_import.py:325
 msgid "Is primary"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:326
+#: ipam/forms/bulk_import.py:326
 msgid "Make this the primary IP for the assigned device"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:365
+#: ipam/forms/bulk_import.py:365
 msgid "No device or virtual machine specified; cannot set as primary IP"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:369
+#: ipam/forms/bulk_import.py:369
 msgid "No interface specified; cannot set as primary IP"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:398
+#: ipam/forms/bulk_import.py:398
 msgid "Auth type"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:413
+#: ipam/forms/bulk_import.py:413
 msgid "Scope type (app & model)"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:440
+#: ipam/forms/bulk_import.py:440
 msgid "Assigned VLAN group"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:471 netbox/ipam/forms/bulk_import.py:497
+#: ipam/forms/bulk_import.py:471 ipam/forms/bulk_import.py:497
 msgid "IP protocol"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:485
+#: ipam/forms/bulk_import.py:485
 msgid "Required if not assigned to a VM"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:492
+#: ipam/forms/bulk_import.py:492
 msgid "Required if not assigned to a device"
 msgstr ""
 
-#: netbox/ipam/forms/bulk_import.py:517
+#: ipam/forms/bulk_import.py:517
 #, python-brace-format
 msgid "{ip} is not assigned to this device/VM."
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:47 netbox/ipam/forms/model_forms.py:63
-#: netbox/netbox/navigation/menu.py:189 netbox/vpn/forms/model_forms.py:410
+#: ipam/forms/filtersets.py:47 ipam/forms/model_forms.py:63
+#: netbox/navigation/menu.py:189 vpn/forms/model_forms.py:410
 msgid "Route Targets"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:53 netbox/ipam/forms/model_forms.py:50
-#: netbox/vpn/forms/filtersets.py:224 netbox/vpn/forms/model_forms.py:397
+#: ipam/forms/filtersets.py:53 ipam/forms/model_forms.py:50
+#: vpn/forms/filtersets.py:224 vpn/forms/model_forms.py:397
 msgid "Import targets"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:58 netbox/ipam/forms/model_forms.py:55
-#: netbox/vpn/forms/filtersets.py:229 netbox/vpn/forms/model_forms.py:402
+#: ipam/forms/filtersets.py:58 ipam/forms/model_forms.py:55
+#: vpn/forms/filtersets.py:229 vpn/forms/model_forms.py:402
 msgid "Export targets"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:73
+#: ipam/forms/filtersets.py:73
 msgid "Imported by VRF"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:78
+#: ipam/forms/filtersets.py:78
 msgid "Exported by VRF"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:87 netbox/ipam/tables/ip.py:89
-#: netbox/templates/ipam/rir.html:30
+#: ipam/forms/filtersets.py:87 ipam/tables/ip.py:89 templates/ipam/rir.html:30
 msgid "Private"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:105 netbox/ipam/forms/filtersets.py:191
-#: netbox/ipam/forms/filtersets.py:272 netbox/ipam/forms/filtersets.py:326
+#: ipam/forms/filtersets.py:105 ipam/forms/filtersets.py:191
+#: ipam/forms/filtersets.py:272 ipam/forms/filtersets.py:326
 msgid "Address family"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:119 netbox/templates/ipam/asnrange.html:25
+#: ipam/forms/filtersets.py:119 templates/ipam/asnrange.html:25
 msgid "Range"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:128
+#: ipam/forms/filtersets.py:128
 msgid "Start"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:132
+#: ipam/forms/filtersets.py:132
 msgid "End"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:186
+#: ipam/forms/filtersets.py:186
 msgid "Search within"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:207 netbox/ipam/forms/filtersets.py:342
+#: ipam/forms/filtersets.py:207 ipam/forms/filtersets.py:342
 msgid "Present in VRF"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:311
+#: ipam/forms/filtersets.py:311
 msgid "Device/VM"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:321
+#: ipam/forms/filtersets.py:321
 msgid "Parent Prefix"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:347
+#: ipam/forms/filtersets.py:347
 msgid "Assigned Device"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:352
+#: ipam/forms/filtersets.py:352
 msgid "Assigned VM"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:366
+#: ipam/forms/filtersets.py:366
 msgid "Assigned to an interface"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:373 netbox/templates/ipam/ipaddress.html:51
+#: ipam/forms/filtersets.py:373 templates/ipam/ipaddress.html:51
 msgid "DNS Name"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:416 netbox/ipam/models/vlans.py:235
-#: netbox/ipam/tables/ip.py:176 netbox/ipam/tables/vlans.py:82
-#: netbox/ipam/views.py:971 netbox/netbox/navigation/menu.py:193
-#: netbox/netbox/navigation/menu.py:195
+#: ipam/forms/filtersets.py:416 ipam/models/vlans.py:235 ipam/tables/ip.py:176
+#: ipam/tables/vlans.py:82 ipam/views.py:971 netbox/navigation/menu.py:193
+#: netbox/navigation/menu.py:195
 msgid "VLANs"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:457
+#: ipam/forms/filtersets.py:457
 msgid "Contains VLAN ID"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:513 netbox/ipam/models/vlans.py:176
-#: netbox/templates/ipam/vlan.html:31
+#: ipam/forms/filtersets.py:513 ipam/models/vlans.py:176
+#: templates/ipam/vlan.html:31
 msgid "VLAN ID"
 msgstr ""
 
-#: netbox/ipam/forms/filtersets.py:556 netbox/ipam/forms/model_forms.py:320
-#: netbox/ipam/forms/model_forms.py:713 netbox/ipam/forms/model_forms.py:739
-#: netbox/ipam/tables/vlans.py:195
-#: netbox/templates/virtualization/virtualdisk.html:21
-#: netbox/templates/virtualization/virtualmachine.html:12
-#: netbox/templates/virtualization/vminterface.html:21
-#: netbox/templates/vpn/tunneltermination.html:25
-#: netbox/virtualization/forms/filtersets.py:197
-#: netbox/virtualization/forms/filtersets.py:242
-#: netbox/virtualization/forms/model_forms.py:220
-#: netbox/virtualization/tables/virtualmachines.py:135
-#: netbox/virtualization/tables/virtualmachines.py:190 netbox/vpn/choices.py:45
-#: netbox/vpn/forms/filtersets.py:293 netbox/vpn/forms/model_forms.py:160
-#: netbox/vpn/forms/model_forms.py:171 netbox/vpn/forms/model_forms.py:273
-#: netbox/vpn/forms/model_forms.py:454
+#: ipam/forms/filtersets.py:556 ipam/forms/model_forms.py:320
+#: ipam/forms/model_forms.py:713 ipam/forms/model_forms.py:739
+#: ipam/tables/vlans.py:195 templates/virtualization/virtualdisk.html:21
+#: templates/virtualization/virtualmachine.html:12
+#: templates/virtualization/vminterface.html:21
+#: templates/vpn/tunneltermination.html:25
+#: virtualization/forms/filtersets.py:197
+#: virtualization/forms/filtersets.py:242
+#: virtualization/forms/model_forms.py:220
+#: virtualization/tables/virtualmachines.py:135
+#: virtualization/tables/virtualmachines.py:190 vpn/choices.py:45
+#: vpn/forms/filtersets.py:293 vpn/forms/model_forms.py:160
+#: vpn/forms/model_forms.py:171 vpn/forms/model_forms.py:273
+#: vpn/forms/model_forms.py:454
 msgid "Virtual Machine"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:80
-#: netbox/templates/ipam/routetarget.html:10
+#: ipam/forms/model_forms.py:80 templates/ipam/routetarget.html:10
 msgid "Route Target"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:114 netbox/ipam/tables/ip.py:117
-#: netbox/templates/ipam/aggregate.html:11 netbox/templates/ipam/prefix.html:38
+#: ipam/forms/model_forms.py:114 ipam/tables/ip.py:117
+#: templates/ipam/aggregate.html:11 templates/ipam/prefix.html:38
 msgid "Aggregate"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:135 netbox/templates/ipam/asnrange.html:12
+#: ipam/forms/model_forms.py:135 templates/ipam/asnrange.html:12
 msgid "ASN Range"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:231
+#: ipam/forms/model_forms.py:231
 msgid "Site/VLAN Assignment"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:259 netbox/templates/ipam/iprange.html:10
+#: ipam/forms/model_forms.py:259 templates/ipam/iprange.html:10
 msgid "IP Range"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:295 netbox/ipam/forms/model_forms.py:321
-#: netbox/ipam/forms/model_forms.py:473 netbox/templates/ipam/fhrpgroup.html:19
+#: ipam/forms/model_forms.py:295 ipam/forms/model_forms.py:321
+#: ipam/forms/model_forms.py:473 templates/ipam/fhrpgroup.html:19
 msgid "FHRP Group"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:310
+#: ipam/forms/model_forms.py:310
 msgid "Make this the primary IP for the device/VM"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:325
+#: ipam/forms/model_forms.py:325
 msgid "NAT IP (Inside)"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:384
+#: ipam/forms/model_forms.py:384
 msgid "An IP address can only be assigned to a single object."
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:390 netbox/ipam/models/ip.py:897
+#: ipam/forms/model_forms.py:390 ipam/models/ip.py:897
 msgid ""
 "Cannot reassign IP address while it is designated as the primary IP for the "
 "parent object"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:400
+#: ipam/forms/model_forms.py:400
 msgid ""
 "Only IP addresses assigned to an interface can be designated as primary IPs."
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:475
+#: ipam/forms/model_forms.py:475
 msgid "Virtual IP Address"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:560
+#: ipam/forms/model_forms.py:560
 msgid "Assignment already exists"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:569 netbox/templates/ipam/vlangroup.html:42
+#: ipam/forms/model_forms.py:569 templates/ipam/vlangroup.html:42
 msgid "VLAN IDs"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:587
+#: ipam/forms/model_forms.py:587
 msgid "Child VLANs"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:664 netbox/ipam/forms/model_forms.py:696
+#: ipam/forms/model_forms.py:664 ipam/forms/model_forms.py:696
 msgid ""
 "Comma-separated list of one or more port numbers. A range may be specified "
 "using a hyphen."
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:669
-#: netbox/templates/ipam/servicetemplate.html:12
+#: ipam/forms/model_forms.py:669 templates/ipam/servicetemplate.html:12
 msgid "Service Template"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:716
+#: ipam/forms/model_forms.py:716
 msgid "Port(s)"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:717 netbox/ipam/forms/model_forms.py:745
-#: netbox/templates/ipam/service.html:21
+#: ipam/forms/model_forms.py:717 ipam/forms/model_forms.py:745
+#: templates/ipam/service.html:21
 msgid "Service"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:730
+#: ipam/forms/model_forms.py:730
 msgid "Service template"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:742
+#: ipam/forms/model_forms.py:742
 msgid "From Template"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:743
+#: ipam/forms/model_forms.py:743
 msgid "Custom"
 msgstr ""
 
-#: netbox/ipam/forms/model_forms.py:773
+#: ipam/forms/model_forms.py:773
 msgid ""
 "Must specify name, protocol, and port(s) if not using a service template."
 msgstr ""
 
-#: netbox/ipam/models/asns.py:34
+#: ipam/models/asns.py:34
 msgid "start"
 msgstr ""
 
-#: netbox/ipam/models/asns.py:51
+#: ipam/models/asns.py:51
 msgid "ASN range"
 msgstr ""
 
-#: netbox/ipam/models/asns.py:52
+#: ipam/models/asns.py:52
 msgid "ASN ranges"
 msgstr ""
 
-#: netbox/ipam/models/asns.py:72
+#: ipam/models/asns.py:72
 #, python-brace-format
 msgid "Starting ASN ({start}) must be lower than ending ASN ({end})."
 msgstr ""
 
-#: netbox/ipam/models/asns.py:104
+#: ipam/models/asns.py:104
 msgid "Regional Internet Registry responsible for this AS number space"
 msgstr ""
 
-#: netbox/ipam/models/asns.py:109
+#: ipam/models/asns.py:109
 msgid "16- or 32-bit autonomous system number"
 msgstr ""
 
-#: netbox/ipam/models/fhrp.py:22
+#: ipam/models/fhrp.py:22
 msgid "group ID"
 msgstr ""
 
-#: netbox/ipam/models/fhrp.py:30 netbox/ipam/models/services.py:22
+#: ipam/models/fhrp.py:30 ipam/models/services.py:22
 msgid "protocol"
 msgstr ""
 
-#: netbox/ipam/models/fhrp.py:38 netbox/wireless/models.py:28
+#: ipam/models/fhrp.py:38 wireless/models.py:28
 msgid "authentication type"
 msgstr ""
 
-#: netbox/ipam/models/fhrp.py:43
+#: ipam/models/fhrp.py:43
 msgid "authentication key"
 msgstr ""
 
-#: netbox/ipam/models/fhrp.py:56
+#: ipam/models/fhrp.py:56
 msgid "FHRP group"
 msgstr ""
 
-#: netbox/ipam/models/fhrp.py:57
+#: ipam/models/fhrp.py:57
 msgid "FHRP groups"
 msgstr ""
 
-#: netbox/ipam/models/fhrp.py:113
+#: ipam/models/fhrp.py:113
 msgid "FHRP group assignment"
 msgstr ""
 
-#: netbox/ipam/models/fhrp.py:114
+#: ipam/models/fhrp.py:114
 msgid "FHRP group assignments"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:65
+#: ipam/models/ip.py:65
 msgid "private"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:66
+#: ipam/models/ip.py:66
 msgid "IP space managed by this RIR is considered private"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:72 netbox/netbox/navigation/menu.py:182
+#: ipam/models/ip.py:72 netbox/navigation/menu.py:182
 msgid "RIRs"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:84
+#: ipam/models/ip.py:84
 msgid "IPv4 or IPv6 network"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:91
+#: ipam/models/ip.py:91
 msgid "Regional Internet Registry responsible for this IP space"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:101
+#: ipam/models/ip.py:101
 msgid "date added"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:115
+#: ipam/models/ip.py:115
 msgid "aggregate"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:116
+#: ipam/models/ip.py:116
 msgid "aggregates"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:132
+#: ipam/models/ip.py:132
 msgid "Cannot create aggregate with /0 mask."
 msgstr ""
 
-#: netbox/ipam/models/ip.py:144
+#: ipam/models/ip.py:144
 #, python-brace-format
 msgid ""
 "Aggregates cannot overlap. {prefix} is already covered by an existing "
 "aggregate ({aggregate})."
 msgstr ""
 
-#: netbox/ipam/models/ip.py:158
+#: ipam/models/ip.py:158
 #, python-brace-format
 msgid ""
 "Prefixes cannot overlap aggregates. {prefix} covers an existing aggregate "
 "({aggregate})."
 msgstr ""
 
-#: netbox/ipam/models/ip.py:200 netbox/ipam/models/ip.py:737
-#: netbox/vpn/models/tunnels.py:114
+#: ipam/models/ip.py:200 ipam/models/ip.py:737 vpn/models/tunnels.py:114
 msgid "role"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:201
+#: ipam/models/ip.py:201
 msgid "roles"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:217 netbox/ipam/models/ip.py:293
+#: ipam/models/ip.py:217 ipam/models/ip.py:293
 msgid "prefix"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:218
+#: ipam/models/ip.py:218
 msgid "IPv4 or IPv6 network with mask"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:254
+#: ipam/models/ip.py:254
 msgid "Operational status of this prefix"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:262
+#: ipam/models/ip.py:262
 msgid "The primary function of this prefix"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:265
+#: ipam/models/ip.py:265
 msgid "is a pool"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:267
+#: ipam/models/ip.py:267
 msgid "All IP addresses within this prefix are considered usable"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:270 netbox/ipam/models/ip.py:537
+#: ipam/models/ip.py:270 ipam/models/ip.py:537
 msgid "mark utilized"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:294
+#: ipam/models/ip.py:294
 msgid "prefixes"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:317
+#: ipam/models/ip.py:317
 msgid "Cannot create prefix with /0 mask."
 msgstr ""
 
-#: netbox/ipam/models/ip.py:324 netbox/ipam/models/ip.py:874
+#: ipam/models/ip.py:324 ipam/models/ip.py:874
 #, python-brace-format
 msgid "VRF {vrf}"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:324 netbox/ipam/models/ip.py:874
+#: ipam/models/ip.py:324 ipam/models/ip.py:874
 msgid "global table"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:326
+#: ipam/models/ip.py:326
 #, python-brace-format
 msgid "Duplicate prefix found in {table}: {prefix}"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:495
+#: ipam/models/ip.py:495
 msgid "start address"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:496 netbox/ipam/models/ip.py:500
-#: netbox/ipam/models/ip.py:712
+#: ipam/models/ip.py:496 ipam/models/ip.py:500 ipam/models/ip.py:712
 msgid "IPv4 or IPv6 address (with mask)"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:499
+#: ipam/models/ip.py:499
 msgid "end address"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:526
+#: ipam/models/ip.py:526
 msgid "Operational status of this range"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:534
+#: ipam/models/ip.py:534
 msgid "The primary function of this range"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:548
+#: ipam/models/ip.py:548
 msgid "IP range"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:549
+#: ipam/models/ip.py:549
 msgid "IP ranges"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:565
+#: ipam/models/ip.py:565
 msgid "Starting and ending IP address versions must match"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:571
+#: ipam/models/ip.py:571
 msgid "Starting and ending IP address masks must match"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:578
+#: ipam/models/ip.py:578
 #, python-brace-format
 msgid ""
 "Ending address must be greater than the starting address ({start_address})"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:590
+#: ipam/models/ip.py:590
 #, python-brace-format
 msgid "Defined addresses overlap with range {overlapping_range} in VRF {vrf}"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:599
+#: ipam/models/ip.py:599
 #, python-brace-format
 msgid "Defined range exceeds maximum supported size ({max_size})"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:711 netbox/tenancy/models/contacts.py:82
+#: ipam/models/ip.py:711 tenancy/models/contacts.py:82
 msgid "address"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:734
+#: ipam/models/ip.py:734
 msgid "The operational status of this IP"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:741
+#: ipam/models/ip.py:741
 msgid "The functional role of this IP"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:765 netbox/templates/ipam/ipaddress.html:72
+#: ipam/models/ip.py:765 templates/ipam/ipaddress.html:72
 msgid "NAT (inside)"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:766
+#: ipam/models/ip.py:766
 msgid "The IP for which this address is the \"outside\" IP"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:773
+#: ipam/models/ip.py:773
 msgid "Hostname or FQDN (not case-sensitive)"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:789 netbox/ipam/models/services.py:94
+#: ipam/models/ip.py:789 ipam/models/services.py:94
 msgid "IP addresses"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:845
+#: ipam/models/ip.py:845
 msgid "Cannot create IP address with /0 mask."
 msgstr ""
 
-#: netbox/ipam/models/ip.py:851
+#: ipam/models/ip.py:851
 #, python-brace-format
 msgid "{ip} is a network ID, which may not be assigned to an interface."
 msgstr ""
 
-#: netbox/ipam/models/ip.py:862
+#: ipam/models/ip.py:862
 #, python-brace-format
 msgid "{ip} is a broadcast address, which may not be assigned to an interface."
 msgstr ""
 
-#: netbox/ipam/models/ip.py:876
+#: ipam/models/ip.py:876
 #, python-brace-format
 msgid "Duplicate IP address found in {table}: {ipaddress}"
 msgstr ""
 
-#: netbox/ipam/models/ip.py:903
+#: ipam/models/ip.py:903
 msgid "Only IPv6 addresses can be assigned SLAAC status"
 msgstr ""
 
-#: netbox/ipam/models/services.py:33
+#: ipam/models/services.py:33
 msgid "port numbers"
 msgstr ""
 
-#: netbox/ipam/models/services.py:59
+#: ipam/models/services.py:59
 msgid "service template"
 msgstr ""
 
-#: netbox/ipam/models/services.py:60
+#: ipam/models/services.py:60
 msgid "service templates"
 msgstr ""
 
-#: netbox/ipam/models/services.py:95
+#: ipam/models/services.py:95
 msgid "The specific IP addresses (if any) to which this service is bound"
 msgstr ""
 
-#: netbox/ipam/models/services.py:102
+#: ipam/models/services.py:102
 msgid "service"
 msgstr ""
 
-#: netbox/ipam/models/services.py:103
+#: ipam/models/services.py:103
 msgid "services"
 msgstr ""
 
-#: netbox/ipam/models/services.py:117
+#: ipam/models/services.py:117
 msgid ""
 "A service cannot be associated with both a device and a virtual machine."
 msgstr ""
 
-#: netbox/ipam/models/services.py:119
+#: ipam/models/services.py:119
 msgid "A service must be associated with either a device or a virtual machine."
 msgstr ""
 
-#: netbox/ipam/models/vlans.py:85
+#: ipam/models/vlans.py:85
 msgid "VLAN groups"
 msgstr ""
 
-#: netbox/ipam/models/vlans.py:95
+#: ipam/models/vlans.py:95
 msgid "Cannot set scope_type without scope_id."
 msgstr ""
 
-#: netbox/ipam/models/vlans.py:97
+#: ipam/models/vlans.py:97
 msgid "Cannot set scope_id without scope_type."
 msgstr ""
 
-#: netbox/ipam/models/vlans.py:101
+#: ipam/models/vlans.py:101
 msgid "Ranges cannot overlap."
 msgstr ""
 
-#: netbox/ipam/models/vlans.py:106
+#: ipam/models/vlans.py:106
 #, python-brace-format
 msgid ""
 "Maximum child VID must be greater than or equal to minimum child VID "
 "({value})"
 msgstr ""
 
-#: netbox/ipam/models/vlans.py:165
+#: ipam/models/vlans.py:165
 msgid "The specific site to which this VLAN is assigned (if any)"
 msgstr ""
 
-#: netbox/ipam/models/vlans.py:173
+#: ipam/models/vlans.py:173
 msgid "VLAN group (optional)"
 msgstr ""
 
-#: netbox/ipam/models/vlans.py:181
+#: ipam/models/vlans.py:181
 msgid "Numeric VLAN ID (1-4094)"
 msgstr ""
 
-#: netbox/ipam/models/vlans.py:199
+#: ipam/models/vlans.py:199
 msgid "Operational status of this VLAN"
 msgstr ""
 
-#: netbox/ipam/models/vlans.py:207
+#: ipam/models/vlans.py:207
 msgid "The primary function of this VLAN"
 msgstr ""
 
-#: netbox/ipam/models/vlans.py:250
+#: ipam/models/vlans.py:250
 #, python-brace-format
 msgid ""
 "VLAN is assigned to group {group} (scope: {scope}); cannot also assign to "
 "site {site}."
 msgstr ""
 
-#: netbox/ipam/models/vlans.py:259
+#: ipam/models/vlans.py:259
 #, python-brace-format
 msgid "VID must be in ranges {ranges} for VLANs in group {group}"
 msgstr ""
 
-#: netbox/ipam/models/vrfs.py:30
+#: ipam/models/vrfs.py:30
 msgid "route distinguisher"
 msgstr ""
 
-#: netbox/ipam/models/vrfs.py:31
+#: ipam/models/vrfs.py:31
 msgid "Unique route distinguisher (as defined in RFC 4364)"
 msgstr ""
 
-#: netbox/ipam/models/vrfs.py:42
+#: ipam/models/vrfs.py:42
 msgid "enforce unique space"
 msgstr ""
 
-#: netbox/ipam/models/vrfs.py:43
+#: ipam/models/vrfs.py:43
 msgid "Prevent duplicate prefixes/IP addresses within this VRF"
 msgstr ""
 
-#: netbox/ipam/models/vrfs.py:63 netbox/netbox/navigation/menu.py:186
-#: netbox/netbox/navigation/menu.py:188
+#: ipam/models/vrfs.py:63 netbox/navigation/menu.py:186
+#: netbox/navigation/menu.py:188
 msgid "VRFs"
 msgstr ""
 
-#: netbox/ipam/models/vrfs.py:82
+#: ipam/models/vrfs.py:82
 msgid "Route target value (formatted in accordance with RFC 4360)"
 msgstr ""
 
-#: netbox/ipam/models/vrfs.py:94
+#: ipam/models/vrfs.py:94
 msgid "route target"
 msgstr ""
 
-#: netbox/ipam/models/vrfs.py:95
+#: ipam/models/vrfs.py:95
 msgid "route targets"
 msgstr ""
 
-#: netbox/ipam/tables/asn.py:52
+#: ipam/tables/asn.py:52
 msgid "ASDOT"
 msgstr ""
 
-#: netbox/ipam/tables/asn.py:57
+#: ipam/tables/asn.py:57
 msgid "Site Count"
 msgstr ""
 
-#: netbox/ipam/tables/asn.py:62
+#: ipam/tables/asn.py:62
 msgid "Provider Count"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:95 netbox/netbox/navigation/menu.py:179
-#: netbox/netbox/navigation/menu.py:181
+#: ipam/tables/ip.py:95 netbox/navigation/menu.py:179
+#: netbox/navigation/menu.py:181
 msgid "Aggregates"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:125
+#: ipam/tables/ip.py:125
 msgid "Added"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:128 netbox/ipam/tables/ip.py:166
-#: netbox/ipam/tables/vlans.py:142 netbox/ipam/views.py:346
-#: netbox/netbox/navigation/menu.py:165 netbox/netbox/navigation/menu.py:167
-#: netbox/templates/ipam/vlan.html:84
+#: ipam/tables/ip.py:128 ipam/tables/ip.py:166 ipam/tables/vlans.py:142
+#: ipam/views.py:346 netbox/navigation/menu.py:165
+#: netbox/navigation/menu.py:167 templates/ipam/vlan.html:84
 msgid "Prefixes"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:131 netbox/ipam/tables/ip.py:270
-#: netbox/ipam/tables/ip.py:324 netbox/ipam/tables/vlans.py:86
-#: netbox/templates/dcim/device.html:260
-#: netbox/templates/ipam/aggregate.html:24
-#: netbox/templates/ipam/iprange.html:29 netbox/templates/ipam/prefix.html:106
+#: ipam/tables/ip.py:131 ipam/tables/ip.py:270 ipam/tables/ip.py:324
+#: ipam/tables/vlans.py:86 templates/dcim/device.html:260
+#: templates/ipam/aggregate.html:24 templates/ipam/iprange.html:29
+#: templates/ipam/prefix.html:106
 msgid "Utilization"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:171 netbox/netbox/navigation/menu.py:161
+#: ipam/tables/ip.py:171 netbox/navigation/menu.py:161
 msgid "IP Ranges"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:221
+#: ipam/tables/ip.py:221
 msgid "Prefix (Flat)"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:225
+#: ipam/tables/ip.py:225
 msgid "Depth"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:262
+#: ipam/tables/ip.py:262
 msgid "Pool"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:266 netbox/ipam/tables/ip.py:320
+#: ipam/tables/ip.py:266 ipam/tables/ip.py:320
 msgid "Marked Utilized"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:304
+#: ipam/tables/ip.py:304
 msgid "Start address"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:383
+#: ipam/tables/ip.py:383
 msgid "NAT (Inside)"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:388
+#: ipam/tables/ip.py:388
 msgid "NAT (Outside)"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:393
+#: ipam/tables/ip.py:393
 msgid "Assigned"
 msgstr ""
 
-#: netbox/ipam/tables/ip.py:429 netbox/templates/vpn/l2vpntermination.html:16
-#: netbox/vpn/forms/filtersets.py:240
+#: ipam/tables/ip.py:429 templates/vpn/l2vpntermination.html:16
+#: vpn/forms/filtersets.py:240
 msgid "Assigned Object"
 msgstr ""
 
-#: netbox/ipam/tables/vlans.py:68
+#: ipam/tables/vlans.py:68
 msgid "Scope Type"
 msgstr ""
 
-#: netbox/ipam/tables/vlans.py:76
+#: ipam/tables/vlans.py:76
 msgid "VID Ranges"
 msgstr ""
 
-#: netbox/ipam/tables/vlans.py:111 netbox/ipam/tables/vlans.py:214
-#: netbox/templates/dcim/inc/interface_vlans_table.html:4
+#: ipam/tables/vlans.py:111 ipam/tables/vlans.py:214
+#: templates/dcim/inc/interface_vlans_table.html:4
 msgid "VID"
 msgstr ""
 
-#: netbox/ipam/tables/vrfs.py:30
+#: ipam/tables/vrfs.py:30
 msgid "RD"
 msgstr ""
 
-#: netbox/ipam/tables/vrfs.py:33
+#: ipam/tables/vrfs.py:33
 msgid "Unique"
 msgstr ""
 
-#: netbox/ipam/tables/vrfs.py:37 netbox/vpn/tables/l2vpn.py:27
+#: ipam/tables/vrfs.py:37 vpn/tables/l2vpn.py:27
 msgid "Import Targets"
 msgstr ""
 
-#: netbox/ipam/tables/vrfs.py:42 netbox/vpn/tables/l2vpn.py:32
+#: ipam/tables/vrfs.py:42 vpn/tables/l2vpn.py:32
 msgid "Export Targets"
 msgstr ""
 
-#: netbox/ipam/validators.py:9
+#: ipam/validators.py:9
 #, python-brace-format
 msgid "{prefix} is not a valid prefix. Did you mean {suggested}?"
 msgstr ""
 
-#: netbox/ipam/validators.py:16
+#: ipam/validators.py:16
 #, python-format
 msgid "The prefix length must be less than or equal to %(limit_value)s."
 msgstr ""
 
-#: netbox/ipam/validators.py:24
+#: ipam/validators.py:24
 #, python-format
 msgid "The prefix length must be greater than or equal to %(limit_value)s."
 msgstr ""
 
-#: netbox/ipam/validators.py:33
+#: ipam/validators.py:33
 msgid ""
 "Only alphanumeric characters, asterisks, hyphens, periods, and underscores "
 "are allowed in DNS names"
 msgstr ""
 
-#: netbox/ipam/views.py:533
+#: ipam/views.py:533
 msgid "Child Prefixes"
 msgstr ""
 
-#: netbox/ipam/views.py:569
+#: ipam/views.py:569
 msgid "Child Ranges"
 msgstr ""
 
-#: netbox/ipam/views.py:898
+#: ipam/views.py:898
 msgid "Related IPs"
 msgstr ""
 
-#: netbox/ipam/views.py:1127
+#: ipam/views.py:1127
 msgid "Device Interfaces"
 msgstr ""
 
-#: netbox/ipam/views.py:1145
+#: ipam/views.py:1145
 msgid "VM Interfaces"
 msgstr ""
 
-#: netbox/netbox/api/fields.py:65
+#: netbox/api/fields.py:65
 msgid "This field may not be blank."
 msgstr ""
 
-#: netbox/netbox/api/fields.py:70
+#: netbox/api/fields.py:70
 msgid ""
 "Value must be passed directly (e.g. \"foo\": 123); do not use a dictionary "
 "or list."
 msgstr ""
 
-#: netbox/netbox/api/fields.py:91
+#: netbox/api/fields.py:91
 #, python-brace-format
 msgid "{value} is not a valid choice."
 msgstr ""
 
-#: netbox/netbox/api/fields.py:104
+#: netbox/api/fields.py:104
 #, python-brace-format
 msgid "Invalid content type: {content_type}"
 msgstr ""
 
-#: netbox/netbox/api/fields.py:105
+#: netbox/api/fields.py:105
 msgid "Invalid value. Specify a content type as '<app_label>.<model_name>'."
 msgstr ""
 
-#: netbox/netbox/api/fields.py:167
+#: netbox/api/fields.py:167
 msgid "Ranges must be specified in the form (lower, upper)."
 msgstr ""
 
-#: netbox/netbox/api/fields.py:169
+#: netbox/api/fields.py:169
 msgid "Range boundaries must be defined as integers."
 msgstr ""
 
-#: netbox/netbox/api/serializers/fields.py:40
+#: netbox/api/serializers/fields.py:40
 #, python-brace-format
 msgid "{class_name} must implement get_view_name()"
 msgstr ""
 
-#: netbox/netbox/authentication/__init__.py:138
+#: netbox/authentication/__init__.py:138
 #, python-brace-format
 msgid "Invalid permission {permission} for model {model}"
 msgstr ""
 
-#: netbox/netbox/choices.py:49
+#: netbox/choices.py:49
 msgid "Dark Red"
 msgstr ""
 
-#: netbox/netbox/choices.py:52
+#: netbox/choices.py:52
 msgid "Rose"
 msgstr ""
 
-#: netbox/netbox/choices.py:53
+#: netbox/choices.py:53
 msgid "Fuchsia"
 msgstr ""
 
-#: netbox/netbox/choices.py:55
+#: netbox/choices.py:55
 msgid "Dark Purple"
 msgstr ""
 
-#: netbox/netbox/choices.py:58
+#: netbox/choices.py:58
 msgid "Light Blue"
 msgstr ""
 
-#: netbox/netbox/choices.py:61
+#: netbox/choices.py:61
 msgid "Aqua"
 msgstr ""
 
-#: netbox/netbox/choices.py:62
+#: netbox/choices.py:62
 msgid "Dark Green"
 msgstr ""
 
-#: netbox/netbox/choices.py:64
+#: netbox/choices.py:64
 msgid "Light Green"
 msgstr ""
 
-#: netbox/netbox/choices.py:65
+#: netbox/choices.py:65
 msgid "Lime"
 msgstr ""
 
-#: netbox/netbox/choices.py:67
+#: netbox/choices.py:67
 msgid "Amber"
 msgstr ""
 
-#: netbox/netbox/choices.py:69
+#: netbox/choices.py:69
 msgid "Dark Orange"
 msgstr ""
 
-#: netbox/netbox/choices.py:70
+#: netbox/choices.py:70
 msgid "Brown"
 msgstr ""
 
-#: netbox/netbox/choices.py:71
+#: netbox/choices.py:71
 msgid "Light Grey"
 msgstr ""
 
-#: netbox/netbox/choices.py:72
+#: netbox/choices.py:72
 msgid "Grey"
 msgstr ""
 
-#: netbox/netbox/choices.py:73
+#: netbox/choices.py:73
 msgid "Dark Grey"
 msgstr ""
 
-#: netbox/netbox/choices.py:128
+#: netbox/choices.py:128
 msgid "Direct"
 msgstr ""
 
-#: netbox/netbox/choices.py:129
+#: netbox/choices.py:129
 msgid "Upload"
 msgstr ""
 
-#: netbox/netbox/choices.py:141 netbox/netbox/choices.py:155
+#: netbox/choices.py:141 netbox/choices.py:155
 msgid "Auto-detect"
 msgstr ""
 
-#: netbox/netbox/choices.py:156
+#: netbox/choices.py:156
 msgid "Comma"
 msgstr ""
 
-#: netbox/netbox/choices.py:157
+#: netbox/choices.py:157
 msgid "Semicolon"
 msgstr ""
 
-#: netbox/netbox/choices.py:158
+#: netbox/choices.py:158
 msgid "Tab"
 msgstr ""
 
-#: netbox/netbox/config/__init__.py:67
+#: netbox/config/__init__.py:67
 #, python-brace-format
 msgid "Invalid configuration parameter: {item}"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:22
-#: netbox/templates/core/inc/config_data.html:62
+#: netbox/config/parameters.py:22 templates/core/inc/config_data.html:62
 msgid "Login banner"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:24
+#: netbox/config/parameters.py:24
 msgid "Additional content to display on the login page"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:33
-#: netbox/templates/core/inc/config_data.html:66
+#: netbox/config/parameters.py:33 templates/core/inc/config_data.html:66
 msgid "Maintenance banner"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:35
+#: netbox/config/parameters.py:35
 msgid "Additional content to display when in maintenance mode"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:44
-#: netbox/templates/core/inc/config_data.html:70
+#: netbox/config/parameters.py:44 templates/core/inc/config_data.html:70
 msgid "Top banner"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:46
+#: netbox/config/parameters.py:46
 msgid "Additional content to display at the top of every page"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:55
-#: netbox/templates/core/inc/config_data.html:74
+#: netbox/config/parameters.py:55 templates/core/inc/config_data.html:74
 msgid "Bottom banner"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:57
+#: netbox/config/parameters.py:57
 msgid "Additional content to display at the bottom of every page"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:68
+#: netbox/config/parameters.py:68
 msgid "Globally unique IP space"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:70
+#: netbox/config/parameters.py:70
 msgid "Enforce unique IP addressing within the global table"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:75
-#: netbox/templates/core/inc/config_data.html:44
+#: netbox/config/parameters.py:75 templates/core/inc/config_data.html:44
 msgid "Prefer IPv4"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:77
+#: netbox/config/parameters.py:77
 msgid "Prefer IPv4 addresses over IPv6"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:84
+#: netbox/config/parameters.py:84
 msgid "Rack unit height"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:86
+#: netbox/config/parameters.py:86
 msgid "Default unit height for rendered rack elevations"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:91
+#: netbox/config/parameters.py:91
 msgid "Rack unit width"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:93
+#: netbox/config/parameters.py:93
 msgid "Default unit width for rendered rack elevations"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:100
+#: netbox/config/parameters.py:100
 msgid "Powerfeed voltage"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:102
+#: netbox/config/parameters.py:102
 msgid "Default voltage for powerfeeds"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:107
+#: netbox/config/parameters.py:107
 msgid "Powerfeed amperage"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:109
+#: netbox/config/parameters.py:109
 msgid "Default amperage for powerfeeds"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:114
+#: netbox/config/parameters.py:114
 msgid "Powerfeed max utilization"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:116
+#: netbox/config/parameters.py:116
 msgid "Default max utilization for powerfeeds"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:123
-#: netbox/templates/core/inc/config_data.html:53
+#: netbox/config/parameters.py:123 templates/core/inc/config_data.html:53
 msgid "Allowed URL schemes"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:128
+#: netbox/config/parameters.py:128
 msgid "Permitted schemes for URLs in user-provided content"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:136
+#: netbox/config/parameters.py:136
 msgid "Default page size"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:142
+#: netbox/config/parameters.py:142
 msgid "Maximum page size"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:150
-#: netbox/templates/core/inc/config_data.html:96
+#: netbox/config/parameters.py:150 templates/core/inc/config_data.html:96
 msgid "Custom validators"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:152
+#: netbox/config/parameters.py:152
 msgid "Custom validation rules (JSON)"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:160
-#: netbox/templates/core/inc/config_data.html:104
+#: netbox/config/parameters.py:160 templates/core/inc/config_data.html:104
 msgid "Protection rules"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:162
+#: netbox/config/parameters.py:162
 msgid "Deletion protection rules (JSON)"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:172
-#: netbox/templates/core/inc/config_data.html:117
+#: netbox/config/parameters.py:172 templates/core/inc/config_data.html:117
 msgid "Default preferences"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:174
+#: netbox/config/parameters.py:174
 msgid "Default preferences for new users"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:181
-#: netbox/templates/core/inc/config_data.html:129
+#: netbox/config/parameters.py:181 templates/core/inc/config_data.html:129
 msgid "Maintenance mode"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:183
+#: netbox/config/parameters.py:183
 msgid "Enable maintenance mode"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:188
-#: netbox/templates/core/inc/config_data.html:133
+#: netbox/config/parameters.py:188 templates/core/inc/config_data.html:133
 msgid "GraphQL enabled"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:190
+#: netbox/config/parameters.py:190
 msgid "Enable the GraphQL API"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:195
-#: netbox/templates/core/inc/config_data.html:137
+#: netbox/config/parameters.py:195 templates/core/inc/config_data.html:137
 msgid "Changelog retention"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:197
+#: netbox/config/parameters.py:197
 msgid "Days to retain changelog history (set to zero for unlimited)"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:202
+#: netbox/config/parameters.py:202
 msgid "Job result retention"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:204
+#: netbox/config/parameters.py:204
 msgid "Days to retain job result history (set to zero for unlimited)"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:209
-#: netbox/templates/core/inc/config_data.html:145
+#: netbox/config/parameters.py:209 templates/core/inc/config_data.html:145
 msgid "Maps URL"
 msgstr ""
 
-#: netbox/netbox/config/parameters.py:211
+#: netbox/config/parameters.py:211
 msgid "Base URL for mapping geographic locations"
 msgstr ""
 
-#: netbox/netbox/forms/__init__.py:12
+#: netbox/forms/__init__.py:12
 msgid "Partial match"
 msgstr ""
 
-#: netbox/netbox/forms/__init__.py:13
+#: netbox/forms/__init__.py:13
 msgid "Exact match"
 msgstr ""
 
-#: netbox/netbox/forms/__init__.py:14
+#: netbox/forms/__init__.py:14
 msgid "Starts with"
 msgstr ""
 
-#: netbox/netbox/forms/__init__.py:15
+#: netbox/forms/__init__.py:15
 msgid "Ends with"
 msgstr ""
 
-#: netbox/netbox/forms/__init__.py:16
+#: netbox/forms/__init__.py:16
 msgid "Regex"
 msgstr ""
 
-#: netbox/netbox/forms/__init__.py:34
+#: netbox/forms/__init__.py:34
 msgid "Object type(s)"
 msgstr ""
 
-#: netbox/netbox/forms/__init__.py:40
+#: netbox/forms/__init__.py:40
 msgid "Lookup"
 msgstr ""
 
-#: netbox/netbox/forms/base.py:90
+#: netbox/forms/base.py:90
 msgid ""
 "Tag slugs separated by commas, encased with double quotes (e.g. \"tag1,tag2,"
 "tag3\")"
 msgstr ""
 
-#: netbox/netbox/forms/base.py:120
+#: netbox/forms/base.py:120
 msgid "Add tags"
 msgstr ""
 
-#: netbox/netbox/forms/base.py:125
+#: netbox/forms/base.py:125
 msgid "Remove tags"
 msgstr ""
 
-#: netbox/netbox/forms/mixins.py:38
+#: netbox/forms/mixins.py:38
 #, python-brace-format
 msgid "{class_name} must specify a model class."
 msgstr ""
 
-#: netbox/netbox/models/features.py:280
+#: netbox/models/features.py:280
 #, python-brace-format
 msgid "Unknown field name '{name}' in custom field data."
 msgstr ""
 
-#: netbox/netbox/models/features.py:286
+#: netbox/models/features.py:286
 #, python-brace-format
 msgid "Invalid value for custom field '{name}': {error}"
 msgstr ""
 
-#: netbox/netbox/models/features.py:295
+#: netbox/models/features.py:295
 #, python-brace-format
 msgid "Custom field '{name}' must have a unique value."
 msgstr ""
 
-#: netbox/netbox/models/features.py:302
+#: netbox/models/features.py:302
 #, python-brace-format
 msgid "Missing required custom field '{name}'."
 msgstr ""
 
-#: netbox/netbox/models/features.py:462
+#: netbox/models/features.py:462
 msgid "Remote data source"
 msgstr ""
 
-#: netbox/netbox/models/features.py:472
+#: netbox/models/features.py:472
 msgid "data path"
 msgstr ""
 
-#: netbox/netbox/models/features.py:476
+#: netbox/models/features.py:476
 msgid "Path to remote file (relative to data source root)"
 msgstr ""
 
-#: netbox/netbox/models/features.py:479
+#: netbox/models/features.py:479
 msgid "auto sync enabled"
 msgstr ""
 
-#: netbox/netbox/models/features.py:481
+#: netbox/models/features.py:481
 msgid "Enable automatic synchronization of data when the data file is updated"
 msgstr ""
 
-#: netbox/netbox/models/features.py:484
+#: netbox/models/features.py:484
 msgid "date synced"
 msgstr ""
 
-#: netbox/netbox/models/features.py:578
+#: netbox/models/features.py:578
 #, python-brace-format
 msgid "{class_name} must implement a sync_data() method."
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:11
+#: netbox/navigation/menu.py:11
 msgid "Organization"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:19
+#: netbox/navigation/menu.py:19
 msgid "Site Groups"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:27
+#: netbox/navigation/menu.py:27
 msgid "Tenant Groups"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:34
+#: netbox/navigation/menu.py:34
 msgid "Contact Groups"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:35
-#: netbox/templates/tenancy/contactrole.html:8
+#: netbox/navigation/menu.py:35 templates/tenancy/contactrole.html:8
 msgid "Contact Roles"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:36
+#: netbox/navigation/menu.py:36
 msgid "Contact Assignments"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:50
+#: netbox/navigation/menu.py:50
 msgid "Rack Roles"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:54
+#: netbox/navigation/menu.py:54
 msgid "Elevations"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:60 netbox/netbox/navigation/menu.py:62
+#: netbox/navigation/menu.py:60 netbox/navigation/menu.py:62
 msgid "Rack Types"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:76
+#: netbox/navigation/menu.py:76
 msgid "Modules"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:80 netbox/templates/dcim/device.html:160
-#: netbox/templates/dcim/virtualdevicecontext.html:8
+#: netbox/navigation/menu.py:80 templates/dcim/device.html:160
+#: templates/dcim/virtualdevicecontext.html:8
 msgid "Virtual Device Contexts"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:88
+#: netbox/navigation/menu.py:88
 msgid "Manufacturers"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:92
+#: netbox/navigation/menu.py:92
 msgid "Device Components"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:104
-#: netbox/templates/dcim/inventoryitemrole.html:8
+#: netbox/navigation/menu.py:104 templates/dcim/inventoryitemrole.html:8
 msgid "Inventory Item Roles"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:111 netbox/netbox/navigation/menu.py:115
+#: netbox/navigation/menu.py:111 netbox/navigation/menu.py:115
 msgid "Connections"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:117
+#: netbox/navigation/menu.py:117
 msgid "Cables"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:118
+#: netbox/navigation/menu.py:118
 msgid "Wireless Links"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:121
+#: netbox/navigation/menu.py:121
 msgid "Interface Connections"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:126
+#: netbox/navigation/menu.py:126
 msgid "Console Connections"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:131
+#: netbox/navigation/menu.py:131
 msgid "Power Connections"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:147
+#: netbox/navigation/menu.py:147
 msgid "Wireless LAN Groups"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:168
+#: netbox/navigation/menu.py:168
 msgid "Prefix & VLAN Roles"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:174
+#: netbox/navigation/menu.py:174
 msgid "ASN Ranges"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:196
+#: netbox/navigation/menu.py:196
 msgid "VLAN Groups"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:203
+#: netbox/navigation/menu.py:203
 msgid "Service Templates"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:204 netbox/templates/dcim/device.html:302
-#: netbox/templates/ipam/ipaddress.html:118
-#: netbox/templates/virtualization/virtualmachine.html:154
+#: netbox/navigation/menu.py:204 templates/dcim/device.html:302
+#: templates/ipam/ipaddress.html:118
+#: templates/virtualization/virtualmachine.html:154
 msgid "Services"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:211
+#: netbox/navigation/menu.py:211
 msgid "VPN"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:215 netbox/netbox/navigation/menu.py:217
-#: netbox/vpn/tables/tunnels.py:24
+#: netbox/navigation/menu.py:215 netbox/navigation/menu.py:217
+#: vpn/tables/tunnels.py:24
 msgid "Tunnels"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:218 netbox/templates/vpn/tunnelgroup.html:8
+#: netbox/navigation/menu.py:218 templates/vpn/tunnelgroup.html:8
 msgid "Tunnel Groups"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:219
+#: netbox/navigation/menu.py:219
 msgid "Tunnel Terminations"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:223 netbox/netbox/navigation/menu.py:225
-#: netbox/vpn/models/l2vpn.py:64
+#: netbox/navigation/menu.py:223 netbox/navigation/menu.py:225
+#: vpn/models/l2vpn.py:64
 msgid "L2VPNs"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:226 netbox/templates/vpn/l2vpn.html:56
-#: netbox/templates/vpn/tunnel.html:72 netbox/vpn/tables/tunnels.py:58
+#: netbox/navigation/menu.py:226 templates/vpn/l2vpn.html:56
+#: templates/vpn/tunnel.html:72 vpn/tables/tunnels.py:58
 msgid "Terminations"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:232
+#: netbox/navigation/menu.py:232
 msgid "IKE Proposals"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:233
-#: netbox/templates/vpn/ikeproposal.html:41
+#: netbox/navigation/menu.py:233 templates/vpn/ikeproposal.html:41
 msgid "IKE Policies"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:234
+#: netbox/navigation/menu.py:234
 msgid "IPSec Proposals"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:235
-#: netbox/templates/vpn/ipsecproposal.html:37
+#: netbox/navigation/menu.py:235 templates/vpn/ipsecproposal.html:37
 msgid "IPSec Policies"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:236 netbox/templates/vpn/ikepolicy.html:38
-#: netbox/templates/vpn/ipsecpolicy.html:25
+#: netbox/navigation/menu.py:236 templates/vpn/ikepolicy.html:38
+#: templates/vpn/ipsecpolicy.html:25
 msgid "IPSec Profiles"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:243
-#: netbox/templates/dcim/device_edit.html:78
+#: netbox/navigation/menu.py:243 templates/dcim/device_edit.html:78
 msgid "Virtualization"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:251
-#: netbox/templates/virtualization/virtualmachine.html:174
-#: netbox/templates/virtualization/virtualmachine/base.html:32
-#: netbox/templates/virtualization/virtualmachine_list.html:21
-#: netbox/virtualization/tables/virtualmachines.py:104
-#: netbox/virtualization/views.py:388
+#: netbox/navigation/menu.py:251
+#: templates/virtualization/virtualmachine.html:174
+#: templates/virtualization/virtualmachine/base.html:32
+#: templates/virtualization/virtualmachine_list.html:21
+#: virtualization/tables/virtualmachines.py:104 virtualization/views.py:388
 msgid "Virtual Disks"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:258
+#: netbox/navigation/menu.py:258
 msgid "Cluster Types"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:259
+#: netbox/navigation/menu.py:259
 msgid "Cluster Groups"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:273
+#: netbox/navigation/menu.py:273
 msgid "Circuit Types"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:274
+#: netbox/navigation/menu.py:274
 msgid "Circuit Groups"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:275
-#: netbox/templates/circuits/circuit.html:66
+#: netbox/navigation/menu.py:275 templates/circuits/circuit.html:66
 msgid "Group Assignments"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:276
+#: netbox/navigation/menu.py:276
 msgid "Circuit Terminations"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:280 netbox/netbox/navigation/menu.py:282
+#: netbox/navigation/menu.py:280 netbox/navigation/menu.py:282
 msgid "Providers"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:283
-#: netbox/templates/circuits/provider.html:51
+#: netbox/navigation/menu.py:283 templates/circuits/provider.html:51
 msgid "Provider Accounts"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:284
+#: netbox/navigation/menu.py:284
 msgid "Provider Networks"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:298
+#: netbox/navigation/menu.py:298
 msgid "Power Panels"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:309
+#: netbox/navigation/menu.py:309
 msgid "Configurations"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:311
+#: netbox/navigation/menu.py:311
 msgid "Config Contexts"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:312
+#: netbox/navigation/menu.py:312
 msgid "Config Templates"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:319 netbox/netbox/navigation/menu.py:323
+#: netbox/navigation/menu.py:319 netbox/navigation/menu.py:323
 msgid "Customization"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:325
-#: netbox/templates/dcim/device_edit.html:103
-#: netbox/templates/dcim/htmx/cable_edit.html:81
-#: netbox/templates/dcim/virtualchassis_add.html:31
-#: netbox/templates/dcim/virtualchassis_edit.html:40
-#: netbox/templates/generic/bulk_edit.html:76
-#: netbox/templates/htmx/form.html:19 netbox/templates/inc/filter_list.html:30
-#: netbox/templates/inc/panels/custom_fields.html:7
-#: netbox/templates/ipam/ipaddress_bulk_add.html:35
-#: netbox/templates/ipam/vlan_edit.html:59
+#: netbox/navigation/menu.py:325 templates/dcim/device_edit.html:103
+#: templates/dcim/htmx/cable_edit.html:81
+#: templates/dcim/virtualchassis_add.html:31
+#: templates/dcim/virtualchassis_edit.html:40
+#: templates/generic/bulk_edit.html:76 templates/htmx/form.html:19
+#: templates/inc/filter_list.html:30 templates/inc/panels/custom_fields.html:7
+#: templates/ipam/ipaddress_bulk_add.html:35 templates/ipam/vlan_edit.html:59
 msgid "Custom Fields"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:326
+#: netbox/navigation/menu.py:326
 msgid "Custom Field Choices"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:327
+#: netbox/navigation/menu.py:327
 msgid "Custom Links"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:328
+#: netbox/navigation/menu.py:328
 msgid "Export Templates"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:329
+#: netbox/navigation/menu.py:329
 msgid "Saved Filters"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:331
+#: netbox/navigation/menu.py:331
 msgid "Image Attachments"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:349
+#: netbox/navigation/menu.py:349
 msgid "Operations"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:353
+#: netbox/navigation/menu.py:353
 msgid "Integrations"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:355
+#: netbox/navigation/menu.py:355
 msgid "Data Sources"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:356
+#: netbox/navigation/menu.py:356
 msgid "Event Rules"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:357
+#: netbox/navigation/menu.py:357
 msgid "Webhooks"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:361 netbox/netbox/navigation/menu.py:365
-#: netbox/netbox/views/generic/feature_views.py:153
-#: netbox/templates/extras/report/base.html:37
-#: netbox/templates/extras/script/base.html:36
+#: netbox/navigation/menu.py:361 netbox/navigation/menu.py:365
+#: netbox/views/generic/feature_views.py:153
+#: templates/extras/report/base.html:37 templates/extras/script/base.html:36
 msgid "Jobs"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:371
+#: netbox/navigation/menu.py:371
 msgid "Logging"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:373
+#: netbox/navigation/menu.py:373
 msgid "Notification Groups"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:374
+#: netbox/navigation/menu.py:374
 msgid "Journal Entries"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:375
-#: netbox/templates/core/objectchange.html:9
-#: netbox/templates/core/objectchange_list.html:4
+#: netbox/navigation/menu.py:375 templates/core/objectchange.html:9
+#: templates/core/objectchange_list.html:4
 msgid "Change Log"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:382 netbox/templates/inc/user_menu.html:29
+#: netbox/navigation/menu.py:382 templates/inc/user_menu.html:29
 msgid "Admin"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:430 netbox/templates/account/base.html:27
-#: netbox/templates/inc/user_menu.html:57
+#: netbox/navigation/menu.py:430 templates/account/base.html:27
+#: templates/inc/user_menu.html:57
 msgid "API Tokens"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:437 netbox/users/forms/model_forms.py:187
-#: netbox/users/forms/model_forms.py:195 netbox/users/forms/model_forms.py:242
-#: netbox/users/forms/model_forms.py:249
+#: netbox/navigation/menu.py:437 users/forms/model_forms.py:187
+#: users/forms/model_forms.py:195 users/forms/model_forms.py:242
+#: users/forms/model_forms.py:249
 msgid "Permissions"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:445 netbox/netbox/navigation/menu.py:449
-#: netbox/templates/core/system.html:7
+#: netbox/navigation/menu.py:445 netbox/navigation/menu.py:449
+#: templates/core/system.html:7
 msgid "System"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:454 netbox/netbox/navigation/menu.py:502
-#: netbox/templates/500.html:35 netbox/templates/account/preferences.html:22
-#: netbox/templates/core/plugin.html:13
-#: netbox/templates/core/plugin_list.html:7
-#: netbox/templates/core/plugin_list.html:12
+#: netbox/navigation/menu.py:454 netbox/navigation/menu.py:502
+#: templates/500.html:35 templates/account/preferences.html:22
+#: templates/core/plugin.html:13 templates/core/plugin_list.html:7
+#: templates/core/plugin_list.html:12
 msgid "Plugins"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:459
+#: netbox/navigation/menu.py:459
 msgid "Configuration History"
 msgstr ""
 
-#: netbox/netbox/navigation/menu.py:465 netbox/templates/core/rq_task.html:8
-#: netbox/templates/core/rq_task_list.html:22
+#: netbox/navigation/menu.py:465 templates/core/rq_task.html:8
+#: templates/core/rq_task_list.html:22
 msgid "Background Tasks"
 msgstr ""
 
-#: netbox/netbox/plugins/navigation.py:47
-#: netbox/netbox/plugins/navigation.py:69
+#: netbox/plugins/navigation.py:47 netbox/plugins/navigation.py:69
 msgid "Permissions must be passed as a tuple or list."
 msgstr ""
 
-#: netbox/netbox/plugins/navigation.py:51
+#: netbox/plugins/navigation.py:51
 msgid "Buttons must be passed as a tuple or list."
 msgstr ""
 
-#: netbox/netbox/plugins/navigation.py:73
+#: netbox/plugins/navigation.py:73
 msgid "Button color must be a choice within ButtonColorChoices."
 msgstr ""
 
-#: netbox/netbox/plugins/registration.py:25
+#: netbox/plugins/registration.py:25
 #, python-brace-format
 msgid ""
 "PluginTemplateExtension class {template_extension} was passed as an instance!"
 msgstr ""
 
-#: netbox/netbox/plugins/registration.py:31
+#: netbox/plugins/registration.py:31
 #, python-brace-format
 msgid ""
 "{template_extension} is not a subclass of netbox.plugins."
 "PluginTemplateExtension!"
 msgstr ""
 
-#: netbox/netbox/plugins/registration.py:51
+#: netbox/plugins/registration.py:51
 #, python-brace-format
 msgid "{item} must be an instance of netbox.plugins.PluginMenuItem"
 msgstr ""
 
-#: netbox/netbox/plugins/registration.py:62
+#: netbox/plugins/registration.py:62
 #, python-brace-format
 msgid "{menu_link} must be an instance of netbox.plugins.PluginMenuItem"
 msgstr ""
 
-#: netbox/netbox/plugins/registration.py:67
+#: netbox/plugins/registration.py:67
 #, python-brace-format
 msgid "{button} must be an instance of netbox.plugins.PluginMenuButton"
 msgstr ""
 
-#: netbox/netbox/plugins/templates.py:37
+#: netbox/plugins/templates.py:37
 msgid "extra_context must be a dictionary"
 msgstr ""
 
-#: netbox/netbox/preferences.py:19
+#: netbox/preferences.py:19
 msgid "HTMX Navigation"
 msgstr ""
 
-#: netbox/netbox/preferences.py:24
+#: netbox/preferences.py:24
 msgid "Enable dynamic UI navigation"
 msgstr ""
 
-#: netbox/netbox/preferences.py:26
+#: netbox/preferences.py:26
 msgid "Experimental feature"
 msgstr ""
 
-#: netbox/netbox/preferences.py:29
+#: netbox/preferences.py:29
 msgid "Language"
 msgstr ""
 
-#: netbox/netbox/preferences.py:34
+#: netbox/preferences.py:34
 msgid "Forces UI translation to the specified language"
 msgstr ""
 
-#: netbox/netbox/preferences.py:36
+#: netbox/preferences.py:36
 msgid "Support for translation has been disabled locally"
 msgstr ""
 
-#: netbox/netbox/preferences.py:42
+#: netbox/preferences.py:42
 msgid "Page length"
 msgstr ""
 
-#: netbox/netbox/preferences.py:44
+#: netbox/preferences.py:44
 msgid "The default number of objects to display per page"
 msgstr ""
 
-#: netbox/netbox/preferences.py:48
+#: netbox/preferences.py:48
 msgid "Paginator placement"
 msgstr ""
 
-#: netbox/netbox/preferences.py:50
+#: netbox/preferences.py:50
 msgid "Bottom"
 msgstr ""
 
-#: netbox/netbox/preferences.py:51
+#: netbox/preferences.py:51
 msgid "Top"
 msgstr ""
 
-#: netbox/netbox/preferences.py:52
+#: netbox/preferences.py:52
 msgid "Both"
 msgstr ""
 
-#: netbox/netbox/preferences.py:55
+#: netbox/preferences.py:55
 msgid "Where the paginator controls will be displayed relative to a table"
 msgstr ""
 
-#: netbox/netbox/preferences.py:60
+#: netbox/preferences.py:60
 msgid "Data format"
 msgstr ""
 
-#: netbox/netbox/preferences.py:65
+#: netbox/preferences.py:65
 msgid "The preferred syntax for displaying generic data within the UI"
 msgstr ""
 
-#: netbox/netbox/registry.py:14
+#: netbox/registry.py:14
 #, python-brace-format
 msgid "Invalid store: {key}"
 msgstr ""
 
-#: netbox/netbox/registry.py:17
+#: netbox/registry.py:17
 msgid "Cannot add stores to registry after initialization"
 msgstr ""
 
-#: netbox/netbox/registry.py:20
+#: netbox/registry.py:20
 msgid "Cannot delete stores from registry"
 msgstr ""
 
-#: netbox/netbox/settings.py:760
+#: netbox/settings.py:760
 msgid "Czech"
 msgstr ""
 
-#: netbox/netbox/settings.py:761
+#: netbox/settings.py:761
 msgid "Danish"
 msgstr ""
 
-#: netbox/netbox/settings.py:762
+#: netbox/settings.py:762
 msgid "German"
 msgstr ""
 
-#: netbox/netbox/settings.py:763
+#: netbox/settings.py:763
 msgid "English"
 msgstr ""
 
-#: netbox/netbox/settings.py:764
+#: netbox/settings.py:764
 msgid "Spanish"
 msgstr ""
 
-#: netbox/netbox/settings.py:765
+#: netbox/settings.py:765
 msgid "French"
 msgstr ""
 
-#: netbox/netbox/settings.py:766
+#: netbox/settings.py:766
 msgid "Italian"
 msgstr ""
 
-#: netbox/netbox/settings.py:767
+#: netbox/settings.py:767
 msgid "Japanese"
 msgstr ""
 
-#: netbox/netbox/settings.py:768
+#: netbox/settings.py:768
 msgid "Dutch"
 msgstr ""
 
-#: netbox/netbox/settings.py:769
+#: netbox/settings.py:769
 msgid "Polish"
 msgstr ""
 
-#: netbox/netbox/settings.py:770
+#: netbox/settings.py:770
 msgid "Portuguese"
 msgstr ""
 
-#: netbox/netbox/settings.py:771
+#: netbox/settings.py:771
 msgid "Russian"
 msgstr ""
 
-#: netbox/netbox/settings.py:772
+#: netbox/settings.py:772
 msgid "Turkish"
 msgstr ""
 
-#: netbox/netbox/settings.py:773
+#: netbox/settings.py:773
 msgid "Ukrainian"
 msgstr ""
 
-#: netbox/netbox/settings.py:774
+#: netbox/settings.py:774
 msgid "Chinese"
 msgstr ""
 
-#: netbox/netbox/tables/columns.py:176
+#: netbox/tables/columns.py:176
 msgid "Select all"
 msgstr ""
 
-#: netbox/netbox/tables/columns.py:189
+#: netbox/tables/columns.py:189
 msgid "Toggle all"
 msgstr ""
 
-#: netbox/netbox/tables/columns.py:300
+#: netbox/tables/columns.py:300
 msgid "Toggle Dropdown"
 msgstr ""
 
-#: netbox/netbox/tables/columns.py:572 netbox/templates/core/job.html:53
+#: netbox/tables/columns.py:572 templates/core/job.html:53
 msgid "Error"
 msgstr ""
 
-#: netbox/netbox/tables/tables.py:58
+#: netbox/tables/tables.py:58
 #, python-brace-format
 msgid "No {model_name} found"
 msgstr ""
 
-#: netbox/netbox/tables/tables.py:249
-#: netbox/templates/generic/bulk_import.html:117
+#: netbox/tables/tables.py:249 templates/generic/bulk_import.html:117
 msgid "Field"
 msgstr ""
 
-#: netbox/netbox/tables/tables.py:252
+#: netbox/tables/tables.py:252
 msgid "Value"
 msgstr ""
 
-#: netbox/netbox/tests/dummy_plugin/navigation.py:29
+#: netbox/tests/dummy_plugin/navigation.py:29
 msgid "Dummy Plugin"
 msgstr ""
 
-#: netbox/netbox/views/generic/bulk_views.py:114
+#: netbox/views/generic/bulk_views.py:114
 #, python-brace-format
 msgid ""
 "There was an error rendering the selected export template ({template}): "
 "{error}"
 msgstr ""
 
-#: netbox/netbox/views/generic/bulk_views.py:416
+#: netbox/views/generic/bulk_views.py:416
 #, python-brace-format
 msgid "Row {i}: Object with ID {id} does not exist"
 msgstr ""
 
-#: netbox/netbox/views/generic/bulk_views.py:702
-#: netbox/netbox/views/generic/bulk_views.py:900
-#: netbox/netbox/views/generic/bulk_views.py:948
+#: netbox/views/generic/bulk_views.py:702
+#: netbox/views/generic/bulk_views.py:900
+#: netbox/views/generic/bulk_views.py:948
 #, python-brace-format
 msgid "No {object_type} were selected."
 msgstr ""
 
-#: netbox/netbox/views/generic/bulk_views.py:782
+#: netbox/views/generic/bulk_views.py:782
 #, python-brace-format
 msgid "Renamed {count} {object_type}"
 msgstr ""
 
-#: netbox/netbox/views/generic/bulk_views.py:878
+#: netbox/views/generic/bulk_views.py:878
 #, python-brace-format
 msgid "Deleted {count} {object_type}"
 msgstr ""
 
-#: netbox/netbox/views/generic/feature_views.py:40
+#: netbox/views/generic/feature_views.py:40
 msgid "Changelog"
 msgstr ""
 
-#: netbox/netbox/views/generic/feature_views.py:93
+#: netbox/views/generic/feature_views.py:93
 msgid "Journal"
 msgstr ""
 
-#: netbox/netbox/views/generic/feature_views.py:207
+#: netbox/views/generic/feature_views.py:207
 msgid "Unable to synchronize data: No data file set."
 msgstr ""
 
-#: netbox/netbox/views/generic/feature_views.py:211
+#: netbox/views/generic/feature_views.py:211
 #, python-brace-format
 msgid "Synchronized data for {object_type} {object}."
 msgstr ""
 
-#: netbox/netbox/views/generic/feature_views.py:236
+#: netbox/views/generic/feature_views.py:236
 #, python-brace-format
 msgid "Synced {count} {object_type}"
 msgstr ""
 
-#: netbox/netbox/views/generic/object_views.py:108
+#: netbox/views/generic/object_views.py:108
 #, python-brace-format
 msgid "{class_name} must implement get_children()"
 msgstr ""
 
-#: netbox/netbox/views/misc.py:44
+#: netbox/views/misc.py:44
 msgid ""
 "There was an error loading the dashboard configuration. A default dashboard "
 "is in use."
 msgstr ""
 
-#: netbox/templates/403.html:4
+#: templates/403.html:4
 msgid "Access Denied"
 msgstr ""
 
-#: netbox/templates/403.html:9
+#: templates/403.html:9
 msgid "You do not have permission to access this page"
 msgstr ""
 
-#: netbox/templates/404.html:4
+#: templates/404.html:4
 msgid "Page Not Found"
 msgstr ""
 
-#: netbox/templates/404.html:9
+#: templates/404.html:9
 msgid "The requested page does not exist"
 msgstr ""
 
-#: netbox/templates/500.html:7 netbox/templates/500.html:18
+#: templates/500.html:7 templates/500.html:18
 msgid "Server Error"
 msgstr ""
 
-#: netbox/templates/500.html:23
+#: templates/500.html:23
 msgid "There was a problem with your request. Please contact an administrator"
 msgstr ""
 
-#: netbox/templates/500.html:28
+#: templates/500.html:28
 msgid "The complete exception is provided below"
 msgstr ""
 
-#: netbox/templates/500.html:33 netbox/templates/core/system.html:40
+#: templates/500.html:33 templates/core/system.html:40
 msgid "Python version"
 msgstr ""
 
-#: netbox/templates/500.html:34
+#: templates/500.html:34
 msgid "NetBox version"
 msgstr ""
 
-#: netbox/templates/500.html:36
+#: templates/500.html:36
 msgid "None installed"
 msgstr ""
 
-#: netbox/templates/500.html:39
+#: templates/500.html:39
 msgid "If further assistance is required, please post to the"
 msgstr ""
 
-#: netbox/templates/500.html:39
+#: templates/500.html:39
 msgid "NetBox discussion forum"
 msgstr ""
 
-#: netbox/templates/500.html:39
+#: templates/500.html:39
 msgid "on GitHub"
 msgstr ""
 
-#: netbox/templates/500.html:42 netbox/templates/base/40x.html:17
+#: templates/500.html:42 templates/base/40x.html:17
 msgid "Home Page"
 msgstr ""
 
-#: netbox/templates/account/base.html:7 netbox/templates/inc/user_menu.html:45
-#: netbox/vpn/forms/bulk_edit.py:255 netbox/vpn/forms/filtersets.py:189
-#: netbox/vpn/forms/model_forms.py:379
+#: templates/account/base.html:7 templates/inc/user_menu.html:45
+#: vpn/forms/bulk_edit.py:255 vpn/forms/filtersets.py:189
+#: vpn/forms/model_forms.py:379
 msgid "Profile"
 msgstr ""
 
-#: netbox/templates/account/base.html:13
-#: netbox/templates/account/notifications.html:7
-#: netbox/templates/inc/user_menu.html:15
+#: templates/account/base.html:13 templates/account/notifications.html:7
+#: templates/inc/user_menu.html:15
 msgid "Notifications"
 msgstr ""
 
-#: netbox/templates/account/base.html:16
-#: netbox/templates/account/subscriptions.html:7
-#: netbox/templates/inc/user_menu.html:51
+#: templates/account/base.html:16 templates/account/subscriptions.html:7
+#: templates/inc/user_menu.html:51
 msgid "Subscriptions"
 msgstr ""
 
-#: netbox/templates/account/base.html:19 netbox/templates/inc/user_menu.html:54
+#: templates/account/base.html:19 templates/inc/user_menu.html:54
 msgid "Preferences"
 msgstr ""
 
-#: netbox/templates/account/password.html:5
+#: templates/account/password.html:5
 msgid "Change Password"
 msgstr ""
 
-#: netbox/templates/account/password.html:19
-#: netbox/templates/account/preferences.html:77
-#: netbox/templates/core/configrevision_restore.html:63
-#: netbox/templates/dcim/devicebay_populate.html:34
-#: netbox/templates/dcim/virtualchassis_add_member.html:26
-#: netbox/templates/dcim/virtualchassis_edit.html:103
-#: netbox/templates/extras/object_journal.html:26
-#: netbox/templates/extras/script.html:38
-#: netbox/templates/generic/bulk_add_component.html:67
-#: netbox/templates/generic/bulk_delete.html:65
-#: netbox/templates/generic/bulk_edit.html:106
-#: netbox/templates/generic/bulk_import.html:56
-#: netbox/templates/generic/bulk_import.html:78
-#: netbox/templates/generic/bulk_import.html:100
-#: netbox/templates/generic/bulk_remove.html:62
-#: netbox/templates/generic/bulk_rename.html:63
-#: netbox/templates/generic/confirmation_form.html:19
-#: netbox/templates/generic/object_edit.html:72
-#: netbox/templates/htmx/delete_form.html:53
-#: netbox/templates/htmx/delete_form.html:55
-#: netbox/templates/ipam/ipaddress_assign.html:28
-#: netbox/templates/virtualization/cluster_add_devices.html:30
+#: templates/account/password.html:19 templates/account/preferences.html:77
+#: templates/core/configrevision_restore.html:63
+#: templates/dcim/devicebay_populate.html:34
+#: templates/dcim/virtualchassis_add_member.html:26
+#: templates/dcim/virtualchassis_edit.html:103
+#: templates/extras/object_journal.html:26 templates/extras/script.html:38
+#: templates/generic/bulk_add_component.html:67
+#: templates/generic/bulk_delete.html:65 templates/generic/bulk_edit.html:106
+#: templates/generic/bulk_import.html:56 templates/generic/bulk_import.html:78
+#: templates/generic/bulk_import.html:100 templates/generic/bulk_remove.html:62
+#: templates/generic/bulk_rename.html:63
+#: templates/generic/confirmation_form.html:19
+#: templates/generic/object_edit.html:72 templates/htmx/delete_form.html:53
+#: templates/htmx/delete_form.html:55 templates/ipam/ipaddress_assign.html:28
+#: templates/virtualization/cluster_add_devices.html:30
 msgid "Cancel"
 msgstr ""
 
-#: netbox/templates/account/password.html:20
-#: netbox/templates/account/preferences.html:78
-#: netbox/templates/dcim/devicebay_populate.html:35
-#: netbox/templates/dcim/virtualchassis_add_member.html:28
-#: netbox/templates/dcim/virtualchassis_edit.html:105
-#: netbox/templates/extras/dashboard/widget_add.html:26
-#: netbox/templates/extras/dashboard/widget_config.html:19
-#: netbox/templates/extras/object_journal.html:27
-#: netbox/templates/generic/object_edit.html:75
-#: netbox/utilities/templates/helpers/applied_filters.html:16
-#: netbox/utilities/templates/helpers/table_config_form.html:40
+#: templates/account/password.html:20 templates/account/preferences.html:78
+#: templates/dcim/devicebay_populate.html:35
+#: templates/dcim/virtualchassis_add_member.html:28
+#: templates/dcim/virtualchassis_edit.html:105
+#: templates/extras/dashboard/widget_add.html:26
+#: templates/extras/dashboard/widget_config.html:19
+#: templates/extras/object_journal.html:27
+#: templates/generic/object_edit.html:75
+#: utilities/templates/helpers/applied_filters.html:16
+#: utilities/templates/helpers/table_config_form.html:40
 msgid "Save"
 msgstr ""
 
-#: netbox/templates/account/preferences.html:34
+#: templates/account/preferences.html:34
 msgid "Table Configurations"
 msgstr ""
 
-#: netbox/templates/account/preferences.html:39
+#: templates/account/preferences.html:39
 msgid "Clear table preferences"
 msgstr ""
 
-#: netbox/templates/account/preferences.html:47
+#: templates/account/preferences.html:47
 msgid "Toggle All"
 msgstr ""
 
-#: netbox/templates/account/preferences.html:49
+#: templates/account/preferences.html:49
 msgid "Table"
 msgstr ""
 
-#: netbox/templates/account/preferences.html:50
+#: templates/account/preferences.html:50
 msgid "Ordering"
 msgstr ""
 
-#: netbox/templates/account/preferences.html:51
+#: templates/account/preferences.html:51
 msgid "Columns"
 msgstr ""
 
-#: netbox/templates/account/preferences.html:71
-#: netbox/templates/dcim/cable_trace.html:113
-#: netbox/templates/extras/object_configcontext.html:43
+#: templates/account/preferences.html:71 templates/dcim/cable_trace.html:113
+#: templates/extras/object_configcontext.html:43
 msgid "None found"
 msgstr ""
 
-#: netbox/templates/account/profile.html:6
+#: templates/account/profile.html:6
 msgid "User Profile"
 msgstr ""
 
-#: netbox/templates/account/profile.html:12
+#: templates/account/profile.html:12
 msgid "Account Details"
 msgstr ""
 
-#: netbox/templates/account/profile.html:29
-#: netbox/templates/tenancy/contact.html:43 netbox/templates/users/user.html:25
-#: netbox/tenancy/forms/bulk_edit.py:109
+#: templates/account/profile.html:29 templates/tenancy/contact.html:43
+#: templates/users/user.html:25 tenancy/forms/bulk_edit.py:109
 msgid "Email"
 msgstr ""
 
-#: netbox/templates/account/profile.html:33 netbox/templates/users/user.html:29
+#: templates/account/profile.html:33 templates/users/user.html:29
 msgid "Account Created"
 msgstr ""
 
-#: netbox/templates/account/profile.html:37 netbox/templates/users/user.html:33
+#: templates/account/profile.html:37 templates/users/user.html:33
 msgid "Last Login"
 msgstr ""
 
-#: netbox/templates/account/profile.html:41 netbox/templates/users/user.html:45
+#: templates/account/profile.html:41 templates/users/user.html:45
 msgid "Superuser"
 msgstr ""
 
-#: netbox/templates/account/profile.html:45
-#: netbox/templates/inc/user_menu.html:31 netbox/templates/users/user.html:41
+#: templates/account/profile.html:45 templates/inc/user_menu.html:31
+#: templates/users/user.html:41
 msgid "Staff"
 msgstr ""
 
-#: netbox/templates/account/profile.html:53
-#: netbox/templates/users/objectpermission.html:82
-#: netbox/templates/users/user.html:53
+#: templates/account/profile.html:53 templates/users/objectpermission.html:82
+#: templates/users/user.html:53
 msgid "Assigned Groups"
 msgstr ""
 
-#: netbox/templates/account/profile.html:58
-#: netbox/templates/circuits/circuit_terminations_swap.html:18
-#: netbox/templates/circuits/circuit_terminations_swap.html:26
-#: netbox/templates/circuits/circuittermination.html:34
-#: netbox/templates/circuits/inc/circuit_termination.html:68
-#: netbox/templates/core/objectchange.html:124
-#: netbox/templates/core/objectchange.html:142
-#: netbox/templates/dcim/devicebay.html:59
-#: netbox/templates/dcim/inc/panels/inventory_items.html:45
-#: netbox/templates/dcim/interface.html:296
-#: netbox/templates/dcim/modulebay.html:80
-#: netbox/templates/extras/configcontext.html:70
-#: netbox/templates/extras/eventrule.html:66
-#: netbox/templates/extras/htmx/script_result.html:60
-#: netbox/templates/extras/webhook.html:65
-#: netbox/templates/extras/webhook.html:75
-#: netbox/templates/inc/panel_table.html:13
-#: netbox/templates/inc/panels/comments.html:10
-#: netbox/templates/ipam/inc/panels/fhrp_groups.html:56
-#: netbox/templates/users/group.html:34 netbox/templates/users/group.html:44
-#: netbox/templates/users/objectpermission.html:77
-#: netbox/templates/users/objectpermission.html:87
-#: netbox/templates/users/user.html:58 netbox/templates/users/user.html:68
+#: templates/account/profile.html:58
+#: templates/circuits/circuit_terminations_swap.html:18
+#: templates/circuits/circuit_terminations_swap.html:26
+#: templates/circuits/circuittermination.html:34
+#: templates/circuits/inc/circuit_termination.html:68
+#: templates/core/objectchange.html:124 templates/core/objectchange.html:142
+#: templates/dcim/devicebay.html:59
+#: templates/dcim/inc/panels/inventory_items.html:45
+#: templates/dcim/interface.html:296 templates/dcim/modulebay.html:80
+#: templates/extras/configcontext.html:70 templates/extras/eventrule.html:66
+#: templates/extras/htmx/script_result.html:60 templates/extras/webhook.html:65
+#: templates/extras/webhook.html:75 templates/inc/panel_table.html:13
+#: templates/inc/panels/comments.html:10
+#: templates/ipam/inc/panels/fhrp_groups.html:56 templates/users/group.html:34
+#: templates/users/group.html:44 templates/users/objectpermission.html:77
+#: templates/users/objectpermission.html:87 templates/users/user.html:58
+#: templates/users/user.html:68
 msgid "None"
 msgstr ""
 
-#: netbox/templates/account/profile.html:68 netbox/templates/users/user.html:78
+#: templates/account/profile.html:68 templates/users/user.html:78
 msgid "Recent Activity"
 msgstr ""
 
-#: netbox/templates/account/token.html:8
-#: netbox/templates/account/token_list.html:6
+#: templates/account/token.html:8 templates/account/token_list.html:6
 msgid "My API Tokens"
 msgstr ""
 
-#: netbox/templates/account/token.html:11
-#: netbox/templates/account/token.html:19 netbox/templates/users/token.html:6
-#: netbox/templates/users/token.html:14 netbox/users/forms/filtersets.py:120
+#: templates/account/token.html:11 templates/account/token.html:19
+#: templates/users/token.html:6 templates/users/token.html:14
+#: users/forms/filtersets.py:120
 msgid "Token"
 msgstr ""
 
-#: netbox/templates/account/token.html:39 netbox/templates/users/token.html:31
-#: netbox/users/forms/bulk_edit.py:107
+#: templates/account/token.html:39 templates/users/token.html:31
+#: users/forms/bulk_edit.py:107
 msgid "Write enabled"
 msgstr ""
 
-#: netbox/templates/account/token.html:51 netbox/templates/users/token.html:43
+#: templates/account/token.html:51 templates/users/token.html:43
 msgid "Last used"
 msgstr ""
 
-#: netbox/templates/account/token_list.html:12
+#: templates/account/token_list.html:12
 msgid "Add a Token"
 msgstr ""
 
-#: netbox/templates/base/base.html:22 netbox/templates/home.html:27
+#: templates/base/base.html:22 templates/home.html:27
 msgid "Home"
 msgstr ""
 
-#: netbox/templates/base/layout.html:25
+#: templates/base/layout.html:25
 msgid "NetBox Motif"
 msgstr ""
 
-#: netbox/templates/base/layout.html:38 netbox/templates/base/layout.html:39
-#: netbox/templates/login.html:14 netbox/templates/login.html:15
+#: templates/base/layout.html:38 templates/base/layout.html:39
+#: templates/login.html:14 templates/login.html:15
 msgid "NetBox Logo"
 msgstr ""
 
-#: netbox/templates/base/layout.html:150 netbox/templates/base/layout.html:151
+#: templates/base/layout.html:150 templates/base/layout.html:151
 msgid "Docs"
 msgstr ""
 
-#: netbox/templates/base/layout.html:156 netbox/templates/base/layout.html:157
-#: netbox/templates/rest_framework/api.html:10
+#: templates/base/layout.html:156 templates/base/layout.html:157
+#: templates/rest_framework/api.html:10
 msgid "REST API"
 msgstr ""
 
-#: netbox/templates/base/layout.html:162 netbox/templates/base/layout.html:163
+#: templates/base/layout.html:162 templates/base/layout.html:163
 msgid "REST API documentation"
 msgstr ""
 
-#: netbox/templates/base/layout.html:169 netbox/templates/base/layout.html:170
+#: templates/base/layout.html:169 templates/base/layout.html:170
 msgid "GraphQL API"
 msgstr ""
 
-#: netbox/templates/base/layout.html:185 netbox/templates/base/layout.html:186
+#: templates/base/layout.html:185 templates/base/layout.html:186
 msgid "NetBox Labs Support"
 msgstr ""
 
-#: netbox/templates/base/layout.html:194 netbox/templates/base/layout.html:195
+#: templates/base/layout.html:194 templates/base/layout.html:195
 msgid "Source Code"
 msgstr ""
 
-#: netbox/templates/base/layout.html:200 netbox/templates/base/layout.html:201
+#: templates/base/layout.html:200 templates/base/layout.html:201
 msgid "Community"
 msgstr ""
 
-#: netbox/templates/circuits/circuit.html:47
+#: templates/circuits/circuit.html:47
 msgid "Install Date"
 msgstr ""
 
-#: netbox/templates/circuits/circuit.html:51
+#: templates/circuits/circuit.html:51
 msgid "Termination Date"
 msgstr ""
 
-#: netbox/templates/circuits/circuit.html:70
-#: netbox/templates/ipam/inc/panels/fhrp_groups.html:15
+#: templates/circuits/circuit.html:70
+#: templates/ipam/inc/panels/fhrp_groups.html:15
 msgid "Assign Group"
 msgstr ""
 
-#: netbox/templates/circuits/circuit_terminations_swap.html:4
+#: templates/circuits/circuit_terminations_swap.html:4
 msgid "Swap Circuit Terminations"
 msgstr ""
 
-#: netbox/templates/circuits/circuit_terminations_swap.html:8
+#: templates/circuits/circuit_terminations_swap.html:8
 #, python-format
 msgid "Swap these terminations for circuit %(circuit)s?"
 msgstr ""
 
-#: netbox/templates/circuits/circuit_terminations_swap.html:14
+#: templates/circuits/circuit_terminations_swap.html:14
 msgid "A side"
 msgstr ""
 
-#: netbox/templates/circuits/circuit_terminations_swap.html:22
+#: templates/circuits/circuit_terminations_swap.html:22
 msgid "Z side"
 msgstr ""
 
-#: netbox/templates/circuits/circuitgroup.html:16
+#: templates/circuits/circuitgroup.html:16
 msgid "Assign Circuit"
 msgstr ""
 
-#: netbox/templates/circuits/circuitgroupassignment.html:19
+#: templates/circuits/circuitgroupassignment.html:19
 msgid "Circuit Group Assignment"
 msgstr ""
 
-#: netbox/templates/circuits/circuittype.html:10
+#: templates/circuits/circuittype.html:10
 msgid "Add Circuit"
 msgstr ""
 
-#: netbox/templates/circuits/circuittype.html:19
+#: templates/circuits/circuittype.html:19
 msgid "Circuit Type"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination.html:10
-#: netbox/templates/dcim/manufacturer.html:11
-#: netbox/templates/generic/bulk_add_component.html:22
-#: netbox/templates/users/objectpermission.html:38
-#: netbox/utilities/templates/buttons/add.html:4
-#: netbox/utilities/templates/helpers/table_config_form.html:20
+#: templates/circuits/inc/circuit_termination.html:10
+#: templates/dcim/manufacturer.html:11
+#: templates/generic/bulk_add_component.html:22
+#: templates/users/objectpermission.html:38
+#: utilities/templates/buttons/add.html:4
+#: utilities/templates/helpers/table_config_form.html:20
 msgid "Add"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination.html:15
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:36
-#: netbox/templates/dcim/inc/panels/inventory_items.html:32
-#: netbox/templates/dcim/powerpanel.html:56
-#: netbox/templates/extras/script_list.html:30
-#: netbox/templates/generic/object_edit.html:47
-#: netbox/templates/ipam/inc/ipaddress_edit_header.html:7
-#: netbox/templates/ipam/inc/panels/fhrp_groups.html:43
-#: netbox/utilities/templates/buttons/edit.html:3
+#: templates/circuits/inc/circuit_termination.html:15
+#: templates/circuits/inc/circuit_termination_fields.html:36
+#: templates/dcim/inc/panels/inventory_items.html:32
+#: templates/dcim/powerpanel.html:56 templates/extras/script_list.html:30
+#: templates/generic/object_edit.html:47
+#: templates/ipam/inc/ipaddress_edit_header.html:7
+#: templates/ipam/inc/panels/fhrp_groups.html:43
+#: utilities/templates/buttons/edit.html:3
 msgid "Edit"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination.html:18
+#: templates/circuits/inc/circuit_termination.html:18
 msgid "Swap"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:19
-#: netbox/templates/dcim/consoleport.html:59
-#: netbox/templates/dcim/consoleserverport.html:60
-#: netbox/templates/dcim/powerfeed.html:114
+#: templates/circuits/inc/circuit_termination_fields.html:19
+#: templates/dcim/consoleport.html:59 templates/dcim/consoleserverport.html:60
+#: templates/dcim/powerfeed.html:114
 msgid "Marked as connected"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:21
+#: templates/circuits/inc/circuit_termination_fields.html:21
 msgid "to"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:31
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:32
-#: netbox/templates/dcim/frontport.html:80
-#: netbox/templates/dcim/inc/connection_endpoints.html:7
-#: netbox/templates/dcim/interface.html:154
-#: netbox/templates/dcim/rearport.html:76
+#: templates/circuits/inc/circuit_termination_fields.html:31
+#: templates/circuits/inc/circuit_termination_fields.html:32
+#: templates/dcim/frontport.html:80
+#: templates/dcim/inc/connection_endpoints.html:7
+#: templates/dcim/interface.html:154 templates/dcim/rearport.html:76
 msgid "Trace"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:35
+#: templates/circuits/inc/circuit_termination_fields.html:35
 msgid "Edit cable"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:40
+#: templates/circuits/inc/circuit_termination_fields.html:40
 msgid "Remove cable"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:41
-#: netbox/templates/dcim/bulk_disconnect.html:5
-#: netbox/templates/dcim/device/consoleports.html:12
-#: netbox/templates/dcim/device/consoleserverports.html:12
-#: netbox/templates/dcim/device/frontports.html:12
-#: netbox/templates/dcim/device/interfaces.html:16
-#: netbox/templates/dcim/device/poweroutlets.html:12
-#: netbox/templates/dcim/device/powerports.html:12
-#: netbox/templates/dcim/device/rearports.html:12
-#: netbox/templates/dcim/powerpanel.html:61
+#: templates/circuits/inc/circuit_termination_fields.html:41
+#: templates/dcim/bulk_disconnect.html:5
+#: templates/dcim/device/consoleports.html:12
+#: templates/dcim/device/consoleserverports.html:12
+#: templates/dcim/device/frontports.html:12
+#: templates/dcim/device/interfaces.html:16
+#: templates/dcim/device/poweroutlets.html:12
+#: templates/dcim/device/powerports.html:12
+#: templates/dcim/device/rearports.html:12 templates/dcim/powerpanel.html:61
 msgid "Disconnect"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:48
-#: netbox/templates/dcim/consoleport.html:69
-#: netbox/templates/dcim/consoleserverport.html:70
-#: netbox/templates/dcim/frontport.html:102
-#: netbox/templates/dcim/interface.html:180
-#: netbox/templates/dcim/interface.html:200
-#: netbox/templates/dcim/powerfeed.html:127
-#: netbox/templates/dcim/poweroutlet.html:71
-#: netbox/templates/dcim/poweroutlet.html:72
-#: netbox/templates/dcim/powerport.html:73
-#: netbox/templates/dcim/rearport.html:98
+#: templates/circuits/inc/circuit_termination_fields.html:48
+#: templates/dcim/consoleport.html:69 templates/dcim/consoleserverport.html:70
+#: templates/dcim/frontport.html:102 templates/dcim/interface.html:180
+#: templates/dcim/interface.html:200 templates/dcim/powerfeed.html:127
+#: templates/dcim/poweroutlet.html:71 templates/dcim/poweroutlet.html:72
+#: templates/dcim/powerport.html:73 templates/dcim/rearport.html:98
 msgid "Connect"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:70
+#: templates/circuits/inc/circuit_termination_fields.html:70
 msgid "Downstream"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:71
+#: templates/circuits/inc/circuit_termination_fields.html:71
 msgid "Upstream"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:80
+#: templates/circuits/inc/circuit_termination_fields.html:80
 msgid "Cross-Connect"
 msgstr ""
 
-#: netbox/templates/circuits/inc/circuit_termination_fields.html:84
+#: templates/circuits/inc/circuit_termination_fields.html:84
 msgid "Patch Panel/Port"
 msgstr ""
 
-#: netbox/templates/circuits/provider.html:11
+#: templates/circuits/provider.html:11
 msgid "Add circuit"
 msgstr ""
 
-#: netbox/templates/circuits/provideraccount.html:17
+#: templates/circuits/provideraccount.html:17
 msgid "Provider Account"
 msgstr ""
 
-#: netbox/templates/core/configrevision.html:35
+#: templates/core/configrevision.html:35
 msgid "Configuration Data"
 msgstr ""
 
-#: netbox/templates/core/configrevision.html:40
+#: templates/core/configrevision.html:40
 msgid "Comment"
 msgstr ""
 
-#: netbox/templates/core/configrevision_restore.html:8
-#: netbox/templates/core/configrevision_restore.html:25
-#: netbox/templates/core/configrevision_restore.html:64
+#: templates/core/configrevision_restore.html:8
+#: templates/core/configrevision_restore.html:25
+#: templates/core/configrevision_restore.html:64
 msgid "Restore"
 msgstr ""
 
-#: netbox/templates/core/configrevision_restore.html:36
+#: templates/core/configrevision_restore.html:36
 msgid "Parameter"
 msgstr ""
 
-#: netbox/templates/core/configrevision_restore.html:37
+#: templates/core/configrevision_restore.html:37
 msgid "Current Value"
 msgstr ""
 
-#: netbox/templates/core/configrevision_restore.html:38
+#: templates/core/configrevision_restore.html:38
 msgid "New Value"
 msgstr ""
 
-#: netbox/templates/core/configrevision_restore.html:50
+#: templates/core/configrevision_restore.html:50
 msgid "Changed"
 msgstr ""
 
-#: netbox/templates/core/datafile.html:42 netbox/templates/ipam/iprange.html:25
-#: netbox/templates/virtualization/virtualdisk.html:29
-#: netbox/virtualization/tables/virtualmachines.py:198
+#: templates/core/datafile.html:42 templates/ipam/iprange.html:25
+#: templates/virtualization/virtualdisk.html:29
+#: virtualization/tables/virtualmachines.py:198
 msgid "Size"
 msgstr ""
 
-#: netbox/templates/core/datafile.html:43
+#: templates/core/datafile.html:43
 msgid "bytes"
 msgstr ""
 
-#: netbox/templates/core/datafile.html:46
+#: templates/core/datafile.html:46
 msgid "SHA256 Hash"
 msgstr ""
 
-#: netbox/templates/core/datasource.html:14
-#: netbox/templates/core/datasource.html:20
-#: netbox/utilities/templates/buttons/sync.html:5
+#: templates/core/datasource.html:14 templates/core/datasource.html:20
+#: utilities/templates/buttons/sync.html:5
 msgid "Sync"
 msgstr ""
 
-#: netbox/templates/core/datasource.html:50
+#: templates/core/datasource.html:50
 msgid "Last synced"
 msgstr ""
 
-#: netbox/templates/core/datasource.html:84
+#: templates/core/datasource.html:84
 msgid "Backend"
 msgstr ""
 
-#: netbox/templates/core/datasource.html:99
+#: templates/core/datasource.html:99
 msgid "No parameters defined"
 msgstr ""
 
-#: netbox/templates/core/datasource.html:114
+#: templates/core/datasource.html:114
 msgid "Files"
 msgstr ""
 
-#: netbox/templates/core/inc/config_data.html:7
+#: templates/core/inc/config_data.html:7
 msgid "Rack elevations"
 msgstr ""
 
-#: netbox/templates/core/inc/config_data.html:10
+#: templates/core/inc/config_data.html:10
 msgid "Default unit height"
 msgstr ""
 
-#: netbox/templates/core/inc/config_data.html:14
+#: templates/core/inc/config_data.html:14
 msgid "Default unit width"
 msgstr ""
 
-#: netbox/templates/core/inc/config_data.html:20
+#: templates/core/inc/config_data.html:20
 msgid "Power feeds"
 msgstr ""
 
-#: netbox/templates/core/inc/config_data.html:23
+#: templates/core/inc/config_data.html:23
 msgid "Default voltage"
 msgstr ""
 
-#: netbox/templates/core/inc/config_data.html:27
+#: templates/core/inc/config_data.html:27
 msgid "Default amperage"
 msgstr ""
 
-#: netbox/templates/core/inc/config_data.html:31
+#: templates/core/inc/config_data.html:31
 msgid "Default max utilization"
 msgstr ""
 
-#: netbox/templates/core/inc/config_data.html:40
+#: templates/core/inc/config_data.html:40
 msgid "Enforce global unique"
 msgstr ""
 
-#: netbox/templates/core/inc/config_data.html:83
+#: templates/core/inc/config_data.html:83
 msgid "Paginate count"
 msgstr ""
 
-#: netbox/templates/core/inc/config_data.html:87
+#: templates/core/inc/config_data.html:87
 msgid "Max page size"
 msgstr ""
 
-#: netbox/templates/core/inc/config_data.html:114
+#: templates/core/inc/config_data.html:114
 msgid "User preferences"
 msgstr ""
 
-#: netbox/templates/core/inc/config_data.html:141
+#: templates/core/inc/config_data.html:141
 msgid "Job retention"
 msgstr ""
 
-#: netbox/templates/core/job.html:35 netbox/templates/core/rq_task.html:12
-#: netbox/templates/core/rq_task.html:49 netbox/templates/core/rq_task.html:58
+#: templates/core/job.html:35 templates/core/rq_task.html:12
+#: templates/core/rq_task.html:49 templates/core/rq_task.html:58
 msgid "Job"
 msgstr ""
 
-#: netbox/templates/core/job.html:58
-#: netbox/templates/extras/journalentry.html:26
+#: templates/core/job.html:58 templates/extras/journalentry.html:26
 msgid "Created By"
 msgstr ""
 
-#: netbox/templates/core/job.html:66
+#: templates/core/job.html:66
 msgid "Scheduling"
 msgstr ""
 
-#: netbox/templates/core/job.html:77
+#: templates/core/job.html:77
 #, python-format
 msgid "every %(interval)s minutes"
 msgstr ""
 
-#: netbox/templates/core/objectchange.html:29
-#: netbox/templates/users/objectpermission.html:42
+#: templates/core/objectchange.html:29 templates/users/objectpermission.html:42
 msgid "Change"
 msgstr ""
 
-#: netbox/templates/core/objectchange.html:79
+#: templates/core/objectchange.html:79
 msgid "Difference"
 msgstr ""
 
-#: netbox/templates/core/objectchange.html:82
+#: templates/core/objectchange.html:82
 msgid "Previous"
 msgstr ""
 
-#: netbox/templates/core/objectchange.html:85
+#: templates/core/objectchange.html:85
 msgid "Next"
 msgstr ""
 
-#: netbox/templates/core/objectchange.html:93
+#: templates/core/objectchange.html:93
 msgid "Object Created"
 msgstr ""
 
-#: netbox/templates/core/objectchange.html:95
+#: templates/core/objectchange.html:95
 msgid "Object Deleted"
 msgstr ""
 
-#: netbox/templates/core/objectchange.html:97
+#: templates/core/objectchange.html:97
 msgid "No Changes"
 msgstr ""
 
-#: netbox/templates/core/objectchange.html:111
+#: templates/core/objectchange.html:111
 msgid "Pre-Change Data"
 msgstr ""
 
-#: netbox/templates/core/objectchange.html:122
+#: templates/core/objectchange.html:122
 msgid "Warning: Comparing non-atomic change to previous change record"
 msgstr ""
 
-#: netbox/templates/core/objectchange.html:131
+#: templates/core/objectchange.html:131
 msgid "Post-Change Data"
 msgstr ""
 
-#: netbox/templates/core/objectchange.html:162
+#: templates/core/objectchange.html:162
 #, python-format
 msgid "See All %(count)s Changes"
 msgstr ""
 
-#: netbox/templates/core/objectchange_list.html:9
-#: netbox/templates/extras/object_changelog.html:15
+#: templates/core/objectchange_list.html:9
+#: templates/extras/object_changelog.html:15
 msgid "Change log retention"
 msgstr ""
 
-#: netbox/templates/core/objectchange_list.html:9
-#: netbox/templates/extras/object_changelog.html:15
+#: templates/core/objectchange_list.html:9
+#: templates/extras/object_changelog.html:15
 msgid "days"
 msgstr ""
 
-#: netbox/templates/core/objectchange_list.html:9
-#: netbox/templates/extras/object_changelog.html:15
+#: templates/core/objectchange_list.html:9
+#: templates/extras/object_changelog.html:15
 msgid "Indefinite"
 msgstr ""
 
-#: netbox/templates/core/plugin.html:22
+#: templates/core/plugin.html:22
 msgid "Not installed"
 msgstr ""
 
-#: netbox/templates/core/plugin.html:33
+#: templates/core/plugin.html:33
 msgid "Overview"
 msgstr ""
 
-#: netbox/templates/core/plugin.html:39
+#: templates/core/plugin.html:39
 msgid "Install"
 msgstr ""
 
-#: netbox/templates/core/plugin.html:51
+#: templates/core/plugin.html:51
 msgid "Plugin Details"
 msgstr ""
 
-#: netbox/templates/core/plugin.html:58
+#: templates/core/plugin.html:58
 msgid "Summary"
 msgstr ""
 
-#: netbox/templates/core/plugin.html:76
+#: templates/core/plugin.html:76
 msgid "License"
 msgstr ""
 
-#: netbox/templates/core/plugin.html:96
+#: templates/core/plugin.html:96
 msgid "Version History"
 msgstr ""
 
-#: netbox/templates/core/plugin.html:107
+#: templates/core/plugin.html:107
 msgid "Local Installation Instructions"
 msgstr ""
 
-#: netbox/templates/core/rq_queue_list.html:5
-#: netbox/templates/core/rq_queue_list.html:13
-#: netbox/templates/core/rq_task_list.html:14
-#: netbox/templates/core/rq_worker.html:7
+#: templates/core/rq_queue_list.html:5 templates/core/rq_queue_list.html:13
+#: templates/core/rq_task_list.html:14 templates/core/rq_worker.html:7
 msgid "Background Queues"
 msgstr ""
 
-#: netbox/templates/core/rq_queue_list.html:24
-#: netbox/templates/core/rq_queue_list.html:25
-#: netbox/templates/core/rq_worker_list.html:49
-#: netbox/templates/core/rq_worker_list.html:50
-#: netbox/templates/extras/script_result.html:67
-#: netbox/templates/extras/script_result.html:69
-#: netbox/templates/inc/table_controls_htmx.html:30
-#: netbox/templates/inc/table_controls_htmx.html:33
+#: templates/core/rq_queue_list.html:24 templates/core/rq_queue_list.html:25
+#: templates/core/rq_worker_list.html:49 templates/core/rq_worker_list.html:50
+#: templates/extras/script_result.html:67
+#: templates/extras/script_result.html:69
+#: templates/inc/table_controls_htmx.html:30
+#: templates/inc/table_controls_htmx.html:33
 msgid "Configure Table"
 msgstr ""
 
-#: netbox/templates/core/rq_task.html:29
+#: templates/core/rq_task.html:29
 msgid "Stop"
 msgstr ""
 
-#: netbox/templates/core/rq_task.html:34
+#: templates/core/rq_task.html:34
 msgid "Requeue"
 msgstr ""
 
-#: netbox/templates/core/rq_task.html:39
+#: templates/core/rq_task.html:39
 msgid "Enqueue"
 msgstr ""
 
-#: netbox/templates/core/rq_task.html:61
+#: templates/core/rq_task.html:61
 msgid "Queue"
 msgstr ""
 
-#: netbox/templates/core/rq_task.html:65
+#: templates/core/rq_task.html:65
 msgid "Timeout"
 msgstr ""
 
-#: netbox/templates/core/rq_task.html:69
+#: templates/core/rq_task.html:69
 msgid "Result TTL"
 msgstr ""
 
-#: netbox/templates/core/rq_task.html:89
+#: templates/core/rq_task.html:89
 msgid "Meta"
 msgstr ""
 
-#: netbox/templates/core/rq_task.html:93
+#: templates/core/rq_task.html:93
 msgid "Arguments"
 msgstr ""
 
-#: netbox/templates/core/rq_task.html:97
+#: templates/core/rq_task.html:97
 msgid "Keyword Arguments"
 msgstr ""
 
-#: netbox/templates/core/rq_task.html:103
+#: templates/core/rq_task.html:103
 msgid "Depends on"
 msgstr ""
 
-#: netbox/templates/core/rq_task.html:109
+#: templates/core/rq_task.html:109
 msgid "Exception"
 msgstr ""
 
-#: netbox/templates/core/rq_task_list.html:28
+#: templates/core/rq_task_list.html:28
 msgid "tasks in "
 msgstr ""
 
-#: netbox/templates/core/rq_task_list.html:33
+#: templates/core/rq_task_list.html:33
 msgid "Queued Jobs"
 msgstr ""
 
-#: netbox/templates/core/rq_task_list.html:64
-#: netbox/templates/extras/script_result.html:86
+#: templates/core/rq_task_list.html:64 templates/extras/script_result.html:86
 #, python-format
 msgid ""
 "Select <strong>all %(count)s %(object_type_plural)s</strong> matching query"
 msgstr ""
 
-#: netbox/templates/core/rq_worker.html:10
+#: templates/core/rq_worker.html:10
 msgid "Worker Info"
 msgstr ""
 
-#: netbox/templates/core/rq_worker.html:31
-#: netbox/templates/core/rq_worker.html:40
+#: templates/core/rq_worker.html:31 templates/core/rq_worker.html:40
 msgid "Worker"
 msgstr ""
 
-#: netbox/templates/core/rq_worker.html:55
+#: templates/core/rq_worker.html:55
 msgid "Queues"
 msgstr ""
 
-#: netbox/templates/core/rq_worker.html:63
+#: templates/core/rq_worker.html:63
 msgid "Curent Job"
 msgstr ""
 
-#: netbox/templates/core/rq_worker.html:67
+#: templates/core/rq_worker.html:67
 msgid "Successful job count"
 msgstr ""
 
-#: netbox/templates/core/rq_worker.html:71
+#: templates/core/rq_worker.html:71
 msgid "Failed job count"
 msgstr ""
 
-#: netbox/templates/core/rq_worker.html:75
+#: templates/core/rq_worker.html:75
 msgid "Total working time"
 msgstr ""
 
-#: netbox/templates/core/rq_worker.html:76
+#: templates/core/rq_worker.html:76
 msgid "seconds"
 msgstr ""
 
-#: netbox/templates/core/rq_worker_list.html:13
-#: netbox/templates/core/rq_worker_list.html:21
+#: templates/core/rq_worker_list.html:13 templates/core/rq_worker_list.html:21
 msgid "Background Workers"
 msgstr ""
 
-#: netbox/templates/core/rq_worker_list.html:29
+#: templates/core/rq_worker_list.html:29
 #, python-format
 msgid "Workers in %(queue_name)s"
 msgstr ""
 
-#: netbox/templates/core/system.html:11
-#: netbox/utilities/templates/buttons/export.html:4
+#: templates/core/system.html:11 utilities/templates/buttons/export.html:4
 msgid "Export"
 msgstr ""
 
-#: netbox/templates/core/system.html:28
+#: templates/core/system.html:28
 msgid "System Status"
 msgstr ""
 
-#: netbox/templates/core/system.html:31
+#: templates/core/system.html:31
 msgid "NetBox release"
 msgstr ""
 
-#: netbox/templates/core/system.html:44
+#: templates/core/system.html:44
 msgid "Django version"
 msgstr ""
 
-#: netbox/templates/core/system.html:48
+#: templates/core/system.html:48
 msgid "PostgreSQL version"
 msgstr ""
 
-#: netbox/templates/core/system.html:52
+#: templates/core/system.html:52
 msgid "Database name"
 msgstr ""
 
-#: netbox/templates/core/system.html:56
+#: templates/core/system.html:56
 msgid "Database size"
 msgstr ""
 
-#: netbox/templates/core/system.html:61
+#: templates/core/system.html:61
 msgid "Unavailable"
 msgstr ""
 
-#: netbox/templates/core/system.html:66
+#: templates/core/system.html:66
 msgid "RQ workers"
 msgstr ""
 
-#: netbox/templates/core/system.html:69
+#: templates/core/system.html:69
 msgid "default queue"
 msgstr ""
 
-#: netbox/templates/core/system.html:73
+#: templates/core/system.html:73
 msgid "System time"
 msgstr ""
 
-#: netbox/templates/core/system.html:85
+#: templates/core/system.html:85
 msgid "Current Configuration"
 msgstr ""
 
-#: netbox/templates/dcim/bulk_disconnect.html:9
+#: templates/dcim/bulk_disconnect.html:9
 #, python-format
 msgid ""
 "Are you sure you want to disconnect these %(count)s %(obj_type_plural)s?"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:10
+#: templates/dcim/cable_trace.html:10
 #, python-format
 msgid "Cable Trace for %(object_type)s %(object)s"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:24
-#: netbox/templates/dcim/inc/rack_elevation.html:7
+#: templates/dcim/cable_trace.html:24 templates/dcim/inc/rack_elevation.html:7
 msgid "Download SVG"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:30
+#: templates/dcim/cable_trace.html:30
 msgid "Asymmetric Path"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:31
+#: templates/dcim/cable_trace.html:31
 msgid "The nodes below have no links and result in an asymmetric path"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:38
+#: templates/dcim/cable_trace.html:38
 msgid "Path split"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:39
+#: templates/dcim/cable_trace.html:39
 msgid "Select a node below to continue"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:55
+#: templates/dcim/cable_trace.html:55
 msgid "Trace Completed"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:58
+#: templates/dcim/cable_trace.html:58
 msgid "Total segments"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:62
+#: templates/dcim/cable_trace.html:62
 msgid "Total length"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:77
+#: templates/dcim/cable_trace.html:77
 msgid "No paths found"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:85
+#: templates/dcim/cable_trace.html:85
 msgid "Related Paths"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:89
+#: templates/dcim/cable_trace.html:89
 msgid "Origin"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:90
+#: templates/dcim/cable_trace.html:90
 msgid "Destination"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:91
+#: templates/dcim/cable_trace.html:91
 msgid "Segments"
 msgstr ""
 
-#: netbox/templates/dcim/cable_trace.html:104
+#: templates/dcim/cable_trace.html:104
 msgid "Incomplete"
 msgstr ""
 
-#: netbox/templates/dcim/component_list.html:14
+#: templates/dcim/component_list.html:14
 msgid "Rename Selected"
 msgstr ""
 
-#: netbox/templates/dcim/consoleport.html:65
-#: netbox/templates/dcim/consoleserverport.html:66
-#: netbox/templates/dcim/frontport.html:98
-#: netbox/templates/dcim/interface.html:176
-#: netbox/templates/dcim/poweroutlet.html:69
-#: netbox/templates/dcim/powerport.html:69
+#: templates/dcim/consoleport.html:65 templates/dcim/consoleserverport.html:66
+#: templates/dcim/frontport.html:98 templates/dcim/interface.html:176
+#: templates/dcim/poweroutlet.html:69 templates/dcim/powerport.html:69
 msgid "Not Connected"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:34
+#: templates/dcim/device.html:34
 msgid "Highlight device in rack"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:55
+#: templates/dcim/device.html:55
 msgid "Not racked"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:62 netbox/templates/dcim/site.html:94
+#: templates/dcim/device.html:62 templates/dcim/site.html:94
 msgid "GPS Coordinates"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:68 netbox/templates/dcim/site.html:81
-#: netbox/templates/dcim/site.html:100
+#: templates/dcim/device.html:68 templates/dcim/site.html:81
+#: templates/dcim/site.html:100
 msgid "Map"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:108
-#: netbox/templates/dcim/inventoryitem.html:56
-#: netbox/templates/dcim/module.html:81 netbox/templates/dcim/modulebay.html:74
-#: netbox/templates/dcim/rack.html:61
+#: templates/dcim/device.html:108 templates/dcim/inventoryitem.html:56
+#: templates/dcim/module.html:81 templates/dcim/modulebay.html:74
+#: templates/dcim/rack.html:61
 msgid "Asset Tag"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:123
+#: templates/dcim/device.html:123
 msgid "View Virtual Chassis"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:164
+#: templates/dcim/device.html:164
 msgid "Create VDC"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:175
-#: netbox/templates/dcim/device_edit.html:64
-#: netbox/virtualization/forms/model_forms.py:223
+#: templates/dcim/device.html:175 templates/dcim/device_edit.html:64
+#: virtualization/forms/model_forms.py:223
 msgid "Management"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:195 netbox/templates/dcim/device.html:211
-#: netbox/templates/dcim/device.html:227
-#: netbox/templates/virtualization/virtualmachine.html:57
-#: netbox/templates/virtualization/virtualmachine.html:73
+#: templates/dcim/device.html:195 templates/dcim/device.html:211
+#: templates/dcim/device.html:227
+#: templates/virtualization/virtualmachine.html:57
+#: templates/virtualization/virtualmachine.html:73
 msgid "NAT for"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:197 netbox/templates/dcim/device.html:213
-#: netbox/templates/dcim/device.html:229
-#: netbox/templates/virtualization/virtualmachine.html:59
-#: netbox/templates/virtualization/virtualmachine.html:75
+#: templates/dcim/device.html:197 templates/dcim/device.html:213
+#: templates/dcim/device.html:229
+#: templates/virtualization/virtualmachine.html:59
+#: templates/virtualization/virtualmachine.html:75
 msgid "NAT"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:252 netbox/templates/dcim/rack.html:73
+#: templates/dcim/device.html:252 templates/dcim/rack.html:73
 msgid "Power Utilization"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:256
+#: templates/dcim/device.html:256
 msgid "Input"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:257
+#: templates/dcim/device.html:257
 msgid "Outlets"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:258
+#: templates/dcim/device.html:258
 msgid "Allocated"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:268 netbox/templates/dcim/device.html:270
-#: netbox/templates/dcim/device.html:286
-#: netbox/templates/dcim/powerfeed.html:67
+#: templates/dcim/device.html:268 templates/dcim/device.html:270
+#: templates/dcim/device.html:286 templates/dcim/powerfeed.html:67
 msgid "VA"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:280
+#: templates/dcim/device.html:280
 msgctxt "Leg of a power feed"
 msgid "Leg"
 msgstr ""
 
-#: netbox/templates/dcim/device.html:306
-#: netbox/templates/virtualization/virtualmachine.html:158
+#: templates/dcim/device.html:306
+#: templates/virtualization/virtualmachine.html:158
 msgid "Add a service"
 msgstr ""
 
-#: netbox/templates/dcim/device/base.html:21
-#: netbox/templates/dcim/device_list.html:9
-#: netbox/templates/dcim/devicetype/base.html:18
-#: netbox/templates/dcim/inc/moduletype_buttons.html:9
-#: netbox/templates/dcim/module.html:18
-#: netbox/templates/virtualization/virtualmachine/base.html:22
-#: netbox/templates/virtualization/virtualmachine_list.html:8
+#: templates/dcim/device/base.html:21 templates/dcim/device_list.html:9
+#: templates/dcim/devicetype/base.html:18
+#: templates/dcim/inc/moduletype_buttons.html:9 templates/dcim/module.html:18
+#: templates/virtualization/virtualmachine/base.html:22
+#: templates/virtualization/virtualmachine_list.html:8
 msgid "Add Components"
 msgstr ""
 
-#: netbox/templates/dcim/device/consoleports.html:24
+#: templates/dcim/device/consoleports.html:24
 msgid "Add Console Ports"
 msgstr ""
 
-#: netbox/templates/dcim/device/consoleserverports.html:24
+#: templates/dcim/device/consoleserverports.html:24
 msgid "Add Console Server Ports"
 msgstr ""
 
-#: netbox/templates/dcim/device/devicebays.html:10
+#: templates/dcim/device/devicebays.html:10
 msgid "Add Device Bays"
 msgstr ""
 
-#: netbox/templates/dcim/device/frontports.html:24
+#: templates/dcim/device/frontports.html:24
 msgid "Add Front Ports"
 msgstr ""
 
-#: netbox/templates/dcim/device/inc/interface_table_controls.html:9
+#: templates/dcim/device/inc/interface_table_controls.html:9
 msgid "Hide Enabled"
 msgstr ""
 
-#: netbox/templates/dcim/device/inc/interface_table_controls.html:10
+#: templates/dcim/device/inc/interface_table_controls.html:10
 msgid "Hide Disabled"
 msgstr ""
 
-#: netbox/templates/dcim/device/inc/interface_table_controls.html:11
+#: templates/dcim/device/inc/interface_table_controls.html:11
 msgid "Hide Virtual"
 msgstr ""
 
-#: netbox/templates/dcim/device/inc/interface_table_controls.html:12
+#: templates/dcim/device/inc/interface_table_controls.html:12
 msgid "Hide Disconnected"
 msgstr ""
 
-#: netbox/templates/dcim/device/interfaces.html:27
+#: templates/dcim/device/interfaces.html:27
 msgid "Add Interfaces"
 msgstr ""
 
-#: netbox/templates/dcim/device/inventory.html:10
-#: netbox/templates/dcim/inc/panels/inventory_items.html:10
+#: templates/dcim/device/inventory.html:10
+#: templates/dcim/inc/panels/inventory_items.html:10
 msgid "Add Inventory Item"
 msgstr ""
 
-#: netbox/templates/dcim/device/modulebays.html:10
+#: templates/dcim/device/modulebays.html:10
 msgid "Add Module Bays"
 msgstr ""
 
-#: netbox/templates/dcim/device/poweroutlets.html:24
+#: templates/dcim/device/poweroutlets.html:24
 msgid "Add Power Outlets"
 msgstr ""
 
-#: netbox/templates/dcim/device/powerports.html:24
+#: templates/dcim/device/powerports.html:24
 msgid "Add Power Port"
 msgstr ""
 
-#: netbox/templates/dcim/device/rearports.html:24
+#: templates/dcim/device/rearports.html:24
 msgid "Add Rear Ports"
 msgstr ""
 
-#: netbox/templates/dcim/device/render_config.html:5
-#: netbox/templates/virtualization/virtualmachine/render_config.html:5
+#: templates/dcim/device/render_config.html:5
+#: templates/virtualization/virtualmachine/render_config.html:5
 msgid "Config"
 msgstr ""
 
-#: netbox/templates/dcim/device/render_config.html:35
-#: netbox/templates/virtualization/virtualmachine/render_config.html:35
+#: templates/dcim/device/render_config.html:35
+#: templates/virtualization/virtualmachine/render_config.html:35
 msgid "Context Data"
 msgstr ""
 
-#: netbox/templates/dcim/device/render_config.html:53
-#: netbox/templates/virtualization/virtualmachine/render_config.html:53
+#: templates/dcim/device/render_config.html:53
+#: templates/virtualization/virtualmachine/render_config.html:53
 msgid "Rendered Config"
 msgstr ""
 
-#: netbox/templates/dcim/device/render_config.html:55
-#: netbox/templates/virtualization/virtualmachine/render_config.html:55
+#: templates/dcim/device/render_config.html:55
+#: templates/virtualization/virtualmachine/render_config.html:55
 msgid "Download"
 msgstr ""
 
-#: netbox/templates/dcim/device/render_config.html:61
-#: netbox/templates/virtualization/virtualmachine/render_config.html:61
+#: templates/dcim/device/render_config.html:61
+#: templates/virtualization/virtualmachine/render_config.html:61
 msgid "No configuration template found"
 msgstr ""
 
-#: netbox/templates/dcim/device_edit.html:44
+#: templates/dcim/device_edit.html:44
 msgid "Parent Bay"
 msgstr ""
 
-#: netbox/templates/dcim/device_edit.html:48
-#: netbox/utilities/templates/form_helpers/render_field.html:22
+#: templates/dcim/device_edit.html:48
+#: utilities/templates/form_helpers/render_field.html:22
 msgid "Regenerate Slug"
 msgstr ""
 
-#: netbox/templates/dcim/device_edit.html:49
-#: netbox/templates/generic/bulk_remove.html:21
-#: netbox/utilities/templates/helpers/table_config_form.html:23
+#: templates/dcim/device_edit.html:49 templates/generic/bulk_remove.html:21
+#: utilities/templates/helpers/table_config_form.html:23
 msgid "Remove"
 msgstr ""
 
-#: netbox/templates/dcim/device_edit.html:110
+#: templates/dcim/device_edit.html:110
 msgid "Local Config Context Data"
 msgstr ""
 
-#: netbox/templates/dcim/device_list.html:82
-#: netbox/templates/generic/bulk_rename.html:57
-#: netbox/templates/virtualization/virtualmachine/interfaces.html:11
-#: netbox/templates/virtualization/virtualmachine/virtual_disks.html:11
+#: templates/dcim/device_list.html:82 templates/generic/bulk_rename.html:57
+#: templates/virtualization/virtualmachine/interfaces.html:11
+#: templates/virtualization/virtualmachine/virtual_disks.html:11
 msgid "Rename"
 msgstr ""
 
-#: netbox/templates/dcim/devicebay.html:17
+#: templates/dcim/devicebay.html:17
 msgid "Device Bay"
 msgstr ""
 
-#: netbox/templates/dcim/devicebay.html:43
+#: templates/dcim/devicebay.html:43
 msgid "Installed Device"
 msgstr ""
 
-#: netbox/templates/dcim/devicebay_depopulate.html:6
+#: templates/dcim/devicebay_depopulate.html:6
 #, python-format
 msgid "Remove %(device)s from %(device_bay)s?"
 msgstr ""
 
-#: netbox/templates/dcim/devicebay_depopulate.html:13
+#: templates/dcim/devicebay_depopulate.html:13
 #, python-format
 msgid ""
 "Are you sure you want to remove <strong>%(device)s</strong> from "
 "<strong>%(device_bay)s</strong>?"
 msgstr ""
 
-#: netbox/templates/dcim/devicebay_populate.html:13
+#: templates/dcim/devicebay_populate.html:13
 msgid "Populate"
 msgstr ""
 
-#: netbox/templates/dcim/devicebay_populate.html:22
+#: templates/dcim/devicebay_populate.html:22
 msgid "Bay"
 msgstr ""
 
-#: netbox/templates/dcim/devicerole.html:14
-#: netbox/templates/dcim/platform.html:17
+#: templates/dcim/devicerole.html:14 templates/dcim/platform.html:17
 msgid "Add Device"
 msgstr ""
 
-#: netbox/templates/dcim/devicerole.html:40
+#: templates/dcim/devicerole.html:40
 msgid "VM Role"
 msgstr ""
 
-#: netbox/templates/dcim/devicetype.html:18
-#: netbox/templates/dcim/moduletype.html:29
+#: templates/dcim/devicetype.html:18 templates/dcim/moduletype.html:29
 msgid "Model Name"
 msgstr ""
 
-#: netbox/templates/dcim/devicetype.html:25
-#: netbox/templates/dcim/moduletype.html:33
+#: templates/dcim/devicetype.html:25 templates/dcim/moduletype.html:33
 msgid "Part Number"
 msgstr ""
 
-#: netbox/templates/dcim/devicetype.html:41
+#: templates/dcim/devicetype.html:41
 msgid "Exclude From Utilization"
 msgstr ""
 
-#: netbox/templates/dcim/devicetype.html:59
+#: templates/dcim/devicetype.html:59
 msgid "Parent/Child"
 msgstr ""
 
-#: netbox/templates/dcim/devicetype.html:71
+#: templates/dcim/devicetype.html:71
 msgid "Front Image"
 msgstr ""
 
-#: netbox/templates/dcim/devicetype.html:83
+#: templates/dcim/devicetype.html:83
 msgid "Rear Image"
 msgstr ""
 
-#: netbox/templates/dcim/frontport.html:54
+#: templates/dcim/frontport.html:54
 msgid "Rear Port Position"
 msgstr ""
 
-#: netbox/templates/dcim/frontport.html:72
-#: netbox/templates/dcim/interface.html:144
-#: netbox/templates/dcim/poweroutlet.html:63
-#: netbox/templates/dcim/powerport.html:63
-#: netbox/templates/dcim/rearport.html:68
+#: templates/dcim/frontport.html:72 templates/dcim/interface.html:144
+#: templates/dcim/poweroutlet.html:63 templates/dcim/powerport.html:63
+#: templates/dcim/rearport.html:68
 msgid "Marked as Connected"
 msgstr ""
 
-#: netbox/templates/dcim/frontport.html:86
-#: netbox/templates/dcim/rearport.html:82
+#: templates/dcim/frontport.html:86 templates/dcim/rearport.html:82
 msgid "Connection Status"
 msgstr ""
 
-#: netbox/templates/dcim/htmx/cable_edit.html:10
+#: templates/dcim/htmx/cable_edit.html:10
 msgid "A Side"
 msgstr ""
 
-#: netbox/templates/dcim/htmx/cable_edit.html:30
+#: templates/dcim/htmx/cable_edit.html:30
 msgid "B Side"
 msgstr ""
 
-#: netbox/templates/dcim/inc/cable_termination.html:65
+#: templates/dcim/inc/cable_termination.html:65
 msgid "No termination"
 msgstr ""
 
-#: netbox/templates/dcim/inc/cable_toggle_buttons.html:3
+#: templates/dcim/inc/cable_toggle_buttons.html:3
 msgid "Mark Planned"
 msgstr ""
 
-#: netbox/templates/dcim/inc/cable_toggle_buttons.html:6
+#: templates/dcim/inc/cable_toggle_buttons.html:6
 msgid "Mark Installed"
 msgstr ""
 
-#: netbox/templates/dcim/inc/connection_endpoints.html:13
+#: templates/dcim/inc/connection_endpoints.html:13
 msgid "Path Status"
 msgstr ""
 
-#: netbox/templates/dcim/inc/connection_endpoints.html:18
+#: templates/dcim/inc/connection_endpoints.html:18
 msgid "Not Reachable"
 msgstr ""
 
-#: netbox/templates/dcim/inc/connection_endpoints.html:23
+#: templates/dcim/inc/connection_endpoints.html:23
 msgid "Path Endpoints"
 msgstr ""
 
-#: netbox/templates/dcim/inc/endpoint_connection.html:8
-#: netbox/templates/dcim/powerfeed.html:120
-#: netbox/templates/dcim/rearport.html:94
+#: templates/dcim/inc/endpoint_connection.html:8
+#: templates/dcim/powerfeed.html:120 templates/dcim/rearport.html:94
 msgid "Not connected"
 msgstr ""
 
-#: netbox/templates/dcim/inc/interface_vlans_table.html:6
+#: templates/dcim/inc/interface_vlans_table.html:6
 msgid "Untagged"
 msgstr ""
 
-#: netbox/templates/dcim/inc/interface_vlans_table.html:37
+#: templates/dcim/inc/interface_vlans_table.html:37
 msgid "No VLANs Assigned"
 msgstr ""
 
-#: netbox/templates/dcim/inc/interface_vlans_table.html:44
-#: netbox/templates/ipam/prefix_list.html:16
-#: netbox/templates/ipam/prefix_list.html:33
+#: templates/dcim/inc/interface_vlans_table.html:44
+#: templates/ipam/prefix_list.html:16 templates/ipam/prefix_list.html:33
 msgid "Clear"
 msgstr ""
 
-#: netbox/templates/dcim/inc/interface_vlans_table.html:47
+#: templates/dcim/inc/interface_vlans_table.html:47
 msgid "Clear All"
 msgstr ""
 
-#: netbox/templates/dcim/inc/panels/racktype_dimensions.html:38
+#: templates/dcim/inc/panels/racktype_dimensions.html:38
 msgid "Mounting Depth"
 msgstr ""
 
-#: netbox/templates/dcim/inc/panels/racktype_numbering.html:6
+#: templates/dcim/inc/panels/racktype_numbering.html:6
 msgid "Starting Unit"
 msgstr ""
 
-#: netbox/templates/dcim/inc/panels/racktype_numbering.html:10
+#: templates/dcim/inc/panels/racktype_numbering.html:10
 msgid "Descending Units"
 msgstr ""
 
-#: netbox/templates/dcim/inc/rack_elevation.html:3
+#: templates/dcim/inc/rack_elevation.html:3
 msgid "Rack elevation"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:17
+#: templates/dcim/interface.html:17
 msgid "Add Child Interface"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:50
+#: templates/dcim/interface.html:50
 msgid "Speed/Duplex"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:73
+#: templates/dcim/interface.html:73
 msgid "PoE Mode"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:77
+#: templates/dcim/interface.html:77
 msgid "PoE Type"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:81
-#: netbox/templates/virtualization/vminterface.html:63
+#: templates/dcim/interface.html:81
+#: templates/virtualization/vminterface.html:63
 msgid "802.1Q Mode"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:125
-#: netbox/templates/virtualization/vminterface.html:59
+#: templates/dcim/interface.html:125
+#: templates/virtualization/vminterface.html:59
 msgid "MAC Address"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:151
+#: templates/dcim/interface.html:151
 msgid "Wireless Link"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:218 netbox/vpn/choices.py:55
+#: templates/dcim/interface.html:218 vpn/choices.py:55
 msgid "Peer"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:230
-#: netbox/templates/wireless/inc/wirelesslink_interface.html:26
+#: templates/dcim/interface.html:230
+#: templates/wireless/inc/wirelesslink_interface.html:26
 msgid "Channel"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:239
-#: netbox/templates/wireless/inc/wirelesslink_interface.html:32
+#: templates/dcim/interface.html:239
+#: templates/wireless/inc/wirelesslink_interface.html:32
 msgid "Channel Frequency"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:242
-#: netbox/templates/dcim/interface.html:250
-#: netbox/templates/dcim/interface.html:261
-#: netbox/templates/dcim/interface.html:269
+#: templates/dcim/interface.html:242 templates/dcim/interface.html:250
+#: templates/dcim/interface.html:261 templates/dcim/interface.html:269
 msgid "MHz"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:258
-#: netbox/templates/wireless/inc/wirelesslink_interface.html:42
+#: templates/dcim/interface.html:258
+#: templates/wireless/inc/wirelesslink_interface.html:42
 msgid "Channel Width"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:285
-#: netbox/templates/wireless/wirelesslan.html:14
-#: netbox/templates/wireless/wirelesslink.html:21
-#: netbox/wireless/forms/bulk_edit.py:60 netbox/wireless/forms/bulk_edit.py:102
-#: netbox/wireless/forms/filtersets.py:40
-#: netbox/wireless/forms/filtersets.py:80 netbox/wireless/models.py:82
-#: netbox/wireless/models.py:156 netbox/wireless/tables/wirelesslan.py:44
+#: templates/dcim/interface.html:285 templates/wireless/wirelesslan.html:14
+#: templates/wireless/wirelesslink.html:21 wireless/forms/bulk_edit.py:60
+#: wireless/forms/bulk_edit.py:102 wireless/forms/filtersets.py:40
+#: wireless/forms/filtersets.py:80 wireless/models.py:82 wireless/models.py:156
+#: wireless/tables/wirelesslan.py:44
 msgid "SSID"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:305
+#: templates/dcim/interface.html:305
 msgid "LAG Members"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:323
+#: templates/dcim/interface.html:323
 msgid "No member interfaces"
 msgstr ""
 
-#: netbox/templates/dcim/interface.html:343
-#: netbox/templates/ipam/fhrpgroup.html:73
-#: netbox/templates/ipam/iprange/ip_addresses.html:7
-#: netbox/templates/ipam/prefix/ip_addresses.html:7
-#: netbox/templates/virtualization/vminterface.html:89
+#: templates/dcim/interface.html:343 templates/ipam/fhrpgroup.html:73
+#: templates/ipam/iprange/ip_addresses.html:7
+#: templates/ipam/prefix/ip_addresses.html:7
+#: templates/virtualization/vminterface.html:89
 msgid "Add IP Address"
 msgstr ""
 
-#: netbox/templates/dcim/inventoryitem.html:24
+#: templates/dcim/inventoryitem.html:24
 msgid "Parent Item"
 msgstr ""
 
-#: netbox/templates/dcim/inventoryitem.html:48
+#: templates/dcim/inventoryitem.html:48
 msgid "Part ID"
 msgstr ""
 
-#: netbox/templates/dcim/location.html:17
+#: templates/dcim/location.html:17
 msgid "Add Child Location"
 msgstr ""
 
-#: netbox/templates/dcim/location.html:77
+#: templates/dcim/location.html:77
 msgid "Child Locations"
 msgstr ""
 
-#: netbox/templates/dcim/location.html:81 netbox/templates/dcim/site.html:131
+#: templates/dcim/location.html:81 templates/dcim/site.html:131
 msgid "Add a Location"
 msgstr ""
 
-#: netbox/templates/dcim/location.html:94 netbox/templates/dcim/site.html:144
+#: templates/dcim/location.html:94 templates/dcim/site.html:144
 msgid "Add a Device"
 msgstr ""
 
-#: netbox/templates/dcim/manufacturer.html:16
+#: templates/dcim/manufacturer.html:16
 msgid "Add Device Type"
 msgstr ""
 
-#: netbox/templates/dcim/manufacturer.html:21
+#: templates/dcim/manufacturer.html:21
 msgid "Add Module Type"
 msgstr ""
 
-#: netbox/templates/dcim/powerfeed.html:53
+#: templates/dcim/powerfeed.html:53
 msgid "Connected Device"
 msgstr ""
 
-#: netbox/templates/dcim/powerfeed.html:63
+#: templates/dcim/powerfeed.html:63
 msgid "Utilization (Allocated"
 msgstr ""
 
-#: netbox/templates/dcim/powerfeed.html:80
+#: templates/dcim/powerfeed.html:80
 msgid "Electrical Characteristics"
 msgstr ""
 
-#: netbox/templates/dcim/powerfeed.html:88
+#: templates/dcim/powerfeed.html:88
 msgctxt "Abbreviation for volts"
 msgid "V"
 msgstr ""
 
-#: netbox/templates/dcim/powerfeed.html:92
+#: templates/dcim/powerfeed.html:92
 msgctxt "Abbreviation for amperes"
 msgid "A"
 msgstr ""
 
-#: netbox/templates/dcim/poweroutlet.html:48
+#: templates/dcim/poweroutlet.html:48
 msgid "Feed Leg"
 msgstr ""
 
-#: netbox/templates/dcim/powerpanel.html:72
+#: templates/dcim/powerpanel.html:72
 msgid "Add Power Feeds"
 msgstr ""
 
-#: netbox/templates/dcim/powerport.html:44
+#: templates/dcim/powerport.html:44
 msgid "Maximum Draw"
 msgstr ""
 
-#: netbox/templates/dcim/powerport.html:48
+#: templates/dcim/powerport.html:48
 msgid "Allocated Draw"
 msgstr ""
 
-#: netbox/templates/dcim/rack.html:69
+#: templates/dcim/rack.html:69
 msgid "Space Utilization"
 msgstr ""
 
-#: netbox/templates/dcim/rack.html:84 netbox/templates/dcim/racktype.html:44
+#: templates/dcim/rack.html:84 templates/dcim/racktype.html:44
 msgid "Rack Weight"
 msgstr ""
 
-#: netbox/templates/dcim/rack.html:94 netbox/templates/dcim/racktype.html:54
+#: templates/dcim/rack.html:94 templates/dcim/racktype.html:54
 msgid "Maximum Weight"
 msgstr ""
 
-#: netbox/templates/dcim/rack.html:104
+#: templates/dcim/rack.html:104
 msgid "Total Weight"
 msgstr ""
 
-#: netbox/templates/dcim/rack.html:125
-#: netbox/templates/dcim/rack_elevation_list.html:15
+#: templates/dcim/rack.html:125 templates/dcim/rack_elevation_list.html:15
 msgid "Images and Labels"
 msgstr ""
 
-#: netbox/templates/dcim/rack.html:126
-#: netbox/templates/dcim/rack_elevation_list.html:16
+#: templates/dcim/rack.html:126 templates/dcim/rack_elevation_list.html:16
 msgid "Images only"
 msgstr ""
 
-#: netbox/templates/dcim/rack.html:127
-#: netbox/templates/dcim/rack_elevation_list.html:17
+#: templates/dcim/rack.html:127 templates/dcim/rack_elevation_list.html:17
 msgid "Labels only"
 msgstr ""
 
-#: netbox/templates/dcim/rack/reservations.html:8
+#: templates/dcim/rack/reservations.html:8
 msgid "Add reservation"
 msgstr ""
 
-#: netbox/templates/dcim/rack_elevation_list.html:12
+#: templates/dcim/rack_elevation_list.html:12
 msgid "View List"
 msgstr ""
 
-#: netbox/templates/dcim/rack_elevation_list.html:14
+#: templates/dcim/rack_elevation_list.html:14
 msgid "Select rack view"
 msgstr ""
 
-#: netbox/templates/dcim/rack_elevation_list.html:25
+#: templates/dcim/rack_elevation_list.html:25
 msgid "Sort By"
 msgstr ""
 
-#: netbox/templates/dcim/rack_elevation_list.html:74
+#: templates/dcim/rack_elevation_list.html:74
 msgid "No Racks Found"
 msgstr ""
 
-#: netbox/templates/dcim/rack_list.html:8
+#: templates/dcim/rack_list.html:8
 msgid "View Elevations"
 msgstr ""
 
-#: netbox/templates/dcim/rackreservation.html:42
+#: templates/dcim/rackreservation.html:42
 msgid "Reservation Details"
 msgstr ""
 
-#: netbox/templates/dcim/rackrole.html:10
+#: templates/dcim/rackrole.html:10
 msgid "Add Rack"
 msgstr ""
 
-#: netbox/templates/dcim/rearport.html:50
+#: templates/dcim/rearport.html:50
 msgid "Positions"
 msgstr ""
 
-#: netbox/templates/dcim/region.html:17 netbox/templates/dcim/sitegroup.html:17
+#: templates/dcim/region.html:17 templates/dcim/sitegroup.html:17
 msgid "Add Site"
 msgstr ""
 
-#: netbox/templates/dcim/region.html:55
+#: templates/dcim/region.html:55
 msgid "Child Regions"
 msgstr ""
 
-#: netbox/templates/dcim/region.html:59
+#: templates/dcim/region.html:59
 msgid "Add Region"
 msgstr ""
 
-#: netbox/templates/dcim/site.html:64
+#: templates/dcim/site.html:64
 msgid "Time Zone"
 msgstr ""
 
-#: netbox/templates/dcim/site.html:67
+#: templates/dcim/site.html:67
 msgid "UTC"
 msgstr ""
 
-#: netbox/templates/dcim/site.html:68
+#: templates/dcim/site.html:68
 msgid "Site time"
 msgstr ""
 
-#: netbox/templates/dcim/site.html:75
+#: templates/dcim/site.html:75
 msgid "Physical Address"
 msgstr ""
 
-#: netbox/templates/dcim/site.html:90
+#: templates/dcim/site.html:90
 msgid "Shipping Address"
 msgstr ""
 
-#: netbox/templates/dcim/sitegroup.html:55
-#: netbox/templates/tenancy/contactgroup.html:46
-#: netbox/templates/tenancy/tenantgroup.html:55
-#: netbox/templates/wireless/wirelesslangroup.html:55
+#: templates/dcim/sitegroup.html:55 templates/tenancy/contactgroup.html:46
+#: templates/tenancy/tenantgroup.html:55
+#: templates/wireless/wirelesslangroup.html:55
 msgid "Child Groups"
 msgstr ""
 
-#: netbox/templates/dcim/sitegroup.html:59
+#: templates/dcim/sitegroup.html:59
 msgid "Add Site Group"
 msgstr ""
 
-#: netbox/templates/dcim/trace/attachment.html:5
-#: netbox/templates/extras/exporttemplate.html:31
+#: templates/dcim/trace/attachment.html:5
+#: templates/extras/exporttemplate.html:31
 msgid "Attachment"
 msgstr ""
 
-#: netbox/templates/dcim/virtualchassis.html:57
+#: templates/dcim/virtualchassis.html:57
 msgid "Add Member"
 msgstr ""
 
-#: netbox/templates/dcim/virtualchassis_add.html:18
+#: templates/dcim/virtualchassis_add.html:18
 msgid "Member Devices"
 msgstr ""
 
-#: netbox/templates/dcim/virtualchassis_add_member.html:10
+#: templates/dcim/virtualchassis_add_member.html:10
 #, python-format
 msgid "Add New Member to Virtual Chassis %(virtual_chassis)s"
 msgstr ""
 
-#: netbox/templates/dcim/virtualchassis_add_member.html:19
+#: templates/dcim/virtualchassis_add_member.html:19
 msgid "Add New Member"
 msgstr ""
 
-#: netbox/templates/dcim/virtualchassis_add_member.html:27
-#: netbox/templates/generic/object_edit.html:78
-#: netbox/templates/users/objectpermission.html:31
-#: netbox/users/forms/filtersets.py:67 netbox/users/forms/model_forms.py:312
+#: templates/dcim/virtualchassis_add_member.html:27
+#: templates/generic/object_edit.html:78
+#: templates/users/objectpermission.html:31 users/forms/filtersets.py:67
+#: users/forms/model_forms.py:312
 msgid "Actions"
 msgstr ""
 
-#: netbox/templates/dcim/virtualchassis_add_member.html:29
+#: templates/dcim/virtualchassis_add_member.html:29
 msgid "Save & Add Another"
 msgstr ""
 
-#: netbox/templates/dcim/virtualchassis_edit.html:7
+#: templates/dcim/virtualchassis_edit.html:7
 #, python-format
 msgid "Editing Virtual Chassis %(name)s"
 msgstr ""
 
-#: netbox/templates/dcim/virtualchassis_edit.html:53
+#: templates/dcim/virtualchassis_edit.html:53
 msgid "Rack/Unit"
 msgstr ""
 
-#: netbox/templates/dcim/virtualchassis_remove_member.html:5
+#: templates/dcim/virtualchassis_remove_member.html:5
 msgid "Remove Virtual Chassis Member"
 msgstr ""
 
-#: netbox/templates/dcim/virtualchassis_remove_member.html:9
+#: templates/dcim/virtualchassis_remove_member.html:9
 #, python-format
 msgid ""
 "Are you sure you want to remove <strong>%(device)s</strong> from virtual "
 "chassis %(name)s?"
 msgstr ""
 
-#: netbox/templates/dcim/virtualdevicecontext.html:26
-#: netbox/templates/vpn/l2vpn.html:18
+#: templates/dcim/virtualdevicecontext.html:26 templates/vpn/l2vpn.html:18
 msgid "Identifier"
 msgstr ""
 
-#: netbox/templates/exceptions/import_error.html:6
+#: templates/exceptions/import_error.html:6
 msgid ""
 "A module import error occurred during this request. Common causes include "
 "the following:"
 msgstr ""
 
-#: netbox/templates/exceptions/import_error.html:10
+#: templates/exceptions/import_error.html:10
 msgid "Missing required packages"
 msgstr ""
 
-#: netbox/templates/exceptions/import_error.html:11
+#: templates/exceptions/import_error.html:11
 msgid ""
 "This installation of NetBox might be missing one or more required Python "
 "packages. These packages are listed in <code>requirements.txt</code> and "
@@ -12738,28 +12083,28 @@ msgid ""
 "of required packages."
 msgstr ""
 
-#: netbox/templates/exceptions/import_error.html:20
+#: templates/exceptions/import_error.html:20
 msgid "WSGI service not restarted after upgrade"
 msgstr ""
 
-#: netbox/templates/exceptions/import_error.html:21
+#: templates/exceptions/import_error.html:21
 msgid ""
 "If this installation has recently been upgraded, check that the WSGI service "
 "(e.g. gunicorn or uWSGI) has been restarted. This ensures that the new code "
 "is running."
 msgstr ""
 
-#: netbox/templates/exceptions/permission_error.html:6
+#: templates/exceptions/permission_error.html:6
 msgid ""
 "A file permission error was detected while processing this request. Common "
 "causes include the following:"
 msgstr ""
 
-#: netbox/templates/exceptions/permission_error.html:10
+#: templates/exceptions/permission_error.html:10
 msgid "Insufficient write permission to the media root"
 msgstr ""
 
-#: netbox/templates/exceptions/permission_error.html:11
+#: templates/exceptions/permission_error.html:11
 #, python-format
 msgid ""
 "The configured media root is <code>%(media_root)s</code>. Ensure that the "
@@ -12767,372 +12112,367 @@ msgid ""
 "path."
 msgstr ""
 
-#: netbox/templates/exceptions/programming_error.html:6
+#: templates/exceptions/programming_error.html:6
 msgid ""
 "A database programming error was detected while processing this request. "
 "Common causes include the following:"
 msgstr ""
 
-#: netbox/templates/exceptions/programming_error.html:10
+#: templates/exceptions/programming_error.html:10
 msgid "Database migrations missing"
 msgstr ""
 
-#: netbox/templates/exceptions/programming_error.html:11
+#: templates/exceptions/programming_error.html:11
 msgid ""
 "When upgrading to a new NetBox release, the upgrade script must be run to "
 "apply any new database migrations. You can run migrations manually by "
 "executing <code>python3 manage.py migrate</code> from the command line."
 msgstr ""
 
-#: netbox/templates/exceptions/programming_error.html:18
+#: templates/exceptions/programming_error.html:18
 msgid "Unsupported PostgreSQL version"
 msgstr ""
 
-#: netbox/templates/exceptions/programming_error.html:19
+#: templates/exceptions/programming_error.html:19
 msgid ""
 "Ensure that PostgreSQL version 12 or later is in use. You can check this by "
 "connecting to the database using NetBox's credentials and issuing a query "
 "for <code>SELECT VERSION()</code>."
 msgstr ""
 
-#: netbox/templates/extras/configcontext.html:45
-#: netbox/templates/extras/configtemplate.html:37
-#: netbox/templates/extras/exporttemplate.html:51
+#: templates/extras/configcontext.html:45
+#: templates/extras/configtemplate.html:37
+#: templates/extras/exporttemplate.html:51
 msgid "The data file associated with this object has been deleted"
 msgstr ""
 
-#: netbox/templates/extras/configcontext.html:54
-#: netbox/templates/extras/configtemplate.html:46
-#: netbox/templates/extras/exporttemplate.html:60
+#: templates/extras/configcontext.html:54
+#: templates/extras/configtemplate.html:46
+#: templates/extras/exporttemplate.html:60
 msgid "Data Synced"
 msgstr ""
 
-#: netbox/templates/extras/configcontext_list.html:7
-#: netbox/templates/extras/configtemplate_list.html:7
-#: netbox/templates/extras/exporttemplate_list.html:7
+#: templates/extras/configcontext_list.html:7
+#: templates/extras/configtemplate_list.html:7
+#: templates/extras/exporttemplate_list.html:7
 msgid "Sync Data"
 msgstr ""
 
-#: netbox/templates/extras/configtemplate.html:56
+#: templates/extras/configtemplate.html:56
 msgid "Environment Parameters"
 msgstr ""
 
-#: netbox/templates/extras/configtemplate.html:67
-#: netbox/templates/extras/exporttemplate.html:79
+#: templates/extras/configtemplate.html:67
+#: templates/extras/exporttemplate.html:79
 msgid "Template"
 msgstr ""
 
-#: netbox/templates/extras/customfield.html:30
-#: netbox/templates/extras/customlink.html:21
+#: templates/extras/customfield.html:30 templates/extras/customlink.html:21
 msgid "Group Name"
 msgstr ""
 
-#: netbox/templates/extras/customfield.html:42
+#: templates/extras/customfield.html:42
 msgid "Must be Unique"
 msgstr ""
 
-#: netbox/templates/extras/customfield.html:46
+#: templates/extras/customfield.html:46
 msgid "Cloneable"
 msgstr ""
 
-#: netbox/templates/extras/customfield.html:56
+#: templates/extras/customfield.html:56
 msgid "Default Value"
 msgstr ""
 
-#: netbox/templates/extras/customfield.html:73
+#: templates/extras/customfield.html:73
 msgid "Search Weight"
 msgstr ""
 
-#: netbox/templates/extras/customfield.html:83
+#: templates/extras/customfield.html:83
 msgid "Filter Logic"
 msgstr ""
 
-#: netbox/templates/extras/customfield.html:87
+#: templates/extras/customfield.html:87
 msgid "Display Weight"
 msgstr ""
 
-#: netbox/templates/extras/customfield.html:91
+#: templates/extras/customfield.html:91
 msgid "UI Visible"
 msgstr ""
 
-#: netbox/templates/extras/customfield.html:95
+#: templates/extras/customfield.html:95
 msgid "UI Editable"
 msgstr ""
 
-#: netbox/templates/extras/customfield.html:115
+#: templates/extras/customfield.html:115
 msgid "Validation Rules"
 msgstr ""
 
-#: netbox/templates/extras/customfield.html:126
+#: templates/extras/customfield.html:126
 msgid "Regular Expression"
 msgstr ""
 
-#: netbox/templates/extras/customlink.html:29
+#: templates/extras/customlink.html:29
 msgid "Button Class"
 msgstr ""
 
-#: netbox/templates/extras/customlink.html:39
-#: netbox/templates/extras/exporttemplate.html:66
-#: netbox/templates/extras/savedfilter.html:39
+#: templates/extras/customlink.html:39 templates/extras/exporttemplate.html:66
+#: templates/extras/savedfilter.html:39
 msgid "Assigned Models"
 msgstr ""
 
-#: netbox/templates/extras/customlink.html:52
+#: templates/extras/customlink.html:52
 msgid "Link Text"
 msgstr ""
 
-#: netbox/templates/extras/customlink.html:58
+#: templates/extras/customlink.html:58
 msgid "Link URL"
 msgstr ""
 
-#: netbox/templates/extras/dashboard/reset.html:4 netbox/templates/home.html:66
+#: templates/extras/dashboard/reset.html:4 templates/home.html:66
 msgid "Reset Dashboard"
 msgstr ""
 
-#: netbox/templates/extras/dashboard/reset.html:8
+#: templates/extras/dashboard/reset.html:8
 msgid ""
 "This will remove <strong>all</strong> configured widgets and restore the "
 "default dashboard configuration."
 msgstr ""
 
-#: netbox/templates/extras/dashboard/reset.html:13
+#: templates/extras/dashboard/reset.html:13
 msgid ""
 "This change affects only <i>your</i> dashboard, and will not impact other "
 "users."
 msgstr ""
 
-#: netbox/templates/extras/dashboard/widget.html:21
+#: templates/extras/dashboard/widget.html:21
 msgid "widget configuration"
 msgstr ""
 
-#: netbox/templates/extras/dashboard/widget.html:36
+#: templates/extras/dashboard/widget.html:36
 msgid "Close widget"
 msgstr ""
 
-#: netbox/templates/extras/dashboard/widget_add.html:7
+#: templates/extras/dashboard/widget_add.html:7
 msgid "Add a Widget"
 msgstr ""
 
-#: netbox/templates/extras/dashboard/widgets/bookmarks.html:14
+#: templates/extras/dashboard/widgets/bookmarks.html:14
 msgid "No bookmarks have been added yet."
 msgstr ""
 
-#: netbox/templates/extras/dashboard/widgets/objectcounts.html:10
+#: templates/extras/dashboard/widgets/objectcounts.html:10
 msgid "No permission"
 msgstr ""
 
-#: netbox/templates/extras/dashboard/widgets/objectlist.html:6
+#: templates/extras/dashboard/widgets/objectlist.html:6
 msgid "No permission to view this content"
 msgstr ""
 
-#: netbox/templates/extras/dashboard/widgets/objectlist.html:10
+#: templates/extras/dashboard/widgets/objectlist.html:10
 msgid "Unable to load content. Invalid view name"
 msgstr ""
 
-#: netbox/templates/extras/dashboard/widgets/rssfeed.html:12
+#: templates/extras/dashboard/widgets/rssfeed.html:12
 msgid "No content found"
 msgstr ""
 
-#: netbox/templates/extras/dashboard/widgets/rssfeed.html:18
+#: templates/extras/dashboard/widgets/rssfeed.html:18
 msgid "There was a problem fetching the RSS feed"
 msgstr ""
 
-#: netbox/templates/extras/dashboard/widgets/rssfeed.html:21
+#: templates/extras/dashboard/widgets/rssfeed.html:21
 msgid "HTTP"
 msgstr ""
 
-#: netbox/templates/extras/eventrule.html:61
+#: templates/extras/eventrule.html:61
 msgid "Conditions"
 msgstr ""
 
-#: netbox/templates/extras/exporttemplate.html:23
+#: templates/extras/exporttemplate.html:23
 msgid "MIME Type"
 msgstr ""
 
-#: netbox/templates/extras/exporttemplate.html:27
+#: templates/extras/exporttemplate.html:27
 msgid "File Extension"
 msgstr ""
 
-#: netbox/templates/extras/htmx/script_result.html:10
+#: templates/extras/htmx/script_result.html:10
 msgid "Scheduled for"
 msgstr ""
 
-#: netbox/templates/extras/htmx/script_result.html:15
+#: templates/extras/htmx/script_result.html:15
 msgid "Duration"
 msgstr ""
 
-#: netbox/templates/extras/htmx/script_result.html:23
+#: templates/extras/htmx/script_result.html:23
 msgid "Test Summary"
 msgstr ""
 
-#: netbox/templates/extras/htmx/script_result.html:43
+#: templates/extras/htmx/script_result.html:43
 msgid "Log"
 msgstr ""
 
-#: netbox/templates/extras/htmx/script_result.html:56
+#: templates/extras/htmx/script_result.html:56
 msgid "Output"
 msgstr ""
 
-#: netbox/templates/extras/inc/result_pending.html:4
+#: templates/extras/inc/result_pending.html:4
 msgid "Loading"
 msgstr ""
 
-#: netbox/templates/extras/inc/result_pending.html:6
+#: templates/extras/inc/result_pending.html:6
 msgid "Results pending"
 msgstr ""
 
-#: netbox/templates/extras/journalentry.html:15
+#: templates/extras/journalentry.html:15
 msgid "Journal Entry"
 msgstr ""
 
-#: netbox/templates/extras/notificationgroup.html:11
+#: templates/extras/notificationgroup.html:11
 msgid "Notification Group"
 msgstr ""
 
-#: netbox/templates/extras/notificationgroup.html:36
-#: netbox/templates/extras/notificationgroup.html:46
-#: netbox/utilities/templates/widgets/clearable_file_input.html:12
+#: templates/extras/notificationgroup.html:36
+#: templates/extras/notificationgroup.html:46
+#: utilities/templates/widgets/clearable_file_input.html:12
 msgid "None assigned"
 msgstr ""
 
-#: netbox/templates/extras/object_configcontext.html:19
+#: templates/extras/object_configcontext.html:19
 msgid "The local config context overwrites all source contexts"
 msgstr ""
 
-#: netbox/templates/extras/object_configcontext.html:25
+#: templates/extras/object_configcontext.html:25
 msgid "Source Contexts"
 msgstr ""
 
-#: netbox/templates/extras/object_journal.html:17
+#: templates/extras/object_journal.html:17
 msgid "New Journal Entry"
 msgstr ""
 
-#: netbox/templates/extras/report/base.html:30
+#: templates/extras/report/base.html:30
 msgid "Report"
 msgstr ""
 
-#: netbox/templates/extras/script.html:14
+#: templates/extras/script.html:14
 msgid "You do not have permission to run scripts"
 msgstr ""
 
-#: netbox/templates/extras/script.html:41
-#: netbox/templates/extras/script.html:45
-#: netbox/templates/extras/script_list.html:86
+#: templates/extras/script.html:41 templates/extras/script.html:45
+#: templates/extras/script_list.html:86
 msgid "Run Script"
 msgstr ""
 
-#: netbox/templates/extras/script.html:51
-#: netbox/templates/extras/script/source.html:10
+#: templates/extras/script.html:51 templates/extras/script/source.html:10
 msgid "Error loading script"
 msgstr ""
 
-#: netbox/templates/extras/script/jobs.html:16
+#: templates/extras/script/jobs.html:16
 msgid "Script no longer exists in the source file."
 msgstr ""
 
-#: netbox/templates/extras/script_list.html:46
+#: templates/extras/script_list.html:46
 msgid "Last Run"
 msgstr ""
 
-#: netbox/templates/extras/script_list.html:61
+#: templates/extras/script_list.html:61
 msgid "Script is no longer present in the source file"
 msgstr ""
 
-#: netbox/templates/extras/script_list.html:74
+#: templates/extras/script_list.html:74
 msgid "Never"
 msgstr ""
 
-#: netbox/templates/extras/script_list.html:84
+#: templates/extras/script_list.html:84
 msgid "Run Again"
 msgstr ""
 
-#: netbox/templates/extras/script_list.html:138
+#: templates/extras/script_list.html:138
 msgid "No Scripts Found"
 msgstr ""
 
-#: netbox/templates/extras/script_list.html:141
+#: templates/extras/script_list.html:141
 #, python-format
 msgid ""
 "Get started by <a href=\"%(create_script_url)s\">creating a script</a> from "
 "an uploaded file or data source."
 msgstr ""
 
-#: netbox/templates/extras/script_result.html:35
-#: netbox/templates/generic/object_list.html:50 netbox/templates/search.html:13
+#: templates/extras/script_result.html:35 templates/generic/object_list.html:50
+#: templates/search.html:13
 msgid "Results"
 msgstr ""
 
-#: netbox/templates/extras/script_result.html:46
+#: templates/extras/script_result.html:46
 msgid "Log threshold"
 msgstr ""
 
-#: netbox/templates/extras/script_result.html:56
+#: templates/extras/script_result.html:56
 msgid "All"
 msgstr ""
 
-#: netbox/templates/extras/tag.html:32
+#: templates/extras/tag.html:32
 msgid "Tagged Items"
 msgstr ""
 
-#: netbox/templates/extras/tag.html:43
+#: templates/extras/tag.html:43
 msgid "Allowed Object Types"
 msgstr ""
 
-#: netbox/templates/extras/tag.html:51
+#: templates/extras/tag.html:51
 msgid "Any"
 msgstr ""
 
-#: netbox/templates/extras/tag.html:57
+#: templates/extras/tag.html:57
 msgid "Tagged Item Types"
 msgstr ""
 
-#: netbox/templates/extras/tag.html:81
+#: templates/extras/tag.html:81
 msgid "Tagged Objects"
 msgstr ""
 
-#: netbox/templates/extras/webhook.html:26
+#: templates/extras/webhook.html:26
 msgid "HTTP Method"
 msgstr ""
 
-#: netbox/templates/extras/webhook.html:34
+#: templates/extras/webhook.html:34
 msgid "HTTP Content Type"
 msgstr ""
 
-#: netbox/templates/extras/webhook.html:47
+#: templates/extras/webhook.html:47
 msgid "SSL Verification"
 msgstr ""
 
-#: netbox/templates/extras/webhook.html:60
+#: templates/extras/webhook.html:60
 msgid "Additional Headers"
 msgstr ""
 
-#: netbox/templates/extras/webhook.html:70
+#: templates/extras/webhook.html:70
 msgid "Body Template"
 msgstr ""
 
-#: netbox/templates/generic/bulk_add_component.html:29
+#: templates/generic/bulk_add_component.html:29
 msgid "Bulk Creation"
 msgstr ""
 
-#: netbox/templates/generic/bulk_add_component.html:34
-#: netbox/templates/generic/bulk_delete.html:32
-#: netbox/templates/generic/bulk_edit.html:33
+#: templates/generic/bulk_add_component.html:34
+#: templates/generic/bulk_delete.html:32 templates/generic/bulk_edit.html:33
 msgid "Selected Objects"
 msgstr ""
 
-#: netbox/templates/generic/bulk_add_component.html:58
+#: templates/generic/bulk_add_component.html:58
 msgid "to Add"
 msgstr ""
 
-#: netbox/templates/generic/bulk_delete.html:27
+#: templates/generic/bulk_delete.html:27
 msgid "Bulk Delete"
 msgstr ""
 
-#: netbox/templates/generic/bulk_delete.html:49
+#: templates/generic/bulk_delete.html:49
 msgid "Confirm Bulk Deletion"
 msgstr ""
 
-#: netbox/templates/generic/bulk_delete.html:50
+#: templates/generic/bulk_delete.html:50
 #, python-format
 msgid ""
 "The following operation will delete <strong>%(count)s</strong> "
@@ -13140,82 +12480,79 @@ msgid ""
 "this action."
 msgstr ""
 
-#: netbox/templates/generic/bulk_edit.html:21
-#: netbox/templates/generic/object_edit.html:22
+#: templates/generic/bulk_edit.html:21 templates/generic/object_edit.html:22
 msgid "Editing"
 msgstr ""
 
-#: netbox/templates/generic/bulk_edit.html:28
+#: templates/generic/bulk_edit.html:28
 msgid "Bulk Edit"
 msgstr ""
 
-#: netbox/templates/generic/bulk_edit.html:107
-#: netbox/templates/generic/bulk_rename.html:66
+#: templates/generic/bulk_edit.html:107 templates/generic/bulk_rename.html:66
 msgid "Apply"
 msgstr ""
 
-#: netbox/templates/generic/bulk_import.html:19
+#: templates/generic/bulk_import.html:19
 msgid "Bulk Import"
 msgstr ""
 
-#: netbox/templates/generic/bulk_import.html:25
+#: templates/generic/bulk_import.html:25
 msgid "Direct Import"
 msgstr ""
 
-#: netbox/templates/generic/bulk_import.html:30
+#: templates/generic/bulk_import.html:30
 msgid "Upload File"
 msgstr ""
 
-#: netbox/templates/generic/bulk_import.html:58
-#: netbox/templates/generic/bulk_import.html:80
-#: netbox/templates/generic/bulk_import.html:102
+#: templates/generic/bulk_import.html:58 templates/generic/bulk_import.html:80
+#: templates/generic/bulk_import.html:102
 msgid "Submit"
 msgstr ""
 
-#: netbox/templates/generic/bulk_import.html:113
+#: templates/generic/bulk_import.html:113
 msgid "Field Options"
 msgstr ""
 
-#: netbox/templates/generic/bulk_import.html:119
+#: templates/generic/bulk_import.html:119
 msgid "Accessor"
 msgstr ""
 
-#: netbox/templates/generic/bulk_import.html:148
+#: templates/generic/bulk_import.html:148
 msgid "choices"
 msgstr ""
 
-#: netbox/templates/generic/bulk_import.html:161
+#: templates/generic/bulk_import.html:161
 msgid "Import Value"
 msgstr ""
 
-#: netbox/templates/generic/bulk_import.html:181
+#: templates/generic/bulk_import.html:181
 msgid "Format: YYYY-MM-DD"
 msgstr ""
 
-#: netbox/templates/generic/bulk_import.html:183
+#: templates/generic/bulk_import.html:183
 msgid "Specify true or false"
 msgstr ""
 
-#: netbox/templates/generic/bulk_import.html:195
+#: templates/generic/bulk_import.html:195
 msgid "Required fields <strong>must</strong> be specified for all objects."
 msgstr ""
 
-#: netbox/templates/generic/bulk_import.html:201
+#: templates/generic/bulk_import.html:201
 #, python-format
 msgid ""
 "Related objects may be referenced by any unique attribute. For example, "
 "<code>%(example)s</code> would identify a VRF by its route distinguisher."
 msgstr ""
 
-#: netbox/templates/generic/bulk_remove.html:28
+#: templates/generic/bulk_remove.html:28
 msgid "Bulk Remove"
 msgstr ""
 
-#: netbox/templates/generic/bulk_remove.html:42
+#: templates/generic/bulk_remove.html:42
 msgid "Confirm Bulk Removal"
 msgstr ""
 
-#: netbox/templates/generic/bulk_remove.html:43
+#: templates/generic/bulk_remove.html:43
 #, python-format
 msgid ""
 "The following operation will remove %(count)s %(obj_type_plural)s from "
@@ -13223,442 +12560,440 @@ msgid ""
 "removed and confirm below."
 msgstr ""
 
-#: netbox/templates/generic/bulk_remove.html:64
+#: templates/generic/bulk_remove.html:64
 #, python-format
 msgid "Remove these %(count)s %(obj_type_plural)s"
 msgstr ""
 
-#: netbox/templates/generic/bulk_rename.html:20
+#: templates/generic/bulk_rename.html:20
 msgid "Renaming"
 msgstr ""
 
-#: netbox/templates/generic/bulk_rename.html:27
+#: templates/generic/bulk_rename.html:27
 msgid "Bulk Rename"
 msgstr ""
 
-#: netbox/templates/generic/bulk_rename.html:39
+#: templates/generic/bulk_rename.html:39
 msgid "Current Name"
 msgstr ""
 
-#: netbox/templates/generic/bulk_rename.html:40
+#: templates/generic/bulk_rename.html:40
 msgid "New Name"
 msgstr ""
 
-#: netbox/templates/generic/bulk_rename.html:64
-#: netbox/utilities/templates/widgets/markdown_input.html:11
+#: templates/generic/bulk_rename.html:64
+#: utilities/templates/widgets/markdown_input.html:11
 msgid "Preview"
 msgstr ""
 
-#: netbox/templates/generic/confirmation_form.html:16
+#: templates/generic/confirmation_form.html:16
 msgid "Are you sure"
 msgstr ""
 
-#: netbox/templates/generic/confirmation_form.html:20
+#: templates/generic/confirmation_form.html:20
 msgid "Confirm"
 msgstr ""
 
-#: netbox/templates/generic/object_children.html:47
-#: netbox/utilities/templates/buttons/bulk_edit.html:4
+#: templates/generic/object_children.html:47
+#: utilities/templates/buttons/bulk_edit.html:4
 msgid "Edit Selected"
 msgstr ""
 
-#: netbox/templates/generic/object_children.html:61
-#: netbox/utilities/templates/buttons/bulk_delete.html:4
+#: templates/generic/object_children.html:61
+#: utilities/templates/buttons/bulk_delete.html:4
 msgid "Delete Selected"
 msgstr ""
 
-#: netbox/templates/generic/object_edit.html:24
+#: templates/generic/object_edit.html:24
 #, python-format
 msgid "Add a new %(object_type)s"
 msgstr ""
 
-#: netbox/templates/generic/object_edit.html:35
+#: templates/generic/object_edit.html:35
 msgid "View model documentation"
 msgstr ""
 
-#: netbox/templates/generic/object_edit.html:36
+#: templates/generic/object_edit.html:36
 msgid "Help"
 msgstr ""
 
-#: netbox/templates/generic/object_edit.html:83
+#: templates/generic/object_edit.html:83
 msgid "Create & Add Another"
 msgstr ""
 
-#: netbox/templates/generic/object_list.html:57
+#: templates/generic/object_list.html:57
 msgid "Filters"
 msgstr ""
 
-#: netbox/templates/generic/object_list.html:88
+#: templates/generic/object_list.html:88
 #, python-format
 msgid ""
 "Select <strong>all <span class=\"total-object-count\">%(count)s</span> "
 "%(object_type_plural)s</strong> matching query"
 msgstr ""
 
-#: netbox/templates/home.html:15
+#: templates/home.html:15
 msgid "New Release Available"
 msgstr ""
 
-#: netbox/templates/home.html:16
+#: templates/home.html:16
 msgid "is available"
 msgstr ""
 
-#: netbox/templates/home.html:18
+#: templates/home.html:18
 msgctxt "Document title"
 msgid "Upgrade Instructions"
 msgstr ""
 
-#: netbox/templates/home.html:40
+#: templates/home.html:40
 msgid "Unlock Dashboard"
 msgstr ""
 
-#: netbox/templates/home.html:49
+#: templates/home.html:49
 msgid "Lock Dashboard"
 msgstr ""
 
-#: netbox/templates/home.html:60
+#: templates/home.html:60
 msgid "Add Widget"
 msgstr ""
 
-#: netbox/templates/home.html:63
+#: templates/home.html:63
 msgid "Save Layout"
 msgstr ""
 
-#: netbox/templates/htmx/delete_form.html:7
+#: templates/htmx/delete_form.html:7
 msgid "Confirm Deletion"
 msgstr ""
 
-#: netbox/templates/htmx/delete_form.html:11
+#: templates/htmx/delete_form.html:11
 #, python-format
 msgid ""
 "Are you sure you want to <strong class=\"text-danger\">delete</strong> "
 "%(object_type)s <strong>%(object)s</strong>?"
 msgstr ""
 
-#: netbox/templates/htmx/delete_form.html:17
+#: templates/htmx/delete_form.html:17
 msgid "The following objects will be deleted as a result of this action."
 msgstr ""
 
-#: netbox/templates/htmx/notifications.html:15
+#: templates/htmx/notifications.html:15
 msgid "ago"
 msgstr ""
 
-#: netbox/templates/htmx/notifications.html:26
+#: templates/htmx/notifications.html:26
 msgid "No unread notifications"
 msgstr ""
 
-#: netbox/templates/htmx/notifications.html:31
+#: templates/htmx/notifications.html:31
 msgid "All notifications"
 msgstr ""
 
-#: netbox/templates/htmx/object_selector.html:5
+#: templates/htmx/object_selector.html:5
 msgid "Select"
 msgstr ""
 
-#: netbox/templates/inc/filter_list.html:43
-#: netbox/utilities/templates/helpers/table_config_form.html:39
+#: templates/inc/filter_list.html:43
+#: utilities/templates/helpers/table_config_form.html:39
 msgid "Reset"
 msgstr ""
 
-#: netbox/templates/inc/light_toggle.html:4
+#: templates/inc/light_toggle.html:4
 msgid "Enable dark mode"
 msgstr ""
 
-#: netbox/templates/inc/light_toggle.html:7
+#: templates/inc/light_toggle.html:7
 msgid "Enable light mode"
 msgstr ""
 
-#: netbox/templates/inc/missing_prerequisites.html:8
+#: templates/inc/missing_prerequisites.html:8
 #, python-format
 msgid ""
 "Before you can add a %(model)s you must first create a "
 "<strong>%(prerequisite_model)s</strong>."
 msgstr ""
 
-#: netbox/templates/inc/paginator.html:15
+#: templates/inc/paginator.html:15
 msgid "Page selection"
 msgstr ""
 
-#: netbox/templates/inc/paginator.html:75
+#: templates/inc/paginator.html:75
 #, python-format
 msgid "Showing %(start)s-%(end)s of %(total)s"
 msgstr ""
 
-#: netbox/templates/inc/paginator.html:82
+#: templates/inc/paginator.html:82
 msgid "Pagination options"
 msgstr ""
 
-#: netbox/templates/inc/paginator.html:86
+#: templates/inc/paginator.html:86
 msgid "Per Page"
 msgstr ""
 
-#: netbox/templates/inc/panels/image_attachments.html:10
+#: templates/inc/panels/image_attachments.html:10
 msgid "Attach an image"
 msgstr ""
 
-#: netbox/templates/inc/panels/related_objects.html:5
+#: templates/inc/panels/related_objects.html:5
 msgid "Related Objects"
 msgstr ""
 
-#: netbox/templates/inc/panels/tags.html:11
+#: templates/inc/panels/tags.html:11
 msgid "No tags assigned"
 msgstr ""
 
-#: netbox/templates/inc/sync_warning.html:10
+#: templates/inc/sync_warning.html:10
 msgid "Data is out of sync with upstream file"
 msgstr ""
 
-#: netbox/templates/inc/table_controls_htmx.html:7
+#: templates/inc/table_controls_htmx.html:7
 msgid "Quick search"
 msgstr ""
 
-#: netbox/templates/inc/table_controls_htmx.html:20
+#: templates/inc/table_controls_htmx.html:20
 msgid "Saved filter"
 msgstr ""
 
-#: netbox/templates/inc/table_htmx.html:18
+#: templates/inc/table_htmx.html:18
 msgid "Clear ordering"
 msgstr ""
 
-#: netbox/templates/inc/user_menu.html:6
+#: templates/inc/user_menu.html:6
 msgid "Help center"
 msgstr ""
 
-#: netbox/templates/inc/user_menu.html:41
+#: templates/inc/user_menu.html:41
 msgid "Django Admin"
 msgstr ""
 
-#: netbox/templates/inc/user_menu.html:61
+#: templates/inc/user_menu.html:61
 msgid "Log Out"
 msgstr ""
 
-#: netbox/templates/inc/user_menu.html:68 netbox/templates/login.html:38
+#: templates/inc/user_menu.html:68 templates/login.html:38
 msgid "Log In"
 msgstr ""
 
-#: netbox/templates/ipam/aggregate.html:14
-#: netbox/templates/ipam/ipaddress.html:14
-#: netbox/templates/ipam/iprange.html:13 netbox/templates/ipam/prefix.html:15
+#: templates/ipam/aggregate.html:14 templates/ipam/ipaddress.html:14
+#: templates/ipam/iprange.html:13 templates/ipam/prefix.html:15
 msgid "Family"
 msgstr ""
 
-#: netbox/templates/ipam/aggregate.html:39
+#: templates/ipam/aggregate.html:39
 msgid "Date Added"
 msgstr ""
 
-#: netbox/templates/ipam/aggregate/prefixes.html:8
-#: netbox/templates/ipam/prefix/prefixes.html:8
-#: netbox/templates/ipam/role.html:10
+#: templates/ipam/aggregate/prefixes.html:8
+#: templates/ipam/prefix/prefixes.html:8 templates/ipam/role.html:10
 msgid "Add Prefix"
 msgstr ""
 
-#: netbox/templates/ipam/asn.html:23
+#: templates/ipam/asn.html:23
 msgid "AS Number"
 msgstr ""
 
-#: netbox/templates/ipam/fhrpgroup.html:52
+#: templates/ipam/fhrpgroup.html:52
 msgid "Authentication Type"
 msgstr ""
 
-#: netbox/templates/ipam/fhrpgroup.html:56
+#: templates/ipam/fhrpgroup.html:56
 msgid "Authentication Key"
 msgstr ""
 
-#: netbox/templates/ipam/fhrpgroup.html:69
+#: templates/ipam/fhrpgroup.html:69
 msgid "Virtual IP Addresses"
 msgstr ""
 
-#: netbox/templates/ipam/inc/ipaddress_edit_header.html:13
+#: templates/ipam/inc/ipaddress_edit_header.html:13
 msgid "Assign IP"
 msgstr ""
 
-#: netbox/templates/ipam/inc/ipaddress_edit_header.html:19
+#: templates/ipam/inc/ipaddress_edit_header.html:19
 msgid "Bulk Create"
 msgstr ""
 
-#: netbox/templates/ipam/inc/panels/fhrp_groups.html:10
+#: templates/ipam/inc/panels/fhrp_groups.html:10
 msgid "Create Group"
 msgstr ""
 
-#: netbox/templates/ipam/inc/panels/fhrp_groups.html:25
+#: templates/ipam/inc/panels/fhrp_groups.html:25
 msgid "Virtual IPs"
 msgstr ""
 
-#: netbox/templates/ipam/inc/toggle_available.html:7
+#: templates/ipam/inc/toggle_available.html:7
 msgid "Show Assigned"
 msgstr ""
 
-#: netbox/templates/ipam/inc/toggle_available.html:10
+#: templates/ipam/inc/toggle_available.html:10
 msgid "Show Available"
 msgstr ""
 
-#: netbox/templates/ipam/inc/toggle_available.html:13
+#: templates/ipam/inc/toggle_available.html:13
 msgid "Show All"
 msgstr ""
 
-#: netbox/templates/ipam/ipaddress.html:23
-#: netbox/templates/ipam/iprange.html:45 netbox/templates/ipam/prefix.html:24
+#: templates/ipam/ipaddress.html:23 templates/ipam/iprange.html:45
+#: templates/ipam/prefix.html:24
 msgid "Global"
 msgstr ""
 
-#: netbox/templates/ipam/ipaddress.html:85
+#: templates/ipam/ipaddress.html:85
 msgid "NAT (outside)"
 msgstr ""
 
-#: netbox/templates/ipam/ipaddress_assign.html:8
+#: templates/ipam/ipaddress_assign.html:8
 msgid "Assign an IP Address"
 msgstr ""
 
-#: netbox/templates/ipam/ipaddress_assign.html:22
+#: templates/ipam/ipaddress_assign.html:22
 msgid "Select IP Address"
 msgstr ""
 
-#: netbox/templates/ipam/ipaddress_assign.html:35
+#: templates/ipam/ipaddress_assign.html:35
 msgid "Search Results"
 msgstr ""
 
-#: netbox/templates/ipam/ipaddress_bulk_add.html:6
+#: templates/ipam/ipaddress_bulk_add.html:6
 msgid "Bulk Add IP Addresses"
 msgstr ""
 
-#: netbox/templates/ipam/iprange.html:17
+#: templates/ipam/iprange.html:17
 msgid "Starting Address"
 msgstr ""
 
-#: netbox/templates/ipam/iprange.html:21
+#: templates/ipam/iprange.html:21
 msgid "Ending Address"
 msgstr ""
 
-#: netbox/templates/ipam/iprange.html:33 netbox/templates/ipam/prefix.html:110
+#: templates/ipam/iprange.html:33 templates/ipam/prefix.html:110
 msgid "Marked fully utilized"
 msgstr ""
 
-#: netbox/templates/ipam/prefix.html:99
+#: templates/ipam/prefix.html:99
 msgid "Addressing Details"
 msgstr ""
 
-#: netbox/templates/ipam/prefix.html:118
+#: templates/ipam/prefix.html:118
 msgid "Child IPs"
 msgstr ""
 
-#: netbox/templates/ipam/prefix.html:126
+#: templates/ipam/prefix.html:126
 msgid "Available IPs"
 msgstr ""
 
-#: netbox/templates/ipam/prefix.html:138
+#: templates/ipam/prefix.html:138
 msgid "First available IP"
 msgstr ""
 
-#: netbox/templates/ipam/prefix.html:179
+#: templates/ipam/prefix.html:179
 msgid "Prefix Details"
 msgstr ""
 
-#: netbox/templates/ipam/prefix.html:185
+#: templates/ipam/prefix.html:185
 msgid "Network Address"
 msgstr ""
 
-#: netbox/templates/ipam/prefix.html:189
+#: templates/ipam/prefix.html:189
 msgid "Network Mask"
 msgstr ""
 
-#: netbox/templates/ipam/prefix.html:193
+#: templates/ipam/prefix.html:193
 msgid "Wildcard Mask"
 msgstr ""
 
-#: netbox/templates/ipam/prefix.html:197
+#: templates/ipam/prefix.html:197
 msgid "Broadcast Address"
 msgstr ""
 
-#: netbox/templates/ipam/prefix/ip_ranges.html:7
+#: templates/ipam/prefix/ip_ranges.html:7
 msgid "Add IP Range"
 msgstr ""
 
-#: netbox/templates/ipam/prefix_list.html:7
+#: templates/ipam/prefix_list.html:7
 msgid "Hide Depth Indicators"
 msgstr ""
 
-#: netbox/templates/ipam/prefix_list.html:11
+#: templates/ipam/prefix_list.html:11
 msgid "Max Depth"
 msgstr ""
 
-#: netbox/templates/ipam/prefix_list.html:28
+#: templates/ipam/prefix_list.html:28
 msgid "Max Length"
 msgstr ""
 
-#: netbox/templates/ipam/rir.html:10
+#: templates/ipam/rir.html:10
 msgid "Add Aggregate"
 msgstr ""
 
-#: netbox/templates/ipam/routetarget.html:38
+#: templates/ipam/routetarget.html:38
 msgid "Importing VRFs"
 msgstr ""
 
-#: netbox/templates/ipam/routetarget.html:44
+#: templates/ipam/routetarget.html:44
 msgid "Exporting VRFs"
 msgstr ""
 
-#: netbox/templates/ipam/routetarget.html:52
+#: templates/ipam/routetarget.html:52
 msgid "Importing L2VPNs"
 msgstr ""
 
-#: netbox/templates/ipam/routetarget.html:58
+#: templates/ipam/routetarget.html:58
 msgid "Exporting L2VPNs"
 msgstr ""
 
-#: netbox/templates/ipam/vlan.html:88
+#: templates/ipam/vlan.html:88
 msgid "Add a Prefix"
 msgstr ""
 
-#: netbox/templates/ipam/vlangroup.html:18
+#: templates/ipam/vlangroup.html:18
 msgid "Add VLAN"
 msgstr ""
 
-#: netbox/templates/ipam/vrf.html:16
+#: templates/ipam/vrf.html:16
 msgid "Route Distinguisher"
 msgstr ""
 
-#: netbox/templates/ipam/vrf.html:29
+#: templates/ipam/vrf.html:29
 msgid "Unique IP Space"
 msgstr ""
 
-#: netbox/templates/login.html:29
-#: netbox/utilities/templates/form_helpers/render_errors.html:7
+#: templates/login.html:29
+#: utilities/templates/form_helpers/render_errors.html:7
 msgid "Errors"
 msgstr ""
 
-#: netbox/templates/login.html:69
+#: templates/login.html:69
 msgid "Sign In"
 msgstr ""
 
-#: netbox/templates/login.html:77
+#: templates/login.html:77
 msgctxt "Denotes an alternative option"
 msgid "Or"
 msgstr ""
 
-#: netbox/templates/media_failure.html:7
+#: templates/media_failure.html:7
 msgid "Static Media Failure - NetBox"
 msgstr ""
 
-#: netbox/templates/media_failure.html:21
+#: templates/media_failure.html:21
 msgid "Static Media Failure"
 msgstr ""
 
-#: netbox/templates/media_failure.html:23
+#: templates/media_failure.html:23
 msgid "The following static media file failed to load"
 msgstr ""
 
-#: netbox/templates/media_failure.html:26
+#: templates/media_failure.html:26
 msgid "Check the following"
 msgstr ""
 
-#: netbox/templates/media_failure.html:29
+#: templates/media_failure.html:29
 msgid ""
 "<code>manage.py collectstatic</code> was run during the most recent upgrade. "
 "This installs the most recent iteration of each static file into the static "
 "root path."
 msgstr ""
 
-#: netbox/templates/media_failure.html:35
+#: templates/media_failure.html:35
 #, python-format
 msgid ""
 "The HTTP service (e.g. nginx or Apache) is configured to serve files from "
@@ -13666,1914 +13001,1879 @@ msgid ""
 "installation documentation</a> for further guidance."
 msgstr ""
 
-#: netbox/templates/media_failure.html:47
+#: templates/media_failure.html:47
 #, python-format
 msgid ""
 "The file <code>%(filename)s</code> exists in the static root directory and "
 "is readable by the HTTP server."
 msgstr ""
 
-#: netbox/templates/media_failure.html:55
+#: templates/media_failure.html:55
 #, python-format
 msgid ""
 "Click <a href=\"%(home_url)s\">here</a> to attempt loading NetBox again."
 msgstr ""
 
-#: netbox/templates/tenancy/contact.html:18 netbox/tenancy/filtersets.py:147
-#: netbox/tenancy/forms/bulk_edit.py:137 netbox/tenancy/forms/filtersets.py:102
-#: netbox/tenancy/forms/forms.py:56 netbox/tenancy/forms/model_forms.py:106
-#: netbox/tenancy/forms/model_forms.py:130 netbox/tenancy/tables/contacts.py:98
+#: templates/tenancy/contact.html:18 tenancy/filtersets.py:147
+#: tenancy/forms/bulk_edit.py:137 tenancy/forms/filtersets.py:102
+#: tenancy/forms/forms.py:56 tenancy/forms/model_forms.py:106
+#: tenancy/forms/model_forms.py:130 tenancy/tables/contacts.py:98
 msgid "Contact"
 msgstr ""
 
-#: netbox/templates/tenancy/contact.html:29
-#: netbox/tenancy/forms/bulk_edit.py:99
+#: templates/tenancy/contact.html:29 tenancy/forms/bulk_edit.py:99
 msgid "Title"
 msgstr ""
 
-#: netbox/templates/tenancy/contact.html:33
-#: netbox/tenancy/forms/bulk_edit.py:104 netbox/tenancy/tables/contacts.py:64
+#: templates/tenancy/contact.html:33 tenancy/forms/bulk_edit.py:104
+#: tenancy/tables/contacts.py:64
 msgid "Phone"
 msgstr ""
 
-#: netbox/templates/tenancy/contactgroup.html:18
-#: netbox/tenancy/forms/forms.py:66 netbox/tenancy/forms/model_forms.py:75
+#: templates/tenancy/contactgroup.html:18 tenancy/forms/forms.py:66
+#: tenancy/forms/model_forms.py:75
 msgid "Contact Group"
 msgstr ""
 
-#: netbox/templates/tenancy/contactgroup.html:50
+#: templates/tenancy/contactgroup.html:50
 msgid "Add Contact Group"
 msgstr ""
 
-#: netbox/templates/tenancy/contactrole.html:15
-#: netbox/tenancy/filtersets.py:152 netbox/tenancy/forms/forms.py:61
-#: netbox/tenancy/forms/model_forms.py:87
+#: templates/tenancy/contactrole.html:15 tenancy/filtersets.py:152
+#: tenancy/forms/forms.py:61 tenancy/forms/model_forms.py:87
 msgid "Contact Role"
 msgstr ""
 
-#: netbox/templates/tenancy/object_contacts.html:9
+#: templates/tenancy/object_contacts.html:9
 msgid "Add a contact"
 msgstr ""
 
-#: netbox/templates/tenancy/tenantgroup.html:17
+#: templates/tenancy/tenantgroup.html:17
 msgid "Add Tenant"
 msgstr ""
 
-#: netbox/templates/tenancy/tenantgroup.html:26
-#: netbox/tenancy/forms/model_forms.py:32 netbox/tenancy/tables/columns.py:51
-#: netbox/tenancy/tables/columns.py:61
+#: templates/tenancy/tenantgroup.html:26 tenancy/forms/model_forms.py:32
+#: tenancy/tables/columns.py:51 tenancy/tables/columns.py:61
 msgid "Tenant Group"
 msgstr ""
 
-#: netbox/templates/tenancy/tenantgroup.html:59
+#: templates/tenancy/tenantgroup.html:59
 msgid "Add Tenant Group"
 msgstr ""
 
-#: netbox/templates/users/group.html:39 netbox/templates/users/user.html:63
+#: templates/users/group.html:39 templates/users/user.html:63
 msgid "Assigned Permissions"
 msgstr ""
 
-#: netbox/templates/users/objectpermission.html:6
-#: netbox/templates/users/objectpermission.html:14
-#: netbox/users/forms/filtersets.py:66
+#: templates/users/objectpermission.html:6
+#: templates/users/objectpermission.html:14 users/forms/filtersets.py:66
 msgid "Permission"
 msgstr ""
 
-#: netbox/templates/users/objectpermission.html:34
+#: templates/users/objectpermission.html:34
 msgid "View"
 msgstr ""
 
-#: netbox/templates/users/objectpermission.html:52
-#: netbox/users/forms/model_forms.py:315
+#: templates/users/objectpermission.html:52 users/forms/model_forms.py:315
 msgid "Constraints"
 msgstr ""
 
-#: netbox/templates/users/objectpermission.html:72
+#: templates/users/objectpermission.html:72
 msgid "Assigned Users"
 msgstr ""
 
-#: netbox/templates/virtualization/cluster.html:52
+#: templates/virtualization/cluster.html:52
 msgid "Allocated Resources"
 msgstr ""
 
-#: netbox/templates/virtualization/cluster.html:55
-#: netbox/templates/virtualization/virtualmachine.html:125
+#: templates/virtualization/cluster.html:55
+#: templates/virtualization/virtualmachine.html:125
 msgid "Virtual CPUs"
 msgstr ""
 
-#: netbox/templates/virtualization/cluster.html:59
-#: netbox/templates/virtualization/virtualmachine.html:129
+#: templates/virtualization/cluster.html:59
+#: templates/virtualization/virtualmachine.html:129
 msgid "Memory"
 msgstr ""
 
-#: netbox/templates/virtualization/cluster.html:69
-#: netbox/templates/virtualization/virtualmachine.html:140
+#: templates/virtualization/cluster.html:69
+#: templates/virtualization/virtualmachine.html:140
 msgid "Disk Space"
 msgstr ""
 
-#: netbox/templates/virtualization/cluster/base.html:18
+#: templates/virtualization/cluster/base.html:18
 msgid "Add Virtual Machine"
 msgstr ""
 
-#: netbox/templates/virtualization/cluster/base.html:24
+#: templates/virtualization/cluster/base.html:24
 msgid "Assign Device"
 msgstr ""
 
-#: netbox/templates/virtualization/cluster/devices.html:10
+#: templates/virtualization/cluster/devices.html:10
 msgid "Remove Selected"
 msgstr ""
 
-#: netbox/templates/virtualization/cluster_add_devices.html:9
+#: templates/virtualization/cluster_add_devices.html:9
 #, python-format
 msgid "Add Device to Cluster %(cluster)s"
 msgstr ""
 
-#: netbox/templates/virtualization/cluster_add_devices.html:23
+#: templates/virtualization/cluster_add_devices.html:23
 msgid "Device Selection"
 msgstr ""
 
-#: netbox/templates/virtualization/cluster_add_devices.html:31
+#: templates/virtualization/cluster_add_devices.html:31
 msgid "Add Devices"
 msgstr ""
 
-#: netbox/templates/virtualization/clustergroup.html:10
-#: netbox/templates/virtualization/clustertype.html:10
+#: templates/virtualization/clustergroup.html:10
+#: templates/virtualization/clustertype.html:10
 msgid "Add Cluster"
 msgstr ""
 
-#: netbox/templates/virtualization/clustergroup.html:19
-#: netbox/virtualization/forms/model_forms.py:50
+#: templates/virtualization/clustergroup.html:19
+#: virtualization/forms/model_forms.py:50
 msgid "Cluster Group"
 msgstr ""
 
-#: netbox/templates/virtualization/clustertype.html:19
-#: netbox/templates/virtualization/virtualmachine.html:110
-#: netbox/virtualization/forms/model_forms.py:36
+#: templates/virtualization/clustertype.html:19
+#: templates/virtualization/virtualmachine.html:110
+#: virtualization/forms/model_forms.py:36
 msgid "Cluster Type"
 msgstr ""
 
-#: netbox/templates/virtualization/virtualdisk.html:18
+#: templates/virtualization/virtualdisk.html:18
 msgid "Virtual Disk"
 msgstr ""
 
-#: netbox/templates/virtualization/virtualmachine.html:122
-#: netbox/virtualization/forms/bulk_edit.py:190
-#: netbox/virtualization/forms/model_forms.py:224
+#: templates/virtualization/virtualmachine.html:122
+#: virtualization/forms/bulk_edit.py:190
+#: virtualization/forms/model_forms.py:224
 msgid "Resources"
 msgstr ""
 
-#: netbox/templates/virtualization/virtualmachine.html:178
+#: templates/virtualization/virtualmachine.html:178
 msgid "Add Virtual Disk"
 msgstr ""
 
-#: netbox/templates/vpn/ikepolicy.html:10
-#: netbox/templates/vpn/ipsecprofile.html:33 netbox/vpn/tables/crypto.py:166
+#: templates/vpn/ikepolicy.html:10 templates/vpn/ipsecprofile.html:33
+#: vpn/tables/crypto.py:166
 msgid "IKE Policy"
 msgstr ""
 
-#: netbox/templates/vpn/ikepolicy.html:21
+#: templates/vpn/ikepolicy.html:21
 msgid "IKE Version"
 msgstr ""
 
-#: netbox/templates/vpn/ikepolicy.html:29
+#: templates/vpn/ikepolicy.html:29
 msgid "Pre-Shared Key"
 msgstr ""
 
-#: netbox/templates/vpn/ikepolicy.html:33
-#: netbox/templates/wireless/inc/authentication_attrs.html:20
+#: templates/vpn/ikepolicy.html:33
+#: templates/wireless/inc/authentication_attrs.html:20
 msgid "Show Secret"
 msgstr ""
 
-#: netbox/templates/vpn/ikepolicy.html:57
-#: netbox/templates/vpn/ipsecpolicy.html:45
-#: netbox/templates/vpn/ipsecprofile.html:52
-#: netbox/templates/vpn/ipsecprofile.html:77
-#: netbox/vpn/forms/model_forms.py:316 netbox/vpn/forms/model_forms.py:352
-#: netbox/vpn/tables/crypto.py:68 netbox/vpn/tables/crypto.py:134
+#: templates/vpn/ikepolicy.html:57 templates/vpn/ipsecpolicy.html:45
+#: templates/vpn/ipsecprofile.html:52 templates/vpn/ipsecprofile.html:77
+#: vpn/forms/model_forms.py:316 vpn/forms/model_forms.py:352
+#: vpn/tables/crypto.py:68 vpn/tables/crypto.py:134
 msgid "Proposals"
 msgstr ""
 
-#: netbox/templates/vpn/ikeproposal.html:10
+#: templates/vpn/ikeproposal.html:10
 msgid "IKE Proposal"
 msgstr ""
 
-#: netbox/templates/vpn/ikeproposal.html:21 netbox/vpn/forms/bulk_edit.py:97
-#: netbox/vpn/forms/bulk_import.py:145 netbox/vpn/forms/filtersets.py:101
+#: templates/vpn/ikeproposal.html:21 vpn/forms/bulk_edit.py:97
+#: vpn/forms/bulk_import.py:145 vpn/forms/filtersets.py:101
 msgid "Authentication method"
 msgstr ""
 
-#: netbox/templates/vpn/ikeproposal.html:25
-#: netbox/templates/vpn/ipsecproposal.html:21 netbox/vpn/forms/bulk_edit.py:102
-#: netbox/vpn/forms/bulk_edit.py:172 netbox/vpn/forms/bulk_import.py:149
-#: netbox/vpn/forms/bulk_import.py:195 netbox/vpn/forms/filtersets.py:106
-#: netbox/vpn/forms/filtersets.py:154
+#: templates/vpn/ikeproposal.html:25 templates/vpn/ipsecproposal.html:21
+#: vpn/forms/bulk_edit.py:102 vpn/forms/bulk_edit.py:172
+#: vpn/forms/bulk_import.py:149 vpn/forms/bulk_import.py:195
+#: vpn/forms/filtersets.py:106 vpn/forms/filtersets.py:154
 msgid "Encryption algorithm"
 msgstr ""
 
-#: netbox/templates/vpn/ikeproposal.html:29
-#: netbox/templates/vpn/ipsecproposal.html:25 netbox/vpn/forms/bulk_edit.py:107
-#: netbox/vpn/forms/bulk_edit.py:177 netbox/vpn/forms/bulk_import.py:153
-#: netbox/vpn/forms/bulk_import.py:200 netbox/vpn/forms/filtersets.py:111
-#: netbox/vpn/forms/filtersets.py:159
+#: templates/vpn/ikeproposal.html:29 templates/vpn/ipsecproposal.html:25
+#: vpn/forms/bulk_edit.py:107 vpn/forms/bulk_edit.py:177
+#: vpn/forms/bulk_import.py:153 vpn/forms/bulk_import.py:200
+#: vpn/forms/filtersets.py:111 vpn/forms/filtersets.py:159
 msgid "Authentication algorithm"
 msgstr ""
 
-#: netbox/templates/vpn/ikeproposal.html:33
+#: templates/vpn/ikeproposal.html:33
 msgid "DH group"
 msgstr ""
 
-#: netbox/templates/vpn/ikeproposal.html:37
-#: netbox/templates/vpn/ipsecproposal.html:29 netbox/vpn/forms/bulk_edit.py:182
-#: netbox/vpn/models/crypto.py:146
+#: templates/vpn/ikeproposal.html:37 templates/vpn/ipsecproposal.html:29
+#: vpn/forms/bulk_edit.py:182 vpn/models/crypto.py:146
 msgid "SA lifetime (seconds)"
 msgstr ""
 
-#: netbox/templates/vpn/ipsecpolicy.html:10
-#: netbox/templates/vpn/ipsecprofile.html:66 netbox/vpn/tables/crypto.py:170
+#: templates/vpn/ipsecpolicy.html:10 templates/vpn/ipsecprofile.html:66
+#: vpn/tables/crypto.py:170
 msgid "IPSec Policy"
 msgstr ""
 
-#: netbox/templates/vpn/ipsecpolicy.html:21 netbox/vpn/forms/bulk_edit.py:210
-#: netbox/vpn/models/crypto.py:193
+#: templates/vpn/ipsecpolicy.html:21 vpn/forms/bulk_edit.py:210
+#: vpn/models/crypto.py:193
 msgid "PFS group"
 msgstr ""
 
-#: netbox/templates/vpn/ipsecprofile.html:10 netbox/vpn/forms/model_forms.py:54
+#: templates/vpn/ipsecprofile.html:10 vpn/forms/model_forms.py:54
 msgid "IPSec Profile"
 msgstr ""
 
-#: netbox/templates/vpn/ipsecprofile.html:89 netbox/vpn/tables/crypto.py:137
+#: templates/vpn/ipsecprofile.html:89 vpn/tables/crypto.py:137
 msgid "PFS Group"
 msgstr ""
 
-#: netbox/templates/vpn/ipsecproposal.html:10
+#: templates/vpn/ipsecproposal.html:10
 msgid "IPSec Proposal"
 msgstr ""
 
-#: netbox/templates/vpn/ipsecproposal.html:33 netbox/vpn/forms/bulk_edit.py:186
-#: netbox/vpn/models/crypto.py:152
+#: templates/vpn/ipsecproposal.html:33 vpn/forms/bulk_edit.py:186
+#: vpn/models/crypto.py:152
 msgid "SA lifetime (KB)"
 msgstr ""
 
-#: netbox/templates/vpn/l2vpn.html:11
-#: netbox/templates/vpn/l2vpntermination.html:9
+#: templates/vpn/l2vpn.html:11 templates/vpn/l2vpntermination.html:9
 msgid "L2VPN Attributes"
 msgstr ""
 
-#: netbox/templates/vpn/l2vpn.html:60 netbox/templates/vpn/tunnel.html:76
+#: templates/vpn/l2vpn.html:60 templates/vpn/tunnel.html:76
 msgid "Add a Termination"
 msgstr ""
 
-#: netbox/templates/vpn/tunnel.html:9
+#: templates/vpn/tunnel.html:9
 msgid "Add Termination"
 msgstr ""
 
-#: netbox/templates/vpn/tunnel.html:37 netbox/vpn/forms/bulk_edit.py:49
-#: netbox/vpn/forms/bulk_import.py:48 netbox/vpn/forms/filtersets.py:57
+#: templates/vpn/tunnel.html:37 vpn/forms/bulk_edit.py:49
+#: vpn/forms/bulk_import.py:48 vpn/forms/filtersets.py:57
 msgid "Encapsulation"
 msgstr ""
 
-#: netbox/templates/vpn/tunnel.html:41 netbox/vpn/forms/bulk_edit.py:55
-#: netbox/vpn/forms/bulk_import.py:53 netbox/vpn/forms/filtersets.py:64
-#: netbox/vpn/models/crypto.py:250 netbox/vpn/tables/tunnels.py:51
+#: templates/vpn/tunnel.html:41 vpn/forms/bulk_edit.py:55
+#: vpn/forms/bulk_import.py:53 vpn/forms/filtersets.py:64
+#: vpn/models/crypto.py:250 vpn/tables/tunnels.py:51
 msgid "IPSec profile"
 msgstr ""
 
-#: netbox/templates/vpn/tunnel.html:45 netbox/vpn/forms/bulk_edit.py:69
-#: netbox/vpn/forms/filtersets.py:68
+#: templates/vpn/tunnel.html:45 vpn/forms/bulk_edit.py:69
+#: vpn/forms/filtersets.py:68
 msgid "Tunnel ID"
 msgstr ""
 
-#: netbox/templates/vpn/tunnelgroup.html:14
+#: templates/vpn/tunnelgroup.html:14
 msgid "Add Tunnel"
 msgstr ""
 
-#: netbox/templates/vpn/tunnelgroup.html:23 netbox/vpn/forms/model_forms.py:36
-#: netbox/vpn/forms/model_forms.py:49
+#: templates/vpn/tunnelgroup.html:23 vpn/forms/model_forms.py:36
+#: vpn/forms/model_forms.py:49
 msgid "Tunnel Group"
 msgstr ""
 
-#: netbox/templates/vpn/tunneltermination.html:10
+#: templates/vpn/tunneltermination.html:10
 msgid "Tunnel Termination"
 msgstr ""
 
-#: netbox/templates/vpn/tunneltermination.html:35
-#: netbox/vpn/forms/bulk_import.py:107 netbox/vpn/forms/model_forms.py:102
-#: netbox/vpn/forms/model_forms.py:138 netbox/vpn/forms/model_forms.py:247
-#: netbox/vpn/tables/tunnels.py:101
+#: templates/vpn/tunneltermination.html:35 vpn/forms/bulk_import.py:107
+#: vpn/forms/model_forms.py:102 vpn/forms/model_forms.py:138
+#: vpn/forms/model_forms.py:247 vpn/tables/tunnels.py:101
 msgid "Outside IP"
 msgstr ""
 
-#: netbox/templates/vpn/tunneltermination.html:51
+#: templates/vpn/tunneltermination.html:51
 msgid "Peer Terminations"
 msgstr ""
 
-#: netbox/templates/wireless/inc/authentication_attrs.html:12
+#: templates/wireless/inc/authentication_attrs.html:12
 msgid "Cipher"
 msgstr ""
 
-#: netbox/templates/wireless/inc/authentication_attrs.html:16
+#: templates/wireless/inc/authentication_attrs.html:16
 msgid "PSK"
 msgstr ""
 
-#: netbox/templates/wireless/inc/wirelesslink_interface.html:35
-#: netbox/templates/wireless/inc/wirelesslink_interface.html:45
+#: templates/wireless/inc/wirelesslink_interface.html:35
+#: templates/wireless/inc/wirelesslink_interface.html:45
 msgctxt "Abbreviation for megahertz"
 msgid "MHz"
 msgstr ""
 
-#: netbox/templates/wireless/wirelesslan.html:57
+#: templates/wireless/wirelesslan.html:57
 msgid "Attached Interfaces"
 msgstr ""
 
-#: netbox/templates/wireless/wirelesslangroup.html:17
+#: templates/wireless/wirelesslangroup.html:17
 msgid "Add Wireless LAN"
 msgstr ""
 
-#: netbox/templates/wireless/wirelesslangroup.html:26
-#: netbox/wireless/forms/model_forms.py:28
+#: templates/wireless/wirelesslangroup.html:26 wireless/forms/model_forms.py:28
 msgid "Wireless LAN Group"
 msgstr ""
 
-#: netbox/templates/wireless/wirelesslangroup.html:59
+#: templates/wireless/wirelesslangroup.html:59
 msgid "Add Wireless LAN Group"
 msgstr ""
 
-#: netbox/templates/wireless/wirelesslink.html:14
+#: templates/wireless/wirelesslink.html:14
 msgid "Link Properties"
 msgstr ""
 
-#: netbox/templates/wireless/wirelesslink.html:38
-#: netbox/wireless/forms/bulk_edit.py:129
-#: netbox/wireless/forms/filtersets.py:102
-#: netbox/wireless/forms/model_forms.py:165
+#: templates/wireless/wirelesslink.html:38 wireless/forms/bulk_edit.py:129
+#: wireless/forms/filtersets.py:102 wireless/forms/model_forms.py:165
 msgid "Distance"
 msgstr ""
 
-#: netbox/tenancy/filtersets.py:28
+#: tenancy/filtersets.py:28
 msgid "Parent contact group (ID)"
 msgstr ""
 
-#: netbox/tenancy/filtersets.py:34
+#: tenancy/filtersets.py:34
 msgid "Parent contact group (slug)"
 msgstr ""
 
-#: netbox/tenancy/filtersets.py:40 netbox/tenancy/filtersets.py:67
-#: netbox/tenancy/filtersets.py:110
+#: tenancy/filtersets.py:40 tenancy/filtersets.py:67 tenancy/filtersets.py:110
 msgid "Contact group (ID)"
 msgstr ""
 
-#: netbox/tenancy/filtersets.py:47 netbox/tenancy/filtersets.py:74
-#: netbox/tenancy/filtersets.py:117
+#: tenancy/filtersets.py:47 tenancy/filtersets.py:74 tenancy/filtersets.py:117
 msgid "Contact group (slug)"
 msgstr ""
 
-#: netbox/tenancy/filtersets.py:104
+#: tenancy/filtersets.py:104
 msgid "Contact (ID)"
 msgstr ""
 
-#: netbox/tenancy/filtersets.py:121
+#: tenancy/filtersets.py:121
 msgid "Contact role (ID)"
 msgstr ""
 
-#: netbox/tenancy/filtersets.py:127
+#: tenancy/filtersets.py:127
 msgid "Contact role (slug)"
 msgstr ""
 
-#: netbox/tenancy/filtersets.py:158
+#: tenancy/filtersets.py:158
 msgid "Contact group"
 msgstr ""
 
-#: netbox/tenancy/filtersets.py:169
+#: tenancy/filtersets.py:169
 msgid "Parent tenant group (ID)"
 msgstr ""
 
-#: netbox/tenancy/filtersets.py:175
+#: tenancy/filtersets.py:175
 msgid "Parent tenant group (slug)"
 msgstr ""
 
-#: netbox/tenancy/filtersets.py:181 netbox/tenancy/filtersets.py:201
+#: tenancy/filtersets.py:181 tenancy/filtersets.py:201
 msgid "Tenant group (ID)"
 msgstr ""
 
-#: netbox/tenancy/filtersets.py:234
+#: tenancy/filtersets.py:234
 msgid "Tenant Group (ID)"
 msgstr ""
 
-#: netbox/tenancy/filtersets.py:241
+#: tenancy/filtersets.py:241
 msgid "Tenant Group (slug)"
 msgstr ""
 
-#: netbox/tenancy/forms/bulk_edit.py:66
+#: tenancy/forms/bulk_edit.py:66
 msgid "Desciption"
 msgstr ""
 
-#: netbox/tenancy/forms/bulk_import.py:101
+#: tenancy/forms/bulk_import.py:101
 msgid "Assigned contact"
 msgstr ""
 
-#: netbox/tenancy/models/contacts.py:32
+#: tenancy/models/contacts.py:32
 msgid "contact group"
 msgstr ""
 
-#: netbox/tenancy/models/contacts.py:33
+#: tenancy/models/contacts.py:33
 msgid "contact groups"
 msgstr ""
 
-#: netbox/tenancy/models/contacts.py:48
+#: tenancy/models/contacts.py:48
 msgid "contact role"
 msgstr ""
 
-#: netbox/tenancy/models/contacts.py:49
+#: tenancy/models/contacts.py:49
 msgid "contact roles"
 msgstr ""
 
-#: netbox/tenancy/models/contacts.py:68
+#: tenancy/models/contacts.py:68
 msgid "title"
 msgstr ""
 
-#: netbox/tenancy/models/contacts.py:73
+#: tenancy/models/contacts.py:73
 msgid "phone"
 msgstr ""
 
-#: netbox/tenancy/models/contacts.py:78
+#: tenancy/models/contacts.py:78
 msgid "email"
 msgstr ""
 
-#: netbox/tenancy/models/contacts.py:87
+#: tenancy/models/contacts.py:87
 msgid "link"
 msgstr ""
 
-#: netbox/tenancy/models/contacts.py:103
+#: tenancy/models/contacts.py:103
 msgid "contact"
 msgstr ""
 
-#: netbox/tenancy/models/contacts.py:104
+#: tenancy/models/contacts.py:104
 msgid "contacts"
 msgstr ""
 
-#: netbox/tenancy/models/contacts.py:153
+#: tenancy/models/contacts.py:153
 msgid "contact assignment"
 msgstr ""
 
-#: netbox/tenancy/models/contacts.py:154
+#: tenancy/models/contacts.py:154
 msgid "contact assignments"
 msgstr ""
 
-#: netbox/tenancy/models/contacts.py:170
+#: tenancy/models/contacts.py:170
 #, python-brace-format
 msgid "Contacts cannot be assigned to this object type ({type})."
 msgstr ""
 
-#: netbox/tenancy/models/tenants.py:32
+#: tenancy/models/tenants.py:32
 msgid "tenant group"
 msgstr ""
 
-#: netbox/tenancy/models/tenants.py:33
+#: tenancy/models/tenants.py:33
 msgid "tenant groups"
 msgstr ""
 
-#: netbox/tenancy/models/tenants.py:70
+#: tenancy/models/tenants.py:70
 msgid "Tenant name must be unique per group."
 msgstr ""
 
-#: netbox/tenancy/models/tenants.py:80
+#: tenancy/models/tenants.py:80
 msgid "Tenant slug must be unique per group."
 msgstr ""
 
-#: netbox/tenancy/models/tenants.py:88
+#: tenancy/models/tenants.py:88
 msgid "tenant"
 msgstr ""
 
-#: netbox/tenancy/models/tenants.py:89
+#: tenancy/models/tenants.py:89
 msgid "tenants"
 msgstr ""
 
-#: netbox/tenancy/tables/contacts.py:112
+#: tenancy/tables/contacts.py:112
 msgid "Contact Title"
 msgstr ""
 
-#: netbox/tenancy/tables/contacts.py:116
+#: tenancy/tables/contacts.py:116
 msgid "Contact Phone"
 msgstr ""
 
-#: netbox/tenancy/tables/contacts.py:121
+#: tenancy/tables/contacts.py:121
 msgid "Contact Email"
 msgstr ""
 
-#: netbox/tenancy/tables/contacts.py:125
+#: tenancy/tables/contacts.py:125
 msgid "Contact Address"
 msgstr ""
 
-#: netbox/tenancy/tables/contacts.py:129
+#: tenancy/tables/contacts.py:129
 msgid "Contact Link"
 msgstr ""
 
-#: netbox/tenancy/tables/contacts.py:133
+#: tenancy/tables/contacts.py:133
 msgid "Contact Description"
 msgstr ""
 
-#: netbox/users/filtersets.py:33 netbox/users/filtersets.py:73
+#: users/filtersets.py:33 users/filtersets.py:73
 msgid "Permission (ID)"
 msgstr ""
 
-#: netbox/users/filtersets.py:38 netbox/users/filtersets.py:78
+#: users/filtersets.py:38 users/filtersets.py:78
 msgid "Notification group (ID)"
 msgstr ""
 
-#: netbox/users/forms/bulk_edit.py:26
+#: users/forms/bulk_edit.py:26
 msgid "First name"
 msgstr ""
 
-#: netbox/users/forms/bulk_edit.py:31
+#: users/forms/bulk_edit.py:31
 msgid "Last name"
 msgstr ""
 
-#: netbox/users/forms/bulk_edit.py:43
+#: users/forms/bulk_edit.py:43
 msgid "Staff status"
 msgstr ""
 
-#: netbox/users/forms/bulk_edit.py:48
+#: users/forms/bulk_edit.py:48
 msgid "Superuser status"
 msgstr ""
 
-#: netbox/users/forms/bulk_import.py:41
+#: users/forms/bulk_import.py:41
 msgid "If no key is provided, one will be generated automatically."
 msgstr ""
 
-#: netbox/users/forms/filtersets.py:51 netbox/users/tables.py:42
+#: users/forms/filtersets.py:51 users/tables.py:42
 msgid "Is Staff"
 msgstr ""
 
-#: netbox/users/forms/filtersets.py:58 netbox/users/tables.py:45
+#: users/forms/filtersets.py:58 users/tables.py:45
 msgid "Is Superuser"
 msgstr ""
 
-#: netbox/users/forms/filtersets.py:91 netbox/users/tables.py:86
+#: users/forms/filtersets.py:91 users/tables.py:86
 msgid "Can View"
 msgstr ""
 
-#: netbox/users/forms/filtersets.py:98 netbox/users/tables.py:89
+#: users/forms/filtersets.py:98 users/tables.py:89
 msgid "Can Add"
 msgstr ""
 
-#: netbox/users/forms/filtersets.py:105 netbox/users/tables.py:92
+#: users/forms/filtersets.py:105 users/tables.py:92
 msgid "Can Change"
 msgstr ""
 
-#: netbox/users/forms/filtersets.py:112 netbox/users/tables.py:95
+#: users/forms/filtersets.py:112 users/tables.py:95
 msgid "Can Delete"
 msgstr ""
 
-#: netbox/users/forms/model_forms.py:62
+#: users/forms/model_forms.py:62
 msgid "User Interface"
 msgstr ""
 
-#: netbox/users/forms/model_forms.py:114
+#: users/forms/model_forms.py:114
 msgid ""
 "Keys must be at least 40 characters in length. <strong>Be sure to record "
 "your key</strong> prior to submitting this form, as it may no longer be "
 "accessible once the token has been created."
 msgstr ""
 
-#: netbox/users/forms/model_forms.py:126
+#: users/forms/model_forms.py:126
 msgid ""
 "Allowed IPv4/IPv6 networks from where the token can be used. Leave blank for "
 "no restrictions. Example: <code>10.1.1.0/24,192.168.10.16/32,2001:"
 "db8:1::/64</code>"
 msgstr ""
 
-#: netbox/users/forms/model_forms.py:175
+#: users/forms/model_forms.py:175
 msgid "Confirm password"
 msgstr ""
 
-#: netbox/users/forms/model_forms.py:178
+#: users/forms/model_forms.py:178
 msgid "Enter the same password as before, for verification."
 msgstr ""
 
-#: netbox/users/forms/model_forms.py:227
+#: users/forms/model_forms.py:227
 msgid "Passwords do not match! Please check your input and try again."
 msgstr ""
 
-#: netbox/users/forms/model_forms.py:294
+#: users/forms/model_forms.py:294
 msgid "Additional actions"
 msgstr ""
 
-#: netbox/users/forms/model_forms.py:297
+#: users/forms/model_forms.py:297
 msgid "Actions granted in addition to those listed above"
 msgstr ""
 
-#: netbox/users/forms/model_forms.py:313
+#: users/forms/model_forms.py:313
 msgid "Objects"
 msgstr ""
 
-#: netbox/users/forms/model_forms.py:325
+#: users/forms/model_forms.py:325
 msgid ""
 "JSON expression of a queryset filter that will return only permitted "
 "objects. Leave null to match all objects of this type. A list of multiple "
 "objects will result in a logical OR operation."
 msgstr ""
 
-#: netbox/users/forms/model_forms.py:364
+#: users/forms/model_forms.py:364
 msgid "At least one action must be selected."
 msgstr ""
 
-#: netbox/users/forms/model_forms.py:382
+#: users/forms/model_forms.py:382
 #, python-brace-format
 msgid "Invalid filter for {model}: {error}"
 msgstr ""
 
-#: netbox/users/models/permissions.py:39
+#: users/models/permissions.py:39
 msgid "The list of actions granted by this permission"
 msgstr ""
 
-#: netbox/users/models/permissions.py:44
+#: users/models/permissions.py:44
 msgid "constraints"
 msgstr ""
 
-#: netbox/users/models/permissions.py:45
+#: users/models/permissions.py:45
 msgid "Queryset filter matching the applicable objects of the selected type(s)"
 msgstr ""
 
-#: netbox/users/models/permissions.py:52
+#: users/models/permissions.py:52
 msgid "permission"
 msgstr ""
 
-#: netbox/users/models/permissions.py:53 netbox/users/models/users.py:47
+#: users/models/permissions.py:53 users/models/users.py:47
 msgid "permissions"
 msgstr ""
 
-#: netbox/users/models/preferences.py:29 netbox/users/models/preferences.py:30
+#: users/models/preferences.py:29 users/models/preferences.py:30
 msgid "user preferences"
 msgstr ""
 
-#: netbox/users/models/preferences.py:97
+#: users/models/preferences.py:97
 #, python-brace-format
 msgid "Key '{path}' is a leaf node; cannot assign new keys"
 msgstr ""
 
-#: netbox/users/models/preferences.py:109
+#: users/models/preferences.py:109
 #, python-brace-format
 msgid "Key '{path}' is a dictionary; cannot assign a non-dictionary value"
 msgstr ""
 
-#: netbox/users/models/tokens.py:36
+#: users/models/tokens.py:36
 msgid "expires"
 msgstr ""
 
-#: netbox/users/models/tokens.py:41
+#: users/models/tokens.py:41
 msgid "last used"
 msgstr ""
 
-#: netbox/users/models/tokens.py:46
+#: users/models/tokens.py:46
 msgid "key"
 msgstr ""
 
-#: netbox/users/models/tokens.py:52
+#: users/models/tokens.py:52
 msgid "write enabled"
 msgstr ""
 
-#: netbox/users/models/tokens.py:54
+#: users/models/tokens.py:54
 msgid "Permit create/update/delete operations using this key"
 msgstr ""
 
-#: netbox/users/models/tokens.py:65
+#: users/models/tokens.py:65
 msgid "allowed IPs"
 msgstr ""
 
-#: netbox/users/models/tokens.py:67
+#: users/models/tokens.py:67
 msgid ""
 "Allowed IPv4/IPv6 networks from where the token can be used. Leave blank for "
 "no restrictions. Ex: \"10.1.1.0/24, 192.168.10.16/32, 2001:DB8:1::/64\""
 msgstr ""
 
-#: netbox/users/models/tokens.py:75
+#: users/models/tokens.py:75
 msgid "token"
 msgstr ""
 
-#: netbox/users/models/tokens.py:76
+#: users/models/tokens.py:76
 msgid "tokens"
 msgstr ""
 
-#: netbox/users/models/users.py:57 netbox/vpn/models/crypto.py:42
+#: users/models/users.py:57 vpn/models/crypto.py:42
 msgid "group"
 msgstr ""
 
-#: netbox/users/models/users.py:92
+#: users/models/users.py:92
 msgid "user"
 msgstr ""
 
-#: netbox/users/models/users.py:104
+#: users/models/users.py:104
 msgid "A user with this username already exists."
 msgstr ""
 
-#: netbox/users/tables.py:98
+#: users/tables.py:98
 msgid "Custom Actions"
 msgstr ""
 
-#: netbox/utilities/api.py:153
+#: utilities/api.py:153
 #, python-brace-format
 msgid "Related object not found using the provided attributes: {params}"
 msgstr ""
 
-#: netbox/utilities/api.py:156
+#: utilities/api.py:156
 #, python-brace-format
 msgid "Multiple objects match the provided attributes: {params}"
 msgstr ""
 
-#: netbox/utilities/api.py:168
+#: utilities/api.py:168
 #, python-brace-format
 msgid ""
 "Related objects must be referenced by numeric ID or by dictionary of "
 "attributes. Received an unrecognized value: {value}"
 msgstr ""
 
-#: netbox/utilities/api.py:177
+#: utilities/api.py:177
 #, python-brace-format
 msgid "Related object not found using the provided numeric ID: {id}"
 msgstr ""
 
-#: netbox/utilities/choices.py:19
+#: utilities/choices.py:19
 #, python-brace-format
 msgid "{name} has a key defined but CHOICES is not a list"
 msgstr ""
 
-#: netbox/utilities/conversion.py:19
+#: utilities/conversion.py:19
 msgid "Weight must be a positive number"
 msgstr ""
 
-#: netbox/utilities/conversion.py:21
+#: utilities/conversion.py:21
 #, python-brace-format
 msgid "Invalid value '{weight}' for weight (must be a number)"
 msgstr ""
 
-#: netbox/utilities/conversion.py:32 netbox/utilities/conversion.py:62
+#: utilities/conversion.py:32 utilities/conversion.py:62
 #, python-brace-format
 msgid "Unknown unit {unit}. Must be one of the following: {valid_units}"
 msgstr ""
 
-#: netbox/utilities/conversion.py:45
+#: utilities/conversion.py:45
 msgid "Length must be a positive number"
 msgstr ""
 
-#: netbox/utilities/conversion.py:47
+#: utilities/conversion.py:47
 #, python-brace-format
 msgid "Invalid value '{length}' for length (must be a number)"
 msgstr ""
 
-#: netbox/utilities/error_handlers.py:31
+#: utilities/error_handlers.py:31
 #, python-brace-format
 msgid ""
 "Unable to delete <strong>{objects}</strong>. {count} dependent objects were "
 "found: "
 msgstr ""
 
-#: netbox/utilities/error_handlers.py:33
+#: utilities/error_handlers.py:33
 msgid "More than 50"
 msgstr ""
 
-#: netbox/utilities/fields.py:30
+#: utilities/fields.py:30
 msgid "RGB color in hexadecimal. Example: "
 msgstr ""
 
-#: netbox/utilities/fields.py:159
+#: utilities/fields.py:159
 #, python-format
 msgid ""
 "%s(%r) is invalid. to_model parameter to CounterCacheField must be a string "
 "in the format 'app.model'"
 msgstr ""
 
-#: netbox/utilities/fields.py:169
+#: utilities/fields.py:169
 #, python-format
 msgid ""
 "%s(%r) is invalid. to_field parameter to CounterCacheField must be a string "
 "in the format 'field'"
 msgstr ""
 
-#: netbox/utilities/forms/bulk_import.py:23
+#: utilities/forms/bulk_import.py:23
 msgid "Enter object data in CSV, JSON or YAML format."
 msgstr ""
 
-#: netbox/utilities/forms/bulk_import.py:36
+#: utilities/forms/bulk_import.py:36
 msgid "CSV delimiter"
 msgstr ""
 
-#: netbox/utilities/forms/bulk_import.py:37
+#: utilities/forms/bulk_import.py:37
 msgid "The character which delimits CSV fields. Applies only to CSV format."
 msgstr ""
 
-#: netbox/utilities/forms/bulk_import.py:51
+#: utilities/forms/bulk_import.py:51
 msgid "Form data must be empty when uploading/selecting a file."
 msgstr ""
 
-#: netbox/utilities/forms/bulk_import.py:80
+#: utilities/forms/bulk_import.py:80
 #, python-brace-format
 msgid "Unknown data format: {format}"
 msgstr ""
 
-#: netbox/utilities/forms/bulk_import.py:100
+#: utilities/forms/bulk_import.py:100
 msgid "Unable to detect data format. Please specify."
 msgstr ""
 
-#: netbox/utilities/forms/bulk_import.py:123
+#: utilities/forms/bulk_import.py:123
 msgid "Invalid CSV delimiter"
 msgstr ""
 
-#: netbox/utilities/forms/bulk_import.py:167
+#: utilities/forms/bulk_import.py:167
 msgid ""
 "Invalid YAML data. Data must be in the form of multiple documents, or a "
 "single document comprising a list of dictionaries."
 msgstr ""
 
-#: netbox/utilities/forms/fields/array.py:20
+#: utilities/forms/fields/array.py:20
 #, python-brace-format
 msgid ""
 "Invalid list ({value}). Must be numeric and ranges must be in ascending "
 "order."
 msgstr ""
 
-#: netbox/utilities/forms/fields/array.py:40
+#: utilities/forms/fields/array.py:40
 msgid ""
 "Specify one or more numeric ranges separated by commas. Example: "
 "<code>1-5,20-30</code>"
 msgstr ""
 
-#: netbox/utilities/forms/fields/array.py:47
+#: utilities/forms/fields/array.py:47
 #, python-brace-format
 msgid ""
 "Invalid ranges ({value}). Must be a range of integers in ascending order."
 msgstr ""
 
-#: netbox/utilities/forms/fields/csv.py:44
+#: utilities/forms/fields/csv.py:44
 #, python-brace-format
 msgid "Invalid value for a multiple choice field: {value}"
 msgstr ""
 
-#: netbox/utilities/forms/fields/csv.py:57
-#: netbox/utilities/forms/fields/csv.py:78
+#: utilities/forms/fields/csv.py:57 utilities/forms/fields/csv.py:78
 #, python-format
 msgid "Object not found: %(value)s"
 msgstr ""
 
-#: netbox/utilities/forms/fields/csv.py:65
+#: utilities/forms/fields/csv.py:65
 #, python-brace-format
 msgid ""
 "\"{value}\" is not a unique value for this field; multiple objects were found"
 msgstr ""
 
-#: netbox/utilities/forms/fields/csv.py:69
+#: utilities/forms/fields/csv.py:69
 #, python-brace-format
 msgid "\"{field_name}\" is an invalid accessor field name."
 msgstr ""
 
-#: netbox/utilities/forms/fields/csv.py:101
+#: utilities/forms/fields/csv.py:101
 msgid "Object type must be specified as \"<app>.<model>\""
 msgstr ""
 
-#: netbox/utilities/forms/fields/csv.py:105
+#: utilities/forms/fields/csv.py:105
 msgid "Invalid object type"
 msgstr ""
 
-#: netbox/utilities/forms/fields/expandable.py:25
+#: utilities/forms/fields/expandable.py:25
 msgid ""
 "Alphanumeric ranges are supported for bulk creation. Mixed cases and types "
 "within a single range are not supported (example: <code>[ge,xe]-0/0/[0-9]</"
 "code>)."
 msgstr ""
 
-#: netbox/utilities/forms/fields/expandable.py:46
+#: utilities/forms/fields/expandable.py:46
 msgid ""
 "Specify a numeric range to create multiple IPs.<br />Example: <code>192.0.2."
 "[1,5,100-254]/24</code>"
 msgstr ""
 
-#: netbox/utilities/forms/fields/fields.py:31
+#: utilities/forms/fields/fields.py:31
 #, python-brace-format
 msgid ""
 "<i class=\"mdi mdi-information-outline\"></i> <a href=\"{url}\" "
 "target=\"_blank\" tabindex=\"-1\">Markdown</a> syntax is supported"
 msgstr ""
 
-#: netbox/utilities/forms/fields/fields.py:48
+#: utilities/forms/fields/fields.py:48
 msgid "URL-friendly unique shorthand"
 msgstr ""
 
-#: netbox/utilities/forms/fields/fields.py:101
+#: utilities/forms/fields/fields.py:101
 msgid "Enter context data in <a href=\"https://json.org/\">JSON</a> format."
 msgstr ""
 
-#: netbox/utilities/forms/fields/fields.py:124
+#: utilities/forms/fields/fields.py:124
 msgid "MAC address must be in EUI-48 format"
 msgstr ""
 
-#: netbox/utilities/forms/forms.py:52
+#: utilities/forms/forms.py:52
 msgid "Use regular expressions"
 msgstr ""
 
-#: netbox/utilities/forms/forms.py:75
+#: utilities/forms/forms.py:75
 msgid ""
 "Numeric ID of an existing object to update (if not creating a new object)"
 msgstr ""
 
-#: netbox/utilities/forms/forms.py:92
+#: utilities/forms/forms.py:92
 #, python-brace-format
 msgid "Unrecognized header: {name}"
 msgstr ""
 
-#: netbox/utilities/forms/forms.py:118
+#: utilities/forms/forms.py:118
 msgid "Available Columns"
 msgstr ""
 
-#: netbox/utilities/forms/forms.py:126
+#: utilities/forms/forms.py:126
 msgid "Selected Columns"
 msgstr ""
 
-#: netbox/utilities/forms/mixins.py:44
+#: utilities/forms/mixins.py:44
 msgid ""
 "This object has been modified since the form was rendered. Please consult "
 "the object's change log for details."
 msgstr ""
 
-#: netbox/utilities/forms/utils.py:42 netbox/utilities/forms/utils.py:68
-#: netbox/utilities/forms/utils.py:85 netbox/utilities/forms/utils.py:87
+#: utilities/forms/utils.py:42 utilities/forms/utils.py:68
+#: utilities/forms/utils.py:85 utilities/forms/utils.py:87
 #, python-brace-format
 msgid "Range \"{value}\" is invalid."
 msgstr ""
 
-#: netbox/utilities/forms/utils.py:74
+#: utilities/forms/utils.py:74
 #, python-brace-format
 msgid ""
 "Invalid range: Ending value ({end}) must be greater than beginning value "
 "({begin})."
 msgstr ""
 
-#: netbox/utilities/forms/utils.py:232
+#: utilities/forms/utils.py:232
 #, python-brace-format
 msgid "Duplicate or conflicting column header for \"{field}\""
 msgstr ""
 
-#: netbox/utilities/forms/utils.py:238
+#: utilities/forms/utils.py:238
 #, python-brace-format
 msgid "Duplicate or conflicting column header for \"{header}\""
 msgstr ""
 
-#: netbox/utilities/forms/utils.py:247
+#: utilities/forms/utils.py:247
 #, python-brace-format
 msgid "Row {row}: Expected {count_expected} columns but found {count_found}"
 msgstr ""
 
-#: netbox/utilities/forms/utils.py:270
+#: utilities/forms/utils.py:270
 #, python-brace-format
 msgid "Unexpected column header \"{field}\" found."
 msgstr ""
 
-#: netbox/utilities/forms/utils.py:272
+#: utilities/forms/utils.py:272
 #, python-brace-format
 msgid "Column \"{field}\" is not a related object; cannot use dots"
 msgstr ""
 
-#: netbox/utilities/forms/utils.py:276
+#: utilities/forms/utils.py:276
 #, python-brace-format
 msgid "Invalid related object attribute for column \"{field}\": {to_field}"
 msgstr ""
 
-#: netbox/utilities/forms/utils.py:284
+#: utilities/forms/utils.py:284
 #, python-brace-format
 msgid "Required column header \"{header}\" not found."
 msgstr ""
 
-#: netbox/utilities/forms/widgets/apiselect.py:124
+#: utilities/forms/widgets/apiselect.py:124
 #, python-brace-format
 msgid "Missing required value for dynamic query param: '{dynamic_params}'"
 msgstr ""
 
-#: netbox/utilities/forms/widgets/apiselect.py:141
+#: utilities/forms/widgets/apiselect.py:141
 #, python-brace-format
 msgid "Missing required value for static query param: '{static_params}'"
 msgstr ""
 
-#: netbox/utilities/password_validation.py:13
+#: utilities/password_validation.py:13
 msgid "Password must have at least one numeral."
 msgstr ""
 
-#: netbox/utilities/password_validation.py:18
+#: utilities/password_validation.py:18
 msgid "Password must have at least one uppercase letter."
 msgstr ""
 
-#: netbox/utilities/password_validation.py:23
+#: utilities/password_validation.py:23
 msgid "Password must have at least one lowercase letter."
 msgstr ""
 
-#: netbox/utilities/password_validation.py:27
+#: utilities/password_validation.py:27
 msgid ""
 "Your password must contain at least one numeral, one uppercase letter and "
 "one lowercase letter."
 msgstr ""
 
-#: netbox/utilities/permissions.py:42
+#: utilities/permissions.py:42
 #, python-brace-format
 msgid ""
 "Invalid permission name: {name}. Must be in the format <app_label>."
 "<action>_<model>"
 msgstr ""
 
-#: netbox/utilities/permissions.py:60
+#: utilities/permissions.py:60
 #, python-brace-format
 msgid "Unknown app_label/model_name for {name}"
 msgstr ""
 
-#: netbox/utilities/request.py:76
+#: utilities/request.py:76
 #, python-brace-format
 msgid "Invalid IP address set for {header}: {ip}"
 msgstr ""
 
-#: netbox/utilities/tables.py:47
+#: utilities/tables.py:47
 #, python-brace-format
 msgid "A column named {name} is already defined for table {table_name}"
 msgstr ""
 
-#: netbox/utilities/templates/builtins/customfield_value.html:30
+#: utilities/templates/builtins/customfield_value.html:30
 msgid "Not defined"
 msgstr ""
 
-#: netbox/utilities/templates/buttons/bookmark.html:9
+#: utilities/templates/buttons/bookmark.html:9
 msgid "Unbookmark"
 msgstr ""
 
-#: netbox/utilities/templates/buttons/bookmark.html:13
+#: utilities/templates/buttons/bookmark.html:13
 msgid "Bookmark"
 msgstr ""
 
-#: netbox/utilities/templates/buttons/clone.html:4
+#: utilities/templates/buttons/clone.html:4
 msgid "Clone"
 msgstr ""
 
-#: netbox/utilities/templates/buttons/export.html:7
+#: utilities/templates/buttons/export.html:7
 msgid "Current View"
 msgstr ""
 
-#: netbox/utilities/templates/buttons/export.html:8
+#: utilities/templates/buttons/export.html:8
 msgid "All Data"
 msgstr ""
 
-#: netbox/utilities/templates/buttons/export.html:28
+#: utilities/templates/buttons/export.html:28
 msgid "Add export template"
 msgstr ""
 
-#: netbox/utilities/templates/buttons/import.html:4
+#: utilities/templates/buttons/import.html:4
 msgid "Import"
 msgstr ""
 
-#: netbox/utilities/templates/buttons/subscribe.html:10
+#: utilities/templates/buttons/subscribe.html:10
 msgid "Unsubscribe"
 msgstr ""
 
-#: netbox/utilities/templates/buttons/subscribe.html:14
+#: utilities/templates/buttons/subscribe.html:14
 msgid "Subscribe"
 msgstr ""
 
-#: netbox/utilities/templates/form_helpers/render_field.html:41
+#: utilities/templates/form_helpers/render_field.html:41
 msgid "Copy to clipboard"
 msgstr ""
 
-#: netbox/utilities/templates/form_helpers/render_field.html:57
+#: utilities/templates/form_helpers/render_field.html:57
 msgid "This field is required"
 msgstr ""
 
-#: netbox/utilities/templates/form_helpers/render_field.html:70
+#: utilities/templates/form_helpers/render_field.html:70
 msgid "Set Null"
 msgstr ""
 
-#: netbox/utilities/templates/helpers/applied_filters.html:11
+#: utilities/templates/helpers/applied_filters.html:11
 msgid "Clear all"
 msgstr ""
 
-#: netbox/utilities/templates/helpers/table_config_form.html:8
+#: utilities/templates/helpers/table_config_form.html:8
 msgid "Table Configuration"
 msgstr ""
 
-#: netbox/utilities/templates/helpers/table_config_form.html:31
+#: utilities/templates/helpers/table_config_form.html:31
 msgid "Move Up"
 msgstr ""
 
-#: netbox/utilities/templates/helpers/table_config_form.html:34
+#: utilities/templates/helpers/table_config_form.html:34
 msgid "Move Down"
 msgstr ""
 
-#: netbox/utilities/templates/navigation/menu.html:14
+#: utilities/templates/navigation/menu.html:14
 msgid "Search…"
 msgstr ""
 
-#: netbox/utilities/templates/navigation/menu.html:14
+#: utilities/templates/navigation/menu.html:14
 msgid "Search NetBox"
 msgstr ""
 
-#: netbox/utilities/templates/widgets/apiselect.html:7
+#: utilities/templates/widgets/apiselect.html:7
 msgid "Open selector"
 msgstr ""
 
-#: netbox/utilities/templates/widgets/markdown_input.html:6
+#: utilities/templates/widgets/markdown_input.html:6
 msgid "Write"
 msgstr ""
 
-#: netbox/utilities/testing/views.py:632
+#: utilities/testing/views.py:632
 msgid "The test must define csv_update_data."
 msgstr ""
 
-#: netbox/utilities/validators.py:65
+#: utilities/validators.py:65
 #, python-brace-format
 msgid "{value} is not a valid regular expression."
 msgstr ""
 
-#: netbox/utilities/views.py:57
+#: utilities/views.py:57
 #, python-brace-format
 msgid "{self.__class__.__name__} must implement get_required_permission()"
 msgstr ""
 
-#: netbox/utilities/views.py:93
+#: utilities/views.py:93
 #, python-brace-format
 msgid "{class_name} must implement get_required_permission()"
 msgstr ""
 
-#: netbox/utilities/views.py:117
+#: utilities/views.py:117
 #, python-brace-format
 msgid ""
 "{class_name} has no queryset defined. ObjectPermissionRequiredMixin may only "
 "be used on views which define a base queryset"
 msgstr ""
 
-#: netbox/virtualization/filtersets.py:79
+#: virtualization/filtersets.py:79
 msgid "Parent group (ID)"
 msgstr ""
 
-#: netbox/virtualization/filtersets.py:85
+#: virtualization/filtersets.py:85
 msgid "Parent group (slug)"
 msgstr ""
 
-#: netbox/virtualization/filtersets.py:89
-#: netbox/virtualization/filtersets.py:141
+#: virtualization/filtersets.py:89 virtualization/filtersets.py:141
 msgid "Cluster type (ID)"
 msgstr ""
 
-#: netbox/virtualization/filtersets.py:151
-#: netbox/virtualization/filtersets.py:271
+#: virtualization/filtersets.py:151 virtualization/filtersets.py:271
 msgid "Cluster (ID)"
 msgstr ""
 
-#: netbox/virtualization/forms/bulk_edit.py:166
-#: netbox/virtualization/models/virtualmachines.py:115
+#: virtualization/forms/bulk_edit.py:166
+#: virtualization/models/virtualmachines.py:115
 msgid "vCPUs"
 msgstr ""
 
-#: netbox/virtualization/forms/bulk_edit.py:170
+#: virtualization/forms/bulk_edit.py:170
 msgid "Memory (MB)"
 msgstr ""
 
-#: netbox/virtualization/forms/bulk_edit.py:174
+#: virtualization/forms/bulk_edit.py:174
 msgid "Disk (GB)"
 msgstr ""
 
-#: netbox/virtualization/forms/bulk_edit.py:334
-#: netbox/virtualization/forms/filtersets.py:251
+#: virtualization/forms/bulk_edit.py:334 virtualization/forms/filtersets.py:251
 msgid "Size (GB)"
 msgstr ""
 
-#: netbox/virtualization/forms/bulk_import.py:44
+#: virtualization/forms/bulk_import.py:44
 msgid "Type of cluster"
 msgstr ""
 
-#: netbox/virtualization/forms/bulk_import.py:51
+#: virtualization/forms/bulk_import.py:51
 msgid "Assigned cluster group"
 msgstr ""
 
-#: netbox/virtualization/forms/bulk_import.py:96
+#: virtualization/forms/bulk_import.py:96
 msgid "Assigned cluster"
 msgstr ""
 
-#: netbox/virtualization/forms/bulk_import.py:103
+#: virtualization/forms/bulk_import.py:103
 msgid "Assigned device within cluster"
 msgstr ""
 
-#: netbox/virtualization/forms/filtersets.py:183
+#: virtualization/forms/filtersets.py:183
 msgid "Serial number"
 msgstr ""
 
-#: netbox/virtualization/forms/model_forms.py:153
+#: virtualization/forms/model_forms.py:153
 #, python-brace-format
 msgid ""
 "{device} belongs to a different site ({device_site}) than the cluster "
 "({cluster_site})"
 msgstr ""
 
-#: netbox/virtualization/forms/model_forms.py:192
+#: virtualization/forms/model_forms.py:192
 msgid "Optionally pin this VM to a specific host device within the cluster"
 msgstr ""
 
-#: netbox/virtualization/forms/model_forms.py:221
+#: virtualization/forms/model_forms.py:221
 msgid "Site/Cluster"
 msgstr ""
 
-#: netbox/virtualization/forms/model_forms.py:244
+#: virtualization/forms/model_forms.py:244
 msgid "Disk size is managed via the attachment of virtual disks."
 msgstr ""
 
-#: netbox/virtualization/forms/model_forms.py:372
-#: netbox/virtualization/tables/virtualmachines.py:111
+#: virtualization/forms/model_forms.py:372
+#: virtualization/tables/virtualmachines.py:111
 msgid "Disk"
 msgstr ""
 
-#: netbox/virtualization/models/clusters.py:25
+#: virtualization/models/clusters.py:25
 msgid "cluster type"
 msgstr ""
 
-#: netbox/virtualization/models/clusters.py:26
+#: virtualization/models/clusters.py:26
 msgid "cluster types"
 msgstr ""
 
-#: netbox/virtualization/models/clusters.py:45
+#: virtualization/models/clusters.py:45
 msgid "cluster group"
 msgstr ""
 
-#: netbox/virtualization/models/clusters.py:46
+#: virtualization/models/clusters.py:46
 msgid "cluster groups"
 msgstr ""
 
-#: netbox/virtualization/models/clusters.py:121
+#: virtualization/models/clusters.py:121
 msgid "cluster"
 msgstr ""
 
-#: netbox/virtualization/models/clusters.py:122
+#: virtualization/models/clusters.py:122
 msgid "clusters"
 msgstr ""
 
-#: netbox/virtualization/models/clusters.py:141
+#: virtualization/models/clusters.py:141
 #, python-brace-format
 msgid ""
 "{count} devices are assigned as hosts for this cluster but are not in site "
 "{site}"
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:123
+#: virtualization/models/virtualmachines.py:123
 msgid "memory (MB)"
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:128
+#: virtualization/models/virtualmachines.py:128
 msgid "disk (MB)"
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:166
+#: virtualization/models/virtualmachines.py:166
 msgid "Virtual machine name must be unique per cluster."
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:169
+#: virtualization/models/virtualmachines.py:169
 msgid "virtual machine"
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:170
+#: virtualization/models/virtualmachines.py:170
 msgid "virtual machines"
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:184
+#: virtualization/models/virtualmachines.py:184
 msgid "A virtual machine must be assigned to a site and/or cluster."
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:191
+#: virtualization/models/virtualmachines.py:191
 #, python-brace-format
 msgid "The selected cluster ({cluster}) is not assigned to this site ({site})."
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:198
+#: virtualization/models/virtualmachines.py:198
 msgid "Must specify a cluster when assigning a host device."
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:203
+#: virtualization/models/virtualmachines.py:203
 #, python-brace-format
 msgid ""
 "The selected device ({device}) is not assigned to this cluster ({cluster})."
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:215
+#: virtualization/models/virtualmachines.py:215
 #, python-brace-format
 msgid ""
 "The specified disk size ({size}) must match the aggregate size of assigned "
 "virtual disks ({total_size})."
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:229
+#: virtualization/models/virtualmachines.py:229
 #, python-brace-format
 msgid "Must be an IPv{family} address. ({ip} is an IPv{version} address.)"
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:238
+#: virtualization/models/virtualmachines.py:238
 #, python-brace-format
 msgid "The specified IP address ({ip}) is not assigned to this VM."
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:396
+#: virtualization/models/virtualmachines.py:396
 #, python-brace-format
 msgid ""
 "The selected parent interface ({parent}) belongs to a different virtual "
 "machine ({virtual_machine})."
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:411
+#: virtualization/models/virtualmachines.py:411
 #, python-brace-format
 msgid ""
 "The selected bridge interface ({bridge}) belongs to a different virtual "
 "machine ({virtual_machine})."
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:422
+#: virtualization/models/virtualmachines.py:422
 #, python-brace-format
 msgid ""
 "The untagged VLAN ({untagged_vlan}) must belong to the same site as the "
 "interface's parent virtual machine, or it must be global."
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:434
+#: virtualization/models/virtualmachines.py:434
 msgid "size (MB)"
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:438
+#: virtualization/models/virtualmachines.py:438
 msgid "virtual disk"
 msgstr ""
 
-#: netbox/virtualization/models/virtualmachines.py:439
+#: virtualization/models/virtualmachines.py:439
 msgid "virtual disks"
 msgstr ""
 
-#: netbox/virtualization/views.py:275
+#: virtualization/views.py:275
 #, python-brace-format
 msgid "Added {count} devices to cluster {cluster}"
 msgstr ""
 
-#: netbox/virtualization/views.py:310
+#: virtualization/views.py:310
 #, python-brace-format
 msgid "Removed {count} devices from cluster {cluster}"
 msgstr ""
 
-#: netbox/vpn/choices.py:31
+#: vpn/choices.py:31
 msgid "IPsec - Transport"
 msgstr ""
 
-#: netbox/vpn/choices.py:32
+#: vpn/choices.py:32
 msgid "IPsec - Tunnel"
 msgstr ""
 
-#: netbox/vpn/choices.py:33
+#: vpn/choices.py:33
 msgid "IP-in-IP"
 msgstr ""
 
-#: netbox/vpn/choices.py:34
+#: vpn/choices.py:34
 msgid "GRE"
 msgstr ""
 
-#: netbox/vpn/choices.py:56
+#: vpn/choices.py:56
 msgid "Hub"
 msgstr ""
 
-#: netbox/vpn/choices.py:57
+#: vpn/choices.py:57
 msgid "Spoke"
 msgstr ""
 
-#: netbox/vpn/choices.py:80
+#: vpn/choices.py:80
 msgid "Aggressive"
 msgstr ""
 
-#: netbox/vpn/choices.py:81
+#: vpn/choices.py:81
 msgid "Main"
 msgstr ""
 
-#: netbox/vpn/choices.py:92
+#: vpn/choices.py:92
 msgid "Pre-shared keys"
 msgstr ""
 
-#: netbox/vpn/choices.py:93
+#: vpn/choices.py:93
 msgid "Certificates"
 msgstr ""
 
-#: netbox/vpn/choices.py:94
+#: vpn/choices.py:94
 msgid "RSA signatures"
 msgstr ""
 
-#: netbox/vpn/choices.py:95
+#: vpn/choices.py:95
 msgid "DSA signatures"
 msgstr ""
 
-#: netbox/vpn/choices.py:178 netbox/vpn/choices.py:179
-#: netbox/vpn/choices.py:180 netbox/vpn/choices.py:181
-#: netbox/vpn/choices.py:182 netbox/vpn/choices.py:183
-#: netbox/vpn/choices.py:184 netbox/vpn/choices.py:185
-#: netbox/vpn/choices.py:186 netbox/vpn/choices.py:187
-#: netbox/vpn/choices.py:188 netbox/vpn/choices.py:189
-#: netbox/vpn/choices.py:190 netbox/vpn/choices.py:191
-#: netbox/vpn/choices.py:192 netbox/vpn/choices.py:193
-#: netbox/vpn/choices.py:194 netbox/vpn/choices.py:195
-#: netbox/vpn/choices.py:196 netbox/vpn/choices.py:197
-#: netbox/vpn/choices.py:198 netbox/vpn/choices.py:199
-#: netbox/vpn/choices.py:200 netbox/vpn/choices.py:201
+#: vpn/choices.py:178 vpn/choices.py:179 vpn/choices.py:180 vpn/choices.py:181
+#: vpn/choices.py:182 vpn/choices.py:183 vpn/choices.py:184 vpn/choices.py:185
+#: vpn/choices.py:186 vpn/choices.py:187 vpn/choices.py:188 vpn/choices.py:189
+#: vpn/choices.py:190 vpn/choices.py:191 vpn/choices.py:192 vpn/choices.py:193
+#: vpn/choices.py:194 vpn/choices.py:195 vpn/choices.py:196 vpn/choices.py:197
+#: vpn/choices.py:198 vpn/choices.py:199 vpn/choices.py:200 vpn/choices.py:201
 #, python-brace-format
 msgid "Group {n}"
 msgstr ""
 
-#: netbox/vpn/choices.py:243
+#: vpn/choices.py:243
 msgid "Ethernet Private LAN"
 msgstr ""
 
-#: netbox/vpn/choices.py:244
+#: vpn/choices.py:244
 msgid "Ethernet Virtual Private LAN"
 msgstr ""
 
-#: netbox/vpn/choices.py:247
+#: vpn/choices.py:247
 msgid "Ethernet Private Tree"
 msgstr ""
 
-#: netbox/vpn/choices.py:248
+#: vpn/choices.py:248
 msgid "Ethernet Virtual Private Tree"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:41
+#: vpn/filtersets.py:41
 msgid "Tunnel group (ID)"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:47
+#: vpn/filtersets.py:47
 msgid "Tunnel group (slug)"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:54
+#: vpn/filtersets.py:54
 msgid "IPSec profile (ID)"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:60
+#: vpn/filtersets.py:60
 msgid "IPSec profile (name)"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:81
+#: vpn/filtersets.py:81
 msgid "Tunnel (ID)"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:87
+#: vpn/filtersets.py:87
 msgid "Tunnel (name)"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:118
+#: vpn/filtersets.py:118
 msgid "Outside IP (ID)"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:130 netbox/vpn/filtersets.py:263
+#: vpn/filtersets.py:130 vpn/filtersets.py:263
 msgid "IKE policy (ID)"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:136 netbox/vpn/filtersets.py:269
+#: vpn/filtersets.py:136 vpn/filtersets.py:269
 msgid "IKE policy (name)"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:200 netbox/vpn/filtersets.py:273
+#: vpn/filtersets.py:200 vpn/filtersets.py:273
 msgid "IPSec policy (ID)"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:206 netbox/vpn/filtersets.py:279
+#: vpn/filtersets.py:206 vpn/filtersets.py:279
 msgid "IPSec policy (name)"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:348
+#: vpn/filtersets.py:348
 msgid "L2VPN (slug)"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:412
+#: vpn/filtersets.py:412
 msgid "VM Interface (ID)"
 msgstr ""
 
-#: netbox/vpn/filtersets.py:418
+#: vpn/filtersets.py:418
 msgid "VLAN (name)"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_edit.py:45 netbox/vpn/forms/bulk_import.py:42
-#: netbox/vpn/forms/filtersets.py:54
+#: vpn/forms/bulk_edit.py:45 vpn/forms/bulk_import.py:42
+#: vpn/forms/filtersets.py:54
 msgid "Tunnel group"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_edit.py:117 netbox/vpn/models/crypto.py:47
+#: vpn/forms/bulk_edit.py:117 vpn/models/crypto.py:47
 msgid "SA lifetime"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_edit.py:151 netbox/wireless/forms/bulk_edit.py:79
-#: netbox/wireless/forms/bulk_edit.py:126
-#: netbox/wireless/forms/filtersets.py:64
-#: netbox/wireless/forms/filtersets.py:98
+#: vpn/forms/bulk_edit.py:151 wireless/forms/bulk_edit.py:79
+#: wireless/forms/bulk_edit.py:126 wireless/forms/filtersets.py:64
+#: wireless/forms/filtersets.py:98
 msgid "Pre-shared key"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_edit.py:237 netbox/vpn/forms/bulk_import.py:239
-#: netbox/vpn/forms/filtersets.py:199 netbox/vpn/forms/model_forms.py:370
-#: netbox/vpn/models/crypto.py:104
+#: vpn/forms/bulk_edit.py:237 vpn/forms/bulk_import.py:239
+#: vpn/forms/filtersets.py:199 vpn/forms/model_forms.py:370
+#: vpn/models/crypto.py:104
 msgid "IKE policy"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_edit.py:242 netbox/vpn/forms/bulk_import.py:244
-#: netbox/vpn/forms/filtersets.py:204 netbox/vpn/forms/model_forms.py:374
-#: netbox/vpn/models/crypto.py:209
+#: vpn/forms/bulk_edit.py:242 vpn/forms/bulk_import.py:244
+#: vpn/forms/filtersets.py:204 vpn/forms/model_forms.py:374
+#: vpn/models/crypto.py:209
 msgid "IPSec policy"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:50
+#: vpn/forms/bulk_import.py:50
 msgid "Tunnel encapsulation"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:83
+#: vpn/forms/bulk_import.py:83
 msgid "Operational role"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:90
+#: vpn/forms/bulk_import.py:90
 msgid "Parent device of assigned interface"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:97
+#: vpn/forms/bulk_import.py:97
 msgid "Parent VM of assigned interface"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:104
+#: vpn/forms/bulk_import.py:104
 msgid "Device or virtual machine interface"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:183
+#: vpn/forms/bulk_import.py:183
 msgid "IKE proposal(s)"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:215 netbox/vpn/models/crypto.py:197
+#: vpn/forms/bulk_import.py:215 vpn/models/crypto.py:197
 msgid "Diffie-Hellman group for Perfect Forward Secrecy"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:222
+#: vpn/forms/bulk_import.py:222
 msgid "IPSec proposal(s)"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:236
+#: vpn/forms/bulk_import.py:236
 msgid "IPSec protocol"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:266
+#: vpn/forms/bulk_import.py:266
 msgid "L2VPN type"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:287
+#: vpn/forms/bulk_import.py:287
 msgid "Parent device (for interface)"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:294
+#: vpn/forms/bulk_import.py:294
 msgid "Parent virtual machine (for interface)"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:301
+#: vpn/forms/bulk_import.py:301
 msgid "Assigned interface (device or VM)"
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:334
+#: vpn/forms/bulk_import.py:334
 msgid "Cannot import device and VM interface terminations simultaneously."
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:336
+#: vpn/forms/bulk_import.py:336
 msgid "Each termination must specify either an interface or a VLAN."
 msgstr ""
 
-#: netbox/vpn/forms/bulk_import.py:338
+#: vpn/forms/bulk_import.py:338
 msgid "Cannot assign both an interface and a VLAN."
 msgstr ""
 
-#: netbox/vpn/forms/filtersets.py:130
+#: vpn/forms/filtersets.py:130
 msgid "IKE version"
 msgstr ""
 
-#: netbox/vpn/forms/filtersets.py:142 netbox/vpn/forms/filtersets.py:175
-#: netbox/vpn/forms/model_forms.py:298 netbox/vpn/forms/model_forms.py:334
+#: vpn/forms/filtersets.py:142 vpn/forms/filtersets.py:175
+#: vpn/forms/model_forms.py:298 vpn/forms/model_forms.py:334
 msgid "Proposal"
 msgstr ""
 
-#: netbox/vpn/forms/filtersets.py:251
+#: vpn/forms/filtersets.py:251
 msgid "Assigned Object Type"
 msgstr ""
 
-#: netbox/vpn/forms/model_forms.py:95 netbox/vpn/forms/model_forms.py:130
-#: netbox/vpn/forms/model_forms.py:240 netbox/vpn/tables/tunnels.py:91
+#: vpn/forms/model_forms.py:95 vpn/forms/model_forms.py:130
+#: vpn/forms/model_forms.py:240 vpn/tables/tunnels.py:91
 msgid "Tunnel interface"
 msgstr ""
 
-#: netbox/vpn/forms/model_forms.py:150
+#: vpn/forms/model_forms.py:150
 msgid "First Termination"
 msgstr ""
 
-#: netbox/vpn/forms/model_forms.py:153
+#: vpn/forms/model_forms.py:153
 msgid "Second Termination"
 msgstr ""
 
-#: netbox/vpn/forms/model_forms.py:197
+#: vpn/forms/model_forms.py:197
 msgid "This parameter is required when defining a termination."
 msgstr ""
 
-#: netbox/vpn/forms/model_forms.py:320 netbox/vpn/forms/model_forms.py:356
+#: vpn/forms/model_forms.py:320 vpn/forms/model_forms.py:356
 msgid "Policy"
 msgstr ""
 
-#: netbox/vpn/forms/model_forms.py:487
+#: vpn/forms/model_forms.py:487
 msgid "A termination must specify an interface or VLAN."
 msgstr ""
 
-#: netbox/vpn/forms/model_forms.py:489
+#: vpn/forms/model_forms.py:489
 msgid ""
 "A termination can only have one terminating object (an interface or VLAN)."
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:33
+#: vpn/models/crypto.py:33
 msgid "encryption algorithm"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:37
+#: vpn/models/crypto.py:37
 msgid "authentication algorithm"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:44
+#: vpn/models/crypto.py:44
 msgid "Diffie-Hellman group ID"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:50
+#: vpn/models/crypto.py:50
 msgid "Security association lifetime (in seconds)"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:59
+#: vpn/models/crypto.py:59
 msgid "IKE proposal"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:60
+#: vpn/models/crypto.py:60
 msgid "IKE proposals"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:76
+#: vpn/models/crypto.py:76
 msgid "version"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:88 netbox/vpn/models/crypto.py:190
+#: vpn/models/crypto.py:88 vpn/models/crypto.py:190
 msgid "proposals"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:91 netbox/wireless/models.py:39
+#: vpn/models/crypto.py:91 wireless/models.py:39
 msgid "pre-shared key"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:105
+#: vpn/models/crypto.py:105
 msgid "IKE policies"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:118
+#: vpn/models/crypto.py:118
 msgid "Mode is required for selected IKE version"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:122
+#: vpn/models/crypto.py:122
 msgid "Mode cannot be used for selected IKE version"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:136
+#: vpn/models/crypto.py:136
 msgid "encryption"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:141
+#: vpn/models/crypto.py:141
 msgid "authentication"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:149
+#: vpn/models/crypto.py:149
 msgid "Security association lifetime (seconds)"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:155
+#: vpn/models/crypto.py:155
 msgid "Security association lifetime (in kilobytes)"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:164
+#: vpn/models/crypto.py:164
 msgid "IPSec proposal"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:165
+#: vpn/models/crypto.py:165
 msgid "IPSec proposals"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:178
+#: vpn/models/crypto.py:178
 msgid "Encryption and/or authentication algorithm must be defined"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:210
+#: vpn/models/crypto.py:210
 msgid "IPSec policies"
 msgstr ""
 
-#: netbox/vpn/models/crypto.py:251
+#: vpn/models/crypto.py:251
 msgid "IPSec profiles"
 msgstr ""
 
-#: netbox/vpn/models/l2vpn.py:116
+#: vpn/models/l2vpn.py:116
 msgid "L2VPN termination"
 msgstr ""
 
-#: netbox/vpn/models/l2vpn.py:117
+#: vpn/models/l2vpn.py:117
 msgid "L2VPN terminations"
 msgstr ""
 
-#: netbox/vpn/models/l2vpn.py:135
+#: vpn/models/l2vpn.py:135
 #, python-brace-format
 msgid "L2VPN Termination already assigned ({assigned_object})"
 msgstr ""
 
-#: netbox/vpn/models/l2vpn.py:147
+#: vpn/models/l2vpn.py:147
 #, python-brace-format
 msgid ""
 "{l2vpn_type} L2VPNs cannot have more than two terminations; found "
 "{terminations_count} already defined."
 msgstr ""
 
-#: netbox/vpn/models/tunnels.py:26
+#: vpn/models/tunnels.py:26
 msgid "tunnel group"
 msgstr ""
 
-#: netbox/vpn/models/tunnels.py:27
+#: vpn/models/tunnels.py:27
 msgid "tunnel groups"
 msgstr ""
 
-#: netbox/vpn/models/tunnels.py:53
+#: vpn/models/tunnels.py:53
 msgid "encapsulation"
 msgstr ""
 
-#: netbox/vpn/models/tunnels.py:72
+#: vpn/models/tunnels.py:72
 msgid "tunnel ID"
 msgstr ""
 
-#: netbox/vpn/models/tunnels.py:94
+#: vpn/models/tunnels.py:94
 msgid "tunnel"
 msgstr ""
 
-#: netbox/vpn/models/tunnels.py:95
+#: vpn/models/tunnels.py:95
 msgid "tunnels"
 msgstr ""
 
-#: netbox/vpn/models/tunnels.py:153
+#: vpn/models/tunnels.py:153
 msgid "An object may be terminated to only one tunnel at a time."
 msgstr ""
 
-#: netbox/vpn/models/tunnels.py:156
+#: vpn/models/tunnels.py:156
 msgid "tunnel termination"
 msgstr ""
 
-#: netbox/vpn/models/tunnels.py:157
+#: vpn/models/tunnels.py:157
 msgid "tunnel terminations"
 msgstr ""
 
-#: netbox/vpn/models/tunnels.py:174
+#: vpn/models/tunnels.py:174
 #, python-brace-format
 msgid "{name} is already attached to a tunnel ({tunnel})."
 msgstr ""
 
-#: netbox/vpn/tables/crypto.py:22
+#: vpn/tables/crypto.py:22
 msgid "Authentication Method"
 msgstr ""
 
-#: netbox/vpn/tables/crypto.py:25 netbox/vpn/tables/crypto.py:97
+#: vpn/tables/crypto.py:25 vpn/tables/crypto.py:97
 msgid "Encryption Algorithm"
 msgstr ""
 
-#: netbox/vpn/tables/crypto.py:28 netbox/vpn/tables/crypto.py:100
+#: vpn/tables/crypto.py:28 vpn/tables/crypto.py:100
 msgid "Authentication Algorithm"
 msgstr ""
 
-#: netbox/vpn/tables/crypto.py:34
+#: vpn/tables/crypto.py:34
 msgid "SA Lifetime"
 msgstr ""
 
-#: netbox/vpn/tables/crypto.py:71
+#: vpn/tables/crypto.py:71
 msgid "Pre-shared Key"
 msgstr ""
 
-#: netbox/vpn/tables/crypto.py:103
+#: vpn/tables/crypto.py:103
 msgid "SA Lifetime (Seconds)"
 msgstr ""
 
-#: netbox/vpn/tables/crypto.py:106
+#: vpn/tables/crypto.py:106
 msgid "SA Lifetime (KB)"
 msgstr ""
 
-#: netbox/vpn/tables/l2vpn.py:69
+#: vpn/tables/l2vpn.py:69
 msgid "Object Parent"
 msgstr ""
 
-#: netbox/vpn/tables/l2vpn.py:74
+#: vpn/tables/l2vpn.py:74
 msgid "Object Site"
 msgstr ""
 
-#: netbox/wireless/choices.py:11
+#: wireless/choices.py:11
 msgid "Access point"
 msgstr ""
 
-#: netbox/wireless/choices.py:12
+#: wireless/choices.py:12
 msgid "Station"
 msgstr ""
 
-#: netbox/wireless/choices.py:467
+#: wireless/choices.py:467
 msgid "Open"
 msgstr ""
 
-#: netbox/wireless/choices.py:469
+#: wireless/choices.py:469
 msgid "WPA Personal (PSK)"
 msgstr ""
 
-#: netbox/wireless/choices.py:470
+#: wireless/choices.py:470
 msgid "WPA Enterprise"
 msgstr ""
 
-#: netbox/wireless/forms/bulk_edit.py:73 netbox/wireless/forms/bulk_edit.py:120
-#: netbox/wireless/forms/bulk_import.py:68
-#: netbox/wireless/forms/bulk_import.py:71
-#: netbox/wireless/forms/bulk_import.py:110
-#: netbox/wireless/forms/bulk_import.py:113
-#: netbox/wireless/forms/filtersets.py:59
-#: netbox/wireless/forms/filtersets.py:93
+#: wireless/forms/bulk_edit.py:73 wireless/forms/bulk_edit.py:120
+#: wireless/forms/bulk_import.py:68 wireless/forms/bulk_import.py:71
+#: wireless/forms/bulk_import.py:110 wireless/forms/bulk_import.py:113
+#: wireless/forms/filtersets.py:59 wireless/forms/filtersets.py:93
 msgid "Authentication cipher"
 msgstr ""
 
-#: netbox/wireless/forms/bulk_edit.py:134
-#: netbox/wireless/forms/bulk_import.py:116
-#: netbox/wireless/forms/bulk_import.py:119
-#: netbox/wireless/forms/filtersets.py:106
+#: wireless/forms/bulk_edit.py:134 wireless/forms/bulk_import.py:116
+#: wireless/forms/bulk_import.py:119 wireless/forms/filtersets.py:106
 msgid "Distance unit"
 msgstr ""
 
-#: netbox/wireless/forms/bulk_import.py:52
+#: wireless/forms/bulk_import.py:52
 msgid "Bridged VLAN"
 msgstr ""
 
-#: netbox/wireless/forms/bulk_import.py:89
-#: netbox/wireless/tables/wirelesslink.py:28
+#: wireless/forms/bulk_import.py:89 wireless/tables/wirelesslink.py:28
 msgid "Interface A"
 msgstr ""
 
-#: netbox/wireless/forms/bulk_import.py:93
-#: netbox/wireless/tables/wirelesslink.py:37
+#: wireless/forms/bulk_import.py:93 wireless/tables/wirelesslink.py:37
 msgid "Interface B"
 msgstr ""
 
-#: netbox/wireless/forms/model_forms.py:161
+#: wireless/forms/model_forms.py:161
 msgid "Side B"
 msgstr ""
 
-#: netbox/wireless/models.py:31
+#: wireless/models.py:31
 msgid "authentication cipher"
 msgstr ""
 
-#: netbox/wireless/models.py:69
+#: wireless/models.py:69
 msgid "wireless LAN group"
 msgstr ""
 
-#: netbox/wireless/models.py:70
+#: wireless/models.py:70
 msgid "wireless LAN groups"
 msgstr ""
 
-#: netbox/wireless/models.py:116
+#: wireless/models.py:116
 msgid "wireless LAN"
 msgstr ""
 
-#: netbox/wireless/models.py:144
+#: wireless/models.py:144
 msgid "interface A"
 msgstr ""
 
-#: netbox/wireless/models.py:151
+#: wireless/models.py:151
 msgid "interface B"
 msgstr ""
 
-#: netbox/wireless/models.py:165
+#: wireless/models.py:165
 msgid "distance"
 msgstr ""
 
-#: netbox/wireless/models.py:172
+#: wireless/models.py:172
 msgid "distance unit"
 msgstr ""
 
-#: netbox/wireless/models.py:219
+#: wireless/models.py:219
 msgid "wireless link"
 msgstr ""
 
-#: netbox/wireless/models.py:220
+#: wireless/models.py:220
 msgid "wireless links"
 msgstr ""
 
-#: netbox/wireless/models.py:236
+#: wireless/models.py:236
 msgid "Must specify a unit when setting a wireless distance"
 msgstr ""
 
-#: netbox/wireless/models.py:242 netbox/wireless/models.py:248
+#: wireless/models.py:242 wireless/models.py:248
 #, python-brace-format
 msgid "{type} is not a wireless interface."
 msgstr ""
 
-#: netbox/wireless/utils.py:16
+#: wireless/utils.py:16
 #, python-brace-format
 msgid "Invalid channel value: {channel}"
 msgstr ""
 
-#: netbox/wireless/utils.py:26
+#: wireless/utils.py:26
 #, python-brace-format
 msgid "Invalid channel attribute: {name}"
 msgstr ""

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -6,7 +6,7 @@ from django.db.models import Prefetch, Sum
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 from django.views.generic.base import RedirectView
 from jinja2.exceptions import TemplateError
 


### PR DESCRIPTION
### Fixes: #17884

- Replace `gettext()` with `gettext_lazy()`
- Update source translation strings
