### PR TITLE
Fixes #17797 - Update MACAddressSerializer to use MACAddressField

### DIFF
--- a/netbox/dcim/api/serializers_/devices.py
+++ b/netbox/dcim/api/serializers_/devices.py
@@ -7,6 +7,7 @@ from rest_framework import serializers
 
 from dcim.choices import *
 from dcim.constants import MACADDRESS_ASSIGNMENT_MODELS
+from dcim.fields import MACAddressField
 from dcim.models import Device, DeviceBay, MACAddress, Module, VirtualDeviceContext
 from extras.api.serializers_.configtemplates import ConfigTemplateSerializer
 from ipam.api.serializers_.ip import IPAddressSerializer
@@ -160,6 +161,7 @@ class ModuleSerializer(NetBoxModelSerializer):
 
 
 class MACAddressSerializer(NetBoxModelSerializer):
+    mac_address = MACAddressField()
     assigned_object_type = ContentTypeField(
         queryset=ContentType.objects.filter(MACADDRESS_ASSIGNMENT_MODELS),
         required=False,


### PR DESCRIPTION
### Fixes: #17797

Configured the `mac_address` field in the `MACAddressSerializer` to use the `MACAddressField` class.

The normalization of the `mac_address` value is configured at: https://github.com/netbox-community/netbox/blob/f845b2cf07cd65a109c46632a2540d3647c1c492/netbox/dcim/fields.py#L43 The current configuration is to use a custom uppercase format.
