### PR TITLE
Fixes: #18742 Location List and Locations not Showing Associated VLAN Groups 

### DIFF
--- a/netbox/dcim/tables/sites.py
+++ b/netbox/dcim/tables/sites.py
@@ -146,6 +146,11 @@ class LocationTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
         url_params={'location_id': 'pk'},
         verbose_name=_('Devices')
     )
+    vlangroup_count = columns.LinkedCountColumn(
+        viewname='ipam:vlangroup_list',
+        url_params={'location': 'pk'},
+        verbose_name=_('VLAN Groups')
+    )
     tags = columns.TagColumn(
         url_name='dcim:location_list'
     )
@@ -157,8 +162,9 @@ class LocationTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
         model = Location
         fields = (
             'pk', 'id', 'name', 'site', 'status', 'facility', 'tenant', 'tenant_group', 'rack_count', 'device_count',
-            'description', 'slug', 'contacts', 'tags', 'actions', 'created', 'last_updated',
+            'description', 'slug', 'contacts', 'tags', 'actions', 'created', 'last_updated', 'vlangroup_count',
         )
         default_columns = (
-            'pk', 'name', 'site', 'status', 'facility', 'tenant', 'rack_count', 'device_count', 'description'
+            'pk', 'name', 'site', 'status', 'facility', 'tenant', 'rack_count', 'device_count', 'vlangroup_count',
+            'description'
         )


### PR DESCRIPTION
### Fixes: #18742 Location List and Locations not Showing Associated VLAN Groups 

- Added VLANGroup relation to `LocationView` `related_models`
- Added `vlangroup_count` to `LocationTable`
- Added another `add_related_count` to `LocationListView` `queryset`, 

That `add_related_count` structure are used only in the `LocationListView` so it may not be very usefull to create a utily function to handle that kind of nested relations.
