### PR TITLE
Fixes: #18400 - Migrate DEFAULT_FILE_STORAGE to STORAGES

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -222,8 +222,18 @@ DATABASES = {
 # Storage backend
 #
 
+# Default STORAGES for Django
+STORAGES = {
+    "default": {
+        "BACKEND": "django.core.files.storage.FileSystemStorage",
+    },
+    "staticfiles": {
+        "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
+    },
+}
+
 if STORAGE_BACKEND is not None:
-    DEFAULT_FILE_STORAGE = STORAGE_BACKEND
+    STORAGES['default']['BACKEND'] = STORAGE_BACKEND
 
     # django-storages
     if STORAGE_BACKEND.startswith('storages.'):


### PR DESCRIPTION
### Fixes: #18400

Because `DEFAULT_FILE_STORAGE` has been deprecated in Django for a long time and is now no longer supported, the existing behavior of `settings.py` to set a custom `STORAGE_BACKEND` to that setting now no longer works. This change instead explicitly redeclares the default `STORAGES` and then overrides the default backend value with `STORAGE_BACKEND`.
