### PR TITLE
Fixes #19120 Add Prefix and IP parent/child fields to Graphql

### DIFF
--- a/netbox/ipam/graphql/types.py
+++ b/netbox/ipam/graphql/types.py
@@ -138,6 +138,17 @@ class IPAddressType(NetBoxObjectType, ContactsMixin, BaseIPAddressFamilyType):
         Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')],
     ], strawberry.union("IPAddressAssignmentType")] | None:
         return self.assigned_object
+        
+    @strawberry_django.field
+    def parent_prefixes(self) -> List[Annotated["PrefixType", strawberry.lazy('ipam.graphql.types')]]:
+        """
+        Return all prefixes containing this IP address.
+        """
+        from ipam.models import Prefix
+        return Prefix.objects.filter(
+            vrf=self.vrf,
+            prefix__net_contains_or_equals=str(self.address.ip)
+        )
 
 
 @strawberry_django.type(

--- a/netbox/ipam/graphql/types.py
+++ b/netbox/ipam/graphql/types.py
@@ -222,6 +222,22 @@ class PrefixType(NetBoxObjectType, ContactsMixin, BaseIPAddressFamilyType):
                 vrf=self.vrf
             )
 
+    @strawberry_django.field
+    def first_available_ip_address(self) -> str:
+        """
+        Return the first available IP address within this prefix as a string, or an empty string if none is available.
+        """
+        first_ip = self.get_first_available_ip()
+        return first_ip if first_ip else ""
+
+    @strawberry_django.field
+    def first_available_child_prefix(self) -> str:
+        """
+        Return the first available child prefix within this prefix as a string, or an empty string if none is available.
+        """
+        first_prefix = self.get_first_available_prefix()
+        return str(first_prefix) if first_prefix else ""
+
 
 @strawberry_django.type(
     models.RIR,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19120

<!--
    Please include a summary of the proposed changes below.
-->

Adds fields to the PrefixType `child_prefixes`, `parent_prefixes` and `child_ip_addresses`. And adds `parent_prefixes` to the IPAddressType.
