### PR TITLE
Fixes #18669 - Populate custom field default values

### DIFF
--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -538,7 +538,6 @@ class FHRPGroupForm(NetBoxModelForm):
                 role=FHRP_PROTOCOL_ROLE_MAPPINGS.get(self.cleaned_data['protocol'], IPAddressRoleChoices.ROLE_VIP),
                 assigned_object=instance
             )
-            ipaddress.populate_custom_field_defaults()
             ipaddress.save()
 
             # Check that the new IPAddress conforms with any assigned object-level permissions

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -301,6 +301,14 @@ class CustomFieldsMixin(models.Model):
             if cf.required and cf.name not in self.custom_field_data:
                 raise ValidationError(_("Missing required custom field '{name}'.").format(name=cf.name))
 
+    def save(self, *args, **kwargs):
+        # Populate default values if omitted
+        for cf in self.custom_fields.filter(default__isnull=False):
+            if cf.name not in self.custom_field_data:
+                self.custom_field_data[cf.name] = cf.default
+
+        super().save(*args, **kwargs)
+
 
 class CustomLinksMixin(models.Model):
     """


### PR DESCRIPTION
### Fixes: #18669

While it is possible to fix this issue by modifying [CustomFieldsDataField.to_internal_value()](https://github.com/netbox-community/netbox/blob/92317248a36c0c57ecfde97d9690cad35fe47d81/netbox/extras/api/customfields.py#L70) as such:
```    
    def to_internal_value(self, data):
        if type(data) is not dict:
            raise ValidationError(
                "Invalid data format. Custom field data must be passed as a dictionary mapping field names to their "
                "values."
            )

        for cf in self._get_custom_fields():
            # Apply default values if omitted in the request
            if cf.name not in data and cf.default is not None:
                data[cf.name] = cf.default
            # Serialize object and multi-object values
            elif cf.name in data and data[cf.name] not in CUSTOMFIELD_EMPTY_VALUES and cf.type in (
                    CustomFieldTypeChoices.TYPE_OBJECT,
                    CustomFieldTypeChoices.TYPE_MULTIOBJECT
            ):
                serializer_class = get_serializer_for_model(cf.related_object_type.model_class())
                many = cf.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT
                serializer = serializer_class(data=data[cf.name], nested=True, many=many, context=self.parent.context)
                if serializer.is_valid():
                    data[cf.name] = [obj['id'] for obj in serializer.data] if many else serializer.data['id']
                else:
                    raise ValidationError(_("Unknown related object(s): {name}").format(name=data[cf.name]))

        # If updating an existing instance, start with existing custom_field_data
        if self.parent.instance:
            data = {**self.parent.instance.custom_field_data, **data}

        return data
```
overriding the `save()` method on the mixin ensures the fix is applied to more than just the API endpoint (i.e. scripts). The `populate_custom_field_defaults()` method on the mixin is no longer needed but retained. It's function is to force the values of custom fields to the default rather than simply setting the default values if the fields are omitted. It was only used to populate newly created IP Addresses for FHRP groups. The `save()` method results are the same.