### PR TITLE
Closes #18774: Set title attribute of each tag to its description

### DIFF
--- a/netbox/utilities/templates/builtins/tag.html
+++ b/netbox/utilities/templates/builtins/tag.html
@@ -1,3 +1,3 @@
 {% load helpers %}
 
-{% if viewname %}<a href="{% url viewname %}?tag={{ tag.slug }}">{% endif %}<span class="badge" style="color: {{ tag.color|fgcolor }}; background-color: #{{ tag.color }}">{{ tag }}</span>{% if viewname %}</a>{% endif %}
+{% if viewname %}<a href="{% url viewname %}?tag={{ tag.slug }}">{% endif %}<span {% if tag.description %}title="{{ tag.description }}"{% endif %} class="badge" style="color: {{ tag.color|fgcolor }}; background-color: #{{ tag.color }}">{{ tag }}</span>{% if viewname %}</a>{% endif %}


### PR DESCRIPTION
### Closes: #18774

Set the `title` attribute of each tag to its description if the description is defined.

This feature would allow users to show a preview tooltip of the tag description when hovering over a tag in the Device and VM general views.

For example, given the following Alpha tag:

![alpha_tag_details](https://github.com/user-attachments/assets/bb11efbb-a827-40f5-a27e-923c93e58604)

The user would be able to hover over the Alpha tag in the Devices tab:

![device_tag_description](https://github.com/user-attachments/assets/c6b276fe-d8d9-4c76-9480-bffa5221e0f8)

And the Virtual Machines tab:

![vm_tag_description](https://github.com/user-attachments/assets/d5ec5577-3251-4dd5-b32d-bca105beed24)
