### PR TITLE
fix #17960 by adding 6 more tunnel encap options

### DIFF
--- a/netbox/vpn/choices.py
+++ b/netbox/vpn/choices.py
@@ -22,16 +22,28 @@ class TunnelStatusChoices(ChoiceSet):
 
 
 class TunnelEncapsulationChoices(ChoiceSet):
+    ENCAP_EOIP = 'eoip'
     ENCAP_GRE = 'gre'
-    ENCAP_IP_IP = 'ip-ip'
     ENCAP_IPSEC_TRANSPORT = 'ipsec-transport'
     ENCAP_IPSEC_TUNNEL = 'ipsec-tunnel'
+    ENCAP_IP_IP = 'ip-ip'
+    ENCAP_L2TP = 'l2tp'
+    ENCAP_OPENVPN = 'openvpn'
+    ENCAP_PPTP = 'pptp'
+    ENCAP_SSTP = 'sstp'
+    ENCAP_WIREGUARD = 'wireguard'
 
     CHOICES = [
         (ENCAP_IPSEC_TRANSPORT, _('IPsec - Transport')),
         (ENCAP_IPSEC_TUNNEL, _('IPsec - Tunnel')),
         (ENCAP_IP_IP, _('IP-in-IP')),
         (ENCAP_GRE, _('GRE')),
+        (ENCAP_WIREGUARD, _('WireGuard')),
+        (ENCAP_OPENVPN, _('OpenVPN')),
+        (ENCAP_L2TP, _('L2TP')),
+        (ENCAP_PPTP, _('PPTP')),
+        (ENCAP_EOIP, _('EoIP')),
+        (ENCAP_SSTP, _('SSTP')),
     ]
 
 

--- a/netbox/vpn/choices.py
+++ b/netbox/vpn/choices.py
@@ -22,7 +22,6 @@ class TunnelStatusChoices(ChoiceSet):
 
 
 class TunnelEncapsulationChoices(ChoiceSet):
-    ENCAP_EOIP = 'eoip'
     ENCAP_GRE = 'gre'
     ENCAP_IPSEC_TRANSPORT = 'ipsec-transport'
     ENCAP_IPSEC_TUNNEL = 'ipsec-tunnel'
@@ -30,7 +29,6 @@ class TunnelEncapsulationChoices(ChoiceSet):
     ENCAP_L2TP = 'l2tp'
     ENCAP_OPENVPN = 'openvpn'
     ENCAP_PPTP = 'pptp'
-    ENCAP_SSTP = 'sstp'
     ENCAP_WIREGUARD = 'wireguard'
 
     CHOICES = [
@@ -42,8 +40,6 @@ class TunnelEncapsulationChoices(ChoiceSet):
         (ENCAP_OPENVPN, _('OpenVPN')),
         (ENCAP_L2TP, _('L2TP')),
         (ENCAP_PPTP, _('PPTP')),
-        (ENCAP_EOIP, _('EoIP')),
-        (ENCAP_SSTP, _('SSTP')),
     ]
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->

Fixes: #17960

<!--
    Please include a summary of the proposed changes below.
-->
I included all 6 types suggested in the issue. I did not include an "other" because it seems like that's against house style (there are a limited number of tunnel encap types, we could get them all in netbox). 

They should now show as an option as a tunnel encap. I wasn't sure what the proper style was for the order of the choices so I sorted them by what I thought was most common. Happy to change the PR to some other sort. 