### PR TITLE
Closes: #18529 - Add auth_required attrib on PluginMenuItem

### DIFF
--- a/netbox/netbox/plugins/navigation.py
+++ b/netbox/netbox/plugins/navigation.py
@@ -38,9 +38,10 @@ class PluginMenuItem:
     permissions = []
     buttons = []
 
-    def __init__(self, link, link_text, staff_only=False, permissions=None, buttons=None):
+    def __init__(self, link, link_text, auth_required=False, staff_only=False, permissions=None, buttons=None):
         self.link = link
         self.link_text = link_text
+        self.auth_required = auth_required
         self.staff_only = staff_only
         if permissions is not None:
             if type(permissions) not in (list, tuple):


### PR DESCRIPTION
### Closes: #18529

This supports the ability of menu items associated with plugins to not be displayed if the user is not authenticated and `LOGIN_REQUIRED` is `False`.

This is not a breaking change for NetBox itself, hence targeting for 4.2.3. However note that plugins that use the `auth_required` attribute on their menu items will require NetBox 4.2.3.
