### PR TITLE
Fixes #18895: Allows VirtualCircuitTerminations as Interface connected endpoints

### DIFF
--- a/netbox/dcim/graphql/mixins.py
+++ b/netbox/dcim/graphql/mixins.py
@@ -30,6 +30,7 @@ class PathEndpointMixin:
 
     connected_endpoints: List[Annotated[Union[
         Annotated["CircuitTerminationType", strawberry.lazy('circuits.graphql.types')],  # noqa: F821
+        Annotated["VirtualCircuitTerminationType", strawberry.lazy('circuits.graphql.types')],  # noqa: F821
         Annotated["ConsolePortType", strawberry.lazy('dcim.graphql.types')],  # noqa: F821
         Annotated["ConsoleServerPortType", strawberry.lazy('dcim.graphql.types')],  # noqa: F821
         Annotated["FrontPortType", strawberry.lazy('dcim.graphql.types')],  # noqa: F821


### PR DESCRIPTION
### Fixes: #18895 

Resolves GraphQL error: "The type `<class 'circuits.models.virtual_circuits.VirtualCircuitTermination'>` cannot be resolved for the field \"connected_endpoints\" , are you using a strawberry.field?"
<!--
    Please include a summary of the proposed changes below.
-->
