### PR TITLE
Fixes: #18497 - Remove 'provider' from VirtualCircuitIndex.display_attrs

### DIFF
--- a/netbox/circuits/search.py
+++ b/netbox/circuits/search.py
@@ -90,7 +90,7 @@ class VirtualCircuitIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
-    display_attrs = ('provider', 'provider_network', 'provider_account', 'status', 'tenant', 'description')
+    display_attrs = ('provider_network', 'provider_account', 'status', 'tenant', 'description')
 
 
 @register_search


### PR DESCRIPTION
### Fixes: #18497

Removes `'provider'` from the `display_attrs` of `VirtualCircuitIndex`, as that field does not exist.