### PR TITLE
Closes #18045: Enable adding a new MAC to an interface via quick add

### DIFF
--- a/netbox/dcim/forms/common.py
+++ b/netbox/dcim/forms/common.py
@@ -3,9 +3,7 @@ from django.utils.translation import gettext_lazy as _
 
 from dcim.choices import *
 from dcim.constants import *
-from dcim.models import MACAddress
 from utilities.forms import get_field_value
-from utilities.forms.fields import DynamicModelChoiceField
 
 __all__ = (
     'InterfaceCommonForm',
@@ -19,12 +17,6 @@ class InterfaceCommonForm(forms.Form):
         min_value=INTERFACE_MTU_MIN,
         max_value=INTERFACE_MTU_MAX,
         label=_('MTU')
-    )
-    primary_mac_address = DynamicModelChoiceField(
-        queryset=MACAddress.objects.all(),
-        label=_('Primary MAC address'),
-        required=False,
-        quick_add=True
     )
 
     def __init__(self, *args, **kwargs):

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -1410,6 +1410,13 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
         required=False,
         label=_('VRF')
     )
+    primary_mac_address = DynamicModelChoiceField(
+        queryset=MACAddress.objects.all(),
+        label=_('Primary MAC address'),
+        required=False,
+        quick_add=True,
+        quick_add_params={'interface': '$pk'}
+    )
     wwn = forms.CharField(
         empty_value=None,
         required=False,

--- a/netbox/utilities/forms/fields/dynamic.py
+++ b/netbox/utilities/forms/fields/dynamic.py
@@ -68,6 +68,8 @@ class DynamicModelChoiceMixin:
         selector: Include an advanced object selection widget to assist the user in identifying the desired object
         quick_add: Include a widget to quickly create a new related object for assignment. NOTE: Nested usage of
             quick-add fields is not currently supported.
+        quick_add_params: A dictionary of initial data to include when launching the quick-add form (optional). The
+            token string "$pk" will be replaced with the primary key of the form's instance, if any.
 
     Context keys:
         value: The name of the attribute which contains the option's value (default: 'id')
@@ -177,8 +179,11 @@ class DynamicModelChoiceMixin:
             }
             for k, v in self.quick_add_params.items():
                 if v == '$pk':
-                    v = form.instance.pk
-                widget.quick_add_context['params'][k] = v
+                    # Replace "$pk" token with the primary key of the form's instance (if any)
+                    if getattr(form.instance, 'pk', None):
+                        widget.quick_add_context['params'][k] = form.instance.pk
+                else:
+                    widget.quick_add_context['params'][k] = v
 
         return bound_field
 

--- a/netbox/utilities/forms/widgets/apiselect.py
+++ b/netbox/utilities/forms/widgets/apiselect.py
@@ -22,6 +22,15 @@ class APISelect(forms.Select):
     dynamic_params: Dict[str, str]
     static_params: Dict[str, List[str]]
 
+    def get_context(self, name, value, attrs):
+        context = super().get_context(name, value, attrs)
+
+        # Add quick-add context data, if set on the widget
+        if hasattr(self, 'quick_add_context'):
+            context['quick_add'] = self.quick_add_context
+
+        return context
+
     def __init__(self, api_url=None, full=False, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/netbox/utilities/forms/widgets/apiselect.py
+++ b/netbox/utilities/forms/widgets/apiselect.py
@@ -25,7 +25,7 @@ class APISelect(forms.Select):
     def get_context(self, name, value, attrs):
         context = super().get_context(name, value, attrs)
 
-        # Add quick-add context data, if set on the widget
+        # Add quick-add context data, if enabled for the widget
         if hasattr(self, 'quick_add_context'):
             context['quick_add'] = self.quick_add_context
 

--- a/netbox/utilities/templates/widgets/apiselect.html
+++ b/netbox/utilities/templates/widgets/apiselect.html
@@ -15,7 +15,7 @@
       <i class="mdi mdi-database-search-outline"></i>
     </button>
   {% endif %}
-  {% if widget.attrs.quick_add and not widget.attrs.disabled %}
+  {% if quick_add and not widget.attrs.disabled %}
     {# Opens the quick add modal #}
     <button
       type="button"
@@ -23,7 +23,7 @@
       class="btn btn-outline-secondary ms-1"
       data-bs-toggle="modal"
       data-bs-target="#htmx-modal"
-      hx-get="{{ widget.attrs.quick_add }}?_quickadd=True&target={{ widget.attrs.id }}"
+      hx-get="{{ quick_add.url }}?_quickadd=True&target={{ widget.attrs.id }}{% for k, v in quick_add.params.items %}&{{ k }}={{ v }}{% endfor %}"
       hx-target="#htmx-modal-content"
     >
       <i class="mdi mdi-plus-circle"></i>

--- a/netbox/virtualization/forms/model_forms.py
+++ b/netbox/virtualization/forms/model_forms.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 
 from dcim.forms.common import InterfaceCommonForm
 from dcim.forms.mixins import ScopedForm
-from dcim.models import Device, DeviceRole, Platform, Rack, Region, Site, SiteGroup
+from dcim.models import Device, DeviceRole, MACAddress, Platform, Rack, Region, Site, SiteGroup
 from extras.models import ConfigTemplate
 from ipam.choices import VLANQinQRoleChoices
 from ipam.models import IPAddress, VLAN, VLANGroup, VLANTranslationPolicy, VRF
@@ -298,6 +298,13 @@ class VMComponentForm(NetBoxModelForm):
 
 
 class VMInterfaceForm(InterfaceCommonForm, VMComponentForm):
+    primary_mac_address = DynamicModelChoiceField(
+        queryset=MACAddress.objects.all(),
+        label=_('Primary MAC address'),
+        required=False,
+        quick_add=True,
+        quick_add_params={'vminterface': '$pk'}
+    )
     parent = DynamicModelChoiceField(
         queryset=VMInterface.objects.all(),
         required=False,


### PR DESCRIPTION
### Fixes: #18045

- Move the `primary_mac_address` field from InterfaceCommonForm to the device & VM interface forms
- Introduce the `quick_add_params` keyword argument on DynamicModelChoiceMixin
- Alter APISelect to set quick-add parameters on the widget (rather than passing as widget attrs) & expose them as template context