### PR TITLE
Fixes #18782: Misconfigured `ObjectListWidget`s now degrade gracefully

### DIFF
--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -9,6 +9,7 @@ import requests
 from django import forms
 from django.conf import settings
 from django.core.cache import cache
+from django.db.models import Model
 from django.template.loader import render_to_string
 from django.urls import NoReverseMatch, resolve, reverse
 from django.utils.translation import gettext as _
@@ -40,6 +41,27 @@ def get_object_type_choices():
         (object_type_identifier(ot), object_type_name(ot))
         for ot in ObjectType.objects.public().order_by('app_label', 'model')
     ]
+
+
+def object_list_widget_supports_model(model: Model) -> bool:
+    """Test whether a model is supported by the ObjectListWidget
+
+    In theory there could be more than one reason why a model isn't supported by the
+    ObjectListWidget, although we've only identified one so far--there's no resolve-able 'list' URL
+    for the model. Add more tests if more conditions arise.
+    """
+    def can_resolve_model_list_view(model: Model) -> bool:
+        try:
+            reverse(get_viewname(model, action='list'))
+            return True
+        except Exception:
+            return False
+
+    tests = [
+        can_resolve_model_list_view,
+    ]
+
+    return all(test(model) for test in tests)
 
 
 def get_bookmarks_object_type_choices():
@@ -233,6 +255,17 @@ class ObjectListWidget(DashboardWidget):
                 except (TypeError, ValueError):
                     raise forms.ValidationError(_("Invalid format. URL parameters must be passed as a dictionary."))
             return data
+
+        def clean_model(self):
+            if model_info := self.cleaned_data['model']:
+                app_label, model_name = model_info.split('.')
+                model = ObjectType.objects.get_by_natural_key(app_label, model_name).model_class()
+                if not object_list_widget_supports_model(model):
+                    raise forms.ValidationError(
+                        _(f"Invalid model selection: {self['model'].data} is not supported.")
+                    )
+
+            return model_info
 
     def render(self, request):
         app_label, model_name = self.config['model'].split('.')

--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -257,7 +257,7 @@ class ObjectListWidget(DashboardWidget):
             parameters['per_page'] = page_size
         parameters['embedded'] = True
 
-        if parameters:
+        if parameters and htmx_url is not None:
             try:
                 htmx_url = f'{htmx_url}?{urlencode(parameters, doseq=True)}'
             except ValueError:

--- a/netbox/extras/tests/test_dashboard.py
+++ b/netbox/extras/tests/test_dashboard.py
@@ -4,6 +4,11 @@ from extras.dashboard.widgets import ObjectListWidget
 
 
 class ObjectListWidgetTests(TestCase):
+    def test_widget_config_form_validates_model(self):
+        model_info = 'extras.notification'
+        form = ObjectListWidget.ConfigForm({'model': model_info})
+        self.assertFalse(form.is_valid())
+
     @tag('regression')
     def test_widget_fails_gracefully(self):
         """

--- a/netbox/extras/tests/test_dashboard.py
+++ b/netbox/extras/tests/test_dashboard.py
@@ -1,0 +1,43 @@
+from django.test import tag, TestCase
+
+from extras.dashboard.widgets import ObjectListWidget
+
+
+class ObjectListWidgetTests(TestCase):
+    @tag('regression')
+    def test_widget_fails_gracefully(self):
+        """
+        Example:
+        '2829fd9b-5dee-4c9a-81f2-5bd84c350a27': {
+            'class': 'extras.ObjectListWidget',
+            'color': 'indigo',
+            'title': 'Object List',
+            'config': {
+                'model': 'extras.notification',
+                'page_size': None,
+                'url_params': None
+            }
+        }
+        """
+        config = {
+            # 'class': 'extras.ObjectListWidget',  # normally popped off, left for clarity
+            'color': 'yellow',
+            'title': 'this should fail',
+            'config': {
+                'model': 'extras.notification',
+                'page_size': None,
+                'url_params': None,
+            },
+        }
+
+        class Request:
+            class User:
+                def has_perm(self, *args, **kwargs):
+                    return True
+
+            user = User()
+
+        mock_request = Request()
+        widget = ObjectListWidget(id='2829fd9b-5dee-4c9a-81f2-5bd84c350a27', **config)
+        rendered = widget.render(mock_request)
+        self.assertTrue('Unable to load content. Invalid view name:' in rendered)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18782 

This PR does two things to address this bug:
- Updated the check before `htmx_url` has query params added so that we don't try to add them to `None`. This has the effect of properly triggering the branch in the template that indicates this widget can not be displayed.
- It also adds validation for `ObjectListWidget.ConfigForm.model` via a `clean_model` method that checks to make sure that a model is supported by `ObjectListWidget` at the time of creation. This results in the following error for the user:
![image](https://github.com/user-attachments/assets/6396ca59-712b-489a-a8d5-918a87ef0cae)

I'm open to adjust that error message as needed.

I also played around with disabling unsupported object choices, but ended up not including those in the PR. Will add a screenshot if anyone is interested in seeing them.


<!--
    Please include a summary of the proposed changes below.
-->
