### PR TITLE
Closes #18024: Add URL pattern for scripts to reference them by module.name

### DIFF
--- a/netbox/extras/urls.py
+++ b/netbox/extras/urls.py
@@ -75,8 +75,11 @@ urlpatterns = [
     path('scripts/add/', views.ScriptModuleCreateView.as_view(), name='scriptmodule_add'),
     path('scripts/results/<int:job_pk>/', views.ScriptResultView.as_view(), name='script_result'),
     path('scripts/<int:pk>/', views.ScriptView.as_view(), name='script'),
+    path('scripts/<str:module>.<str:name>/', views.ScriptView.as_view(), name='script'),
     path('scripts/<int:pk>/source/', views.ScriptSourceView.as_view(), name='script_source'),
+    path('scripts/<str:module>.<str:name>/source/', views.ScriptSourceView.as_view(), name='script_source'),
     path('scripts/<int:pk>/jobs/', views.ScriptJobsView.as_view(), name='script_jobs'),
+    path('scripts/<str:module>.<str:name>/jobs/', views.ScriptJobsView.as_view(), name='script_jobs'),
     path('script-modules/<int:pk>/', include(get_model_urls('extras', 'scriptmodule'))),
 
     # Markdown

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1251,16 +1251,12 @@ class ScriptListView(ContentTypePermissionRequiredMixin, View):
 class BaseScriptView(generic.ObjectView):
     queryset = Script.objects.all()
 
-    def _get_script(self, **kwargs):
-        if 'pk' in kwargs:
-            pk = kwargs.get('pk')
+    def get_object(self, **kwargs):
+        if pk := kwargs.get('pk', False):
             return get_object_or_404(self.queryset, pk=pk)
-        elif 'module' in kwargs and 'name' in kwargs:
-            module = kwargs.get('module')
-            name = kwargs.get('name')
+        elif (module := kwargs.get('module')) and (name := kwargs.get('name', False)):
             return get_object_or_404(self.queryset, module__file_path=f'{module}.py', name=name)
-        else:
-            raise Http404
+        else: raise Http404
 
     def _get_script_class(self, script):
         """
@@ -1273,7 +1269,7 @@ class BaseScriptView(generic.ObjectView):
 class ScriptView(BaseScriptView):
 
     def get(self, request, **kwargs):
-        script = self._get_script(**kwargs)
+        script = self.get_object(**kwargs)
         script_class = self._get_script_class(script)
         if not script_class:
             return render(request, 'extras/script.html', {
@@ -1292,7 +1288,7 @@ class ScriptView(BaseScriptView):
         })
 
     def post(self, request, **kwargs):
-        script = self._get_script(**kwargs)
+        script = self.get_object(**kwargs)
 
         if not request.user.has_perm('extras.run_script', obj=script):
             return HttpResponseForbidden()
@@ -1337,7 +1333,7 @@ class ScriptSourceView(BaseScriptView):
     queryset = Script.objects.all()
 
     def get(self, request, **kwargs):
-        script = self._get_script(**kwargs)
+        script = self.get_object(**kwargs)
         script_class = self._get_script_class(script)
 
         return render(request, 'extras/script/source.html', {
@@ -1352,7 +1348,7 @@ class ScriptJobsView(BaseScriptView):
     queryset = Script.objects.all()
 
     def get(self, request, **kwargs):
-        script = self._get_script(**kwargs)
+        script = self.get_object(**kwargs)
 
         jobs_table = JobTable(
             data=script.jobs.all(),

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1256,7 +1256,8 @@ class BaseScriptView(generic.ObjectView):
             return get_object_or_404(self.queryset, pk=pk)
         elif (module := kwargs.get('module')) and (name := kwargs.get('name', False)):
             return get_object_or_404(self.queryset, module__file_path=f'{module}.py', name=name)
-        else: raise Http404
+        else:
+            raise Http404
 
     def _get_script_class(self, script):
         """


### PR DESCRIPTION
### Closes: #18024

Added script URL patterns to include the `module` and `name` references. Added a function to return the specified script when referenced by either the PK or the module.name pattern. The new URL patterns should match the existing URL patterns for the API.
