### PR TITLE
wip: Filter by custom fields in graph ql

### DIFF
--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -27,7 +27,7 @@ from wireless.models import WirelessLAN, WirelessLink
 from .choices import *
 from .constants import *
 from .models import *
-
+from django.db.models import JSONField
 __all__ = (
     'CableFilterSet',
     'CabledObjectFilterSet',
@@ -1186,6 +1186,7 @@ class DeviceFilterSet(
             'module_bay_count',
             'inventory_item_count',
         )
+
 
     def search(self, queryset, name, value):
         if not value.strip():


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Works on : #7598 

<!--
    Please include a summary of the proposed changes below.
-->
I worked on issue #7598 and made progress. Unfortunaltely, I hit some roadblocks and none of the maintainers were available to answer my questions. I open this merge request with my partial solution so that it might be of use for the project in the future.

I utilized `autotype_decorator`, which is used to communicate the filterset to graphql, in order to add `CustomField` entries with the same logic applied as in `netbox.filtersets.NetBoxModelFilterSet`. The code calls `create_attribute_and_function` for each custom field of the current model. This successfully adds a new filter to GraphQL, which is recognized in the backend. Unfortunately, there are still some problems:
- The generated Filter itereates over the filter argument, so a filter by "Foo" filters by "F" OR "o" OR "o", which is not the desired functionality.
- Additionally, filters on non-iterable datatypes such as `int` do not work.
- After adding a new CustomField, the server needs to be restarted in order for GraphQL to be aware of the new field. Since GraphQL is a schema-based tool, it is not clear if the restart requirement can be avoided.
- The lints in the GraphIQL-Frontend do not recognize the new CustomField filter. Nevertheless, applying the filter will lead to a change in the output, so it is recognized by the server. For instance, after creating a custom field `a_string` on `Device`, the following graphql statement can be used to filter the devices, but GraphIQL does not know of `cf_a_string`:
```graphql
{
 device_list(filters: {cf_a_string: "a"}) {
  id
  name
  custom_fields
  local_context_data
  device_type {
   id
   display
   slug
  }
 }
}
```


