### PR TITLE
Fixes #17810: Fix assignment of device to rack via REST API without specifying position/face

### DIFF
--- a/netbox/dcim/migrations/0192_device_adjust_rack_position_constraint.py
+++ b/netbox/dcim/migrations/0192_device_adjust_rack_position_constraint.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dcim', '0191_module_bay_rebuild'),
+        ('extras', '0121_customfield_related_object_filter'),
+        ('ipam', '0070_vlangroup_vlan_id_ranges'),
+        ('tenancy', '0015_contactassignment_rename_content_type'),
+        ('virtualization', '0040_convert_disk_size'),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name='device',
+            name='dcim_device_unique_rack_position_face',
+        ),
+        migrations.AddConstraint(
+            model_name='device',
+            constraint=models.UniqueConstraint(
+                condition=models.Q(
+                    ('position__isnull', False),
+                    ('rack__isnull', False)
+                ),
+                fields=('rack', 'position', 'face'),
+                name='dcim_device_unique_rack_position_face'
+            ),
+        ),
+    ]

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -798,6 +798,7 @@ class Device(
             ),
             models.UniqueConstraint(
                 fields=('rack', 'position', 'face'),
+                condition=Q(rack__isnull=False, position__isnull=False),
                 name='%(app_label)s_%(class)s_unique_rack_position_face'
             ),
             models.UniqueConstraint(


### PR DESCRIPTION
### Fixes: #17810

This applies some conditions to the unique constraint on the Device model, which prevents DRF from raising a validation error when `rack` is set but `position` is not.