### PR TITLE
Closes #18980: Optimize update of object data when adding/removing custom fields

### DIFF
--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -304,9 +304,10 @@ class CustomField(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel):
         no longer assigned to a model, or because it has been deleted).
         """
         for ct in content_types:
-            ct.model_class().objects.update(
-                custom_field_data=F('custom_field_data') - self.name
-            )
+            if model := ct.model_class():
+                model.objects.update(
+                    custom_field_data=F('custom_field_data') - self.name
+                )
 
     def rename_object_data(self, old_name, new_name):
         """


### PR DESCRIPTION
### Fixes: #18980

- `populate_initial_data()` now uses the PostgreSQL-native `jsonb_set()` function to set initial values on objects when creating a custom field
- `remove_stale_data()` now uses native JSON mutation to remove the keys for deleted custom fields
- `rename_object_data()` has likewise been optimized to rename custom field keys in object data using `jsonb_set()`

A quick test using a REST API call adding a custom field to ~11,000 interfaces took 0.543s with this change versus 5.556s in `main`.