### PR TITLE
Fixes: 18593 - "Create & Add Another" broken for new IP addresses

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -864,12 +864,11 @@ class IPAddressEditView(generic.ObjectEditView):
         return obj
 
     def get_extra_addanother_params(self, request):
-        extra_params = super().get_extra_addanother_params(request)
         if 'interface' in request.GET:
-            extra_params['interface'] = request.GET['interface']
+            return {'interface': request.GET['interface']}
         elif 'vminterface' in request.GET:
-            extra_params['vminterface'] = request.GET['vminterface']
-        return extra_params
+            return {'vminterface': request.GET['vminterface']}
+        return {}
 
 
 # TODO: Standardize or remove this view

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -864,10 +864,12 @@ class IPAddressEditView(generic.ObjectEditView):
         return obj
 
     def get_extra_addanother_params(self, request):
+        extra_params = super().get_extra_addanother_params(request)
         if 'interface' in request.GET:
-            return {'interface': request.GET['interface']}
+            extra_params['interface'] = request.GET['interface']
         elif 'vminterface' in request.GET:
-            return {'vminterface': request.GET['vminterface']}
+            extra_params['vminterface'] = request.GET['vminterface']
+        return extra_params
 
 
 # TODO: Standardize or remove this view


### PR DESCRIPTION
### Fixes: #18593 - "Create & Add Another" broken for new IP addresses

* Changes IPAddressEditView's get_extra_addanother_params to return `super().get_extra_addanother_params(request)`  when the GET params `interface` or `vminterface`

Its also possible to solve this issue returning `{}` if there aren't any match in the if clauses, IMO returning  `super().get_extra_addanother_params(request)`  could be more flexible in the future.
Please let me know if you prefer to use another approach.