### PR TITLE
Closes #18652: Run housekeeping GitHub actions only on the main repository

### DIFF
--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   stale:
+    if: github.repository == 'netbox-community/netbox'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   stale:
+    if: github.repository == 'netbox-community/netbox'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   lock:
+    if: github.repository == 'netbox-community/netbox'
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v5

--- a/.github/workflows/update-translation-strings.yml
+++ b/.github/workflows/update-translation-strings.yml
@@ -13,6 +13,7 @@ env:
 
 jobs:
   makemessages:
+    if: github.repository == 'netbox-community/netbox'
     runs-on: ubuntu-latest
     env:
       NETBOX_CONFIGURATION: netbox.configuration_testing


### PR DESCRIPTION
### Closes: #18652

Note that this change is applied only for scheduled housekeeping tasks.