### PR TITLE
Remove redundant check for 'vminterface' in assigned_object_parent

### DIFF
--- a/netbox/vpn/models/l2vpn.py
+++ b/netbox/vpn/models/l2vpn.py
@@ -155,8 +155,6 @@ class L2VPNTermination(NetBoxModel):
             return self.assigned_object.virtual_machine
         elif obj_type.model == 'interface':
             return self.assigned_object.device
-        elif obj_type.model == 'vminterface':
-            return self.assigned_object.virtual_machine
         return None
 
     @property


### PR DESCRIPTION
## Description
This pull request removes a redundant check for the 'vminterface' model in the assigned_object_parent property of the L2VPNTermination class. 

## Changes
- Removed the redundant `elif obj_type.model == 'vminterface':` statement

## Impact
This change simplifies the assigned_object_parent property by eliminating unnecessary code, ensuring that the logic is clear and maintainable.