### PR TITLE
Closes #17136: Add read-only database support to the upgrade script

### DIFF
--- a/docs/installation/3-netbox.md
+++ b/docs/installation/3-netbox.md
@@ -246,7 +246,7 @@ Once NetBox has been configured, we're ready to proceed with the actual installa
 
 * Create a Python virtual environment
 * Installs all required Python packages
-* Run database schema migrations
+* Run database schema migrations (skip with `--readonly`)
 * Builds the documentation locally (for offline use)
 * Aggregate static resource files on disk
 
@@ -265,6 +265,9 @@ sudo PYTHON=/usr/bin/python3.10 /opt/netbox/upgrade.sh
 
 !!! note
     Upon completion, the upgrade script may warn that no existing virtual environment was detected. As this is a new installation, this warning can be safely ignored.
+
+!!! note
+    To run the script on a node connected to a database in read-only mode, include the `--readonly` parameter. This will skip the application of any database migrations.
 
 ## Create a Super User
 

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -152,6 +152,9 @@ sudo ./upgrade.sh
     sudo PYTHON=/usr/bin/python3.10 ./upgrade.sh
     ```
 
+!!! note
+    To run the script on a node connected to a database in read-only mode, include the `--readonly` parameter. This will skip the application of any database migrations.
+
 This script performs the following actions:
 
 * Destroys and rebuilds the Python virtual environment

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -6,6 +6,13 @@
 # variable (if set), or fall back to "python3". Note that NetBox v4.0+ requires
 # Python 3.10 or later.
 
+# Parse arguments
+if [[ "$1" == "--readonly" ]]; then
+  READONLY_MODE=true
+else
+  READONLY_MODE=false
+fi
+
 cd "$(dirname "$0")"
 
 NETBOX_VERSION="$(grep ^version netbox/release.yaml | cut -d \" -f2)"
@@ -83,9 +90,14 @@ else
 fi
 
 # Apply any database migrations
-COMMAND="python3 netbox/manage.py migrate"
-echo "Applying database migrations ($COMMAND)..."
-eval $COMMAND || exit 1
+if [ "$READONLY_MODE" = true ]; then
+  echo "Skipping database migrations (read-only mode)"
+  exit 0
+else
+  COMMAND="python3 netbox/manage.py migrate"
+  echo "Applying database migrations ($COMMAND)..."
+  eval $COMMAND || exit 1
+fi
 
 # Trace any missing cable paths (not typically needed)
 COMMAND="python3 netbox/manage.py trace_paths --no-input"


### PR DESCRIPTION
### Fixes: #17136

Skip database migrations when calling the `upgrade.sh` script with `--readonly`