### PR TITLE
Fixes #18368: Restore missing fields on REST API serializer for MAC addresses

### DIFF
--- a/netbox/dcim/api/serializers_/devices.py
+++ b/netbox/dcim/api/serializers_/devices.py
@@ -171,7 +171,7 @@ class MACAddressSerializer(NetBoxModelSerializer):
         model = MACAddress
         fields = [
             'id', 'url', 'display_url', 'display', 'mac_address', 'assigned_object_type', 'assigned_object_id',
-            'assigned_object', 'description', 'comments',
+            'assigned_object', 'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
         brief_fields = ('id', 'url', 'display', 'mac_address', 'description')
 


### PR DESCRIPTION
### Fixes: #18368

- Adds fields missing from MACAddressSerializer:
  - `tags`
  - `custom_fields`
  - `created`
  - `last_updated`
