### PR TITLE
Closes #18425: Remove the triage priority field from GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/01-feature_request.yaml
@@ -27,19 +27,6 @@ body:
         - Other
     validations:
       required: true
-  - type: dropdown
-    attributes:
-      label: Triage priority
-      description: >
-        Issue triage may be prioritized in some cases. Select whichever of the following
-        conditions applies, if any.
-      options:
-        - I volunteer to perform this work (if approved)
-        - I'm a NetBox Labs customer
-        - N/A
-      default: 2
-    validations:
-      required: true
   - type: textarea
     attributes:
       label: Proposed functionality

--- a/.github/ISSUE_TEMPLATE/02-bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/02-bug_report.yaml
@@ -22,19 +22,6 @@ body:
         - Self-hosted
     validations:
       required: true
-  - type: dropdown
-    attributes:
-      label: Triage priority
-      description: >
-        Issue triage may be prioritized in some cases. Select whichever of the following
-        conditions applies, if any.
-      options:
-        - I volunteer to perform this work (if approved)
-        - I'm a NetBox Labs customer
-        - N/A
-      default: 2
-    validations:
-      required: true
   - type: input
     attributes:
       label: NetBox Version


### PR DESCRIPTION
### Fixes: #18425

Remove the "triage priority" field from the GitHub issue templates for bug reports and feature requests.