### PR TITLE
Fixes #18271: Require only encryption OR authentication algorithm when creating an IPSec proposal via REST API

### DIFF
--- a/netbox/vpn/api/serializers_/crypto.py
+++ b/netbox/vpn/api/serializers_/crypto.py
@@ -64,10 +64,12 @@ class IKEPolicySerializer(NetBoxModelSerializer):
 
 class IPSecProposalSerializer(NetBoxModelSerializer):
     encryption_algorithm = ChoiceField(
-        choices=EncryptionAlgorithmChoices
+        choices=EncryptionAlgorithmChoices,
+        required=False
     )
     authentication_algorithm = ChoiceField(
-        choices=AuthenticationAlgorithmChoices
+        choices=AuthenticationAlgorithmChoices,
+        required=False
     )
 
     class Meta:


### PR DESCRIPTION
### Fixes: #18271

- Set `required=False` on `encryption_algorithm` & `authentication_algorithm` for IPSecProposalSerializer
