### PR TITLE
Fix #18181 - Create & Add another IP address on interfaces is not working correctly

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -863,6 +863,12 @@ class IPAddressEditView(generic.ObjectEditView):
 
         return obj
 
+    def get_extra_addanother_params(self, request):
+        if 'interface' in request.GET:
+            return {'interface': request.GET['interface']}
+        elif 'vminterface' in request.GET:
+            return {'vminterface': request.GET['vminterface']}
+
 
 # TODO: Standardize or remove this view
 @register_model_view(IPAddress, 'assign', path='assign', detail=False)


### PR DESCRIPTION
### Fixes: #18181 Create & Add another IP address on interfaces is not working correctly
 
* Add method get_extra_addanother_params to IPAddressEditView
* Check if vminterface or interface exists in request.GET and returns the correct dict
