### PR TITLE
Fixes #18278: Restore missing columns on MACAddressTable

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -1155,6 +1155,7 @@ class MACAddressTable(NetBoxTable):
     class Meta(DeviceComponentTable.Meta):
         model = models.MACAddress
         fields = (
-            'pk', 'id', 'mac_address', 'assigned_object_parent', 'assigned_object', 'created', 'last_updated',
+            'pk', 'id', 'mac_address', 'assigned_object_parent', 'assigned_object', 'description', 'comments', 'tags',
+            'created', 'last_updated',
         )
-        default_columns = ('pk', 'mac_address', 'assigned_object_parent', 'assigned_object')
+        default_columns = ('pk', 'mac_address', 'assigned_object_parent', 'assigned_object', 'description')


### PR DESCRIPTION
### Fixes: #18278

Add missing columns `description`, `comments`, and `tags` on MACAddressTable, with `description` designated as a default column.
