### PR TITLE
Fixes #19023: `get_field_value()` should respect null values in bound forms

### DIFF
--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -136,9 +136,11 @@ def get_field_value(form, field_name):
     """
     field = form.fields[field_name]
 
-    if form.is_bound and (data := form.data.get(field_name)):
-        if hasattr(field, 'valid_value') and field.valid_value(data):
-            return data
+    if form.is_bound and field_name in form.data:
+        if (value := form.data[field_name]) is None:
+            return
+        if hasattr(field, 'valid_value') and field.valid_value(value):
+            return value
 
     return form.get_initial_for_field(field, field_name)
 


### PR DESCRIPTION
### Fixes: #19023

- Adapt `get_field_value()` to return null when the value of a bound field is null, regardless of any initial data provided.
- Include tests for the six potential scenarios