### PR TITLE
Fixes: #18369 - Remove the json filter for protection rules

### DIFF
--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -570,8 +570,9 @@ class SystemView(UserPassesTestMixin, View):
             return response
 
         # Serialize any CustomValidator classes
-        if hasattr(config, 'CUSTOM_VALIDATORS') and config.CUSTOM_VALIDATORS:
-            config.CUSTOM_VALIDATORS = json.dumps(config.CUSTOM_VALIDATORS, cls=ConfigJSONEncoder, indent=4)
+        for attr in ['CUSTOM_VALIDATORS', 'PROTECTION_RULES']:
+            if hasattr(config, attr) and getattr(config, attr):
+                setattr(config, attr, json.dumps(getattr(config, attr), cls=ConfigJSONEncoder, indent=4))
 
         return render(request, 'core/system.html', {
             'stats': stats,

--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -571,7 +571,7 @@ class SystemView(UserPassesTestMixin, View):
 
         # Serialize any CustomValidator classes
         for attr in ['CUSTOM_VALIDATORS', 'PROTECTION_RULES']:
-            if hasattr(config, attr) and getattr(config, attr):
+            if hasattr(config, attr) and getattr(config, attr, None):
                 setattr(config, attr, json.dumps(getattr(config, attr), cls=ConfigJSONEncoder, indent=4))
 
         return render(request, 'core/system.html', {

--- a/netbox/templates/core/inc/config_data.html
+++ b/netbox/templates/core/inc/config_data.html
@@ -103,7 +103,7 @@
   <tr>
     <th scope="row" class="border-0 ps-3">{% trans "Protection rules" %}</th>
     {% if config.PROTECTION_RULES %}
-      <td class="border-0"><pre>{{ config.PROTECTION_RULES|json }}</pre></td>
+      <td class="border-0"><pre>{{ config.PROTECTION_RULES }}</pre></td>
     {% else %}
       <td class="border-0">{{ ''|placeholder }}</td>
     {% endif %}


### PR DESCRIPTION
Fixes: #18369

Removing the json filter resolves the TypeError exception and aligns the protection rules template with the custom validators template.