### PR TITLE
Fixes 17357: Use virtual chassis name as fallback for device 

### DIFF
--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -1193,6 +1193,7 @@ class DeviceFilterSet(
             return queryset
         return queryset.filter(
             Q(name__icontains=value) |
+            Q(virtual_chassis__name__icontains=value) |
             Q(serial__icontains=value.strip()) |
             Q(inventoryitems__serial__icontains=value.strip()) |
             Q(asset_tag__icontains=value.strip()) |

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -1069,7 +1069,7 @@ class Device(
             device.location = self.location
             device.save()
 
-    @cached_property
+    @property
     def label(self):
         """
         Return the device name if set; otherwise return a generated name if available.

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -802,14 +802,10 @@ class Device(
         verbose_name_plural = _('devices')
 
     def __str__(self):
-        if self.name and self.asset_tag:
-            return f'{self.name} ({self.asset_tag})'
-        elif self.name:
-            return self.name
-        elif self.virtual_chassis and self.asset_tag:
-            return f'{self.virtual_chassis.name}:{self.vc_position} ({self.asset_tag})'
-        elif self.virtual_chassis:
-            return f'{self.virtual_chassis.name}:{self.vc_position} ({self.pk})'
+        if self.label and self.asset_tag:
+            return f'{self.label} ({self.asset_tag})'
+        elif self.label:
+            return self.label
         elif self.device_type and self.asset_tag:
             return f'{self.device_type.manufacturer} {self.device_type.model} ({self.asset_tag})'
         elif self.device_type:
@@ -1073,14 +1069,22 @@ class Device(
             device.location = self.location
             device.save()
 
+    @cached_property
+    def label(self):
+        """
+        Return the device name if set; otherwise return a generated name if available.
+        """
+        if self.name:
+            return self.name
+        if self.virtual_chassis:
+            return f'{self.virtual_chassis.name}:{self.vc_position}'
+
     @property
     def identifier(self):
         """
         Return the device name if set; otherwise return the Device's primary key as {pk}
         """
-        if self.name is not None:
-            return self.name
-        return '{{{}}}'.format(self.pk)
+        return self.label or '{{{}}}'.format(self.pk)
 
     @property
     def primary_ip(self):

--- a/netbox/dcim/search.py
+++ b/netbox/dcim/search.py
@@ -44,6 +44,7 @@ class DeviceIndex(SearchIndex):
         ('asset_tag', 50),
         ('serial', 60),
         ('name', 100),
+        ('virtual_chassis', 200),
         ('description', 500),
         ('comments', 5000),
     )

--- a/netbox/dcim/svg/racks.py
+++ b/netbox/dcim/svg/racks.py
@@ -30,10 +30,8 @@ STROKE_RESERVED = '#4d4dff'
 
 
 def get_device_name(device):
-    if device.virtual_chassis:
-        name = f'{device.virtual_chassis.name}:{device.vc_position}'
-    elif device.name:
-        name = device.name
+    if device.label:
+        name = device.label
     else:
         name = str(device.device_type)
     if device.devicebay_count:

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -143,6 +143,7 @@ class PlatformTable(NetBoxTable):
 class DeviceTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
     name = tables.TemplateColumn(
         verbose_name=_('Name'),
+        accessor=Accessor('label'),
         template_code=DEVICE_LINK,
         linkify=True
     )

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -590,6 +590,34 @@ class DeviceTestCase(TestCase):
         device2.full_clean()
         device2.save()
 
+    def test_device_label(self):
+        device1 = Device(
+            site=Site.objects.first(),
+            device_type=DeviceType.objects.first(),
+            role=DeviceRole.objects.first(),
+            name=None,
+        )
+        self.assertEqual(device1.label, None)
+
+        device2 = Device(
+            site=Site.objects.first(),
+            device_type=DeviceType.objects.first(),
+            role=DeviceRole.objects.first(),
+            name='Test Device 2',
+        )
+        self.assertEqual(device2.label, 'Test Device 2')
+
+        virtual_chassis = VirtualChassis.objects.create(name='VC 1')
+        device3 = Device(
+            site=Site.objects.first(),
+            device_type=DeviceType.objects.first(),
+            role=DeviceRole.objects.first(),
+            name=None,
+            virtual_chassis=virtual_chassis,
+            vc_position=2,
+        )
+        self.assertEqual(device3.label, 'VC 1:2')
+
     def test_device_mismatched_site_cluster(self):
         cluster_type = ClusterType.objects.create(name='Cluster Type 1', slug='cluster-type-1')
         Cluster.objects.create(name='Cluster 1', type=cluster_type)

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -599,16 +599,11 @@ class DeviceTestCase(TestCase):
         )
         self.assertEqual(device1.label, None)
 
-        device2 = Device(
-            site=Site.objects.first(),
-            device_type=DeviceType.objects.first(),
-            role=DeviceRole.objects.first(),
-            name='Test Device 2',
-        )
-        self.assertEqual(device2.label, 'Test Device 2')
+        device1.name = 'Test Device 1'
+        self.assertEqual(device1.label, 'Test Device 1')
 
         virtual_chassis = VirtualChassis.objects.create(name='VC 1')
-        device3 = Device(
+        device2 = Device(
             site=Site.objects.first(),
             device_type=DeviceType.objects.first(),
             role=DeviceRole.objects.first(),
@@ -616,7 +611,10 @@ class DeviceTestCase(TestCase):
             virtual_chassis=virtual_chassis,
             vc_position=2,
         )
-        self.assertEqual(device3.label, 'VC 1:2')
+        self.assertEqual(device2.label, 'VC 1:2')
+
+        device2.name = 'Test Device 2'
+        self.assertEqual(device2.label, 'Test Device 2')
 
     def test_device_mismatched_site_cluster(self):
         cluster_type = ClusterType.objects.create(name='Cluster Type 1', slug='cluster-type-1')


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #17357

<!--
    Please include a summary of the proposed changes below.
-->

If a name is not defined for a device, it is automatically generated from other device data (i.e. virtual chassis member) if possible. This name is available as `label` attribute to not interfere with existing functionality or break APIs. This label will be used in several places like tables, while the API still returns the real name.