### PR TITLE
Closes: #17795 - Add concurrency to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: read
 
+# Add concurrency group to control job running
 concurrency:
   group: ${{ github.event_name }}-${{ github.ref }}-${{ github.actor }}
   cancel-in-progress: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.event_name }}-${{ github.ref }}-${{ github.actor }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Closes: #17795 - Add concurrency to CI

* Add a concurrency group to CI to automatically cancel running jobs on new push to branch/PR