### PR TITLE
Fixes: #18582 Bulk import prefixes with associated VLAN not working when multiple VLANs with the same vid exist. 

### DIFF
--- a/netbox/ipam/forms/bulk_import.py
+++ b/netbox/ipam/forms/bulk_import.py
@@ -177,6 +177,13 @@ class PrefixImportForm(ScopedImportForm, NetBoxModelImportForm):
         to_field_name='name',
         help_text=_("VLAN's group (if any)")
     )
+    site = CSVModelChoiceField(
+        label=_('VLAN Site'),
+        queryset=Site.objects.all(),
+        required=False,
+        to_field_name='name',
+        help_text=_("VLAN's site (if any)")
+    )
     vlan = CSVModelChoiceField(
         label=_('VLAN'),
         queryset=VLAN.objects.all(),
@@ -200,8 +207,8 @@ class PrefixImportForm(ScopedImportForm, NetBoxModelImportForm):
     class Meta:
         model = Prefix
         fields = (
-            'prefix', 'vrf', 'tenant', 'vlan_group', 'vlan', 'status', 'role', 'scope_type', 'scope_id', 'is_pool',
-            'mark_utilized', 'description', 'comments', 'tags',
+            'prefix', 'vrf', 'tenant', 'vlan_group', 'site', 'vlan', 'status', 'role', 'scope_type', 'scope_id',
+            'is_pool', 'mark_utilized', 'description', 'comments', 'tags',
         )
         labels = {
             'scope_id': _('Scope ID'),

--- a/netbox/ipam/forms/bulk_import.py
+++ b/netbox/ipam/forms/bulk_import.py
@@ -177,7 +177,7 @@ class PrefixImportForm(ScopedImportForm, NetBoxModelImportForm):
         to_field_name='name',
         help_text=_("VLAN's group (if any)")
     )
-    site = CSVModelChoiceField(
+    vlan_site = CSVModelChoiceField(
         label=_('VLAN Site'),
         queryset=Site.objects.all(),
         required=False,
@@ -207,7 +207,7 @@ class PrefixImportForm(ScopedImportForm, NetBoxModelImportForm):
     class Meta:
         model = Prefix
         fields = (
-            'prefix', 'vrf', 'tenant', 'vlan_group', 'site', 'vlan', 'status', 'role', 'scope_type', 'scope_id',
+            'prefix', 'vrf', 'tenant', 'vlan_group', 'vlan_site', 'vlan', 'status', 'role', 'scope_type', 'scope_id',
             'is_pool', 'mark_utilized', 'description', 'comments', 'tags',
         )
         labels = {
@@ -220,19 +220,19 @@ class PrefixImportForm(ScopedImportForm, NetBoxModelImportForm):
         if not data:
             return
 
-        site = data.get('site')
+        vlan_site = data.get('vlan_site')
         vlan_group = data.get('vlan_group')
 
         # Limit VLAN queryset by assigned site and/or group (if specified)
         query = Q()
 
-        if site:
+        if vlan_site:
             query |= Q(**{
-                f"site__{self.fields['site'].to_field_name}": site
+                f"site__{self.fields['vlan_site'].to_field_name}": vlan_site
             })
             # Don't Forget to include VLANs without a site in the filter
             query |= Q(**{
-                f"site__{self.fields['site'].to_field_name}__isnull": True
+                f"site__{self.fields['vlan_site'].to_field_name}__isnull": True
             })
 
         if vlan_group:


### PR DESCRIPTION
### Fixes: #18582 Bulk import prefixes with associated VLAN not working when multiple VLANs with the same vid exist. 

- `PrefixImportForm` already implemented a test case for VLAN `Site` and `VLANGroup` [code](https://github.com/netbox-community/netbox/blob/29c25e39fce5b549d4d960bcc7a65379059855ac/netbox/ipam/forms/bulk_import.py#L222)
- Only a `CSVModelChoiceField` for vlan_group was implemented

The fix consisted in implementing a `CSVModelChoiceField` for `Site`

Aditional observations:

It should be possible to setup the `VLAN` queryset to the same as the Prefix scope if existent, but IMO that could lead to unwanted results, like:
- User Creates a `VLAN` that doesn't belong to any `Site`, that `VLAN` gonna be missing in the queryset.
