### PR TITLE
Fixes: #18263 - Iterate through a freshly queried set of CableTerminations to find endpoints in update_connected_endpoints

### DIFF
--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -607,6 +607,10 @@ class CablePath(models.Model):
                     cable_end = 'A' if lct.cable_end == 'B' else 'B'
                     q_filter |= Q(cable=lct.cable, cable_end=cable_end)
 
+                # Make sure this filter has been populated; if not, we have probably been given invalid data
+                if not q_filter:
+                    break
+
                 remote_cable_terminations = CableTermination.objects.filter(q_filter)
                 remote_terminations = [ct.termination for ct in remote_cable_terminations]
             else:

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -85,7 +85,8 @@ def update_connected_endpoints(instance, created, raw=False, **kwargs):
     if instance._terminations_modified:
         a_terminations = []
         b_terminations = []
-        for t in instance.terminations.all():
+        # Note: instance.terminations.all() is not safe to use here as it might be stale
+        for t in CableTermination.objects.filter(cable=instance):
             if t.cable_end == CableEndChoices.SIDE_A:
                 a_terminations.append(t.termination)
             else:


### PR DESCRIPTION
### Fixes: #18263

During an API PATCH update to a Cable where one or both endpoints is changed, the signal handler `update_connected_endpoints` iterates through `self.terminations.all()` which in the case of an API call has not necessarily been refreshed after the deletion of stale endpoints at https://github.com/netbox-community/netbox/blob/b6265d828526a97962e8feefa0ff57c534d2da27/netbox/dcim/models/cables.py#L224-L240

This leads to the `local_cable_terminations` being empty here (because the pks don't match): https://github.com/netbox-community/netbox/blob/b6265d828526a97962e8feefa0ff57c534d2da27/netbox/dcim/models/cables.py#L597-L611 (Step 6 of `Cable.from_origin`), which leads to `q_filter` being empty and thus the completely unfiltered iteration at L611 potentially taking O(n) time depending on the number of terminations in the DB.

This change ensures that the iteration of CableTerminations associated with a Cable after an update is freshly queried from the DB following the deletion of stale endpoints rather than relying on the (potentially stale or cached) `self.terminations` reverse relation, and thus ensuring `from_origin` is calculated correctly.
