### PR TITLE
Fixes: #7699  - Access _site of cluster instead of site

### DIFF
--- a/netbox/virtualization/forms/bulk_edit.py
+++ b/netbox/virtualization/forms/bulk_edit.py
@@ -279,7 +279,7 @@ class VMInterfaceBulkEditForm(NetBoxModelBulkEditForm):
                 # Check interface sites.  First interface should set site, further interfaces will either continue the
                 # loop or reset back to no site and break the loop.
                 for interface in interfaces:
-                    vm_site = interface.virtual_machine.site or interface.virtual_machine.cluster.site
+                    vm_site = interface.virtual_machine.site or interface.virtual_machine.cluster._site
                     if site is None:
                         site = vm_site
                     elif vm_site is not site:


### PR DESCRIPTION
### Fixes: #7699

Addresses a bug related to #7699 (Scope attributes moved to GFKs and cached accessors) where bulk-editing VMInterfaces would raise an AttributeError due to looking up `interface.virtual_machine.cluster.site` directly.

This is a low-impact fix that should not add more risk (`virtual_machine.cluster` appears to always be set); however it is accessing a private attribute of the `CachedScopeMixin` which may not be great style-wise.
