### PR TITLE
Fixes: #18336 - Perform Rack object validation of u_height and starting_unit on rack_type if present

### DIFF
--- a/netbox/dcim/models/racks.py
+++ b/netbox/dcim/models/racks.py
@@ -377,19 +377,23 @@ class Rack(ContactsMixin, ImageAttachmentsMixin, RackBase):
             # Validate that Rack is tall enough to house the highest mounted Device
             if top_device := mounted_devices.last():
                 min_height = top_device.position + top_device.device_type.u_height - self.starting_unit
-                if self.u_height < min_height:
+                effective_u_height = self.rack_type.u_height if self.rack_type else self.u_height
+                if effective_u_height < min_height:
+                    field = 'rack_type' if self.rack_type else 'u_height'
                     raise ValidationError({
-                        'u_height': _(
+                        field: _(
                             "Rack must be at least {min_height}U tall to house currently installed devices."
                         ).format(min_height=min_height)
                     })
 
             # Validate that the Rack's starting unit is less than or equal to the position of the lowest mounted Device
             if last_device := mounted_devices.first():
-                if self.starting_unit > last_device.position:
+                effective_starting_unit = self.rack_type.starting_unit if self.rack_type else self.starting_unit
+                if effective_starting_unit > last_device.position:
+                    field = 'rack_type' if self.rack_type else 'starting_unit'
                     raise ValidationError({
-                        'starting_unit': _("Rack unit numbering must begin at {position} or less to house "
-                                           "currently installed devices.").format(position=last_device.position)
+                        field: _("Rack unit numbering must begin at {position} or less to house "
+                                 "currently installed devices.").format(position=last_device.position)
                     })
 
             # Validate that Rack was assigned a Location of its same site, if applicable

--- a/netbox/dcim/models/racks.py
+++ b/netbox/dcim/models/racks.py
@@ -374,10 +374,12 @@ class Rack(ContactsMixin, ImageAttachmentsMixin, RackBase):
         if not self._state.adding:
             mounted_devices = Device.objects.filter(rack=self).exclude(position__isnull=True).order_by('position')
 
+            effective_u_height = self.rack_type.u_height if self.rack_type else self.u_height
+            effective_starting_unit = self.rack_type.starting_unit if self.rack_type else self.starting_unit
+
             # Validate that Rack is tall enough to house the highest mounted Device
             if top_device := mounted_devices.last():
-                min_height = top_device.position + top_device.device_type.u_height - self.starting_unit
-                effective_u_height = self.rack_type.u_height if self.rack_type else self.u_height
+                min_height = top_device.position + top_device.device_type.u_height - effective_starting_unit
                 if effective_u_height < min_height:
                     field = 'rack_type' if self.rack_type else 'u_height'
                     raise ValidationError({
@@ -388,7 +390,6 @@ class Rack(ContactsMixin, ImageAttachmentsMixin, RackBase):
 
             # Validate that the Rack's starting unit is less than or equal to the position of the lowest mounted Device
             if last_device := mounted_devices.first():
-                effective_starting_unit = self.rack_type.starting_unit if self.rack_type else self.starting_unit
                 if effective_starting_unit > last_device.position:
                     field = 'rack_type' if self.rack_type else 'starting_unit'
                     raise ValidationError({


### PR DESCRIPTION
### Fixes: #18336

Current model validation in `Rack.clean()` examines the `u_height` and `starting_unit` fields but only considers the fields on the Rack itself, not on the RackType if assigned, in which those fields' values override those on the Rack. This can lead to a situation where a Rack with assigned devices above a certain elevation can be assigned to a RackType incompatible with those elevations, because the validation misses the effective `u_height` and `starting_unit` of the requested RackType. Subsequent errors occur in SVG rendering and `RackForm` validation.

This situation is prevented with this change, which ensures that these two fields are validated with consideration of both Rack and RackType values, and assigns the resulting `ValidationError` to the appropriate form field depending on whether a RackType has been selected or not.