### PR TITLE
Fixes #18949: Add missing GraphQL ContactsMixin in types with ContactAssignments

### DIFF
--- a/netbox/circuits/graphql/types.py
+++ b/netbox/circuits/graphql/types.py
@@ -43,7 +43,7 @@ class ProviderType(NetBoxObjectType, ContactsMixin):
     fields='__all__',
     filters=ProviderAccountFilter
 )
-class ProviderAccountType(NetBoxObjectType):
+class ProviderAccountType(ContactsMixin, NetBoxObjectType):
     provider: Annotated["ProviderType", strawberry.lazy('circuits.graphql.types')]
 
     circuits: List[Annotated["CircuitType", strawberry.lazy('circuits.graphql.types')]]

--- a/netbox/ipam/graphql/types.py
+++ b/netbox/ipam/graphql/types.py
@@ -5,6 +5,7 @@ import strawberry_django
 
 from circuits.graphql.types import ProviderType
 from dcim.graphql.types import SiteType
+from extras.graphql.mixins import ContactsMixin
 from ipam import models
 from netbox.graphql.scalars import BigInt
 from netbox.graphql.types import BaseObjectType, NetBoxObjectType, OrganizationalObjectType
@@ -83,7 +84,7 @@ class ASNRangeType(NetBoxObjectType):
     fields='__all__',
     filters=AggregateFilter
 )
-class AggregateType(NetBoxObjectType, BaseIPAddressFamilyType):
+class AggregateType(NetBoxObjectType, ContactsMixin, BaseIPAddressFamilyType):
     prefix: str
     rir: Annotated["RIRType", strawberry.lazy('ipam.graphql.types')] | None
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
@@ -120,7 +121,7 @@ class FHRPGroupAssignmentType(BaseObjectType):
     exclude=('assigned_object_type', 'assigned_object_id', 'address'),
     filters=IPAddressFilter
 )
-class IPAddressType(NetBoxObjectType, BaseIPAddressFamilyType):
+class IPAddressType(NetBoxObjectType, ContactsMixin, BaseIPAddressFamilyType):
     address: str
     vrf: Annotated["VRFType", strawberry.lazy('ipam.graphql.types')] | None
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
@@ -144,7 +145,7 @@ class IPAddressType(NetBoxObjectType, BaseIPAddressFamilyType):
     fields='__all__',
     filters=IPRangeFilter
 )
-class IPRangeType(NetBoxObjectType):
+class IPRangeType(NetBoxObjectType, ContactsMixin):
     start_address: str
     end_address: str
     vrf: Annotated["VRFType", strawberry.lazy('ipam.graphql.types')] | None
@@ -157,7 +158,7 @@ class IPRangeType(NetBoxObjectType):
     exclude=('scope_type', 'scope_id', '_location', '_region', '_site', '_site_group'),
     filters=PrefixFilter
 )
-class PrefixType(NetBoxObjectType, BaseIPAddressFamilyType):
+class PrefixType(NetBoxObjectType, ContactsMixin, BaseIPAddressFamilyType):
     prefix: str
     vrf: Annotated["VRFType", strawberry.lazy('ipam.graphql.types')] | None
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
@@ -217,7 +218,7 @@ class RouteTargetType(NetBoxObjectType):
     fields='__all__',
     filters=ServiceFilter
 )
-class ServiceType(NetBoxObjectType):
+class ServiceType(NetBoxObjectType, ContactsMixin):
     ports: List[int]
     device: Annotated["DeviceType", strawberry.lazy('dcim.graphql.types')] | None
     virtual_machine: Annotated["VirtualMachineType", strawberry.lazy('virtualization.graphql.types')] | None

--- a/netbox/tenancy/graphql/types.py
+++ b/netbox/tenancy/graphql/types.py
@@ -3,7 +3,7 @@ from typing import Annotated, List
 import strawberry
 import strawberry_django
 
-from extras.graphql.mixins import CustomFieldsMixin, TagsMixin
+from extras.graphql.mixins import CustomFieldsMixin, TagsMixin, ContactsMixin
 from netbox.graphql.types import BaseObjectType, OrganizationalObjectType, NetBoxObjectType
 from tenancy import models
 from .mixins import ContactAssignmentsMixin
@@ -28,7 +28,7 @@ __all__ = (
     fields='__all__',
     filters=TenantFilter
 )
-class TenantType(NetBoxObjectType):
+class TenantType(ContactsMixin, NetBoxObjectType):
     group: Annotated["TenantGroupType", strawberry.lazy('tenancy.graphql.types')] | None
 
     asns: List[Annotated["ASNType", strawberry.lazy('ipam.graphql.types')]]

--- a/netbox/virtualization/graphql/types.py
+++ b/netbox/virtualization/graphql/types.py
@@ -33,7 +33,7 @@ class ComponentType(NetBoxObjectType):
     exclude=('scope_type', 'scope_id', '_location', '_region', '_site', '_site_group'),
     filters=ClusterFilter
 )
-class ClusterType(VLANGroupsMixin, NetBoxObjectType):
+class ClusterType(ContactsMixin, VLANGroupsMixin, NetBoxObjectType):
     type: Annotated["ClusterTypeType", strawberry.lazy('virtualization.graphql.types')] | None
     group: Annotated["ClusterGroupType", strawberry.lazy('virtualization.graphql.types')] | None
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
@@ -55,7 +55,7 @@ class ClusterType(VLANGroupsMixin, NetBoxObjectType):
     fields='__all__',
     filters=ClusterGroupFilter
 )
-class ClusterGroupType(VLANGroupsMixin, OrganizationalObjectType):
+class ClusterGroupType(ContactsMixin, VLANGroupsMixin, OrganizationalObjectType):
 
     clusters: List[Annotated["ClusterType", strawberry.lazy('virtualization.graphql.types')]]
 

--- a/netbox/vpn/graphql/types.py
+++ b/netbox/vpn/graphql/types.py
@@ -27,7 +27,7 @@ __all__ = (
     fields='__all__',
     filters=TunnelGroupFilter
 )
-class TunnelGroupType(OrganizationalObjectType):
+class TunnelGroupType(ContactsMixin, OrganizationalObjectType):
 
     tunnels: List[Annotated["TunnelType", strawberry.lazy('vpn.graphql.types')]]
 
@@ -48,7 +48,7 @@ class TunnelTerminationType(CustomFieldsMixin, TagsMixin, ObjectType):
     fields='__all__',
     filters=TunnelFilter
 )
-class TunnelType(NetBoxObjectType):
+class TunnelType(ContactsMixin, NetBoxObjectType):
     group: Annotated["TunnelGroupType", strawberry.lazy('vpn.graphql.types')] | None
     ipsec_profile: Annotated["IPSecProfileType", strawberry.lazy('vpn.graphql.types')] | None
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18949

<!--
    Please include a summary of the proposed changes below.
-->

* Add missing `ContactMixin` in GraphQL for all the types that have `ContactMixin` in `models/` but not in `graphql/types.py`.
