### PR TITLE
Fixes: #18353 - Don't cache CACHE_KEY_CATALOG_ERROR if ISOLATED_DEPLOYMENT is True

### DIFF
--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -594,7 +594,7 @@ class BasePluginView(UserPassesTestMixin, View):
         catalog_plugins_error = cache.get(self.CACHE_KEY_CATALOG_ERROR, default=False)
         if not catalog_plugins_error:
             catalog_plugins = get_catalog_plugins()
-            if not catalog_plugins:
+            if not catalog_plugins and not settings.ISOLATED_DEPLOYMENT:
                 # Cache for 5 minutes to avoid spamming connection
                 cache.set(self.CACHE_KEY_CATALOG_ERROR, True, 300)
                 messages.warning(request, _("Plugins catalog could not be loaded"))


### PR DESCRIPTION
### Fixes: #18353

Skips caching the result of an errored call to `get_catalog_plugins` if `ISOLATED_DEPLOYMENT == True`. This call to the catalog API already has a short-circuit which returns `{}` and skips making the API call if `ISOLATED_DEPLOYMENT` is True; this change makes it so that the error popup does not appear and the errored result is not cached so that if the setting is turned off, the API call attempt will occur again right away.
