### PR TITLE
Fixes: #18192 - Use assigned_object instead of interface in display_attrs

### DIFF
--- a/netbox/dcim/search.py
+++ b/netbox/dcim/search.py
@@ -105,7 +105,7 @@ class MACAddressIndex(SearchIndex):
         ('mac_address', 100),
         ('description', 500),
     )
-    display_attrs = ('mac_address', 'interface')
+    display_attrs = ('mac_address', 'assigned_object')
 
 
 @register_search

--- a/netbox/dcim/search.py
+++ b/netbox/dcim/search.py
@@ -105,7 +105,7 @@ class MACAddressIndex(SearchIndex):
         ('mac_address', 100),
         ('description', 500),
     )
-    display_attrs = ('mac_address', 'assigned_object')
+    display_attrs = ('assigned_object', 'description')
 
 
 @register_search


### PR DESCRIPTION
### Fixes: #18192

Uses `assigned_object` instead of `interface` in `MACAddressIndex.display_attrs`.