### PR TITLE
Fixes: #18203 - Validate that scope is selected if scope type is specified

### DIFF
--- a/netbox/dcim/models/mixins.py
+++ b/netbox/dcim/models/mixins.py
@@ -94,6 +94,7 @@ class CachedScopeMixin(models.Model):
                     "Please select a {scope_type}."
                 ).format(scope_type=scope_type._meta.model_name)
             })
+        super().clean()
 
     def save(self, *args, **kwargs):
         # Cache objects associated with the terminating object (for filtering)

--- a/netbox/dcim/models/mixins.py
+++ b/netbox/dcim/models/mixins.py
@@ -1,6 +1,8 @@
 from django.apps import apps
 from django.contrib.contenttypes.fields import GenericForeignKey
+from django.core.exceptions import ValidationError
 from django.db import models
+from django.utils.translation import gettext_lazy as _
 from dcim.constants import LOCATION_SCOPE_TYPES
 
 __all__ = (
@@ -83,6 +85,16 @@ class CachedScopeMixin(models.Model):
 
     class Meta:
         abstract = True
+
+    def clean(self):
+        if self.scope_type:
+            scope_type = self.scope_type.model_class()
+            if not self.scope:
+                raise ValidationError({
+                    'scope': _(
+                        "Please select a {scope_type}."
+                    ).format(scope_type=scope_type._meta.model_name)
+                })
 
     def save(self, *args, **kwargs):
         # Cache objects associated with the terminating object (for filtering)

--- a/netbox/dcim/models/mixins.py
+++ b/netbox/dcim/models/mixins.py
@@ -87,14 +87,13 @@ class CachedScopeMixin(models.Model):
         abstract = True
 
     def clean(self):
-        if self.scope_type:
+        if self.scope_type and not self.scope:
             scope_type = self.scope_type.model_class()
-            if not self.scope:
-                raise ValidationError({
-                    'scope': _(
-                        "Please select a {scope_type}."
-                    ).format(scope_type=scope_type._meta.model_name)
-                })
+            raise ValidationError({
+                'scope': _(
+                    "Please select a {scope_type}."
+                ).format(scope_type=scope_type._meta.model_name)
+            })
 
     def save(self, *args, **kwargs):
         # Cache objects associated with the terminating object (for filtering)


### PR DESCRIPTION
### Fixes: #18203

On models with `CachedScopeMixin` (`Prefix`, `Cluster`, `WirelessLAN`), ensure that if a ScopeType is specified in the create or edit form, a Scope must also be selected. This prevents a spurious error being raised: `'PrefixForm' has no field named 'scope_id'.`
