### PR TITLE
Fixes: #18021 - Clear Swagger/drf-spectacular API cache on startup

### DIFF
--- a/netbox/core/apps.py
+++ b/netbox/core/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.conf import settings
 from django.core.cache import cache
 from django.db import models
 from django.db.migrations.operations import AlterModelOptions
@@ -24,5 +25,6 @@ class CoreConfig(AppConfig):
         # Register models
         register_models(*self.get_models())
 
-        # Clear Swagger API cache on startup
-        cache.delete("*api_schema_*")
+        # Clear Redis cache on startup in development mode
+        if settings.DEBUG:
+            cache.clear()

--- a/netbox/core/apps.py
+++ b/netbox/core/apps.py
@@ -1,4 +1,5 @@
 from django.apps import AppConfig
+from django.core.cache import cache
 from django.db import models
 from django.db.migrations.operations import AlterModelOptions
 
@@ -22,3 +23,6 @@ class CoreConfig(AppConfig):
 
         # Register models
         register_models(*self.get_models())
+
+        # Clear Swagger API cache on startup
+        cache.delete("*api_schema_*")


### PR DESCRIPTION
### Fixes: #18021

Clears the Swagger API schema cache upon startup, ensuring that API endpoint changes by developers are not cached and do not have to be manually refreshed upon every restart of the app.
