### PR TITLE
Fix #18314: Use get to avoid KeyError

### DIFF
--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -314,7 +314,7 @@ class RSSFeedWidget(DashboardWidget):
         return f'dashboard_rss_{url_checksum}'
 
     def get_feed(self):
-        if self.config['requires_internet'] and settings.ISOLATED_DEPLOYMENT:
+        if self.config.get('requires_internet') and settings.ISOLATED_DEPLOYMENT:
             return {
                 'isolated_deployment': True,
             }


### PR DESCRIPTION
### Fixes: #18314
