### PR TITLE
Fixes #19255: Improved documentation consistency for configuration default values

### DIFF
--- a/docs/configuration/default-values.md
+++ b/docs/configuration/default-values.md
@@ -69,7 +69,7 @@ For a complete list of available preferences, log into NetBox and navigate to `/
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: 50
+Default: `50`
 
 The default maximum number of objects to display per page within each list of objects.
 
@@ -79,7 +79,7 @@ The default maximum number of objects to display per page within each list of ob
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: 15
+Default: `15`
 
 The default value for the `amperage` field when creating new power feeds.
 
@@ -89,7 +89,7 @@ The default value for the `amperage` field when creating new power feeds.
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: 80
+Default: `80`
 
 The default value (percentage) for the `max_utilization` field when creating new power feeds.
 
@@ -99,7 +99,7 @@ The default value (percentage) for the `max_utilization` field when creating new
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: 120
+Default: `120`
 
 The default value for the `voltage` field when creating new power feeds.
 
@@ -109,7 +109,7 @@ The default value for the `voltage` field when creating new power feeds.
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: 22
+Default: `22`
 
 Default height (in pixels) of a unit within a rack elevation. For best results, this should be approximately one tenth of `RACK_ELEVATION_DEFAULT_UNIT_WIDTH`.
 
@@ -119,6 +119,6 @@ Default height (in pixels) of a unit within a rack elevation. For best results, 
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: 220
+Default: `220`
 
 Default width (in pixels) of a unit within a rack elevation.

--- a/docs/configuration/development.md
+++ b/docs/configuration/development.md
@@ -2,7 +2,7 @@
 
 ## DEBUG
 
-Default: False
+Default: `False`
 
 This setting enables debugging. Debugging should be enabled only during development or troubleshooting. Note that only
 clients which access NetBox from a recognized [internal IP address](./system.md#internal_ips) will see debugging tools in the user
@@ -16,6 +16,6 @@ interface.
 
 ## DEVELOPER
 
-Default: False
+Default: `False`
 
 This parameter serves as a safeguard to prevent some potentially dangerous behavior, such as generating new database schema migrations. Additionally, enabling this setting disables the debug warning banner in the UI. Set this to `True` **only** if you are actively developing the NetBox code base.

--- a/docs/configuration/error-reporting.md
+++ b/docs/configuration/error-reporting.md
@@ -2,7 +2,7 @@
 
 ## SENTRY_DSN
 
-Default: None
+Default: `None`
 
 Defines a Sentry data source name (DSN) for automated error reporting. `SENTRY_ENABLED` must be True for this parameter to take effect. For example:
 
@@ -14,7 +14,7 @@ SENTRY_DSN = "https://examplePublicKey@o0.ingest.sentry.io/0"
 
 ## SENTRY_ENABLED
 
-Default: False
+Default: `False`
 
 Set to True to enable automatic error reporting via [Sentry](https://sentry.io/).
 
@@ -25,7 +25,7 @@ Set to True to enable automatic error reporting via [Sentry](https://sentry.io/)
 
 ## SENTRY_SAMPLE_RATE
 
-Default: 1.0 (all)
+Default: `1.0` (all)
 
 The sampling rate for errors. Must be a value between 0 (disabled) and 1.0 (report on all errors).
 
@@ -33,7 +33,7 @@ The sampling rate for errors. Must be a value between 0 (disabled) and 1.0 (repo
 
 ## SENTRY_SEND_DEFAULT_PII
 
-Default: False
+Default: `False`
 
 Maps to the Sentry SDK's [`send_default_pii`](https://docs.sentry.io/platforms/python/configuration/options/#send-default-pii) parameter. If enabled, certain personally identifiable information (PII) is added.
 
@@ -60,7 +60,7 @@ SENTRY_TAGS = {
 
 ## SENTRY_TRACES_SAMPLE_RATE
 
-Default: 0 (disabled)
+Default: `0` (disabled)
 
 The sampling rate for transactions. Must be a value between 0 (disabled) and 1.0 (report on all transactions).
 

--- a/docs/configuration/graphql-api.md
+++ b/docs/configuration/graphql-api.md
@@ -4,7 +4,7 @@
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: True
+Default: `True`
 
 Setting this to False will disable the GraphQL API.
 
@@ -12,6 +12,6 @@ Setting this to False will disable the GraphQL API.
 
 ## GRAPHQL_MAX_ALIASES
 
-Default: 10
+Default: `10`
 
 The maximum number of queries that a GraphQL API request may contain.

--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -55,7 +55,7 @@ Sets content for the top banner in the user interface.
 
 ## CENSUS_REPORTING_ENABLED
 
-Default: True
+Default: `True`
 
 Enables anonymous census reporting. To opt out of census reporting, set this to False.
 
@@ -67,7 +67,7 @@ This data enables the project maintainers to estimate how many NetBox deployment
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: 90
+Default: `90`
 
 The number of days to retain logged changes (object creations, updates, and deletions). Set this to `0` to retain
 changes in the database indefinitely.
@@ -79,7 +79,7 @@ changes in the database indefinitely.
 
 ## CHANGELOG_SKIP_EMPTY_CHANGES
 
-Default: True
+Default: `True`
 
 If enabled, a change log record will not be created when an object is updated without any changes to its existing field values.
 
@@ -100,7 +100,7 @@ The maximum size (in bytes) of an incoming HTTP request (i.e. `GET` or `POST` da
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: True
+Default: `True`
 
 By default, NetBox will prevent the creation of duplicate prefixes and IP addresses in the global table (that is, those which are not assigned to any VRF). This validation can be disabled by setting `ENFORCE_GLOBAL_UNIQUE` to False.
 
@@ -128,7 +128,7 @@ The maximum amount (in bytes) of uploaded data that will be held in memory befor
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: 90
+Default: `90`
 
 The number of days to retain job results (scripts and reports). Set this to `0` to retain job results in the database indefinitely.
 
@@ -141,7 +141,7 @@ The number of days to retain job results (scripts and reports). Set this to `0` 
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: False
+Default: `False`
 
 Setting this to True will display a "maintenance mode" banner at the top of every page. Additionally, NetBox will no longer update a user's "last active" time upon login. This is to allow new logins when the database is in a read-only state. Recording of login times will resume when maintenance mode is disabled.
 
@@ -161,7 +161,7 @@ This specifies the URL to use when presenting a map of a physical location by st
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: 1000
+Default: `1000`
 
 A web user or API consumer can request an arbitrary number of objects by appending the "limit" parameter to the URL (e.g. `?limit=1000`). This parameter defines the maximum acceptable limit. Setting this to `0` or `None` will allow a client to retrieve _all_ matching objects at once with no limit by specifying `?limit=0`.
 
@@ -169,7 +169,7 @@ A web user or API consumer can request an arbitrary number of objects by appendi
 
 ## METRICS_ENABLED
 
-Default: False
+Default: `False`
 
 Toggle the availability Prometheus-compatible metrics at `/metrics`. See the [Prometheus Metrics](../integrations/prometheus-metrics.md) documentation for more details.
 
@@ -179,7 +179,7 @@ Toggle the availability Prometheus-compatible metrics at `/metrics`. See the [Pr
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: False
+Default: `False`
 
 When determining the primary IP address for a device, IPv6 is preferred over IPv4 by default. Set this to True to prefer IPv4 instead.
 
@@ -203,7 +203,7 @@ If no queue is defined the queue named `default` will be used.
 
 ## RELEASE_CHECK_URL
 
-Default: None (disabled)
+Default: `None` (disabled)
 
 This parameter defines the URL of the repository that will be checked for new NetBox releases. When a new release is detected, a message will be displayed to administrative users on the home page. This can be set to the official repository (`'https://api.github.com/repos/netbox-community/netbox/releases'`) or a custom fork. Set this to `None` to disable automatic update checks.
 

--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -2,7 +2,7 @@
 
 ## PLUGINS
 
-Default: `Empty`
+Default: ``
 
 A list of installed [NetBox plugins](../plugins/index.md) to enable. Plugins will not take effect unless they are listed here.
 
@@ -13,7 +13,7 @@ A list of installed [NetBox plugins](../plugins/index.md) to enable. Plugins wil
 
 ## PLUGINS_CONFIG
 
-Default: `Empty`
+Default: ``
 
 This parameter holds configuration settings for individual NetBox plugins. It is defined as a dictionary, with each key using the name of an installed plugin. The specific parameters supported are unique to each plugin: Reference the plugin's documentation to determine the supported parameters. An example configuration is shown below:
 

--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -2,7 +2,7 @@
 
 ## PLUGINS
 
-Default: ``
+Default: `[]`
 
 A list of installed [NetBox plugins](../plugins/index.md) to enable. Plugins will not take effect unless they are listed here.
 
@@ -13,7 +13,7 @@ A list of installed [NetBox plugins](../plugins/index.md) to enable. Plugins wil
 
 ## PLUGINS_CONFIG
 
-Default: ``
+Default: `[]`
 
 This parameter holds configuration settings for individual NetBox plugins. It is defined as a dictionary, with each key using the name of an installed plugin. The specific parameters supported are unique to each plugin: Reference the plugin's documentation to determine the supported parameters. An example configuration is shown below:
 

--- a/docs/configuration/plugins.md
+++ b/docs/configuration/plugins.md
@@ -2,7 +2,7 @@
 
 ## PLUGINS
 
-Default: Empty
+Default: `Empty`
 
 A list of installed [NetBox plugins](../plugins/index.md) to enable. Plugins will not take effect unless they are listed here.
 
@@ -13,7 +13,7 @@ A list of installed [NetBox plugins](../plugins/index.md) to enable. Plugins wil
 
 ## PLUGINS_CONFIG
 
-Default: Empty
+Default: `Empty`
 
 This parameter holds configuration settings for individual NetBox plugins. It is defined as a dictionary, with each key using the name of an installed plugin. The specific parameters supported are unique to each plugin: Reference the plugin's documentation to determine the supported parameters. An example configuration is shown below:
 

--- a/docs/configuration/security.md
+++ b/docs/configuration/security.md
@@ -2,7 +2,7 @@
 
 ## ALLOW_TOKEN_RETRIEVAL
 
-Default: True
+Default: `True`
 
 If disabled, the values of API tokens will not be displayed after each token's initial creation. A user **must** record the value of a token prior to its creation, or it will be lost. Note that this affects _all_ users, regardless of assigned permissions.
 
@@ -47,7 +47,7 @@ Although it is not recommended, the default validation rules can be disabled by 
 
 ## CORS_ORIGIN_ALLOW_ALL
 
-Default: False
+Default: `False`
 
 If True, cross-origin resource sharing (CORS) requests will be accepted from all origins. If False, a whitelist will be used (see below).
 
@@ -79,7 +79,7 @@ The name of the cookie to use for the cross-site request forgery (CSRF) authenti
 
 ## CSRF_COOKIE_SECURE
 
-Default: False
+Default: `False`
 
 If true, the cookie employed for cross-site request forgery (CSRF) protection will be marked as secure, meaning that it can only be sent across an HTTPS connection.
 
@@ -159,7 +159,7 @@ EXEMPT_VIEW_PERMISSIONS = ['*']
 
 ## LOGIN_PERSISTENCE
 
-Default: False
+Default: `False`
 
 If true, the lifetime of a user's authentication session will be automatically reset upon each valid request. For example, if [`LOGIN_TIMEOUT`](#login_timeout) is configured to 14 days (the default), and a user whose session is due to expire in five days makes a NetBox request (with a valid session cookie), the session's lifetime will be reset to 14 days.
 
@@ -169,7 +169,7 @@ Note that enabling this setting causes NetBox to update a user's session in the 
 
 ## LOGIN_REQUIRED
 
-Default: True
+Default: `True`
 
 When enabled, only authenticated users are permitted to access any part of NetBox. Disabling this will allow unauthenticated users to access most areas of NetBox (but not make any changes).
 
@@ -180,7 +180,7 @@ When enabled, only authenticated users are permitted to access any part of NetBo
 
 ## LOGIN_TIMEOUT
 
-Default: 1209600 seconds (14 days)
+Default: `1209600` seconds (14 days)
 
 The lifetime (in seconds) of the authentication cookie issued to a NetBox user upon login.
 
@@ -196,7 +196,7 @@ The view name or URL to which a user is redirected after logging out.
 
 ## SECURE_HSTS_INCLUDE_SUBDOMAINS
 
-Default: False
+Default: `False`
 
 If true, the `includeSubDomains` directive will be included in the HTTP Strict Transport Security (HSTS) header. This directive instructs the browser to apply the HSTS policy to all subdomains of the current domain.
 
@@ -204,7 +204,7 @@ If true, the `includeSubDomains` directive will be included in the HTTP Strict T
 
 ## SECURE_HSTS_PRELOAD
 
-Default: False
+Default: `False`
 
 If true, the `preload` directive will be included in the HTTP Strict Transport Security (HSTS) header. This directive instructs the browser to preload the site in HTTPS. Browsers that use the HSTS preload list will force the site to be accessed via HTTPS even if the user types HTTP in the address bar.
 
@@ -212,7 +212,7 @@ If true, the `preload` directive will be included in the HTTP Strict Transport S
 
 ## SECURE_HSTS_SECONDS
 
-Default: 0
+Default: `0`
 
 If set to a non-zero integer value, the SecurityMiddleware sets the HTTP Strict Transport Security (HSTS) header on all responses that do not already have it. This will instruct the browser that the website must be accessed via HTTPS, blocking any HTTP request.
 
@@ -220,7 +220,7 @@ If set to a non-zero integer value, the SecurityMiddleware sets the HTTP Strict 
 
 ## SECURE_SSL_REDIRECT
 
-Default: False
+Default: `False`
 
 If true, all non-HTTPS requests will be automatically redirected to use HTTPS.
 
@@ -239,7 +239,7 @@ The name used for the session cookie. See the [Django documentation](https://doc
 
 ## SESSION_COOKIE_SECURE
 
-Default: False
+Default: `False`
 
 If true, the cookie employed for session authentication will be marked as secure, meaning that it can only be sent across an HTTPS connection.
 
@@ -247,6 +247,6 @@ If true, the cookie employed for session authentication will be marked as secure
 
 ## SESSION_FILE_PATH
 
-Default: None
+Default: `None`
 
 HTTP session data is used to track authenticated users when they access NetBox. By default, NetBox stores session data in its PostgreSQL database. However, this inhibits authentication to a standby instance of NetBox without write access to the database. Alternatively, a local file path may be specified here and NetBox will store session data as files instead of using the database. Note that the NetBox system user must have read and write permissions to this path.

--- a/docs/configuration/system.md
+++ b/docs/configuration/system.md
@@ -64,7 +64,7 @@ Email is sent from NetBox only for critical events or if configured for [logging
 
 ## HTTP_PROXIES
 
-Default: None
+Default: `None`
 
 A dictionary of HTTP proxies to use for outbound requests originating from NetBox (e.g. when sending webhook requests). Proxies should be specified by schema (HTTP and HTTPS) as per the [Python requests library documentation](https://requests.readthedocs.io/en/latest/user/advanced/#proxies). For example:
 
@@ -89,7 +89,7 @@ addresses (and [`DEBUG`](./development.md#debug) is true).
 
 ## ISOLATED_DEPLOYMENT
 
-Default: False
+Default: `False`
 
 Set this configuration parameter to True for NetBox deployments which do not have Internet access. This will disable miscellaneous functionality which depends on access to the Internet.
 
@@ -206,7 +206,7 @@ If `STORAGE_BACKEND` is not defined, this setting will be ignored.
 
 ## TIME_ZONE
 
-Default: UTC
+Default: `UTC`
 
 The time zone NetBox will use when dealing with dates and times. It is recommended to use UTC time unless you have a specific need to use a local time zone. Please see the [list of available time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
@@ -214,6 +214,6 @@ The time zone NetBox will use when dealing with dates and times. It is recommend
 
 ## TRANSLATION_ENABLED
 
-Default: True
+Default: `True`
 
 Enables language translation for the user interface. (This parameter maps to Django's [USE_I18N](https://docs.djangoproject.com/en/stable/ref/settings/#std-setting-USE_I18N) setting.)

--- a/docs/configuration/system.md
+++ b/docs/configuration/system.md
@@ -2,7 +2,7 @@
 
 ## BASE_PATH
 
-Default: None
+Default: `None`
 
 The base URL path to use when accessing NetBox. Do not include the scheme or domain name. For example, if installed at https://example.com/netbox/, set:
 
@@ -206,7 +206,7 @@ If `STORAGE_BACKEND` is not defined, this setting will be ignored.
 
 ## TIME_ZONE
 
-Default: `UTC`
+Default: `"UTC"`
 
 The time zone NetBox will use when dealing with dates and times. It is recommended to use UTC time unless you have a specific need to use a local time zone. Please see the [list of available time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 


### PR DESCRIPTION
### Fixes: #19255
<!--
    Please include a summary of the proposed changes below.
-->
The changes ensure that the default values are highlighted the same way in the documentation