### PR TITLE
Fixes: #19150 - Populate STORAGE_CONFIG into STORAGES['default']['OPTIONS']

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -237,11 +237,10 @@ STORAGES = {
         "BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage",
     },
 }
+STORAGES.update(getattr(configuration, 'STORAGES', {}))
 
 if STORAGE_BACKEND is not None:
     STORAGES['default']['BACKEND'] = STORAGE_BACKEND
-    if STORAGE_CONFIG:
-        STORAGES['default']['OPTIONS'] = STORAGE_CONFIG
 
     # django-storages
     if STORAGE_BACKEND.startswith('storages.'):

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -240,6 +240,8 @@ STORAGES = {
 
 if STORAGE_BACKEND is not None:
     STORAGES['default']['BACKEND'] = STORAGE_BACKEND
+    if STORAGE_CONFIG:
+        STORAGES['default']['OPTIONS'] = STORAGE_CONFIG
 
     # django-storages
     if STORAGE_BACKEND.startswith('storages.'):


### PR DESCRIPTION
### Fixes: #19150

Fixes an oversight in support for Django 4.2's `STORAGES` in that `STORAGE_CONFIG` was not being populated into `STORAGES['default']['OPTIONS']` as well as being monkey-patched into `storages.utils.setting` as in the pre-Django-4.2 behavior. This fix ensures that both styles of backend will be supported.

Note that this support will be obviated/deprecated in NetBox v4.3 which allows `STORAGES` to be specified directly in `configuration.py`.
