### PR TITLE
Fixes: #18038 - Ensure DeviceType._abs_weight is stored as an integer

### DIFF
--- a/netbox/dcim/models/mixins.py
+++ b/netbox/dcim/models/mixins.py
@@ -37,7 +37,7 @@ class WeightMixin(models.Model):
 
         # Store the given weight (if any) in grams for use in database ordering
         if self.weight and self.weight_unit:
-            self._abs_weight = to_grams(self.weight, self.weight_unit)
+            self._abs_weight = int(to_grams(self.weight, self.weight_unit))
         else:
             self._abs_weight = None
 

--- a/netbox/dcim/models/mixins.py
+++ b/netbox/dcim/models/mixins.py
@@ -37,7 +37,7 @@ class WeightMixin(models.Model):
 
         # Store the given weight (if any) in grams for use in database ordering
         if self.weight and self.weight_unit:
-            self._abs_weight = int(to_grams(self.weight, self.weight_unit))
+            self._abs_weight = to_grams(self.weight, self.weight_unit)
         else:
             self._abs_weight = None
 

--- a/netbox/utilities/conversion.py
+++ b/netbox/utilities/conversion.py
@@ -10,9 +10,9 @@ __all__ = (
 )
 
 
-def to_grams(weight, unit) -> float:
+def to_grams(weight, unit) -> int:
     """
-    Convert the given weight to kilograms.
+    Convert the given weight to integer grams.
     """
     try:
         if weight < 0:
@@ -21,13 +21,13 @@ def to_grams(weight, unit) -> float:
         raise TypeError(_("Invalid value '{weight}' for weight (must be a number)").format(weight=weight))
 
     if unit == WeightUnitChoices.UNIT_KILOGRAM:
-        return weight * 1000
+        return int(weight * 1000)
     if unit == WeightUnitChoices.UNIT_GRAM:
-        return weight
+        return int(weight)
     if unit == WeightUnitChoices.UNIT_POUND:
-        return weight * Decimal(453.592)
+        return int(weight * Decimal(453.592))
     if unit == WeightUnitChoices.UNIT_OUNCE:
-        return weight * Decimal(28.3495)
+        return int(weight * Decimal(28.3495))
     raise ValueError(
         _("Unknown unit {unit}. Must be one of the following: {valid_units}").format(
             unit=unit,

--- a/netbox/utilities/conversion.py
+++ b/netbox/utilities/conversion.py
@@ -10,7 +10,7 @@ __all__ = (
 )
 
 
-def to_grams(weight, unit):
+def to_grams(weight, unit) -> float:
     """
     Convert the given weight to kilograms.
     """


### PR DESCRIPTION
### Fixes: #18038

`WeightMixin` provides an `_abs_weight` field which stores the normalized weight in grams. It is a `PositiveBigIntegerField`, yet the value stored in it is the unvalidated output of `to_grams`, which may be a float. This does not normally cause issues in the app, but in the case of netbox-branching, the field validation fails when the field value is synced from one branch to another because it expects an integer but receives a float.

This fix adds type annotation and consistent return values to `to_grams`.