### PR TITLE
Closes #18820: Bump minimum PostgreSQL version to 14

### DIFF
--- a/docs/configuration/required-parameters.md
+++ b/docs/configuration/required-parameters.md
@@ -25,7 +25,7 @@ ALLOWED_HOSTS = ['*']
 
 ## DATABASE
 
-NetBox requires access to a PostgreSQL 13 or later database service to store data. This service can run locally on the NetBox server or on a remote system. The following parameters must be defined within the `DATABASE` dictionary:
+NetBox requires access to a PostgreSQL 14 or later database service to store data. This service can run locally on the NetBox server or on a remote system. The following parameters must be defined within the `DATABASE` dictionary:
 
 * `NAME` - Database name
 * `USER` - PostgreSQL username

--- a/docs/installation/1-postgresql.md
+++ b/docs/installation/1-postgresql.md
@@ -2,8 +2,8 @@
 
 This section entails the installation and configuration of a local PostgreSQL database. If you already have a PostgreSQL database service in place, skip to [the next section](2-redis.md).
 
-!!! warning "PostgreSQL 13 or later required"
-    NetBox requires PostgreSQL 13 or later. Please note that MySQL and other relational databases are **not** supported.
+!!! warning "PostgreSQL 14 or later required"
+    NetBox requires PostgreSQL 14 or later. Please note that MySQL and other relational databases are **not** supported.
 
 ## Installation
 
@@ -34,7 +34,7 @@ This section entails the installation and configuration of a local PostgreSQL da
     sudo systemctl enable --now postgresql
     ```
 
-Before continuing, verify that you have installed PostgreSQL 13 or later:
+Before continuing, verify that you have installed PostgreSQL 14 or later:
 
 ```no-highlight
 psql -V

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -21,7 +21,7 @@ The following sections detail how to set up a new instance of NetBox:
 | Dependency | Supported Versions |
 |------------|--------------------|
 | Python     | 3.10, 3.11, 3.12   |
-| PostgreSQL | 13+                |
+| PostgreSQL | 14+                |
 | Redis      | 4.0+               |
 
 Below is a simplified overview of the NetBox application stack for reference:

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -20,7 +20,7 @@ NetBox requires the following dependencies:
 | Dependency | Supported Versions |
 |------------|--------------------|
 | Python     | 3.10, 3.11, 3.12   |
-| PostgreSQL | 13+                |
+| PostgreSQL | 14+                |
 | Redis      | 4.0+               |
 
 ## 3. Install the Latest Release

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -79,5 +79,5 @@ NetBox is built on the [Django](https://djangoproject.com/) Python framework and
 | HTTP service       | nginx or Apache   |
 | WSGI service       | gunicorn or uWSGI |
 | Application        | Django/Python     |
-| Database           | PostgreSQL 13+    |
+| Database           | PostgreSQL 14+    |
 | Task queuing       | Redis/django-rq   |


### PR DESCRIPTION
### Fixes: #18820

Dump minimum supported PostgreSQL version from 13 to 14.