### PR TITLE
Added the cable -> CableType-Annotation in CableTerminationType.

### DIFF
--- a/netbox/dcim/graphql/types.py
+++ b/netbox/dcim/graphql/types.py
@@ -116,7 +116,7 @@ class ModularComponentTemplateType(ComponentTemplateType):
     filters=CableTerminationFilter
 )
 class CableTerminationType(NetBoxObjectType):
-
+    cable: Annotated["CableType", strawberry.lazy('dcim.graphql.types')] | None
     termination: Annotated[Union[
         Annotated["CircuitTerminationType", strawberry.lazy('circuits.graphql.types')],
         Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')],


### PR DESCRIPTION
### Fixes: https://github.com/netbox-community/netbox/issues/18124
The OpenAPI schema for  CableTerminationType auto retrieves the cable-property as default DjangoType and therefore no properties of the cable can be retrieved. Adding the reference annotation to CableType solves this issue.
