### PR TITLE
Fixes #18758: Enable sorting by Account count on prodiver list

### DIFF
--- a/netbox/circuits/tables/providers.py
+++ b/netbox/circuits/tables/providers.py
@@ -23,7 +23,6 @@ class ProviderTable(ContactsColumnMixin, NetBoxTable):
         verbose_name=_('Accounts')
     )
     account_count = columns.LinkedCountColumn(
-        accessor=tables.A('accounts__count'),
         viewname='circuits:provideraccount_list',
         url_params={'provider_id': 'pk'},
         verbose_name=_('Account Count')

--- a/netbox/circuits/views.py
+++ b/netbox/circuits/views.py
@@ -23,6 +23,7 @@ class ProviderListView(generic.ObjectListView):
     queryset = Provider.objects.annotate(
         count_circuits=count_related(Circuit, 'provider'),
         asn_count=count_related(ASN, 'providers'),
+        account_count=count_related(ProviderAccount, 'provider'),
     )
     filterset = filtersets.ProviderFilterSet
     filterset_form = forms.ProviderFilterForm


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18758 
- sets `ProviderAcount` count annotation on `ProviderListView`
- removes unneeded `ProviderTable.account_count` accessor kwarg

<!--
    Please include a summary of the proposed changes below.
-->
