### PR TITLE
Fixes: #18656 Unable to import IP Address and assign to FHRP Group

### DIFF
--- a/netbox/ipam/forms/bulk_import.py
+++ b/netbox/ipam/forms/bulk_import.py
@@ -328,11 +328,11 @@ class IPAddressImportForm(NetBoxModelImportForm):
         help_text=_('Assigned interface')
     )
     fhrpgroup = CSVModelChoiceField(
-        label=_('FHRP Group (ID)'),
+        label=_('FHRP Group'),
         queryset=FHRPGroup.objects.all(),
         required=False,
-        to_field_name='group_id',
-        help_text=_('Assigned FHRP Group ID')
+        to_field_name='name',
+        help_text=_('Assigned FHRP Group name')
     )
     is_primary = forms.BooleanField(
         label=_('Is primary'),

--- a/netbox/ipam/forms/bulk_import.py
+++ b/netbox/ipam/forms/bulk_import.py
@@ -327,6 +327,13 @@ class IPAddressImportForm(NetBoxModelImportForm):
         to_field_name='name',
         help_text=_('Assigned interface')
     )
+    fhrpgroup = CSVModelChoiceField(
+        label=_('FHRP Group (ID)'),
+        queryset=FHRPGroup.objects.all(),
+        required=False,
+        to_field_name='group_id',
+        help_text=_('Assigned FHRP Group ID')
+    )
     is_primary = forms.BooleanField(
         label=_('Is primary'),
         help_text=_('Make this the primary IP for the assigned device'),
@@ -341,8 +348,8 @@ class IPAddressImportForm(NetBoxModelImportForm):
     class Meta:
         model = IPAddress
         fields = [
-            'address', 'vrf', 'tenant', 'status', 'role', 'device', 'virtual_machine', 'interface', 'is_primary',
-            'is_oob', 'dns_name', 'description', 'comments', 'tags',
+            'address', 'vrf', 'tenant', 'status', 'role', 'device', 'virtual_machine', 'interface', 'fhrpgroup',
+            'is_primary', 'is_oob', 'dns_name', 'description', 'comments', 'tags',
         ]
 
     def __init__(self, data=None, *args, **kwargs):
@@ -398,6 +405,8 @@ class IPAddressImportForm(NetBoxModelImportForm):
         # Set interface assignment
         if self.cleaned_data.get('interface'):
             self.instance.assigned_object = self.cleaned_data['interface']
+        if self.cleaned_data.get('fhrpgroup'):
+            self.instance.assigned_object = self.cleaned_data['fhrpgroup']
 
         ipaddress = super().save(*args, **kwargs)
 

--- a/netbox/ipam/forms/bulk_import.py
+++ b/netbox/ipam/forms/bulk_import.py
@@ -327,7 +327,7 @@ class IPAddressImportForm(NetBoxModelImportForm):
         to_field_name='name',
         help_text=_('Assigned interface')
     )
-    fhrpgroup = CSVModelChoiceField(
+    fhrp_group = CSVModelChoiceField(
         label=_('FHRP Group'),
         queryset=FHRPGroup.objects.all(),
         required=False,
@@ -348,7 +348,7 @@ class IPAddressImportForm(NetBoxModelImportForm):
     class Meta:
         model = IPAddress
         fields = [
-            'address', 'vrf', 'tenant', 'status', 'role', 'device', 'virtual_machine', 'interface', 'fhrpgroup',
+            'address', 'vrf', 'tenant', 'status', 'role', 'device', 'virtual_machine', 'interface', 'fhrp_group',
             'is_primary', 'is_oob', 'dns_name', 'description', 'comments', 'tags',
         ]
 
@@ -405,8 +405,8 @@ class IPAddressImportForm(NetBoxModelImportForm):
         # Set interface assignment
         if self.cleaned_data.get('interface'):
             self.instance.assigned_object = self.cleaned_data['interface']
-        if self.cleaned_data.get('fhrpgroup'):
-            self.instance.assigned_object = self.cleaned_data['fhrpgroup']
+        if self.cleaned_data.get('fhrp_group'):
+            self.instance.assigned_object = self.cleaned_data['fhrp_group']
 
         ipaddress = super().save(*args, **kwargs)
 

--- a/netbox/ipam/tests/test_views.py
+++ b/netbox/ipam/tests/test_views.py
@@ -666,6 +666,24 @@ class IPAddressTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 
         tags = create_tags('Alpha', 'Bravo', 'Charlie')
 
+        fhrp_groups = (
+            FHRPGroup(
+                name='FHRP Group 1',
+                protocol=FHRPGroupProtocolChoices.PROTOCOL_HSRP,
+                group_id=10
+            ),
+            FHRPGroup(
+                name='FHRP Group 2',
+                protocol=FHRPGroupProtocolChoices.PROTOCOL_HSRP,
+                group_id=20
+            ),
+            FHRPGroup(
+                name='FHRP Group 3',
+                protocol=FHRPGroupProtocolChoices.PROTOCOL_HSRP,
+                group_id=30
+            ),
+        )
+        FHRPGroup.objects.bulk_create(fhrp_groups)
         cls.form_data = {
             'vrf': vrfs[1].pk,
             'address': IPNetwork('192.0.2.99/24'),
@@ -679,10 +697,10 @@ class IPAddressTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         }
 
         cls.csv_data = (
-            "vrf,address,status",
-            "VRF 1,192.0.2.4/24,active",
-            "VRF 1,192.0.2.5/24,active",
-            "VRF 1,192.0.2.6/24,active",
+            "vrf,address,status,fhrp_group",
+            "VRF 1,192.0.2.4/24,active,FHRP Group 1",
+            "VRF 1,192.0.2.5/24,active,FHRP Group 2",
+            "VRF 1,192.0.2.6/24,active,FHRP Group 3",
         )
 
         cls.csv_update_data = (


### PR DESCRIPTION
### Fixes: #18656 Unable to import IP Address and assign to FHRP Group

- Created the `fhrpgroup` field in `IPAddressImportForm`


#### Observations:

Since [FHRPGroup Model](https://github.com/netbox-community/netbox/blob/7c152e92340779a889bfe5ebec7d6c97c230fc72/netbox/ipam/models/fhrp.py#L54) doesn't implement uniqueness method, choosing the appropriated accessor for the `fhrpgroup` its a bit tricky.
I choose `name` instead of the `group_id` beacuse, IMO, `group_id` is more likely to get repeated, but maybe a more accurate approach could be open a new Issue to setup some uniqueness criteria for FHRPGroup, make the import form following that pattern.