### PR TITLE
Fixes: #18584 Add rack types column to manufacturers table

### DIFF
--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -303,7 +303,7 @@ class RackTypeFilterForm(RackBaseFilterForm):
     model = RackType
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('form_factor', 'width', 'u_height', name=_('Rack Type')),
+        FieldSet('manufacturer_id', 'form_factor', 'width', 'u_height', name=_('Rack Type')),
         FieldSet('starting_unit', 'desc_units', name=_('Numbering')),
         FieldSet('weight', 'max_weight', 'weight_unit', name=_('Weight')),
     )

--- a/netbox/dcim/tables/devicetypes.py
+++ b/netbox/dcim/tables/devicetypes.py
@@ -31,6 +31,11 @@ class ManufacturerTable(ContactsColumnMixin, NetBoxTable):
         verbose_name=_('Name'),
         linkify=True
     )
+    racktype_count = columns.LinkedCountColumn(
+        viewname='dcim:racktype_list',
+        url_params={'manufacturer_id': 'pk'},
+        verbose_name=_('Rack Types')
+    )
     devicetype_count = columns.LinkedCountColumn(
         viewname='dcim:devicetype_list',
         url_params={'manufacturer_id': 'pk'},
@@ -58,12 +63,12 @@ class ManufacturerTable(ContactsColumnMixin, NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = models.Manufacturer
         fields = (
-            'pk', 'id', 'name', 'devicetype_count', 'moduletype_count', 'inventoryitem_count', 'platform_count',
-            'description', 'slug', 'tags', 'contacts', 'actions', 'created', 'last_updated',
+            'pk', 'id', 'name', 'racktype_count', 'devicetype_count', 'moduletype_count', 'inventoryitem_count',
+            'platform_count', 'description', 'slug', 'tags', 'contacts', 'actions', 'created', 'last_updated',
         )
         default_columns = (
-            'pk', 'name', 'devicetype_count', 'moduletype_count', 'inventoryitem_count', 'platform_count',
-            'description', 'slug',
+            'pk', 'name', 'racktype_count', 'devicetype_count', 'moduletype_count', 'inventoryitem_count',
+            'platform_count', 'description', 'slug',
         )
 
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -964,6 +964,7 @@ class RackReservationBulkDeleteView(generic.BulkDeleteView):
 @register_model_view(Manufacturer, 'list', path='', detail=False)
 class ManufacturerListView(generic.ObjectListView):
     queryset = Manufacturer.objects.annotate(
+        racktype_count=count_related(RackType, 'manufacturer'),
         devicetype_count=count_related(DeviceType, 'manufacturer'),
         moduletype_count=count_related(ModuleType, 'manufacturer'),
         inventoryitem_count=count_related(InventoryItem, 'manufacturer'),


### PR DESCRIPTION
### Fixes: #18584 Add rack types column to manufacturers table

* Add Add racktype_count annotation to list view queryset
* create the LinkedCountColumn in ManufacturerTable

The result is the following image
![image](https://github.com/user-attachments/assets/3c231853-162f-485e-88ab-f2c645fb935f)


### Aditional Thougts:

* The issue makes the following statement: 

> Currently, users can assign manufacturers when creating rack types; however, there isn’t a straightforward way to view or filter these rack types by manufacturer within the interface.

* IMO only adding the `Rack Types` Collumn in the `Manufacturer` List View isn't enougth to solve the user issue.
* Looking at [RackTypeFilterForm](https://github.com/netbox-community/netbox/blob/f8022040b245790796a82b38a67570335a320b74/netbox/dcim/forms/filtersets.py#L302) code the `manufacturer_id` field are defined but since it isn't referenced in any FieldSet the user are unable to select a `Manufacturer` to the filter.
* That's a really quick fix but sligtly outside the issue scope, so let me  know if I should add the `manufacturer_id` field inside some filterset
* The  `Rack Type`  FilterSet seens the best option.




