### PR TITLE
Fixes #18318: Correct navigation breadcrumbs for module type UI view

### DIFF
--- a/netbox/templates/dcim/inc/devicetype_breadcrumbs.html
+++ b/netbox/templates/dcim/inc/devicetype_breadcrumbs.html
@@ -1,2 +1,0 @@
-
-<li class="breadcrumb-item"><a href="{% url 'dcim:devicetype_list' %}?manufacturer_id={{ object.manufacturer.pk }}">{{ object.manufacturer }}</a></li>

--- a/netbox/templates/dcim/moduletype.html
+++ b/netbox/templates/dcim/moduletype.html
@@ -8,7 +8,9 @@
 
 {% block breadcrumbs %}
   {{ block.super }}
-  {%  include 'dcim/inc/devicetype_breadcrumbs.html' %}
+  <li class="breadcrumb-item">
+    <a href="{% url 'dcim:moduletype_list' %}?manufacturer_id={{ object.manufacturer.pk }}">{{ object.manufacturer }}</a>
+  </li>
 {% endblock %}
 
 {% block extra_controls %}

--- a/netbox/templates/dcim/moduletype/component_templates.html
+++ b/netbox/templates/dcim/moduletype/component_templates.html
@@ -3,13 +3,6 @@
 {% load helpers %}
 {% load i18n %}
 
-{% block title %}{{ object.manufacturer }} {{ object.model }}{% endblock %}
-
-{% block breadcrumbs %}
-  {{ block.super }}
-  {%  include 'dcim/inc/devicetype_breadcrumbs.html' %}
-{% endblock %}
-
 {% block extra_controls %}
   {%  include 'dcim/inc/moduletype_buttons.html' %}
 {% endblock %}


### PR DESCRIPTION
### Fixes: #18318

- Remove the duplicate breadcrumb
- Correct the filtered link for manufacturer