### PR TITLE
Closes #17944: Allow filtering of ObjectVar and MultiObjectVar script inputs

### DIFF
--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -308,6 +308,7 @@ A particular object within NetBox. Each ObjectVar must specify a particular mode
 * `query_params` - A dictionary of query parameters to use when retrieving available options (optional)
 * `context` - A custom dictionary mapping template context variables to fields, used when rendering `<option>` elements within the dropdown menu (optional; see below)
 * `null_option` - A label representing a "null" or empty choice (optional)
+* `selector` - A boolean that, when True, includes an advanced object selection widget to assist the user in identifying the desired object (optional; False by default)
 
 To limit the selections available within the list, additional query parameters can be passed as the `query_params` dictionary. For example, to show only devices with an "active" status:
 

--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -211,7 +211,8 @@ class ObjectVar(ScriptVariable):
     :param context: A custom dictionary mapping template context variables to fields, used when rendering <option>
         elements within the dropdown menu (optional)
     :param null_option: The label to use as a "null" selection option (optional)
-    :param selector: Include an advanced object selection widget to assist the user in identifying the desired object (optional)
+    :param selector: Include an advanced object selection widget to assist the user in identifying the desired
+        object (optional)
     """
     form_field = DynamicModelChoiceField
 

--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -211,10 +211,11 @@ class ObjectVar(ScriptVariable):
     :param context: A custom dictionary mapping template context variables to fields, used when rendering <option>
         elements within the dropdown menu (optional)
     :param null_option: The label to use as a "null" selection option (optional)
+    :param selector: Include an advanced object selection widget to assist the user in identifying the desired object (optional)
     """
     form_field = DynamicModelChoiceField
 
-    def __init__(self, model, query_params=None, context=None, null_option=None, *args, **kwargs):
+    def __init__(self, model, query_params=None, context=None, null_option=None, selector=False, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         self.field_attrs.update({
@@ -222,6 +223,7 @@ class ObjectVar(ScriptVariable):
             'query_params': query_params,
             'context': context,
             'null_option': null_option,
+            'selector': selector,
         })
 
 

--- a/netbox/templates/extras/script.html
+++ b/netbox/templates/extras/script.html
@@ -54,3 +54,7 @@
     </div>
   </div>
 {% endblock content %}
+
+{% block modals %}
+  {% include 'inc/htmx_modal.html' with size='lg' %}
+{% endblock %}


### PR DESCRIPTION
### Closes: #17944

Added the advanced object selection widget to the ObjectVar and MultiObjectVar script inputs. To render the selector button set `selector = True` on the input. The modals block was added to the script template to pass the `size='lg'`  parameter. Without it the modal was rendering thinner than normal.

I discovered an issue where the `query_params` defined for the input are not passed to the advanced object selector widget. I plan to open a separate bug issue for this.
