### PR TITLE
Fixes #18213: Enable searching for ASN ranges by name

### DIFF
--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -211,8 +211,10 @@ class ASNRangeFilterSet(OrganizationalModelFilterSet, TenancyFilterSet):
     def search(self, queryset, name, value):
         if not value.strip():
             return queryset
-        qs_filter = Q(description__icontains=value)
-        return queryset.filter(qs_filter)
+        return queryset.filter(
+            Q(name__icontains=value) |
+            Q(description__icontains=value)
+        )
 
 
 class ASNFilterSet(OrganizationalModelFilterSet, TenancyFilterSet):


### PR DESCRIPTION
### Fixes: #18213

Add the mistakenly omitted `name` field to the `search()` method on ASNRangeFilterSet