### PR TITLE
Fixes: #17923, #17921 - Fix non-null constraint for script execution

### DIFF
--- a/netbox/extras/jobs.py
+++ b/netbox/extras/jobs.py
@@ -22,9 +22,7 @@ class ScriptJob(JobRunner):
     """
 
     class Meta:
-        # An explicit job name is not set because it doesn't make sense in this context. Currently, there's no scenario
-        # where jobs other than this one are used. Therefore, it is hidden, resulting in a cleaner job table overview.
-        name = ''
+        name = 'Run Script'
 
     def run_script(self, script, request, data, commit):
         """

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1181,7 +1181,6 @@ class ScriptView(BaseScriptView):
                 request=copy_safe_request(request),
                 job_timeout=script.python_class.job_timeout,
                 commit=form.cleaned_data.pop('_commit'),
-                name=script.name
             )
 
             return redirect('extras:script_result', job_pk=job.pk)

--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -72,6 +72,7 @@ class JobRunner(ABC):
                     kwargs["job_timeout"] = job.object.python_class.job_timeout
                 cls.enqueue(
                     instance=job.object,
+                    name=job.name,
                     user=job.user,
                     schedule_at=new_scheduled_time,
                     interval=job.interval,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #17921

<!--
    Please include a summary of the proposed changes below.
-->

With c34a0e2, validation of job object fields is enabled, so ScriptJob must not set required fields to empty strings. Changes of this PR revert b18f193 and (hopefully) fix this issue not only for UI views, but for all interactions with scripts.