### PR TITLE
Fixes: #19038 Change ClusterView behaivour 

### DIFF
--- a/netbox/templates/virtualization/cluster.html
+++ b/netbox/templates/virtualization/cluster.html
@@ -81,6 +81,7 @@
           </tr>
       </table>
   </div>
+    {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% include 'inc/panels/tags.html' %}
     {% plugin_right_page object %}

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -1,4 +1,5 @@
 from django.contrib import messages
+from django.contrib.contenttypes.models import ContentType
 from django.db import transaction
 from django.db.models import Prefetch, Sum
 from django.shortcuts import get_object_or_404, redirect, render
@@ -10,7 +11,7 @@ from dcim.forms import DeviceFilterForm
 from dcim.models import Device
 from dcim.tables import DeviceTable
 from extras.views import ObjectConfigContextView, ObjectRenderConfigView
-from ipam.models import IPAddress
+from ipam.models import IPAddress, VLANGroup
 from ipam.tables import InterfaceVLANTable, VLANTranslationRuleTable
 from netbox.constants import DEFAULT_ACTION_PERMISSIONS
 from netbox.views import generic
@@ -168,15 +169,28 @@ class ClusterListView(generic.ObjectListView):
 
 
 @register_model_view(Cluster)
-class ClusterView(generic.ObjectView):
+class ClusterView(GetRelatedModelsMixin, generic.ObjectView):
     queryset = Cluster.objects.all()
 
     def get_extra_context(self, request, instance):
-        return instance.virtual_machines.aggregate(
-            vcpus_sum=Sum('vcpus'),
-            memory_sum=Sum('memory'),
-            disk_sum=Sum('disk')
-        )
+        return {
+            **instance.virtual_machines.aggregate(
+                vcpus_sum=Sum('vcpus'),
+                memory_sum=Sum('memory'),
+                disk_sum=Sum('disk')
+            ),
+            'related_models': self.get_related_models(
+                request,
+                instance,
+                omit=(),
+                extra=(
+                    (VLANGroup.objects.restrict(request.user, 'view').filter(
+                        scope_type=ContentType.objects.get_for_model(Cluster),
+                        scope_id=instance.pk
+                    ), 'cluster'),
+                )
+                ),
+        }
 
 
 @register_model_view(Cluster, 'virtualmachines', path='virtual-machines')


### PR DESCRIPTION
### Fixes: #19038 Change ClusterView behaivour 

- Add `GetRelatedModelsMixin` to `ClusterView`
- Setup `get_extra_context` with `related_models` including `VLANGroup` 
- Add relatad_models panel to `cluster.html` template


### Observations:

The `Cluster` model implement a child view for devices, and VMs but it can be redundant to have both the panel and those tabs, so removing those tab since the related_model already delivers a similar experience could be done.