### PR TITLE
Fixes: #18833 Inventory Item Bulk Import - 'InventoryItemImportForm' has no field named 'component_id'.

### DIFF
--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -1164,8 +1164,8 @@ class InventoryItemImportForm(NetBoxModelImportForm):
     def clean(self):
         super().clean()
         cleaned_data = self.cleaned_data
-        component_type = cleaned_data.get('component_type', None)
-        component_name = cleaned_data.get('component_name', None)
+        component_type = cleaned_data.get('component_type')
+        component_name = cleaned_data.get('component_name')
         device = self.cleaned_data.get("device")
 
         if component_type:

--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -1161,27 +1161,35 @@ class InventoryItemImportForm(NetBoxModelImportForm):
         else:
             self.fields['parent'].queryset = InventoryItem.objects.none()
 
-    def clean_component_name(self):
-        content_type = self.cleaned_data.get('component_type')
-        component_name = self.cleaned_data.get('component_name')
+    def clean(self):
+        cleaned_data = self.cleaned_data
+        content_type = cleaned_data.get('component_type')
+        component_name = cleaned_data.get('component_name')
         device = self.cleaned_data.get("device")
 
-        if not device and hasattr(self, 'instance') and hasattr(self.instance, 'device'):
-            device = self.instance.device
-
-        if not all([device, content_type, component_name]):
-            return None
-
-        model = content_type.model_class()
-        try:
-            component = model.objects.get(device=device, name=component_name)
-            self.instance.component = component
-        except ObjectDoesNotExist:
-            raise forms.ValidationError(
-                _("Component not found: {device} - {component_name}").format(
-                    device=device, component_name=component_name
+        if content_type:
+            if device is None:
+                cleaned_data.pop('component_type')
+            if component_name is None:
+                cleaned_data.pop('component_type')
+                raise forms.ValidationError(
+                    _("Component name must be specified when component type is specified")
                 )
-            )
+            if all([device, component_name]):
+                try:
+                    model = content_type.model_class()
+                    component = model.objects.get(device=device, name=component_name)
+                    self.instance.component = component
+                except ObjectDoesNotExist:
+                    cleaned_data.pop('component_type')
+                    cleaned_data.pop('component_name')
+                    raise forms.ValidationError(
+                        _("Component not found: {device} - {component_name}").format(
+                            device=device, component_name=component_name
+                        )
+                    )
+
+        return cleaned_data
 
 
 #

--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -1164,15 +1164,15 @@ class InventoryItemImportForm(NetBoxModelImportForm):
     def clean(self):
         super().clean()
         cleaned_data = self.cleaned_data
-        component_type = cleaned_data.get('component_type')
-        component_name = cleaned_data.get('component_name')
+        component_type = cleaned_data.get('component_type', None)
+        component_name = cleaned_data.get('component_name', None)
         device = self.cleaned_data.get("device")
 
         if component_type:
             if device is None:
-                cleaned_data.pop('component_type')
+                cleaned_data.pop('component_type', None)
             if component_name is None:
-                cleaned_data.pop('component_type')
+                cleaned_data.pop('component_type', None)
                 raise forms.ValidationError(
                     _("Component name must be specified when component type is specified")
                 )
@@ -1181,12 +1181,18 @@ class InventoryItemImportForm(NetBoxModelImportForm):
                     model = component_type.model_class()
                     self.instance.component = model.objects.get(device=device, name=component_name)
                 except ObjectDoesNotExist:
-                    cleaned_data.pop('component_type')
-                    cleaned_data.pop('component_name')
+                    cleaned_data.pop('component_type', None)
+                    cleaned_data.pop('component_name', None)
                     raise forms.ValidationError(
                         _("Component not found: {device} - {component_name}").format(
                             device=device, component_name=component_name
                         )
+                    )
+            else:
+                cleaned_data.pop('component_type', None)
+                if not component_name:
+                    raise forms.ValidationError(
+                        _("Component name must be specified when component type is specified")
                     )
         else:
             if component_name:


### PR DESCRIPTION
### Fixes: #18833 Inventory Item Bulk Import - 'InventoryItemImportForm' has no field named 'component_id'.

### Root Cause:

In Django's `BaseModelForm` `_post_clean` method, an instance of the model is created with data from `self.cleaned_data`. After the model instantiation, the `full_clean()` method is executed on that model instance.  
Since `component_type` is a field of the `InventoryItem` model, the execution of `full_clean()` on the instance was failing without being captured by any form validation method.

### Solution:

In Django's form validation process, the `clean_<fieldname>()` methods are executed before the `clean_form()` method. Inside the `clean_<fieldname>()` method, there are no guarantees about which field names have already been processed and is available at `self.cleaned_data`.And to fully validate `component_type` use cases, the `device`, `component_type`, and `component_name` fields must be available.  

To fix the validation process, the `clean_component_name` method was replaced by the `clean` method, and the fields `component_name` and `component_type` were removed from `cleaned_data` when incorrect data was provided.  


