### PR TITLE
Fixes #19092: scope type selection lost when editing multiple/all objects

### DIFF
--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -666,7 +666,9 @@ class BulkEditView(GetReturnURLMixin, BaseMultiObjectView):
         elif 'virtual_machine' in request.GET:
             initial_data['virtual_machine'] = request.GET.get('virtual_machine')
 
-        form = self.form(request.POST, initial=initial_data)
+        post_data = request.POST.copy()
+        post_data.setlist('pk', pk_list)
+        form = self.form(post_data, initial=initial_data)
         restrict_form_fields(form, request.user)
 
         if '_apply' in request.POST:
@@ -699,10 +701,6 @@ class BulkEditView(GetReturnURLMixin, BaseMultiObjectView):
 
             else:
                 logger.debug("Form validation failed")
-
-        else:
-            form = self.form(initial=initial_data)
-            restrict_form_fields(form, request.user)
 
         # Retrieve objects being edited
         table = self.table(self.queryset.filter(pk__in=pk_list), orderable=False)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19092 

This essentially reverts the previous fix for #18964, which attempted to fix the issue with some objects not being updated when the "select all <n> <object type>s matching query" checkbox was marked by restoring an `else` clause that had been removed in the fix for #18194. However, doing so regressed the fix for #18194 while still leaving most of the changes for that fix in place.

Rather than trying to guess all of the possible fields that might need to be stuffed in to `initial_data` across all bulk edit view/form combinations, I took the approach of making a copy of `request.POST` and over-writing the `pk` list with what ever we determined to use earlier in the `BulkEditView.post()` method. With this approach, anything that is set in the form is still transmitted to the form instance via `request.POST` but the `pk` list set in `initial_data` is instead overridden by the expected value. The end result is that all users selections on the form, as well as the object selections to edit, are preserved for the next iteration of the form.

<!--
    Please include a summary of the proposed changes below.
-->
