### PR TITLE
Fixes: #18436 - Prevent unassigning mac address when primary on an interface

### DIFF
--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -1810,6 +1810,11 @@ class MACAddressForm(NetBoxModelForm):
 
         super().__init__(*args, **kwargs)
 
+        if instance and instance.assigned_object and instance.assigned_object.primary_mac_address:
+            if instance.assigned_object.primary_mac_address.pk == instance.pk:
+                self.fields['interface'].disabled = True
+                self.fields['vminterface'].disabled = True
+
     def clean(self):
         super().clean()
 

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -1534,15 +1534,16 @@ class MACAddress(PrimaryModel):
     def clean(self, *args, **kwargs):
         super().clean()
         if self._original_assigned_object_id and self._original_assigned_object_type_id:
-            assigned_object = getattr(self.assigned_object, 'parent_object', None)
+            assigned_object = self.assigned_object
             ct = ObjectType.objects.get_for_id(self._original_assigned_object_type_id)
             original_assigned_object = ct.get_object_for_this_type(pk=self._original_assigned_object_id)
 
-            if original_assigned_object and not assigned_object:
-                raise ValidationError(
-                    _("Cannot unassign MAC Address while it is designated as the primary MAC for an object")
-                )
-            elif original_assigned_object and original_assigned_object != assigned_object:
-                raise ValidationError(
-                    _("Cannot reassign MAC Address while it is designated as the primary MAC for an object")
-                )
+            if original_assigned_object.primary_mac_address:
+                if not assigned_object:
+                    raise ValidationError(
+                        _("Cannot unassign MAC Address while it is designated as the primary MAC for an object")
+                    )
+                elif original_assigned_object != assigned_object:
+                    raise ValidationError(
+                        _("Cannot reassign MAC Address while it is designated as the primary MAC for an object")
+                    )


### PR DESCRIPTION
### Fixes: #18436 - Prevent unassigning mac address when primary on an interface

* Prevent unassigning mac address when set as primary on an interface
* Prevent reassigning mac address when set as primary on an interface
* Update UI to prevent editing when `MACAddress` is set as primary