### PR TITLE
Fixes: #18150 - Get pagination limit with default 0

### DIFF
--- a/netbox/netbox/api/pagination.py
+++ b/netbox/netbox/api/pagination.py
@@ -38,12 +38,14 @@ class OptionalLimitOffsetPagination(LimitOffsetPagination):
 
     def get_limit(self, request):
         if self.limit_query_param:
+            MAX_PAGE_SIZE = get_config().MAX_PAGE_SIZE
+            if MAX_PAGE_SIZE:
+                MAX_PAGE_SIZE = max(MAX_PAGE_SIZE, self.default_limit)
             try:
                 limit = int(request.query_params[self.limit_query_param])
                 if limit < 0:
                     raise ValueError()
                 # Enforce maximum page size, if defined
-                MAX_PAGE_SIZE = get_config().MAX_PAGE_SIZE
                 if MAX_PAGE_SIZE:
                     return MAX_PAGE_SIZE if limit == 0 else min(limit, MAX_PAGE_SIZE)
                 return limit

--- a/netbox/netbox/api/pagination.py
+++ b/netbox/netbox/api/pagination.py
@@ -39,7 +39,7 @@ class OptionalLimitOffsetPagination(LimitOffsetPagination):
     def get_limit(self, request):
         if self.limit_query_param:
             try:
-                limit = int(request.query_params[self.limit_query_param])
+                limit = int(request.query_params.get(self.limit_query_param, 0))
                 if limit < 0:
                     raise ValueError()
                 # Enforce maximum page size, if defined

--- a/netbox/netbox/api/pagination.py
+++ b/netbox/netbox/api/pagination.py
@@ -39,10 +39,10 @@ class OptionalLimitOffsetPagination(LimitOffsetPagination):
     def get_limit(self, request):
         if self.limit_query_param:
             MAX_PAGE_SIZE = get_config().MAX_PAGE_SIZE
-            if self.limit_query_param not in request.query_params:
-                return min(self.default_limit, MAX_PAGE_SIZE)
+            if MAX_PAGE_SIZE:
+                MAX_PAGE_SIZE = max(MAX_PAGE_SIZE, self.default_limit)
             try:
-                limit = int(request.query_params.get(self.limit_query_param, 0))
+                limit = int(request.query_params[self.limit_query_param])
                 if limit < 0:
                     raise ValueError()
                 # Enforce maximum page size, if defined

--- a/netbox/netbox/api/pagination.py
+++ b/netbox/netbox/api/pagination.py
@@ -38,14 +38,12 @@ class OptionalLimitOffsetPagination(LimitOffsetPagination):
 
     def get_limit(self, request):
         if self.limit_query_param:
-            MAX_PAGE_SIZE = get_config().MAX_PAGE_SIZE
-            if MAX_PAGE_SIZE:
-                MAX_PAGE_SIZE = max(MAX_PAGE_SIZE, self.default_limit)
             try:
                 limit = int(request.query_params[self.limit_query_param])
                 if limit < 0:
                     raise ValueError()
                 # Enforce maximum page size, if defined
+                MAX_PAGE_SIZE = get_config().MAX_PAGE_SIZE
                 if MAX_PAGE_SIZE:
                     return MAX_PAGE_SIZE if limit == 0 else min(limit, MAX_PAGE_SIZE)
                 return limit

--- a/netbox/netbox/api/pagination.py
+++ b/netbox/netbox/api/pagination.py
@@ -38,12 +38,14 @@ class OptionalLimitOffsetPagination(LimitOffsetPagination):
 
     def get_limit(self, request):
         if self.limit_query_param:
+            MAX_PAGE_SIZE = get_config().MAX_PAGE_SIZE
+            if self.limit_query_param not in request.query_params:
+                return min(self.default_limit, MAX_PAGE_SIZE)
             try:
                 limit = int(request.query_params.get(self.limit_query_param, 0))
                 if limit < 0:
                     raise ValueError()
                 # Enforce maximum page size, if defined
-                MAX_PAGE_SIZE = get_config().MAX_PAGE_SIZE
                 if MAX_PAGE_SIZE:
                     return min(self.default_limit, MAX_PAGE_SIZE) if limit == 0 else min(limit, MAX_PAGE_SIZE)
                 return limit

--- a/netbox/netbox/api/pagination.py
+++ b/netbox/netbox/api/pagination.py
@@ -47,7 +47,7 @@ class OptionalLimitOffsetPagination(LimitOffsetPagination):
                     raise ValueError()
                 # Enforce maximum page size, if defined
                 if MAX_PAGE_SIZE:
-                    return min(self.default_limit, MAX_PAGE_SIZE) if limit == 0 else min(limit, MAX_PAGE_SIZE)
+                    return MAX_PAGE_SIZE if limit == 0 else min(limit, MAX_PAGE_SIZE)
                 return limit
             except (KeyError, ValueError):
                 pass

--- a/netbox/netbox/api/pagination.py
+++ b/netbox/netbox/api/pagination.py
@@ -45,7 +45,7 @@ class OptionalLimitOffsetPagination(LimitOffsetPagination):
                 # Enforce maximum page size, if defined
                 MAX_PAGE_SIZE = get_config().MAX_PAGE_SIZE
                 if MAX_PAGE_SIZE:
-                    return MAX_PAGE_SIZE if limit == 0 else min(limit, MAX_PAGE_SIZE)
+                    return min(self.default_limit, MAX_PAGE_SIZE) if limit == 0 else min(limit, MAX_PAGE_SIZE)
                 return limit
             except (KeyError, ValueError):
                 pass

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -129,8 +129,10 @@ LOGIN_PERSISTENCE = getattr(configuration, 'LOGIN_PERSISTENCE', False)
 LOGIN_REQUIRED = getattr(configuration, 'LOGIN_REQUIRED', True)
 LOGIN_TIMEOUT = getattr(configuration, 'LOGIN_TIMEOUT', None)
 LOGOUT_REDIRECT_URL = getattr(configuration, 'LOGOUT_REDIRECT_URL', 'home')
+MAX_PAGE_SIZE = getattr(configuration, 'MAX_PAGE_SIZE', 1000)
 MEDIA_ROOT = getattr(configuration, 'MEDIA_ROOT', os.path.join(BASE_DIR, 'media')).rstrip('/')
 METRICS_ENABLED = getattr(configuration, 'METRICS_ENABLED', False)
+PAGINATE_COUNT = getattr(configuration, 'PAGINATE_COUNT', 50)
 PLUGINS = getattr(configuration, 'PLUGINS', [])
 PLUGINS_CONFIG = getattr(configuration, 'PLUGINS_CONFIG', {})
 QUEUE_MAPPINGS = getattr(configuration, 'QUEUE_MAPPINGS', {})
@@ -684,6 +686,10 @@ REST_FRAMEWORK = {
     },
     'VIEW_NAME_FUNCTION': 'utilities.api.get_view_name',
 }
+
+if MAX_PAGE_SIZE < PAGINATE_COUNT:
+    raise ImproperlyConfigured(f'MAX_PAGE_SIZE ({MAX_PAGE_SIZE}) cannot be less than PAGINATE_COUNT ({PAGINATE_COUNT}).')
+
 
 #
 # DRF Spectacular

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -129,10 +129,8 @@ LOGIN_PERSISTENCE = getattr(configuration, 'LOGIN_PERSISTENCE', False)
 LOGIN_REQUIRED = getattr(configuration, 'LOGIN_REQUIRED', True)
 LOGIN_TIMEOUT = getattr(configuration, 'LOGIN_TIMEOUT', None)
 LOGOUT_REDIRECT_URL = getattr(configuration, 'LOGOUT_REDIRECT_URL', 'home')
-MAX_PAGE_SIZE = getattr(configuration, 'MAX_PAGE_SIZE', 1000)
 MEDIA_ROOT = getattr(configuration, 'MEDIA_ROOT', os.path.join(BASE_DIR, 'media')).rstrip('/')
 METRICS_ENABLED = getattr(configuration, 'METRICS_ENABLED', False)
-PAGINATE_COUNT = getattr(configuration, 'PAGINATE_COUNT', 50)
 PLUGINS = getattr(configuration, 'PLUGINS', [])
 PLUGINS_CONFIG = getattr(configuration, 'PLUGINS_CONFIG', {})
 QUEUE_MAPPINGS = getattr(configuration, 'QUEUE_MAPPINGS', {})
@@ -686,10 +684,6 @@ REST_FRAMEWORK = {
     },
     'VIEW_NAME_FUNCTION': 'utilities.api.get_view_name',
 }
-
-if MAX_PAGE_SIZE < PAGINATE_COUNT:
-    raise ImproperlyConfigured(f'MAX_PAGE_SIZE ({MAX_PAGE_SIZE}) cannot be less than PAGINATE_COUNT ({PAGINATE_COUNT}).')
-
 
 #
 # DRF Spectacular

--- a/netbox/utilities/tests/test_api.py
+++ b/netbox/utilities/tests/test_api.py
@@ -144,7 +144,7 @@ class APIPaginationTestCase(APITestCase):
         self.assertIsNone(response.data['previous'])
         self.assertEqual(len(response.data['results']), page_size)
 
-    @override_settings(MAX_PAGE_SIZE=20)
+    @override_settings(MAX_PAGE_SIZE=30)
     def test_default_page_size_with_small_max_page_size(self):
         response = self.client.get(self.url, format='json', **self.header)
         page_size = get_config().MAX_PAGE_SIZE
@@ -166,15 +166,15 @@ class APIPaginationTestCase(APITestCase):
         self.assertIsNone(response.data['previous'])
         self.assertEqual(len(response.data['results']), 10)
 
-    @override_settings(MAX_PAGE_SIZE=20)
+    @override_settings(MAX_PAGE_SIZE=80)
     def test_max_page_size(self):
         response = self.client.get(f'{self.url}?limit=0', format='json', **self.header)
 
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 100)
-        self.assertTrue(response.data['next'].endswith('?limit=20&offset=20'))
+        self.assertTrue(response.data['next'].endswith('?limit=80&offset=80'))
         self.assertIsNone(response.data['previous'])
-        self.assertEqual(len(response.data['results']), 20)
+        self.assertEqual(len(response.data['results']), 80)
 
     @override_settings(MAX_PAGE_SIZE=0)
     def test_max_page_size_disabled(self):

--- a/netbox/utilities/tests/test_api.py
+++ b/netbox/utilities/tests/test_api.py
@@ -144,7 +144,7 @@ class APIPaginationTestCase(APITestCase):
         self.assertIsNone(response.data['previous'])
         self.assertEqual(len(response.data['results']), page_size)
 
-    @override_settings(MAX_PAGE_SIZE=30)
+    @override_settings(MAX_PAGE_SIZE=20)
     def test_default_page_size_with_small_max_page_size(self):
         response = self.client.get(self.url, format='json', **self.header)
         page_size = get_config().MAX_PAGE_SIZE
@@ -166,15 +166,15 @@ class APIPaginationTestCase(APITestCase):
         self.assertIsNone(response.data['previous'])
         self.assertEqual(len(response.data['results']), 10)
 
-    @override_settings(MAX_PAGE_SIZE=80)
+    @override_settings(MAX_PAGE_SIZE=20)
     def test_max_page_size(self):
         response = self.client.get(f'{self.url}?limit=0', format='json', **self.header)
 
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 100)
-        self.assertTrue(response.data['next'].endswith('?limit=80&offset=80'))
+        self.assertTrue(response.data['next'].endswith('?limit=20&offset=20'))
         self.assertIsNone(response.data['previous'])
-        self.assertEqual(len(response.data['results']), 80)
+        self.assertEqual(len(response.data['results']), 20)
 
     @override_settings(MAX_PAGE_SIZE=0)
     def test_max_page_size_disabled(self):

--- a/netbox/utilities/tests/test_api.py
+++ b/netbox/utilities/tests/test_api.py
@@ -144,6 +144,18 @@ class APIPaginationTestCase(APITestCase):
         self.assertIsNone(response.data['previous'])
         self.assertEqual(len(response.data['results']), page_size)
 
+    @override_settings(MAX_PAGE_SIZE=30)
+    def test_default_page_size_with_small_max_page_size(self):
+        response = self.client.get(self.url, format='json', **self.header)
+        page_size = get_config().MAX_PAGE_SIZE
+        self.assertLess(page_size, 100, "Default page size not sufficient for data set")
+
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        self.assertEqual(response.data['count'], 100)
+        self.assertTrue(response.data['next'].endswith(f'?limit={page_size}&offset={page_size}'))
+        self.assertIsNone(response.data['previous'])
+        self.assertEqual(len(response.data['results']), page_size)
+
     def test_custom_page_size(self):
         response = self.client.get(f'{self.url}?limit=10', format='json', **self.header)
 

--- a/netbox/utilities/tests/test_api.py
+++ b/netbox/utilities/tests/test_api.py
@@ -148,13 +148,14 @@ class APIPaginationTestCase(APITestCase):
     def test_default_page_size_with_small_max_page_size(self):
         response = self.client.get(self.url, format='json', **self.header)
         page_size = get_config().MAX_PAGE_SIZE
+        paginate_count = get_config().PAGINATE_COUNT
         self.assertLess(page_size, 100, "Default page size not sufficient for data set")
 
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 100)
-        self.assertTrue(response.data['next'].endswith(f'?limit={page_size}&offset={page_size}'))
+        self.assertTrue(response.data['next'].endswith(f'?limit={paginate_count}&offset={paginate_count}'))
         self.assertIsNone(response.data['previous'])
-        self.assertEqual(len(response.data['results']), page_size)
+        self.assertEqual(len(response.data['results']), paginate_count)
 
     def test_custom_page_size(self):
         response = self.client.get(f'{self.url}?limit=10', format='json', **self.header)
@@ -165,15 +166,15 @@ class APIPaginationTestCase(APITestCase):
         self.assertIsNone(response.data['previous'])
         self.assertEqual(len(response.data['results']), 10)
 
-    @override_settings(MAX_PAGE_SIZE=20)
+    @override_settings(MAX_PAGE_SIZE=80)
     def test_max_page_size(self):
         response = self.client.get(f'{self.url}?limit=0', format='json', **self.header)
 
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 100)
-        self.assertTrue(response.data['next'].endswith('?limit=20&offset=20'))
+        self.assertTrue(response.data['next'].endswith('?limit=80&offset=80'))
         self.assertIsNone(response.data['previous'])
-        self.assertEqual(len(response.data['results']), 20)
+        self.assertEqual(len(response.data['results']), 80)
 
     @override_settings(MAX_PAGE_SIZE=0)
     def test_max_page_size_disabled(self):


### PR DESCRIPTION
### Fixes: #18150

If `limit` is not specified in an API list view, the value raises a `KeyError` which is silently swallowed without processing `MAX_PAGE_SIZE`, leading to inconsistent pagination results. This change uses `.get()` with a default of 0 to ensure no exception is raised and the configured page limit is enforced.

Specifically: in our current behavior, we have these scenarios:
```
    defaults:
    PAGINATE_COUNT: 50
    MAX_PAGE_SIZE: 1000

    limit=0 => MAX_PAGE_SIZE (this can functionally be "unlimited" if MAX_PAGE_SIZE is set very high)
    limit=n => min(n, MAX_PAGE_SIZE)
    limit omitted => PAGINATE_COUNT
```

With this behavior, if a script hits a list endpoint with no `limit`, the `next` URL will be paginated by `PAGINATE_COUNT`; but if the script follows that link, the next page will use the `limit=n` case, and the overall page count and `next` and `previous` links are paginated by `MAX_PAGE_SIZE` rather than `PAGINATE_COUNT`, which would re-flow all the pages and potentially lead to miscounts or other unexpected script behavior. This can be worked around by a script always specifying a `limit`, but it seems more sensible for omitting `limit` to be consistent with `limit=0`.

After this change:
```
    limit=0 (or omitted) => min(PAGINATE_COUNT, MAX_PAGE_SIZE)
    limit=n => min(n, MAX_PAGE_SIZE)
    No way to get "unlimited" except by setting both limit and MAX_PAGE_SIZE very high
```

Open question(s): 
- Should we support a use case for "unlimited" results, and if so, how? Is the above suggestion good?
- Is `limit=0` being a synonym for "unlimited" more intuitive than having `limit=0` behave the same as omitting `limit`?
- Will `limit=0` being interpreted as `limit=50` be surprising to the user?


**NOTE:** The fix has changed; leaving the above to preserve the discussion history.

This fix maintains the existing (separate) behaviors of `limit=0` and `limit` omitted. However, it changes the "`limit` omitted" case to return `min(PAGINATE_COUNT, MAX_PAGE_SIZE)`, i.e. to ensure `MAX_PAGE_SIZE` is enforced.
