### PR TITLE
Fixes #17963: Fix selection of all listed objects during bulk edit

### DIFF
--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -698,7 +698,7 @@ class BulkEditView(GetReturnURLMixin, BaseMultiObjectView):
                 logger.debug("Form validation failed")
 
         else:
-            form = self.form(request.POST, initial=initial_data)
+            form = self.form(initial=initial_data)
             restrict_form_fields(form, request.user)
 
         # Retrieve objects being edited


### PR DESCRIPTION
### Fixes: #17963

Revert regression from 6a316df787915141f8038507c531cdcfaffc2b39