### PR TITLE
Closes #18211: Enable dynamic registration of request processors

### DIFF
--- a/docs/development/application-registry.md
+++ b/docs/development/application-registry.md
@@ -51,7 +51,7 @@ This store maintains all registered items for plugins, such as navigation menus,
 
 ### `request_processors`
 
-A list of context managers to invoke when processing a request e.g. in middleware or when executing a background job. Request processors can be registered with the `register_request_processor()` decorator.
+A list of context managers to invoke when processing a request e.g. in middleware or when executing a background job. Request processors can be registered with the `@register_request_processor` decorator.
 
 ### `search`
 

--- a/docs/development/application-registry.md
+++ b/docs/development/application-registry.md
@@ -49,6 +49,10 @@ This key lists all models which have been registered in NetBox which are not des
 
 This store maintains all registered items for plugins, such as navigation menus, template extensions, etc.
 
+### `request_processors`
+
+A list of context managers to invoke when processing a request e.g. in middleware or when executing a background job. Request processors can be registered with the `register_request_processor()` decorator.
+
 ### `search`
 
 A dictionary mapping each model (identified by its app and label) to its search index class, if one has been registered for it.

--- a/netbox/netbox/context_managers.py
+++ b/netbox/netbox/context_managers.py
@@ -1,9 +1,11 @@
 from contextlib import contextmanager
 
 from netbox.context import current_request, events_queue
+from netbox.utils import register_request_processor
 from extras.events import flush_events
 
 
+@register_request_processor
 @contextmanager
 def event_tracking(request):
     """

--- a/netbox/netbox/registry.py
+++ b/netbox/netbox/registry.py
@@ -29,6 +29,7 @@ registry = Registry({
     'model_features': dict(),
     'models': collections.defaultdict(set),
     'plugins': dict(),
+    'request_processors': list(),
     'search': dict(),
     'tables': collections.defaultdict(dict),
     'views': collections.defaultdict(dict),

--- a/netbox/netbox/utils.py
+++ b/netbox/netbox/utils.py
@@ -3,6 +3,7 @@ from netbox.registry import registry
 __all__ = (
     'get_data_backend_choices',
     'register_data_backend',
+    'register_request_processor',
 )
 
 
@@ -24,3 +25,12 @@ def register_data_backend():
         return cls
 
     return _wrapper
+
+
+def register_request_processor(func):
+    """
+    Decorator for registering a request processor.
+    """
+    registry['request_processors'].append(func)
+
+    return func


### PR DESCRIPTION
### Fixes: #18211

- Enable registration of request processors in the application registry
- Adapt CoreMiddleware to apply all registered request processors

Thanks to @arthanson for knocking out some of the preliminary work here in PR #18137.