### PR TITLE
#19002: Display boolean attributes as checkmarks

### DIFF
--- a/netbox/templates/dcim/moduletype.html
+++ b/netbox/templates/dcim/moduletype.html
@@ -75,7 +75,13 @@
             {% for k, v in object.attributes.items %}
               <tr>
                 <th scope="row">{{ k }}</th>
-                <td>{{ v|placeholder }}</td>
+                <td>
+                  {% if v is True or v is False %}
+                    {% checkmark v %}
+                  {% else %}
+                    {{ v|placeholder }}
+                  {% endif %}
+                </td>
               </tr>
             {% endfor %}
           </table>


### PR DESCRIPTION
### Fixes: #19002

Render boolean attribute values as checkmarks or Xes in the UI.