### PR TITLE
Closed #9763: Treat IP ranges as fully populated

### DIFF
--- a/docs/models/ipam/iprange.md
+++ b/docs/models/ipam/iprange.md
@@ -29,9 +29,11 @@ The IP range's operational status. Note that the status of a range does _not_ ha
 !!! tip
     Additional statuses may be defined by setting `IPRange.status` under the [`FIELD_CHOICES`](../../configuration/data-validation.md#field_choices) configuration parameter.
 
-### Mark Reserved
+### Mark Populated
 
-If enabled, NetBox will prevent the creation of IP addresses which fall within the declared range (and assigned VRF, if any).
+!!! note "This field was added in NetBox v4.3."
+
+If enabled, NetBox will treat this IP range as being fully populated when calculating available IP space. It will also prevent the creation of IP addresses which fall within the declared range (and assigned VRF, if any).
 
 ### Mark Utilized
 

--- a/docs/models/ipam/iprange.md
+++ b/docs/models/ipam/iprange.md
@@ -2,11 +2,11 @@
 
 This model represents an arbitrary range of individual IPv4 or IPv6 addresses, inclusive of its starting and ending addresses. For instance, the range 192.0.2.10 to 192.0.2.20 has eleven members. (The total member count is available as the `size` property on an IPRange instance.) Like [prefixes](./prefix.md) and [IP addresses](./ipaddress.md), each IP range may optionally be assigned to a [VRF](./vrf.md).
 
-Each IP range can be marked as populated, which instructs NetBox to treat the range as though every IP address within it has been created (even though these individual IP addresses have not been created). This can be helpful in scenarios where the management of a subset of IP addresses has been deferred to an external system of record, such as a DHCP server. NetBox will prohibit the creation of individual IP addresses within a range that has been marked as populated.
+Each IP range can be marked as populated, which instructs NetBox to treat the range as though every IP address within it has been created (even though these individual IP addresses don't actually exist in the database). This can be helpful in scenarios where the management of a subset of IP addresses has been deferred to an external system of record, such as a DHCP server. NetBox will prohibit the creation of individual IP addresses within a range that has been marked as populated.
 
-An IP range can also be marked as fully utilized. This will cause its utilization to always be reported as 100% when viewing the range or when calculating the utilization of a parent prefix. (If not enabled, a range's utilization is calculated based on the number of IP addresses which have been created within it.)
+An IP range can also be marked as utilized. This will cause its utilization to always be reported as 100% when viewing the range or when calculating the utilization of a parent prefix. (If not enabled, a range's utilization is calculated based on the number of IP addresses which have been created within it.)
 
-Typically, IP ranges marked as populated should also be marked as fully utilized, though there may be scenarios where this is undesirable (e.g. when reclaiming old IP space). An IP range which has been marked as populated but _not_ marked as fully utilized will always report a utilization of 0%, as it cannot contain child IP addresses.
+Typically, IP ranges marked as populated should also be marked as utilized, although there may be scenarios where this is undesirable (e.g. when reclaiming old IP space). An IP range which has been marked as populated but _not_ marked as utilized will always report a utilization of 0%, as it cannot contain child IP addresses.
 
 ## Fields
 

--- a/docs/models/ipam/iprange.md
+++ b/docs/models/ipam/iprange.md
@@ -2,6 +2,12 @@
 
 This model represents an arbitrary range of individual IPv4 or IPv6 addresses, inclusive of its starting and ending addresses. For instance, the range 192.0.2.10 to 192.0.2.20 has eleven members. (The total member count is available as the `size` property on an IPRange instance.) Like [prefixes](./prefix.md) and [IP addresses](./ipaddress.md), each IP range may optionally be assigned to a [VRF](./vrf.md).
 
+Each IP range can be marked as populated, which instructs NetBox to treat the range as though every IP address within it has been created (even though these individual IP addresses have not been created). This can be helpful in scenarios where the management of a subset of IP addresses has been deferred to an external system of record, such as a DHCP server. NetBox will prohibit the creation of individual IP addresses within a range that has been marked as populated.
+
+An IP range can also be marked as fully utilized. This will cause its utilization to always be reported as 100% when viewing the range or when calculating the utilization of a parent prefix. (If not enabled, a range's utilization is calculated based on the number of IP addresses which have been created within it.)
+
+Typically, IP ranges marked as populated should also be marked as fully utilized, though there may be scenarios where this is undesirable (e.g. when reclaiming old IP space). An IP range which has been marked as populated but _not_ marked as fully utilized will always report a utilization of 0%, as it cannot contain child IP addresses.
+
 ## Fields
 
 ### VRF

--- a/docs/models/ipam/iprange.md
+++ b/docs/models/ipam/iprange.md
@@ -29,6 +29,10 @@ The IP range's operational status. Note that the status of a range does _not_ ha
 !!! tip
     Additional statuses may be defined by setting `IPRange.status` under the [`FIELD_CHOICES`](../../configuration/data-validation.md#field_choices) configuration parameter.
 
+### Mark Reserved
+
+If enabled, NetBox will prevent the creation of IP addresses which fall within the declared range (and assigned VRF, if any).
+
 ### Mark Utilized
 
 If enabled, the IP range will be considered 100% utilized regardless of how many IP addresses are defined within it. This is useful for documenting DHCP ranges, for example.

--- a/netbox/ipam/api/serializers_/ip.py
+++ b/netbox/ipam/api/serializers_/ip.py
@@ -147,7 +147,7 @@ class IPRangeSerializer(NetBoxModelSerializer):
         fields = [
             'id', 'url', 'display_url', 'display', 'family', 'start_address', 'end_address', 'size', 'vrf', 'tenant',
             'status', 'role', 'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
-            'mark_reserved', 'mark_utilized', 'description', 'comments', 'tags', 'custom_fields', 'created',
+            'mark_populated', 'mark_utilized', 'description', 'comments', 'tags', 'custom_fields', 'created',
             'last_updated',
         ]
         brief_fields = ('id', 'url', 'display', 'family', 'start_address', 'end_address', 'description')

--- a/netbox/ipam/api/serializers_/ip.py
+++ b/netbox/ipam/api/serializers_/ip.py
@@ -147,7 +147,8 @@ class IPRangeSerializer(NetBoxModelSerializer):
         fields = [
             'id', 'url', 'display_url', 'display', 'family', 'start_address', 'end_address', 'size', 'vrf', 'tenant',
             'status', 'role', 'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
-            'mark_utilized', 'description', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
+            'mark_reserved', 'mark_utilized', 'description', 'comments', 'tags', 'custom_fields', 'created',
+            'last_updated',
         ]
         brief_fields = ('id', 'url', 'display', 'family', 'start_address', 'end_address', 'description')
 

--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -478,7 +478,7 @@ class IPRangeFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
 
     class Meta:
         model = IPRange
-        fields = ('id', 'mark_reserved', 'mark_utilized', 'size', 'description')
+        fields = ('id', 'mark_populated', 'mark_utilized', 'size', 'description')
 
     def search(self, queryset, name, value):
         if not value.strip():

--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -478,7 +478,7 @@ class IPRangeFilterSet(TenancyFilterSet, NetBoxModelFilterSet):
 
     class Meta:
         model = IPRange
-        fields = ('id', 'mark_utilized', 'size', 'description')
+        fields = ('id', 'mark_reserved', 'mark_utilized', 'size', 'description')
 
     def search(self, queryset, name, value):
         if not value.strip():

--- a/netbox/ipam/forms/bulk_edit.py
+++ b/netbox/ipam/forms/bulk_edit.py
@@ -296,10 +296,10 @@ class IPRangeBulkEditForm(NetBoxModelBulkEditForm):
         queryset=Role.objects.all(),
         required=False
     )
-    mark_reserved = forms.NullBooleanField(
+    mark_populated = forms.NullBooleanField(
         required=False,
         widget=BulkEditNullBooleanSelect(),
-        label=_('Treat as reserved')
+        label=_('Treat as populated')
     )
     mark_utilized = forms.NullBooleanField(
         required=False,

--- a/netbox/ipam/forms/bulk_edit.py
+++ b/netbox/ipam/forms/bulk_edit.py
@@ -296,6 +296,11 @@ class IPRangeBulkEditForm(NetBoxModelBulkEditForm):
         queryset=Role.objects.all(),
         required=False
     )
+    mark_reserved = forms.NullBooleanField(
+        required=False,
+        widget=BulkEditNullBooleanSelect(),
+        label=_('Treat as reserved')
+    )
     mark_utilized = forms.NullBooleanField(
         required=False,
         widget=BulkEditNullBooleanSelect(),

--- a/netbox/ipam/forms/bulk_import.py
+++ b/netbox/ipam/forms/bulk_import.py
@@ -268,8 +268,8 @@ class IPRangeImportForm(NetBoxModelImportForm):
     class Meta:
         model = IPRange
         fields = (
-            'start_address', 'end_address', 'vrf', 'tenant', 'status', 'role', 'mark_utilized', 'description',
-            'comments', 'tags',
+            'start_address', 'end_address', 'vrf', 'tenant', 'status', 'role', 'mark_reserved', 'mark_utilized',
+            'description', 'comments', 'tags',
         )
 
 

--- a/netbox/ipam/forms/bulk_import.py
+++ b/netbox/ipam/forms/bulk_import.py
@@ -268,7 +268,7 @@ class IPRangeImportForm(NetBoxModelImportForm):
     class Meta:
         model = IPRange
         fields = (
-            'start_address', 'end_address', 'vrf', 'tenant', 'status', 'role', 'mark_reserved', 'mark_utilized',
+            'start_address', 'end_address', 'vrf', 'tenant', 'status', 'role', 'mark_populated', 'mark_utilized',
             'description', 'comments', 'tags',
         )
 

--- a/netbox/ipam/forms/filtersets.py
+++ b/netbox/ipam/forms/filtersets.py
@@ -266,7 +266,7 @@ class IPRangeFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
     model = IPRange
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('family', 'vrf_id', 'status', 'role_id', 'mark_reserved', 'mark_utilized', name=_('Attributes')),
+        FieldSet('family', 'vrf_id', 'status', 'role_id', 'mark_populated', 'mark_utilized', name=_('Attributes')),
         FieldSet('tenant_group_id', 'tenant_id', name=_('Tenant')),
     )
     family = forms.ChoiceField(
@@ -291,9 +291,9 @@ class IPRangeFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
         null_option='None',
         label=_('Role')
     )
-    mark_reserved = forms.NullBooleanField(
+    mark_populated = forms.NullBooleanField(
         required=False,
-        label=_('Treat as reserved'),
+        label=_('Treat as populated'),
         widget=forms.Select(
             choices=BOOLEAN_WITH_BLANK_CHOICES
         )

--- a/netbox/ipam/forms/filtersets.py
+++ b/netbox/ipam/forms/filtersets.py
@@ -266,7 +266,7 @@ class IPRangeFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
     model = IPRange
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('family', 'vrf_id', 'status', 'role_id', 'mark_utilized', name=_('Attributes')),
+        FieldSet('family', 'vrf_id', 'status', 'role_id', 'mark_reserved', 'mark_utilized', name=_('Attributes')),
         FieldSet('tenant_group_id', 'tenant_id', name=_('Tenant')),
     )
     family = forms.ChoiceField(
@@ -290,6 +290,13 @@ class IPRangeFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
         required=False,
         null_option='None',
         label=_('Role')
+    )
+    mark_reserved = forms.NullBooleanField(
+        required=False,
+        label=_('Treat as reserved'),
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        )
     )
     mark_utilized = forms.NullBooleanField(
         required=False,

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -257,8 +257,8 @@ class IPRangeForm(TenancyForm, NetBoxModelForm):
 
     fieldsets = (
         FieldSet(
-            'vrf', 'start_address', 'end_address', 'role', 'status', 'mark_utilized', 'description', 'tags',
-            name=_('IP Range')
+            'vrf', 'start_address', 'end_address', 'role', 'status', 'mark_reserved', 'mark_utilized', 'description',
+            'tags', name=_('IP Range')
         ),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
     )
@@ -266,8 +266,8 @@ class IPRangeForm(TenancyForm, NetBoxModelForm):
     class Meta:
         model = IPRange
         fields = [
-            'vrf', 'start_address', 'end_address', 'status', 'role', 'tenant_group', 'tenant', 'mark_utilized',
-            'description', 'comments', 'tags',
+            'vrf', 'start_address', 'end_address', 'status', 'role', 'tenant_group', 'tenant', 'mark_reserved',
+            'mark_utilized', 'description', 'comments', 'tags',
         ]
 
 

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -257,7 +257,7 @@ class IPRangeForm(TenancyForm, NetBoxModelForm):
 
     fieldsets = (
         FieldSet(
-            'vrf', 'start_address', 'end_address', 'role', 'status', 'mark_reserved', 'mark_utilized', 'description',
+            'vrf', 'start_address', 'end_address', 'role', 'status', 'mark_populated', 'mark_utilized', 'description',
             'tags', name=_('IP Range')
         ),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
@@ -266,7 +266,7 @@ class IPRangeForm(TenancyForm, NetBoxModelForm):
     class Meta:
         model = IPRange
         fields = [
-            'vrf', 'start_address', 'end_address', 'status', 'role', 'tenant_group', 'tenant', 'mark_reserved',
+            'vrf', 'start_address', 'end_address', 'status', 'role', 'tenant_group', 'tenant', 'mark_populated',
             'mark_utilized', 'description', 'comments', 'tags',
         ]
 

--- a/netbox/ipam/migrations/0078_iprange_mark_utilized.py
+++ b/netbox/ipam/migrations/0078_iprange_mark_utilized.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ipam', '0077_vlangroup_tenant'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='iprange',
+            name='mark_reserved',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/netbox/ipam/migrations/0078_iprange_mark_utilized.py
+++ b/netbox/ipam/migrations/0078_iprange_mark_utilized.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name='iprange',
-            name='mark_reserved',
+            name='mark_populated',
             field=models.BooleanField(default=False),
         ),
     ]

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -407,15 +407,16 @@ class Prefix(ContactsMixin, GetAvailablePrefixesMixin, CachedScopeMixin, Primary
         """
         Return all available IPs within this prefix as an IPSet.
         """
-        if self.mark_utilized:
-            return netaddr.IPSet()
+        # TODO: Add mark_reserved
 
         prefix = netaddr.IPSet(self.prefix)
-        child_ips = netaddr.IPSet([ip.address.ip for ip in self.get_child_ips()])
-        child_ranges = []
-        for iprange in self.get_child_ranges():
-            child_ranges.append(iprange.range)
-        available_ips = prefix - child_ips - netaddr.IPSet(child_ranges)
+        child_ips = netaddr.IPSet([
+            ip.address.ip for ip in self.get_child_ips()
+        ])
+        child_ranges = netaddr.IPSet([
+            iprange.range for iprange in self.get_child_ranges().filter(mark_reserved=True)
+        ])
+        available_ips = prefix - child_ips - child_ranges
 
         # IPv6 /127's, pool, or IPv4 /31-/32 sets are fully usable
         if (self.family == 6 and self.prefix.prefixlen >= 127) or self.is_pool or (
@@ -433,6 +434,7 @@ class Prefix(ContactsMixin, GetAvailablePrefixesMixin, CachedScopeMixin, Primary
             # For IPv6 prefixes, omit the Subnet-Router anycast address
             # per RFC 4291
             available_ips -= netaddr.IPSet([netaddr.IPAddress(self.prefix.first)])
+
         return available_ips
 
     def get_first_available_ip(self):
@@ -461,9 +463,11 @@ class Prefix(ContactsMixin, GetAvailablePrefixesMixin, CachedScopeMixin, Primary
             utilization = float(child_prefixes.size) / self.prefix.size * 100
         else:
             # Compile an IPSet to avoid counting duplicate IPs
-            child_ips = netaddr.IPSet(
-                [_.range for _ in self.get_child_ranges()] + [_.address.ip for _ in self.get_child_ips()]
-            )
+            child_ips = netaddr.IPSet()
+            for iprange in self.get_child_ranges().filter(mark_utilized=True):
+                child_ips.add(iprange.range)
+            for ip in self.get_child_ips():
+                child_ips.add(ip.address.ip)
 
             prefix_size = self.prefix.size
             if self.prefix.version == 4 and self.prefix.prefixlen < 31 and not self.is_pool:
@@ -668,6 +672,9 @@ class IPRange(ContactsMixin, PrimaryModel):
         """
         Return all available IPs within this range as an IPSet.
         """
+        if self.mark_reserved:
+            return netaddr.IPSet()
+
         range = netaddr.IPRange(self.start_address.ip, self.end_address.ip)
         child_ips = netaddr.IPSet([ip.address.ip for ip in self.get_child_ips()])
 

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -383,14 +383,15 @@ class Prefix(ContactsMixin, GetAvailablePrefixesMixin, CachedScopeMixin, Primary
         else:
             return Prefix.objects.filter(prefix__net_contained=str(self.prefix), vrf=self.vrf)
 
-    def get_child_ranges(self):
+    def get_child_ranges(self, **kwargs):
         """
         Return all IPRanges within this Prefix and VRF.
         """
         return IPRange.objects.filter(
             vrf=self.vrf,
             start_address__net_host_contained=str(self.prefix),
-            end_address__net_host_contained=str(self.prefix)
+            end_address__net_host_contained=str(self.prefix),
+            **kwargs
         )
 
     def get_child_ips(self):

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -407,14 +407,14 @@ class Prefix(ContactsMixin, GetAvailablePrefixesMixin, CachedScopeMixin, Primary
         """
         Return all available IPs within this prefix as an IPSet.
         """
-        # TODO: Add mark_reserved
+        # TODO: Add mark_populated
 
         prefix = netaddr.IPSet(self.prefix)
         child_ips = netaddr.IPSet([
             ip.address.ip for ip in self.get_child_ips()
         ])
         child_ranges = netaddr.IPSet([
-            iprange.range for iprange in self.get_child_ranges().filter(mark_reserved=True)
+            iprange.range for iprange in self.get_child_ranges().filter(mark_populated=True)
         ])
         available_ips = prefix - child_ips - child_ranges
 
@@ -523,19 +523,19 @@ class IPRange(ContactsMixin, PrimaryModel):
         null=True,
         help_text=_('The primary function of this range')
     )
-    mark_reserved = models.BooleanField(
-        verbose_name=_('mark reserved'),
+    mark_populated = models.BooleanField(
+        verbose_name=_('mark populated'),
         default=False,
         help_text=_("Prevent the creation of IP addresses within this range")
     )
     mark_utilized = models.BooleanField(
         verbose_name=_('mark utilized'),
         default=False,
-        help_text=_("Treat as fully utilized")
+        help_text=_("Report space as 100% utilized")
     )
 
     clone_fields = (
-        'vrf', 'tenant', 'status', 'role', 'description', 'mark_reserved', 'mark_utilized',
+        'vrf', 'tenant', 'status', 'role', 'description', 'mark_populated', 'mark_utilized',
     )
 
     class Meta:
@@ -672,7 +672,7 @@ class IPRange(ContactsMixin, PrimaryModel):
         """
         Return all available IPs within this range as an IPSet.
         """
-        if self.mark_reserved:
+        if self.mark_populated:
             return netaddr.IPSet()
 
         range = netaddr.IPRange(self.start_address.ip, self.end_address.ip)

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -519,6 +519,11 @@ class IPRange(ContactsMixin, PrimaryModel):
         null=True,
         help_text=_('The primary function of this range')
     )
+    mark_reserved = models.BooleanField(
+        verbose_name=_('mark reserved'),
+        default=False,
+        help_text=_("Prevent the creation of IP addresses within this range")
+    )
     mark_utilized = models.BooleanField(
         verbose_name=_('mark utilized'),
         default=False,
@@ -526,7 +531,7 @@ class IPRange(ContactsMixin, PrimaryModel):
     )
 
     clone_fields = (
-        'vrf', 'tenant', 'status', 'role', 'description',
+        'vrf', 'tenant', 'status', 'role', 'description', 'mark_reserved', 'mark_utilized',
     )
 
     class Meta:

--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -268,6 +268,10 @@ class IPRangeTable(TenancyColumnsMixin, NetBoxTable):
         verbose_name=_('Role'),
         linkify=True
     )
+    mark_reserved = columns.BooleanColumn(
+        verbose_name=_('Marked Reserved'),
+        false_mark=None
+    )
     mark_utilized = columns.BooleanColumn(
         verbose_name=_('Marked Utilized'),
         false_mark=None
@@ -288,7 +292,8 @@ class IPRangeTable(TenancyColumnsMixin, NetBoxTable):
         model = IPRange
         fields = (
             'pk', 'id', 'start_address', 'end_address', 'size', 'vrf', 'status', 'role', 'tenant', 'tenant_group',
-            'mark_utilized', 'utilization', 'description', 'comments', 'tags', 'created', 'last_updated',
+            'mark_reserved', 'mark_utilized', 'utilization', 'description', 'comments', 'tags', 'created',
+            'last_updated',
         )
         default_columns = (
             'pk', 'start_address', 'end_address', 'size', 'vrf', 'status', 'role', 'tenant', 'description',

--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -10,6 +10,7 @@ from .template_code import *
 
 __all__ = (
     'AggregateTable',
+    'AnnotatedIPAddressTable',
     'AssignedIPAddressesTable',
     'IPAddressAssignTable',
     'IPAddressTable',
@@ -308,8 +309,8 @@ class IPRangeTable(TenancyColumnsMixin, NetBoxTable):
 #
 
 class IPAddressTable(TenancyColumnsMixin, NetBoxTable):
-    address = tables.TemplateColumn(
-        template_code=IPADDRESS_LINK,
+    address = tables.Column(
+        linkify=True,
         verbose_name=_('IP Address')
     )
     vrf = tables.TemplateColumn(
@@ -372,6 +373,16 @@ class IPAddressTable(TenancyColumnsMixin, NetBoxTable):
         row_attrs = {
             'class': lambda record: 'success' if not isinstance(record, IPAddress) else '',
         }
+
+
+class AnnotatedIPAddressTable(IPAddressTable):
+    address = tables.TemplateColumn(
+        template_code=IPADDRESS_LINK,
+        verbose_name=_('IP Address')
+    )
+
+    class Meta(IPAddressTable.Meta):
+        pass
 
 
 class IPAddressAssignTable(NetBoxTable):

--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -268,8 +268,8 @@ class IPRangeTable(TenancyColumnsMixin, NetBoxTable):
         verbose_name=_('Role'),
         linkify=True
     )
-    mark_reserved = columns.BooleanColumn(
-        verbose_name=_('Marked Reserved'),
+    mark_populated = columns.BooleanColumn(
+        verbose_name=_('Marked Populated'),
         false_mark=None
     )
     mark_utilized = columns.BooleanColumn(
@@ -292,7 +292,7 @@ class IPRangeTable(TenancyColumnsMixin, NetBoxTable):
         model = IPRange
         fields = (
             'pk', 'id', 'start_address', 'end_address', 'size', 'vrf', 'status', 'role', 'tenant', 'tenant_group',
-            'mark_reserved', 'mark_utilized', 'utilization', 'description', 'comments', 'tags', 'created',
+            'mark_populated', 'mark_utilized', 'utilization', 'description', 'comments', 'tags', 'created',
             'last_updated',
         )
         default_columns = (

--- a/netbox/ipam/tables/template_code.py
+++ b/netbox/ipam/tables/template_code.py
@@ -26,12 +26,14 @@ PREFIX_LINK_WITH_DEPTH = """
 """ + PREFIX_LINK
 
 IPADDRESS_LINK = """
-{% if record.pk %}
+{% if record.address %}
     <a href="{{ record.get_absolute_url }}" id="ipaddress_{{ record.pk }}">{{ record.address }}</a>
+{% elif record.start_address %}
+    <a href="{{ record.get_absolute_url }}" id="range_{{ record.pk }}">{{ record }}</a>
 {% elif perms.ipam.add_ipaddress %}
-    <a href="{% url 'ipam:ipaddress_add' %}?address={{ record.1 }}{% if object.vrf %}&vrf={{ object.vrf.pk }}{% endif %}{% if object.tenant %}&tenant={{ object.tenant.pk }}{% endif %}&return_url={% url 'ipam:prefix_ipaddresses' pk=object.pk %}" class="btn btn-sm btn-success">{% if record.0 <= 65536 %}{{ record.0 }}{% else %}Many{% endif %} IP{{ record.0|pluralize }} available</a>
+    <a href="{% url 'ipam:ipaddress_add' %}?address={{ record.first_ip }}{% if object.vrf %}&vrf={{ object.vrf.pk }}{% endif %}{% if object.tenant %}&tenant={{ object.tenant.pk }}{% endif %}&return_url={% url 'ipam:prefix_ipaddresses' pk=object.pk %}" class="btn btn-sm btn-success">{% if record.size <= 65536 %}{{ record.size }}{% else %}Many{% endif %} IP{{ record.size|pluralize }} available</a>
 {% else %}
-    {% if record.0 <= 65536 %}{{ record.0 }}{% else %}Many{% endif %} IP{{ record.0|pluralize }} available
+    {% if record.size <= 65536 %}{{ record.size }}{% else %}Many{% endif %} IP{{ record.size|pluralize }} available
 {% endif %}
 """
 

--- a/netbox/ipam/tables/template_code.py
+++ b/netbox/ipam/tables/template_code.py
@@ -26,14 +26,12 @@ PREFIX_LINK_WITH_DEPTH = """
 """ + PREFIX_LINK
 
 IPADDRESS_LINK = """
-{% if record.address %}
-    <a href="{{ record.get_absolute_url }}" id="ipaddress_{{ record.pk }}">{{ record.address }}</a>
-{% elif record.start_address %}
-    <a href="{{ record.get_absolute_url }}" id="range_{{ record.pk }}">{{ record }}</a>
+{% if record.address or record.start_address %}
+    <a href="{{ record.get_absolute_url }}">{{ record }}</a>
 {% elif perms.ipam.add_ipaddress %}
-    <a href="{% url 'ipam:ipaddress_add' %}?address={{ record.first_ip }}{% if object.vrf %}&vrf={{ object.vrf.pk }}{% endif %}{% if object.tenant %}&tenant={{ object.tenant.pk }}{% endif %}&return_url={% url 'ipam:prefix_ipaddresses' pk=object.pk %}" class="btn btn-sm btn-success">{% if record.size <= 65536 %}{{ record.size }}{% else %}Many{% endif %} IP{{ record.size|pluralize }} available</a>
+    <a href="{% url 'ipam:ipaddress_add' %}?address={{ record.first_ip }}{% if object.vrf %}&vrf={{ object.vrf.pk }}{% endif %}{% if object.tenant %}&tenant={{ object.tenant.pk }}{% endif %}&return_url={% url 'ipam:prefix_ipaddresses' pk=object.pk %}" class="btn btn-sm btn-success">{{ record.title }}</a>
 {% else %}
-    {% if record.size <= 65536 %}{{ record.size }}{% else %}Many{% endif %} IP{{ record.size|pluralize }} available
+    {{ record.title }}
 {% endif %}
 """
 

--- a/netbox/ipam/tests/test_filtersets.py
+++ b/netbox/ipam/tests/test_filtersets.py
@@ -918,7 +918,9 @@ class IPRangeTestCase(TestCase, ChangeLoggedFilterSetTests):
                 tenant=None,
                 role=None,
                 status=IPRangeStatusChoices.STATUS_ACTIVE,
-                description='foobar1'
+                description='foobar1',
+                mark_populated=True,
+                mark_utilized=True,
             ),
             IPRange(
                 start_address='10.0.2.100/24',
@@ -955,7 +957,9 @@ class IPRangeTestCase(TestCase, ChangeLoggedFilterSetTests):
                 vrf=None,
                 tenant=None,
                 role=None,
-                status=IPRangeStatusChoices.STATUS_ACTIVE
+                status=IPRangeStatusChoices.STATUS_ACTIVE,
+                mark_populated=True,
+                mark_utilized=True,
             ),
             IPRange(
                 start_address='2001:db8:0:2::1/64',
@@ -1050,6 +1054,18 @@ class IPRangeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'parent': ['10.0.1.0/25']}  # Range 10.0.1.100-199 is not fully contained by 10.0.1.0/25
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 0)
+
+    def test_mark_utilized(self):
+        params = {'mark_utilized': 'true'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'mark_utilized': 'false'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+
+    def test_mark_populated(self):
+        params = {'mark_populated': 'true'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'mark_populated': 'false'}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
 
 
 class IPAddressTestCase(TestCase, ChangeLoggedFilterSetTests):

--- a/netbox/ipam/tests/test_models.py
+++ b/netbox/ipam/tests/test_models.py
@@ -582,6 +582,27 @@ class TestIPAddress(TestCase):
         IPAddress.objects.create(address=IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)
         IPAddress.objects.create(address=IPNetwork('192.0.2.1/24'), role=IPAddressRoleChoices.ROLE_VIP)
 
+    #
+    # Range validation
+    #
+
+    def test_create_ip_in_unpopulated_range(self):
+        IPRange.objects.create(
+            start_address=IPNetwork('192.0.2.1/24'),
+            end_address=IPNetwork('192.0.2.100/24')
+        )
+        ip = IPAddress(address=IPNetwork('192.0.2.10/24'))
+        ip.full_clean()
+
+    def test_create_ip_in_populated_range(self):
+        IPRange.objects.create(
+            start_address=IPNetwork('192.0.2.1/24'),
+            end_address=IPNetwork('192.0.2.100/24'),
+            mark_populated=True
+        )
+        ip = IPAddress(address=IPNetwork('192.0.2.10/24'))
+        self.assertRaises(ValidationError, ip.full_clean)
+
 
 class TestVLANGroup(TestCase):
 

--- a/netbox/ipam/tests/test_models.py
+++ b/netbox/ipam/tests/test_models.py
@@ -211,16 +211,25 @@ class TestPrefix(TestCase):
             IPAddress(address=IPNetwork('10.0.0.5/26')),
             IPAddress(address=IPNetwork('10.0.0.7/26')),
         ))
+        # Range is not marked as populated, so it doesn't count against available IP space
         IPRange.objects.create(
             start_address=IPNetwork('10.0.0.9/26'),
-            end_address=IPNetwork('10.0.0.12/26')
+            end_address=IPNetwork('10.0.0.10/26')
+        )
+        # Populated range reduces available IP space
+        IPRange.objects.create(
+            start_address=IPNetwork('10.0.0.12/26'),
+            end_address=IPNetwork('10.0.0.13/26'),
+            mark_populated=True
         )
         missing_ips = IPSet([
             '10.0.0.2/32',
             '10.0.0.4/32',
             '10.0.0.6/32',
             '10.0.0.8/32',
-            '10.0.0.13/32',
+            '10.0.0.9/32',
+            '10.0.0.10/32',
+            '10.0.0.11/32',
             '10.0.0.14/32',
         ])
         available_ips = parent_prefix.get_available_ips()
@@ -286,8 +295,12 @@ class TestPrefix(TestCase):
         ])
         self.assertEqual(prefix.get_utilization(), 32 / 254 * 100)  # ~12.5% utilization
 
-        # Create a child range with 32 additional IPs
-        IPRange.objects.create(start_address=IPNetwork('10.0.0.33/24'), end_address=IPNetwork('10.0.0.64/24'))
+        # Create a utilized child range with 32 additional IPs
+        IPRange.objects.create(
+            start_address=IPNetwork('10.0.0.33/24'),
+            end_address=IPNetwork('10.0.0.64/24'),
+            mark_utilized=True
+        )
         self.assertEqual(prefix.get_utilization(), 64 / 254 * 100)  # ~25% utilization
 
     #

--- a/netbox/ipam/utils.py
+++ b/netbox/ipam/utils.py
@@ -88,15 +88,11 @@ def annotate_ip_space(prefix):
             first_ip=f'{first_ip_in_prefix}/{prefix.mask_length}'
         ))
 
-    # Iterate through existing IPs and annotate free ranges
+    # Add IP ranges & addresses, annotating available space in between records
     for record in records:
         if prev_ip:
-            # We've already listed a range which covers this IP
-            if record[0] < prev_ip:
-                continue
-
             # Annotate available space
-            if (diff := int(record[0] - prev_ip)) > 1:
+            if (diff := int(record[0]) - int(prev_ip)) > 1:
                 first_skipped = f'{prev_ip + 1}/{prefix.mask_length}'
                 output.append(AvailableIPSpace(
                     size=diff - 1,
@@ -110,7 +106,6 @@ def annotate_ip_space(prefix):
             prev_ip = record[1].end_address.ip
         else:
             prev_ip = record[0]
-        print(f'prev_ip: {prev_ip}')
 
     # Include any remaining available IPs
     if prev_ip < last_ip_in_prefix:

--- a/netbox/ipam/utils.py
+++ b/netbox/ipam/utils.py
@@ -1,15 +1,23 @@
+from dataclasses import dataclass
 import netaddr
 
 from .constants import *
 from .models import Prefix, VLAN
 
 __all__ = (
-    'add_available_ipaddresses',
+    'AvailableIPSpace',
     'add_available_vlans',
     'add_requested_prefixes',
+    'annotate_ip_space',
     'get_next_available_prefix',
     'rebuild_prefixes',
 )
+
+
+@dataclass
+class AvailableIPSpace:
+    size: int
+    first_ip: str
 
 
 def add_requested_prefixes(parent, prefix_list, show_available=True, show_assigned=True):
@@ -42,50 +50,74 @@ def add_requested_prefixes(parent, prefix_list, show_available=True, show_assign
     return child_prefixes
 
 
-def add_available_ipaddresses(prefix, ipaddress_list, is_pool=False):
-    """
-    Annotate ranges of available IP addresses within a given prefix. If is_pool is True, the first and last IP will be
-    considered usable (regardless of mask length).
-    """
+def annotate_ip_space(prefix):
+    # Compile child objects
+    records = []
+    records.extend([
+        (iprange.start_address.ip, iprange) for iprange in prefix.get_child_ranges(mark_populated=True)
+    ])
+    records.extend([
+        (ip.address.ip, ip) for ip in prefix.get_child_ips()
+    ])
+    records = sorted(records, key=lambda x: x[0])
+
+    # Determine the first & last valid IP addresses in the prefix
+    if prefix.family == 4 and prefix.mask_length < 31 and not prefix.is_pool:
+        # Ignore the network and broadcast addresses for non-pool IPv4 prefixes larger than /31
+        first_ip_in_prefix = netaddr.IPAddress(prefix.prefix.first + 1)
+        last_ip_in_prefix = netaddr.IPAddress(prefix.prefix.last - 1)
+    else:
+        first_ip_in_prefix = netaddr.IPAddress(prefix.prefix.first)
+        last_ip_in_prefix = netaddr.IPAddress(prefix.prefix.last)
+
+    if not records:
+        return [
+            AvailableIPSpace(
+                size=int(last_ip_in_prefix - first_ip_in_prefix + 1),
+                first_ip=f'{first_ip_in_prefix}/{prefix.mask_length}'
+            )
+        ]
 
     output = []
     prev_ip = None
 
-    # Ignore the network and broadcast addresses for non-pool IPv4 prefixes larger than /31.
-    if prefix.version == 4 and prefix.prefixlen < 31 and not is_pool:
-        first_ip_in_prefix = netaddr.IPAddress(prefix.first + 1)
-        last_ip_in_prefix = netaddr.IPAddress(prefix.last - 1)
-    else:
-        first_ip_in_prefix = netaddr.IPAddress(prefix.first)
-        last_ip_in_prefix = netaddr.IPAddress(prefix.last)
-
-    if not ipaddress_list:
-        return [(
-            int(last_ip_in_prefix - first_ip_in_prefix + 1),
-            '{}/{}'.format(first_ip_in_prefix, prefix.prefixlen)
-        )]
-
     # Account for any available IPs before the first real IP
-    if ipaddress_list[0].address.ip > first_ip_in_prefix:
-        skipped_count = int(ipaddress_list[0].address.ip - first_ip_in_prefix)
-        first_skipped = '{}/{}'.format(first_ip_in_prefix, prefix.prefixlen)
-        output.append((skipped_count, first_skipped))
+    if records[0][0] > first_ip_in_prefix:
+        output.append(AvailableIPSpace(
+            size=int(records[0][0] - first_ip_in_prefix),
+            first_ip=f'{first_ip_in_prefix}/{prefix.mask_length}'
+        ))
 
     # Iterate through existing IPs and annotate free ranges
-    for ip in ipaddress_list:
+    for record in records:
         if prev_ip:
-            diff = int(ip.address.ip - prev_ip.address.ip)
-            if diff > 1:
-                first_skipped = '{}/{}'.format(prev_ip.address.ip + 1, prefix.prefixlen)
-                output.append((diff - 1, first_skipped))
-        output.append(ip)
-        prev_ip = ip
+            # We've already listed a range which covers this IP
+            if record[0] < prev_ip:
+                continue
+
+            # Annotate available space
+            if (diff := int(record[0] - prev_ip)) > 1:
+                first_skipped = f'{prev_ip + 1}/{prefix.mask_length}'
+                output.append(AvailableIPSpace(
+                    size=diff - 1,
+                    first_ip=first_skipped
+                ))
+
+        output.append(record[1])
+
+        # Update the previous IP address
+        if hasattr(record[1], 'end_address'):
+            prev_ip = record[1].end_address.ip
+        else:
+            prev_ip = record[0]
+        print(f'prev_ip: {prev_ip}')
 
     # Include any remaining available IPs
-    if prev_ip.address.ip < last_ip_in_prefix:
-        skipped_count = int(last_ip_in_prefix - prev_ip.address.ip)
-        first_skipped = '{}/{}'.format(prev_ip.address.ip + 1, prefix.prefixlen)
-        output.append((skipped_count, first_skipped))
+    if prev_ip < last_ip_in_prefix:
+        output.append(AvailableIPSpace(
+            size=int(last_ip_in_prefix - prev_ip),
+            first_ip=f'{prev_ip + 1}/{prefix.mask_length}'
+        ))
 
     return output
 

--- a/netbox/ipam/utils.py
+++ b/netbox/ipam/utils.py
@@ -1,6 +1,8 @@
 from dataclasses import dataclass
 import netaddr
 
+from django.utils.translation import gettext_lazy as _
+
 from .constants import *
 from .models import Prefix, VLAN
 
@@ -16,8 +18,19 @@ __all__ = (
 
 @dataclass
 class AvailableIPSpace:
+    """
+    A representation of available IP space between two IP addresses/ranges.
+    """
     size: int
     first_ip: str
+
+    @property
+    def title(self):
+        if self.size == 1:
+            return _('1 IP available')
+        if self.size <= 65536:
+            return _('{count} IPs available').format(count=self.size)
+        return _('Many IPs available')
 
 
 def add_requested_prefixes(parent, prefix_list, show_available=True, show_assigned=True):

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -619,7 +619,7 @@ class PrefixIPRangesView(generic.ObjectChildrenView):
 class PrefixIPAddressesView(generic.ObjectChildrenView):
     queryset = Prefix.objects.all()
     child_model = IPAddress
-    table = tables.IPAddressTable
+    table = tables.AnnotatedIPAddressTable
     filterset = filtersets.IPAddressFilterSet
     filterset_form = forms.IPAddressFilterForm
     template_name = 'ipam/prefix/ip_addresses.html'

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -21,7 +21,7 @@ from . import filtersets, forms, tables
 from .choices import PrefixStatusChoices
 from .constants import *
 from .models import *
-from .utils import add_requested_prefixes, add_available_ipaddresses, add_available_vlans
+from .utils import add_requested_prefixes, add_available_vlans, annotate_ip_space
 
 
 #
@@ -635,7 +635,7 @@ class PrefixIPAddressesView(generic.ObjectChildrenView):
 
     def prep_table_data(self, request, queryset, parent):
         if not request.GET.get('q') and not get_table_ordering(request, self.table):
-            return add_available_ipaddresses(parent.prefix, queryset, parent.is_pool)
+            return annotate_ip_space(parent)
         return queryset
 
     def get_extra_context(self, request, instance):

--- a/netbox/templates/ipam/iprange.html
+++ b/netbox/templates/ipam/iprange.html
@@ -26,6 +26,10 @@
             <td>{{ object.size }}</td>
         </tr>
         <tr>
+            <th scope="row">{% trans "Reserved" %}</th>
+            <td>{% checkmark object.mark_reserved %}</td>
+        </tr>
+        <tr>
             <th scope="row">{% trans "Utilization" %}</th>
             <td>
               {% if object.mark_utilized %}

--- a/netbox/templates/ipam/iprange.html
+++ b/netbox/templates/ipam/iprange.html
@@ -26,15 +26,18 @@
             <td>{{ object.size }}</td>
         </tr>
         <tr>
-            <th scope="row">{% trans "Reserved" %}</th>
-            <td>{% checkmark object.mark_reserved %}</td>
+            <th scope="row">{% trans "Marked Populated" %}</th>
+            <td>{% checkmark object.mark_populated %}</td>
+        </tr>
+        <tr>
+            <th scope="row">{% trans "Marked Utilized" %}</th>
+            <td>{% checkmark object.mark_utilized %}</td>
         </tr>
         <tr>
             <th scope="row">{% trans "Utilization" %}</th>
             <td>
               {% if object.mark_utilized %}
                 {% utilization_graph 100 warning_threshold=0 danger_threshold=0 %}
-                <small>({% trans "Marked fully utilized" %})</small>
               {% else %}
                 {% utilization_graph object.utilization %}
               {% endif %}


### PR DESCRIPTION
### Fixes: #9763

- Add a `mark_populated` boolean field to the IPRange model
- Replace the `add_available_ipaddresses()` utility function with `annotate_ip_space()`
- Introduce the AvailableIPSpace data class to represent unallocated space between two real IP objects
- Extend the `get_child_ranges()` method the Prefix model to allow passing filters

Note: Calling `get_available_ips()` on a prefix with `mark_utilized=True` no longer automatically returns an empty IPSet. This is a deviation from the current behavior that, while not explicitly addressed in the FR, is necessary to ensure the consistent treatment of both prefixes and IP ranges.