### PR TITLE
Closes #16630: Enable plugins to embed custom <head> content

### DIFF
--- a/docs/plugins/development/views.md
+++ b/docs/plugins/development/views.md
@@ -198,6 +198,7 @@ Plugins can inject custom content into certain areas of core NetBox views. This 
 
 | Method              | View        | Description                                         |
 |---------------------|-------------|-----------------------------------------------------|
+| `head()`            | All         | Custom HTML `<head>` block includes                 |
 | `navbar()`          | All         | Inject content inside the top navigation bar        |
 | `list_buttons()`    | List view   | Add buttons to the top of the page                  |
 | `buttons()`         | Object view | Add buttons to the top of the page                  |

--- a/netbox/netbox/plugins/templates.py
+++ b/netbox/netbox/plugins/templates.py
@@ -47,6 +47,13 @@ class PluginTemplateExtension:
     # Global methods
     #
 
+    def head(self):
+        """
+        HTML returned by this method will be inserted in the page's `<head>` block. This may be useful e.g. for
+        including additional Javascript or CSS resources.
+        """
+        raise NotImplementedError
+
     def navbar(self):
         """
         Content that will be rendered inside the top navigation menu. Content should be returned as an HTML

--- a/netbox/netbox/tests/dummy_plugin/template_content.py
+++ b/netbox/netbox/tests/dummy_plugin/template_content.py
@@ -3,6 +3,9 @@ from netbox.plugins.templates import PluginTemplateExtension
 
 class GlobalContent(PluginTemplateExtension):
 
+    def head(self):
+        return "<!-- HEAD CONTENT -->"
+
     def navbar(self):
         return "GLOBAL CONTENT - NAVBAR"
 

--- a/netbox/templates/base/base.html
+++ b/netbox/templates/base/base.html
@@ -3,6 +3,7 @@
 {% load helpers %}
 {% load i18n %}
 {% load django_htmx %}
+{% load plugins %}
 <!DOCTYPE html>
 <html
   lang="en"
@@ -59,6 +60,7 @@
 
     {# Additional <head> content #}
     {% block head %}{% endblock %}
+    {% plugin_head %}
 
   </head>
   <body>

--- a/netbox/utilities/templatetags/plugins.py
+++ b/netbox/utilities/templatetags/plugins.py
@@ -46,6 +46,14 @@ def _get_registered_content(obj, method, template_context):
 
 
 @register.simple_tag(takes_context=True)
+def plugin_head(context):
+    """
+    Render any <head> content embedded by plugins
+    """
+    return _get_registered_content(None, 'head', context)
+
+
+@register.simple_tag(takes_context=True)
 def plugin_navbar(context):
     """
     Render any navbar content embedded by plugins


### PR DESCRIPTION
### Fixes: #16630

- Introduce a `head()` method on PluginTemplateExtension
- Introduce the `plugin_head` template tag & include it within the base template