### PR TITLE
Fixes #18480: use script form's cleaned data when calling script from CLI

### DIFF
--- a/netbox/extras/management/commands/runscript.py
+++ b/netbox/extras/management/commands/runscript.py
@@ -81,12 +81,17 @@ class Command(BaseCommand):
                     logger.error(f'\t{field}: {error.get("message")}')
             raise CommandError()
 
+        # Remove extra fields from ScriptForm before passng data to script
+        form.cleaned_data.pop('_schedule_at')
+        form.cleaned_data.pop('_interval')
+        form.cleaned_data.pop('_commit')
+
         # Execute the script.
         job = ScriptJob.enqueue(
             instance=script_obj,
             user=user,
             immediate=True,
-            data=data,
+            data=form.cleaned_data,
             request=NetBoxFakeRequest({
                 'META': {},
                 'POST': data,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18480

<!--
    Please include a summary of the proposed changes below.
-->

When calling netbox script via `runscript` CLI command we pass `cleaned_data` to script so any so `ObjectVar` and other field values have proper types in script's data variable.

Before passing data we remove values that are added by `ScriptForm` in a similar was as in `ScriptView` (`extras/views.py`)
