### PR TITLE
Fixes #18959: Preserve ordering of terminations in cable traces

### DIFF
--- a/netbox/dcim/svg/cables.py
+++ b/netbox/dcim/svg/cables.py
@@ -226,7 +226,7 @@ class CableTraceSVG:
         nodes_height = 0
         nodes = []
         # Sort them by name to make renders more readable
-        for i, term in enumerate(sorted(terminations, key=lambda x: str(x))):
+        for i, term in enumerate(terminations):
             node = Node(
                 position=(offset_x + i * width, self.cursor),
                 width=width,

--- a/netbox/dcim/svg/cables.py
+++ b/netbox/dcim/svg/cables.py
@@ -225,7 +225,6 @@ class CableTraceSVG:
         """
         nodes_height = 0
         nodes = []
-        # Sort them by name to make renders more readable
         for i, term in enumerate(terminations):
             node = Node(
                 position=(offset_x + i * width, self.cursor),


### PR DESCRIPTION
### Fixes: #18959

Remove the call to `sorted()` as terminations should already be ordered naturally.