### PR TITLE
Fixes #18991: AttributeError: NoneType object has not attribute model

### DIFF
--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -1,6 +1,6 @@
 import json
 
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse
 from django.utils.translation import gettext as _
 from rest_framework import status
@@ -1904,6 +1904,27 @@ class FrontPortTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+    @tag('regression')  # Issue #18991
+    def test_front_port_paths(self):
+        device = Device.objects.first()
+        rear_port = RearPort.objects.create(
+            device=device, name='Rear Port 10', type=PortTypeChoices.TYPE_8P8C
+        )
+        interface1 = Interface.objects.create(device=device, name='Interface 1')
+        front_port = FrontPort.objects.create(
+            device=device,
+            name='Rear Port 10',
+            type=PortTypeChoices.TYPE_8P8C,
+            rear_port=rear_port,
+        )
+        Cable.objects.create(a_terminations=[interface1], b_terminations=[front_port])
+
+        self.add_permissions(f'dcim.view_{self.model._meta.model_name}')
+        url = reverse(f'dcim-api:{self.model._meta.model_name}-paths', kwargs={'pk': front_port.pk})
+        response = self.client.get(url, **self.header)
+
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
 
 class RearPortTest(APIViewTestCases.APIViewTestCase):
     model = RearPort
@@ -1946,6 +1967,23 @@ class RearPortTest(APIViewTestCases.APIViewTestCase):
                 'type': PortTypeChoices.TYPE_8P8C,
             },
         ]
+
+    @tag('regression')  # Issue #18991
+    def test_rear_port_paths(self):
+        device = Device.objects.first()
+        interface1 = Interface.objects.create(device=device, name='Interface 1')
+        rear_port = RearPort.objects.create(
+            device=device,
+            name='Rear Port 10',
+            type=PortTypeChoices.TYPE_8P8C,
+        )
+        Cable.objects.create(a_terminations=[interface1], b_terminations=[rear_port])
+
+        self.add_permissions(f'dcim.view_{self.model._meta.model_name}')
+        url = reverse(f'dcim-api:{self.model._meta.model_name}-paths', kwargs={'pk': rear_port.pk})
+        response = self.client.get(url, **self.header)
+
+        self.assertHttpStatus(response, status.HTTP_200_OK)
 
 
 class ModuleBayTest(APIViewTestCases.APIViewTestCase):

--- a/netbox/utilities/fields.py
+++ b/netbox/utilities/fields.py
@@ -198,9 +198,9 @@ class GenericArrayForeignKey(FieldCacheMixin, models.Field):
     Provide a generic many-to-many relation through an 2d array field
     """
 
-    many_to_many = True
+    many_to_many = False
     many_to_one = False
-    one_to_many = False
+    one_to_many = True
     one_to_one = False
 
     def __init__(self, field, for_concrete_model=True):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18991 

`GenericArrayForeignKey`, which was added in #18826, advertised itself as a many_to_many relation, which is seemingly somewhat inaccurate and [triggered DRF's introspection of many_to_many relations](https://github.com/encode/django-rest-framework/blob/73cbb9cd4acd36f859d9f656b8f134c9d2a754f3/rest_framework/utils/model_meta.py#L88-L101) which looks for a `remote_field.model` property chain on the relation. Since that doesn't exist, DRF threw an AttributeError resulting in a 500 error.

This changes `GenericArrayForeignKey` to advertise itself to DRF as a one_to_many relation, which is more accurate, and does not trigger the property access in DRF that was causing the problem.

This also adds a regression test for both FrontPort and RearPort "path" API views.


<!--
    Please include a summary of the proposed changes below.
-->
