### PR TITLE
Fixes 18286: Replace DurationChoices by JobIntervalChoices

### DIFF
--- a/netbox/core/choices.py
+++ b/netbox/core/choices.py
@@ -81,8 +81,10 @@ class JobIntervalChoices(ChoiceSet):
     CHOICES = (
         (INTERVAL_MINUTELY, _('Minutely')),
         (INTERVAL_HOURLY, _('Hourly')),
+        (INTERVAL_HOURLY * 12, _('12 hours')),
         (INTERVAL_DAILY, _('Daily')),
         (INTERVAL_WEEKLY, _('Weekly')),
+        (INTERVAL_DAILY * 30, _('30 days')),
     )
 
 

--- a/netbox/extras/choices.py
+++ b/netbox/extras/choices.py
@@ -178,17 +178,6 @@ class LogLevelChoices(ChoiceSet):
     }
 
 
-class DurationChoices(ChoiceSet):
-
-    CHOICES = (
-        (60, _('Hourly')),
-        (720, _('12 hours')),
-        (1440, _('Daily')),
-        (10080, _('Weekly')),
-        (43200, _('30 days')),
-    )
-
-
 #
 # Webhooks
 #

--- a/netbox/extras/forms/reports.py
+++ b/netbox/extras/forms/reports.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
-from extras.choices import DurationChoices
+from core.choices import JobIntervalChoices
 from utilities.forms.widgets import DateTimePicker, NumberWithOptions
 from utilities.datetime import local_now
 
@@ -22,7 +22,7 @@ class ReportForm(forms.Form):
         min_value=1,
         label=_("Recurs every"),
         widget=NumberWithOptions(
-            options=DurationChoices
+            options=JobIntervalChoices
         ),
         help_text=_("Interval at which this report is re-run (in minutes)")
     )

--- a/netbox/extras/forms/scripts.py
+++ b/netbox/extras/forms/scripts.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
-from extras.choices import DurationChoices
+from core.choices import JobIntervalChoices
 from utilities.forms.widgets import DateTimePicker, NumberWithOptions
 from utilities.datetime import local_now
 
@@ -28,7 +28,7 @@ class ScriptForm(forms.Form):
         min_value=1,
         label=_("Recurs every"),
         widget=NumberWithOptions(
-            options=DurationChoices
+            options=JobIntervalChoices
         ),
         help_text=_("Interval at which this script is re-run (in minutes)")
     )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18286

<!--
    Please include a summary of the proposed changes below.
-->

`DurationChoices` has been replaced by `JobIntervalChoices`. Choices not often used by jobs, but available in the UI, have been merged into `CHOICES` only, without adding a new choice preset variable.

Technically, this is not an API change, just housekeeping. However, #18286 is tagged as "needs milestone", so it can be moved to the feature branch instead if needed.