### PR TITLE
Fixes #18376: Include tagged VLANs in interfaces list for Q-in-Q interfaces

### DIFF
--- a/netbox/dcim/tables/template_code.py
+++ b/netbox/dcim/tables/template_code.py
@@ -69,16 +69,18 @@ INTERFACE_FHRPGROUPS = """
 """
 
 INTERFACE_TAGGED_VLANS = """
-{% if record.mode == 'tagged' %}
+{% load i18n %}
+{% if record.mode == 'access' %}
+{% elif record.mode == 'tagged-all' %}
+  {% trans "All" %}
+{% else %}
   {% if value.count > 3 %}
     <a href="{% url 'ipam:vlan_list' %}?{{ record|meta:"model_name" }}_id={{ record.pk }}">{{ value.count }} VLANs</a>
   {% else %}
     {% for vlan in value.all %}
-        <a href="{{ vlan.get_absolute_url }}">{{ vlan }}</a><br />
+      <a href="{{ vlan.get_absolute_url }}">{{ vlan }}</a><br />
     {% endfor %}
   {% endif %}
-{% elif record.mode == 'tagged-all' %}
-  All
 {% endif %}
 """
 


### PR DESCRIPTION
### Fixes: #18376

Fix the table column template code to support the `q-in-q` interface mode.