### PR TITLE
Fixes #19195: Language cookie should respect `SESSION_COOKIE_SECURE` value

### DIFF
--- a/netbox/account/views.py
+++ b/netbox/account/views.py
@@ -123,7 +123,12 @@ class LoginView(View):
 
             # Set the user's preferred language (if any)
             if language := request.user.config.get('locale.language'):
-                response.set_cookie(settings.LANGUAGE_COOKIE_NAME, language, max_age=request.session.get_expiry_age())
+                response.set_cookie(
+                    key=settings.LANGUAGE_COOKIE_NAME,
+                    value=language,
+                    max_age=request.session.get_expiry_age(),
+                    secure=settings.SESSION_COOKIE_SECURE,
+                )
 
             return response
 
@@ -218,7 +223,12 @@ class UserConfigView(LoginRequiredMixin, View):
 
             # Set/clear language cookie
             if language := form.cleaned_data['locale.language']:
-                response.set_cookie(settings.LANGUAGE_COOKIE_NAME, language, max_age=request.session.get_expiry_age())
+                response.set_cookie(
+                    key=settings.LANGUAGE_COOKIE_NAME,
+                    value=language,
+                    max_age=request.session.get_expiry_age(),
+                    secure=settings.SESSION_COOKIE_SECURE,
+                )
             else:
                 response.delete_cookie(settings.LANGUAGE_COOKIE_NAME)
 

--- a/netbox/netbox/middleware.py
+++ b/netbox/netbox/middleware.py
@@ -43,7 +43,12 @@ class CoreMiddleware:
         # Check if language cookie should be renewed
         if request.user.is_authenticated and settings.SESSION_SAVE_EVERY_REQUEST:
             if language := request.user.config.get('locale.language'):
-                response.set_cookie(settings.LANGUAGE_COOKIE_NAME, language, max_age=request.session.get_expiry_age())
+                response.set_cookie(
+                    key=settings.LANGUAGE_COOKIE_NAME,
+                    value=language,
+                    max_age=request.session.get_expiry_age(),
+                    secure=settings.SESSION_COOKIE_SECURE,
+                )
 
         # Attach the unique request ID as an HTTP header.
         response['X-Request-ID'] = request.id


### PR DESCRIPTION
### Fixes: #19195

Pass `secure` when calling `set_cookie()` to set the user's preferred language