### PR TITLE
Fixes: #18316 - Fix PrefixIndex reference to 'site'

### DIFF
--- a/netbox/ipam/search.py
+++ b/netbox/ipam/search.py
@@ -79,7 +79,7 @@ class PrefixIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
-    display_attrs = ('site', 'vrf', 'tenant', 'vlan', 'status', 'role', 'description')
+    display_attrs = ('scope', 'vrf', 'tenant', 'vlan', 'status', 'role', 'description')
 
 
 @register_search

--- a/netbox/virtualization/search.py
+++ b/netbox/virtualization/search.py
@@ -10,7 +10,7 @@ class ClusterIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
-    display_attrs = ('type', 'group', 'status', 'tenant', 'site', 'description')
+    display_attrs = ('type', 'group', 'status', 'tenant', 'scope', 'description')
 
 
 @register_search

--- a/netbox/wireless/search.py
+++ b/netbox/wireless/search.py
@@ -11,7 +11,7 @@ class WirelessLANIndex(SearchIndex):
         ('auth_psk', 2000),
         ('comments', 5000),
     )
-    display_attrs = ('group', 'status', 'vlan', 'tenant', 'description')
+    display_attrs = ('group', 'status', 'vlan', 'tenant', 'scope', 'description')
 
 
 @register_search


### PR DESCRIPTION
### Fixes: #18316

`PrefixIndex` was incorrectly referring to `site` as an indexable field following the scoping refactor; this should be `scope` now.