### PR TITLE
Fixes: #18606 UI Racks Table View Performance Scaling Problem - Loading time increases with large number of racks - django N+1 query issue

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -723,8 +723,11 @@ class RackTypeBulkDeleteView(generic.BulkDeleteView):
 
 @register_model_view(Rack, 'list', path='', detail=False)
 class RackListView(generic.ObjectListView):
-    queryset = Rack.objects.annotate(
-        device_count=count_related(Device, 'rack')
+    queryset = Rack.objects.prefetch_related(
+        'reservations',
+        'devices__device_type'
+    ).annotate(
+        device_count=count_related(Device, 'rack'),
     )
     filterset = filtersets.RackFilterSet
     filterset_form = forms.RackFilterForm


### PR DESCRIPTION
### Fixes: #18606 UI Racks Table View Performance Scaling Problem - Loading time increases with large number of racks - django N+1 query issue

- The issue happens with the collumns: `get_utilization` and `get_power_utilization`
- Both collumns are calculated inside the model
- Adding a prefetch for `reservations` inside the `RackListView` queryset partially fixes the problem reduncing the amount of queries from 123 to 85 using NetBox sample data with 42 rack models


Investigating the  `get_utilization` method of the `Rack` model and comparing with the executed queries in the List view it seens the N+1 queries happens from this [line](https://github.com/netbox-community/netbox/blob/d208ddde9af2859299b9923b05872c91d307c046/netbox/dcim/models/racks.py#L517)