### PR TITLE
Fixes 18277: Cover multitable inheritance in serialization

### DIFF
--- a/netbox/utilities/serialization.py
+++ b/netbox/utilities/serialization.py
@@ -29,7 +29,7 @@ def serialize_object(obj, resolve_tags=True, extra=None, exclude=None):
     exclude = exclude or []
 
     # Include custom_field_data as "custom_fields"
-    if hasattr(obj, 'custom_field_data'):
+    if 'custom_field_data' in data:
         data['custom_fields'] = data.pop('custom_field_data')
 
     # Resolve any assigned tags to their names. Check for tags cached on the instance;


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18277

<!--
    Please include a summary of the proposed changes below.
-->

During serialization, custom fields may be available to a model due to multi-table inheritance, but might not be available in serialized data because only direct fields of the model are covered. Now this attribute is only used if available in serialized data. Models using multi-table inheritance must modify their serialize_object() method to cover parent serialization.

#### Example 

Tested example for child models:

```Python
class ChildModel(Tenant):
    def serialize_object(self, exclude=None) -> dict[str, Any]:
        data = self.tenant_ptr.serialize_object(exclude)
        data.update(super().serialize_object(exclude))
        return data
```

If not defined, only fields of the child are serialized.