### PR TITLE
Fixes: #18933 VLANGroupFilterSet site_group field doesn't match VLANGroupFilterForm sitegroup field

### DIFF
--- a/netbox/ipam/forms/filtersets.py
+++ b/netbox/ipam/forms/filtersets.py
@@ -418,7 +418,7 @@ class FHRPGroupFilterForm(NetBoxModelFilterSetForm):
 class VLANGroupFilterForm(NetBoxModelFilterSetForm):
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('region', 'sitegroup', 'site', 'location', 'rack', name=_('Location')),
+        FieldSet('region', 'site_group', 'site', 'location', 'rack', name=_('Location')),
         FieldSet('cluster_group', 'cluster', name=_('Cluster')),
         FieldSet('contains_vid', name=_('VLANs')),
     )
@@ -428,7 +428,7 @@ class VLANGroupFilterForm(NetBoxModelFilterSetForm):
         required=False,
         label=_('Region')
     )
-    sitegroup = DynamicModelMultipleChoiceField(
+    site_group = DynamicModelMultipleChoiceField(
         queryset=SiteGroup.objects.all(),
         required=False,
         label=_('Site group')


### PR DESCRIPTION
### Fixes: #18933 VLANGroupFilterSet site_group field doesn't match VLANGroupFilterForm sitegroup field

Fixes `site_group` field typo, it was defined as `sitegroup` in the `FilterForm` and as `site_group` in the `FilterSet`
Followed `site_group` pattern as it was already used in other places like:
`ProviderFilterSet`, `CircuitTerminationFilterSet`, `LocationFilterSet` and several others