### PR TITLE
Closes #18072: Remove support for single model registration from PluginTemplateExtension

### DIFF
--- a/netbox/netbox/plugins/registration.py
+++ b/netbox/netbox/plugins/registration.py
@@ -1,7 +1,7 @@
 import inspect
-import warnings
 
 from django.utils.translation import gettext_lazy as _
+
 from netbox.registry import registry
 from .navigation import PluginMenu, PluginMenuButton, PluginMenuItem
 from .templates import PluginTemplateExtension
@@ -35,16 +35,8 @@ def register_template_extensions(class_list):
             )
 
         if template_extension.models:
-            # Registration for multiple models
+            # Registration for specific models
             models = template_extension.models
-        elif template_extension.model:
-            # Registration for a single model (deprecated)
-            warnings.warn(
-                "PluginTemplateExtension.model is deprecated and will be removed in a future release. Use "
-                "'models' instead.",
-                DeprecationWarning
-            )
-            models = [template_extension.model]
         else:
             # Global registration (no specific models)
             models = [None]

--- a/netbox/netbox/plugins/templates.py
+++ b/netbox/netbox/plugins/templates.py
@@ -11,8 +11,14 @@ class PluginTemplateExtension:
     This class is used to register plugin content to be injected into core NetBox templates. It contains methods
     that are overridden by plugin authors to return template content.
 
-    The `model` attribute on the class defines the which model detail page this class renders content for. It
-    should be set as a string in the form '<app_label>.<model_name>'. render() provides the following context data:
+    The `models` attribute on the class defines the which specific model detail pages this class renders content
+    for. It should be defined as a list of strings in the following form:
+
+        models = ['<app_label>.<model_name>', '<app_label>.<model_name>']
+
+    If `models` is left as None, the extension will render for _all_ models.
+
+    The `render()` method provides the following context data:
 
     * object - The object being viewed (object views only)
     * model - The type of object being viewed (list views only)
@@ -21,7 +27,6 @@ class PluginTemplateExtension:
     * config - Plugin-specific configuration parameters
     """
     models = None
-    model = None  # Deprecated; use `models` instead
 
     def __init__(self, context):
         self.context = context


### PR DESCRIPTION
### Fixes: #18072

- Remove the deprecated `model` attribute from PluginTemplateExtension
- Remove the backward-compatible registration logic