### PR TITLE
Fixes #17972: Force evaluation of LOGIN_REQUIRED when requesting static media

### DIFF
--- a/netbox/netbox/tests/test_views.py
+++ b/netbox/netbox/tests/test_views.py
@@ -1,7 +1,7 @@
 import urllib.parse
 
 from django.urls import reverse
-from django.test import override_settings
+from django.test import Client, override_settings
 
 from dcim.models import Site
 from netbox.constants import EMPTY_TABLE_TEXT
@@ -74,3 +74,21 @@ class SearchViewTestCase(TestCase):
         self.assertHttpStatus(response, 200)
         content = str(response.content)
         self.assertIn(EMPTY_TABLE_TEXT, content)
+
+
+class MediaViewTestCase(TestCase):
+
+    def test_media_login_required(self):
+        url = reverse('media', kwargs={'path': 'foo.txt'})
+        response = Client().get(url)
+
+        # Unauthenticated request should redirect to login page
+        self.assertHttpStatus(response, 302)
+
+    @override_settings(LOGIN_REQUIRED=False)
+    def test_media_login_not_required(self):
+        url = reverse('media', kwargs={'path': 'foo.txt'})
+        response = Client().get(url)
+
+        # Unauthenticated request should return a 404 (not found)
+        self.assertHttpStatus(response, 404)

--- a/netbox/netbox/urls.py
+++ b/netbox/netbox/urls.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.conf.urls import include
 from django.urls import path
 from django.views.decorators.cache import cache_page
-from django.views.static import serve
 from drf_spectacular.views import SpectacularAPIView, SpectacularRedocView, SpectacularSwaggerView
 
 from account.views import LoginView, LogoutView
@@ -10,7 +9,7 @@ from netbox.api.views import APIRootView, StatusView
 from netbox.graphql.schema import schema
 from netbox.graphql.views import NetBoxGraphQLView
 from netbox.plugins.urls import plugin_patterns, plugin_api_patterns
-from netbox.views import HomeView, StaticMediaFailureView, SearchView, htmx
+from netbox.views import HomeView, MediaView, StaticMediaFailureView, SearchView, htmx
 
 _patterns = [
 
@@ -69,7 +68,7 @@ _patterns = [
     path('graphql/', NetBoxGraphQLView.as_view(schema=schema), name='graphql'),
 
     # Serving static media in Django to pipe it through LoginRequiredMiddleware
-    path('media/<path:path>', serve, {'document_root': settings.MEDIA_ROOT}),
+    path('media/<path:path>', MediaView.as_view(), name='media'),
     path('media-failure/', StaticMediaFailureView.as_view(), name='media_failure'),
 
     # Plugins

--- a/netbox/netbox/views/misc.py
+++ b/netbox/netbox/views/misc.py
@@ -8,6 +8,7 @@ from django.core.cache import cache
 from django.shortcuts import redirect, render
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
+from django.views.static import serve
 from django_tables2 import RequestConfig
 from packaging import version
 
@@ -23,6 +24,7 @@ from utilities.views import ConditionalLoginRequiredMixin
 
 __all__ = (
     'HomeView',
+    'MediaView',
     'SearchView',
 )
 
@@ -115,3 +117,11 @@ class SearchView(ConditionalLoginRequiredMixin, View):
             'form': form,
             'table': table,
         })
+
+
+class MediaView(ConditionalLoginRequiredMixin, View):
+    """
+    Wrap Django's serve() view to enforce LOGIN_REQUIRED for static media.
+    """
+    def get(self, request, path):
+        return serve(request, path, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
### Fixes: #17972

Creates a new view, MediaView, to wrap Django's `serve()` view and enforce `LOGIN_REQUIRED` (if enabled) for uploaded media (e.g. image attachments).