### PR TITLE
Fixes: #18288 - Fix prefetch_related incorrectly looking for "site" on scoped models

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -713,7 +713,7 @@ class IPRangeView(generic.ObjectView):
             Q(prefix__net_contains_or_equals=str(instance.end_address.ip)),
             vrf=instance.vrf
         ).prefetch_related(
-            'site', 'role', 'tenant', 'vlan', 'role'
+            'scope', 'role', 'tenant', 'vlan', 'role'
         )
         parent_prefixes_table = tables.PrefixTable(
             list(parent_prefixes),
@@ -805,7 +805,7 @@ class IPAddressView(generic.ObjectView):
             vrf=instance.vrf,
             prefix__net_contains_or_equals=str(instance.address.ip)
         ).prefetch_related(
-            'site', 'role'
+            'scope', 'role'
         )
         parent_prefixes_table = tables.PrefixTable(
             list(parent_prefixes),
@@ -1288,7 +1288,7 @@ class VLANView(generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         prefixes = Prefix.objects.restrict(request.user, 'view').filter(vlan=instance).prefetch_related(
-            'vrf', 'site', 'role', 'tenant'
+            'vrf', 'scope', 'role', 'tenant'
         )
         prefix_table = tables.PrefixTable(list(prefixes), exclude=('vlan', 'utilization'), orderable=False)
 


### PR DESCRIPTION
### Fixes: #18288

At least three detail views in `ipam/views.py` are using `prefetch_related` on the `site` field, which no longer is compatible with that pattern after changing to generic scopes. This change updates those prefetched fields to `scope`.
