### PR TITLE
DOCS : fix data-validation.md code example

### DIFF
--- a/docs/configuration/data-validation.md
+++ b/docs/configuration/data-validation.md
@@ -49,7 +49,7 @@ Appending a plus sign to the field identifier would instead _add_ these choices 
 FIELD_CHOICES = {
     'dcim.Site.status+': (
         ...
-    )
+    ),
 }
 ```
 


### PR DESCRIPTION
Syntax fix in pseudo code to avoid silent error : add coma to define a tuple