### PR TITLE
Fixes: #18282 - Change PrefixTable.vlan to represent the VLAN ID rather than the rich VLAN object

### DIFF
--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -200,9 +200,9 @@ class PrefixTable(TenancyColumnsMixin, NetBoxTable):
         verbose_name=_('VLAN Group')
     )
     vlan = tables.Column(
-        accessor='vlan__vid',
+        order_by=('vlan__vid', 'vlan__pk'),
         linkify=True,
-        verbose_name=_('VLAN ID')
+        verbose_name=_('VLAN')
     )
     role = tables.Column(
         verbose_name=_('Role'),

--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -200,8 +200,9 @@ class PrefixTable(TenancyColumnsMixin, NetBoxTable):
         verbose_name=_('VLAN Group')
     )
     vlan = tables.Column(
+        accessor='vlan__vid',
         linkify=True,
-        verbose_name=_('VLAN')
+        verbose_name=_('VLAN ID')
     )
     role = tables.Column(
         verbose_name=_('Role'),


### PR DESCRIPTION
### Fixes: #18282

Changes `PrefixTable.vlan` to represent the numeric `vid` field of `VLAN` to enable more meaningful sorting of the Prefixes table, rather than sorting by that column taking into account the many disparate Sites to which the VLAN objects belong.