### PR TITLE
17608 L2VPNSerializer Status should be ChoiceField

### DIFF
--- a/netbox/vpn/api/serializers_/l2vpn.py
+++ b/netbox/vpn/api/serializers_/l2vpn.py
@@ -34,6 +34,7 @@ class L2VPNSerializer(NetBoxModelSerializer):
         many=True
     )
     tenant = TenantSerializer(nested=True, required=False, allow_null=True)
+    status = ChoiceField(choices=L2VPNStatusChoices, required=False)
 
     class Meta:
         model = L2VPN


### PR DESCRIPTION
### Fixes: #17608 

From review of v4.3 - L2VPNSerializer status should be ChoiceField
