### PR TITLE
19073 fix display of installed plugins

### DIFF
--- a/netbox/templates/core/plugin.html
+++ b/netbox/templates/core/plugin.html
@@ -15,8 +15,8 @@
 
 {% block subtitle %}
   <span class="text-secondary fs-5">
-    {% checkmark plugin.is_installed %}
-    {% if plugin.is_installed %}
+    {% checkmark plugin.is_local %}
+    {% if plugin.is_local %}
       v{{ plugin.installed_version }} {% trans "installed" %}
     {% else %}
       {% trans "Not installed" %}


### PR DESCRIPTION
### Fixes: #19073 

From follow on discovered in 4.3 review, Installed plugins show "not installed" in plugin view.

![Monosnap NetBox Branching | NetBox 2025-04-11 08-42-11](https://github.com/user-attachments/assets/2f695f40-9f2c-4e59-b607-58009c6d04a3)
