### PR TITLE
Fixes: #18557 Editing a Custom Field with Default Value does not pre-populate form with correct value

### DIFF
--- a/netbox/utilities/forms/fields/fields.py
+++ b/netbox/utilities/forms/fields/fields.py
@@ -111,7 +111,7 @@ class JSONField(_JSONField):
             try:
                 value = json.loads(value, cls=self.decoder)
             except json.decoder.JSONDecodeError:
-                return value
+                return f'"{value}"'
         return json.dumps(value, sort_keys=True, indent=4, ensure_ascii=False, cls=self.encoder)
 
 


### PR DESCRIPTION
### Fixes: #18557 Editing a Custom Field with Default Value does not pre-populate form with correct value

- `JSONField` from `utilities.forms.fields` writes strings as is, intead of enclosed by `"`
- Change the behaviour of `prepare_value` to add the extra `"`

This issue also affects other fields like:

`EventRule`'s `Action data` field

Doesn't find any other field that uses `JSONField` and stop working after the fix.