### PR TITLE
Fixes 18183 - Hide Light/Dark Mode and Login Info from Printed Pages

### DIFF
--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -19,7 +19,7 @@ Blocks:
   <div class="page">
 
     {# Sidebar #}
-    <aside class="navbar navbar-vertical navbar-expand-lg">
+    <aside class="navbar navbar-vertical navbar-expand-lg d-print-none">
 
       {% if 'commercial' in settings.RELEASE.features %}
         <img class="motif" src="{% static 'motif.svg' %}" alt="{% trans "NetBox Motif" %}">
@@ -42,7 +42,7 @@ Blocks:
         </h1>
 
         {# User menu (mobile view) #}
-        <div class="navbar-nav flex-row align-items-center d-lg-none d-print-none">
+        <div class="navbar-nav flex-row align-items-center d-lg-none">
           {% plugin_navbar %}
           {% include 'inc/light_toggle.html' %}
           {% include 'inc/user_menu.html' %}

--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -42,7 +42,7 @@ Blocks:
         </h1>
 
         {# User menu (mobile view) #}
-        <div class="navbar-nav flex-row align-items-center d-lg-none">
+        <div class="navbar-nav flex-row align-items-center d-lg-none d-print-none">
           {% plugin_navbar %}
           {% include 'inc/light_toggle.html' %}
           {% include 'inc/user_menu.html' %}


### PR DESCRIPTION
### Fixes: #18183 
This will add the `d-print-none` to the mobile view so objects being printed out will suppress the Light/Dark Mode and Login Info. Looking at the template, it was intended to suppress these details, but Chrome and Firefox are triggering in the mobile view for printing. I tested on both Chrome (131.0.6778.109 (Official Build) (64-bit)) and Firefox (128.5.1esr (64-bit)).

### Pre-Change:
![393964173-19d8d757-40dd-406a-9424-63ec6b464072](https://github.com/user-attachments/assets/8fe9d144-9a2b-47c9-b7ca-9f22ebbb1ce1)

### Post Change: 
![393964481-8cfff0cc-e9b0-4bf2-87d0-f3c11009df9c](https://github.com/user-attachments/assets/f5f1a535-df09-4d59-bdf3-05ef0b1b8f89)
