### PR TITLE
Closes #18403: Do not retrieve the data field from Job objects unless needed

### DIFF
--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -165,7 +165,7 @@ class DataFileBulkDeleteView(generic.BulkDeleteView):
 
 @register_model_view(Job, 'list', path='', detail=False)
 class JobListView(generic.ObjectListView):
-    queryset = Job.objects.all()
+    queryset = Job.objects.defer('data')
     filterset = filtersets.JobFilterSet
     filterset_form = forms.JobFilterForm
     table = tables.JobTable
@@ -182,12 +182,12 @@ class JobView(generic.ObjectView):
 
 @register_model_view(Job, 'delete')
 class JobDeleteView(generic.ObjectDeleteView):
-    queryset = Job.objects.all()
+    queryset = Job.objects.defer('data')
 
 
 @register_model_view(Job, 'bulk_delete', path='delete', detail=False)
 class JobBulkDeleteView(generic.BulkDeleteView):
-    queryset = Job.objects.all()
+    queryset = Job.objects.defer('data')
     filterset = filtersets.JobFilterSet
     table = tables.JobTable
 

--- a/netbox/netbox/views/generic/feature_views.py
+++ b/netbox/netbox/views/generic/feature_views.py
@@ -166,7 +166,7 @@ class ObjectJobsView(ConditionalLoginRequiredMixin, View):
 
     def get_jobs(self, instance):
         object_type = ContentType.objects.get_for_model(instance)
-        return Job.objects.filter(
+        return Job.objects.defer('data').filter(
             object_type=object_type,
             object_id=instance.id
         )


### PR DESCRIPTION
### Closes: #18403

Defer the retrieval of the `data` field for certain Job queries (queries that do not need access to the data). This improves responsiveness of the forms and reduces memory consumption.

The housekeeping queries were not changed because both use either the `count()` aggregate or the `delete()` function. Adding the `defer()` function would not alter the SQL statement.
