### PR TITLE
Fixes: #17796 Custom Field Choices -> Create & Add Another causes IndexError

### DIFF
--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -178,12 +178,15 @@ class CustomFieldChoiceSetForm(forms.ModelForm):
     def __init__(self, *args, initial=None, **kwargs):
         super().__init__(*args, initial=initial, **kwargs)
 
-        # Escape colons in extra_choices
+        # Convert extra_choices Array Field from model to CharField for form
         if 'extra_choices' in self.initial and self.initial['extra_choices']:
-            choices = []
-            for choice in self.initial['extra_choices']:
-                choice = (choice[0].replace(':', '\\:'), choice[1].replace(':', '\\:'))
-                choices.append(choice)
+            extra_choices = self.initial['extra_choices']
+            if isinstance(extra_choices, str):
+                extra_choices = [extra_choices]
+            choices = ""
+            for choice in extra_choices:
+                choice_str = ":".join(choice.replace("'", "").replace(" ", "")[1:-1].split(","))
+                choices += choice_str + "\n"
 
             self.initial['extra_choices'] = choices
 

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -162,6 +162,7 @@ class CustomFieldForm(forms.ModelForm):
 
 
 class CustomFieldChoiceSetForm(forms.ModelForm):
+    # TODO: The extra_choices field definition diverge from the CustomFieldChoiceSet model
     extra_choices = forms.CharField(
         widget=ChoicesWidget(),
         required=False,
@@ -178,6 +179,9 @@ class CustomFieldChoiceSetForm(forms.ModelForm):
     def __init__(self, *args, initial=None, **kwargs):
         super().__init__(*args, initial=initial, **kwargs)
 
+        # TODO: Handle divergence in extra_choices field definition from CustomFieldChoiceSetForm & CustomFieldChoiceSet
+        # In CustomFieldChoiceSetForm, extra_choices is a CharField
+        # But in CustomFieldChoiceSet, it is an ArrayField
         # Convert extra_choices Array Field from model to CharField for form
         if 'extra_choices' in self.initial and self.initial['extra_choices']:
             extra_choices = self.initial['extra_choices']

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -185,8 +185,14 @@ class CustomFieldChoiceSetForm(forms.ModelForm):
                 extra_choices = [extra_choices]
             choices = ""
             for choice in extra_choices:
-                choice_str = ":".join(choice.replace("'", "").replace(" ", "")[1:-1].split(","))
-                choices += choice_str + "\n"
+                # Setup choices in Add Another use case
+                if isinstance(choice, str):
+                    choice_str = ":".join(choice.replace("'", "").replace(" ", "")[1:-1].split(","))
+                    choices += choice_str + "\n"
+                # Setup choices in Edit use case
+                elif isinstance(choice, list):
+                    choice_str = ":".join(choice)
+                    choices += choice_str + "\n"
 
             self.initial['extra_choices'] = choices
 

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -179,9 +179,10 @@ class CustomFieldChoiceSetForm(forms.ModelForm):
     def __init__(self, *args, initial=None, **kwargs):
         super().__init__(*args, initial=initial, **kwargs)
 
-        # TODO: Handle divergence in extra_choices field definition from CustomFieldChoiceSetForm & CustomFieldChoiceSet
-        # In CustomFieldChoiceSetForm, extra_choices is a CharField
-        # But in CustomFieldChoiceSet, it is an ArrayField
+        # TODO: The check for str / list below is to handle difference in extra_choices field definition
+        # In CustomFieldChoiceSetForm, extra_choices is a CharField but in CustomFieldChoiceSet, it is an ArrayField
+        # if standardize these, we can simplify this code
+
         # Convert extra_choices Array Field from model to CharField for form
         if 'extra_choices' in self.initial and self.initial['extra_choices']:
             extra_choices = self.initial['extra_choices']


### PR DESCRIPTION
### Fixes:  #17796 Custom Field Choices -> Create & Add Another causes IndexError

* In the current release this issue doesn't raises an Exception, but setups a wrong vaule to the form after clicking in Create & Add Another
* The fix consists in convert the array query into a string to fit the Form field that is an CharField
* It should be possible to change the behaiviour of prepare_cloned_fields, but IMO that may lead to unwanted collateral effects, and its leads to a more complex solution