### PR TITLE
Fixes: #18230 - Handle editing IPAddresses on VMInterfaces without parent.oob_ip

### DIFF
--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -361,7 +361,7 @@ class IPAddressForm(TenancyForm, NetBoxModelForm):
             ):
                 self.initial['primary_for_parent'] = True
 
-            if parent and (parent.oob_ip_id == self.instance.pk):
+            if parent and getattr(parent, 'oob_ip_id', None) == self.instance.pk:
                 self.initial['oob_for_parent'] = True
 
             if type(instance.assigned_object) is Interface:


### PR DESCRIPTION
### Fixes: #18230

Handles a case in the edit flow for IPAddresses that are attached to VMInterfaces, whose parent VMs do not have the new `oob_ip` field.
