### PR TITLE
Fixes #18872: JournalEntry `kind` is a required field

### DIFF
--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -14,7 +14,7 @@ from netbox.events import get_event_type_choices
 from netbox.forms import NetBoxModelForm
 from tenancy.models import Tenant, TenantGroup
 from users.models import Group, User
-from utilities.forms import add_blank_choice, get_field_value
+from utilities.forms import get_field_value
 from utilities.forms.fields import (
     CommentField, ContentTypeChoiceField, ContentTypeMultipleChoiceField, DynamicModelChoiceField,
     DynamicModelMultipleChoiceField, JSONField, SlugField,
@@ -687,8 +687,7 @@ class ImageAttachmentForm(forms.ModelForm):
 class JournalEntryForm(NetBoxModelForm):
     kind = forms.ChoiceField(
         label=_('Kind'),
-        choices=add_blank_choice(JournalEntryKindChoices),
-        required=False
+        choices=JournalEntryKindChoices
     )
     comments = CommentField()
 

--- a/netbox/extras/migrations/0123_journalentry_kind_default.py
+++ b/netbox/extras/migrations/0123_journalentry_kind_default.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+from extras.choices import JournalEntryKindChoices
+
+
+def set_kind_default(apps, schema_editor):
+    """
+    Set kind to "info" on any entries with no kind assigned.
+    """
+    JournalEntry = apps.get_model('extras', 'JournalEntry')
+    JournalEntry.objects.filter(kind='').update(kind=JournalEntryKindChoices.KIND_INFO)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('extras', '0122_charfield_null_choices'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            code=set_kind_default,
+            reverse_code=migrations.RunPython.noop
+        ),
+    ]


### PR DESCRIPTION
### Fixes: #18872

- Mark `kind` as a required field on JournalEntryForm
- Include a migration to update any journal entries with no kind assigned to "info"