### PR TITLE
12596 Add Allocated Resources to Cluster API

### DIFF
--- a/netbox/virtualization/api/serializers_/clusters.py
+++ b/netbox/virtualization/api/serializers_/clusters.py
@@ -64,7 +64,7 @@ class ClusterSerializer(NetBoxModelSerializer):
         decimal_places=2,
     )
     allocated_memory = serializers.IntegerField()
-    allocated_disk_space =  serializers.IntegerField()
+    allocated_disk_space = serializers.IntegerField()
 
     # Related object counts
     device_count = RelatedObjectCountField('devices')

--- a/netbox/virtualization/api/serializers_/clusters.py
+++ b/netbox/virtualization/api/serializers_/clusters.py
@@ -59,14 +59,14 @@ class ClusterSerializer(NetBoxModelSerializer):
     )
     scope_id = serializers.IntegerField(allow_null=True, required=False, default=None)
     scope = serializers.SerializerMethodField(read_only=True)
-    allocated_virtual_cpus = serializers.DecimalField(
+    allocated_vcpus = serializers.DecimalField(
         read_only=True,
         max_digits=8,
         decimal_places=2,
 
     )
     allocated_memory = serializers.IntegerField(read_only=True)
-    allocated_disk_space = serializers.IntegerField(read_only=True)
+    allocated_disk = serializers.IntegerField(read_only=True)
 
     # Related object counts
     device_count = RelatedObjectCountField('devices')
@@ -77,7 +77,7 @@ class ClusterSerializer(NetBoxModelSerializer):
         fields = [
             'id', 'url', 'display_url', 'display', 'name', 'type', 'group', 'status', 'tenant', 'scope_type', 'scope_id', 'scope',
             'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated', 'device_count',
-            'virtualmachine_count', 'allocated_virtual_cpus', 'allocated_memory', 'allocated_disk_space'
+            'virtualmachine_count', 'allocated_vcpus', 'allocated_memory', 'allocated_disk'
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'description', 'virtualmachine_count')
 

--- a/netbox/virtualization/api/serializers_/clusters.py
+++ b/netbox/virtualization/api/serializers_/clusters.py
@@ -60,11 +60,13 @@ class ClusterSerializer(NetBoxModelSerializer):
     scope_id = serializers.IntegerField(allow_null=True, required=False, default=None)
     scope = serializers.SerializerMethodField(read_only=True)
     allocated_virtual_cpus = serializers.DecimalField(
+        read_only=True,
         max_digits=8,
         decimal_places=2,
+
     )
-    allocated_memory = serializers.IntegerField()
-    allocated_disk_space = serializers.IntegerField()
+    allocated_memory = serializers.IntegerField(read_only=True)
+    allocated_disk_space = serializers.IntegerField(read_only=True)
 
     # Related object counts
     device_count = RelatedObjectCountField('devices')

--- a/netbox/virtualization/api/serializers_/clusters.py
+++ b/netbox/virtualization/api/serializers_/clusters.py
@@ -59,6 +59,12 @@ class ClusterSerializer(NetBoxModelSerializer):
     )
     scope_id = serializers.IntegerField(allow_null=True, required=False, default=None)
     scope = serializers.SerializerMethodField(read_only=True)
+    allocated_virtual_cpus = serializers.DecimalField(
+        max_digits=8,
+        decimal_places=2,
+    )
+    allocated_memory = serializers.IntegerField()
+    allocated_disk_space =  serializers.IntegerField()
 
     # Related object counts
     device_count = RelatedObjectCountField('devices')
@@ -69,7 +75,7 @@ class ClusterSerializer(NetBoxModelSerializer):
         fields = [
             'id', 'url', 'display_url', 'display', 'name', 'type', 'group', 'status', 'tenant', 'scope_type', 'scope_id', 'scope',
             'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated', 'device_count',
-            'virtualmachine_count',
+            'virtualmachine_count', 'allocated_virtual_cpus', 'allocated_memory', 'allocated_disk_space'
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'description', 'virtualmachine_count')
 

--- a/netbox/virtualization/api/views.py
+++ b/netbox/virtualization/api/views.py
@@ -34,9 +34,14 @@ class ClusterGroupViewSet(NetBoxModelViewSet):
 
 
 class ClusterViewSet(NetBoxModelViewSet):
-    queryset = Cluster.objects.prefetch_related('virtual_machines').annotate(allocated_virtual_cpus=Sum('virtual_machines__vcpus'), allocated_memory=Sum('virtual_machines__memory'), allocated_disk_space=Sum('virtual_machines__disk'))
+    queryset = Cluster.objects.prefetch_related('virtual_machines').annotate(
+        allocated_vcpus=Sum('virtual_machines__vcpus'),
+        allocated_memory=Sum('virtual_machines__memory'),
+        allocated_disk=Sum('virtual_machines__disk'),
+    )
     serializer_class = serializers.ClusterSerializer
     filterset_class = filtersets.ClusterFilterSet
+
 
 #
 # Virtual machines

--- a/netbox/virtualization/api/views.py
+++ b/netbox/virtualization/api/views.py
@@ -42,6 +42,7 @@ class ClusterViewSet(NetBoxModelViewSet):
 # Virtual machines
 #
 
+
 class VirtualMachineViewSet(ConfigContextQuerySetMixin, RenderConfigMixin, NetBoxModelViewSet):
     queryset = VirtualMachine.objects.all()
     filterset_class = filtersets.VirtualMachineFilterSet

--- a/netbox/virtualization/api/views.py
+++ b/netbox/virtualization/api/views.py
@@ -1,3 +1,4 @@
+from django.db.models import Sum
 from rest_framework.routers import APIRootView
 
 from extras.api.mixins import ConfigContextQuerySetMixin, RenderConfigMixin
@@ -33,10 +34,9 @@ class ClusterGroupViewSet(NetBoxModelViewSet):
 
 
 class ClusterViewSet(NetBoxModelViewSet):
-    queryset = Cluster.objects.all()
+    queryset = Cluster.objects.prefetch_related('virtual_machines').annotate(allocated_virtual_cpus=Sum('virtual_machines__vcpus'), allocated_memory=Sum('virtual_machines__memory'), allocated_disk_space=Sum('virtual_machines__disk'))
     serializer_class = serializers.ClusterSerializer
     filterset_class = filtersets.ClusterFilterSet
-
 
 #
 # Virtual machines

--- a/netbox/virtualization/api/views.py
+++ b/netbox/virtualization/api/views.py
@@ -47,7 +47,6 @@ class ClusterViewSet(NetBoxModelViewSet):
 # Virtual machines
 #
 
-
 class VirtualMachineViewSet(ConfigContextQuerySetMixin, RenderConfigMixin, NetBoxModelViewSet):
     queryset = VirtualMachine.objects.all()
     filterset_class = filtersets.VirtualMachineFilterSet

--- a/netbox/wireless/forms/bulk_import.py
+++ b/netbox/wireless/forms/bulk_import.py
@@ -7,7 +7,7 @@ from ipam.models import VLAN
 from netbox.choices import *
 from netbox.forms import NetBoxModelImportForm
 from tenancy.models import Tenant
-from utilities.forms.fields import CSVChoiceField,  CSVModelChoiceField, SlugField
+from utilities.forms.fields import CSVChoiceField, CSVModelChoiceField, SlugField
 from wireless.choices import *
 from wireless.models import *
 


### PR DESCRIPTION
### Fixes: #12596

**Note:** There is a caveat in the Django docs about using multiple aggregates with annotation - but from testing this looks like it works correctly with multiple virtual_machines on different clusters.