### PR TITLE
Fixes #18944: Clearing widget type field no longer causes 500 error

### DIFF
--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1103,7 +1103,7 @@ class DashboardWidgetAddView(LoginRequiredMixin, View):
         }
         widget_form = DashboardWidgetAddForm(initial=initial)
         widget_name = get_field_value(widget_form, 'widget_class')
-        widget_class = get_widget_class(widget_name)
+        widget_class = get_widget_class(widget_name or 'extras.NoteWidget')
         config_form = widget_class.ConfigForm(initial=widget_class.default_config, prefix='config')
 
         return render(request, self.template_name, {

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1098,12 +1098,12 @@ class DashboardWidgetAddView(LoginRequiredMixin, View):
         if not request.htmx:
             return redirect('home')
 
-        initial = request.GET or {
-            'widget_class': 'extras.NoteWidget',
+        initial = {
+            'widget_class': request.GET.get('widget_class') or 'extras.NoteWidget',
         }
         widget_form = DashboardWidgetAddForm(initial=initial)
         widget_name = get_field_value(widget_form, 'widget_class')
-        widget_class = get_widget_class(widget_name or 'extras.NoteWidget')
+        widget_class = get_widget_class(widget_name)
         config_form = widget_class.ConfigForm(initial=widget_class.default_config, prefix='config')
 
         return render(request, self.template_name, {


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18944 

I don't love this fix since the feedback to the user is pretty bad--it just resets the form to defaults without explaining what happened. I didn't find an easy way to include an error message for the 'Widget type' field on GET (so that it might show in the UI) but that may just be me missing something.

I also took a quick look at our `DynamicTomSelect` code and didn't see an immediate way to fix this there.

Either way, I think it's worth getting at least this fix in for the time being to remove a potentially very visible 500 error for users with better user feedback in a follow up fix. But, I'm open to other options. Thoughts?

<!--
    Please include a summary of the proposed changes below.
-->
