### PR TITLE
17170 ContactGroup Serializer nested and fix related objects

### DIFF
--- a/netbox/tenancy/api/serializers_/contacts.py
+++ b/netbox/tenancy/api/serializers_/contacts.py
@@ -47,7 +47,8 @@ class ContactSerializer(NetBoxModelSerializer):
         queryset=ContactGroup.objects.all(),
         serializer=ContactGroupSerializer,
         required=False,
-        many=True
+        many=True,
+        nested=True
     )
 
     class Meta:

--- a/netbox/tenancy/views.py
+++ b/netbox/tenancy/views.py
@@ -164,7 +164,13 @@ class ContactGroupView(GetRelatedModelsMixin, generic.ObjectView):
         groups = instance.get_descendants(include_self=True)
 
         return {
-            'related_models': self.get_related_models(request, groups),
+            'related_models': self.get_related_models(
+                request,
+                groups,
+                extra=(
+                    (Contact.objects.restrict(request.user, 'view').filter(groups__in=groups), 'group_id'),
+                ),
+            ),
         }
 
 


### PR DESCRIPTION
### Fixes: #17170 

From review of NetBox v4.3 - 
* ContactSerializer group field should pass nested=True
* Group should show number of assigned contacts under related objects

![Monosnap newcgroup | NetBox 2025-04-11 10-25-49](https://github.com/user-attachments/assets/88450c8b-be38-4ade-ab52-7837a7010635)
