### PR TITLE
Issue 17924 (BGP_ASN_MIN change from 1 to 0)

### DIFF
--- a/netbox/ipam/fields.py
+++ b/netbox/ipam/fields.py
@@ -14,7 +14,7 @@ __all__ = (
 )
 
 # BGP ASN bounds
-BGP_ASN_MIN = 1
+BGP_ASN_MIN = 0
 BGP_ASN_MAX = 2**32 - 1
 
 


### PR DESCRIPTION
### Implements: [17924](https://github.com/netbox-community/netbox/issues/17924)

Changing BGP_ASN_MIN from 1 to 0 to reflect the validity of ASN 0 (not used in BGP route updates, but used in BGP RPKI ROAs.) [https://github.com/netbox-community/netbox/issues/17924](https://github.com/netbox-community/netbox/issues/17924)
