### PR TITLE
Fixes: #18013 - All saved filters showing up for Change Log table, regardless of defined object type

### DIFF
--- a/netbox/core/forms/filtersets.py
+++ b/netbox/core/forms/filtersets.py
@@ -62,6 +62,7 @@ class DataFileFilterForm(NetBoxModelFilterSetForm):
 
 
 class JobFilterForm(SavedFiltersMixin, FilterForm):
+    model = Job
     fieldsets = (
         FieldSet('q', 'filter_id'),
         FieldSet('object_type', 'status', name=_('Attributes')),
@@ -162,6 +163,7 @@ class ObjectChangeFilterForm(SavedFiltersMixin, FilterForm):
 
 
 class ConfigRevisionFilterForm(SavedFiltersMixin, FilterForm):
+    model = ConfigRevision
     fieldsets = (
         FieldSet('q', 'filter_id'),
     )

--- a/netbox/core/forms/filtersets.py
+++ b/netbox/core/forms/filtersets.py
@@ -128,16 +128,6 @@ class JobFilterForm(SavedFiltersMixin, FilterForm):
 
 
 class ObjectChangeFilterForm(SavedFiltersMixin, FilterForm):
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Limit saved filters to those applicable to the form's model
-        object_type = ObjectType.objects.get_for_model(self.model)
-        self.fields['filter_id'].widget.add_query_params({
-            'object_type_id': object_type.pk,
-        })
-
     model = ObjectChange
     fieldsets = (
         FieldSet('q', 'filter_id'),
@@ -169,6 +159,15 @@ class ObjectChangeFilterForm(SavedFiltersMixin, FilterForm):
         required=False,
         label=_('Object Type'),
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Limit saved filters to those applicable to the form's model
+        object_type = ObjectType.objects.get_for_model(self.model)
+        self.fields['filter_id'].widget.add_query_params({
+            'object_type_id': object_type.pk,
+        })
 
 
 class ConfigRevisionFilterForm(SavedFiltersMixin, FilterForm):

--- a/netbox/core/forms/filtersets.py
+++ b/netbox/core/forms/filtersets.py
@@ -128,6 +128,16 @@ class JobFilterForm(SavedFiltersMixin, FilterForm):
 
 
 class ObjectChangeFilterForm(SavedFiltersMixin, FilterForm):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Limit saved filters to those applicable to the form's model
+        object_type = ObjectType.objects.get_for_model(self.model)
+        self.fields['filter_id'].widget.add_query_params({
+            'object_type_id': object_type.pk,
+        })
+
     model = ObjectChange
     fieldsets = (
         FieldSet('q', 'filter_id'),

--- a/netbox/core/forms/filtersets.py
+++ b/netbox/core/forms/filtersets.py
@@ -160,15 +160,6 @@ class ObjectChangeFilterForm(SavedFiltersMixin, FilterForm):
         label=_('Object Type'),
     )
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Limit saved filters to those applicable to the form's model
-        object_type = ObjectType.objects.get_for_model(self.model)
-        self.fields['filter_id'].widget.add_query_params({
-            'object_type_id': object_type.pk,
-        })
-
 
 class ConfigRevisionFilterForm(SavedFiltersMixin, FilterForm):
     fieldsets = (

--- a/netbox/extras/forms/filtersets.py
+++ b/netbox/extras/forms/filtersets.py
@@ -37,6 +37,7 @@ __all__ = (
 
 
 class CustomFieldFilterForm(SavedFiltersMixin, FilterForm):
+    model = CustomField
     fieldsets = (
         FieldSet('q', 'filter_id'),
         FieldSet(
@@ -115,6 +116,7 @@ class CustomFieldFilterForm(SavedFiltersMixin, FilterForm):
 
 
 class CustomFieldChoiceSetFilterForm(SavedFiltersMixin, FilterForm):
+    model = CustomFieldChoiceSet
     fieldsets = (
         FieldSet('q', 'filter_id'),
         FieldSet('base_choices', 'choice', name=_('Choices')),
@@ -129,6 +131,7 @@ class CustomFieldChoiceSetFilterForm(SavedFiltersMixin, FilterForm):
 
 
 class CustomLinkFilterForm(SavedFiltersMixin, FilterForm):
+    model = CustomLink
     fieldsets = (
         FieldSet('q', 'filter_id'),
         FieldSet('object_type', 'enabled', 'new_window', 'weight', name=_('Attributes')),
@@ -159,6 +162,7 @@ class CustomLinkFilterForm(SavedFiltersMixin, FilterForm):
 
 
 class ExportTemplateFilterForm(SavedFiltersMixin, FilterForm):
+    model = ExportTemplate
     fieldsets = (
         FieldSet('q', 'filter_id'),
         FieldSet('data_source_id', 'data_file_id', name=_('Data')),
@@ -200,6 +204,7 @@ class ExportTemplateFilterForm(SavedFiltersMixin, FilterForm):
 
 
 class ImageAttachmentFilterForm(SavedFiltersMixin, FilterForm):
+    model = ImageAttachment
     fieldsets = (
         FieldSet('q', 'filter_id'),
         FieldSet('object_type_id', 'name', name=_('Attributes')),
@@ -216,6 +221,7 @@ class ImageAttachmentFilterForm(SavedFiltersMixin, FilterForm):
 
 
 class SavedFilterFilterForm(SavedFiltersMixin, FilterForm):
+    model = SavedFilter
     fieldsets = (
         FieldSet('q', 'filter_id'),
         FieldSet('object_type', 'enabled', 'shared', 'weight', name=_('Attributes')),
@@ -314,6 +320,7 @@ class TagFilterForm(SavedFiltersMixin, FilterForm):
 
 
 class ConfigContextFilterForm(SavedFiltersMixin, FilterForm):
+    model = ConfigContext
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag_id'),
         FieldSet('data_source_id', 'data_file_id', name=_('Data')),
@@ -403,6 +410,7 @@ class ConfigContextFilterForm(SavedFiltersMixin, FilterForm):
 
 
 class ConfigTemplateFilterForm(SavedFiltersMixin, FilterForm):
+    model = ConfigTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet('data_source_id', 'data_file_id', name=_('Data')),
@@ -469,6 +477,7 @@ class JournalEntryFilterForm(NetBoxModelFilterSetForm):
 
 
 class NotificationGroupFilterForm(SavedFiltersMixin, FilterForm):
+    model = NotificationGroup
     user_id = DynamicModelMultipleChoiceField(
         queryset=User.objects.all(),
         required=False,

--- a/netbox/netbox/forms/base.py
+++ b/netbox/netbox/forms/base.py
@@ -169,15 +169,6 @@ class NetBoxModelFilterSetForm(CustomFieldsMixin, SavedFiltersMixin, forms.Form)
 
     selector_fields = ('filter_id', 'q')
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # Limit saved filters to those applicable to the form's model
-        object_type = ObjectType.objects.get_for_model(self.model)
-        self.fields['filter_id'].widget.add_query_params({
-            'object_type_id': object_type.pk,
-        })
-
     def _get_custom_fields(self, content_type):
         return super()._get_custom_fields(content_type).exclude(
             Q(filter_logic=CustomFieldFilterLogicChoices.FILTER_DISABLED) |

--- a/netbox/netbox/forms/mixins.py
+++ b/netbox/netbox/forms/mixins.py
@@ -73,6 +73,16 @@ class SavedFiltersMixin(forms.Form):
         }
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Limit saved filters to those applicable to the form's model
+        if hasattr(self, 'model'):
+            object_type = ObjectType.objects.get_for_model(self.model)
+            self.fields['filter_id'].widget.add_query_params({
+                'object_type_id': object_type.pk,
+            })
+
 
 class TagsMixin(forms.Form):
     tags = DynamicModelMultipleChoiceField(


### PR DESCRIPTION
### Fixes: #18013 - All saved filters showing up for Change Log table, regardless of defined object type

Since ObjectChangeFilterForm doesn't inherid from NetBoxModelFilterSetForm the filter_id field doesn't get updated

Changes:

* Add `__init__` method to ObjectChangeFilterForm, and setup filter_id `query_params`