### PR TITLE
Fixes 17309: Omit empty related models

### DIFF
--- a/netbox/templates/inc/panels/related_objects.html
+++ b/netbox/templates/inc/panels/related_objects.html
@@ -19,6 +19,8 @@
         </a>
         {% endif %}
       {% endwith %}
+    {% empty %}
+      <span class="list-group-item text-muted">{% trans "None" %}</span>
     {% endfor %}
   </ul>
 </div>

--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -196,7 +196,10 @@ class GetRelatedModelsMixin:
         ]
         related_models.extend(extra)
 
-        return sorted(related_models, key=lambda x: x[0].model._meta.verbose_name.lower())
+        return sorted(
+            filter(lambda qs: qs[0].exists(), related_models),
+            key=lambda qs: qs[0].model._meta.verbose_name.lower(),
+        )
 
 
 class ViewTab:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #17309

<!--
    Please include a summary of the proposed changes below.
-->

Related models that count as zero are omitted from the Related Models pane. If no models are related to the one being displayed, the pane displays "None" instead.