### PR TITLE
Assign GitHub issue type on creation

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/01-feature_request.yaml
@@ -1,5 +1,6 @@
 ---
 name: ✨ Feature Request
+type: Feature
 description: Propose a new NetBox feature or enhancement
 labels: ["type: feature", "status: needs triage"]
 body:

--- a/.github/ISSUE_TEMPLATE/02-bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/02-bug_report.yaml
@@ -1,5 +1,6 @@
 ---
 name: 🐛 Bug Report
+type: Bug
 description: Report a reproducible bug in the current release of NetBox
 labels: ["type: bug", "status: needs triage"]
 body:


### PR DESCRIPTION
Seeing if we can assign [GitHub issue types](https://docs.github.com/en/issues/tracking-your-work-with-issues/configuring-issues/managing-issue-types-in-an-organization) automatically from the issue forms.