### PR TITLE
Fixes #18964 Select all with bulk edit only changes the currently visible objects

### DIFF
--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -700,6 +700,10 @@ class BulkEditView(GetReturnURLMixin, BaseMultiObjectView):
             else:
                 logger.debug("Form validation failed")
 
+        else:
+            form = self.form(initial=initial_data)
+            restrict_form_fields(form, request.user)
+
         # Retrieve objects being edited
         table = self.table(self.queryset.filter(pk__in=pk_list), orderable=False)
         if not table.rows:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18964 

Select all with bulk edit only changes the currently visible objects.

Reinsert the else condition that have disappeared here: https://github.com/netbox-community/netbox/pull/18197 to have the edit all work again.
