### PR TITLE
Fixes: #17950 - Handle InvalidJobOperation error in job enqueueing test

### DIFF
--- a/netbox/core/models/jobs.py
+++ b/netbox/core/models/jobs.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext as _
+from rq.exceptions import InvalidJobOperation
 
 from core.choices import JobStatusChoices
 from core.models import ObjectType
@@ -158,7 +159,11 @@ class Job(models.Model):
         job = queue.fetch_job(str(self.job_id))
 
         if job:
-            job.cancel()
+            try:
+                job.cancel()
+            except InvalidJobOperation:
+                # Job may raise this exception from get_status() if missing from Redis
+                pass
 
     def start(self):
         """

--- a/netbox/netbox/tests/test_jobs.py
+++ b/netbox/netbox/tests/test_jobs.py
@@ -1,8 +1,11 @@
+import time
 from datetime import timedelta
+from redis import Redis
 
 from django.test import TestCase
 from django.utils import timezone
 from django_rq import get_queue
+from rq.job import Job as RQJob
 
 from ..jobs import *
 from core.models import DataSource, Job
@@ -121,7 +124,15 @@ class EnqueueTest(JobRunnerTestCase):
 
     def test_enqueue_once_after_enqueue(self):
         instance = DataSource()
+        redis = Redis()
         job1 = TestJobRunner.enqueue(instance, schedule_at=self.get_schedule_at())
+        job1_rq = None
+        max_sleep = 5
+        sleep_count = 0
+        while job1_rq is None and sleep_count < max_sleep:
+            job1_rq = RQJob.fetch(str(job1.job_id), connection=redis)
+            time.sleep(1)
+            sleep_count += 1
         job2 = TestJobRunner.enqueue_once(instance, schedule_at=self.get_schedule_at(2))
 
         self.assertNotEqual(job1, job2)

--- a/netbox/netbox/tests/test_jobs.py
+++ b/netbox/netbox/tests/test_jobs.py
@@ -126,11 +126,10 @@ class EnqueueTest(JobRunnerTestCase):
         instance = DataSource()
         redis = Redis()
         job1 = TestJobRunner.enqueue(instance, schedule_at=self.get_schedule_at())
-        job1_rq = None
+        job1_rq = RQJob.fetch(str(job1.job_id), connection=redis)
         max_sleep = 5
         sleep_count = 0
-        while job1_rq is None and sleep_count < max_sleep:
-            job1_rq = RQJob.fetch(str(job1.job_id), connection=redis)
+        while not job1_rq.get_status() and sleep_count < max_sleep:
             time.sleep(1)
             sleep_count += 1
         job2 = TestJobRunner.enqueue_once(instance, schedule_at=self.get_schedule_at(2))

--- a/netbox/netbox/tests/test_jobs.py
+++ b/netbox/netbox/tests/test_jobs.py
@@ -5,7 +5,7 @@ from redis import Redis
 from django.test import TestCase
 from django.utils import timezone
 from django_rq import get_queue
-from rq.job import Job as RQJob
+from rq.job import Job as RQJob, InvalidJobOperation
 
 from ..jobs import *
 from core.models import DataSource, Job
@@ -127,11 +127,15 @@ class EnqueueTest(JobRunnerTestCase):
         redis = Redis()
         job1 = TestJobRunner.enqueue(instance, schedule_at=self.get_schedule_at())
         job1_rq = RQJob.fetch(str(job1.job_id), connection=redis)
+        job1_status = None
         max_sleep = 5
         sleep_count = 0
-        while not job1_rq.get_status() and sleep_count < max_sleep:
-            time.sleep(1)
-            sleep_count += 1
+        while job1_status is None and sleep_count < max_sleep:
+            try:
+                job1_status = job1_rq.get_status()
+            except InvalidJobOperation:
+                time.sleep(1)
+                sleep_count += 1
         job2 = TestJobRunner.enqueue_once(instance, schedule_at=self.get_schedule_at(2))
 
         self.assertNotEqual(job1, job2)

--- a/netbox/netbox/tests/test_jobs.py
+++ b/netbox/netbox/tests/test_jobs.py
@@ -1,11 +1,8 @@
-import time
 from datetime import timedelta
-from redis import Redis
 
 from django.test import TestCase
 from django.utils import timezone
 from django_rq import get_queue
-from rq.job import Job as RQJob, InvalidJobOperation
 
 from ..jobs import *
 from core.models import DataSource, Job
@@ -124,18 +121,7 @@ class EnqueueTest(JobRunnerTestCase):
 
     def test_enqueue_once_after_enqueue(self):
         instance = DataSource()
-        redis = Redis()
         job1 = TestJobRunner.enqueue(instance, schedule_at=self.get_schedule_at())
-        job1_rq = RQJob.fetch(str(job1.job_id), connection=redis)
-        job1_status = None
-        max_sleep = 5
-        sleep_count = 0
-        while job1_status is None and sleep_count < max_sleep:
-            try:
-                job1_status = job1_rq.get_status()
-            except InvalidJobOperation:
-                time.sleep(1)
-                sleep_count += 1
         job2 = TestJobRunner.enqueue_once(instance, schedule_at=self.get_schedule_at(2))
 
         self.assertNotEqual(job1, job2)


### PR DESCRIPTION
### Fixes: #17950

This alters the `Job.delete()` method to wrap `job.cancel()` in a try-except which handles the condition where the inner `get_status` call fails to find a non-null status for the job in Redis. This should fix a recurring intermittent test failure in `test_enqueue_once_after_enqueue`.

My investigation showed that whereas the job UUID key must be in Redis in order for `fetch_job` to work (which occurs in `delete` prior to the `cancel` call), it is occasionally the case that a call to `self.connection.hget(self.key, 'status')` returns a null value, leading to the exception being raised in `rq/job.py#L400`. This never occurs locally, and may be a side effect of concurrency within the CI environment.

The risk of this fix is low, I think, because the `job.cancel` is only being used in order to clear out a job from the cache during a `delete` operation; leaving a job in undeleted or partially-deleted state (particularly specifically in CI) is unlikely to have negative side effects.
