### PR TITLE
Closes #17857: Add `release_track` attribute to PluginConfig

### DIFF
--- a/docs/plugins/development/index.md
+++ b/docs/plugins/development/index.md
@@ -103,6 +103,7 @@ NetBox looks for the `config` variable within a plugin's `__init__.py` to load i
 | `name`                | Raw plugin name; same as the plugin's source directory                                                                             |
 | `verbose_name`        | Human-friendly name for the plugin                                                                                                 |
 | `version`             | Current release ([semantic versioning](https://semver.org/) is encouraged)                                                         |
+| `release_track`       | An alternate release track (e.g. `dev` or `beta`) to which a release belongs                                                       |
 | `description`         | Brief description of the plugin's purpose                                                                                          |
 | `author`              | Name of plugin's author                                                                                                            |
 | `author_email`        | Author's public email address                                                                                                      |

--- a/netbox/core/plugins.py
+++ b/netbox/core/plugins.py
@@ -79,6 +79,9 @@ def get_local_plugins(plugins=None):
     for plugin_name in settings.PLUGINS:
         plugin = importlib.import_module(plugin_name)
         plugin_config: PluginConfig = plugin.config
+        installed_version = plugin_config.version
+        if plugin_config.release_track:
+            installed_version = f'{installed_version}-{plugin_config.release_track}'
 
         local_plugins[plugin_config.name] = Plugin(
             config_name=plugin_config.name,
@@ -88,7 +91,7 @@ def get_local_plugins(plugins=None):
             description_short=plugin_config.description,
             is_local=True,
             is_installed=True,
-            installed_version=plugin_config.version,
+            installed_version=installed_version,
         )
 
     # Update catalog entries for local plugins, or add them to the list if not listed

--- a/netbox/netbox/plugins/__init__.py
+++ b/netbox/netbox/plugins/__init__.py
@@ -47,6 +47,7 @@ class PluginConfig(AppConfig):
     author_email = ''
     description = ''
     version = ''
+    release_track = ''
 
     # Root URL path under /plugins. If not set, the plugin's label will be used.
     base_url = None

--- a/netbox/netbox/plugins/utils.py
+++ b/netbox/netbox/plugins/utils.py
@@ -16,7 +16,10 @@ def get_installed_plugins():
     for plugin_name in settings.PLUGINS:
         plugin_name = plugin_name.rsplit('.', 1)[-1]
         plugin_config = apps.get_app_config(plugin_name)
-        plugins[plugin_name] = getattr(plugin_config, 'version', None)
+        if plugin_config.release_track:
+            plugins[plugin_name] = f'{plugin_config.version}-{plugin_config.release_track}'
+        else:
+            plugins[plugin_name] = plugin_config.version or None
 
     return dict(sorted(plugins.items()))
 

--- a/netbox/netbox/plugins/views.py
+++ b/netbox/netbox/plugins/views.py
@@ -30,7 +30,8 @@ class InstalledPluginsAPIView(APIView):
             'author': plugin_app_config.author,
             'author_email': plugin_app_config.author_email,
             'description': plugin_app_config.description,
-            'version': plugin_app_config.version
+            'version': plugin_app_config.version,
+            'release_track': plugin_app_config.release_track,
         }
 
     def get(self, request, format=None):


### PR DESCRIPTION
### Fixes: #17857

- Add `release_track` as an optional attribute on PluginConfig
- Update the relevant UI & REST API views to include the release track (if set) alongside the plugin version