### PR TITLE
Fixes: #18037 - Bound VLANGroup VLAN ID max by `VLAN_VID_MAX`

### DIFF
--- a/netbox/ipam/models/vlans.py
+++ b/netbox/ipam/models/vlans.py
@@ -98,19 +98,25 @@ class VLANGroup(OrganizationalModel):
 
         # Validate VID ranges
         for vid_range in self.vid_ranges:
-            if vid_range.lower < VLAN_VID_MIN:
+            lower_vid = vid_range.lower if vid_range.lower_inc else vid_range.lower + 1
+            upper_vid = vid_range.upper if vid_range.upper_inc else vid_range.upper - 1
+            if lower_vid < VLAN_VID_MIN:
                 raise ValidationError({
-                    'vid_ranges': _("Starting VLAN ID in range cannot be less than {value}").format(value=VLAN_VID_MIN)
+                    'vid_ranges': _("Starting VLAN ID in range ({value}) cannot be less than {minimum}").format(
+                        value=lower_vid, minimum=VLAN_VID_MIN
+                    )
                 })
-            if vid_range.upper > VLAN_VID_MAX:
+            if upper_vid > VLAN_VID_MAX:
                 raise ValidationError({
-                    'vid_ranges': _("Ending VLAN ID in range cannot exceed {value}").format(value=VLAN_VID_MAX)
+                    'vid_ranges': _("Ending VLAN ID in range ({value}) cannot exceed {maximum}").format(
+                        value=upper_vid, maximum=VLAN_VID_MAX
+                    )
                 })
-            if vid_range.lower > vid_range.upper:
+            if lower_vid > upper_vid:
                 raise ValidationError({
                     'vid_ranges': _(
-                        "Ending VLAN ID in range must be greater than or equal to the starting VLAN ID ({value})"
-                    ).format(value=vid_range)
+                        "Ending VLAN ID in range must be greater than or equal to the starting VLAN ID ({range})"
+                    ).format(range=f'{lower_vid}-{upper_vid}')
                 })
 
         # Check for overlapping VID ranges

--- a/netbox/ipam/models/vlans.py
+++ b/netbox/ipam/models/vlans.py
@@ -99,7 +99,11 @@ class VLANGroup(OrganizationalModel):
         # Validate VID ranges
         if self.vid_ranges and check_ranges_overlap(self.vid_ranges):
             raise ValidationError({'vid_ranges': _("Ranges cannot overlap.")})
+
+        # Validate max VID
         for vid_range in self.vid_ranges:
+            if vid_range.lower > VLAN_VID_MAX or vid_range.upper > VLAN_VID_MAX:
+                raise ValidationError({'vid_ranges': _("VLAN ID cannot exceed 4094")})
             if vid_range.lower > vid_range.upper:
                 raise ValidationError({
                     'vid_ranges': _(

--- a/netbox/ipam/models/vlans.py
+++ b/netbox/ipam/models/vlans.py
@@ -103,7 +103,7 @@ class VLANGroup(OrganizationalModel):
         # Validate max VID
         for vid_range in self.vid_ranges:
             if vid_range.lower > VLAN_VID_MAX or vid_range.upper > VLAN_VID_MAX:
-                raise ValidationError({'vid_ranges': _("VLAN ID cannot exceed 4094")})
+                raise ValidationError({'vid_ranges': _("Child vid cannot exceed {value}").format(value=VLAN_VID_MAX)})
             if vid_range.lower > vid_range.upper:
                 raise ValidationError({
                     'vid_ranges': _(


### PR DESCRIPTION
### Fixes: #18037 - Restrict VLANGroup VID max to 4094

* Bound VLANGroup VLAN ID max by `VLAN_VID_MAX`
