### PR TITLE
Closes #17166: Remove obsolete `limit_choices_to` argument from ForeignKey & M2M fields

### DIFF
--- a/netbox/circuits/migrations/0047_circuittermination__termination.py
+++ b/netbox/circuits/migrations/0047_circuittermination__termination.py
@@ -39,9 +39,6 @@ class Migration(migrations.Migration):
             name='termination_type',
             field=models.ForeignKey(
                 blank=True,
-                limit_choices_to=models.Q(
-                    ('model__in', ('region', 'sitegroup', 'site', 'location', 'providernetwork'))
-                ),
                 null=True,
                 on_delete=django.db.models.deletion.PROTECT,
                 related_name='+',

--- a/netbox/circuits/migrations/0051_virtualcircuit_group_assignment.py
+++ b/netbox/circuits/migrations/0051_virtualcircuit_group_assignment.py
@@ -51,7 +51,6 @@ class Migration(migrations.Migration):
             name='member_type',
             field=models.ForeignKey(
                 on_delete=django.db.models.deletion.PROTECT,
-                limit_choices_to=models.Q(('app_label', 'circuits'), ('model__in', ['circuit', 'virtualcircuit'])),
                 related_name='+',
                 to='contenttypes.contenttype',
                 blank=True,
@@ -68,7 +67,6 @@ class Migration(migrations.Migration):
             model_name='circuitgroupassignment',
             name='member_type',
             field=models.ForeignKey(
-                limit_choices_to=models.Q(('app_label', 'circuits'), ('model__in', ['circuit', 'virtualcircuit'])),
                 on_delete=django.db.models.deletion.PROTECT,
                 related_name='+',
                 to='contenttypes.contenttype'

--- a/netbox/circuits/models/circuits.py
+++ b/netbox/circuits/models/circuits.py
@@ -182,7 +182,6 @@ class CircuitGroupAssignment(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin,
     """
     member_type = models.ForeignKey(
         to='contenttypes.ContentType',
-        limit_choices_to=CIRCUIT_GROUP_ASSIGNMENT_MEMBER_MODELS,
         on_delete=models.PROTECT,
         related_name='+'
     )
@@ -249,7 +248,6 @@ class CircuitTermination(
     termination_type = models.ForeignKey(
         to='contenttypes.ContentType',
         on_delete=models.PROTECT,
-        limit_choices_to=Q(model__in=CIRCUIT_TERMINATION_TERMINATION_TYPES),
         related_name='+',
         blank=True,
         null=True

--- a/netbox/dcim/migrations/0003_squashed_0130.py
+++ b/netbox/dcim/migrations/0003_squashed_0130.py
@@ -505,28 +505,6 @@ class Migration(migrations.Migration):
             model_name='cable',
             name='termination_a_type',
             field=models.ForeignKey(
-                limit_choices_to=models.Q(
-                    models.Q(
-                        models.Q(('app_label', 'circuits'), ('model__in', ('circuittermination',))),
-                        models.Q(
-                            ('app_label', 'dcim'),
-                            (
-                                'model__in',
-                                (
-                                    'consoleport',
-                                    'consoleserverport',
-                                    'frontport',
-                                    'interface',
-                                    'powerfeed',
-                                    'poweroutlet',
-                                    'powerport',
-                                    'rearport',
-                                ),
-                            ),
-                        ),
-                        _connector='OR',
-                    )
-                ),
                 on_delete=django.db.models.deletion.PROTECT,
                 related_name='+',
                 to='contenttypes.contenttype',
@@ -536,28 +514,6 @@ class Migration(migrations.Migration):
             model_name='cable',
             name='termination_b_type',
             field=models.ForeignKey(
-                limit_choices_to=models.Q(
-                    models.Q(
-                        models.Q(('app_label', 'circuits'), ('model__in', ('circuittermination',))),
-                        models.Q(
-                            ('app_label', 'dcim'),
-                            (
-                                'model__in',
-                                (
-                                    'consoleport',
-                                    'consoleserverport',
-                                    'frontport',
-                                    'interface',
-                                    'powerfeed',
-                                    'poweroutlet',
-                                    'powerport',
-                                    'rearport',
-                                ),
-                            ),
-                        ),
-                        _connector='OR',
-                    )
-                ),
                 on_delete=django.db.models.deletion.PROTECT,
                 related_name='+',
                 to='contenttypes.contenttype',

--- a/netbox/dcim/migrations/0131_squashed_0159.py
+++ b/netbox/dcim/migrations/0131_squashed_0159.py
@@ -866,21 +866,6 @@ class Migration(migrations.Migration):
             name='component_type',
             field=models.ForeignKey(
                 blank=True,
-                limit_choices_to=models.Q(
-                    ('app_label', 'dcim'),
-                    (
-                        'model__in',
-                        (
-                            'consoleport',
-                            'consoleserverport',
-                            'frontport',
-                            'interface',
-                            'poweroutlet',
-                            'powerport',
-                            'rearport',
-                        ),
-                    ),
-                ),
                 null=True,
                 on_delete=django.db.models.deletion.PROTECT,
                 related_name='+',
@@ -1238,21 +1223,6 @@ class Migration(migrations.Migration):
                     'component_type',
                     models.ForeignKey(
                         blank=True,
-                        limit_choices_to=models.Q(
-                            ('app_label', 'dcim'),
-                            (
-                                'model__in',
-                                (
-                                    'consoleporttemplate',
-                                    'consoleserverporttemplate',
-                                    'frontporttemplate',
-                                    'interfacetemplate',
-                                    'poweroutlettemplate',
-                                    'powerporttemplate',
-                                    'rearporttemplate',
-                                ),
-                            ),
-                        ),
                         null=True,
                         on_delete=django.db.models.deletion.PROTECT,
                         related_name='+',
@@ -1478,28 +1448,6 @@ class Migration(migrations.Migration):
                 (
                     'termination_type',
                     models.ForeignKey(
-                        limit_choices_to=models.Q(
-                            models.Q(
-                                models.Q(('app_label', 'circuits'), ('model__in', ('circuittermination',))),
-                                models.Q(
-                                    ('app_label', 'dcim'),
-                                    (
-                                        'model__in',
-                                        (
-                                            'consoleport',
-                                            'consoleserverport',
-                                            'frontport',
-                                            'interface',
-                                            'powerfeed',
-                                            'poweroutlet',
-                                            'powerport',
-                                            'rearport',
-                                        ),
-                                    ),
-                                ),
-                                _connector='OR',
-                            )
-                        ),
                         on_delete=django.db.models.deletion.PROTECT,
                         related_name='+',
                         to='contenttypes.contenttype',

--- a/netbox/dcim/migrations/0199_macaddress.py
+++ b/netbox/dcim/migrations/0199_macaddress.py
@@ -31,13 +31,6 @@ class Migration(migrations.Migration):
                     'assigned_object_type',
                     models.ForeignKey(
                         blank=True,
-                        limit_choices_to=models.Q(
-                            models.Q(
-                                models.Q(('app_label', 'dcim'), ('model', 'interface')),
-                                models.Q(('app_label', 'virtualization'), ('model', 'vminterface')),
-                                _connector='OR',
-                            )
-                        ),
                         null=True,
                         on_delete=django.db.models.deletion.PROTECT,
                         related_name='+',

--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -259,7 +259,6 @@ class CableTermination(ChangeLoggedModel):
     )
     termination_type = models.ForeignKey(
         to='contenttypes.ContentType',
-        limit_choices_to=CABLE_TERMINATION_MODELS,
         on_delete=models.PROTECT,
         related_name='+'
     )

--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -751,7 +751,6 @@ class InventoryItemTemplate(MPTTModel, ComponentTemplateModel):
     )
     component_type = models.ForeignKey(
         to='contenttypes.ContentType',
-        limit_choices_to=MODULAR_COMPONENT_TEMPLATE_MODELS,
         on_delete=models.PROTECT,
         related_name='+',
         blank=True,

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -1274,7 +1274,6 @@ class InventoryItem(MPTTModel, ComponentModel, TrackingModelMixin):
     )
     component_type = models.ForeignKey(
         to='contenttypes.ContentType',
-        limit_choices_to=MODULAR_COMPONENT_MODELS,
         on_delete=models.PROTECT,
         related_name='+',
         blank=True,

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -1225,7 +1225,6 @@ class MACAddress(PrimaryModel):
     )
     assigned_object_type = models.ForeignKey(
         to='contenttypes.ContentType',
-        limit_choices_to=MACADDRESS_ASSIGNMENT_MODELS,
         on_delete=models.PROTECT,
         related_name='+',
         blank=True,

--- a/netbox/dcim/models/mixins.py
+++ b/netbox/dcim/models/mixins.py
@@ -3,7 +3,6 @@ from django.contrib.contenttypes.fields import GenericForeignKey
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
-from dcim.constants import LOCATION_SCOPE_TYPES
 
 __all__ = (
     'CachedScopeMixin',
@@ -44,7 +43,6 @@ class CachedScopeMixin(models.Model):
     scope_type = models.ForeignKey(
         to='contenttypes.ContentType',
         on_delete=models.PROTECT,
-        limit_choices_to=models.Q(model__in=LOCATION_SCOPE_TYPES),
         related_name='+',
         blank=True,
         null=True

--- a/netbox/ipam/migrations/0001_squashed.py
+++ b/netbox/ipam/migrations/0001_squashed.py
@@ -195,12 +195,6 @@ class Migration(migrations.Migration):
                     'scope_type',
                     models.ForeignKey(
                         blank=True,
-                        limit_choices_to=models.Q(
-                            (
-                                'model__in',
-                                ('region', 'sitegroup', 'site', 'location', 'rack', 'clustergroup', 'cluster'),
-                            )
-                        ),
                         null=True,
                         on_delete=django.db.models.deletion.CASCADE,
                         to='contenttypes.contenttype',

--- a/netbox/ipam/migrations/0002_squashed_0046.py
+++ b/netbox/ipam/migrations/0002_squashed_0046.py
@@ -154,13 +154,6 @@ class Migration(migrations.Migration):
             name='assigned_object_type',
             field=models.ForeignKey(
                 blank=True,
-                limit_choices_to=models.Q(
-                    models.Q(
-                        models.Q(('app_label', 'dcim'), ('model', 'interface')),
-                        models.Q(('app_label', 'virtualization'), ('model', 'vminterface')),
-                        _connector='OR',
-                    )
-                ),
                 null=True,
                 on_delete=django.db.models.deletion.PROTECT,
                 related_name='+',

--- a/netbox/ipam/migrations/0047_squashed_0053.py
+++ b/netbox/ipam/migrations/0047_squashed_0053.py
@@ -136,14 +136,6 @@ class Migration(migrations.Migration):
             name='assigned_object_type',
             field=models.ForeignKey(
                 blank=True,
-                limit_choices_to=models.Q(
-                    models.Q(
-                        models.Q(('app_label', 'dcim'), ('model', 'interface')),
-                        models.Q(('app_label', 'ipam'), ('model', 'fhrpgroup')),
-                        models.Q(('app_label', 'virtualization'), ('model', 'vminterface')),
-                        _connector='OR',
-                    )
-                ),
                 null=True,
                 on_delete=django.db.models.deletion.PROTECT,
                 related_name='+',

--- a/netbox/ipam/migrations/0054_squashed_0067.py
+++ b/netbox/ipam/migrations/0054_squashed_0067.py
@@ -304,14 +304,6 @@ class Migration(migrations.Migration):
                 (
                     'assigned_object_type',
                     models.ForeignKey(
-                        limit_choices_to=models.Q(
-                            models.Q(
-                                models.Q(('app_label', 'dcim'), ('model', 'interface')),
-                                models.Q(('app_label', 'ipam'), ('model', 'vlan')),
-                                models.Q(('app_label', 'virtualization'), ('model', 'vminterface')),
-                                _connector='OR',
-                            )
-                        ),
                         on_delete=django.db.models.deletion.PROTECT,
                         related_name='+',
                         to='contenttypes.contenttype',

--- a/netbox/ipam/migrations/0071_prefix_scope.py
+++ b/netbox/ipam/migrations/0071_prefix_scope.py
@@ -33,7 +33,6 @@ class Migration(migrations.Migration):
             name='scope_type',
             field=models.ForeignKey(
                 blank=True,
-                limit_choices_to=models.Q(('model__in', ('region', 'sitegroup', 'site', 'location'))),
                 null=True,
                 on_delete=django.db.models.deletion.PROTECT,
                 related_name='+',

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -742,7 +742,6 @@ class IPAddress(ContactsMixin, PrimaryModel):
     )
     assigned_object_type = models.ForeignKey(
         to='contenttypes.ContentType',
-        limit_choices_to=IPADDRESS_ASSIGNMENT_MODELS,
         on_delete=models.PROTECT,
         related_name='+',
         blank=True,

--- a/netbox/ipam/models/vlans.py
+++ b/netbox/ipam/models/vlans.py
@@ -45,7 +45,6 @@ class VLANGroup(OrganizationalModel):
     scope_type = models.ForeignKey(
         to='contenttypes.ContentType',
         on_delete=models.CASCADE,
-        limit_choices_to=Q(model__in=VLANGROUP_SCOPE_TYPES),
         blank=True,
         null=True
     )

--- a/netbox/users/migrations/0001_squashed_0011.py
+++ b/netbox/users/migrations/0001_squashed_0011.py
@@ -132,20 +132,6 @@ class Migration(migrations.Migration):
                 (
                     'object_types',
                     models.ManyToManyField(
-                        limit_choices_to=models.Q(
-                            models.Q(
-                                models.Q(
-                                    (
-                                        'app_label__in',
-                                        ['account', 'admin', 'auth', 'contenttypes', 'sessions', 'taggit', 'users'],
-                                    ),
-                                    _negated=True,
-                                ),
-                                models.Q(('app_label', 'auth'), ('model__in', ['group', 'user'])),
-                                models.Q(('app_label', 'users'), ('model__in', ['objectpermission', 'token'])),
-                                _connector='OR',
-                            )
-                        ),
                         related_name='object_permissions',
                         to='contenttypes.ContentType',
                     ),

--- a/netbox/users/migrations/0007_objectpermission_update_object_types.py
+++ b/netbox/users/migrations/0007_objectpermission_update_object_types.py
@@ -13,23 +13,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='objectpermission',
             name='object_types',
-            field=models.ManyToManyField(
-                limit_choices_to=models.Q(
-                    models.Q(
-                        models.Q(
-                            (
-                                'app_label__in',
-                                ['account', 'admin', 'auth', 'contenttypes', 'sessions', 'taggit', 'users'],
-                            ),
-                            _negated=True,
-                        ),
-                        models.Q(('app_label', 'auth'), ('model__in', ['group', 'user'])),
-                        models.Q(('app_label', 'users'), ('model__in', ['objectpermission', 'token'])),
-                        _connector='OR',
-                    )
-                ),
-                related_name='object_permissions',
-                to='core.objecttype',
-            ),
+            field=models.ManyToManyField(related_name='object_permissions', to='core.objecttype'),
         ),
     ]

--- a/netbox/users/migrations/0009_update_group_perms.py
+++ b/netbox/users/migrations/0009_update_group_perms.py
@@ -28,22 +28,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='objectpermission',
             name='object_types',
-            field=models.ManyToManyField(
-                limit_choices_to=models.Q(
-                    models.Q(
-                        models.Q(
-                            (
-                                'app_label__in',
-                                ['account', 'admin', 'auth', 'contenttypes', 'sessions', 'taggit', 'users'],
-                            ),
-                            _negated=True,
-                        ),
-                        models.Q(('app_label', 'users'), ('model__in', ['objectpermission', 'token', 'group', 'user'])),
-                        _connector='OR',
-                    )
-                ),
-                related_name='object_permissions',
-                to='core.objecttype',
-            ),
+            field=models.ManyToManyField(related_name='object_permissions', to='core.objecttype'),
         ),
     ]

--- a/netbox/users/models/permissions.py
+++ b/netbox/users/models/permissions.py
@@ -3,7 +3,6 @@ from django.db import models
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
-from users.constants import OBJECTPERMISSION_OBJECT_TYPES
 from utilities.querysets import RestrictedQuerySet
 
 __all__ = (
@@ -31,7 +30,6 @@ class ObjectPermission(models.Model):
     )
     object_types = models.ManyToManyField(
         to='core.ObjectType',
-        limit_choices_to=OBJECTPERMISSION_OBJECT_TYPES,
         related_name='object_permissions'
     )
     actions = ArrayField(

--- a/netbox/virtualization/migrations/0001_squashed_0022.py
+++ b/netbox/virtualization/migrations/0001_squashed_0022.py
@@ -154,7 +154,6 @@ class Migration(migrations.Migration):
                     'role',
                     models.ForeignKey(
                         blank=True,
-                        limit_choices_to={'vm_role': True},
                         null=True,
                         on_delete=django.db.models.deletion.PROTECT,
                         related_name='virtual_machines',

--- a/netbox/virtualization/migrations/0044_cluster_scope.py
+++ b/netbox/virtualization/migrations/0044_cluster_scope.py
@@ -32,7 +32,6 @@ class Migration(migrations.Migration):
             name='scope_type',
             field=models.ForeignKey(
                 blank=True,
-                limit_choices_to=models.Q(('model__in', ('region', 'sitegroup', 'site', 'location'))),
                 null=True,
                 on_delete=django.db.models.deletion.PROTECT,
                 related_name='+',

--- a/netbox/virtualization/models/virtualmachines.py
+++ b/netbox/virtualization/models/virtualmachines.py
@@ -82,7 +82,6 @@ class VirtualMachine(ContactsMixin, ImageAttachmentsMixin, RenderConfigMixin, Co
         to='dcim.DeviceRole',
         on_delete=models.PROTECT,
         related_name='virtual_machines',
-        limit_choices_to={'vm_role': True},
         blank=True,
         null=True
     )

--- a/netbox/vpn/migrations/0002_move_l2vpn.py
+++ b/netbox/vpn/migrations/0002_move_l2vpn.py
@@ -72,14 +72,6 @@ class Migration(migrations.Migration):
                         (
                             'assigned_object_type',
                             models.ForeignKey(
-                                limit_choices_to=models.Q(
-                                    models.Q(
-                                        models.Q(('app_label', 'dcim'), ('model', 'interface')),
-                                        models.Q(('app_label', 'ipam'), ('model', 'vlan')),
-                                        models.Q(('app_label', 'virtualization'), ('model', 'vminterface')),
-                                        _connector='OR',
-                                    )
-                                ),
                                 on_delete=django.db.models.deletion.PROTECT,
                                 related_name='+',
                                 to='contenttypes.contenttype',

--- a/netbox/vpn/models/l2vpn.py
+++ b/netbox/vpn/models/l2vpn.py
@@ -8,7 +8,6 @@ from core.models import ObjectType
 from netbox.models import NetBoxModel, PrimaryModel
 from netbox.models.features import ContactsMixin
 from vpn.choices import L2VPNStatusChoices, L2VPNTypeChoices
-from vpn.constants import L2VPN_ASSIGNMENT_MODELS
 
 __all__ = (
     'L2VPN',
@@ -93,7 +92,6 @@ class L2VPNTermination(NetBoxModel):
     )
     assigned_object_type = models.ForeignKey(
         to='contenttypes.ContentType',
-        limit_choices_to=L2VPN_ASSIGNMENT_MODELS,
         on_delete=models.PROTECT,
         related_name='+'
     )

--- a/netbox/wireless/migrations/0001_squashed_0008.py
+++ b/netbox/wireless/migrations/0001_squashed_0008.py
@@ -4,7 +4,6 @@ import taggit.managers
 from django.db import migrations, models
 
 import utilities.json
-import wireless.models
 
 
 class Migration(migrations.Migration):
@@ -149,7 +148,6 @@ class Migration(migrations.Migration):
                 (
                     'interface_a',
                     models.ForeignKey(
-                        limit_choices_to=wireless.models.get_wireless_interface_types,
                         on_delete=django.db.models.deletion.PROTECT,
                         related_name='+',
                         to='dcim.interface',
@@ -158,7 +156,6 @@ class Migration(migrations.Migration):
                 (
                     'interface_b',
                     models.ForeignKey(
-                        limit_choices_to=wireless.models.get_wireless_interface_types,
                         on_delete=django.db.models.deletion.PROTECT,
                         related_name='+',
                         to='dcim.interface',

--- a/netbox/wireless/migrations/0011_wirelesslan__location_wirelesslan__region_and_more.py
+++ b/netbox/wireless/migrations/0011_wirelesslan__location_wirelesslan__region_and_more.py
@@ -66,7 +66,6 @@ class Migration(migrations.Migration):
             name='scope_type',
             field=models.ForeignKey(
                 blank=True,
-                limit_choices_to=models.Q(('model__in', ('region', 'sitegroup', 'site', 'location'))),
                 null=True,
                 on_delete=django.db.models.deletion.PROTECT,
                 related_name='+',

--- a/netbox/wireless/models.py
+++ b/netbox/wireless/models.py
@@ -123,26 +123,18 @@ class WirelessLAN(WirelessAuthenticationBase, CachedScopeMixin, PrimaryModel):
         return WirelessLANStatusChoices.colors.get(self.status)
 
 
-def get_wireless_interface_types():
-    # Wrap choices in a callable to avoid generating dummy migrations
-    # when the choices are updated.
-    return {'type__in': WIRELESS_IFACE_TYPES}
-
-
 class WirelessLink(WirelessAuthenticationBase, DistanceMixin, PrimaryModel):
     """
     A point-to-point connection between two wireless Interfaces.
     """
     interface_a = models.ForeignKey(
         to='dcim.Interface',
-        limit_choices_to=get_wireless_interface_types,
         on_delete=models.PROTECT,
         related_name='+',
         verbose_name=_('interface A'),
     )
     interface_b = models.ForeignKey(
         to='dcim.Interface',
-        limit_choices_to=get_wireless_interface_types,
         on_delete=models.PROTECT,
         related_name='+',
         verbose_name=_('interface B'),


### PR DESCRIPTION
### Fixes: #17166

- Remove the `limit_choices_to` argument on all ForeignKey & ManyToMany fields.
- Remove the argument from existing migrations as well, to avoid generating new migrations. (This field attribute has no impact on the database schema.)