### PR TITLE
Show virtual ips in interfaces table

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -643,8 +643,8 @@ class InterfaceTable(ModularDeviceComponentTable, BaseInterfaceTable, PathEndpoi
             'speed', 'speed_formatted', 'duplex', 'mode', 'mac_address', 'wwn', 'poe_mode', 'poe_type', 'rf_role', 'rf_channel',
             'rf_channel_frequency', 'rf_channel_width', 'tx_power', 'description', 'mark_connected', 'cable',
             'cable_color', 'wireless_link', 'wireless_lans', 'link_peer', 'connection', 'tags', 'vdcs', 'vrf', 'l2vpn',
-            'tunnel', 'ip_addresses', 'virtual_ips', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'inventory_items', 'created',
-            'last_updated',
+            'tunnel', 'ip_addresses', 'virtual_ips', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'inventory_items',
+            'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'device', 'label', 'enabled', 'type', 'description')
 
@@ -680,8 +680,8 @@ class DeviceInterfaceTable(InterfaceTable):
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'enabled', 'type', 'parent', 'bridge', 'lag',
             'mgmt_only', 'mtu', 'mode', 'mac_address', 'wwn', 'rf_role', 'rf_channel', 'rf_channel_frequency',
             'rf_channel_width', 'tx_power', 'description', 'mark_connected', 'cable', 'cable_color', 'wireless_link',
-            'wireless_lans', 'link_peer', 'connection', 'tags', 'vdcs', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses', 'virtual_ips',
-            'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'actions',
+            'wireless_lans', 'link_peer', 'connection', 'tags', 'vdcs', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses',
+            'virtual_ips', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'actions',
         )
         default_columns = (
             'pk', 'name', 'label', 'enabled', 'type', 'parent', 'lag', 'mtu', 'mode', 'description', 'ip_addresses',

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -557,6 +557,12 @@ class BaseInterfaceTable(NetBoxTable):
         orderable=False,
         verbose_name=_('IP Addresses')
     )
+    virtual_ips = tables.TemplateColumn(
+        accessor=Accessor('fhrp_group_assignments'),
+        template_code=INTERFACE_VIRTUAL_IPS,
+        orderable=False,
+        verbose_name=_('Virtual IPs')
+    )
     fhrp_groups = tables.TemplateColumn(
         accessor=Accessor('fhrp_group_assignments'),
         template_code=INTERFACE_FHRPGROUPS,
@@ -637,7 +643,7 @@ class InterfaceTable(ModularDeviceComponentTable, BaseInterfaceTable, PathEndpoi
             'speed', 'speed_formatted', 'duplex', 'mode', 'mac_address', 'wwn', 'poe_mode', 'poe_type', 'rf_role', 'rf_channel',
             'rf_channel_frequency', 'rf_channel_width', 'tx_power', 'description', 'mark_connected', 'cable',
             'cable_color', 'wireless_link', 'wireless_lans', 'link_peer', 'connection', 'tags', 'vdcs', 'vrf', 'l2vpn',
-            'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'inventory_items', 'created',
+            'tunnel', 'ip_addresses', 'virtual_ips', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'inventory_items', 'created',
             'last_updated',
         )
         default_columns = ('pk', 'name', 'device', 'label', 'enabled', 'type', 'description')
@@ -674,7 +680,7 @@ class DeviceInterfaceTable(InterfaceTable):
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'enabled', 'type', 'parent', 'bridge', 'lag',
             'mgmt_only', 'mtu', 'mode', 'mac_address', 'wwn', 'rf_role', 'rf_channel', 'rf_channel_frequency',
             'rf_channel_width', 'tx_power', 'description', 'mark_connected', 'cable', 'cable_color', 'wireless_link',
-            'wireless_lans', 'link_peer', 'connection', 'tags', 'vdcs', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses',
+            'wireless_lans', 'link_peer', 'connection', 'tags', 'vdcs', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses', 'virtual_ips',
             'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'actions',
         )
         default_columns = (

--- a/netbox/dcim/tables/template_code.py
+++ b/netbox/dcim/tables/template_code.py
@@ -48,6 +48,18 @@ INTERFACE_IPADDRESSES = """
   {% endif %}
 """
 
+INTERFACE_VIRTUAL_IPS = """
+  {% for fhrp_assignment in value.all %}
+    {% for ip in fhrp_assignment.group.ip_addresses.all %}
+      {% if ip.status != 'active' %}
+        <a href="{{ ip.get_absolute_url }}" class="badge text-bg-{{ ip.get_status_color }}" data-bs-toggle="tooltip" data-bs-placement="left" title="{{ ip.get_status_display }}">{{ ip }}</a>
+      {% else %}
+        <a href="{{ ip.get_absolute_url }}">{{ ip }}</a>
+      {% endif %}
+    {% endfor %}
+  {% endfor %}
+"""
+
 INTERFACE_FHRPGROUPS = """
   {% for assignment in value.all %}
     <a href="{{ assignment.group.get_absolute_url }}">{{ assignment.group.get_protocol_display }}: {{ assignment.group.group_id }}</a>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18070

<!--
    Please include a summary of the proposed changes below.
-->
Adds a column named `Virtual IPs` to the interfaces table. 

The new column behaves almost exactly like the existing column for directly assigned IP addresses, except that it doesn't limit the number of virtual IPs displayed directly on the table. Since the virtual IPs could come from multiple FHRP Groups, I don't see an easy way to link to a filtered table of IPs that are virtual IPs of the interface.

If that is a problem, I can limit the number that are displayed and add an elipsis (or something to indicate that the list is cropped), or maybe someone with real django experience can figure it out.