### PR TITLE
Fixes #18928: Fix support for cascading deletions when cleaning up expired changelog records

### DIFF
--- a/netbox/extras/management/commands/housekeeping.py
+++ b/netbox/extras/management/commands/housekeeping.py
@@ -5,7 +5,6 @@ import requests
 from django.conf import settings
 from django.core.cache import cache
 from django.core.management.base import BaseCommand
-from django.db import DEFAULT_DB_ALIAS
 from django.utils import timezone
 from packaging import version
 
@@ -53,7 +52,7 @@ class Command(BaseCommand):
                         ending=""
                     )
                     self.stdout.flush()
-                ObjectChange.objects.filter(time__lt=cutoff)._raw_delete(using=DEFAULT_DB_ALIAS)
+                ObjectChange.objects.filter(time__lt=cutoff).delete()
                 if options['verbosity']:
                     self.stdout.write("Done.", self.style.SUCCESS)
             elif options['verbosity']:


### PR DESCRIPTION
### Fixes: #18928

- Use the conventional `delete()` method rather than `_raw_delete()`

Note: This _will_ have some performance impact, but it should be negligible in most circumstances. It's not expected to be concerning as the housekeeping task is typically run in the background anyway.