### PR TITLE
Fixes #18194: Always pass POST data to bulk edit form

### DIFF
--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -661,15 +661,13 @@ class BulkEditView(GetReturnURLMixin, BaseMultiObjectView):
         elif 'virtual_machine' in request.GET:
             initial_data['virtual_machine'] = request.GET.get('virtual_machine')
 
-        if '_apply' in request.POST:
-            form = self.form(request.POST, initial=initial_data)
-            restrict_form_fields(form, request.user)
+        form = self.form(request.POST, initial=initial_data)
+        restrict_form_fields(form, request.user)
 
+        if '_apply' in request.POST:
             if form.is_valid():
                 logger.debug("Form validation was successful")
-
                 try:
-
                     with transaction.atomic():
                         updated_objects = self._update_objects(form, request)
 
@@ -696,10 +694,6 @@ class BulkEditView(GetReturnURLMixin, BaseMultiObjectView):
 
             else:
                 logger.debug("Form validation failed")
-
-        else:
-            form = self.form(initial=initial_data)
-            restrict_form_fields(form, request.user)
 
         # Retrieve objects being edited
         table = self.table(self.queryset.filter(pk__in=pk_list), orderable=False)


### PR DESCRIPTION
### Fixes: #18194

Always initialize the bulk edit form with POST data, to fix support for the HTMXSelect widget.