### PR TITLE
Fixes: #18808 -  Fix incorrect dependencies on squashed migrations

### DIFF
--- a/netbox/account/migrations/0001_initial.py
+++ b/netbox/account/migrations/0001_initial.py
@@ -8,7 +8,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('users', '0004_netboxgroup_netboxuser'),
+        ('users', '0002_squashed_0004'),
     ]
 
     operations = [

--- a/netbox/circuits/migrations/0002_squashed_0029.py
+++ b/netbox/circuits/migrations/0002_squashed_0029.py
@@ -5,11 +5,11 @@ import taggit.managers
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('dcim', '0001_initial'),
+        ('dcim', '0001_squashed'),
         ('contenttypes', '0002_remove_content_type_name'),
-        ('circuits', '0001_initial'),
-        ('extras', '0001_initial'),
-        ('tenancy', '0001_initial'),
+        ('circuits', '0001_squashed'),
+        ('extras', '0001_squashed'),
+        ('tenancy', '0001_squashed_0012'),
     ]
 
     replaces = [

--- a/netbox/circuits/migrations/0038_squashed_0042.py
+++ b/netbox/circuits/migrations/0038_squashed_0042.py
@@ -15,8 +15,8 @@ class Migration(migrations.Migration):
     ]
 
     dependencies = [
-        ('circuits', '0037_new_cabling_models'),
-        ('dcim', '0160_populate_cable_ends'),
+        ('circuits', '0003_squashed_0037'),
+        ('dcim', '0160_squashed_0166'),
     ]
 
     operations = [

--- a/netbox/circuits/migrations/0043_circuittype_color.py
+++ b/netbox/circuits/migrations/0043_circuittype_color.py
@@ -6,7 +6,7 @@ import utilities.fields
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('circuits', '0042_provideraccount'),
+        ('circuits', '0038_squashed_0042'),
     ]
 
     operations = [

--- a/netbox/core/migrations/0006_datasource_type_remove_choices.py
+++ b/netbox/core/migrations/0006_datasource_type_remove_choices.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('core', '0005_job_created_auto_now'),
+        ('core', '0001_squashed_0005'),
     ]
 
     operations = [

--- a/netbox/dcim/migrations/0002_squashed.py
+++ b/netbox/dcim/migrations/0002_squashed.py
@@ -7,11 +7,11 @@ import taggit.managers
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('dcim', '0001_initial'),
+        ('dcim', '0001_squashed'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('contenttypes', '0002_remove_content_type_name'),
-        ('extras', '0001_initial'),
-        ('tenancy', '0001_initial'),
+        ('extras', '0001_squashed'),
+        ('tenancy', '0001_squashed_0012'),
     ]
 
     replaces = [

--- a/netbox/dcim/migrations/0003_squashed_0130.py
+++ b/netbox/dcim/migrations/0003_squashed_0130.py
@@ -5,12 +5,12 @@ import taggit.managers
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('dcim', '0002_auto_20160622_1821'),
-        ('virtualization', '0001_virtualization'),
+        ('dcim', '0002_squashed'),
+        ('virtualization', '0001_squashed_0022'),
         ('contenttypes', '0002_remove_content_type_name'),
-        ('ipam', '0001_initial'),
-        ('tenancy', '0001_initial'),
-        ('extras', '0002_custom_fields'),
+        ('ipam', '0001_squashed'),
+        ('tenancy', '0001_squashed_0012'),
+        ('extras', '0002_squashed_0059'),
     ]
 
     replaces = [

--- a/netbox/dcim/migrations/0131_squashed_0159.py
+++ b/netbox/dcim/migrations/0131_squashed_0159.py
@@ -43,12 +43,12 @@ class Migration(migrations.Migration):
     ]
 
     dependencies = [
-        ('tenancy', '0012_standardize_models'),
+        ('tenancy', '0001_squashed_0012'),
         ('extras', '0002_squashed_0059'),
-        ('dcim', '0130_sitegroup'),
+        ('dcim', '0003_squashed_0130'),
         ('contenttypes', '0002_remove_content_type_name'),
-        ('ipam', '0053_asn_model'),
-        ('wireless', '0001_wireless'),
+        ('ipam', '0047_squashed_0053'),
+        ('wireless', '0001_squashed_0008'),
     ]
 
     operations = [

--- a/netbox/dcim/migrations/0160_squashed_0166.py
+++ b/netbox/dcim/migrations/0160_squashed_0166.py
@@ -18,9 +18,9 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('ipam', '0047_squashed_0053'),
-        ('tenancy', '0009_standardize_description_comments'),
-        ('circuits', '0037_new_cabling_models'),
-        ('dcim', '0159_populate_cable_paths'),
+        ('tenancy', '0001_squashed_0012'),
+        ('circuits', '0003_squashed_0037'),
+        ('dcim', '0131_squashed_0159'),
     ]
 
     operations = [

--- a/netbox/dcim/migrations/0167_squashed_0182.py
+++ b/netbox/dcim/migrations/0167_squashed_0182.py
@@ -27,10 +27,10 @@ class Migration(migrations.Migration):
     ]
 
     dependencies = [
-        ('extras', '0086_configtemplate'),
-        ('tenancy', '0010_tenant_relax_uniqueness'),
+        ('extras', '0060_squashed_0086'),
+        ('tenancy', '0002_squashed_0011'),
         ('ipam', '0047_squashed_0053'),
-        ('dcim', '0166_virtualdevicecontext'),
+        ('dcim', '0160_squashed_0166'),
     ]
 
     operations = [

--- a/netbox/dcim/migrations/0183_devicetype_exclude_from_utilization.py
+++ b/netbox/dcim/migrations/0183_devicetype_exclude_from_utilization.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('dcim', '0182_zero_length_cable_fix'),
+        ('dcim', '0167_squashed_0182'),
     ]
 
     operations = [

--- a/netbox/extras/migrations/0002_squashed_0059.py
+++ b/netbox/extras/migrations/0002_squashed_0059.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
     dependencies = [
         ('dcim', '0002_auto_20160622_1821'),
-        ('extras', '0001_initial'),
+        ('extras', '0001_squashed'),
         ('virtualization', '0001_virtualization'),
         ('tenancy', '0001_initial'),
     ]

--- a/netbox/extras/migrations/0002_squashed_0059.py
+++ b/netbox/extras/migrations/0002_squashed_0059.py
@@ -3,10 +3,10 @@ from django.db import migrations, models
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('dcim', '0002_auto_20160622_1821'),
+        ('dcim', '0002_squashed'),
         ('extras', '0001_squashed'),
-        ('virtualization', '0001_virtualization'),
-        ('tenancy', '0001_initial'),
+        ('virtualization', '0001_squashed_0022'),
+        ('tenancy', '0001_squashed_0012'),
     ]
 
     replaces = [

--- a/netbox/extras/migrations/0060_squashed_0086.py
+++ b/netbox/extras/migrations/0060_squashed_0086.py
@@ -45,13 +45,13 @@ class Migration(migrations.Migration):
     dependencies = [
         ('virtualization', '0001_squashed_0022'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('core', '0001_initial'),
+        ('core', '0001_squashed_0005'),
         ('contenttypes', '0002_remove_content_type_name'),
-        ('wireless', '0008_wirelesslan_status'),
-        ('dcim', '0166_virtualdevicecontext'),
-        ('tenancy', '0009_standardize_description_comments'),
+        ('wireless', '0001_squashed_0008'),
+        ('dcim', '0160_squashed_0166'),
+        ('tenancy', '0001_squashed_0012'),
         ('extras', '0002_squashed_0059'),
-        ('circuits', '0041_standardize_description_comments'),
+        ('circuits', '0038_squashed_0042'),
     ]
 
     operations = [

--- a/netbox/extras/migrations/0060_squashed_0086.py
+++ b/netbox/extras/migrations/0060_squashed_0086.py
@@ -50,7 +50,7 @@ class Migration(migrations.Migration):
         ('wireless', '0008_wirelesslan_status'),
         ('dcim', '0166_virtualdevicecontext'),
         ('tenancy', '0009_standardize_description_comments'),
-        ('extras', '0059_exporttemplate_as_attachment'),
+        ('extras', '0002_squashed_0059'),
         ('circuits', '0041_standardize_description_comments'),
     ]
 

--- a/netbox/extras/migrations/0087_squashed_0098.py
+++ b/netbox/extras/migrations/0087_squashed_0098.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('contenttypes', '0002_remove_content_type_name'),
-        ('extras', '0086_configtemplate'),
+        ('extras', '0060_squashed_0086'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ('core', '0002_managedfile'),
     ]

--- a/netbox/extras/migrations/0087_squashed_0098.py
+++ b/netbox/extras/migrations/0087_squashed_0098.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
         ('contenttypes', '0002_remove_content_type_name'),
         ('extras', '0060_squashed_0086'),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('core', '0002_managedfile'),
+        ('core', '0001_squashed_0005'),
     ]
 
     operations = [

--- a/netbox/extras/migrations/0099_cachedvalue_ordering.py
+++ b/netbox/extras/migrations/0099_cachedvalue_ordering.py
@@ -5,7 +5,7 @@ from django.db import migrations
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('extras', '0098_webhook_custom_field_data_webhook_tags'),
+        ('extras', '0087_squashed_0098'),
     ]
 
     operations = [

--- a/netbox/ipam/migrations/0001_squashed.py
+++ b/netbox/ipam/migrations/0001_squashed.py
@@ -13,9 +13,9 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('contenttypes', '0002_remove_content_type_name'),
-        ('dcim', '0002_auto_20160622_1821'),
-        ('extras', '0001_initial'),
-        ('tenancy', '0001_initial'),
+        ('dcim', '0002_squashed'),
+        ('extras', '0001_squashed'),
+        ('tenancy', '0001_squashed_0012'),
     ]
 
     replaces = [

--- a/netbox/ipam/migrations/0002_squashed_0046.py
+++ b/netbox/ipam/migrations/0002_squashed_0046.py
@@ -5,12 +5,12 @@ import taggit.managers
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('dcim', '0003_auto_20160628_1721'),
-        ('virtualization', '0001_virtualization'),
+        ('dcim', '0003_squashed_0130'),
+        ('virtualization', '0001_squashed_0022'),
         ('contenttypes', '0002_remove_content_type_name'),
-        ('ipam', '0001_initial'),
-        ('extras', '0002_custom_fields'),
-        ('tenancy', '0001_initial'),
+        ('ipam', '0001_squashed'),
+        ('extras', '0002_squashed_0059'),
+        ('tenancy', '0001_squashed_0012'),
     ]
 
     replaces = [

--- a/netbox/ipam/migrations/0047_squashed_0053.py
+++ b/netbox/ipam/migrations/0047_squashed_0053.py
@@ -19,7 +19,7 @@ class Migration(migrations.Migration):
     ]
 
     dependencies = [
-        ('ipam', '0046_set_vlangroup_scope_types'),
+        ('ipam', '0002_squashed_0046'),
         ('tenancy', '0001_squashed_0012'),
         ('extras', '0002_squashed_0059'),
         ('contenttypes', '0002_remove_content_type_name'),

--- a/netbox/ipam/migrations/0054_squashed_0067.py
+++ b/netbox/ipam/migrations/0054_squashed_0067.py
@@ -28,11 +28,11 @@ class Migration(migrations.Migration):
     ]
 
     dependencies = [
-        ('tenancy', '0007_contact_link'),
+        ('tenancy', '0002_squashed_0011'),
         ('contenttypes', '0002_remove_content_type_name'),
         ('extras', '0060_squashed_0086'),
-        ('ipam', '0053_asn_model'),
-        ('tenancy', '0009_standardize_description_comments'),
+        ('ipam', '0047_squashed_0053'),
+        ('tenancy', '0002_squashed_0011'),
     ]
 
     operations = [

--- a/netbox/ipam/migrations/0068_move_l2vpn.py
+++ b/netbox/ipam/migrations/0068_move_l2vpn.py
@@ -16,7 +16,7 @@ def update_content_types(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('ipam', '0067_ipaddress_index_host'),
+        ('ipam', '0054_squashed_0067'),
     ]
 
     operations = [

--- a/netbox/tenancy/migrations/0001_squashed_0012.py
+++ b/netbox/tenancy/migrations/0001_squashed_0012.py
@@ -9,7 +9,7 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('extras', '0001_initial'),
+        ('extras', '0001_squashed'),
     ]
 
     replaces = [

--- a/netbox/tenancy/migrations/0012_contactassignment_custom_fields.py
+++ b/netbox/tenancy/migrations/0012_contactassignment_custom_fields.py
@@ -6,7 +6,7 @@ import utilities.json
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('tenancy', '0011_contactassignment_tags'),
+        ('tenancy', '0002_squashed_0011'),
     ]
 
     operations = [

--- a/netbox/virtualization/migrations/0001_squashed_0022.py
+++ b/netbox/virtualization/migrations/0001_squashed_0022.py
@@ -13,10 +13,10 @@ class Migration(migrations.Migration):
     initial = True
 
     dependencies = [
-        ('dcim', '0002_auto_20160622_1821'),
-        ('ipam', '0001_initial'),
-        ('extras', '0001_initial'),
-        ('tenancy', '0001_initial'),
+        ('dcim', '0002_squashed'),
+        ('ipam', '0001_squashed'),
+        ('extras', '0001_squashed'),
+        ('tenancy', '0001_squashed_0012'),
     ]
 
     replaces = [

--- a/netbox/virtualization/migrations/0023_squashed_0036.py
+++ b/netbox/virtualization/migrations/0023_squashed_0036.py
@@ -28,7 +28,7 @@ class Migration(migrations.Migration):
         ('dcim', '0003_squashed_0130'),
         ('extras', '0098_webhook_custom_field_data_webhook_tags'),
         ('ipam', '0047_squashed_0053'),
-        ('virtualization', '0022_vminterface_parent'),
+        ('virtualization', '0001_squashed_0022'),
     ]
 
     operations = [

--- a/netbox/virtualization/migrations/0023_squashed_0036.py
+++ b/netbox/virtualization/migrations/0023_squashed_0036.py
@@ -26,7 +26,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('dcim', '0003_squashed_0130'),
-        ('extras', '0098_webhook_custom_field_data_webhook_tags'),
+        ('extras', '0087_squashed_0098'),
         ('ipam', '0047_squashed_0053'),
         ('virtualization', '0001_squashed_0022'),
     ]

--- a/netbox/virtualization/migrations/0037_protect_child_interfaces.py
+++ b/netbox/virtualization/migrations/0037_protect_child_interfaces.py
@@ -6,7 +6,7 @@ import django.db.models.deletion
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('virtualization', '0036_virtualmachine_config_template'),
+        ('virtualization', '0023_squashed_0036'),
     ]
 
     operations = [

--- a/netbox/vpn/migrations/0001_initial.py
+++ b/netbox/vpn/migrations/0001_initial.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ('contenttypes', '0002_remove_content_type_name'),
         ('extras', '0099_cachedvalue_ordering'),
-        ('ipam', '0067_ipaddress_index_host'),
+        ('ipam', '0054_squashed_0067'),
         ('tenancy', '0012_contactassignment_custom_fields'),
     ]
 

--- a/netbox/wireless/migrations/0001_squashed_0008.py
+++ b/netbox/wireless/migrations/0001_squashed_0008.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         ('ipam', '0002_squashed_0046'),
-        ('tenancy', '0007_contact_link'),
+        ('tenancy', '0002_squashed_0011'),
         ('extras', '0002_squashed_0059'),
         ('dcim', '0003_squashed_0130'),
     ]


### PR DESCRIPTION
### Fixes: #18808

After previously squashing migrations, many child migrations depending on those original migrations had not been updated to point to the new squashed migrations in `dependencies`. This caused errors when using `./manage.py sqlmigrate`.

This change fixes the `dependencies` of all erroneous migrations to point to the correct squashed parent migrations.