### PR TITLE
Fixes #18768: allow removing secondary MACAddress from interface

### DIFF
--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -1550,7 +1550,10 @@ class MACAddress(PrimaryModel):
             ct = ObjectType.objects.get_for_id(self._original_assigned_object_type_id)
             original_assigned_object = ct.get_object_for_this_type(pk=self._original_assigned_object_id)
 
-            if original_assigned_object.primary_mac_address:
+            if (
+                original_assigned_object.primary_mac_address
+                and original_assigned_object.primary_mac_address.pk == self.pk
+            ):
                 if not assigned_object:
                     raise ValidationError(
                         _("Cannot unassign MAC Address while it is designated as the primary MAC for an object")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18768 
- Changes check in `MACAddress.clean()` to also check if this MAC address is currently marked as the primary MAC address in the interface it is assigned to
- Adds regression tests

<!--
    Please include a summary of the proposed changes below.
-->
