### PR TITLE
Fixes: #18184 - Gracefully handle unavailable internet connection on RSS feed dashboard widget if ISOLATED_DEPLOYMENT is set

### DIFF
--- a/netbox/extras/constants.py
+++ b/netbox/extras/constants.py
@@ -79,6 +79,7 @@ DEFAULT_DASHBOARD = [
             'feed_url': 'http://netbox.dev/rss/',
             'max_entries': 10,
             'cache_timeout': 14400,
+            'requires_internet': True,
         }
     },
     {

--- a/netbox/extras/dashboard/utils.py
+++ b/netbox/extras/dashboard/utils.py
@@ -61,9 +61,6 @@ def get_default_dashboard(config=None):
     config = config or settings.DEFAULT_DASHBOARD or DEFAULT_DASHBOARD
 
     for widget in config:
-        if settings.ISOLATED_DEPLOYMENT and widget['widget'] == 'extras.RSSFeedWidget':
-            continue
-
         id = str(uuid.uuid4())
         dashboard.layout.append({
             'id': id,

--- a/netbox/extras/dashboard/utils.py
+++ b/netbox/extras/dashboard/utils.py
@@ -61,6 +61,9 @@ def get_default_dashboard(config=None):
     config = config or settings.DEFAULT_DASHBOARD or DEFAULT_DASHBOARD
 
     for widget in config:
+        if settings.ISOLATED_DEPLOYMENT and widget['widget'] == 'extras.RSSFeedWidget':
+            continue
+
         id = str(uuid.uuid4())
         dashboard.layout.append({
             'id': id,

--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -275,6 +275,7 @@ class RSSFeedWidget(DashboardWidget):
     default_config = {
         'max_entries': 10,
         'cache_timeout': 3600,  # seconds
+        'requires_internet': True,
     }
     description = _('Embed an RSS feed from an external website.')
     template_name = 'extras/dashboard/widgets/rssfeed.html'
@@ -284,6 +285,9 @@ class RSSFeedWidget(DashboardWidget):
     class ConfigForm(WidgetConfigForm):
         feed_url = forms.URLField(
             label=_('Feed URL')
+        )
+        requires_internet = forms.BooleanField(
+            label=_('Requires external connection')
         )
         max_entries = forms.IntegerField(
             min_value=1,
@@ -309,6 +313,11 @@ class RSSFeedWidget(DashboardWidget):
         return f'dashboard_rss_{url_checksum}'
 
     def get_feed(self):
+        if self.config['requires_internet'] and settings.ISOLATED_DEPLOYMENT:
+            return {
+                'isolated_deployment': True,
+            }
+
         # Fetch RSS content from cache if available
         if feed_content := cache.get(self.cache_key):
             return {

--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -287,7 +287,8 @@ class RSSFeedWidget(DashboardWidget):
             label=_('Feed URL')
         )
         requires_internet = forms.BooleanField(
-            label=_('Requires external connection')
+            label=_('Requires external connection'),
+            required=False,
         )
         max_entries = forms.IntegerField(
             min_value=1,

--- a/netbox/templates/extras/dashboard/widgets/rssfeed.html
+++ b/netbox/templates/extras/dashboard/widgets/rssfeed.html
@@ -12,6 +12,10 @@
       <div class="list-group-item text-muted">{% trans "No content found" %}</div>
     {% endfor %}
   </div>
+{% elif isolated_deployment %}
+  <span class="text-danger">
+    <i class="mdi mdi-alert"></i> {% trans "This RSS feed requires an external connection. Check the ISOLATED_DEPLOYMENT setting." %}
+  </span>
 {% else %}
   {# There was an error retrieving/parsing the feed #}
   <span class="text-danger">


### PR DESCRIPTION
### Fixes: #18184

Because the RSS feed widget ("NetBox News") will return an error in an isolated deployment, this change skips adding that widget to the default dashboard if `ISOLATED_DEPLOYMENT` is set in the configuration.

Note that this matches all `extras.RSSFeedWidget` type widgets, so any additional RSS feeds we add to `DEFAULT_DASHBOARD` in the future will also be skipped in this situation.