### PR TITLE
Update Transifex resource slug

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,7 +1,7 @@
 [main]
 host = https://app.transifex.com
 
-[o:netbox-community:p:netbox:r:9cbf4fcf95b3d92e4ebbf1a5e5d1caee]
+[o:netbox-community:p:netbox:r:034999968a7366ba27a8bdf1ab63bf42]
 file_filter            = netbox/translations/<lang>/LC_MESSAGES/django.po
 source_file            = netbox/translations/en/LC_MESSAGES/django.po
 type                   = PO


### PR DESCRIPTION
We had to modify the slug of the Transifex resource recently when the repository's default branch was changed from `develop` to `main`. This change fixes the `tx` client to pull the correct resource:

```
$ tx pull
# Getting info about resources

netbox.9cbf4fcf95b3d92e4ebbf1a5e5d1caee - Resource netbox.9cbf4fcf95b3d92e4ebbf1a5e5d1caee does not exist
```