### PR TITLE
Closes #19004: Mark inventory items as deprecated in the documentation

### DIFF
--- a/docs/models/dcim/inventoryitem.md
+++ b/docs/models/dcim/inventoryitem.md
@@ -1,5 +1,8 @@
 # Inventory Items
 
+!!! warning "Deprecation Warning"
+    Beginning in NetBox v4.3, the use of inventory items has been deprecated. They are planned for removal in a future NetBox release. Users are strongly encouraged to begin using [modules](./module.md) and [module types](./moduletype.md) in place of inventory items. Modules provide enhanced functionality and can be configured with user-defined attributes.
+
 Inventory items represent hardware components installed within a device, such as a power supply or CPU or line card. They are intended to be used primarily for inventory purposes.
 
 Inventory items are hierarchical in nature, such that any individual item may be designated as the parent for other items. For example, an inventory item might be created to represent a line card which houses several SFP optics, each of which exists as a child item within the device. An inventory item may also be associated with a specific component within the same device. For example, you may wish to associate a transceiver with an interface.

--- a/docs/models/dcim/inventoryitemrole.md
+++ b/docs/models/dcim/inventoryitemrole.md
@@ -1,5 +1,8 @@
 # Inventory Item Roles
 
+!!! warning "Deprecation Warning"
+    Beginning in NetBox v4.3, the use of inventory items has been deprecated. They are planned for removal in a future NetBox release. Users are strongly encouraged to begin using [modules](./module.md) and [module types](./moduletype.md) in place of inventory items. Modules provide enhanced functionality and can be configured with user-defined attributes.
+
 Inventory items can be organized by functional roles, which are fully customizable by the user. For example, you might create roles for power supplies, fans, interface optics, etc.
 
 ## Fields

--- a/docs/models/dcim/inventoryitemtemplate.md
+++ b/docs/models/dcim/inventoryitemtemplate.md
@@ -1,3 +1,6 @@
 # Inventory Item Templates
 
+!!! warning "Deprecation Warning"
+    Beginning in NetBox v4.3, the use of inventory items has been deprecated. They are planned for removal in a future NetBox release. Users are strongly encouraged to begin using [modules](./module.md) and [module types](./moduletype.md) in place of inventory items. Modules provide enhanced functionality and can be configured with user-defined attributes.
+
 A template for an inventory item that will be automatically created when instantiating a new device. All attributes of this object will be copied to the new inventory item, including the associations with a parent item and assigned component, if any. See the [inventory item](./inventoryitem.md) documentation for more detail.


### PR DESCRIPTION
### Fixes: #19004

I've added deprecation warnings in the documentation for the affected models. Not sure if there's anything more we should do right now.