### PR TITLE
Closes #19035: Move the registration of core event types to the app config

### DIFF
--- a/netbox/core/apps.py
+++ b/netbox/core/apps.py
@@ -3,7 +3,10 @@ from django.conf import settings
 from django.core.cache import cache
 from django.db import models
 from django.db.migrations.operations import AlterModelOptions
+from django.utils.translation import gettext as _
 
+from core.events import *
+from netbox.events import EventType, EVENT_TYPE_KIND_DANGER, EVENT_TYPE_KIND_SUCCESS, EVENT_TYPE_KIND_WARNING
 from utilities.migration import custom_deconstruct
 
 # Ignore verbose_name & verbose_name_plural Meta options when calculating model migrations
@@ -25,6 +28,15 @@ class CoreConfig(AppConfig):
 
         # Register models
         register_models(*self.get_models())
+
+        # Register core events
+        EventType(OBJECT_CREATED, _('Object created')).register()
+        EventType(OBJECT_UPDATED, _('Object updated')).register()
+        EventType(OBJECT_DELETED, _('Object deleted'), destructive=True).register()
+        EventType(JOB_STARTED, _('Job started')).register()
+        EventType(JOB_COMPLETED, _('Job completed'), kind=EVENT_TYPE_KIND_SUCCESS).register()
+        EventType(JOB_FAILED, _('Job failed'), kind=EVENT_TYPE_KIND_WARNING).register()
+        EventType(JOB_ERRORED, _('Job errored'), kind=EVENT_TYPE_KIND_DANGER).register()
 
         # Clear Redis cache on startup in development mode
         if settings.DEBUG:

--- a/netbox/core/events.py
+++ b/netbox/core/events.py
@@ -1,7 +1,3 @@
-from django.utils.translation import gettext as _
-
-from netbox.events import EventType, EVENT_TYPE_KIND_DANGER, EVENT_TYPE_KIND_SUCCESS, EVENT_TYPE_KIND_WARNING
-
 __all__ = (
     'JOB_COMPLETED',
     'JOB_ERRORED',
@@ -22,12 +18,3 @@ JOB_STARTED = 'job_started'
 JOB_COMPLETED = 'job_completed'
 JOB_FAILED = 'job_failed'
 JOB_ERRORED = 'job_errored'
-
-# Register core events
-EventType(OBJECT_CREATED, _('Object created')).register()
-EventType(OBJECT_UPDATED, _('Object updated')).register()
-EventType(OBJECT_DELETED, _('Object deleted'), destructive=True).register()
-EventType(JOB_STARTED, _('Job started')).register()
-EventType(JOB_COMPLETED, _('Job completed'), kind=EVENT_TYPE_KIND_SUCCESS).register()
-EventType(JOB_FAILED, _('Job failed'), kind=EVENT_TYPE_KIND_WARNING).register()
-EventType(JOB_ERRORED, _('Job errored'), kind=EVENT_TYPE_KIND_DANGER).register()


### PR DESCRIPTION
### Closes: #19035

Defer the registration of core event types to avoid potential import issues.