### PR TITLE
Fixes #18553: Update site for VMs only if cluster has a site assigned

### DIFF
--- a/netbox/virtualization/apps.py
+++ b/netbox/virtualization/apps.py
@@ -1,7 +1,5 @@
 from django.apps import AppConfig
 
-from netbox import denormalized
-
 
 class VirtualizationConfig(AppConfig):
     name = 'virtualization'
@@ -14,11 +12,6 @@ class VirtualizationConfig(AppConfig):
 
         # Register models
         register_models(*self.get_models())
-
-        # Register denormalized fields
-        denormalized.register(VirtualMachine, 'cluster', {
-            'site': '_site',
-        })
 
         # Register counters
         connect_counters(VirtualMachine)

--- a/netbox/virtualization/signals.py
+++ b/netbox/virtualization/signals.py
@@ -2,7 +2,7 @@ from django.db.models import Sum
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
-from .models import VirtualDisk, VirtualMachine
+from .models import Cluster, VirtualDisk, VirtualMachine
 
 
 @receiver((post_delete, post_save), sender=VirtualDisk)
@@ -14,3 +14,12 @@ def update_virtualmachine_disk(instance, **kwargs):
     VirtualMachine.objects.filter(pk=vm.pk).update(
         disk=vm.virtualdisks.aggregate(Sum('size'))['size__sum']
     )
+
+
+@receiver(post_save, sender=Cluster)
+def update_virtualmachine_site(instance, **kwargs):
+    """
+    Update the assigned site for all VMs to match that of the Cluster (if any).
+    """
+    if instance._site:
+        VirtualMachine.objects.filter(cluster=instance).update(site=instance._site)


### PR DESCRIPTION
### Fixes: #18553

- Unregister VirtualMachine.site as a denormalized field
- Introduce a post-save handler `update_virtualmachine_site()` to conditionally update the site assignments of VMs when a cluster is modified

I believe this solves for the use cases in both #18553 and #15020, but additional testing is appreciated.