### PR TITLE
17898 upgrade to django-rq v3

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -42,7 +42,7 @@ django-rich
 
 # Django integration for RQ (Reqis queuing)
 # https://github.com/rq/django-rq/blob/master/CHANGELOG.md
-django-rq<3.0
+django-rq
 
 # Abstraction models for rendering and paginating HTML tables
 # https://github.com/jieter/django-tables2/blob/master/CHANGELOG.md
@@ -118,7 +118,7 @@ requests
 
 # rq
 # https://github.com/rq/rq/blob/master/CHANGES.md
-rq<2.0
+rq
 
 # Social authentication framework
 # https://github.com/python-social-auth/social-core/blob/master/CHANGELOG.md

--- a/netbox/core/tests/test_views.py
+++ b/netbox/core/tests/test_views.py
@@ -308,6 +308,7 @@ class BackgroundTaskTestCase(TestCase):
         worker = get_worker('default')
         job = queue.enqueue(self.dummy_job_default)
         worker.prepare_job_execution(job)
+        worker.prepare_execution(job)
 
         self.assertEqual(job.get_status(), JobStatus.STARTED)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ django-pglocks==1.0.4
 django-prometheus==2.3.1
 django-redis==5.4.0
 django-rich==1.12.0
-django-rq==2.10.2
+django-rq==3.0
 django-taggit==6.1.0
 django-tables2==2.7.0
 django-timezone-field==7.0
@@ -28,7 +28,7 @@ Pillow==11.0.0
 psycopg[c,pool]==3.2.3
 PyYAML==6.0.2
 requests==2.32.3
-rq==1.16.2
+rq==2.0
 social-auth-app-django==5.4.2
 social-auth-core==4.5.4
 strawberry-graphql==0.247.0


### PR DESCRIPTION
### Fixes: #17898

Upgrades to django-rq v3.  They added prepare_execution function to be used after prepare_job_execution, this is the only place we are using that.  However this call is not present in older django-rq so the libraries must be updated.