### PR TITLE
Fixes #18738: Ensure ScriptList respects script_order option

### DIFF
--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -118,6 +118,15 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
         return self.python_name
 
     @property
+    def ordered_scripts(self):
+        script_objects = {s.name: s for s in self.scripts.all()}
+        ordered = [
+            script_objects.pop(sc) for sc in self.module_scripts.keys() if sc in script_objects
+        ]
+        ordered.extend(script_objects.items())
+        return ordered
+
+    @property
     def module_scripts(self):
 
         def _get_name(cls):

--- a/netbox/templates/extras/script_list.html
+++ b/netbox/templates/extras/script_list.html
@@ -37,7 +37,7 @@
           {% endif %}
         </div>
       </h2>
-      {% with scripts=module.scripts.all %}
+      {% with scripts=module.ordered_scripts %}
         {% if scripts %}
           <table class="table table-hover scripts">
             <thead>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18738 

Ordering of scripts via the `script_order` option in script modules appears to have been broken when #17700 was fixed. This change introduces a new property, `ScriptModule.ordered_scripts`, which is then used in `script_list.html` when rendering the script list view.

<!--
    Please include a summary of the proposed changes below.
-->
