### PR TITLE
Hide `sensitive_parameters` from datasource view even for high privil…

### DIFF
--- a/netbox/templates/core/datasource.html
+++ b/netbox/templates/core/datasource.html
@@ -87,7 +87,7 @@
               {% for name, field in backend.parameters.items %}
                 <tr>
                   <th scope="row">{{ field.label }}</th>
-                  {% if name in backend.sensitive_parameters and not perms.core.change_datasource %}
+                  {% if name in backend.sensitive_parameters %}
                     <td>********</td>
                   {% else %}
                     <td>{{ object.parameters|get_key:name|placeholder }}</td>


### PR DESCRIPTION
…ege users

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18007

<!--
    Please include a summary of the proposed changes below.
-->
This PR hides `sensitive_parameters` in the Data Source view's Backend Panel, even for users with sufficient permissions to set that field.

My preference would be to also hide sensitive fields in the edit form, but I don't think that is done anywhere else in NetBox, and I'm not in a position to make that design choice.