### PR TITLE
Closes #19112: Configure ruff to target Python 3.10

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -2,6 +2,7 @@ exclude = [
     "netbox/project-static/**"
 ]
 line-length = 120
+target-version = "py310"
 
 [lint]
 extend-select = ["E1", "E2", "E3", "E501", "W"]


### PR DESCRIPTION
### Closes: #19112
