### PR TITLE
### Issue #issue-2772772879 docs/installation add note to check postgres database encoding

### DIFF
--- a/docs/installation/1-postgresql.md
+++ b/docs/installation/1-postgresql.md
@@ -62,6 +62,8 @@ GRANT CREATE ON SCHEMA public TO netbox;
 !!! danger "Use a strong password"
     **Do not use the password from the example.** Choose a strong, random password to ensure secure database authentication for your NetBox installation.
 
+The database encoding should be set to `UTF8`, to check, enter `\l`.
+
 Once complete, enter `\q` to exit the PostgreSQL shell.
 
 ## Verify Service Status


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18319 
<!--
    Please include a summary of the proposed changes below.
-->

Installation fails if database encoding is not set o UTF8, add a line in the docs to remind the installer to check before proceeding with the installation.
