### PR TITLE
Closes 18061: Hide traceback from rendered device config

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -2104,7 +2104,8 @@ class DeviceRenderConfigView(generic.ObjectView):
         # If a direct export has been requested, return the rendered template content as a
         # downloadable file.
         if request.GET.get('export'):
-            response = HttpResponse(context['rendered_config'], content_type='text')
+            content = context['rendered_config'] or context['error_message']
+            response = HttpResponse(content, content_type='text')
             filename = f"{instance.name or 'config'}.txt"
             response['Content-Disposition'] = f'attachment; filename="{filename}"'
             return response
@@ -2122,18 +2123,18 @@ class DeviceRenderConfigView(generic.ObjectView):
 
         # Render the config template
         rendered_config = None
+        error_message = None
         if config_template := instance.get_config_template():
             try:
                 rendered_config = config_template.render(context=context_data)
             except TemplateError as e:
-                msg = _("An error occurred while rendering the template: {error}").format(error=e)
-                messages.error(request, msg)
-                rendered_config = msg
+                error_message = _("An error occurred while rendering the template: {error}").format(error=e)
 
         return {
             'config_template': config_template,
             'context_data': context_data,
             'rendered_config': rendered_config,
+            'error_message': error_message,
         }
 
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1,5 +1,3 @@
-import traceback
-
 from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
 from django.core.paginator import EmptyPage, PageNotAnInteger
@@ -2128,8 +2126,9 @@ class DeviceRenderConfigView(generic.ObjectView):
             try:
                 rendered_config = config_template.render(context=context_data)
             except TemplateError as e:
-                messages.error(request, _("An error occurred while rendering the template: {error}").format(error=e))
-                rendered_config = traceback.format_exc()
+                msg = _("An error occurred while rendering the template: {error}").format(error=e)
+                messages.error(request, msg)
+                rendered_config = msg
 
         return {
             'config_template': config_template,

--- a/netbox/templates/dcim/device/render_config.html
+++ b/netbox/templates/dcim/device/render_config.html
@@ -5,7 +5,7 @@
 {% block title %}{{ object }} - {% trans "Config" %}{% endblock %}
 
 {% block content %}
-  <div class="row mb-3">
+  <div class="row">
     <div class="col-5">
       <div class="card">
         <h2 class="card-header">{% trans "Config Template" %}</h2>
@@ -48,19 +48,28 @@
   </div>
   <div class="row">
     <div class="col">
-      <div class="card">
-        <h2 class="card-header d-flex justify-content-between">
-          {% trans "Rendered Config" %}
-            <a href="?export=True" class="btn btn-primary lh-1" role="button">
-              <i class="mdi mdi-download" aria-hidden="true"></i> {% trans "Download" %}
-            </a>
-        </h2>
-        {% if config_template %}
-          <pre class="card-body">{{ rendered_config }}</pre>
+      {% if config_template %}
+        {% if rendered_config %}
+          <div class="card">
+            <h2 class="card-header d-flex justify-content-between">
+              {% trans "Rendered Config" %}
+              <a href="?export=True" class="btn btn-primary lh-1" role="button">
+                <i class="mdi mdi-download" aria-hidden="true"></i> {% trans "Download" %}
+              </a>
+            </h2>
+            <pre class="card-body">{{ rendered_config }}</pre>
+          </div>
         {% else %}
-          <div class="card-body text-muted">{% trans "No configuration template found" %}</div>
+          <div class="alert alert-warning">
+            <h4 class="alert-title mb-1">{% trans "Error rendering template" %}</h4>
+            {% trans error_message %}
+          </div>
         {% endif %}
-      </div>
+      {% else %}
+        <div class="alert alert-info">
+          {% trans "No configuration template has been assigned for this device." %}
+        </div>
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/netbox/templates/virtualization/virtualmachine/render_config.html
+++ b/netbox/templates/virtualization/virtualmachine/render_config.html
@@ -5,7 +5,7 @@
 {% block title %}{{ object }} - {% trans "Config" %}{% endblock %}
 
 {% block content %}
-  <div class="row mb-3">
+  <div class="row">
     <div class="col-5">
       <div class="card">
         <h2 class="card-header">{% trans "Config Template" %}</h2>
@@ -48,19 +48,28 @@
   </div>
   <div class="row">
     <div class="col">
-      <div class="card">
-        <h2 class="card-header d-flex justify-content-between">
-          {% trans "Rendered Config" %}
-            <a href="?export=True" class="btn btn-primary lh-1" role="button">
-              <i class="mdi mdi-download" aria-hidden="true"></i> {% trans "Download" %}
-            </a>
-        </h2>
-        {% if config_template %}
-          <pre class="card-body">{{ rendered_config }}</pre>
+      {% if config_template %}
+        {% if rendered_config %}
+          <div class="card">
+            <h2 class="card-header d-flex justify-content-between">
+              {% trans "Rendered Config" %}
+              <a href="?export=True" class="btn btn-primary lh-1" role="button">
+                <i class="mdi mdi-download" aria-hidden="true"></i> {% trans "Download" %}
+              </a>
+            </h2>
+            <pre class="card-body">{{ rendered_config }}</pre>
+          </div>
         {% else %}
-          <div class="card-body text-muted">{% trans "No configuration template found" %}</div>
+          <div class="alert alert-warning">
+            <h4 class="alert-title mb-1">{% trans "Error rendering template" %}</h4>
+            {% trans error_message %}
+          </div>
         {% endif %}
-      </div>
+      {% else %}
+        <div class="alert alert-info">
+          {% trans "No configuration template has been assigned for this virtual machine." %}
+        </div>
+      {% endif %}
     </div>
   </div>
 {% endblock %}

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -1,5 +1,3 @@
-import traceback
-
 from django.contrib import messages
 from django.db import transaction
 from django.db.models import Prefetch, Sum
@@ -425,7 +423,8 @@ class VirtualMachineRenderConfigView(generic.ObjectView):
         # If a direct export has been requested, return the rendered template content as a
         # downloadable file.
         if request.GET.get('export'):
-            response = HttpResponse(context['rendered_config'], content_type='text')
+            content = context['rendered_config'] or context['error_message']
+            response = HttpResponse(content, content_type='text')
             filename = f"{instance.name or 'config'}.txt"
             response['Content-Disposition'] = f'attachment; filename="{filename}"'
             return response
@@ -443,17 +442,18 @@ class VirtualMachineRenderConfigView(generic.ObjectView):
 
         # Render the config template
         rendered_config = None
+        error_message = None
         if config_template := instance.get_config_template():
             try:
                 rendered_config = config_template.render(context=context_data)
             except TemplateError as e:
-                messages.error(request, _("An error occurred while rendering the template: {error}").format(error=e))
-                rendered_config = traceback.format_exc()
+                error_message = _("An error occurred while rendering the template: {error}").format(error=e)
 
         return {
             'config_template': config_template,
             'context_data': context_data,
             'rendered_config': rendered_config,
+            'error_message': error_message,
         }
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18061

<!--
    Please include a summary of the proposed changes below.
-->

When an exception occurs during device configuration rendering, it usually doesn't contain information about the template being rendered, but rather the trace of **how** the template was rendered. Since this could confuse users and expose internal server information, it is now hidden.

#### Before:

```
Traceback (most recent call last):
  File "/opt/netbox/netbox/dcim/views.py", line 2129, in get_extra_context
    rendered_config = config_template.render(context=context_data)
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/netbox/netbox/extras/models/configs.py", line 282, in render
    output = template.render(**_context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/netbox/venv/lib/python3.12/site-packages/jinja2/environment.py", line 1304, in render
    self.environment.handle_exception()
  File "/opt/netbox/venv/lib/python3.12/site-packages/jinja2/environment.py", line 939, in handle_exception
    raise rewrite_traceback_stack(source=source)
  File "<template>", line 1, in top-level template code
  File "/opt/netbox/venv/lib/python3.12/site-packages/jinja2/sandbox.py", line 327, in getattr
    value = getattr(obj, attribute)
            ^^^^^^^^^^^^^^^^^^^^^^^
jinja2.exceptions.UndefinedError: 'dcim.models.devices.Device object' has no attribute 'next'
```

#### After:

```
An error occurred while rendering the template: 'dcim.models.devices.Device object' has no attribute 'next'
```

This is the same message as displayed in the message notification.
