### PR TITLE
Fixes: #18350 - Remove 'site' and 'provider_network' from CircuitTerminationIndex.display_attrs

### DIFF
--- a/netbox/circuits/search.py
+++ b/netbox/circuits/search.py
@@ -34,7 +34,7 @@ class CircuitTerminationIndex(SearchIndex):
         ('port_speed', 2000),
         ('upstream_speed', 2000),
     )
-    display_attrs = ('circuit', 'site', 'provider_network', 'description')
+    display_attrs = ('circuit', 'description')
 
 
 @register_search

--- a/netbox/circuits/search.py
+++ b/netbox/circuits/search.py
@@ -34,7 +34,7 @@ class CircuitTerminationIndex(SearchIndex):
         ('port_speed', 2000),
         ('upstream_speed', 2000),
     )
-    display_attrs = ('circuit', 'description')
+    display_attrs = ('circuit', '_site', '_provider_network', 'description')
 
 
 @register_search

--- a/netbox/circuits/search.py
+++ b/netbox/circuits/search.py
@@ -34,7 +34,7 @@ class CircuitTerminationIndex(SearchIndex):
         ('port_speed', 2000),
         ('upstream_speed', 2000),
     )
-    display_attrs = ('circuit', '_site', '_provider_network', 'description')
+    display_attrs = ('circuit', 'termination', 'description')
 
 
 @register_search


### PR DESCRIPTION
### Fixes: #18350

As `CircuitTermination` has been refactored to move the fields `site` and `provider_network` to the new scoping model, this change uses the new internal (cached) versions of those fields in the displayed attributes in search results, resolving a crash condition.
