### PR TITLE
Fixes #18965: Ensure script list run buttons respect scripts' commit_default option

### DIFF
--- a/netbox/templates/extras/script_list.html
+++ b/netbox/templates/extras/script_list.html
@@ -63,7 +63,7 @@
                         </span>
                       {% endif %}
                     </td>
-                    <td>{{ script.python_class.Meta.description|markdown|placeholder }}</td>
+                    <td>{{ script.python_class.description|markdown|placeholder }}</td>
                     {% if last_job %}
                       <td>
                         <a href="{% url 'extras:script_result' job_pk=last_job.pk %}">{{ last_job.created|isodatetime }}</a>

--- a/netbox/templates/extras/script_list.html
+++ b/netbox/templates/extras/script_list.html
@@ -79,6 +79,9 @@
                       {% if request.user|can_run:script and script.is_executable %}
                         <div class="float-end d-print-none">
                           <form action="{% url 'extras:script' script.pk %}" method="post">
+                            {% if script.python_class.commit_default %}
+                              <input type="checkbox" name="_commit" hidden checked>
+                            {% endif %}
                             {% csrf_token %}
                             <button type="submit" name="_run" class="btn btn-primary btn-sm">
                               {% if last_job %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18965

For the ScriptListView, we're rendering one-off forms directly in HTML for each of the scripts in a module. Previous to this change, that form consisted only of a hidden CSRF token input and the Run/Run Again button. This meant that that the post handler was interpreting the incoming `request.POST` as indicating `_commit=False`, essentially.

This change checks the script's associated `python_class.commit_default` attribute and conditionally renders a hidden `_commit` checkbox input for each script's form in ScriptListView so that the post handler will behave accordingly. This has the added benefit of ensuring that the commit default checkbox button is rendered checked or not correctly on the subsequent ScriptView if the RQ worker is not available.
<!--
    Please include a summary of the proposed changes below.
-->
