### PR TITLE
Fixes: #18406 - Make GFK scope field sortable=False on tables where it appears

### DIFF
--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -192,7 +192,8 @@ class PrefixTable(TenancyColumnsMixin, NetBoxTable):
     )
     scope = tables.Column(
         verbose_name=_('Scope'),
-        linkify=True
+        linkify=True,
+        orderable=False
     )
     vlan_group = tables.Column(
         accessor='vlan__group',

--- a/netbox/virtualization/tables/clusters.py
+++ b/netbox/virtualization/tables/clusters.py
@@ -78,7 +78,8 @@ class ClusterTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
     )
     scope = tables.Column(
         verbose_name=_('Scope'),
-        linkify=True
+        linkify=True,
+        orderable=False
     )
     device_count = columns.LinkedCountColumn(
         viewname='dcim:device_list',

--- a/netbox/wireless/tables/wirelesslan.py
+++ b/netbox/wireless/tables/wirelesslan.py
@@ -56,7 +56,8 @@ class WirelessLANTable(TenancyColumnsMixin, NetBoxTable):
     )
     scope = tables.Column(
         verbose_name=_('Scope'),
-        linkify=True
+        linkify=True,
+        orderable=False
     )
     interface_count = tables.Column(
         verbose_name=_('Interfaces')


### PR DESCRIPTION
### Fixes: #18406

There is a `scope` field on several tables that causes a crash when it is selected for sorting:

`django.core.exceptions.FieldError: Field 'scope' does not generate an automatic reverse relation and therefore cannot be used for reverse querying. If it is a GenericForeignKey, consider adding a GenericRelation.`

This change disables ordering on those fields, which is consistent with the existing behavior of the `scope` field on `VLANGroupTable`. It would be more ideal to find a way to sort on this column in all such tables, but since we have precedent for just disabling it this will at least prevent crashes.
