### PR TITLE
Fixes: #18241 - Script results log_threshold should default to Default 

### DIFF
--- a/netbox/extras/choices.py
+++ b/netbox/extras/choices.py
@@ -166,7 +166,7 @@ class LogLevelChoices(ChoiceSet):
         (LOG_SUCCESS, _('Success'), 'green'),
         (LOG_WARNING, _('Warning'), 'yellow'),
         (LOG_FAILURE, _('Failure'), 'red'),
-        
+
     )
 
     SYSTEM_LEVELS = {

--- a/netbox/extras/choices.py
+++ b/netbox/extras/choices.py
@@ -162,12 +162,12 @@ class LogLevelChoices(ChoiceSet):
     LOG_FAILURE = 'failure'
 
     CHOICES = (
-        (LOG_DEBUG, _('Debug'), 'teal'),
         (LOG_DEFAULT, _('Default'), 'gray'),
         (LOG_INFO, _('Info'), 'cyan'),
         (LOG_SUCCESS, _('Success'), 'green'),
         (LOG_WARNING, _('Warning'), 'yellow'),
         (LOG_FAILURE, _('Failure'), 'red'),
+        (LOG_DEBUG, _('Debug'), 'teal'),
     )
 
     SYSTEM_LEVELS = {

--- a/netbox/extras/choices.py
+++ b/netbox/extras/choices.py
@@ -155,24 +155,22 @@ class JournalEntryKindChoices(ChoiceSet):
 class LogLevelChoices(ChoiceSet):
 
     LOG_DEBUG = 'debug'
-    LOG_DEFAULT = 'default'
     LOG_INFO = 'info'
     LOG_SUCCESS = 'success'
     LOG_WARNING = 'warning'
     LOG_FAILURE = 'failure'
 
     CHOICES = (
-        (LOG_DEFAULT, _('Default'), 'gray'),
+        (LOG_DEBUG, _('Debug'), 'teal'),
         (LOG_INFO, _('Info'), 'cyan'),
         (LOG_SUCCESS, _('Success'), 'green'),
         (LOG_WARNING, _('Warning'), 'yellow'),
         (LOG_FAILURE, _('Failure'), 'red'),
-        (LOG_DEBUG, _('Debug'), 'teal'),
+        
     )
 
     SYSTEM_LEVELS = {
         LOG_DEBUG: logging.DEBUG,
-        LOG_DEFAULT: logging.INFO,
         LOG_INFO: logging.INFO,
         LOG_SUCCESS: logging.INFO,
         LOG_WARNING: logging.WARNING,

--- a/netbox/extras/constants.py
+++ b/netbox/extras/constants.py
@@ -138,9 +138,8 @@ DEFAULT_DASHBOARD = [
 
 LOG_LEVEL_RANK = {
     LogLevelChoices.LOG_DEBUG: 0,
-    LogLevelChoices.LOG_DEFAULT: 1,
-    LogLevelChoices.LOG_INFO: 2,
-    LogLevelChoices.LOG_SUCCESS: 3,
-    LogLevelChoices.LOG_WARNING: 4,
-    LogLevelChoices.LOG_FAILURE: 5,
+    LogLevelChoices.LOG_INFO: 1,
+    LogLevelChoices.LOG_SUCCESS: 2,
+    LogLevelChoices.LOG_WARNING: 3,
+    LogLevelChoices.LOG_FAILURE: 4,
 }

--- a/netbox/extras/reports.py
+++ b/netbox/extras/reports.py
@@ -15,7 +15,7 @@ class Report(BaseScript):
 
     # There is no generic log() equivalent on BaseScript
     def log(self, message):
-        self._log(message, None, level=LogLevelChoices.LOG_DEFAULT)
+        self._log(message, None, level=LogLevelChoices.LOG_INFO)
 
     def log_success(self, obj=None, message=None):
         super().log_success(message, obj)

--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -460,7 +460,7 @@ class BaseScript:
     # Logging
     #
 
-    def _log(self, message, obj=None, level=LogLevelChoices.LOG_DEFAULT):
+    def _log(self, message, obj=None, level=LogLevelChoices.LOG_INFO):
         """
         Log a message. Do not call this method directly; use one of the log_* wrappers below.
         """

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1374,9 +1374,9 @@ class ScriptResultView(TableMixin, generic.ObjectView):
         if job.completed:
             table = self.get_table(job, request, bulk_actions=False)
 
-        log_threshold = request.GET.get('log_threshold', LogLevelChoices.LOG_DEBUG)
+        log_threshold = request.GET.get('log_threshold', LogLevelChoices.LOG_DEFAULT)
         if log_threshold not in LOG_LEVEL_RANK:
-            log_threshold = LogLevelChoices.LOG_DEBUG
+            log_threshold = LogLevelChoices.LOG_DEFAULT
 
         context = {
             'script': job.object,

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1315,9 +1315,9 @@ class ScriptResultView(TableMixin, generic.ObjectView):
         index = 0
 
         try:
-            log_threshold = LOG_LEVEL_RANK[request.GET.get('log_threshold', LogLevelChoices.LOG_DEFAULT)]
+            log_threshold = LOG_LEVEL_RANK[request.GET.get('log_threshold', LogLevelChoices.LOG_INFO)]
         except KeyError:
-            log_threshold = LOG_LEVEL_RANK[LogLevelChoices.LOG_DEFAULT]
+            log_threshold = LOG_LEVEL_RANK[LogLevelChoices.LOG_INFO]
         if job.data:
 
             if 'log' in job.data:
@@ -1325,7 +1325,7 @@ class ScriptResultView(TableMixin, generic.ObjectView):
                     tests = job.data['tests']
 
                 for log in job.data['log']:
-                    log_level = LOG_LEVEL_RANK.get(log.get('status'), LogLevelChoices.LOG_DEFAULT)
+                    log_level = LOG_LEVEL_RANK.get(log.get('status'), LogLevelChoices.LOG_INFO)
                     if log_level >= log_threshold:
                         index += 1
                         result = {
@@ -1348,7 +1348,7 @@ class ScriptResultView(TableMixin, generic.ObjectView):
             for method, test_data in tests.items():
                 if 'log' in test_data:
                     for time, status, obj, url, message in test_data['log']:
-                        log_level = LOG_LEVEL_RANK.get(status, LogLevelChoices.LOG_DEFAULT)
+                        log_level = LOG_LEVEL_RANK.get(status, LogLevelChoices.LOG_INFO)
                         if log_level >= log_threshold:
                             index += 1
                             result = {
@@ -1374,9 +1374,9 @@ class ScriptResultView(TableMixin, generic.ObjectView):
         if job.completed:
             table = self.get_table(job, request, bulk_actions=False)
 
-        log_threshold = request.GET.get('log_threshold', LogLevelChoices.LOG_DEFAULT)
+        log_threshold = request.GET.get('log_threshold', LogLevelChoices.LOG_INFO)
         if log_threshold not in LOG_LEVEL_RANK:
-            log_threshold = LogLevelChoices.LOG_DEFAULT
+            log_threshold = LogLevelChoices.LOG_INFO
 
         context = {
             'script': job.object,

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1315,9 +1315,9 @@ class ScriptResultView(TableMixin, generic.ObjectView):
         index = 0
 
         try:
-            log_threshold = LOG_LEVEL_RANK[request.GET.get('log_threshold', LogLevelChoices.LOG_DEBUG)]
+            log_threshold = LOG_LEVEL_RANK[request.GET.get('log_threshold', LogLevelChoices.LOG_DEFAULT)]
         except KeyError:
-            log_threshold = LOG_LEVEL_RANK[LogLevelChoices.LOG_DEBUG]
+            log_threshold = LOG_LEVEL_RANK[LogLevelChoices.LOG_DEFAULT]
         if job.data:
 
             if 'log' in job.data:

--- a/netbox/templates/extras/script_result.html
+++ b/netbox/templates/extras/script_result.html
@@ -53,7 +53,7 @@
             <div class="dropdown-menu">
               {% for level, name in log_levels.items %}
                 <a class="dropdown-item d-flex justify-content-between" href="{% url 'extras:script_result' job_pk=job.pk %}?log_threshold={{ level }}">
-                  {{ name }}{% if forloop.first %} ({% trans "All" %}){% endif %}
+                  {{ name }}{% if forloop.last %} ({% trans "All" %}){% endif %}
                   {% if level == log_threshold %}<span class="badge bg-green ms-auto"></span>{% endif %}
                 </a>
               {% endfor %}

--- a/netbox/templates/extras/script_result.html
+++ b/netbox/templates/extras/script_result.html
@@ -53,7 +53,7 @@
             <div class="dropdown-menu">
               {% for level, name in log_levels.items %}
                 <a class="dropdown-item d-flex justify-content-between" href="{% url 'extras:script_result' job_pk=job.pk %}?log_threshold={{ level }}">
-                  {{ name }}{% if forloop.last %} ({% trans "All" %}){% endif %}
+                  {{ name }}{% if forloop.counter == 1 %} ({% trans "All" %}){% elif forloop.counter == 2 %} ({% trans "Default" %}){% endif %}
                   {% if level == log_threshold %}<span class="badge bg-green ms-auto"></span>{% endif %}
                 </a>
               {% endfor %}


### PR DESCRIPTION
### Fixes: #18241 - Script results log_threshold should default to Default 
 
*  Changes the LogLevelChoices `Choices` order, putting `LOG_DEBUG` in the last position.
* Changes `script_result.html` dropdown to add the string `(All)` only to the last possition following the new `LogLevelChoices` order
* Changes `ScriptResultView` get method to return `log_threshold` with `LOG_DEFAULT` instead of `LOG_DEBUG`