### PR TITLE
Fixes: #17868 - Handle orphaned cable condition gracefully in SVG rendering

### DIFF
--- a/netbox/dcim/svg/cables.py
+++ b/netbox/dcim/svg/cables.py
@@ -268,6 +268,10 @@ class CableTraceSVG:
         """
         Draw the far-end objects and its terminations and return all created nodes
         """
+        # If an empty list is passed in, return empty results so this cable can be skipped
+        if len(obj_list) == 0:
+            return [], []
+
         # Make sure elements are sorted by name for readability
         objects = sorted(obj_list, key=lambda x: str(x))
         width = self.width / len(objects)
@@ -404,6 +408,10 @@ class CableTraceSVG:
                             # a and b terminations may be swapped
                             near = [term for term in near_terminations if term.object == cable.interface_b]
                             far = [term for term in far_terminations if term.object == cable.interface_a]
+
+                    # If at this point we have no near or no far terminations, this cable can't be rendered, so skip.
+                    if not (near and far):
+                        continue
 
                     # Select most-probable start and end position
                     start = near[0].bottom_center

--- a/netbox/dcim/svg/cables.py
+++ b/netbox/dcim/svg/cables.py
@@ -269,7 +269,7 @@ class CableTraceSVG:
         Draw the far-end objects and its terminations and return all created nodes
         """
         # If an empty list is passed in, return empty results so this cable can be skipped
-        if len(obj_list) == 0:
+        if not len(obj_list):
             return [], []
 
         # Make sure elements are sorted by name for readability

--- a/netbox/dcim/svg/cables.py
+++ b/netbox/dcim/svg/cables.py
@@ -268,10 +268,6 @@ class CableTraceSVG:
         """
         Draw the far-end objects and its terminations and return all created nodes
         """
-        # If an empty list is passed in, return empty results so this cable can be skipped
-        if not len(obj_list):
-            return [], []
-
         # Make sure elements are sorted by name for readability
         objects = sorted(obj_list, key=lambda x: str(x))
         width = self.width / len(objects)
@@ -366,15 +362,10 @@ class CableTraceSVG:
             self.cursor += CABLE_HEIGHT
 
             # Connector (a Cable or WirelessLink)
-            if links:
+            if links and far_ends:
 
                 obj_list = {end.parent_object for end in far_ends}
                 parent_object_nodes, far_terminations = self.draw_far_objects(obj_list, far_ends)
-
-                # If there are no far terminations, this segment can't be rendered, so skip.
-                if not far_terminations:
-                    continue
-
                 for cable in links:
                     # Fill in labels and description with all available data
                     description = [

--- a/netbox/dcim/svg/cables.py
+++ b/netbox/dcim/svg/cables.py
@@ -370,6 +370,11 @@ class CableTraceSVG:
 
                 obj_list = {end.parent_object for end in far_ends}
                 parent_object_nodes, far_terminations = self.draw_far_objects(obj_list, far_ends)
+
+                # If there are no far terminations, this segment can't be rendered, so skip.
+                if not far_terminations:
+                    continue
+
                 for cable in links:
                     # Fill in labels and description with all available data
                     description = [
@@ -408,10 +413,6 @@ class CableTraceSVG:
                             # a and b terminations may be swapped
                             near = [term for term in near_terminations if term.object == cable.interface_b]
                             far = [term for term in far_terminations if term.object == cable.interface_a]
-
-                    # If at this point we have no near or no far terminations, this cable can't be rendered, so skip.
-                    if not (near and far):
-                        continue
 
                     # Select most-probable start and end position
                     start = near[0].bottom_center


### PR DESCRIPTION
### Fixes: #17868

If a device has been deleted, attached cables may be left orphaned, which leads to rendering errors when generating the cable trace SVG. This fix handles the case where the object list passed in to `draw_far_objects` is empty by returning empty lists of results and then handling those gracefully so that the remaining portion of the SVG can be rendered.
