### PR TITLE
17613 Add column support for mobile devices

### DIFF
--- a/netbox/templates/circuits/circuit.html
+++ b/netbox/templates/circuits/circuit.html
@@ -10,7 +10,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Circuit" %}</h2>
         <table class="table table-hover attr-table">
@@ -89,7 +89,7 @@
       {% include 'inc/panels/comments.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'circuits/inc/circuit_termination.html' with termination=object.termination_a side='A' %}
       {% include 'circuits/inc/circuit_termination.html' with termination=object.termination_z side='Z' %}
       {% include 'inc/panels/image_attachments.html' %}

--- a/netbox/templates/circuits/circuitgroup.html
+++ b/netbox/templates/circuits/circuitgroup.html
@@ -20,7 +20,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Circuit Group" %}</h2>
         <table class="table table-hover attr-table">
@@ -46,7 +46,7 @@
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/related_objects.html' %}
       {% include 'inc/panels/comments.html' %}
       {% include 'inc/panels/custom_fields.html' %}

--- a/netbox/templates/circuits/circuitgroupassignment.html
+++ b/netbox/templates/circuits/circuitgroupassignment.html
@@ -14,7 +14,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Circuit Group Assignment" %}</h2>
         <table class="table table-hover attr-table">
@@ -39,7 +39,7 @@
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% plugin_right_page object %}
     </div>

--- a/netbox/templates/circuits/circuittermination.html
+++ b/netbox/templates/circuits/circuittermination.html
@@ -10,7 +10,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
 
       <div class="card">
             {% if object %}
@@ -37,7 +37,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/tags.html' %}
       {% plugin_right_page object %}

--- a/netbox/templates/circuits/circuittype.html
+++ b/netbox/templates/circuits/circuittype.html
@@ -14,7 +14,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Circuit Type" %}</h2>
       <table class="table table-hover attr-table">
@@ -41,7 +41,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
   </div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/circuits/provider.html
+++ b/netbox/templates/circuits/provider.html
@@ -15,7 +15,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	  <div class="col col-md-6">
+	  <div class="col col-12 col-md-6">
         <div class="card">
           <h2 class="card-header">{% trans "Provider" %}</h2>
           <table class="table table-hover attr-table">
@@ -39,7 +39,7 @@
         {% include 'inc/panels/comments.html' %}
         {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
         {% include 'inc/panels/related_objects.html' %}
         {% include 'inc/panels/custom_fields.html' %}
         {% plugin_right_page object %}

--- a/netbox/templates/circuits/provideraccount.html
+++ b/netbox/templates/circuits/provideraccount.html
@@ -12,7 +12,7 @@
 
 {% block content %}
   <div class="row mb-3">
-	  <div class="col col-md-6">
+	  <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Provider Account" %}</h2>
         <table class="table table-hover attr-table">
@@ -33,7 +33,7 @@
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/related_objects.html' %}
       {% include 'inc/panels/comments.html' %}
       {% include 'inc/panels/custom_fields.html' %}

--- a/netbox/templates/circuits/providernetwork.html
+++ b/netbox/templates/circuits/providernetwork.html
@@ -12,7 +12,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Provider Network" %}</h2>
         <table class="table table-hover attr-table">
@@ -37,7 +37,7 @@
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/related_objects.html' %}
       {% include 'inc/panels/comments.html' %}
       {% include 'inc/panels/custom_fields.html' %}

--- a/netbox/templates/circuits/virtualcircuit.html
+++ b/netbox/templates/circuits/virtualcircuit.html
@@ -15,7 +15,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Virtual circuit" %}</h2>
         <table class="table table-hover attr-table">
@@ -61,7 +61,7 @@
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/comments.html' %}
       <div class="card">

--- a/netbox/templates/circuits/virtualcircuittermination.html
+++ b/netbox/templates/circuits/virtualcircuittermination.html
@@ -18,7 +18,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Virtual Circuit Termination" %}</h2>
         <table class="table table-hover attr-table">
@@ -48,7 +48,7 @@
       {% include 'inc/panels/custom_fields.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Interface" %}</h2>
         <table class="table table-hover attr-table">

--- a/netbox/templates/circuits/virtualcircuittype.html
+++ b/netbox/templates/circuits/virtualcircuittype.html
@@ -14,7 +14,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Virtual Circuit Type" %}</h2>
       <table class="table table-hover attr-table">
@@ -41,7 +41,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
   </div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/core/datasource.html
+++ b/netbox/templates/core/datasource.html
@@ -26,7 +26,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Data Source" %}</h2>
         <table class="table table-hover attr-table">
@@ -79,7 +79,7 @@
       {% include 'inc/panels/comments.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Backend" %}</h2>
           {% with backend=object.backend_class %}

--- a/netbox/templates/core/job.html
+++ b/netbox/templates/core/job.html
@@ -30,7 +30,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Job" %}</h2>
         <table class="table table-hover attr-table">
@@ -61,7 +61,7 @@
         </table>
       </div>
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Scheduling" %}</h2>
         <table class="table table-hover attr-table">

--- a/netbox/templates/core/objectchange.html
+++ b/netbox/templates/core/objectchange.html
@@ -106,7 +106,7 @@
     </div>
 </div>
 <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
         <div class="card">
             <h2 class="card-header">{% trans "Pre-Change Data" %}</h2>
             <div class="card-body">
@@ -126,7 +126,7 @@
             </div>
         </div>
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
         <div class="card">
             <h2 class="card-header">{% trans "Post-Change Data" %}</h2>
             <div class="card-body">
@@ -146,10 +146,10 @@
     </div>
 </div>
 <div class="row">
-  <div class="col col-md-6">
+  <div class="col col-12 col-md-6">
     {% plugin_left_page object %}
   </div>
-  <div class="col col-md-6">
+  <div class="col col-12 col-md-6">
     {% plugin_right_page object %}
   </div>
 </div>

--- a/netbox/templates/core/objectchange.html
+++ b/netbox/templates/core/objectchange.html
@@ -24,7 +24,7 @@
 
 {% block content %}
 <div class="row">
-    <div class="col col-md-5">
+    <div class="col col-12 col-md-5">
         <div class="card">
             <h2 class="card-header">{% trans "Change" %}</h2>
             <table class="table table-hover attr-table">
@@ -73,7 +73,7 @@
             </table>
         </div>
     </div>
-    <div class="col col-md-7">
+    <div class="col col-12 col-md-7">
         <div class="card">
             <h2 class="card-header d-flex justify-content-between">
               {% trans "Difference" %}

--- a/netbox/templates/dcim/cable.html
+++ b/netbox/templates/dcim/cable.html
@@ -7,7 +7,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Cable" %}</h2>
         <table class="table table-hover attr-table">
@@ -63,7 +63,7 @@
       {% include 'inc/panels/comments.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Termination" %} A</h2>
         {% include 'dcim/inc/cable_termination.html' with terminations=object.a_terminations %}

--- a/netbox/templates/dcim/consoleport.html
+++ b/netbox/templates/dcim/consoleport.html
@@ -12,7 +12,7 @@
 
 {% block content %}
     <div class="row">
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 <h2 class="card-header">{% trans "Console Port" %}</h2>
                 <table class="table table-hover attr-table">
@@ -50,7 +50,7 @@
             {% include 'inc/panels/tags.html' %}
             {% plugin_left_page object %}
         </div>
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
           <div class="card">
             <h2 class="card-header">{% trans "Connection" %}</h2>
             {% if object.mark_connected %}

--- a/netbox/templates/dcim/consoleserverport.html
+++ b/netbox/templates/dcim/consoleserverport.html
@@ -12,7 +12,7 @@
 
 {% block content %}
     <div class="row">
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 <h2 class="card-header">{% trans "Console Server Port" %}</h2>
                 <table class="table table-hover attr-table">
@@ -50,7 +50,7 @@
             {% include 'inc/panels/tags.html' %}
             {% plugin_left_page object %}
         </div>
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
           <div class="card">
             <h2 class="card-header">{% trans "Connection" %}</h2>
             <div class="card-body">

--- a/netbox/templates/dcim/devicebay.html
+++ b/netbox/templates/dcim/devicebay.html
@@ -12,7 +12,7 @@
 
 {% block content %}
     <div class="row">
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 <h2 class="card-header">{% trans "Device Bay" %}</h2>
                 <table class="table table-hover attr-table">
@@ -38,7 +38,7 @@
         {% include 'inc/panels/tags.html' %}
         {% plugin_left_page object %}
         </div>
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 <h2 class="card-header">{% trans "Installed Device" %}</h2>
                 {% if object.installed_device %}

--- a/netbox/templates/dcim/devicerole.html
+++ b/netbox/templates/dcim/devicerole.html
@@ -18,7 +18,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Device Role" %}</h2>
       <table class="table table-hover attr-table">
@@ -49,7 +49,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/dcim/devicetype.html
+++ b/netbox/templates/dcim/devicetype.html
@@ -6,7 +6,7 @@
 
 {% block content %}
     <div class="row">
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 <h2 class="card-header">{% trans "Chassis" %}</h2>
                 <table class="table table-hover attr-table">
@@ -96,7 +96,7 @@
             {% include 'inc/panels/tags.html' %}
             {% plugin_left_page object %}
         </div>
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             {% include 'inc/panels/related_objects.html' %}
             {% include 'inc/panels/custom_fields.html' %}
             {% include 'inc/panels/comments.html' %}

--- a/netbox/templates/dcim/frontport.html
+++ b/netbox/templates/dcim/frontport.html
@@ -12,7 +12,7 @@
 
 {% block content %}
     <div class="row">
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 <h2 class="card-header">{% trans "Front Port" %}</h2>
                 <table class="table table-hover attr-table">
@@ -64,7 +64,7 @@
             {% include 'inc/panels/tags.html' %}
             {% plugin_left_page object %}
         </div>
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 <h2 class="card-header">{% trans "Connection" %}</h2>
                 {% if object.mark_connected %}

--- a/netbox/templates/dcim/interface.html
+++ b/netbox/templates/dcim/interface.html
@@ -22,7 +22,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Interface" %}</h2>
         <table class="table table-hover attr-table">
@@ -122,7 +122,7 @@
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panel_table.html' with table=vdc_table heading="Virtual Device Contexts" %}
       <div class="card">
         <h2 class="card-header">{% trans "Addressing" %}</h2>

--- a/netbox/templates/dcim/inventoryitem.html
+++ b/netbox/templates/dcim/inventoryitem.html
@@ -12,7 +12,7 @@
 
 {% block content %}
     <div class="row mb-3">
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 <h2 class="card-header">{% trans "Inventory Item" %}</h2>
                 <table class="table table-hover attr-table">
@@ -70,7 +70,7 @@
             {% include 'inc/panels/tags.html' %}
             {% plugin_left_page object %}
         </div>
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             {% plugin_right_page object %}
         </div>
     </div>

--- a/netbox/templates/dcim/inventoryitemrole.html
+++ b/netbox/templates/dcim/inventoryitemrole.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Inventory Item Role" %}</h2>
       <table class="table table-hover attr-table">
@@ -39,7 +39,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}
   </div>

--- a/netbox/templates/dcim/location.html
+++ b/netbox/templates/dcim/location.html
@@ -21,7 +21,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Location" %}</h2>
       <table class="table table-hover attr-table">
@@ -64,7 +64,7 @@
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_left_page object %}
   </div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/image_attachments.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/dcim/macaddress.html
+++ b/netbox/templates/dcim/macaddress.html
@@ -6,7 +6,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "MAC Address" %}</h2>
         <table class="table table-hover attr-table">
@@ -42,7 +42,7 @@
       {% include 'inc/panels/custom_fields.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/comments.html' %}
       {% plugin_right_page object %}
     </div>

--- a/netbox/templates/dcim/manufacturer.html
+++ b/netbox/templates/dcim/manufacturer.html
@@ -28,7 +28,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Manufacturer" %}</h2>
       <table class="table table-hover attr-table">
@@ -45,7 +45,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/dcim/module.html
+++ b/netbox/templates/dcim/module.html
@@ -49,7 +49,7 @@
 
 {% block content %}
 <div class="row">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Module" %}</h2>
       <table class="table table-hover attr-table">
@@ -87,7 +87,7 @@
     {% include 'inc/panels/comments.html' %}
     {% plugin_left_page object %}
   </div>
-  <div class="col col-md-6">
+  <div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/dcim/modulebay.html
+++ b/netbox/templates/dcim/modulebay.html
@@ -12,7 +12,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Module Bay" %}</h2>
         <table class="table table-hover attr-table">
@@ -47,7 +47,7 @@
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       <div class="card">
         <h2 class="card-header">{% trans "Installed Module" %}</h2>

--- a/netbox/templates/dcim/moduletype.html
+++ b/netbox/templates/dcim/moduletype.html
@@ -19,7 +19,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Module Type" %}</h2>
         <table class="table table-hover attr-table">
@@ -59,7 +59,7 @@
       {% include 'inc/panels/comments.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/related_objects.html' %}
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/image_attachments.html' %}

--- a/netbox/templates/dcim/platform.html
+++ b/netbox/templates/dcim/platform.html
@@ -21,7 +21,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Platform" %}</h2>
       <table class="table table-hover attr-table">
@@ -46,7 +46,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/dcim/powerfeed.html
+++ b/netbox/templates/dcim/powerfeed.html
@@ -16,7 +16,7 @@
 
 {% block content %}
 <div class="row">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
         <div class="card">
             <h2 class="card-header">{% trans "Power Feed" %}</h2>
             <table class="table table-hover attr-table">
@@ -105,7 +105,7 @@
         {% include 'inc/panels/tags.html' %}
         {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Connection" %}</h2>
         {% if object.mark_connected %}

--- a/netbox/templates/dcim/poweroutlet.html
+++ b/netbox/templates/dcim/poweroutlet.html
@@ -12,7 +12,7 @@
 
 {% block content %}
     <div class="row mb-3">
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 <h2 class="card-header">{% trans "Power Outlet" %}</h2>
                 <table class="table table-hover attr-table">
@@ -64,7 +64,7 @@
             {% include 'inc/panels/tags.html' %}
             {% plugin_left_page object %}
         </div>
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
           <div class="card">
             <h2 class="card-header">{% trans "Connection" %}</h2>
             {% if object.mark_connected %}

--- a/netbox/templates/dcim/powerpanel.html
+++ b/netbox/templates/dcim/powerpanel.html
@@ -14,7 +14,7 @@
 
 {% block content %}
 <div class="row">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Power Panel" %}</h2>
       <table class="table table-hover attr-table">
@@ -36,7 +36,7 @@
     {% include 'inc/panels/comments.html' %}
     {% plugin_left_page object %}
   </div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% include 'inc/panels/image_attachments.html' %}

--- a/netbox/templates/dcim/powerport.html
+++ b/netbox/templates/dcim/powerport.html
@@ -12,7 +12,7 @@
 
 {% block content %}
     <div class="row mb-3">
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 <h2 class="card-header">{% trans "Power Port" %}</h2>
                 <table class="table table-hover attr-table">
@@ -54,7 +54,7 @@
             {% include 'inc/panels/tags.html' %}
             {% plugin_left_page object %}
         </div>
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
           <div class="card">
             <h2 class="card-header">{% trans "Connection" %}</h2>
             {% if object.mark_connected %}

--- a/netbox/templates/dcim/rackrole.html
+++ b/netbox/templates/dcim/rackrole.html
@@ -14,7 +14,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Rack Role" %}</h2>
       <table class="table table-hover attr-table">
@@ -37,7 +37,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/dcim/racktype.html
+++ b/netbox/templates/dcim/racktype.html
@@ -8,7 +8,7 @@
 
 {% block content %}
   <div class="row">
-	  <div class="col col-6">
+	  <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Rack Type" %}</h2>
         <table class="table table-hover attr-table">
@@ -35,7 +35,7 @@
       {% include 'inc/panels/comments.html' %}
       {% plugin_left_page object %}
 	  </div>
-    <div class="col col-6">
+    <div class="col col-12 col-md-6">
       {% include 'dcim/inc/panels/racktype_numbering.html' %}
       <div class="card">
         <h2 class="card-header">{% trans "Weight" %}</h2>

--- a/netbox/templates/dcim/rearport.html
+++ b/netbox/templates/dcim/rearport.html
@@ -12,7 +12,7 @@
 
 {% block content %}
     <div class="row">
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 <h2 class="card-header">{% trans "Rear Port" %}</h2>
                 <table class="table table-hover attr-table">
@@ -60,7 +60,7 @@
             {% include 'inc/panels/tags.html' %}
             {% plugin_left_page object %}
         </div>
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 <h2 class="card-header">{% trans "Connection" %}</h2>
                 {% if object.mark_connected %}

--- a/netbox/templates/dcim/region.html
+++ b/netbox/templates/dcim/region.html
@@ -21,7 +21,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Region" %}</h2>
       <table class="table table-hover attr-table">
@@ -43,7 +43,7 @@
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_left_page object %}
   </div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% plugin_right_page object %}
 	</div>

--- a/netbox/templates/dcim/site.html
+++ b/netbox/templates/dcim/site.html
@@ -23,7 +23,7 @@
 
 {% block content %}
 <div class="row">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Site" %}</h2>
       <table class="table table-hover attr-table">
@@ -114,7 +114,7 @@
     {% include 'inc/panels/comments.html' %}
     {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/related_objects.html' with filter_name='site_id' %}
       {% include 'inc/panels/image_attachments.html' %}
       {% plugin_right_page object %}

--- a/netbox/templates/dcim/sitegroup.html
+++ b/netbox/templates/dcim/sitegroup.html
@@ -21,7 +21,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Site Group" %}</h2>
       <table class="table table-hover attr-table">
@@ -43,7 +43,7 @@
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_left_page object %}
   </div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% plugin_right_page object %}
 	</div>

--- a/netbox/templates/dcim/virtualchassis.html
+++ b/netbox/templates/dcim/virtualchassis.html
@@ -15,7 +15,7 @@
 
 {% block content %}
 <div class="row">
-	<div class="col col-md-4">
+	<div class="col col-12 col-md-4">
     <div class="card">
       <h2 class="card-header">{% trans "Virtual Chassis" %}</h2>
       <table class="table table-hover attr-table">
@@ -47,7 +47,7 @@
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_left_page object %}
     </div>
-    <div class="col col-md-8">
+    <div class="col col-12 col-md-8">
       <div class="card">
         <h2 class="card-header">
           {% trans "Members" %}

--- a/netbox/templates/dcim/virtualdevicecontext.html
+++ b/netbox/templates/dcim/virtualdevicecontext.html
@@ -10,7 +10,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Virtual Device Context" %}</h2>
       <table class="table table-hover attr-table">
@@ -68,7 +68,7 @@
     {% plugin_left_page object %}
     {% include 'inc/panels/tags.html' %}
   </div>
-  <div class="col col-md-6">
+  <div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/comments.html' %}
     {% include 'inc/panels/custom_fields.html' %}

--- a/netbox/templates/extras/configcontext.html
+++ b/netbox/templates/extras/configcontext.html
@@ -5,7 +5,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-5">
+    <div class="col col-12 col-md-5">
       <div class="card">
         <h2 class="card-header">{% trans "Config Context" %}</h2>
         <table class="table table-hover attr-table">
@@ -76,7 +76,7 @@
         </table>
       </div>
     </div>
-    <div class="col col-md-7">
+    <div class="col col-12 col-md-7">
       {% include 'inc/sync_warning.html' %}
       <div class="card">
         {% include 'extras/inc/configcontext_data.html' with title="Data" data=object.data format=format copyid="data" %}

--- a/netbox/templates/extras/configtemplate.html
+++ b/netbox/templates/extras/configtemplate.html
@@ -5,7 +5,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-5">
+    <div class="col col-12 col-md-5">
       <div class="card">
         <h2 class="card-header">{% trans "Config Template" %}</h2>
         <table class="table table-hover attr-table">

--- a/netbox/templates/extras/customfield.html
+++ b/netbox/templates/extras/customfield.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Custom Field" %}</h2>
       <table class="table table-hover attr-table">
@@ -100,7 +100,7 @@
     {% include 'inc/panels/comments.html' %}
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Object Types" %}</h2>
       <table class="table table-hover attr-table">

--- a/netbox/templates/extras/customfieldchoiceset.html
+++ b/netbox/templates/extras/customfieldchoiceset.html
@@ -4,7 +4,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">Custom Field Choice Set</h2>
         <table class="table table-hover attr-table">
@@ -42,7 +42,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">Choices ({{ object.choices|length }})</h2>
         <table class="table table-hover">

--- a/netbox/templates/extras/customlink.html
+++ b/netbox/templates/extras/customlink.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-5">
+	<div class="col col-12 col-md-5">
     <div class="card">
       <h2 class="card-header">{% trans "Custom Link" %}</h2>
       <table class="table table-hover attr-table">
@@ -47,7 +47,7 @@
     </div>
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-7">
+	<div class="col col-12 col-md-7">
     <div class="card">
       <h2 class="card-header">{% trans "Link Text" %}</h2>
       <div class="card-body">

--- a/netbox/templates/extras/eventrule.html
+++ b/netbox/templates/extras/eventrule.html
@@ -5,7 +5,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Event Rule" %}</h2>
         <table class="table table-hover attr-table">
@@ -56,7 +56,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Conditions" %}</h2>
         <div class="card-body">

--- a/netbox/templates/extras/exporttemplate.html
+++ b/netbox/templates/extras/exporttemplate.html
@@ -7,7 +7,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-5">
+    <div class="col col-12 col-md-5">
       <div class="card">
         <h2 class="card-header">{% trans "Export Template" %}</h2>
         <table class="table table-hover attr-table">

--- a/netbox/templates/extras/notificationgroup.html
+++ b/netbox/templates/extras/notificationgroup.html
@@ -6,7 +6,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Notification Group" %}</h2>
         <table class="table table-hover attr-table">
@@ -26,7 +26,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Groups" %}</h2>
         <div class="list-group list-group-flush">

--- a/netbox/templates/extras/object_configcontext.html
+++ b/netbox/templates/extras/object_configcontext.html
@@ -5,12 +5,12 @@
 
 {% block content %}
     <div class="row">
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
           <div class="card">
             {% include 'extras/inc/configcontext_data.html' with title="Rendered Context" data=rendered_context format=format copyid="rendered_context" %}
           </div>
         </div>
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 {% include 'extras/inc/configcontext_data.html' with title="Local Context" data=object.local_context_data format=format copyid="local_context" %}
                 <div class="card-footer">

--- a/netbox/templates/extras/savedfilter.html
+++ b/netbox/templates/extras/savedfilter.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-5">
+	<div class="col col-12 col-md-5">
     <div class="card">
       <h2 class="card-header">{% trans "Saved Filter" %}</h2>
       <table class="table table-hover attr-table">
@@ -47,7 +47,7 @@
     </div>
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-7">
+	<div class="col col-12 col-md-7">
     <div class="card">
       <h2 class="card-header">{% trans "Parameters" %}</h2>
       <div class="card-body">

--- a/netbox/templates/extras/tag.html
+++ b/netbox/templates/extras/tag.html
@@ -6,7 +6,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Tag" %}</h2>
         <table class="table table-hover attr-table">
@@ -38,7 +38,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Allowed Object Types" %}</h2>
         <table class="table table-hover attr-table">

--- a/netbox/templates/extras/webhook.html
+++ b/netbox/templates/extras/webhook.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Webhook" %}</h2>
       <table class="table table-hover attr-table">
@@ -55,7 +55,7 @@
     </div>
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Additional Headers" %}</h2>
       <div class="card-body">

--- a/netbox/templates/ipam/aggregate.html
+++ b/netbox/templates/ipam/aggregate.html
@@ -6,7 +6,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Aggregate" %}</h2>
         <table class="table table-hover attr-table">
@@ -47,7 +47,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/tags.html' %}
       {% include 'inc/panels/comments.html' %}

--- a/netbox/templates/ipam/asn.html
+++ b/netbox/templates/ipam/asn.html
@@ -15,7 +15,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "ASN" %}</h2>
         <table class="table table-hover attr-table">
@@ -47,7 +47,7 @@
       {% plugin_left_page object %}
       {% include 'inc/panels/tags.html' %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/related_objects.html' %}
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/comments.html' %}

--- a/netbox/templates/ipam/asnrange.html
+++ b/netbox/templates/ipam/asnrange.html
@@ -7,7 +7,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "ASN Range" %}</h2>
         <table class="table table-hover attr-table">
@@ -43,7 +43,7 @@
       {% plugin_left_page object %}
       {% include 'inc/panels/tags.html' %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% plugin_right_page object %}
     </div>

--- a/netbox/templates/ipam/fhrpgroup.html
+++ b/netbox/templates/ipam/fhrpgroup.html
@@ -14,7 +14,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "FHRP Group" %}</h2>
         <table class="table table-hover attr-table">
@@ -44,7 +44,7 @@
       {% include 'inc/panels/comments.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Authentication" %}</h2>
         <table class="table table-hover attr-table">

--- a/netbox/templates/ipam/ipaddress.html
+++ b/netbox/templates/ipam/ipaddress.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div class="row">
-	<div class="col col-md-4">
+	<div class="col col-12 col-md-4">
       <div class="card">
           <h2 class="card-header">{% trans "IP Address" %}</h2>
           <table class="table table-hover attr-table">

--- a/netbox/templates/ipam/iprange.html
+++ b/netbox/templates/ipam/iprange.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="row">
-  <div class="col col-md-6">
+  <div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "IP Range" %}</h2>
       <table class="table table-hover attr-table">
@@ -71,7 +71,7 @@
     </div>
     {% plugin_left_page object %}
   </div>
-  <div class="col col-md-6">
+  <div class="col col-12 col-md-6">
     {% include 'inc/panels/tags.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% include 'inc/panels/comments.html' %}

--- a/netbox/templates/ipam/prefix.html
+++ b/netbox/templates/ipam/prefix.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 <div class="row">
-  <div class="col col-md-6">
+  <div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Prefix" %}</h2>
       <table class="table table-hover attr-table">
@@ -85,7 +85,7 @@
     </div>
     {% plugin_left_page object %}
   </div>
-  <div class="col col-md-6">
+  <div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">
         {% trans "Addressing" %}

--- a/netbox/templates/ipam/rir.html
+++ b/netbox/templates/ipam/rir.html
@@ -14,7 +14,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "RIR" %}</h2>
         <table class="table table-hover attr-table">
@@ -35,7 +35,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/ipam/role.html
+++ b/netbox/templates/ipam/role.html
@@ -14,7 +14,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Role" %}</h2>
       <table class="table table-hover attr-table">
@@ -35,7 +35,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/ipam/routetarget.html
+++ b/netbox/templates/ipam/routetarget.html
@@ -5,7 +5,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Route Target" %}</h2>
         <table class="table table-hover attr-table">
@@ -26,20 +26,20 @@
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/comments.html' %}
       {% plugin_right_page object %}
     </div>
   </div>
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Importing VRFs" %}</h2>
         {% htmx_table 'ipam:vrf_list' import_target_id=object.pk %}
       </div>
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Exporting VRFs" %}</h2>
         {% htmx_table 'ipam:vrf_list' export_target_id=object.pk %}
@@ -47,13 +47,13 @@
     </div>
   </div>
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Importing L2VPNs" %}</h2>
         {% htmx_table 'vpn:l2vpn_list' import_target_id=object.pk %}
       </div>
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Exporting L2VPNs" %}</h2>
         {% htmx_table 'vpn:l2vpn_list' export_target_id=object.pk %}

--- a/netbox/templates/ipam/service.html
+++ b/netbox/templates/ipam/service.html
@@ -16,7 +16,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
         <div class="card">
             <h2 class="card-header">{% trans "Service" %}</h2>
             <table class="table table-hover attr-table">
@@ -54,7 +54,7 @@
         </div>
         {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/tags.html' %}
       {% include 'inc/panels/comments.html' %}

--- a/netbox/templates/ipam/servicetemplate.html
+++ b/netbox/templates/ipam/servicetemplate.html
@@ -7,7 +7,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Service Template" %}</h2>
         <table class="table table-hover attr-table">
@@ -31,7 +31,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/tags.html' %}
       {% include 'inc/panels/comments.html' %}

--- a/netbox/templates/ipam/vlan.html
+++ b/netbox/templates/ipam/vlan.html
@@ -7,7 +7,7 @@
 
 {% block content %}
     <div class="row">
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
             <div class="card">
                 <h2 class="card-header">{% trans "VLAN" %}</h2>
                 <table class="table table-hover attr-table">
@@ -86,7 +86,7 @@
             </div>
             {% plugin_left_page object %}
         </div>
-        <div class="col col-md-6">
+        <div class="col col-12 col-md-6">
           {% include 'inc/panels/custom_fields.html' %}
           {% include 'inc/panels/tags.html' %}
           {% include 'inc/panels/comments.html' %}

--- a/netbox/templates/ipam/vlangroup.html
+++ b/netbox/templates/ipam/vlangroup.html
@@ -22,7 +22,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "VLAN Group" %}</h2>
       <table class="table table-hover attr-table">
@@ -51,7 +51,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/ipam/vlantranslationpolicy.html
+++ b/netbox/templates/ipam/vlantranslationpolicy.html
@@ -6,7 +6,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-4">
+    <div class="col col-12 col-md-4">
       <div class="card">
         <h2 class="card-header">{% trans "VLAN Translation Policy" %}</h2>
         <table class="table table-hover attr-table">

--- a/netbox/templates/ipam/vlantranslationrule.html
+++ b/netbox/templates/ipam/vlantranslationrule.html
@@ -6,7 +6,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-4">
+    <div class="col col-12 col-md-4">
       <div class="card">
         <h2 class="card-header">{% trans "VLAN Translation Rule" %}</h2>
         <table class="table table-hover attr-table">
@@ -30,7 +30,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-8">
+    <div class="col col-12 col-md-8">
       {% include 'inc/panels/tags.html' %}
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/comments.html' %}

--- a/netbox/templates/ipam/vrf.html
+++ b/netbox/templates/ipam/vrf.html
@@ -8,7 +8,7 @@
 
 {% block content %}
 <div class="row">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
       <div class="card">
           <h2 class="card-header">{% trans "VRF" %}</h2>
           <table class="table table-hover attr-table">
@@ -38,7 +38,7 @@
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
   </div>
-  <div class="col col-md-6">
+  <div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% include 'inc/panels/comments.html' %}
@@ -46,10 +46,10 @@
 	</div>
 </div>
 <div class="row">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panel_table.html' with table=import_targets_table heading="Import Route Targets" %}
   </div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panel_table.html' with table=export_targets_table heading="Export Route Targets" %}
   </div>
 </div>

--- a/netbox/templates/tenancy/contact.html
+++ b/netbox/templates/tenancy/contact.html
@@ -13,7 +13,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-7">
+    <div class="col col-12 col-md-7">
       <div class="card">
         <h2 class="card-header">{% trans "Contact" %}</h2>
         <table class="table table-hover attr-table">

--- a/netbox/templates/tenancy/contactgroup.html
+++ b/netbox/templates/tenancy/contactgroup.html
@@ -13,7 +13,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Contact Group" %}</h2>
         <table class="table table-hover attr-table">
@@ -34,7 +34,7 @@
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/related_objects.html' %}
       {% include 'inc/panels/custom_fields.html' %}
       {% plugin_right_page object %}

--- a/netbox/templates/tenancy/contactrole.html
+++ b/netbox/templates/tenancy/contactrole.html
@@ -10,7 +10,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Contact Role" %}</h2>
         <table class="table table-hover attr-table">
@@ -27,7 +27,7 @@
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/related_objects.html' %}
       {% include 'inc/panels/custom_fields.html' %}
       {% plugin_right_page object %}

--- a/netbox/templates/tenancy/tenant.html
+++ b/netbox/templates/tenancy/tenant.html
@@ -12,7 +12,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-7">
+    <div class="col col-12 col-md-7">
       <div class="card">
         <h2 class="card-header">{% trans "Tenant" %}</h2>
         <table class="table table-hover attr-table">

--- a/netbox/templates/tenancy/tenantgroup.html
+++ b/netbox/templates/tenancy/tenantgroup.html
@@ -21,7 +21,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Tenant Group" %}</h2>
       <table class="table table-hover attr-table">
@@ -42,7 +42,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
   </div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/virtualization/cluster.html
+++ b/netbox/templates/virtualization/cluster.html
@@ -5,7 +5,7 @@
 
 {% block content %}
 <div class="row">
-  <div class="col col-md-6">
+  <div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Cluster" %}</h2>
       <table class="table table-hover attr-table">
@@ -51,7 +51,7 @@
     {% include 'inc/panels/comments.html' %}
     {% plugin_left_page object %}
   </div>
-  <div class="col col-md-6">
+  <div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Allocated Resources" %}</h2>
       <table class="table table-hover attr-table">

--- a/netbox/templates/virtualization/clustergroup.html
+++ b/netbox/templates/virtualization/clustergroup.html
@@ -14,7 +14,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Cluster Group" %}</h2>
       <table class="table table-hover attr-table">
@@ -31,7 +31,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/virtualization/clustertype.html
+++ b/netbox/templates/virtualization/clustertype.html
@@ -14,7 +14,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Cluster Type" %}</h2>
       <table class="table table-hover attr-table">
@@ -37,7 +37,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/virtualization/virtualdisk.html
+++ b/netbox/templates/virtualization/virtualdisk.html
@@ -13,7 +13,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Virtual Disk" %}</h2>
         <table class="table table-hover attr-table">
@@ -44,7 +44,7 @@
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% plugin_right_page object %}
     </div>

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 <div class="row my-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
         <div class="card">
             <h2 class="card-header">{% trans "Virtual Machine" %}</h2>
             <table class="table table-hover attr-table">
@@ -87,7 +87,7 @@
         {% include 'inc/panels/comments.html' %}
         {% plugin_left_page object %}
     </div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
         <div class="card">
             <h2 class="card-header">{% trans "Cluster" %}</h2>
             <table class="table table-hover attr-table">

--- a/netbox/templates/virtualization/vminterface.html
+++ b/netbox/templates/virtualization/vminterface.html
@@ -13,7 +13,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Interface" %}</h2>
       <table class="table table-hover attr-table">
@@ -64,7 +64,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
   </div>
-  <div class="col col-md-6">
+  <div class="col col-12 col-md-6">
     {% include 'inc/panels/custom_fields.html' %}
     <div class="card">
       <h2 class="card-header">{% trans "Addressing" %}</h2>

--- a/netbox/templates/vpn/ikepolicy.html
+++ b/netbox/templates/vpn/ikepolicy.html
@@ -5,7 +5,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "IKE Policy" %}</h2>
         <table class="table table-hover attr-table">
@@ -44,7 +44,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/comments.html' %}
       {% include 'inc/panels/tags.html' %}

--- a/netbox/templates/vpn/ikeproposal.html
+++ b/netbox/templates/vpn/ikeproposal.html
@@ -5,7 +5,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "IKE Proposal" %}</h2>
         <table class="table table-hover attr-table">
@@ -47,7 +47,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/comments.html' %}
       {% include 'inc/panels/tags.html' %}

--- a/netbox/templates/vpn/ipsecpolicy.html
+++ b/netbox/templates/vpn/ipsecpolicy.html
@@ -5,7 +5,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "IPSec Policy" %}</h2>
         <table class="table table-hover attr-table">
@@ -31,7 +31,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/comments.html' %}
       {% include 'inc/panels/tags.html' %}

--- a/netbox/templates/vpn/ipsecprofile.html
+++ b/netbox/templates/vpn/ipsecprofile.html
@@ -5,7 +5,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "IPSec Profile" %}</h2>
         <table class="table table-hover attr-table">
@@ -28,7 +28,7 @@
       {% include 'inc/panels/comments.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "IKE Policy" %}</h2>
         <table class="table table-hover attr-table">

--- a/netbox/templates/vpn/ipsecproposal.html
+++ b/netbox/templates/vpn/ipsecproposal.html
@@ -5,7 +5,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "IPSec Proposal" %}</h2>
         <table class="table table-hover attr-table">
@@ -43,7 +43,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/comments.html' %}
       {% include 'inc/panels/tags.html' %}

--- a/netbox/templates/vpn/l2vpn.html
+++ b/netbox/templates/vpn/l2vpn.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "L2VPN Attributes" %}</h2>
       <table class="table table-hover attr-table">
@@ -35,17 +35,17 @@
     {% include 'inc/panels/tags.html' with tags=object.tags.all url='vpn:l2vpn_list' %}
     {% plugin_left_page object %}
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/comments.html' %}
       {% plugin_right_page object %}
     </div>
 </div>
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panel_table.html' with table=import_targets_table heading="Import Route Targets" %}
   </div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     {% include 'inc/panel_table.html' with table=export_targets_table heading="Export Route Targets" %}
   </div>
 </div>

--- a/netbox/templates/vpn/l2vpntermination.html
+++ b/netbox/templates/vpn/l2vpntermination.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="row">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
         <div class="card">
             <h2 class="card-header">{% trans "L2VPN Attributes" %}</h2>
             <table class="table table-hover">
@@ -19,7 +19,7 @@
             </table>
         </div>
 	</div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
         {% include 'inc/panels/custom_fields.html' %}
         {% include 'inc/panels/tags.html' with tags=object.tags.all url='vpn:l2vpntermination_list' %}
     </div>

--- a/netbox/templates/vpn/tunnel.html
+++ b/netbox/templates/vpn/tunnel.html
@@ -13,7 +13,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Tunnel" %}</h2>
         <table class="table table-hover attr-table">
@@ -58,7 +58,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/tags.html' %}
       {% include 'inc/panels/comments.html' %}

--- a/netbox/templates/vpn/tunnelgroup.html
+++ b/netbox/templates/vpn/tunnelgroup.html
@@ -18,7 +18,7 @@
 
 {% block content %}
   <div class="row mb-3">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Tunnel Group" %}</h2>
         <table class="table table-hover attr-table">
@@ -35,7 +35,7 @@
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/related_objects.html' %}
       {% include 'inc/panels/custom_fields.html' %}
       {% plugin_right_page object %}

--- a/netbox/templates/vpn/tunneltermination.html
+++ b/netbox/templates/vpn/tunneltermination.html
@@ -5,7 +5,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Tunnel Termination" %}</h2>
         <table class="table table-hover attr-table">
@@ -39,7 +39,7 @@
       </div>
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       {% include 'inc/panels/custom_fields.html' %}
       {% include 'inc/panels/tags.html' %}
       {% plugin_right_page object %}

--- a/netbox/templates/wireless/wirelesslan.html
+++ b/netbox/templates/wireless/wirelesslan.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 <div class="row">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Wireless LAN" %}</h2>
       <table class="table table-hover attr-table">
@@ -53,7 +53,7 @@
     {% include 'inc/panels/comments.html' %}
     {% plugin_left_page object %}
   </div>
-  <div class="col col-md-6">
+  <div class="col col-12 col-md-6">
     {% include 'wireless/inc/authentication_attrs.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/wireless/wirelesslangroup.html
+++ b/netbox/templates/wireless/wirelesslangroup.html
@@ -21,7 +21,7 @@
 
 {% block content %}
 <div class="row mb-3">
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
     <div class="card">
       <h2 class="card-header">{% trans "Wireless LAN Group" %}</h2>
       <table class="table table-hover attr-table">
@@ -42,7 +42,7 @@
     {% include 'inc/panels/tags.html' %}
     {% plugin_left_page object %}
   </div>
-	<div class="col col-md-6">
+	<div class="col col-12 col-md-6">
       {% include 'inc/panels/related_objects.html' %}
     {% include 'inc/panels/custom_fields.html' %}
     {% plugin_right_page object %}

--- a/netbox/templates/wireless/wirelesslink.html
+++ b/netbox/templates/wireless/wirelesslink.html
@@ -5,7 +5,7 @@
 
 {% block content %}
   <div class="row">
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Interface" %} A</h2>
         {% include 'wireless/inc/wirelesslink_interface.html' with interface=object.interface_a %}
@@ -50,7 +50,7 @@
       {% include 'inc/panels/comments.html' %}
       {% plugin_left_page object %}
     </div>
-    <div class="col col-md-6">
+    <div class="col col-12 col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Interface" %} B</h2>
         {% include 'wireless/inc/wirelesslink_interface.html' with interface=object.interface_b %}


### PR DESCRIPTION
### Fixes: #17613 

Adds col-12 to templates so they work better on mobile devices (so columns stack linearly instead of side-by-side).  Lots of files but pretty straight-forward changes.  Doesn't effect larger (non mobile) display sizes.

![Monosnap 10 0 0 0:24 | NetBox 2025-04-21 11-03-19](https://github.com/user-attachments/assets/b01fc300-6c00-46b4-ab61-4ea40445a84e)
![Monosnap 10 0 0 0:24 | NetBox 2025-04-21 11-03-48](https://github.com/user-attachments/assets/1e6bf338-ff77-4c59-8a77-0e60d88bfb64)
