### PR TITLE
Fixes: #18474 - Fix typo in Site Groups docs

### DIFF
--- a/docs/features/facilities.md
+++ b/docs/features/facilities.md
@@ -46,7 +46,7 @@ Regions will always be listed alphabetically by name within each parent, and the
 
 Like regions, site groups can be arranged in a recursive hierarchy for grouping sites. However, whereas regions are intended for geographic organization, site groups may be used for functional grouping. For example, you might classify sites as corporate, branch, or customer sites in addition to where they are physically located.
 
-The use of both regions and site groups affords to independent but complementary dimensions across which sites can be organized.
+The use of both regions and site groups affords two independent but complementary dimensions across which sites can be organized.
 
 ## Sites
 


### PR DESCRIPTION
### Fixes: #18474

"to" -> "two"