### PR TITLE
Fixes #18379: Ensure RSS feed content within dashboard widget is sanitized

### DIFF
--- a/netbox/templates/extras/dashboard/widgets/rssfeed.html
+++ b/netbox/templates/extras/dashboard/widgets/rssfeed.html
@@ -5,7 +5,7 @@
       <div class="list-group-item px-1 py-2">
         <a href="{{ entry.link }}" class="text-body">{{ entry.title }}</a>
         <div class="text-secondary">
-          {{ entry.summary|safe }}
+          {{ entry.summary }}
         </div>
       </div>
     {% empty %}


### PR DESCRIPTION
### Fixes: #18379

Remove the `safe` filter from RSS feed content. This will likely break some corner cases where special character rendering fails.