### PR TITLE
Fixes #18961: Virtual chassis form should exclude members of other VCs when adding members

### DIFF
--- a/netbox/dcim/forms/object_create.py
+++ b/netbox/dcim/forms/object_create.py
@@ -404,6 +404,7 @@ class VirtualChassisCreateForm(NetBoxModelForm):
         queryset=Device.objects.all(),
         required=False,
         query_params={
+            'virtual_chassis_id': 'null',
             'site_id': '$site',
             'rack_id': '$rack',
         }


### PR DESCRIPTION
### Fixes: #18961

This exclusion is already in place for VCMemberSelectForm.