### PR TITLE
Fixes #17895: Ensure GraphiQL UI resources are served locally

### DIFF
--- a/netbox/netbox/graphql/views.py
+++ b/netbox/netbox/graphql/views.py
@@ -14,7 +14,6 @@ class NetBoxGraphQLView(GraphQLView):
     """
     Extends strawberry's GraphQLView to support DRF's token-based authentication.
     """
-    graphiql_template = 'graphiql.html'
 
     @csrf_exempt
     def dispatch(self, request, *args, **kwargs):

--- a/netbox/templates/graphql/graphiql.html
+++ b/netbox/templates/graphql/graphiql.html
@@ -1,15 +1,8 @@
+{% load static %}
 {% comment %}
   This template derives from the strawberry-graphql project:
   https://github.com/strawberry-graphql/strawberry/blob/main/strawberry/static/graphiql.html
 {% endcomment %}
-<!--
-The request to this GraphQL server provided the header "Accept: text/html"
-and as a result has been presented GraphiQL - an in-browser IDE for
-exploring GraphQL.
-If you wish to receive JSON, provide the header "Accept: application/json" or
-add "&raw" to the end of the URL within a browser.
--->
-{% load static %}
 <!DOCTYPE html>
 <html>
   <head>
@@ -112,10 +105,7 @@ add "&raw" to the end of the URL within a browser.
         headers["x-csrftoken"] = csrfToken;
       }
 
-      const subscriptionsEnabled = JSON.parse("{{ SUBSCRIPTION_ENABLED }}");
-      const subscriptionUrl = subscriptionsEnabled
-        ? httpUrlToWebSockeUrl(fetchURL)
-        : null;
+      const subscriptionUrl = httpUrlToWebSockeUrl(fetchURL);
 
       const fetcher = GraphiQL.createFetcher({
         url: fetchURL,


### PR DESCRIPTION
### Fixes: #17895

Ensure our local HTML template is employed by the GraphiQL UI to ensure frontend Javascript resources are loaded locally.