### PR TITLE
Closes #13366: Update documentation for `main` branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,7 +2,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📖 Contributing Policy
-    url: https://github.com/netbox-community/netbox/blob/develop/CONTRIBUTING.md
+    url: https://github.com/netbox-community/netbox/blob/main/CONTRIBUTING.md
     about: "Please read through our contributing policy before opening an issue or pull request."
   - name: ❓ Discussion
     url: https://github.com/netbox-community/netbox/discussions

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -38,7 +38,7 @@ jobs:
             issues may receive direct feedback. **Do not** attempt to circumvent this
             process by "bumping" the issue; doing so will result in its immediate closure
             and you may be barred from participating in any future discussions. Please see
-            our [contributing guide](https://github.com/netbox-community/netbox/blob/develop/CONTRIBUTING.md).
+            our [contributing guide](https://github.com/netbox-community/netbox/blob/main/CONTRIBUTING.md).
 
           # Pull request parameters
           close-pr-message: >

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 <div align="center">
-  <img src="https://raw.githubusercontent.com/netbox-community/netbox/develop/docs/netbox_logo_light.svg" width="400" alt="NetBox logo" />
+  <img src="https://raw.githubusercontent.com/netbox-community/netbox/main/docs/netbox_logo_light.svg" width="400" alt="NetBox logo" />
   <p><strong>The cornerstone of every automated network</strong></p>
   <a href="https://github.com/netbox-community/netbox/releases"><img src="https://img.shields.io/github/v/release/netbox-community/netbox" alt="Latest release" /></a>
-  <a href="https://github.com/netbox-community/netbox/blob/master/LICENSE.txt"><img src="https://img.shields.io/badge/license-Apache_2.0-blue.svg" alt="License" /></a>
+  <a href="https://github.com/netbox-community/netbox/blob/main/LICENSE.txt"><img src="https://img.shields.io/badge/license-Apache_2.0-blue.svg" alt="License" /></a>
   <a href="https://github.com/netbox-community/netbox/graphs/contributors"><img src="https://img.shields.io/github/contributors/netbox-community/netbox?color=blue" alt="Contributors" /></a>
   <a href="https://github.com/netbox-community/netbox/stargazers"><img src="https://img.shields.io/github/stars/netbox-community/netbox?style=flat" alt="GitHub stars" /></a>
   <a href="https://explore.transifex.com/netbox-community/netbox/"><img src="https://img.shields.io/badge/languages-15-blue" alt="Languages supported" /></a>
-  <a href="https://github.com/netbox-community/netbox/actions/workflows/ci.yml"><img src="https://github.com/netbox-community/netbox/workflows/CI/badge.svg?branch=master" alt="CI status" /></a>
+  <a href="https://github.com/netbox-community/netbox/actions/workflows/ci.yml"><img src="https://github.com/netbox-community/netbox/workflows/CI/badge.svg?branch=main" alt="CI status" /></a>
   <p>
     <strong><a href="https://github.com/netbox-community/netbox/">NetBox Community</a></strong> |
     <strong><a href="https://netboxlabs.com/netbox-cloud/">NetBox Cloud</a></strong> |

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -42,7 +42,7 @@ The NetBox project utilizes two persistent git branches to track work:
 * `main` - All development on the upcoming stable (patch) release occurs here. Releases are published from this branch.
 * `feature` - All work planned for the upcoming minor release is done here.
 
-Typically, you'll base pull requests off of the `main` branch, or off of `feature` if you're working on a new major release. For example, assume that the current NetBox release is v4.2.3. Work applied to the `main` branch will appear in v4.2.4, and work done under the `feature` branch will be included in the next minor release (v4.3.0).
+Typically, you'll base pull requests off of the `main` branch, or off of `feature` if you're working on the upcoming minor or major release. For example, assume that the current NetBox release is v4.2.3. Work applied to the `main` branch will appear in v4.2.4, and work done under the `feature` branch will be included in the next minor release (v4.3.0).
 
 To create a new branch, first ensure that you've checked out the desired base branch, then run:
 

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -37,16 +37,12 @@ CHANGELOG.md           CONTRIBUTING.md  LICENSE.txt  netbox      README.md  scri
 
 ### 2. Create a New Branch
 
-The NetBox project utilizes three persistent git branches to track work:
+The NetBox project utilizes two persistent git branches to track work:
 
-* `master` - Serves as a snapshot of the current stable release
-* `develop` - All development on the upcoming stable (patch) release occurs here
-* `feature` - Tracks work on an upcoming minor release
+* `main` - All development on the upcoming stable (patch) release occurs here. Releases are published from this branch.
+* `feature` - All work planned for the upcoming minor release is done here.
 
-Typically, you'll base pull requests off of the `develop` branch, or off of `feature` if you're working on a new major release. For example, assume that the current NetBox release is v3.3.5. Work applied to the `develop` branch will appear in v3.3.6, and work done under the `feature` branch will be included in the next minor release (v3.4.0).
-
-!!! warning
-    **Never** merge pull requests into the `master` branch: This branch only ever merges pull requests from the `develop` branch, to effect a new release.
+Typically, you'll base pull requests off of the `main` branch, or off of `feature` if you're working on a new major release. For example, assume that the current NetBox release is v4.2.3. Work applied to the `main` branch will appear in v4.2.4, and work done under the `feature` branch will be included in the next minor release (v4.3.0).
 
 To create a new branch, first ensure that you've checked out the desired base branch, then run:
 

--- a/docs/development/git-cheat-sheet.md
+++ b/docs/development/git-cheat-sheet.md
@@ -128,7 +128,7 @@ Fast-forward
 ```
 
 !!! warning "Avoid Merging Remote Branches"
-    You generally want to avoid merging branches that exist on the remote (upstream) repository, such as `develop` and `feature`: Merges into these branches should be done via a pull request on GitHub. Only merge branches when it is necessary to consolidate work you've done locally.
+    You generally want to avoid merging branches that exist on the remote (upstream) repository, namely `main` and `feature`: Merges into these branches should be done via a pull request on GitHub. Only merge branches when it is necessary to consolidate work you've done locally.
 
 ### Show Pending Changes
 
@@ -196,7 +196,7 @@ index 93e125079..4344fb514 100644
 +and here too
 +
  <div align="center">
-   <img src="https://raw.githubusercontent.com/netbox-community/netbox/develop/docs/netbox_logo.svg" width="400" alt="NetBox logo" />
+   <img src="https://raw.githubusercontent.com/netbox-community/netbox/main/docs/netbox_logo.svg" width="400" alt="NetBox logo" />
  </div>
 diff --git a/foo.py b/foo.py
 new file mode 100644

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -8,11 +8,10 @@ NetBox and many of its related projects are maintained on [GitHub](https://githu
 
 ![GitHub](../media/development/github.png)
 
-There are three permanent branches in the repository:
+There are two permanent branches in the repository:
 
-* `master` - The current stable release. Individual changes should never be pushed directly to this branch, but rather merged from `develop`.
-* `develop` - Active development for the upcoming patch release. Pull requests will typically be based on this branch unless they introduce breaking changes that must be deferred until the next minor release.
-* `feature` - New feature work to be introduced in the next minor release (e.g. from v3.3 to v3.4).
+* `main` - Active development for the upcoming patch release. Pull requests will typically be based on this branch unless they introduce breaking changes that must be deferred until the next minor release.
+* `feature` - New feature work to be introduced in the next minor release (e.g. from v4.2 to v4.3).
 
 NetBox components are arranged into Django apps. Each app holds the models, views, and other resources relevant to a particular function:
 
@@ -57,4 +56,4 @@ NetBox follows the [benevolent dictator](http://oss-watch.ac.uk/resources/benevo
 
 ## Licensing
 
-The entire NetBox project is licensed as open source under the [Apache 2.0 license](https://github.com/netbox-community/netbox/blob/master/LICENSE.txt). This is a very permissive license which allows unlimited redistribution of all code within the project. Note that all submissions to the project are subject to the same license.
+The entire NetBox project is licensed as open source under the [Apache 2.0 license](https://github.com/netbox-community/netbox/blob/main/LICENSE.txt). This is a very permissive license which allows unlimited redistribution of all code within the project. Note that all submissions to the project are subject to the same license.

--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -43,9 +43,9 @@ Follow these instructions to perform a new installation of NetBox in a temporary
 
 Upgrading from a previous version typically involves database migrations, which must work without errors. Supported upgrade paths include from one minor version to another within the same major version (i.e. 4.0 to 4.1), as well as from the latest patch version of the previous minor version (i.e. 3.7 to 4.0 or to 4.1). Prior to release, test all these supported paths by loading demo data from the source version and performing a `./manage.py migrate`.
 
-### Merge the Release Branch
+### Merge the `feature` Branch
 
-Submit a pull request to merge the `feature` branch into the `develop` branch in preparation for its release. Once it has been merged, continue with the section for patch releases below.
+Submit a pull request to merge the `feature` branch into the `main` branch in preparation for its release. Once it has been merged, continue with the section for patch releases below.
 
 ### Rebuild Demo Data (After Release)
 
@@ -54,6 +54,15 @@ After the release of a new minor version, generate a new demo data snapshot comp
 ---
 
 ## Patch Releases
+
+### Create a Release Branch
+
+Begin by creating a new branch (based off of `main`) to effect the release. This will comprise the changes listed below.
+
+```
+git checkout main
+git checkout -B release-vX.Y.Z
+```
 
 ### Notify netbox-docker Project of Any Relevant Changes
 
@@ -111,25 +120,25 @@ Then, compile these portable (`.po`) files for use in the application:
 * Update the example version numbers in the feature request and bug report templates under `.github/ISSUE_TEMPLATES/`.
 * Replace the "FUTURE" placeholder in the release notes with the current date.
 
-Commit these changes to the `develop` branch and push upstream.
+Commit these changes to the `main` branch and push upstream.
 
 ### Verify CI Build Status
 
-Ensure that continuous integration testing on the `develop` branch is completing successfully. If it fails, take action to correct the failure before proceeding with the release.
+Ensure that continuous integration testing on the `main` branch is completing successfully. If it fails, take action to correct the failure before proceeding with the release.
 
 ### Submit a Pull Request
 
-Submit a pull request titled **"Release vX.Y.Z"** to merge the `develop` branch into `master`. Copy the documented release notes into the pull request's body.
+Submit a pull request titled **"Release vX.Y.Z"** to merge the current release branch (e.g. `release-vX.Y.Z`) into `main`. Copy the documented release notes into the pull request's body.
 
-Once CI has completed on the PR, merge it. This effects a new release in the `master` branch.
+Once CI has completed and a colleague has reviewed the PR, merge it. This effects a new release in the `main` branch.
 
 ### Create a New Release
 
 Create a [new release](https://github.com/netbox-community/netbox/releases/new) on GitHub with the following parameters.
 
-* **Tag:** Current version (e.g. `v3.3.1`)
-* **Target:** `master`
-* **Title:** Version and date (e.g. `v3.3.1 - 2022-08-25`)
+* **Tag:** Current version (e.g. `v4.2.1`)
+* **Target:** `main`
+* **Title:** Version and date (e.g. `v4.2.1 - 2025-01-17`)
 * **Description:** Copy from the pull request body, then promote the `###` headers to `##` ones
 
 Once created, the release will become available for users to install.

--- a/docs/development/translations.md
+++ b/docs/development/translations.md
@@ -14,10 +14,10 @@ To update the English `.po` file from which all translations are derived, use th
 ./manage.py makemessages -l en -i "project-static/*"
 ```
 
-Then, commit the change and push to the `develop` branch on GitHub. Any new strings will appear for translation on Transifex automatically.
+Then, commit the change and push to the `main` branch on GitHub. Any new strings will appear for translation on Transifex automatically.
 
 !!! note
-    It is typically not necessary to update source strings manually, as this is done nightly by a [GitHub action](https://github.com/netbox-community/netbox/blob/develop/.github/workflows/update-translation-strings.yml).
+    It is typically not necessary to update source strings manually, as this is done nightly by a [GitHub action](https://github.com/netbox-community/netbox/blob/main/.github/workflows/update-translation-strings.yml).
 
 ## Updating Translated Strings
 

--- a/docs/installation/3-netbox.md
+++ b/docs/installation/3-netbox.md
@@ -29,7 +29,7 @@ python3 -V
 
 ## Download NetBox
 
-This documentation provides two options for installing NetBox: from a downloadable archive, or from the git repository. Installing from a package (option A below) requires manually fetching and extracting the archive for every future update, whereas installation via git (option B) allows for seamless upgrades by re-pulling the `master` branch.
+This documentation provides two options for installing NetBox: from a downloadable archive, or from the git repository. Installing from a package (option A below) requires manually fetching and extracting the archive for every future update, whereas installation via git (option B) allows for seamless upgrades by checking out the latest release tag.
 
 ### Option A: Download a Release Archive
 
@@ -67,16 +67,13 @@ If `git` is not already installed, install it:
     sudo yum install -y git
     ```
 
-Next, clone the **master** branch of the NetBox GitHub repository into the current directory. (This branch always holds the current stable release.)
+Next, clone the git repository:
 
 ```no-highlight
-sudo git clone -b master --depth 1 https://github.com/netbox-community/netbox.git .
+sudo git clone https://github.com/netbox-community/netbox.git .
 ```
 
-!!! note
-    The `git clone` command above utilizes a "shallow clone" to retrieve only the most recent commit. If you need to download the entire history, omit the `--depth 1` argument.
-
-The `git clone` command should generate output similar to the following:
+This command should generate output similar to the following:
 
 ```
 Cloning into '.'...
@@ -88,8 +85,13 @@ Receiving objects: 100% (996/996), 4.26 MiB | 9.81 MiB/s, done.
 Resolving deltas: 100% (148/148), done.
 ```
 
-!!! note
-    Installation via git also allows you to easily try out different versions of NetBox. To check out a [specific NetBox release](https://github.com/netbox-community/netbox/releases), use the `git checkout` command with the desired release tag. For example, `git checkout v3.0.8`.
+Finally, check out the tag for the desired release. You can find these on our [releases page](https://github.com/netbox-community/netbox/releases). Replace `vX.Y.Z` with your selected release tag below.
+
+```
+sudo git checkout vX.Y.Z
+```
+
+Using this installation method enables easy upgrades in the future by simply checking out the latest release tag.
 
 ## Create the NetBox System User
 

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -25,10 +25,10 @@ NetBox requires the following dependencies:
 
 ## 3. Install the Latest Release
 
-As with the initial installation, you can upgrade NetBox by either downloading the latest release package or by cloning the `master` branch of the git repository. 
+As with the initial installation, you can upgrade NetBox by either downloading the latest release package or by checking out the latest production release from the git repository.
 
 !!! warning
-    Use the same method as you used to install NetBox originally
+    Use the same method as you used to install NetBox originally.
 
 If you are not sure how NetBox was installed originally, check with this command:
 
@@ -36,10 +36,7 @@ If you are not sure how NetBox was installed originally, check with this command
 ls -ld /opt/netbox /opt/netbox/.git
 ```
 
-If NetBox was installed from a release package, then `/opt/netbox` will be a
-symlink pointing to the current version, and `/opt/netbox/.git` will not
-exist.  If it was installed from git, then `/opt/netbox` and
-`/opt/netbox/.git` will both exist as normal directories.
+If NetBox was installed from a release package, then `/opt/netbox` will be a symlink pointing to the current version, and `/opt/netbox/.git` will not exist.  If it was installed from git, then `/opt/netbox` and `/opt/netbox/.git` will both exist as normal directories.
 
 ### Option A: Download a Release
 
@@ -84,20 +81,20 @@ If you followed the original installation guide to set up gunicorn, be sure to c
 sudo cp /opt/netbox-$OLDVER/gunicorn.py /opt/netbox/
 ```
 
-### Option B: Clone the Git Repository
+### Option B: Check Out a Git Release
 
-This guide assumes that NetBox is installed at `/opt/netbox`. Pull down the most recent iteration of the master branch:
+This guide assumes that NetBox is installed at `/opt/netbox`. First, determine the latest release either by visiting our [releases page](https://github.com/netbox-community/netbox/releases) or by running the following `git` commands:
 
-```no-highlight
-cd /opt/netbox
-sudo git checkout master
-sudo git pull origin master
+```
+sudo git fetch --tags
+git describe --tags $(git rev-list --tags --max-count=1)
 ```
 
-!!! info "Checking out an older release"
-    If you need to upgrade to an older version rather than the current stable release, you can check out any valid [git tag](https://github.com/netbox-community/netbox/tags), each of which represents a release. For example, to checkout the code for NetBox v2.11.11, do:
+Check out the desired release by specifying its tag:
 
-        sudo git checkout v2.11.11
+```
+sudo git checkout v4.2.0
+```
 
 ## 4. Run the Upgrade Script
 


### PR DESCRIPTION
This updates the installation and upgrade documentation to reflect the change in branching strategy per #13366. It also updates miscellaneous intra-repo code references.