### PR TITLE
Fixes #18838: Correctly reject invalid falsy local context data

### DIFF
--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -1396,6 +1396,34 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.data['content'], f'Config for device {device.name}')
 
+    def test_valid_local_context_data(self):
+        self.add_permissions('dcim.change_device')
+        device = Device.objects.first()
+        url = reverse('dcim-api:device-detail', kwargs={'pk': device.pk})
+
+        response = self.client.patch(url, {"local_context_data": None}, format='json', **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
+        response = self.client.patch(url, {"local_context_data": {"foo": "bar"}}, format='json', **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
+    def test_invalid_local_context_data(self):
+        self.add_permissions('dcim.change_device')
+        device = Device.objects.first()
+        url = reverse('dcim-api:device-detail', kwargs={'pk': device.pk})
+
+        response = self.client.patch(url, {"local_context_data": ""}, format='json', **self.header)
+        self.assertContains(response, 'JSON data must be in object form.', status_code=status.HTTP_400_BAD_REQUEST)
+
+        response = self.client.patch(url, {"local_context_data": 0}, format='json', **self.header)
+        self.assertContains(response, 'JSON data must be in object form.', status_code=status.HTTP_400_BAD_REQUEST)
+
+        response = self.client.patch(url, {"local_context_data": False}, format='json', **self.header)
+        self.assertContains(response, 'JSON data must be in object form.', status_code=status.HTTP_400_BAD_REQUEST)
+
+        response = self.client.patch(url, {"local_context_data": "foo"}, format='json', **self.header)
+        self.assertContains(response, 'JSON data must be in object form.', status_code=status.HTTP_400_BAD_REQUEST)
+
 
 class ModuleTest(APIViewTestCases.APIViewTestCase):
     model = Module

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -1396,34 +1396,6 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.data['content'], f'Config for device {device.name}')
 
-    def test_valid_local_context_data(self):
-        self.add_permissions('dcim.change_device')
-        device = Device.objects.first()
-        url = reverse('dcim-api:device-detail', kwargs={'pk': device.pk})
-
-        response = self.client.patch(url, {"local_context_data": None}, format='json', **self.header)
-        self.assertHttpStatus(response, status.HTTP_200_OK)
-
-        response = self.client.patch(url, {"local_context_data": {"foo": "bar"}}, format='json', **self.header)
-        self.assertHttpStatus(response, status.HTTP_200_OK)
-
-    def test_invalid_local_context_data(self):
-        self.add_permissions('dcim.change_device')
-        device = Device.objects.first()
-        url = reverse('dcim-api:device-detail', kwargs={'pk': device.pk})
-
-        response = self.client.patch(url, {"local_context_data": ""}, format='json', **self.header)
-        self.assertContains(response, 'JSON data must be in object form.', status_code=status.HTTP_400_BAD_REQUEST)
-
-        response = self.client.patch(url, {"local_context_data": 0}, format='json', **self.header)
-        self.assertContains(response, 'JSON data must be in object form.', status_code=status.HTTP_400_BAD_REQUEST)
-
-        response = self.client.patch(url, {"local_context_data": False}, format='json', **self.header)
-        self.assertContains(response, 'JSON data must be in object form.', status_code=status.HTTP_400_BAD_REQUEST)
-
-        response = self.client.patch(url, {"local_context_data": "foo"}, format='json', **self.header)
-        self.assertContains(response, 'JSON data must be in object form.', status_code=status.HTTP_400_BAD_REQUEST)
-
 
 class ModuleTest(APIViewTestCases.APIViewTestCase):
     model = Module

--- a/netbox/extras/models/configs.py
+++ b/netbox/extras/models/configs.py
@@ -200,7 +200,7 @@ class ConfigContextModel(models.Model):
         super().clean()
 
         # Verify that JSON data is provided as an object
-        if self.local_context_data and type(self.local_context_data) is not dict:
+        if self.local_context_data is not None and type(self.local_context_data) is not dict:
             raise ValidationError(
                 {'local_context_data': _('JSON data must be in object form. Example:') + ' {"foo": 123}'}
             )

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -1,3 +1,4 @@
+from django.forms import ValidationError
 from django.test import TestCase
 
 from core.models import ObjectType
@@ -478,3 +479,30 @@ class ConfigContextTest(TestCase):
         annotated_queryset = Device.objects.filter(name=device.name).annotate_config_context_data()
         self.assertEqual(ConfigContext.objects.get_for_object(device).count(), 2)
         self.assertEqual(device.get_config_context(), annotated_queryset[0].get_config_context())
+
+    def test_valid_local_context_data(self):
+        device = Device.objects.first()
+        device.local_context_data = None
+        device.clean()
+
+        device.local_context_data = {"foo": "bar"}
+        device.clean()
+
+    def test_invalid_local_context_data(self):
+        device = Device.objects.first()
+
+        device.local_context_data = ""
+        with self.assertRaises(ValidationError):
+            device.clean()
+
+        device.local_context_data = 0
+        with self.assertRaises(ValidationError):
+            device.clean()
+
+        device.local_context_data = False
+        with self.assertRaises(ValidationError):
+            device.clean()
+
+        device.local_context_data = 'foo'
+        with self.assertRaises(ValidationError):
+            device.clean()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18838

Reject falsy values like the empty string, 0 or False as local context data.

I verified that `None`/`null` still works as expected and that an empty string in UI gets correctly converted to `None` before `clean()` is called.