### PR TITLE
Closes #18743: Upgrade to Django 5.2

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -1,6 +1,6 @@
 # The Python web framework on which NetBox is built
 # https://docs.djangoproject.com/en/stable/releases/
-Django<5.2
+Django==5.2.*
 
 # Django middleware which permits cross-domain API requests
 # https://github.com/adamchainz/django-cors-headers/blob/main/CHANGELOG.rst

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,12 +28,7 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
-          setup_commands:
-            - import os
-            - import django
-            - os.chdir('netbox/')
-            - os.environ.setdefault("DJANGO_SETTINGS_MODULE", "netbox.settings")
-            - django.setup()
+          paths: ["netbox"]
           options:
             heading_level: 3
             members_order: source

--- a/netbox/netbox/middleware.py
+++ b/netbox/netbox/middleware.py
@@ -98,18 +98,23 @@ class RemoteUserMiddleware(RemoteUserMiddleware_):
     """
     Custom implementation of Django's RemoteUserMiddleware which allows for a user-configurable HTTP header name.
     """
+    async_capable = False
     force_logout_if_no_header = False
+
+    def __init__(self, get_response):
+        if get_response is None:
+            raise ValueError("get_response must be provided.")
+        self.get_response = get_response
 
     @property
     def header(self):
         return settings.REMOTE_AUTH_HEADER
 
-    def process_request(self, request):
-        logger = logging.getLogger(
-            'netbox.authentication.RemoteUserMiddleware')
+    def __call__(self, request):
+        logger = logging.getLogger('netbox.authentication.RemoteUserMiddleware')
         # Bypass middleware if remote authentication is not enabled
         if not settings.REMOTE_AUTH_ENABLED:
-            return
+            return self.get_response(request)
         # AuthenticationMiddleware is required so that request.user exists.
         if not hasattr(request, 'user'):
             raise ImproperlyConfigured(
@@ -126,13 +131,13 @@ class RemoteUserMiddleware(RemoteUserMiddleware_):
             # AnonymousUser by the AuthenticationMiddleware).
             if self.force_logout_if_no_header and request.user.is_authenticated:
                 self._remove_invalid_user(request)
-            return
+            return self.get_response(request)
         # If the user is already authenticated and that user is the user we are
         # getting passed in the headers, then the correct user is already
         # persisted in the session and we don't need to continue.
         if request.user.is_authenticated:
             if request.user.get_username() == self.clean_username(username, request):
-                return
+                return self.get_response(request)
             else:
                 # An authenticated user is associated with the request, but
                 # it does not match the authorized user in the header.
@@ -161,6 +166,8 @@ class RemoteUserMiddleware(RemoteUserMiddleware_):
             # by logging the user in.
             request.user = user
             auth.login(request, user)
+
+        return self.get_response(request)
 
     def _get_groups(self, request):
         logger = logging.getLogger(

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,8 +20,8 @@ feedparser==6.0.11
 gunicorn==23.0.0
 Jinja2==3.1.5
 Markdown==3.7
-mkdocs-material==9.6.2
-mkdocstrings[python-legacy]==0.27.0
+mkdocs-material==9.6.7
+mkdocstrings[python]==0.28.2
 netaddr==1.3.0
 nh3==0.2.20
 Pillow==11.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==5.1.5
+Django==5.2b1
 django-cors-headers==4.6.0
 django-debug-toolbar==5.0.1
 django-filter==24.3


### PR DESCRIPTION
### Closes: #18743

- Bumps Django from 5.1 to 5.2
- Adapts `RemoteUserMiddleware` to use the newer middleware format for Django 5.2

We're currently running Django 5.2 beta1 as the final release is not yet available (ETA April 2).

Note: Django 5.2 drops support for PostgreSQL 13. This will be addressed under #18820.