### PR TITLE
Fixes #17969: Fix system info export when a config revision exists

### DIFF
--- a/netbox/core/tests/test_views.py
+++ b/netbox/core/tests/test_views.py
@@ -346,3 +346,32 @@ class BackgroundTaskTestCase(TestCase):
         self.assertIn(str(worker1.name), str(response.content))
         self.assertIn('Birth', str(response.content))
         self.assertIn('Total working time', str(response.content))
+
+
+class SystemTestCase(TestCase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.user.is_staff = True
+        self.user.save()
+
+    def test_system_view_default(self):
+        # Test UI render
+        response = self.client.get(reverse('core:system'))
+        self.assertEqual(response.status_code, 200)
+
+        # Test export
+        response = self.client.get(f"{reverse('core:system')}?export=true")
+        self.assertEqual(response.status_code, 200)
+
+    def test_system_view_with_config_revision(self):
+        ConfigRevision.objects.create()
+
+        # Test UI render
+        response = self.client.get(reverse('core:system'))
+        self.assertEqual(response.status_code, 200)
+
+        # Test export
+        response = self.client.get(f"{reverse('core:system')}?export=true")
+        self.assertEqual(response.status_code, 200)

--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -626,11 +626,7 @@ class SystemView(UserPassesTestMixin, View):
         }
 
         # Configuration
-        try:
-            config = ConfigRevision.objects.get(pk=cache.get('config_version'))
-        except ConfigRevision.DoesNotExist:
-            # Fall back to using the active config data if no record is found
-            config = get_config()
+        config = get_config()
 
         # Raw data export
         if 'export' in request.GET:


### PR DESCRIPTION
### Fixes: #17969

- Tweak SystemView to use `get_config()` consistently
- Add SystemTestCase