### PR TITLE
Fixes: #18863 - Exempt MPTT-based models from centrally applying ordering on querysets

### DIFF
--- a/netbox/netbox/api/viewsets/__init__.py
+++ b/netbox/netbox/api/viewsets/__init__.py
@@ -12,6 +12,7 @@ from rest_framework.viewsets import GenericViewSet
 
 from utilities.api import get_annotations_for_serializer, get_prefetches_for_serializer
 from utilities.exceptions import AbortRequest
+from utilities.mptt import TreeManager
 from . import mixins
 
 __all__ = (
@@ -127,6 +128,9 @@ class NetBoxModelViewSet(
         https://code.djangoproject.com/ticket/32811
         """
         qs = super().get_queryset()
+        # MPTT-based models are exempt from this; use caution when annotating querysets of these models
+        if any(isinstance(manager, TreeManager) for manager in qs.model._meta.local_managers):
+            return qs
         ordering = qs.model._meta.ordering
         return qs.order_by(*ordering)
 

--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -27,8 +27,8 @@ from utilities.exceptions import AbortRequest, AbortTransaction, PermissionsViol
 from utilities.forms import BulkRenameForm, ConfirmationForm, restrict_form_fields
 from utilities.forms.bulk_import import BulkImportForm
 from utilities.htmx import htmx_partial
-from utilities.mptt import TreeManager
 from utilities.permissions import get_permission_for_model
+from utilities.query import reapply_model_ordering
 from utilities.views import GetReturnURLMixin, get_viewname
 from .base import BaseMultiObjectView
 from .mixins import ActionsMixin, TableMixin
@@ -127,16 +127,8 @@ class ObjectListView(BaseMultiObjectView, ActionsMixin, TableMixin):
     #
 
     def get_queryset(self, request):
-        """
-        Reapply model-level ordering in case it has been lost through .annotate().
-        https://code.djangoproject.com/ticket/32811
-        """
         qs = super().get_queryset(request)
-        # MPTT-based models are exempt from this; use caution when annotating querysets of these models
-        if any(isinstance(manager, TreeManager) for manager in qs.model._meta.local_managers):
-            return qs
-        ordering = qs.model._meta.ordering
-        return qs.order_by(*ordering)
+        return reapply_model_ordering(qs)
 
     def get(self, request):
         """

--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -27,6 +27,7 @@ from utilities.exceptions import AbortRequest, AbortTransaction, PermissionsViol
 from utilities.forms import BulkRenameForm, ConfirmationForm, restrict_form_fields
 from utilities.forms.bulk_import import BulkImportForm
 from utilities.htmx import htmx_partial
+from utilities.mptt import TreeManager
 from utilities.permissions import get_permission_for_model
 from utilities.views import GetReturnURLMixin, get_viewname
 from .base import BaseMultiObjectView
@@ -131,6 +132,9 @@ class ObjectListView(BaseMultiObjectView, ActionsMixin, TableMixin):
         https://code.djangoproject.com/ticket/32811
         """
         qs = super().get_queryset(request)
+        # MPTT-based models are exempt from this; use caution when annotating querysets of these models
+        if any(isinstance(manager, TreeManager) for manager in qs.model._meta.local_managers):
+            return qs
         ordering = qs.model._meta.ordering
         return qs.order_by(*ordering)
 


### PR DESCRIPTION
### Fixes: #18863

Because MPTT-based models rely on an implicit hierarchical ordering behavior, the central ordering of querysets of these models as introduced in https://github.com/netbox-community/netbox/issues/18729 causes its own unpredictability when using list views (which should preserve the hierarchical presentation). This includes models such as `Region`, `ContactGroup`, `TenantGroup`, etc.

This change identifies these models through checking `model._meta.local_managers` and exempts them from having `order_by` reapplied during list views in the API and UI.
