### PR TITLE
Closes #18976 Display FHRP Group name on VM Interface page

### DIFF
--- a/netbox/dcim/tables/template_code.py
+++ b/netbox/dcim/tables/template_code.py
@@ -64,7 +64,7 @@ INTERFACE_IPADDRESSES = """
 
 INTERFACE_FHRPGROUPS = """
   {% for assignment in value.all %}
-    <a href="{{ assignment.group.get_absolute_url }}">{{ assignment.group.get_protocol_display }}: {{ assignment.group.group_id }}</a>
+    <a href="{{ assignment.group.get_absolute_url }}">{{ assignment.group }}</a>
   {% endfor %}
 """
 


### PR DESCRIPTION
### Closes: #18976 Display FHRP Group name on VM Interface page

The `FHRPGroup` model defines a logic for its `__str__` representation, as seen in the [code implementation](https://github.com/netbox-community/netbox/blob/248c94bd3536e11b63eac7e05973274911fb5e7b/netbox/ipam/models/fhrp.py#L59). However, the `INTERFACE_FHRPGROUPS` template currently uses a different representation for `FHRPGroup`, instead of relying on its `__str__` method.

Since the `__str__` representation already encapsulates all the necessary data for this use case, it makes sense to standardize the logic by ensuring `INTERFACE_FHRPGROUPS` utilizes the `FHRPGroup` model’s `__str__` method when displaying the field.