### PR TITLE
Fixes 18095: inherit contacts

### DIFF
--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -364,9 +364,11 @@ class ContactsMixin(models.Model):
     class Meta:
         abstract = True
 
-    def get_contacts(self):
+    def get_contacts(self, inherited=True):
         """
         Return a `QuerySet` matching all contacts assigned to this object.
+
+        :param inherited: If `True`, inherited contacts from parent objects are included.
         """
         from tenancy.models import ContactAssignment
         from . import NestedGroupModel
@@ -377,7 +379,7 @@ class ContactsMixin(models.Model):
                 object_type=ObjectType.objects.get_for_model(obj),
                 object_id__in=(
                     obj.get_ancestors(include_self=True).values_list('pk', flat=True)
-                    if isinstance(obj, NestedGroupModel)
+                    if (isinstance(obj, NestedGroupModel) and inherited)
                     else [obj.pk]
                 ),
             )

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -373,16 +373,14 @@ class ContactsMixin(models.Model):
         from tenancy.models import ContactAssignment
         from . import NestedGroupModel
 
-        filter = Q()
-        for obj in [self]:
-            filter |= Q(
-                object_type=ObjectType.objects.get_for_model(obj),
-                object_id__in=(
-                    obj.get_ancestors(include_self=True).values_list('pk', flat=True)
-                    if (isinstance(obj, NestedGroupModel) and inherited)
-                    else [obj.pk]
-                ),
-            )
+        filter = Q(
+            object_type=ObjectType.objects.get_for_model(self),
+            object_id__in=(
+                self.get_ancestors(include_self=True).values_list('pk', flat=True)
+                if (isinstance(self, NestedGroupModel) and inherited)
+                else [self.pk]
+            ),
+        )
 
         return ContactAssignment.objects.filter(filter)
 

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -376,7 +376,7 @@ class ContactsMixin(models.Model):
         filter = Q(
             object_type=ObjectType.objects.get_for_model(self),
             object_id__in=(
-                self.get_ancestors(include_self=True).values_list('pk', flat=True)
+                self.get_ancestors(include_self=True)
                 if (isinstance(self, NestedGroupModel) and inherited)
                 else [self.pk]
             ),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18095

<!--
    Please include a summary of the proposed changes below.
-->

Contacts for a `NestedGroupModel` will also include the contact assignments of the parents.

While at first it seemed tempting to include other related contact assignments (e.g. for a `Location` those of a `Site`), this is much more complicated than expected. The code proposed in this PR can also handle these relationships by iterating over related objects and adding constraints to the `filter`. In practice, however, it remains unclear which relationships are important to users, as these may vary between different NetBox deployments and even within a single deployment. In this case, I suggest opening a new FR with details of a possible lookup logic and adding it to `get_contacts()`.