### PR TITLE
Fixes: #18447 - Fix sorting by `mac_address` field

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -697,6 +697,10 @@ class DeviceInterfaceTable(InterfaceTable):
         linkify=True,
         verbose_name=_('LAG')
     )
+    mac_address = tables.Column(
+        verbose_name=_('MAC Address'),
+        orderable=False,
+    )
     actions = columns.ActionsColumn(
         extra_buttons=INTERFACE_BUTTONS
     )
@@ -705,10 +709,10 @@ class DeviceInterfaceTable(InterfaceTable):
         model = models.Interface
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'enabled', 'type', 'parent', 'bridge', 'lag',
-            'mgmt_only', 'mtu', 'mode', 'mac_address', 'wwn', 'rf_role', 'rf_channel', 'rf_channel_frequency',
-            'rf_channel_width', 'tx_power', 'description', 'mark_connected', 'cable', 'cable_color', 'wireless_link',
-            'wireless_lans', 'link_peer', 'connection', 'tags', 'vdcs', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses',
-            'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'actions',
+            'mgmt_only', 'mtu', 'mode', 'mac_address', 'primary_mac_address', 'wwn', 'rf_role', 'rf_channel',
+            'rf_channel_frequency', 'rf_channel_width', 'tx_power', 'description', 'mark_connected', 'cable',
+            'cable_color', 'wireless_link', 'wireless_lans', 'link_peer', 'connection', 'tags', 'vdcs', 'vrf', 'l2vpn',
+            'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'actions',
         )
         default_columns = (
             'pk', 'name', 'label', 'enabled', 'type', 'parent', 'lag', 'mtu', 'mode', 'description', 'ip_addresses',

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -697,10 +697,6 @@ class DeviceInterfaceTable(InterfaceTable):
         linkify=True,
         verbose_name=_('LAG')
     )
-    mac_address = tables.Column(
-        verbose_name=_('MAC Address'),
-        orderable=False,
-    )
     actions = columns.ActionsColumn(
         extra_buttons=INTERFACE_BUTTONS
     )
@@ -709,10 +705,10 @@ class DeviceInterfaceTable(InterfaceTable):
         model = models.Interface
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'enabled', 'type', 'parent', 'bridge', 'lag',
-            'mgmt_only', 'mtu', 'mode', 'mac_address', 'primary_mac_address', 'wwn', 'rf_role', 'rf_channel',
-            'rf_channel_frequency', 'rf_channel_width', 'tx_power', 'description', 'mark_connected', 'cable',
-            'cable_color', 'wireless_link', 'wireless_lans', 'link_peer', 'connection', 'tags', 'vdcs', 'vrf', 'l2vpn',
-            'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'actions',
+            'mgmt_only', 'mtu', 'mode', 'primary_mac_address', 'wwn', 'rf_role', 'rf_channel', 'rf_channel_frequency',
+            'rf_channel_width', 'tx_power', 'description', 'mark_connected', 'cable', 'cable_color', 'wireless_link',
+            'wireless_lans', 'link_peer', 'connection', 'tags', 'vdcs', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses',
+            'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'actions',
         )
         default_columns = (
             'pk', 'name', 'label', 'enabled', 'type', 'parent', 'lag', 'mtu', 'mode', 'description', 'ip_addresses',

--- a/netbox/virtualization/tables/virtualmachines.py
+++ b/netbox/virtualization/tables/virtualmachines.py
@@ -113,6 +113,10 @@ class VMInterfaceTable(BaseInterfaceTable):
         verbose_name=_('VRF'),
         linkify=True
     )
+    mac_address = tables.Column(
+        verbose_name=_('MAC Address'),
+        orderable=False,
+    )
     tags = columns.TagColumn(
         url_name='virtualization:vminterface_list'
     )
@@ -120,8 +124,8 @@ class VMInterfaceTable(BaseInterfaceTable):
     class Meta(NetBoxTable.Meta):
         model = VMInterface
         fields = (
-            'pk', 'id', 'name', 'virtual_machine', 'enabled', 'mac_address', 'mtu', 'mode', 'description', 'tags',
-            'vrf', 'primary_mac_address', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan',
+            'pk', 'id', 'name', 'virtual_machine', 'enabled', 'mtu', 'mode', 'description', 'tags', 'vrf',
+            'mac_address', 'primary_mac_address', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan',
             'tagged_vlans', 'qinq_svlan', 'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'virtual_machine', 'enabled', 'description')

--- a/netbox/virtualization/tables/virtualmachines.py
+++ b/netbox/virtualization/tables/virtualmachines.py
@@ -148,11 +148,11 @@ class VirtualMachineVMInterfaceTable(VMInterfaceTable):
     class Meta(NetBoxTable.Meta):
         model = VMInterface
         fields = (
-            'pk', 'id', 'name', 'enabled', 'parent', 'bridge', 'mac_address', 'mtu', 'mode', 'description', 'tags',
-            'vrf', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'qinq_svlan',
-            'actions',
+            'pk', 'id', 'name', 'enabled', 'parent', 'bridge', 'mac_address', 'primary_mac_address', 'mtu', 'mode',
+            'description', 'tags', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan',
+            'tagged_vlans', 'qinq_svlan', 'actions',
         )
-        default_columns = ('pk', 'name', 'enabled', 'mac_address', 'mtu', 'mode', 'description', 'ip_addresses')
+        default_columns = ('pk', 'name', 'enabled', 'primary_mac_address', 'mtu', 'mode', 'description', 'ip_addresses')
         row_attrs = {
             'data-name': lambda record: record.name,
             'data-virtual': lambda record: "true",

--- a/netbox/virtualization/tables/virtualmachines.py
+++ b/netbox/virtualization/tables/virtualmachines.py
@@ -113,10 +113,6 @@ class VMInterfaceTable(BaseInterfaceTable):
         verbose_name=_('VRF'),
         linkify=True
     )
-    mac_address = tables.Column(
-        verbose_name=_('MAC Address'),
-        orderable=False,
-    )
     tags = columns.TagColumn(
         url_name='virtualization:vminterface_list'
     )
@@ -125,8 +121,8 @@ class VMInterfaceTable(BaseInterfaceTable):
         model = VMInterface
         fields = (
             'pk', 'id', 'name', 'virtual_machine', 'enabled', 'mtu', 'mode', 'description', 'tags', 'vrf',
-            'mac_address', 'primary_mac_address', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan',
-            'tagged_vlans', 'qinq_svlan', 'created', 'last_updated',
+            'primary_mac_address', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans',
+            'qinq_svlan', 'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'virtual_machine', 'enabled', 'description')
 
@@ -148,9 +144,9 @@ class VirtualMachineVMInterfaceTable(VMInterfaceTable):
     class Meta(NetBoxTable.Meta):
         model = VMInterface
         fields = (
-            'pk', 'id', 'name', 'enabled', 'parent', 'bridge', 'mac_address', 'primary_mac_address', 'mtu', 'mode',
-            'description', 'tags', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan',
-            'tagged_vlans', 'qinq_svlan', 'actions',
+            'pk', 'id', 'name', 'enabled', 'parent', 'bridge', 'primary_mac_address', 'mtu', 'mode', 'description',
+            'tags', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans',
+            'qinq_svlan', 'actions',
         )
         default_columns = ('pk', 'name', 'enabled', 'primary_mac_address', 'mtu', 'mode', 'description', 'ip_addresses')
         row_attrs = {


### PR DESCRIPTION
### Fixes: #18447 - Fix sorting by `mac_address` field

* Disable sorting by `mac_address` for legacy `mac_address` field for Device and VM Interfaces
* Ensure `primary_mac_address` field is included in field list for Device and VM Interfaces