### PR TITLE
Fixes: #17436 {module} variable is not replaced when installing a module that has submodules (modules bays) in a device

### DIFF
--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -1298,6 +1298,7 @@ class Module(PrimaryModel, ConfigContextModel):
             else:
                 # ModuleBays must be saved individually for MPTT
                 for instance in create_instances:
+                    instance.name = instance.name.replace(MODULE_TOKEN, str(self.module_bay.position))
                     instance.save()
 
             update_fields = ['module']


### PR DESCRIPTION
### Fixes: #17436 {module} variable is not replaced when installing a module that has submodules (modules bays) in a device

* Update ModuleBay instance name before saving it