### PR TITLE
Fixes #17490: Config Template unable to dynamically include templates

### DIFF
--- a/netbox/utilities/jinja2.py
+++ b/netbox/utilities/jinja2.py
@@ -29,7 +29,6 @@ class DataFileLoader(BaseLoader):
 
         # Find and pre-fetch referenced templates
         if referenced_templates := tuple(find_referenced_templates(environment.parse(template_source))):
-            if None in referenced_templates:
             related_files = DataFile.objects.filter(source=self.data_source)
             # None indicates the use of dynamic resolution. If dependent files are statically
             # defined, we can filter by path for optimization.

--- a/netbox/utilities/jinja2.py
+++ b/netbox/utilities/jinja2.py
@@ -29,10 +29,16 @@ class DataFileLoader(BaseLoader):
 
         # Find and pre-fetch referenced templates
         if referenced_templates := find_referenced_templates(environment.parse(template_source)):
-            self.cache_templates({
-                df.path: df.data_as_string for df in
-                DataFile.objects.filter(source=self.data_source, path__in=referenced_templates)
-            })
+            if None in referenced_templates:
+                self.cache_templates({
+                    df.path: df.data_as_string for df in
+                    DataFile.objects.filter(source=self.data_source)
+                })
+            else:
+                self.cache_templates({
+                    df.path: df.data_as_string for df in
+                    DataFile.objects.filter(source=self.data_source, path__in=referenced_templates)
+                })
 
         return template_source, template, lambda: True
 

--- a/netbox/utilities/jinja2.py
+++ b/netbox/utilities/jinja2.py
@@ -28,7 +28,7 @@ class DataFileLoader(BaseLoader):
             raise TemplateNotFound(template)
 
         # Find and pre-fetch referenced templates
-        if referenced_templates := find_referenced_templates(environment.parse(template_source)):
+        if referenced_templates := tuple(find_referenced_templates(environment.parse(template_source))):
             if None in referenced_templates:
                 self.cache_templates({
                     df.path: df.data_as_string for df in

--- a/netbox/utilities/jinja2.py
+++ b/netbox/utilities/jinja2.py
@@ -30,15 +30,14 @@ class DataFileLoader(BaseLoader):
         # Find and pre-fetch referenced templates
         if referenced_templates := tuple(find_referenced_templates(environment.parse(template_source))):
             if None in referenced_templates:
-                self.cache_templates({
-                    df.path: df.data_as_string for df in
-                    DataFile.objects.filter(source=self.data_source)
-                })
-            else:
-                self.cache_templates({
-                    df.path: df.data_as_string for df in
-                    DataFile.objects.filter(source=self.data_source, path__in=referenced_templates)
-                })
+            related_files = DataFile.objects.filter(source=self.data_source)
+            # None indicates the use of dynamic resolution. If dependent files are statically
+            # defined, we can filter by path for optimization.
+            if None not in referenced_templates:
+                related_files = related_files.filter(path__in=referenced_templates)
+            self.cache_templates({
+                df.path: df.data_as_string for df in related_files
+            })
 
         return template_source, template, lambda: True
 


### PR DESCRIPTION
### Fixes: #17490

Config templates are unable to dynamically include child templates.  This is a proposed fix as suggested by @ed-ud in #18066 which was closed as a duplicate. 