### PR TITLE
Closes #17752: Rename URL paths for bulk import to `*_bulk_import`

### DIFF
--- a/netbox/circuits/tests/test_views.py
+++ b/netbox/circuits/tests/test_views.py
@@ -239,10 +239,10 @@ class CircuitTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
         # Try GET with model-level permission
-        self.assertHttpStatus(self.client.get(self._get_url('import')), 200)
+        self.assertHttpStatus(self.client.get(self._get_url('bulk_import')), 200)
 
         # Test POST with permission
-        self.assertHttpStatus(self.client.post(self._get_url('import'), data), 302)
+        self.assertHttpStatus(self.client.post(self._get_url('bulk_import'), data), 302)
         self.assertEqual(self._get_queryset().count(), initial_count + 1)
 
 
@@ -655,10 +655,10 @@ class VirtualCircuitTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
         # Try GET with model-level permission
-        self.assertHttpStatus(self.client.get(self._get_url('import')), 200)
+        self.assertHttpStatus(self.client.get(self._get_url('bulk_import')), 200)
 
         # Test POST with permission
-        self.assertHttpStatus(self.client.post(self._get_url('import'), data), 302)
+        self.assertHttpStatus(self.client.post(self._get_url('bulk_import'), data), 302)
         self.assertEqual(self._get_queryset().count(), initial_count + 1)
 
 

--- a/netbox/circuits/urls.py
+++ b/netbox/circuits/urls.py
@@ -37,7 +37,7 @@ urlpatterns = [
     # Virtual circuits
     path('virtual-circuits/', views.VirtualCircuitListView.as_view(), name='virtualcircuit_list'),
     path('virtual-circuits/add/', views.VirtualCircuitEditView.as_view(), name='virtualcircuit_add'),
-    path('virtual-circuits/import/', views.VirtualCircuitBulkImportView.as_view(), name='virtualcircuit_import'),
+    path('virtual-circuits/import/', views.VirtualCircuitBulkImportView.as_view(), name='virtualcircuit_bulk_import'),
     path('virtual-circuits/edit/', views.VirtualCircuitBulkEditView.as_view(), name='virtualcircuit_bulk_edit'),
     path('virtual-circuits/delete/', views.VirtualCircuitBulkDeleteView.as_view(), name='virtualcircuit_bulk_delete'),
     path('virtual-circuits/<int:pk>/', include(get_model_urls('circuits', 'virtualcircuit'))),
@@ -56,7 +56,7 @@ urlpatterns = [
     path(
         'virtual-circuit-terminations/import/',
         views.VirtualCircuitTerminationBulkImportView.as_view(),
-        name='virtualcircuittermination_import',
+        name='virtualcircuittermination_bulk_import',
     ),
     path(
         'virtual-circuit-terminations/edit/',

--- a/netbox/circuits/views.py
+++ b/netbox/circuits/views.py
@@ -49,7 +49,7 @@ class ProviderDeleteView(generic.ObjectDeleteView):
     queryset = Provider.objects.all()
 
 
-@register_model_view(Provider, 'import', detail=False)
+@register_model_view(Provider, 'bulk_import', detail=False)
 class ProviderBulkImportView(generic.BulkImportView):
     queryset = Provider.objects.all()
     model_form = forms.ProviderImportForm
@@ -115,7 +115,7 @@ class ProviderAccountDeleteView(generic.ObjectDeleteView):
     queryset = ProviderAccount.objects.all()
 
 
-@register_model_view(ProviderAccount, 'import', detail=False)
+@register_model_view(ProviderAccount, 'bulk_import', detail=False)
 class ProviderAccountBulkImportView(generic.BulkImportView):
     queryset = ProviderAccount.objects.all()
     model_form = forms.ProviderAccountImportForm
@@ -189,7 +189,7 @@ class ProviderNetworkDeleteView(generic.ObjectDeleteView):
     queryset = ProviderNetwork.objects.all()
 
 
-@register_model_view(ProviderNetwork, 'import', detail=False)
+@register_model_view(ProviderNetwork, 'bulk_import', detail=False)
 class ProviderNetworkBulkImportView(generic.BulkImportView):
     queryset = ProviderNetwork.objects.all()
     model_form = forms.ProviderNetworkImportForm
@@ -246,7 +246,7 @@ class CircuitTypeDeleteView(generic.ObjectDeleteView):
     queryset = CircuitType.objects.all()
 
 
-@register_model_view(CircuitType, 'import', detail=False)
+@register_model_view(CircuitType, 'bulk_import', detail=False)
 class CircuitTypeBulkImportView(generic.BulkImportView):
     queryset = CircuitType.objects.all()
     model_form = forms.CircuitTypeImportForm
@@ -302,7 +302,7 @@ class CircuitDeleteView(generic.ObjectDeleteView):
     queryset = Circuit.objects.all()
 
 
-@register_model_view(Circuit, 'import', detail=False)
+@register_model_view(Circuit, 'bulk_import', detail=False)
 class CircuitBulkImportView(generic.BulkImportView):
     queryset = Circuit.objects.all()
     model_form = forms.CircuitImportForm
@@ -447,7 +447,7 @@ class CircuitTerminationDeleteView(generic.ObjectDeleteView):
     queryset = CircuitTermination.objects.all()
 
 
-@register_model_view(CircuitTermination, 'import', detail=False)
+@register_model_view(CircuitTermination, 'bulk_import', detail=False)
 class CircuitTerminationBulkImportView(generic.BulkImportView):
     queryset = CircuitTermination.objects.all()
     model_form = forms.CircuitTerminationImportForm
@@ -508,7 +508,7 @@ class CircuitGroupDeleteView(generic.ObjectDeleteView):
     queryset = CircuitGroup.objects.all()
 
 
-@register_model_view(CircuitGroup, 'import', detail=False)
+@register_model_view(CircuitGroup, 'bulk_import', detail=False)
 class CircuitGroupBulkImportView(generic.BulkImportView):
     queryset = CircuitGroup.objects.all()
     model_form = forms.CircuitGroupImportForm
@@ -558,7 +558,7 @@ class CircuitGroupAssignmentDeleteView(generic.ObjectDeleteView):
     queryset = CircuitGroupAssignment.objects.all()
 
 
-@register_model_view(CircuitGroupAssignment, 'import', detail=False)
+@register_model_view(CircuitGroupAssignment, 'bulk_import', detail=False)
 class CircuitGroupAssignmentBulkImportView(generic.BulkImportView):
     queryset = CircuitGroupAssignment.objects.all()
     model_form = forms.CircuitGroupAssignmentImportForm

--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -105,7 +105,7 @@ class DataSourceDeleteView(generic.ObjectDeleteView):
     queryset = DataSource.objects.all()
 
 
-@register_model_view(DataSource, 'import', detail=False)
+@register_model_view(DataSource, 'bulk_import', detail=False)
 class DataSourceBulkImportView(generic.BulkImportView):
     queryset = DataSource.objects.all()
     model_form = forms.DataSourceImportForm

--- a/netbox/dcim/tests/test_views.py
+++ b/netbox/dcim/tests/test_views.py
@@ -900,7 +900,7 @@ inventory-items:
             'data': IMPORT_DATA,
             'format': 'yaml'
         }
-        response = self.client.post(reverse('dcim:devicetype_import'), data=form_data, follow=True)
+        response = self.client.post(reverse('dcim:devicetype_bulk_import'), data=form_data, follow=True)
         self.assertHttpStatus(response, 200)
 
         device_type = DeviceType.objects.get(model='TEST-1000')
@@ -1228,7 +1228,7 @@ front-ports:
             'data': IMPORT_DATA,
             'format': 'yaml'
         }
-        response = self.client.post(reverse('dcim:moduletype_import'), data=form_data, follow=True)
+        response = self.client.post(reverse('dcim:moduletype_bulk_import'), data=form_data, follow=True)
         self.assertHttpStatus(response, 200)
 
         module_type = ModuleType.objects.get(model='TEST-1000')
@@ -2170,7 +2170,7 @@ class ModuleTestCase(
             f"{device.name},{module_bay.name},{module_type.model},active,false"
         ]
         request = {
-            'path': self._get_url('import'),
+            'path': self._get_url('bulk_import'),
             'data': {
                 'data': '\n'.join(csv_data),
                 'format': ImportFormatChoices.CSV,
@@ -2187,7 +2187,7 @@ class ModuleTestCase(
         module_bay = ModuleBay.objects.get(device=device, name='Module Bay 5')
         csv_data[1] = f"{device.name},{module_bay.name},{module_type.model},active,true"
         request = {
-            'path': self._get_url('import'),
+            'path': self._get_url('bulk_import'),
             'data': {
                 'data': '\n'.join(csv_data),
                 'format': ImportFormatChoices.CSV,
@@ -2264,7 +2264,7 @@ class ModuleTestCase(
             f"{device.name},{module_bay.name},{module_type.model},active,false,true"
         ]
         request = {
-            'path': self._get_url('import'),
+            'path': self._get_url('bulk_import'),
             'data': {
                 'data': '\n'.join(csv_data),
                 'format': ImportFormatChoices.CSV,

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -266,7 +266,7 @@ class RegionDeleteView(generic.ObjectDeleteView):
     queryset = Region.objects.all()
 
 
-@register_model_view(Region, 'import', detail=False)
+@register_model_view(Region, 'bulk_import', detail=False)
 class RegionBulkImportView(generic.BulkImportView):
     queryset = Region.objects.all()
     model_form = forms.RegionImportForm
@@ -359,7 +359,7 @@ class SiteGroupDeleteView(generic.ObjectDeleteView):
     queryset = SiteGroup.objects.all()
 
 
-@register_model_view(SiteGroup, 'import', detail=False)
+@register_model_view(SiteGroup, 'bulk_import', detail=False)
 class SiteGroupBulkImportView(generic.BulkImportView):
     queryset = SiteGroup.objects.all()
     model_form = forms.SiteGroupImportForm
@@ -448,7 +448,7 @@ class SiteDeleteView(generic.ObjectDeleteView):
     queryset = Site.objects.all()
 
 
-@register_model_view(Site, 'import', detail=False)
+@register_model_view(Site, 'bulk_import', detail=False)
 class SiteBulkImportView(generic.BulkImportView):
     queryset = Site.objects.all()
     model_form = forms.SiteImportForm
@@ -533,7 +533,7 @@ class LocationDeleteView(generic.ObjectDeleteView):
     queryset = Location.objects.all()
 
 
-@register_model_view(Location, 'import', detail=False)
+@register_model_view(Location, 'bulk_import', detail=False)
 class LocationBulkImportView(generic.BulkImportView):
     queryset = Location.objects.all()
     model_form = forms.LocationImportForm
@@ -607,7 +607,7 @@ class RackRoleDeleteView(generic.ObjectDeleteView):
     queryset = RackRole.objects.all()
 
 
-@register_model_view(RackRole, 'import', detail=False)
+@register_model_view(RackRole, 'bulk_import', detail=False)
 class RackRoleBulkImportView(generic.BulkImportView):
     queryset = RackRole.objects.all()
     model_form = forms.RackRoleImportForm
@@ -668,7 +668,7 @@ class RackTypeDeleteView(generic.ObjectDeleteView):
     queryset = RackType.objects.all()
 
 
-@register_model_view(RackType, 'import', detail=False)
+@register_model_view(RackType, 'bulk_import', detail=False)
 class RackTypeBulkImportView(generic.BulkImportView):
     queryset = RackType.objects.all()
     model_form = forms.RackTypeImportForm
@@ -836,7 +836,7 @@ class RackDeleteView(generic.ObjectDeleteView):
     queryset = Rack.objects.all()
 
 
-@register_model_view(Rack, 'import', detail=False)
+@register_model_view(Rack, 'bulk_import', detail=False)
 class RackBulkImportView(generic.BulkImportView):
     queryset = Rack.objects.all()
     model_form = forms.RackImportForm
@@ -898,7 +898,7 @@ class RackReservationDeleteView(generic.ObjectDeleteView):
     queryset = RackReservation.objects.all()
 
 
-@register_model_view(RackReservation, 'import', detail=False)
+@register_model_view(RackReservation, 'bulk_import', detail=False)
 class RackReservationImportView(generic.BulkImportView):
     queryset = RackReservation.objects.all()
     model_form = forms.RackReservationImportForm
@@ -968,7 +968,7 @@ class ManufacturerDeleteView(generic.ObjectDeleteView):
     queryset = Manufacturer.objects.all()
 
 
-@register_model_view(Manufacturer, 'import', detail=False)
+@register_model_view(Manufacturer, 'bulk_import', detail=False)
 class ManufacturerBulkImportView(generic.BulkImportView):
     queryset = Manufacturer.objects.all()
     model_form = forms.ManufacturerImportForm
@@ -1194,7 +1194,7 @@ class DeviceTypeInventoryItemsView(DeviceTypeComponentsView):
     )
 
 
-@register_model_view(DeviceType, 'import', detail=False)
+@register_model_view(DeviceType, 'bulk_import', detail=False)
 class DeviceTypeImportView(generic.BulkImportView):
     additional_permissions = [
         'dcim.add_devicetype',
@@ -1408,7 +1408,7 @@ class ModuleTypeModuleBaysView(ModuleTypeComponentsView):
     )
 
 
-@register_model_view(ModuleType, 'import', detail=False)
+@register_model_view(ModuleType, 'bulk_import', detail=False)
 class ModuleTypeImportView(generic.BulkImportView):
     additional_permissions = [
         'dcim.add_moduletype',
@@ -1904,7 +1904,7 @@ class DeviceRoleDeleteView(generic.ObjectDeleteView):
     queryset = DeviceRole.objects.all()
 
 
-@register_model_view(DeviceRole, 'import', detail=False)
+@register_model_view(DeviceRole, 'bulk_import', detail=False)
 class DeviceRoleBulkImportView(generic.BulkImportView):
     queryset = DeviceRole.objects.all()
     model_form = forms.DeviceRoleImportForm
@@ -1968,7 +1968,7 @@ class PlatformDeleteView(generic.ObjectDeleteView):
     queryset = Platform.objects.all()
 
 
-@register_model_view(Platform, 'import', detail=False)
+@register_model_view(Platform, 'bulk_import', detail=False)
 class PlatformBulkImportView(generic.BulkImportView):
     queryset = Platform.objects.all()
     model_form = forms.PlatformImportForm
@@ -2289,7 +2289,7 @@ class DeviceVirtualMachinesView(generic.ObjectChildrenView):
         return self.child_model.objects.restrict(request.user, 'view').filter(cluster=parent.cluster, device=parent)
 
 
-@register_model_view(Device, 'import', detail=False)
+@register_model_view(Device, 'bulk_import', detail=False)
 class DeviceBulkImportView(generic.BulkImportView):
     queryset = Device.objects.all()
     model_form = forms.DeviceImportForm
@@ -2367,7 +2367,7 @@ class ModuleDeleteView(generic.ObjectDeleteView):
     queryset = Module.objects.all()
 
 
-@register_model_view(Module, 'import', detail=False)
+@register_model_view(Module, 'bulk_import', detail=False)
 class ModuleBulkImportView(generic.BulkImportView):
     queryset = Module.objects.all()
     model_form = forms.ModuleImportForm
@@ -2428,7 +2428,7 @@ class ConsolePortDeleteView(generic.ObjectDeleteView):
     queryset = ConsolePort.objects.all()
 
 
-@register_model_view(ConsolePort, 'import', detail=False)
+@register_model_view(ConsolePort, 'bulk_import', detail=False)
 class ConsolePortBulkImportView(generic.BulkImportView):
     queryset = ConsolePort.objects.all()
     model_form = forms.ConsolePortImportForm
@@ -2503,7 +2503,7 @@ class ConsoleServerPortDeleteView(generic.ObjectDeleteView):
     queryset = ConsoleServerPort.objects.all()
 
 
-@register_model_view(ConsoleServerPort, 'import', detail=False)
+@register_model_view(ConsoleServerPort, 'bulk_import', detail=False)
 class ConsoleServerPortBulkImportView(generic.BulkImportView):
     queryset = ConsoleServerPort.objects.all()
     model_form = forms.ConsoleServerPortImportForm
@@ -2578,7 +2578,7 @@ class PowerPortDeleteView(generic.ObjectDeleteView):
     queryset = PowerPort.objects.all()
 
 
-@register_model_view(PowerPort, 'import', detail=False)
+@register_model_view(PowerPort, 'bulk_import', detail=False)
 class PowerPortBulkImportView(generic.BulkImportView):
     queryset = PowerPort.objects.all()
     model_form = forms.PowerPortImportForm
@@ -2653,7 +2653,7 @@ class PowerOutletDeleteView(generic.ObjectDeleteView):
     queryset = PowerOutlet.objects.all()
 
 
-@register_model_view(PowerOutlet, 'import', detail=False)
+@register_model_view(PowerOutlet, 'bulk_import', detail=False)
 class PowerOutletBulkImportView(generic.BulkImportView):
     queryset = PowerOutlet.objects.all()
     model_form = forms.PowerOutletImportForm
@@ -2785,7 +2785,7 @@ class InterfaceDeleteView(generic.ObjectDeleteView):
     queryset = Interface.objects.all()
 
 
-@register_model_view(Interface, 'import', detail=False)
+@register_model_view(Interface, 'bulk_import', detail=False)
 class InterfaceBulkImportView(generic.BulkImportView):
     queryset = Interface.objects.all()
     model_form = forms.InterfaceImportForm
@@ -2871,7 +2871,7 @@ class FrontPortDeleteView(generic.ObjectDeleteView):
     queryset = FrontPort.objects.all()
 
 
-@register_model_view(FrontPort, 'import', detail=False)
+@register_model_view(FrontPort, 'bulk_import', detail=False)
 class FrontPortBulkImportView(generic.BulkImportView):
     queryset = FrontPort.objects.all()
     model_form = forms.FrontPortImportForm
@@ -2946,7 +2946,7 @@ class RearPortDeleteView(generic.ObjectDeleteView):
     queryset = RearPort.objects.all()
 
 
-@register_model_view(RearPort, 'import', detail=False)
+@register_model_view(RearPort, 'bulk_import', detail=False)
 class RearPortBulkImportView(generic.BulkImportView):
     queryset = RearPort.objects.all()
     model_form = forms.RearPortImportForm
@@ -3021,7 +3021,7 @@ class ModuleBayDeleteView(generic.ObjectDeleteView):
     queryset = ModuleBay.objects.all()
 
 
-@register_model_view(ModuleBay, 'import', detail=False)
+@register_model_view(ModuleBay, 'bulk_import', detail=False)
 class ModuleBayBulkImportView(generic.BulkImportView):
     queryset = ModuleBay.objects.all()
     model_form = forms.ModuleBayImportForm
@@ -3168,7 +3168,7 @@ class DeviceBayDepopulateView(generic.ObjectEditView):
         })
 
 
-@register_model_view(DeviceBay, 'import', detail=False)
+@register_model_view(DeviceBay, 'bulk_import', detail=False)
 class DeviceBayBulkImportView(generic.BulkImportView):
     queryset = DeviceBay.objects.all()
     model_form = forms.DeviceBayImportForm
@@ -3234,7 +3234,7 @@ class InventoryItemDeleteView(generic.ObjectDeleteView):
     queryset = InventoryItem.objects.all()
 
 
-@register_model_view(InventoryItem, 'import', detail=False)
+@register_model_view(InventoryItem, 'bulk_import', detail=False)
 class InventoryItemBulkImportView(generic.BulkImportView):
     queryset = InventoryItem.objects.all()
     model_form = forms.InventoryItemImportForm
@@ -3315,7 +3315,7 @@ class InventoryItemRoleDeleteView(generic.ObjectDeleteView):
     queryset = InventoryItemRole.objects.all()
 
 
-@register_model_view(InventoryItemRole, 'import', detail=False)
+@register_model_view(InventoryItemRole, 'bulk_import', detail=False)
 class InventoryItemRoleBulkImportView(generic.BulkImportView):
     queryset = InventoryItemRole.objects.all()
     model_form = forms.InventoryItemRoleImportForm
@@ -3511,7 +3511,7 @@ class CableDeleteView(generic.ObjectDeleteView):
     queryset = Cable.objects.all()
 
 
-@register_model_view(Cable, 'import', detail=False)
+@register_model_view(Cable, 'bulk_import', detail=False)
 class CableBulkImportView(generic.BulkImportView):
     queryset = Cable.objects.all()
     model_form = forms.CableImportForm
@@ -3812,7 +3812,7 @@ class VirtualChassisRemoveMemberView(ObjectPermissionRequiredMixin, GetReturnURL
         })
 
 
-@register_model_view(VirtualChassis, 'import', detail=False)
+@register_model_view(VirtualChassis, 'bulk_import', detail=False)
 class VirtualChassisBulkImportView(generic.BulkImportView):
     queryset = VirtualChassis.objects.all()
     model_form = forms.VirtualChassisImportForm
@@ -3869,7 +3869,7 @@ class PowerPanelDeleteView(generic.ObjectDeleteView):
     queryset = PowerPanel.objects.all()
 
 
-@register_model_view(PowerPanel, 'import', detail=False)
+@register_model_view(PowerPanel, 'bulk_import', detail=False)
 class PowerPanelBulkImportView(generic.BulkImportView):
     queryset = PowerPanel.objects.all()
     model_form = forms.PowerPanelImportForm
@@ -3926,7 +3926,7 @@ class PowerFeedDeleteView(generic.ObjectDeleteView):
     queryset = PowerFeed.objects.all()
 
 
-@register_model_view(PowerFeed, 'import', detail=False)
+@register_model_view(PowerFeed, 'bulk_import', detail=False)
 class PowerFeedBulkImportView(generic.BulkImportView):
     queryset = PowerFeed.objects.all()
     model_form = forms.PowerFeedImportForm
@@ -3998,7 +3998,7 @@ class VirtualDeviceContextDeleteView(generic.ObjectDeleteView):
     queryset = VirtualDeviceContext.objects.all()
 
 
-@register_model_view(VirtualDeviceContext, 'import', detail=False)
+@register_model_view(VirtualDeviceContext, 'bulk_import', detail=False)
 class VirtualDeviceContextBulkImportView(generic.BulkImportView):
     queryset = VirtualDeviceContext.objects.all()
     model_form = forms.VirtualDeviceContextImportForm
@@ -4048,7 +4048,7 @@ class MACAddressDeleteView(generic.ObjectDeleteView):
     queryset = MACAddress.objects.all()
 
 
-@register_model_view(MACAddress, 'import', detail=False)
+@register_model_view(MACAddress, 'bulk_import', detail=False)
 class MACAddressBulkImportView(generic.BulkImportView):
     queryset = MACAddress.objects.all()
     model_form = forms.MACAddressImportForm

--- a/netbox/extras/tests/test_custom_validation.py
+++ b/netbox/extras/tests/test_custom_validation.py
@@ -191,7 +191,7 @@ class BulkImportCustomValidationTest(ModelViewTestCase):
 
         # Attempt to import providers without tags
         request = {
-            'path': self._get_url('import'),
+            'path': self._get_url('bulk_import'),
             'data': post_data(data),
         }
         response = self.client.post(**request)
@@ -207,7 +207,7 @@ class BulkImportCustomValidationTest(ModelViewTestCase):
         )
         data['data'] = '\n'.join(csv_data)
         request = {
-            'path': self._get_url('import'),
+            'path': self._get_url('bulk_import'),
             'data': post_data(data),
         }
         response = self.client.post(**request)

--- a/netbox/extras/tests/test_customfields.py
+++ b/netbox/extras/tests/test_customfields.py
@@ -1325,7 +1325,7 @@ class CustomFieldImportTest(TestCase):
         )
         csv_data = '\n'.join(','.join(row) for row in data)
 
-        response = self.client.post(reverse('dcim:site_import'), {
+        response = self.client.post(reverse('dcim:site_bulk_import'), {
             'data': csv_data,
             'format': ImportFormatChoices.CSV,
             'csv_delimiter': CSVDelimiterChoices.AUTO,

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -82,7 +82,7 @@ class CustomFieldDeleteView(generic.ObjectDeleteView):
     queryset = CustomField.objects.select_related('choice_set')
 
 
-@register_model_view(CustomField, 'import', detail=False)
+@register_model_view(CustomField, 'bulk_import', detail=False)
 class CustomFieldBulkImportView(generic.BulkImportView):
     queryset = CustomField.objects.select_related('choice_set')
     model_form = forms.CustomFieldImportForm
@@ -151,7 +151,7 @@ class CustomFieldChoiceSetDeleteView(generic.ObjectDeleteView):
     queryset = CustomFieldChoiceSet.objects.all()
 
 
-@register_model_view(CustomFieldChoiceSet, 'import', detail=False)
+@register_model_view(CustomFieldChoiceSet, 'bulk_import', detail=False)
 class CustomFieldChoiceSetBulkImportView(generic.BulkImportView):
     queryset = CustomFieldChoiceSet.objects.all()
     model_form = forms.CustomFieldChoiceSetImportForm
@@ -201,7 +201,7 @@ class CustomLinkDeleteView(generic.ObjectDeleteView):
     queryset = CustomLink.objects.all()
 
 
-@register_model_view(CustomLink, 'import', detail=False)
+@register_model_view(CustomLink, 'bulk_import', detail=False)
 class CustomLinkBulkImportView(generic.BulkImportView):
     queryset = CustomLink.objects.all()
     model_form = forms.CustomLinkImportForm
@@ -256,7 +256,7 @@ class ExportTemplateDeleteView(generic.ObjectDeleteView):
     queryset = ExportTemplate.objects.all()
 
 
-@register_model_view(ExportTemplate, 'import', detail=False)
+@register_model_view(ExportTemplate, 'bulk_import', detail=False)
 class ExportTemplateBulkImportView(generic.BulkImportView):
     queryset = ExportTemplate.objects.all()
     model_form = forms.ExportTemplateImportForm
@@ -333,7 +333,7 @@ class SavedFilterDeleteView(SavedFilterMixin, generic.ObjectDeleteView):
     queryset = SavedFilter.objects.all()
 
 
-@register_model_view(SavedFilter, 'import', detail=False)
+@register_model_view(SavedFilter, 'bulk_import', detail=False)
 class SavedFilterBulkImportView(SavedFilterMixin, generic.BulkImportView):
     queryset = SavedFilter.objects.all()
     model_form = forms.SavedFilterImportForm
@@ -414,7 +414,7 @@ class NotificationGroupDeleteView(generic.ObjectDeleteView):
     queryset = NotificationGroup.objects.all()
 
 
-@register_model_view(NotificationGroup, 'import', detail=False)
+@register_model_view(NotificationGroup, 'bulk_import', detail=False)
 class NotificationGroupBulkImportView(generic.BulkImportView):
     queryset = NotificationGroup.objects.all()
     model_form = forms.NotificationGroupImportForm
@@ -560,7 +560,7 @@ class WebhookDeleteView(generic.ObjectDeleteView):
     queryset = Webhook.objects.all()
 
 
-@register_model_view(Webhook, 'import', detail=False)
+@register_model_view(Webhook, 'bulk_import', detail=False)
 class WebhookBulkImportView(generic.BulkImportView):
     queryset = Webhook.objects.all()
     model_form = forms.WebhookImportForm
@@ -610,7 +610,7 @@ class EventRuleDeleteView(generic.ObjectDeleteView):
     queryset = EventRule.objects.all()
 
 
-@register_model_view(EventRule, 'import', detail=False)
+@register_model_view(EventRule, 'bulk_import', detail=False)
 class EventRuleBulkImportView(generic.BulkImportView):
     queryset = EventRule.objects.all()
     model_form = forms.EventRuleImportForm
@@ -683,7 +683,7 @@ class TagDeleteView(generic.ObjectDeleteView):
     queryset = Tag.objects.all()
 
 
-@register_model_view(Tag, 'import', detail=False)
+@register_model_view(Tag, 'bulk_import', detail=False)
 class TagBulkImportView(generic.BulkImportView):
     queryset = Tag.objects.all()
     model_form = forms.TagImportForm
@@ -859,7 +859,7 @@ class ConfigTemplateDeleteView(generic.ObjectDeleteView):
     queryset = ConfigTemplate.objects.all()
 
 
-@register_model_view(ConfigTemplate, 'import', detail=False)
+@register_model_view(ConfigTemplate, 'bulk_import', detail=False)
 class ConfigTemplateBulkImportView(generic.BulkImportView):
     queryset = ConfigTemplate.objects.all()
     model_form = forms.ConfigTemplateImportForm
@@ -942,8 +942,8 @@ class JournalEntryListView(generic.ObjectListView):
     filterset_form = forms.JournalEntryFilterForm
     table = tables.JournalEntryTable
     actions = {
-        'import': {'add'},
         'export': {'view'},
+        'bulk_import': {'add'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
     }
@@ -983,7 +983,7 @@ class JournalEntryDeleteView(generic.ObjectDeleteView):
         return reverse(viewname, kwargs={'pk': obj.pk})
 
 
-@register_model_view(JournalEntry, 'import', detail=False)
+@register_model_view(JournalEntry, 'bulk_import', detail=False)
 class JournalEntryBulkImportView(generic.BulkImportView):
     queryset = JournalEntry.objects.all()
     model_form = forms.JournalEntryImportForm

--- a/netbox/ipam/tests/test_views.py
+++ b/netbox/ipam/tests/test_views.py
@@ -521,7 +521,7 @@ scope_id: {site.pk}
             'data': IMPORT_DATA,
             'format': 'yaml'
         }
-        response = self.client.post(reverse('ipam:prefix_import'), data=form_data, follow=True)
+        response = self.client.post(reverse('ipam:prefix_bulk_import'), data=form_data, follow=True)
         self.assertHttpStatus(response, 200)
 
         prefix = Prefix.objects.get(prefix='10.1.1.0/24')
@@ -553,7 +553,7 @@ vlan: 102
             'data': IMPORT_DATA,
             'format': 'yaml'
         }
-        response = self.client.post(reverse('ipam:prefix_import'), data=form_data, follow=True)
+        response = self.client.post(reverse('ipam:prefix_bulk_import'), data=form_data, follow=True)
         self.assertHttpStatus(response, 200)
 
         prefix = Prefix.objects.get(prefix='10.1.2.0/24')

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -70,7 +70,7 @@ class VRFDeleteView(generic.ObjectDeleteView):
     queryset = VRF.objects.all()
 
 
-@register_model_view(VRF, 'import', detail=False)
+@register_model_view(VRF, 'bulk_import', detail=False)
 class VRFBulkImportView(generic.BulkImportView):
     queryset = VRF.objects.all()
     model_form = forms.VRFImportForm
@@ -120,7 +120,7 @@ class RouteTargetDeleteView(generic.ObjectDeleteView):
     queryset = RouteTarget.objects.all()
 
 
-@register_model_view(RouteTarget, 'import', detail=False)
+@register_model_view(RouteTarget, 'bulk_import', detail=False)
 class RouteTargetBulkImportView(generic.BulkImportView):
     queryset = RouteTarget.objects.all()
     model_form = forms.RouteTargetImportForm
@@ -177,7 +177,7 @@ class RIRDeleteView(generic.ObjectDeleteView):
     queryset = RIR.objects.all()
 
 
-@register_model_view(RIR, 'import', detail=False)
+@register_model_view(RIR, 'bulk_import', detail=False)
 class RIRBulkImportView(generic.BulkImportView):
     queryset = RIR.objects.all()
     model_form = forms.RIRImportForm
@@ -252,7 +252,7 @@ class ASNRangeDeleteView(generic.ObjectDeleteView):
     queryset = ASNRange.objects.all()
 
 
-@register_model_view(ASNRange, 'import', detail=False)
+@register_model_view(ASNRange, 'bulk_import', detail=False)
 class ASNRangeBulkImportView(generic.BulkImportView):
     queryset = ASNRange.objects.all()
     model_form = forms.ASNRangeImportForm
@@ -317,7 +317,7 @@ class ASNDeleteView(generic.ObjectDeleteView):
     queryset = ASN.objects.all()
 
 
-@register_model_view(ASN, 'import', detail=False)
+@register_model_view(ASN, 'bulk_import', detail=False)
 class ASNBulkImportView(generic.BulkImportView):
     queryset = ASN.objects.all()
     model_form = forms.ASNImportForm
@@ -409,7 +409,7 @@ class AggregateDeleteView(generic.ObjectDeleteView):
     queryset = Aggregate.objects.all()
 
 
-@register_model_view(Aggregate, 'import', detail=False)
+@register_model_view(Aggregate, 'bulk_import', detail=False)
 class AggregateBulkImportView(generic.BulkImportView):
     queryset = Aggregate.objects.all()
     model_form = forms.AggregateImportForm
@@ -477,7 +477,7 @@ class RoleDeleteView(generic.ObjectDeleteView):
     queryset = Role.objects.all()
 
 
-@register_model_view(Role, 'import', detail=False)
+@register_model_view(Role, 'bulk_import', detail=False)
 class RoleBulkImportView(generic.BulkImportView):
     queryset = Role.objects.all()
     model_form = forms.RoleImportForm
@@ -663,7 +663,7 @@ class PrefixDeleteView(generic.ObjectDeleteView):
     queryset = Prefix.objects.all()
 
 
-@register_model_view(Prefix, 'import', detail=False)
+@register_model_view(Prefix, 'bulk_import', detail=False)
 class PrefixBulkImportView(generic.BulkImportView):
     queryset = Prefix.objects.all()
     model_form = forms.PrefixImportForm
@@ -757,7 +757,7 @@ class IPRangeDeleteView(generic.ObjectDeleteView):
     queryset = IPRange.objects.all()
 
 
-@register_model_view(IPRange, 'import', detail=False)
+@register_model_view(IPRange, 'bulk_import', detail=False)
 class IPRangeBulkImportView(generic.BulkImportView):
     queryset = IPRange.objects.all()
     model_form = forms.IPRangeImportForm
@@ -919,7 +919,7 @@ class IPAddressBulkCreateView(generic.BulkCreateView):
     template_name = 'ipam/ipaddress_bulk_add.html'
 
 
-@register_model_view(IPAddress, 'import', detail=False)
+@register_model_view(IPAddress, 'bulk_import', detail=False)
 class IPAddressBulkImportView(generic.BulkImportView):
     queryset = IPAddress.objects.all()
     model_form = forms.IPAddressImportForm
@@ -997,7 +997,7 @@ class VLANGroupDeleteView(generic.ObjectDeleteView):
     queryset = VLANGroup.objects.all()
 
 
-@register_model_view(VLANGroup, 'import', detail=False)
+@register_model_view(VLANGroup, 'bulk_import', detail=False)
 class VLANGroupBulkImportView(generic.BulkImportView):
     queryset = VLANGroup.objects.all()
     model_form = forms.VLANGroupImportForm
@@ -1082,7 +1082,7 @@ class VLANTranslationPolicyDeleteView(generic.ObjectDeleteView):
     queryset = VLANTranslationPolicy.objects.all()
 
 
-@register_model_view(VLANTranslationPolicy, 'import', detail=False)
+@register_model_view(VLANTranslationPolicy, 'bulk_import', detail=False)
 class VLANTranslationPolicyBulkImportView(generic.BulkImportView):
     queryset = VLANTranslationPolicy.objects.all()
     model_form = forms.VLANTranslationPolicyImportForm
@@ -1137,7 +1137,7 @@ class VLANTranslationRuleDeleteView(generic.ObjectDeleteView):
     queryset = VLANTranslationRule.objects.all()
 
 
-@register_model_view(VLANTranslationRule, 'import', detail=False)
+@register_model_view(VLANTranslationRule, 'bulk_import', detail=False)
 class VLANTranslationRuleBulkImportView(generic.BulkImportView):
     queryset = VLANTranslationRule.objects.all()
     model_form = forms.VLANTranslationRuleImportForm
@@ -1218,7 +1218,7 @@ class FHRPGroupDeleteView(generic.ObjectDeleteView):
     queryset = FHRPGroup.objects.all()
 
 
-@register_model_view(FHRPGroup, 'import', detail=False)
+@register_model_view(FHRPGroup, 'bulk_import', detail=False)
 class FHRPGroupBulkImportView(generic.BulkImportView):
     queryset = FHRPGroup.objects.all()
     model_form = forms.FHRPGroupImportForm
@@ -1344,7 +1344,7 @@ class VLANDeleteView(generic.ObjectDeleteView):
     queryset = VLAN.objects.all()
 
 
-@register_model_view(VLAN, 'import', detail=False)
+@register_model_view(VLAN, 'bulk_import', detail=False)
 class VLANBulkImportView(generic.BulkImportView):
     queryset = VLAN.objects.all()
     model_form = forms.VLANImportForm
@@ -1394,7 +1394,7 @@ class ServiceTemplateDeleteView(generic.ObjectDeleteView):
     queryset = ServiceTemplate.objects.all()
 
 
-@register_model_view(ServiceTemplate, 'import', detail=False)
+@register_model_view(ServiceTemplate, 'bulk_import', detail=False)
 class ServiceTemplateBulkImportView(generic.BulkImportView):
     queryset = ServiceTemplate.objects.all()
     model_form = forms.ServiceTemplateImportForm
@@ -1449,7 +1449,7 @@ class ServiceDeleteView(generic.ObjectDeleteView):
     queryset = Service.objects.all()
 
 
-@register_model_view(Service, 'import', detail=False)
+@register_model_view(Service, 'bulk_import', detail=False)
 class ServiceBulkImportView(generic.BulkImportView):
     queryset = Service.objects.all()
     model_form = forms.ServiceImportForm

--- a/netbox/netbox/constants.py
+++ b/netbox/netbox/constants.py
@@ -31,8 +31,8 @@ ADVISORY_LOCK_KEYS = {
 # Default view action permission mapping
 DEFAULT_ACTION_PERMISSIONS = {
     'add': {'add'},
-    'import': {'add'},
     'export': {'view'},
+    'bulk_import': {'add'},
     'bulk_edit': {'change'},
     'bulk_delete': {'delete'},
 }

--- a/netbox/netbox/navigation/__init__.py
+++ b/netbox/netbox/navigation/__init__.py
@@ -60,7 +60,7 @@ class Menu:
 # Utility functions
 #
 
-def get_model_item(app_label, model_name, label, actions=('add', 'import')):
+def get_model_item(app_label, model_name, label, actions=('add', 'bulk_import')):
     return MenuItem(
         link=f'{app_label}:{model_name}_list',
         link_text=label,
@@ -69,7 +69,7 @@ def get_model_item(app_label, model_name, label, actions=('add', 'import')):
     )
 
 
-def get_model_buttons(app_label, model_name, actions=('add', 'import')):
+def get_model_buttons(app_label, model_name, actions=('add', 'bulk_import')):
     buttons = []
 
     if 'add' in actions:
@@ -81,10 +81,10 @@ def get_model_buttons(app_label, model_name, actions=('add', 'import')):
                 permissions=[f'{app_label}.add_{model_name}']
             )
         )
-    if 'import' in actions:
+    if 'bulk_import' in actions:
         buttons.append(
             MenuItemButton(
-                link=f'{app_label}:{model_name}_import',
+                link=f'{app_label}:{model_name}_bulk_import',
                 title='Import',
                 icon_class='mdi mdi-upload',
                 permissions=[f'{app_label}.add_{model_name}']

--- a/netbox/netbox/navigation/menu.py
+++ b/netbox/netbox/navigation/menu.py
@@ -33,7 +33,7 @@ ORGANIZATION_MENU = Menu(
                 get_model_item('tenancy', 'contact', _('Contacts')),
                 get_model_item('tenancy', 'contactgroup', _('Contact Groups')),
                 get_model_item('tenancy', 'contactrole', _('Contact Roles')),
-                get_model_item('tenancy', 'contactassignment', _('Contact Assignments'), actions=['import']),
+                get_model_item('tenancy', 'contactassignment', _('Contact Assignments'), actions=['bulk_import']),
             ),
         ),
     ),
@@ -386,7 +386,7 @@ OPERATIONS_MENU = Menu(
             label=_('Logging'),
             items=(
                 get_model_item('extras', 'notificationgroup', _('Notification Groups')),
-                get_model_item('extras', 'journalentry', _('Journal Entries'), actions=['import']),
+                get_model_item('extras', 'journalentry', _('Journal Entries'), actions=['bulk_import']),
                 get_model_item('core', 'objectchange', _('Change Log'), actions=[]),
             ),
         ),
@@ -413,7 +413,7 @@ ADMIN_MENU = Menu(
                             permissions=['users.add_user']
                         ),
                         MenuItemButton(
-                            link='users:user_import',
+                            link='users:user_bulk_import',
                             title='Import',
                             icon_class='mdi mdi-upload',
                             permissions=['users.add_user']
@@ -433,7 +433,7 @@ ADMIN_MENU = Menu(
                             permissions=['users.add_group']
                         ),
                         MenuItemButton(
-                            link='users:group_import',
+                            link='users:group_bulk_import',
                             title='Import',
                             icon_class='mdi mdi-upload',
                             permissions=['users.add_group']

--- a/netbox/netbox/tests/test_import.py
+++ b/netbox/netbox/tests/test_import.py
@@ -37,7 +37,7 @@ class CSVImportTestCase(ModelViewTestCase):
         }
 
         # Form validation should fail with invalid header present
-        self.assertHttpStatus(self.client.post(self._get_url('import'), data), 200)
+        self.assertHttpStatus(self.client.post(self._get_url('bulk_import'), data), 200)
         self.assertEqual(Region.objects.count(), 0)
 
         # Correct the CSV header name
@@ -45,7 +45,7 @@ class CSVImportTestCase(ModelViewTestCase):
         data['data'] = self._get_csv_data(csv_data)
 
         # Validation should succeed
-        self.assertHttpStatus(self.client.post(self._get_url('import'), data), 302)
+        self.assertHttpStatus(self.client.post(self._get_url('bulk_import'), data), 302)
         self.assertEqual(Region.objects.count(), 3)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
@@ -71,10 +71,10 @@ class CSVImportTestCase(ModelViewTestCase):
         obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
         # Try GET with model-level permission
-        self.assertHttpStatus(self.client.get(self._get_url('import')), 200)
+        self.assertHttpStatus(self.client.get(self._get_url('bulk_import')), 200)
 
         # Test POST with permission
-        self.assertHttpStatus(self.client.post(self._get_url('import'), data), 302)
+        self.assertHttpStatus(self.client.post(self._get_url('bulk_import'), data), 302)
         regions = Region.objects.all()
         self.assertEqual(regions.count(), 4)
         self.assertEqual(
@@ -111,10 +111,10 @@ class CSVImportTestCase(ModelViewTestCase):
         obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
         # Try GET with model-level permission
-        self.assertHttpStatus(self.client.get(self._get_url('import')), 200)
+        self.assertHttpStatus(self.client.get(self._get_url('bulk_import')), 200)
 
         # Test POST with permission
-        self.assertHttpStatus(self.client.post(self._get_url('import'), data), 200)
+        self.assertHttpStatus(self.client.post(self._get_url('bulk_import'), data), 200)
         self.assertEqual(Region.objects.count(), 0)
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
@@ -138,6 +138,6 @@ class CSVImportTestCase(ModelViewTestCase):
         )
         cf.object_types.set([ObjectType.objects.get_for_model(self.model)])
 
-        self.assertHttpStatus(self.client.post(self._get_url('import'), data), 302)
+        self.assertHttpStatus(self.client.post(self._get_url('bulk_import'), data), 302)
         region = Region.objects.get(slug='region-1')
         self.assertEqual(region.cf['tcf'], 'def-cf-text')

--- a/netbox/templates/generic/object_list.html
+++ b/netbox/templates/generic/object_list.html
@@ -34,7 +34,7 @@ Context:
     {% if 'add' in actions %}
       {% add_button model %}
     {% endif %}
-    {% if 'import' in actions %}
+    {% if 'bulk_import' in actions %}
       {% import_button model %}
     {% endif %}
     {% if 'export' in actions %}

--- a/netbox/tenancy/views.py
+++ b/netbox/tenancy/views.py
@@ -80,7 +80,7 @@ class TenantGroupDeleteView(generic.ObjectDeleteView):
     queryset = TenantGroup.objects.all()
 
 
-@register_model_view(TenantGroup, 'import', detail=False)
+@register_model_view(TenantGroup, 'bulk_import', detail=False)
 class TenantGroupBulkImportView(generic.BulkImportView):
     queryset = TenantGroup.objects.all()
     model_form = forms.TenantGroupImportForm
@@ -147,7 +147,7 @@ class TenantDeleteView(generic.ObjectDeleteView):
     queryset = Tenant.objects.all()
 
 
-@register_model_view(Tenant, 'import', detail=False)
+@register_model_view(Tenant, 'bulk_import', detail=False)
 class TenantBulkImportView(generic.BulkImportView):
     queryset = Tenant.objects.all()
     model_form = forms.TenantImportForm
@@ -215,7 +215,7 @@ class ContactGroupDeleteView(generic.ObjectDeleteView):
     queryset = ContactGroup.objects.all()
 
 
-@register_model_view(ContactGroup, 'import', detail=False)
+@register_model_view(ContactGroup, 'bulk_import', detail=False)
 class ContactGroupBulkImportView(generic.BulkImportView):
     queryset = ContactGroup.objects.all()
     model_form = forms.ContactGroupImportForm
@@ -282,7 +282,7 @@ class ContactRoleDeleteView(generic.ObjectDeleteView):
     queryset = ContactRole.objects.all()
 
 
-@register_model_view(ContactRole, 'import', detail=False)
+@register_model_view(ContactRole, 'bulk_import', detail=False)
 class ContactRoleBulkImportView(generic.BulkImportView):
     queryset = ContactRole.objects.all()
     model_form = forms.ContactRoleImportForm
@@ -334,7 +334,7 @@ class ContactDeleteView(generic.ObjectDeleteView):
     queryset = Contact.objects.all()
 
 
-@register_model_view(Contact, 'import', detail=False)
+@register_model_view(Contact, 'bulk_import', detail=False)
 class ContactBulkImportView(generic.BulkImportView):
     queryset = Contact.objects.all()
     model_form = forms.ContactImportForm
@@ -370,8 +370,8 @@ class ContactAssignmentListView(generic.ObjectListView):
     filterset_form = forms.ContactAssignmentFilterForm
     table = tables.ContactAssignmentTable
     actions = {
-        'import': {'add'},
         'export': {'view'},
+        'bulk_import': {'add'},
         'bulk_edit': {'change'},
         'bulk_delete': {'delete'},
     }
@@ -397,7 +397,7 @@ class ContactAssignmentEditView(generic.ObjectEditView):
         }
 
 
-@register_model_view(ContactAssignment, 'import', detail=False)
+@register_model_view(ContactAssignment, 'bulk_import', detail=False)
 class ContactAssignmentBulkImportView(generic.BulkImportView):
     queryset = ContactAssignment.objects.all()
     model_form = forms.ContactAssignmentImportForm

--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -38,7 +38,7 @@ class TokenDeleteView(generic.ObjectDeleteView):
     queryset = Token.objects.all()
 
 
-@register_model_view(Token, 'import', detail=False)
+@register_model_view(Token, 'bulk_import', detail=False)
 class TokenBulkImportView(generic.BulkImportView):
     queryset = Token.objects.all()
     model_form = forms.TokenImportForm
@@ -95,7 +95,7 @@ class UserDeleteView(generic.ObjectDeleteView):
     queryset = User.objects.all()
 
 
-@register_model_view(User, 'import', detail=False)
+@register_model_view(User, 'bulk_import', detail=False)
 class UserBulkImportView(generic.BulkImportView):
     queryset = User.objects.all()
     model_form = forms.UserImportForm
@@ -146,7 +146,7 @@ class GroupDeleteView(generic.ObjectDeleteView):
     queryset = Group.objects.all()
 
 
-@register_model_view(Group, 'import', detail=False)
+@register_model_view(Group, 'bulk_import', detail=False)
 class GroupBulkImportView(generic.BulkImportView):
     queryset = Group.objects.all()
     model_form = forms.GroupImportForm

--- a/netbox/utilities/templatetags/buttons.py
+++ b/netbox/utilities/templatetags/buttons.py
@@ -158,7 +158,7 @@ def add_button(model, action='add'):
 
 
 @register.inclusion_tag('buttons/import.html')
-def import_button(model, action='import'):
+def import_button(model, action='bulk_import'):
     try:
         url = reverse(get_viewname(model, action))
     except NoReverseMatch:

--- a/netbox/utilities/testing/views.py
+++ b/netbox/utilities/testing/views.py
@@ -594,10 +594,10 @@ class ViewTestCases:
 
             # Test GET without permission
             with disable_warnings('django.request'):
-                self.assertHttpStatus(self.client.get(self._get_url('import')), 403)
+                self.assertHttpStatus(self.client.get(self._get_url('bulk_import')), 403)
 
             # Try POST without permission
-            response = self.client.post(self._get_url('import'), data)
+            response = self.client.post(self._get_url('bulk_import'), data)
             with disable_warnings('django.request'):
                 self.assertHttpStatus(response, 403)
 
@@ -620,10 +620,10 @@ class ViewTestCases:
             obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
             # Try GET with model-level permission
-            self.assertHttpStatus(self.client.get(self._get_url('import')), 200)
+            self.assertHttpStatus(self.client.get(self._get_url('bulk_import')), 200)
 
             # Test POST with permission
-            self.assertHttpStatus(self.client.post(self._get_url('import'), data), 302)
+            self.assertHttpStatus(self.client.post(self._get_url('bulk_import'), data), 302)
             self.assertEqual(self._get_queryset().count(), initial_count + len(self.csv_data) - 1)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
@@ -649,7 +649,7 @@ class ViewTestCases:
             obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
             # Test POST with permission
-            self.assertHttpStatus(self.client.post(self._get_url('import'), data), 302)
+            self.assertHttpStatus(self.client.post(self._get_url('bulk_import'), data), 302)
             self.assertEqual(initial_count, self._get_queryset().count())
 
             reader = csv.DictReader(array, delimiter=',')
@@ -684,7 +684,7 @@ class ViewTestCases:
             obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
 
             # Attempt to import non-permitted objects
-            self.assertHttpStatus(self.client.post(self._get_url('import'), data), 200)
+            self.assertHttpStatus(self.client.post(self._get_url('bulk_import'), data), 200)
             self.assertEqual(self._get_queryset().count(), initial_count)
 
             # Update permission constraints
@@ -692,7 +692,7 @@ class ViewTestCases:
             obj_perm.save()
 
             # Import permitted objects
-            self.assertHttpStatus(self.client.post(self._get_url('import'), data), 302)
+            self.assertHttpStatus(self.client.post(self._get_url('bulk_import'), data), 302)
             self.assertEqual(self._get_queryset().count(), initial_count + len(self.csv_data) - 1)
 
     class BulkEditObjectsViewTestCase(ModelViewTestCase):

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -63,7 +63,7 @@ class ClusterTypeDeleteView(generic.ObjectDeleteView):
     queryset = ClusterType.objects.all()
 
 
-@register_model_view(ClusterType, 'import', detail=False)
+@register_model_view(ClusterType, 'bulk_import', detail=False)
 class ClusterTypeBulkImportView(generic.BulkImportView):
     queryset = ClusterType.objects.all()
     model_form = forms.ClusterTypeImportForm
@@ -124,7 +124,7 @@ class ClusterGroupDeleteView(generic.ObjectDeleteView):
     queryset = ClusterGroup.objects.all()
 
 
-@register_model_view(ClusterGroup, 'import', detail=False)
+@register_model_view(ClusterGroup, 'bulk_import', detail=False)
 class ClusterGroupBulkImportView(generic.BulkImportView):
     queryset = ClusterGroup.objects.annotate(
         cluster_count=count_related(Cluster, 'group')
@@ -212,8 +212,8 @@ class ClusterDevicesView(generic.ObjectChildrenView):
     template_name = 'virtualization/cluster/devices.html'
     actions = {
         'add': {'add'},
-        'import': {'add'},
         'export': {'view'},
+        'bulk_import': {'add'},
         'bulk_edit': {'change'},
         'bulk_remove_devices': {'change'},
     }
@@ -240,7 +240,7 @@ class ClusterDeleteView(generic.ObjectDeleteView):
     queryset = Cluster.objects.all()
 
 
-@register_model_view(Cluster, 'import', detail=False)
+@register_model_view(Cluster, 'bulk_import', detail=False)
 class ClusterBulkImportView(generic.BulkImportView):
     queryset = Cluster.objects.all()
     model_form = forms.ClusterImportForm
@@ -489,7 +489,7 @@ class VirtualMachineDeleteView(generic.ObjectDeleteView):
     queryset = VirtualMachine.objects.all()
 
 
-@register_model_view(VirtualMachine, 'import', detail=False)
+@register_model_view(VirtualMachine, 'bulk_import', detail=False)
 class VirtualMachineBulkImportView(generic.BulkImportView):
     queryset = VirtualMachine.objects.all()
     model_form = forms.VirtualMachineImportForm
@@ -588,7 +588,7 @@ class VMInterfaceDeleteView(generic.ObjectDeleteView):
     queryset = VMInterface.objects.all()
 
 
-@register_model_view(VMInterface, 'import', detail=False)
+@register_model_view(VMInterface, 'bulk_import', detail=False)
 class VMInterfaceBulkImportView(generic.BulkImportView):
     queryset = VMInterface.objects.all()
     model_form = forms.VMInterfaceImportForm
@@ -651,7 +651,7 @@ class VirtualDiskDeleteView(generic.ObjectDeleteView):
     queryset = VirtualDisk.objects.all()
 
 
-@register_model_view(VirtualDisk, 'import', detail=False)
+@register_model_view(VirtualDisk, 'bulk_import', detail=False)
 class VirtualDiskBulkImportView(generic.BulkImportView):
     queryset = VirtualDisk.objects.all()
     model_form = forms.VirtualDiskImportForm

--- a/netbox/vpn/views.py
+++ b/netbox/vpn/views.py
@@ -43,7 +43,7 @@ class TunnelGroupDeleteView(generic.ObjectDeleteView):
     queryset = TunnelGroup.objects.all()
 
 
-@register_model_view(TunnelGroup, 'import', detail=False)
+@register_model_view(TunnelGroup, 'bulk_import', detail=False)
 class TunnelGroupBulkImportView(generic.BulkImportView):
     queryset = TunnelGroup.objects.all()
     model_form = forms.TunnelGroupImportForm
@@ -107,7 +107,7 @@ class TunnelDeleteView(generic.ObjectDeleteView):
     queryset = Tunnel.objects.all()
 
 
-@register_model_view(Tunnel, 'import', detail=False)
+@register_model_view(Tunnel, 'bulk_import', detail=False)
 class TunnelBulkImportView(generic.BulkImportView):
     queryset = Tunnel.objects.all()
     model_form = forms.TunnelImportForm
@@ -161,7 +161,7 @@ class TunnelTerminationDeleteView(generic.ObjectDeleteView):
     queryset = TunnelTermination.objects.all()
 
 
-@register_model_view(TunnelTermination, 'import', detail=False)
+@register_model_view(TunnelTermination, 'bulk_import', detail=False)
 class TunnelTerminationBulkImportView(generic.BulkImportView):
     queryset = TunnelTermination.objects.all()
     model_form = forms.TunnelTerminationImportForm
@@ -211,7 +211,7 @@ class IKEProposalDeleteView(generic.ObjectDeleteView):
     queryset = IKEProposal.objects.all()
 
 
-@register_model_view(IKEProposal, 'import', detail=False)
+@register_model_view(IKEProposal, 'bulk_import', detail=False)
 class IKEProposalBulkImportView(generic.BulkImportView):
     queryset = IKEProposal.objects.all()
     model_form = forms.IKEProposalImportForm
@@ -261,7 +261,7 @@ class IKEPolicyDeleteView(generic.ObjectDeleteView):
     queryset = IKEPolicy.objects.all()
 
 
-@register_model_view(IKEPolicy, 'import', detail=False)
+@register_model_view(IKEPolicy, 'bulk_import', detail=False)
 class IKEPolicyBulkImportView(generic.BulkImportView):
     queryset = IKEPolicy.objects.all()
     model_form = forms.IKEPolicyImportForm
@@ -311,7 +311,7 @@ class IPSecProposalDeleteView(generic.ObjectDeleteView):
     queryset = IPSecProposal.objects.all()
 
 
-@register_model_view(IPSecProposal, 'import', detail=False)
+@register_model_view(IPSecProposal, 'bulk_import', detail=False)
 class IPSecProposalBulkImportView(generic.BulkImportView):
     queryset = IPSecProposal.objects.all()
     model_form = forms.IPSecProposalImportForm
@@ -361,7 +361,7 @@ class IPSecPolicyDeleteView(generic.ObjectDeleteView):
     queryset = IPSecPolicy.objects.all()
 
 
-@register_model_view(IPSecPolicy, 'import', detail=False)
+@register_model_view(IPSecPolicy, 'bulk_import', detail=False)
 class IPSecPolicyBulkImportView(generic.BulkImportView):
     queryset = IPSecPolicy.objects.all()
     model_form = forms.IPSecPolicyImportForm
@@ -411,7 +411,7 @@ class IPSecProfileDeleteView(generic.ObjectDeleteView):
     queryset = IPSecProfile.objects.all()
 
 
-@register_model_view(IPSecProfile, 'import', detail=False)
+@register_model_view(IPSecProfile, 'bulk_import', detail=False)
 class IPSecProfileBulkImportView(generic.BulkImportView):
     queryset = IPSecProfile.objects.all()
     model_form = forms.IPSecProfileImportForm
@@ -476,7 +476,7 @@ class L2VPNDeleteView(generic.ObjectDeleteView):
     queryset = L2VPN.objects.all()
 
 
-@register_model_view(L2VPN, 'import', detail=False)
+@register_model_view(L2VPN, 'bulk_import', detail=False)
 class L2VPNBulkImportView(generic.BulkImportView):
     queryset = L2VPN.objects.all()
     model_form = forms.L2VPNImportForm
@@ -531,7 +531,7 @@ class L2VPNTerminationDeleteView(generic.ObjectDeleteView):
     queryset = L2VPNTermination.objects.all()
 
 
-@register_model_view(L2VPNTermination, 'import', detail=False)
+@register_model_view(L2VPNTermination, 'bulk_import', detail=False)
 class L2VPNTerminationBulkImportView(generic.BulkImportView):
     queryset = L2VPNTermination.objects.all()
     model_form = forms.L2VPNTerminationImportForm

--- a/netbox/wireless/views.py
+++ b/netbox/wireless/views.py
@@ -48,7 +48,7 @@ class WirelessLANGroupDeleteView(generic.ObjectDeleteView):
     queryset = WirelessLANGroup.objects.all()
 
 
-@register_model_view(WirelessLANGroup, 'import', detail=False)
+@register_model_view(WirelessLANGroup, 'bulk_import', detail=False)
 class WirelessLANGroupBulkImportView(generic.BulkImportView):
     queryset = WirelessLANGroup.objects.all()
     model_form = forms.WirelessLANGroupImportForm
@@ -123,7 +123,7 @@ class WirelessLANDeleteView(generic.ObjectDeleteView):
     queryset = WirelessLAN.objects.all()
 
 
-@register_model_view(WirelessLAN, 'import', detail=False)
+@register_model_view(WirelessLAN, 'bulk_import', detail=False)
 class WirelessLANBulkImportView(generic.BulkImportView):
     queryset = WirelessLAN.objects.all()
     model_form = forms.WirelessLANImportForm
@@ -173,7 +173,7 @@ class WirelessLinkDeleteView(generic.ObjectDeleteView):
     queryset = WirelessLink.objects.all()
 
 
-@register_model_view(WirelessLink, 'import', detail=False)
+@register_model_view(WirelessLink, 'bulk_import', detail=False)
 class WirelessLinkBulkImportView(generic.BulkImportView):
     queryset = WirelessLink.objects.all()
     model_form = forms.WirelessLinkImportForm


### PR DESCRIPTION
### Fixes: #17752

- Update all bulk import view names to use the `bulk_` prefix as `bulk_edit` & `bulk_delete` do