### PR TITLE
#14591, #17841: Adjust default weighting

### DIFF
--- a/netbox/extras/migrations/0125_alter_tag_options_tag_weight.py
+++ b/netbox/extras/migrations/0125_alter_tag_options_tag_weight.py
@@ -15,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AddField(
             model_name='tag',
             name='weight',
-            field=models.PositiveSmallIntegerField(default=0),
+            field=models.PositiveSmallIntegerField(default=1000),
         ),
     ]

--- a/netbox/extras/migrations/0128_tableconfig.py
+++ b/netbox/extras/migrations/0128_tableconfig.py
@@ -21,7 +21,7 @@ class Migration(migrations.Migration):
                 ('table', models.CharField(max_length=100)),
                 ('name', models.CharField(max_length=100)),
                 ('description', models.CharField(blank=True, max_length=200)),
-                ('weight', models.PositiveSmallIntegerField(default=100)),
+                ('weight', models.PositiveSmallIntegerField(default=1000)),
                 ('enabled', models.BooleanField(default=True)),
                 ('shared', models.BooleanField(default=True)),
                 (

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -557,7 +557,7 @@ class TableConfig(CloningMixin, ChangeLoggedModel):
     )
     weight = models.PositiveSmallIntegerField(
         verbose_name=_('weight'),
-        default=100
+        default=1000,
     )
     enabled = models.BooleanField(
         verbose_name=_('enabled'),

--- a/netbox/extras/models/tags.py
+++ b/netbox/extras/models/tags.py
@@ -42,7 +42,7 @@ class Tag(CloningMixin, ExportTemplatesMixin, ChangeLoggedModel, TagBase):
     )
     weight = models.PositiveSmallIntegerField(
         verbose_name=_('weight'),
-        default=0,
+        default=1000,
     )
 
     clone_fields = (

--- a/netbox/extras/tests/test_filtersets.py
+++ b/netbox/extras/tests/test_filtersets.py
@@ -1275,9 +1275,9 @@ class TagTestCase(TestCase, ChangeLoggedFilterSetTests):
         }
 
         tags = (
-            Tag(name='Tag 1', slug='tag-1', color='ff0000', description='foobar1'),
-            Tag(name='Tag 2', slug='tag-2', color='00ff00', description='foobar2'),
-            Tag(name='Tag 3', slug='tag-3', color='0000ff', weight=1000),
+            Tag(name='Tag 1', slug='tag-1', color='ff0000', weight=1000, description='foobar1'),
+            Tag(name='Tag 2', slug='tag-2', color='00ff00', weight=2000, description='foobar2'),
+            Tag(name='Tag 3', slug='tag-3', color='0000ff', weight=3000),
         )
         Tag.objects.bulk_create(tags)
         tags[0].object_types.add(object_types['site'])
@@ -1331,11 +1331,8 @@ class TagTestCase(TestCase, ChangeLoggedFilterSetTests):
         )
 
     def test_weight(self):
-        params = {'weight': [1000]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
-
-        params = {'weight': [0]}
-        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+        params = {'weight': [1000, 2000]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
 class TaggedItemFilterSetTestCase(TestCase):

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -12,10 +12,10 @@ from virtualization.models import Cluster, ClusterGroup, ClusterType, VirtualMac
 class TagTest(TestCase):
 
     def test_default_ordering_weight_then_name_is_set(self):
-        Tag.objects.create(name='Tag 1', slug='tag-1', weight=100)
-        Tag.objects.create(name='Tag 2', slug='tag-2')
-        Tag.objects.create(name='Tag 3', slug='tag-3', weight=10)
-        Tag.objects.create(name='Tag 4', slug='tag-4', weight=10)
+        Tag.objects.create(name='Tag 1', slug='tag-1', weight=3000)
+        Tag.objects.create(name='Tag 2', slug='tag-2')  # Default: 1000
+        Tag.objects.create(name='Tag 3', slug='tag-3', weight=2000)
+        Tag.objects.create(name='Tag 4', slug='tag-4', weight=2000)
 
         tags = Tag.objects.all()
 
@@ -26,10 +26,10 @@ class TagTest(TestCase):
 
     def test_tag_related_manager_ordering_weight_then_name(self):
         tags = [
-            Tag.objects.create(name='Tag 1', slug='tag-1', weight=100),
-            Tag.objects.create(name='Tag 2', slug='tag-2'),
-            Tag.objects.create(name='Tag 3', slug='tag-3', weight=10),
-            Tag.objects.create(name='Tag 4', slug='tag-4', weight=10),
+            Tag.objects.create(name='Tag 1', slug='tag-1', weight=3000),
+            Tag.objects.create(name='Tag 2', slug='tag-2'),  # Default: 1000
+            Tag.objects.create(name='Tag 3', slug='tag-3', weight=2000),
+            Tag.objects.create(name='Tag 4', slug='tag-4', weight=2000),
         ]
 
         site = Site.objects.create(name='Site 1')


### PR DESCRIPTION
### Clean up for #14591 & #17841

Set the default value for `weight` fields to 1000. This allows more room to declare weights lower than the default value.