### PR TITLE
Fixes #18926: Uses correct icon for base GitHub auth

### DIFF
--- a/netbox/netbox/authentication/__init__.py
+++ b/netbox/netbox/authentication/__init__.py
@@ -28,7 +28,7 @@ AUTH_BACKEND_ATTRS = {
     'bitbucket-oauth2': ('BitBucket', 'bitbucket'),
     'digitalocean': ('DigitalOcean', 'digital-ocean'),
     'docker': ('Docker', 'docker'),
-    'github': ('GitHub', 'docker'),
+    'github': ('GitHub', 'github'),
     'github-app': ('GitHub', 'github'),
     'github-org': ('GitHub', 'github'),
     'github-team': ('GitHub', 'github'),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18926 

- corrects GitHub auth MDI icon from `docker` to `github`

<!--
    Please include a summary of the proposed changes below.
-->
