### PR TITLE
Introducing NetBox Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
   <a href="https://github.com/netbox-community/netbox/stargazers"><img src="https://img.shields.io/github/stars/netbox-community/netbox?style=flat" alt="GitHub stars" /></a>
   <a href="https://explore.transifex.com/netbox-community/netbox/"><img src="https://img.shields.io/badge/languages-15-blue" alt="Languages supported" /></a>
   <a href="https://github.com/netbox-community/netbox/actions/workflows/ci.yml"><img src="https://github.com/netbox-community/netbox/workflows/CI/badge.svg?branch=master" alt="CI status" /></a>
+  <a href="https://gurubase.io/g/netbox"><img src="https://img.shields.io/badge/Gurubase-Ask%20NetBox%20Guru-006BFF" alt="Gurubase" /></a>
   <p>
     <strong><a href="https://github.com/netbox-community/netbox/">NetBox Community</a></strong> |
     <strong><a href="https://netboxlabs.com/netbox-cloud/">NetBox Cloud</a></strong> |


### PR DESCRIPTION
Hello Team,

This PR is a friendly notification that the [NetBox Guru](https://gurubase.io/g/netbox) has been added to Gurubase. The NetBox Guru uses data from this repository and the [documentation](https://netboxlabs.com/docs/netbox/en/stable/) to answer questions by leveraging the LLM.

Gurubase is a centralized, RAG-based learning and troubleshooting assistant platform. Each "Guru" is equipped with custom knowledge to answer user questions based on data collected for that tool. More information can be found in [this repo](https://github.com/getanteon/gurubase).

This PR updates the README to indicate that NetBox users can now ask questions to NetBox Guru. As shown in the [Used By](https://github.com/getanteon/gurubase?tab=readme-ov-file#used-by) section, over 100 open-source repositories currently showcase their Guru in their README.md.

By default, there are three possible actions:
1. If you dislike it, we can immediately disable NetBox Guru in Gurubase and remove this PR.
2. If you like it but don’t want to add it to the README, we can remove this PR or include it in another place you prefer.
3. If you’re happy with it, we can keep it as is and merge the PR.

Although this PR is created by the Gurubase Notifier account, the team monitors it and will answer any questions you may have.

**Note:** If you consider this PR a time-waster, apologize for the inconvenience. Developers often request us to create a Guru for the tools they use. Once we create it, we notify the maintainers to inform them and seek their approval.
