### PR TITLE
Fix definition of `vid_ranges` in `VLANGroup` so it shows up in the OpenAPI schema

### DIFF
--- a/netbox/core/api/schema.py
+++ b/netbox/core/api/schema.py
@@ -2,12 +2,13 @@ import re
 import typing
 from collections import OrderedDict
 
-from drf_spectacular.extensions import OpenApiSerializerFieldExtension
+from drf_spectacular.extensions import OpenApiSerializerFieldExtension, OpenApiSerializerExtension, _SchemaType
 from drf_spectacular.openapi import AutoSchema
 from drf_spectacular.plumbing import (
     build_basic_type, build_choice_field, build_media_type_object, build_object_type, get_doc,
 )
 from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import Direction
 
 from netbox.api.fields import ChoiceField
 from netbox.api.serializers import WritableNestedSerializer
@@ -277,3 +278,20 @@ class FixSerializedPKRelatedField(OpenApiSerializerFieldExtension):
             return component.ref if component else None
         else:
             return build_basic_type(OpenApiTypes.INT)
+
+
+class FixIntegerRangeSerializerSchema(OpenApiSerializerExtension):
+    target_class = 'netbox.api.fields.IntegerRangeSerializer'
+
+    def map_serializer(self, auto_schema: 'AutoSchema', direction: Direction) -> _SchemaType:
+        return {
+            'type': 'array',
+            'items': {
+                'type': 'array',
+                'items': {
+                    'type': 'integer',
+                },
+                'minItems': 2,
+                'maxItems': 2,
+            },
+        }

--- a/netbox/netbox/api/fields.py
+++ b/netbox/netbox/api/fields.py
@@ -158,29 +158,7 @@ class RelatedObjectCountField(serializers.ReadOnlyField):
         super().__init__(**kwargs)
 
 
-_integer_range_schema = {
-    'type': 'array',
-    'items': {
-        'type': 'integer',
-    },
-    'minItems': 2,
-    'maxItems': 2,
-}
-
-@extend_schema_field({
-    'type': 'array',
-    'items': _integer_range_schema,
-})
-class IntegerRangeListSerializer(serializers.ListSerializer):
-    # this special class is only here to work around
-    # https://github.com/tfranzel/drf-spectacular/issues/1353
-    pass
-
-@extend_schema_field(_integer_range_schema)
 class IntegerRangeSerializer(serializers.Serializer):
-    class Meta:
-        list_serializer_class = IntegerRangeListSerializer
-
     """
     Represents a range of integers.
     """

--- a/netbox/netbox/api/fields.py
+++ b/netbox/netbox/api/fields.py
@@ -158,7 +158,29 @@ class RelatedObjectCountField(serializers.ReadOnlyField):
         super().__init__(**kwargs)
 
 
+_integer_range_schema = {
+    'type': 'array',
+    'items': {
+        'type': 'integer',
+    },
+    'minItems': 2,
+    'maxItems': 2,
+}
+
+@extend_schema_field({
+    'type': 'array',
+    'items': _integer_range_schema,
+})
+class IntegerRangeListSerializer(serializers.ListSerializer):
+    # this special class is only here to work around
+    # https://github.com/tfranzel/drf-spectacular/issues/1353
+    pass
+
+@extend_schema_field(_integer_range_schema)
 class IntegerRangeSerializer(serializers.Serializer):
+    class Meta:
+        list_serializer_class = IntegerRangeListSerializer
+
     """
     Represents a range of integers.
     """


### PR DESCRIPTION
### Fixes: https://github.com/netbox-community/netbox/issues/17488

The OpenAPI schema for `vid_ranges` cannot automatically be discovered by drf-spectacular since it's a custom serializer with no fields. Therefore we need to manually provide the OpenAPI schema for the type we expect to see in requests and responses.

On top of that there is a bug in drf-spectacular that required the workaround with the custom list class (https://github.com/tfranzel/drf-spectacular/issues/1353).