### PR TITLE
Handle null table in TableConfigForm

### DIFF
--- a/netbox/utilities/forms/forms.py
+++ b/netbox/utilities/forms/forms.py
@@ -132,8 +132,9 @@ class TableConfigForm(forms.Form):
         super().__init__(*args, **kwargs)
 
         # Initialize columns field based on table attributes
-        self.fields['available_columns'].choices = table.available_columns
-        self.fields['columns'].choices = table.selected_columns
+        if table:
+            self.fields['available_columns'].choices = table.available_columns
+            self.fields['columns'].choices = table.selected_columns
 
     @property
     def table_name(self):


### PR DESCRIPTION
### Fixes: #18722

This simple defensive fix ensures that `table` is not null before trying to initialize the fields on it. This handles the case where a custom script fails due to an error, resulting in an `AttributeError: 'NoneType' object has no attribute 'available_columns'` on the ephemeral job result page (http://127.0.0.1:8000/extras/scripts/results/33/) which only appears after directly running the script via the UI.

Normally NetBox will validate any syntax errors or other issues with a newly uploaded script and prevent it from being runnable. However, if an existing script fails to run due to an emergent systemic issue, the result page will throw the above error because `table` (which would show log results) is null. With this fix, the table is simply omitted and the "Errored" badge is shown. The specifics of the error can then be seen in the job detail page (http://127.0.0.1:8000/core/jobs/14/).
