### PR TITLE
18044 enable alert for plugins in script

### DIFF
--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1141,12 +1141,14 @@ class ScriptView(BaseScriptView):
         script_class = self._get_script_class(script)
         if not script_class:
             return render(request, 'extras/script.html', {
+                'object': script,
                 'script': script,
             })
 
         form = script_class.as_form(initial=normalize_querydict(request.GET))
 
         return render(request, 'extras/script.html', {
+            'object': script,
             'script': script,
             'script_class': script_class,
             'form': form,
@@ -1162,6 +1164,7 @@ class ScriptView(BaseScriptView):
         script_class = self._get_script_class(script)
         if not script_class:
             return render(request, 'extras/script.html', {
+                'object': script,
                 'script': script,
             })
 
@@ -1186,6 +1189,7 @@ class ScriptView(BaseScriptView):
             return redirect('extras:script_result', job_pk=job.pk)
 
         return render(request, 'extras/script.html', {
+            'object': script,
             'script': script,
             'script_class': script.python_class(),
             'form': form,


### PR DESCRIPTION
### Fixes: #18044 

script.html already derives from generic/object.html which has the plugin alert include, the issue was that the alert is keyed off of the context var `object` and the view uses `script`. It isn't really DRY to pass in both object and script, but to change would require it to change in the template extras/script/base.html which is included in other templates and this would cause the the branching message to also appear in those templates which isn't desired.  We could then mask that out in the template include, but this way just keeps it isolated.

**Note:** This will not display anything without changes in the branching plugin which will be in a separate PR for that project. Screenshot shown with change in branching plugin to enable an alert here.

![New Branch | NetBox 2024-11-25 08-52-37](https://github.com/user-attachments/assets/eb2fc513-1fd2-416e-b7fb-baea5bb697b9)

