### PR TITLE
Fixes: #19045 - Add strip method to ScriptVariable to prevent markdown filter crash

### DIFF
--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -80,6 +80,10 @@ class ScriptVariable:
 
         return form_field
 
+    def strip(self):
+        # Necessary for template tags/filters such as markdown
+        ...
+
 
 class StringVar(ScriptVariable):
     """


### PR DESCRIPTION
### Fixes: #19045

Adds a no-op `strip` method to `ScriptVariable` so that if such a variable is used in a template along with a template tag/filter such as `markdown` which calls that method, it silently passes through rather than crashing.