### PR TITLE
18500 fix check for cloning mixin

### DIFF
--- a/netbox/utilities/querydict.py
+++ b/netbox/utilities/querydict.py
@@ -2,6 +2,7 @@ from urllib.parse import urlencode
 
 from django.http import QueryDict
 from django.utils.datastructures import MultiValueDict
+from netbox.models import CloningMixin
 
 __all__ = (
     'dict_to_querydict',
@@ -46,7 +47,7 @@ def prepare_cloned_fields(instance):
     Generate a QueryDict comprising attributes from an object's clone() method.
     """
     # Generate the clone attributes from the instance
-    if not hasattr(instance, 'clone'):
+    if not issubclass(type(instance), CloningMixin):
         return QueryDict(mutable=True)
     attrs = instance.clone()
 


### PR DESCRIPTION
### Fixes: #18500 

Fixes the check for CloningMixin - old check would fail if plugin had a clone method defined.
