### PR TITLE
Fixes: #17820 - Store default values from custom fields on newly created module components

### DIFF
--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -1277,6 +1277,11 @@ class Module(PrimaryModel, ConfigContextModel):
                 if not disable_replication:
                     create_instances.append(template_instance)
 
+            for component in create_instances:
+                # Set default values for any applicable custom fields
+                if cf_defaults := CustomField.objects.get_defaults_for_model(component_model):
+                    component.custom_field_data = cf_defaults
+
             if component_model is not ModuleBay:
                 component_model.objects.bulk_create(create_instances)
                 # Emit the post_save signal for each newly created object

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -1277,9 +1277,9 @@ class Module(PrimaryModel, ConfigContextModel):
                 if not disable_replication:
                     create_instances.append(template_instance)
 
-            for component in create_instances:
-                # Set default values for any applicable custom fields
-                if cf_defaults := CustomField.objects.get_defaults_for_model(component_model):
+            # Set default values for any applicable custom fields
+            if cf_defaults := CustomField.objects.get_defaults_for_model(component_model):
+                for component in create_instances:
                     component.custom_field_data = cf_defaults
 
             if component_model is not ModuleBay:


### PR DESCRIPTION
### Fixes: #17820

Fixes a piece of missing functionality in the `Module.save()` method where custom field default values are not applied during creation of new module-templated components.

Does not apply to update operations, only create.
