### PR TITLE
Fixes #17954 - Handle CircuitTerminations in Cable Bulk Import

### DIFF
--- a/netbox/templates/generic/bulk_import.html
+++ b/netbox/templates/generic/bulk_import.html
@@ -129,6 +129,8 @@ Context:
                 <td>
                   {% if field.required %}
                     {% checkmark True true="Required" %}
+                  {% elif field.conditional %}
+                    {% tag "Conditional" %}
                   {% else %}
                     {{ ''|placeholder }}
                   {% endif %}

--- a/netbox/templates/generic/bulk_import.html
+++ b/netbox/templates/generic/bulk_import.html
@@ -130,7 +130,7 @@ Context:
                   {% if field.required %}
                     {% checkmark True true="Required" %}
                   {% elif field.conditional %}
-                    {% tag "Conditional" %}
+                    <span class="badge bg-yellow text-yellow-fg" >{% trans "Conditional" %}</span>
                   {% else %}
                     {{ ''|placeholder }}
                   {% endif %}

--- a/netbox/utilities/forms/fields/csv.py
+++ b/netbox/utilities/forms/fields/csv.py
@@ -57,6 +57,11 @@ class CSVModelChoiceField(forms.ModelChoiceField):
         'invalid_choice': _('Object not found: %(value)s'),
     }
 
+    def __init__(self, conditional=False, *args, **kwargs):
+        # Used to trigger conditional validation in the forms
+        self.conditional = conditional
+        super().__init__(*args, **kwargs)
+
     def to_python(self, value):
         try:
             return super().to_python(value)

--- a/netbox/utilities/forms/fields/csv.py
+++ b/netbox/utilities/forms/fields/csv.py
@@ -58,7 +58,7 @@ class CSVModelChoiceField(forms.ModelChoiceField):
     }
 
     def __init__(self, conditional=False, *args, **kwargs):
-        # Used to trigger conditional validation in the forms
+        # Used to display tags for fields that are conditionally required
         self.conditional = conditional
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
### Fixes: #17954

### Add Support for Bulk Importing Cables Connected to Circuits

This pull request enhances the bulk import functionality for cables by allowing users to specify circuits as termination points on either side of a cable. Previously, only devices could be specified for cable terminations during bulk import which didn't allow for Cables to be connected to Circuit Terminations properly.

**Key Changes:**

- **Added Fields for Circuit Terminations:**
  - Introduced `side_a_circuit` and `side_b_circuit` fields in the `CableImportForm` within `dcim/forms/bulk_import.py`.
  - These fields are optional and conditional, allowing users to specify a Circuit ID (`cid`) as a termination point.
  
- **Updated CableImportForm Validation Logic:**
  - Modified the `_clean_side` method in `CableImportForm` to handle cases where a circuit is specified instead of a device.
  - Added validation to ensure that both a device and a circuit cannot be specified simultaneously for the same side.
  - Ensured that the termination object is correctly retrieved based on whether a device or circuit is provided.
  - Added checks to prevent connecting to a circuit termination that is already connected to a Provider Network.

- **Enhanced Bulk Import Template:**
  - Updated `bulk_import.html` to display a "Conditional" tag for fields that are conditionally required, improving user experience during the import process.

- **Extended CSV Field Functionality:**
  - Modified `CSVModelChoiceField` in `utilities/forms/fields/csv.py` to accept a `conditional` parameter.
  - This parameter is used to indicate fields that are conditionally required based on other form fields.

**Benefits:**

- **Improved Flexibility:** Users can now bulk import cables that connect directly to circuits, not just devices.
- **Enhanced User Experience:** Clearer form validation messages and template indicators help prevent import errors.
- **Increased Efficiency:** Streamlines the process of importing large numbers of cables connected to circuits.

**Usage Notes:**

- When importing, specify either a device or a circuit for each side of the cable—not both.
- Ensure that the circuit terminations are not already connected to a Provider Network to avoid validation errors.
