### PR TITLE
Closes: #18416 - Add warning about UTF8 encoding in PostgreSQL

### DIFF
--- a/docs/installation/1-postgresql.md
+++ b/docs/installation/1-postgresql.md
@@ -62,6 +62,9 @@ GRANT CREATE ON SCHEMA public TO netbox;
 !!! danger "Use a strong password"
     **Do not use the password from the example.** Choose a strong, random password to ensure secure database authentication for your NetBox installation.
 
+!!! danger "Use UTF8 encoding"
+    Make sure that your database uses `UTF8` encoding (the default for new installations). Especially do not use `SQL_ASCII` encoding, as it can lead to unpredictable and unrecoverable errors.
+
 Once complete, enter `\q` to exit the PostgreSQL shell.
 
 ## Verify Service Status

--- a/docs/installation/1-postgresql.md
+++ b/docs/installation/1-postgresql.md
@@ -63,7 +63,7 @@ GRANT CREATE ON SCHEMA public TO netbox;
     **Do not use the password from the example.** Choose a strong, random password to ensure secure database authentication for your NetBox installation.
 
 !!! danger "Use UTF8 encoding"
-    Make sure that your database uses `UTF8` encoding (the default for new installations). Especially do not use `SQL_ASCII` encoding, as it can lead to unpredictable and unrecoverable errors.
+    Make sure that your database uses `UTF8` encoding (the default for new installations). Especially do not use `SQL_ASCII` encoding, as it can lead to unpredictable and unrecoverable errors. Enter `\l` to check your encoding.
 
 Once complete, enter `\q` to exit the PostgreSQL shell.
 


### PR DESCRIPTION
### Fixes: #18416

Adds a warning to the documentation's Database Creation section to use `UTF8` encoding and not `SQL_ASCII`.