### PR TITLE
Fix #18515: Don't fail in DEBUG mode

### DIFF
--- a/netbox/core/apps.py
+++ b/netbox/core/apps.py
@@ -28,4 +28,7 @@ class CoreConfig(AppConfig):
 
         # Clear Redis cache on startup in development mode
         if settings.DEBUG:
-            cache.clear()
+            try:
+                cache.clear()
+            except Exception:
+                pass


### PR DESCRIPTION
### Fixes: #18515

When no Redis server is reachable management commands failed without this try...except block.