### PR TITLE
Fixes: #18289 - Add 'created' and 'last_updated' fields to ModuleTypeTable

### DIFF
--- a/netbox/dcim/tables/modules.py
+++ b/netbox/dcim/tables/modules.py
@@ -41,6 +41,7 @@ class ModuleTypeTable(NetBoxTable):
         model = ModuleType
         fields = (
             'pk', 'id', 'model', 'manufacturer', 'part_number', 'airflow', 'weight', 'description', 'comments', 'tags',
+            'created', 'last_updated',
         )
         default_columns = (
             'pk', 'model', 'manufacturer', 'part_number',

--- a/netbox/dcim/tables/modules.py
+++ b/netbox/dcim/tables/modules.py
@@ -80,7 +80,7 @@ class ModuleTable(NetBoxTable):
         model = Module
         fields = (
             'pk', 'id', 'device', 'module_bay', 'manufacturer', 'module_type', 'status', 'serial', 'asset_tag',
-            'description', 'comments', 'tags',
+            'description', 'comments', 'tags', 'created', 'last_updated',
         )
         default_columns = (
             'pk', 'id', 'device', 'module_bay', 'manufacturer', 'module_type', 'status', 'serial', 'asset_tag',


### PR DESCRIPTION
### Fixes: #18289

`ModuleTypeTable` is missing `created` and `last_updated` as selectable fields for sorting, as is consistent for other tables such as `DeviceTypeTable`. This change adds those fields to `fields`.
