### PR TITLE
Fixes: #18729 - Reapply model-level ordering on list views (UI and API) to account for annotation

### DIFF
--- a/netbox/netbox/api/viewsets/__init__.py
+++ b/netbox/netbox/api/viewsets/__init__.py
@@ -121,6 +121,11 @@ class NetBoxModelViewSet(
             obj.snapshot()
         return obj
 
+    def get_queryset(self):
+        qs = super().get_queryset()
+        ordering = qs.model._meta.ordering
+        return qs.order_by(*ordering)
+
     def get_serializer(self, *args, **kwargs):
         # If a list of objects has been provided, initialize the serializer with many=True
         if isinstance(kwargs.get('data', {}), list):

--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -125,6 +125,11 @@ class ObjectListView(BaseMultiObjectView, ActionsMixin, TableMixin):
     # Request handlers
     #
 
+    def get_queryset(self, request):
+        qs = super().get_queryset(request)
+        ordering = qs.model._meta.ordering
+        return qs.order_by(*ordering)
+
     def get(self, request):
         """
         GET request handler.


### PR DESCRIPTION
### Fixes: #18729

Adding `.annotate` to querysets has the effect of negating the `ordering` setting defined on models. Thus when we put annotations/groupings on the `queryset` on various list views (for example `ClusterViewSet` in the API, or `ProviderListView` in the UI), i.e. to count related objects to show in columns or fields, the model-level sorting is lost and records are returned in an unpredictable order, leading to repetitions and misses by paginating clients.

This change adds a `get_queryset` override to each of the relevant list view classes, to take the specified `queryset` and reapply the `ordering` fields that are defined in the queryset's model class. This occurs centrally and uniformly, thus not requiring many changes throughout the system. It also does not interfere with custom sorting as specified via query params (e.g. `&ordering=name`).
