### PR TITLE
Fixes: #18305 make contacts mixin available for plugins

### DIFF
--- a/docs/plugins/development/models.md
+++ b/docs/plugins/development/models.md
@@ -136,6 +136,8 @@ For more information about database migrations, see the [Django documentation](h
 
 ::: netbox.models.features.TagsMixin
 
+::: netbox.models.features.ContactsMixin
+
 ## Choice Sets
 
 For model fields which support the selection of one or more values from a predefined list of choices, NetBox provides the `ChoiceSet` utility class. This can be used in place of a regular choices tuple to provide enhanced functionality, namely dynamic configuration and colorization. (See [Django's documentation](https://docs.djangoproject.com/en/stable/ref/models/fields/#choices) on the `choices` parameter for supported model fields.)

--- a/netbox/circuits/views.py
+++ b/netbox/circuits/views.py
@@ -6,7 +6,6 @@ from django.utils.translation import gettext_lazy as _
 from dcim.views import PathTraceView
 from ipam.models import ASN
 from netbox.views import generic
-from tenancy.views import ObjectContactsView
 from utilities.forms import ConfirmationForm
 from utilities.query import count_related
 from utilities.views import GetRelatedModelsMixin, register_model_view
@@ -77,11 +76,6 @@ class ProviderBulkDeleteView(generic.BulkDeleteView):
     table = tables.ProviderTable
 
 
-@register_model_view(Provider, 'contacts')
-class ProviderContactsView(ObjectContactsView):
-    queryset = Provider.objects.all()
-
-
 #
 # ProviderAccounts
 #
@@ -142,11 +136,6 @@ class ProviderAccountBulkDeleteView(generic.BulkDeleteView):
     )
     filterset = filtersets.ProviderAccountFilterSet
     table = tables.ProviderAccountTable
-
-
-@register_model_view(ProviderAccount, 'contacts')
-class ProviderAccountContactsView(ObjectContactsView):
-    queryset = ProviderAccount.objects.all()
 
 
 #
@@ -414,11 +403,6 @@ class CircuitSwapTerminations(generic.ObjectEditView):
             'button_class': 'primary',
             'return_url': circuit.get_absolute_url(),
         })
-
-
-@register_model_view(Circuit, 'contacts')
-class CircuitContactsView(ObjectContactsView):
-    queryset = Circuit.objects.all()
 
 
 #

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -17,7 +17,6 @@ from ipam.models import ASN, IPAddress, Prefix, VLANGroup
 from ipam.tables import InterfaceVLANTable, VLANTranslationRuleTable
 from netbox.constants import DEFAULT_ACTION_PERMISSIONS
 from netbox.views import generic
-from tenancy.views import ObjectContactsView
 from utilities.forms import ConfirmationForm
 from utilities.paginator import EnhancedPaginator, get_paginate_count
 from utilities.permissions import get_permission_for_model
@@ -302,11 +301,6 @@ class RegionBulkDeleteView(generic.BulkDeleteView):
     table = tables.RegionTable
 
 
-@register_model_view(Region, 'contacts')
-class RegionContactsView(ObjectContactsView):
-    queryset = Region.objects.all()
-
-
 #
 # Site groups
 #
@@ -410,11 +404,6 @@ class SiteGroupBulkDeleteView(generic.BulkDeleteView):
     table = tables.SiteGroupTable
 
 
-@register_model_view(SiteGroup, 'contacts')
-class SiteGroupContactsView(ObjectContactsView):
-    queryset = SiteGroup.objects.all()
-
-
 #
 # Sites
 #
@@ -491,11 +480,6 @@ class SiteBulkDeleteView(generic.BulkDeleteView):
     queryset = Site.objects.all()
     filterset = filtersets.SiteFilterSet
     table = tables.SiteTable
-
-
-@register_model_view(Site, 'contacts')
-class SiteContactsView(ObjectContactsView):
-    queryset = Site.objects.all()
 
 
 #
@@ -602,11 +586,6 @@ class LocationBulkDeleteView(generic.BulkDeleteView):
     ).prefetch_related('site')
     filterset = filtersets.LocationFilterSet
     table = tables.LocationTable
-
-
-@register_model_view(Location, 'contacts')
-class LocationContactsView(ObjectContactsView):
-    queryset = Location.objects.all()
 
 
 #
@@ -896,7 +875,7 @@ class RackBulkDeleteView(generic.BulkDeleteView):
 
 
 @register_model_view(Rack, 'contacts')
-class RackContactsView(ObjectContactsView):
+class RackContactsView():
     queryset = Rack.objects.all()
 
 
@@ -1036,11 +1015,6 @@ class ManufacturerBulkDeleteView(generic.BulkDeleteView):
     )
     filterset = filtersets.ManufacturerFilterSet
     table = tables.ManufacturerTable
-
-
-@register_model_view(Manufacturer, 'contacts')
-class ManufacturerContactsView(ObjectContactsView):
-    queryset = Manufacturer.objects.all()
 
 
 #
@@ -2327,11 +2301,6 @@ class DeviceBulkRenameView(generic.BulkRenameView):
     queryset = Device.objects.all()
     filterset = filtersets.DeviceFilterSet
     table = tables.DeviceTable
-
-
-@register_model_view(Device, 'contacts')
-class DeviceContactsView(ObjectContactsView):
-    queryset = Device.objects.all()
 
 
 #
@@ -3891,11 +3860,6 @@ class PowerPanelBulkDeleteView(generic.BulkDeleteView):
     )
     filterset = filtersets.PowerPanelFilterSet
     table = tables.PowerPanelTable
-
-
-@register_model_view(PowerPanel, 'contacts')
-class PowerPanelContactsView(ObjectContactsView):
-    queryset = PowerPanel.objects.all()
 
 
 #

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -11,7 +11,6 @@ from dcim.forms import InterfaceFilterForm
 from dcim.models import Interface, Site
 from ipam.tables import VLANTranslationRuleTable
 from netbox.views import generic
-from tenancy.views import ObjectContactsView
 from utilities.query import count_related
 from utilities.tables import get_table_ordering
 from utilities.views import GetRelatedModelsMixin, ViewTab, register_model_view
@@ -434,11 +433,6 @@ class AggregateBulkDeleteView(generic.BulkDeleteView):
     table = tables.AggregateTable
 
 
-@register_model_view(Aggregate, 'contacts')
-class AggregateContactsView(ObjectContactsView):
-    queryset = Aggregate.objects.all()
-
-
 #
 # Prefix/VLAN roles
 #
@@ -684,11 +678,6 @@ class PrefixBulkDeleteView(generic.BulkDeleteView):
     table = tables.PrefixTable
 
 
-@register_model_view(Prefix, 'contacts')
-class PrefixContactsView(ObjectContactsView):
-    queryset = Prefix.objects.all()
-
-
 #
 # IP Ranges
 #
@@ -776,11 +765,6 @@ class IPRangeBulkDeleteView(generic.BulkDeleteView):
     queryset = IPRange.objects.all()
     filterset = filtersets.IPRangeFilterSet
     table = tables.IPRangeTable
-
-
-@register_model_view(IPRange, 'contacts')
-class IPRangeContactsView(ObjectContactsView):
-    queryset = IPRange.objects.all()
 
 
 #
@@ -963,11 +947,6 @@ class IPAddressRelatedIPsView(generic.ObjectChildrenView):
 
     def get_children(self, request, parent):
         return parent.get_related_ips().restrict(request.user, 'view')
-
-
-@register_model_view(IPAddress, 'contacts')
-class IPAddressContactsView(ObjectContactsView):
-    queryset = IPAddress.objects.all()
 
 
 #
@@ -1477,8 +1456,3 @@ class ServiceBulkDeleteView(generic.BulkDeleteView):
     queryset = Service.objects.prefetch_related('device', 'virtual_machine')
     filterset = filtersets.ServiceFilterSet
     table = tables.ServiceTable
-
-
-@register_model_view(Service, 'contacts')
-class ServiceContactsView(ObjectContactsView):
-    queryset = Service.objects.all()

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -637,6 +637,10 @@ def register_models(*models):
                 )
 
         # Register applicable feature views for the model
+        if issubclass(model, ContactsMixin):
+            register_model_view(model, 'contacts', kwargs={'model': model})(
+                'netbox.views.generic.ObjectContactsView'
+            )
         if issubclass(model, JournalingMixin):
             register_model_view(model, 'journal', kwargs={'model': model})(
                 'netbox.views.generic.ObjectJournalView'

--- a/netbox/netbox/views/generic/feature_views.py
+++ b/netbox/netbox/views/generic/feature_views.py
@@ -12,9 +12,15 @@ from core.tables import JobTable, ObjectChangeTable
 from extras.forms import JournalEntryForm
 from extras.models import JournalEntry
 from extras.tables import JournalEntryTable
+from tenancy.models import ContactAssignment
+from tenancy.tables import ContactAssignmentTable
+from tenancy.filtersets import ContactAssignmentFilterSet
+from tenancy.forms import ContactAssignmentFilterForm
 from utilities.permissions import get_permission_for_model
 from utilities.views import ConditionalLoginRequiredMixin, GetReturnURLMixin, ViewTab
+from utilities.htmx import htmx_partial
 from .base import BaseMultiObjectView
+from .mixins import ActionsMixin, TableMixin
 
 __all__ = (
     'BulkSyncDataView',
@@ -22,7 +28,79 @@ __all__ = (
     'ObjectJobsView',
     'ObjectJournalView',
     'ObjectSyncDataView',
+    'ObjectContactsView',
 )
+
+
+class ObjectContactsView(ConditionalLoginRequiredMixin, ActionsMixin, TableMixin, View):
+    """
+    Show all Contacts associated with an object. The model class must be passed as a keyword argument when referencing
+    this view in a URL path. For example:
+
+        path('sites/<int:pk>/contacts/', ObjectContactsView.as_view(), name='site_contacts', kwargs={'model': Site}),
+
+    Attributes:
+        base_template: The name of the template to extend. If not provided, "{app}/{model}.html" will be used.
+    """
+    base_template = None
+    tab = ViewTab(
+        label=_('Contacts'),
+        badge=lambda obj: obj.contacts.count(),
+        permission='tenancy.view_contactassignment',
+        weight=9000
+    )
+    table = ContactAssignmentTable
+    filterset = ContactAssignmentFilterSet
+    filterset_form = ContactAssignmentFilterForm
+
+    def get(self, request, model, **kwargs):
+        # Handle QuerySet restriction of parent object if needed
+        if hasattr(model.objects, 'restrict'):
+            obj = get_object_or_404(model.objects.restrict(request.user, 'view'), **kwargs)
+        else:
+            obj = get_object_or_404(model, **kwargs)
+
+        # Gather all Contact Assignments for this object
+        content_type = ContentType.objects.get_for_model(model)
+        contactassignments = ContactAssignment.objects.restrict(request.user, 'view').prefetch_related(
+            'contact',
+        ).filter(
+            object_type=content_type,
+            object_id=obj.pk
+        ).order_by('priority', 'contact', 'role')
+        contactassignments = self.filterset(request.GET, contactassignments, request=request).qs
+
+        # Determine the available actions
+        actions = self.get_permitted_actions(request.user, model=ContactAssignment)
+        has_bulk_actions = any([a.startswith('bulk_') for a in actions])
+
+        table = self.get_table(contactassignments, request, has_bulk_actions)
+        table.columns.hide('object_type')
+        table.columns.hide('object')
+
+        if htmx_partial(request):
+            return render(request, 'htmx/table.html', {
+                'object': obj,
+                'table': table,
+                'model': ContactAssignment,
+            })
+
+        # Default to using "<app>/<model>.html" as the template, if it exists. Otherwise,
+        # fall back to using base.html.
+        if self.base_template is None:
+            self.base_template = f"{model._meta.app_label}/{model._meta.model_name}.html"
+
+        return render(request, 'tenancy/object_contacts.html', {
+            'object': obj,
+            'model': ContactAssignment,
+            'base_template': self.base_template,
+            'table': table,
+            'table_config': f'{table.name}_config',
+            'filter_form': self.filterset_form(request.GET) if self.filterset_form else None,
+            'actions': actions,
+            'tab': self.tab,
+            'return_url': request.get_full_path(),
+        })
 
 
 class ObjectChangeLogView(ConditionalLoginRequiredMixin, View):

--- a/netbox/templates/tenancy/object_contacts.html
+++ b/netbox/templates/tenancy/object_contacts.html
@@ -1,4 +1,4 @@
-{% extends 'generic/object_children.html' %}
+{% extends base_template %}
 {% load helpers %}
 {% load i18n %}
 
@@ -11,3 +11,56 @@
     {% endwith %}
   {% endif %}
 {% endblock %}
+
+{% block content %}
+    {% block table_controls %}
+        {% include 'inc/table_controls_htmx.html' with table_modal=table_config %}
+    {% endblock table_controls %}
+    <form method="post">
+        {% csrf_token %}
+        <div class="card">
+            <div class="htmx-container table-responsive" id="object_list">
+                {% include 'htmx/table.html' %}
+            </div>
+        </div>
+        <div class="d-print-none mt-2">
+            {% block bulk_controls %}
+                <div class="btn-group" role="group">
+                    {# Bulk edit buttons #}
+                    {% block bulk_edit_controls %}
+                        {% with bulk_edit_view=model|validated_viewname:"bulk_edit" %}
+                            {% if 'bulk_edit' in actions and bulk_edit_view %}
+                                <button type="submit" name="_edit"
+                                        {% formaction %}="{% url bulk_edit_view %}?return_url={{ return_url }}"
+                                        class="btn btn-warning">
+                                    <i class="mdi mdi-pencil" aria-hidden="true"></i> {% trans "Edit Selected" %}
+                                </button>
+                            {% endif %}
+                        {% endwith %}
+                    {% endblock bulk_edit_controls %}
+                </div>
+                <div class="btn-group" role="group">
+                    {# Bulk delete buttons #}
+                    {% block bulk_delete_controls %}
+                        {% with bulk_delete_view=model|validated_viewname:"bulk_delete" %}
+                            {% if 'bulk_delete' in actions and bulk_delete_view %}
+                                <button type="submit"
+                                        {% formaction %}="{% url bulk_delete_view %}?return_url={{ return_url }}"
+                                        class="btn btn-danger">
+                                    <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i> {% trans "Delete Selected" %}
+                                </button>
+                            {% endif %}
+                        {% endwith %}
+                    {% endblock bulk_delete_controls %}
+                </div>
+                {# Other bulk action buttons #}
+                {% block bulk_extra_controls %}{% endblock %}
+            {% endblock bulk_controls %}
+        </div>
+    </form>
+{% endblock content %}
+
+{% block modals %}
+    {{ block.super }}
+    {% table_config_form table %}
+{% endblock modals %}

--- a/netbox/tenancy/views.py
+++ b/netbox/tenancy/views.py
@@ -1,41 +1,11 @@
 from django.contrib.contenttypes.models import ContentType
 from django.shortcuts import get_object_or_404
-from django.utils.translation import gettext_lazy as _
 
 from netbox.views import generic
 from utilities.query import count_related
-from utilities.views import GetRelatedModelsMixin, ViewTab, register_model_view
+from utilities.views import GetRelatedModelsMixin, register_model_view
 from . import filtersets, forms, tables
 from .models import *
-
-
-class ObjectContactsView(generic.ObjectChildrenView):
-    child_model = ContactAssignment
-    table = tables.ContactAssignmentTable
-    filterset = filtersets.ContactAssignmentFilterSet
-    filterset_form = forms.ContactAssignmentFilterForm
-    template_name = 'tenancy/object_contacts.html'
-    tab = ViewTab(
-        label=_('Contacts'),
-        badge=lambda obj: obj.contacts.count(),
-        permission='tenancy.view_contactassignment',
-        weight=5000
-    )
-
-    def get_children(self, request, parent):
-        return ContactAssignment.objects.restrict(request.user, 'view').filter(
-            object_type=ContentType.objects.get_for_model(parent),
-            object_id=parent.pk
-        ).order_by('priority', 'contact', 'role')
-
-    def get_table(self, *args, **kwargs):
-        table = super().get_table(*args, **kwargs)
-
-        # Hide object columns
-        table.columns.hide('object_type')
-        table.columns.hide('object')
-
-        return table
 
 
 #
@@ -166,11 +136,6 @@ class TenantBulkDeleteView(generic.BulkDeleteView):
     queryset = Tenant.objects.all()
     filterset = filtersets.TenantFilterSet
     table = tables.TenantTable
-
-
-@register_model_view(Tenant, 'contacts')
-class TenantContactsView(ObjectContactsView):
-    queryset = Tenant.objects.all()
 
 
 #

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -14,7 +14,6 @@ from ipam.models import IPAddress
 from ipam.tables import InterfaceVLANTable, VLANTranslationRuleTable
 from netbox.constants import DEFAULT_ACTION_PERMISSIONS
 from netbox.views import generic
-from tenancy.views import ObjectContactsView
 from utilities.query import count_related
 from utilities.query_functions import CollateAsChar
 from utilities.views import GetRelatedModelsMixin, ViewTab, register_model_view
@@ -144,11 +143,6 @@ class ClusterGroupBulkDeleteView(generic.BulkDeleteView):
     )
     filterset = filtersets.ClusterGroupFilterSet
     table = tables.ClusterGroupTable
-
-
-@register_model_view(ClusterGroup, 'contacts')
-class ClusterGroupContactsView(ObjectContactsView):
-    queryset = ClusterGroup.objects.all()
 
 
 #
@@ -342,11 +336,6 @@ class ClusterRemoveDevicesView(generic.ObjectEditView):
         })
 
 
-@register_model_view(Cluster, 'contacts')
-class ClusterContactsView(ObjectContactsView):
-    queryset = Cluster.objects.all()
-
-
 #
 # Virtual machines
 #
@@ -465,11 +454,6 @@ class VirtualMachineBulkDeleteView(generic.BulkDeleteView):
     queryset = VirtualMachine.objects.prefetch_related('primary_ip4', 'primary_ip6')
     filterset = filtersets.VirtualMachineFilterSet
     table = tables.VirtualMachineTable
-
-
-@register_model_view(VirtualMachine, 'contacts')
-class VirtualMachineContactsView(ObjectContactsView):
-    queryset = VirtualMachine.objects.all()
 
 
 #

--- a/netbox/vpn/views.py
+++ b/netbox/vpn/views.py
@@ -1,6 +1,5 @@
 from ipam.tables import RouteTargetTable
 from netbox.views import generic
-from tenancy.views import ObjectContactsView
 from utilities.query import count_related
 from utilities.views import GetRelatedModelsMixin, register_model_view
 from . import filtersets, forms, tables
@@ -68,11 +67,6 @@ class TunnelGroupBulkDeleteView(generic.BulkDeleteView):
     table = tables.TunnelGroupTable
 
 
-@register_model_view(TunnelGroup, 'contacts')
-class TunnelGroupContactsView(ObjectContactsView):
-    queryset = TunnelGroup.objects.all()
-
-
 #
 # Tunnels
 #
@@ -135,11 +129,6 @@ class TunnelBulkDeleteView(generic.BulkDeleteView):
     )
     filterset = filtersets.TunnelFilterSet
     table = tables.TunnelTable
-
-
-@register_model_view(Tunnel, 'contacts')
-class TunnelContactsView(ObjectContactsView):
-    queryset = Tunnel.objects.all()
 
 
 #
@@ -505,11 +494,6 @@ class L2VPNBulkDeleteView(generic.BulkDeleteView):
     queryset = L2VPN.objects.all()
     filterset = filtersets.L2VPNFilterSet
     table = tables.L2VPNTable
-
-
-@register_model_view(L2VPN, 'contacts')
-class L2VPNContactsView(ObjectContactsView):
-    queryset = L2VPN.objects.all()
 
 
 #


### PR DESCRIPTION
### Fixes: #18305 make contacts mixin available for plugins

- Create `ObjectContactsView` feature view
- Deleted `tenancy.views.ObjectContactsView`
- Updated `object_contacts.html` removing `object_children` template
- Added  `netbox.views.generic.ObjectContactsView` use case to registry
- Removed `SiteContactsView`
- Removed `ProviderContactsView`
- Removed `ProviderAccountContactsView`
- Removed `CircuitContactsView`
- Removed `RegionContactsView`
- Removed `SiteGroupContactsView`
- Removed `LocationContactsView`
- Removed `ManufacturerContactsView`
- Removed `DeviceContactsView`
- Removed `PowerPanelContactsView`
- Removed `AggregateContactsView`
- Removed `PrefixContactsView`
- Removed `IPRangeContactsView`
- Removed `IPAddressContactsView`
- Removed `ServiceContactsView`
- Removed `TenantContactsView`
- Removed `ClusterGroupContactsView`
- Removed `ClusterContactsView`
- Removed `VirtualMachineContactsView`
- Removed `TunnelGroupContactsView`
- Removed `TunnelContactsView`
- Removed `L2VPNContactsView`
- Updated `docs/plugins/development/models.md` adding `ContactsMixin` as available feature

I also tested with some plugins and its working when `ContactsMixin` is added to `Model` definition class