### PR TITLE
Fixes #19268: Restore editing conflict protection for several object forms

### DIFF
--- a/netbox/templates/dcim/cable_edit.html
+++ b/netbox/templates/dcim/cable_edit.html
@@ -1,5 +1,5 @@
 {% extends 'generic/object_edit.html' %}
 
 {% block form %}
-  {%  include 'dcim/htmx/cable_edit.html' %}
+  {% include 'dcim/htmx/cable_edit.html' %}
 {% endblock %}

--- a/netbox/templates/dcim/device_edit.html
+++ b/netbox/templates/dcim/device_edit.html
@@ -3,7 +3,9 @@
 {% load i18n %}
 
 {% block form %}
-    {% render_errors form %}
+    {% for field in form.hidden_fields %}
+      {{ field }}
+    {% endfor %}
 
     <div class="field-group my-5">
       <div class="row">

--- a/netbox/templates/dcim/htmx/cable_edit.html
+++ b/netbox/templates/dcim/htmx/cable_edit.html
@@ -3,6 +3,9 @@
 {% load form_helpers %}
 {% load i18n %}
 
+{% for field in form.hidden_fields %}
+  {{ field }}
+{% endfor %}
 
 {# A side termination #}
 <div class="field-group mb-5">

--- a/netbox/templates/dcim/virtualchassis_add.html
+++ b/netbox/templates/dcim/virtualchassis_add.html
@@ -3,6 +3,10 @@
 {% load i18n %}
 
 {% block form %}
+  {% for field in form.hidden_fields %}
+    {{ field }}
+  {% endfor %}
+
   <div class="field-group my-5">
     <div class="row">
       <h2 class="col-9 offset-3">{% trans "Virtual Chassis" %}</h2>

--- a/netbox/templates/dcim/virtualchassis_edit.html
+++ b/netbox/templates/dcim/virtualchassis_edit.html
@@ -12,11 +12,15 @@
 {% block content %}
   <div class="tab-pane show active" id="edit-form" role="tabpanel" aria-labelledby="object-list-tab">
     <form action="" method="post" enctype="multipart/form-data" class="object-edit">
+      {% render_errors vc_form %}
       {% for form in formset %}
         {% render_errors form %}
       {% endfor %}
 
       {% csrf_token %}
+      {% for field in vc_form.hidden_fields %}
+        {{ field }}
+      {% endfor %}
       {{ pk_form.pk }}
       {{ formset.management_form }}
       <div class="field-group my-5">

--- a/netbox/templates/ipam/vlan_edit.html
+++ b/netbox/templates/ipam/vlan_edit.html
@@ -5,6 +5,10 @@
 {% load i18n %}
 
 {% block form %}
+  {% for field in form.hidden_fields %}
+    {{ field }}
+  {% endfor %}
+
   <div class="field-group my-5">
     <div class="row">
       <h2 class="col-9 offset-3">{% trans "VLAN" %}</h2>


### PR DESCRIPTION
### Fixes: #19268

- Ensure all custom HTML templates for object editing render hidden form fields
- Miscellaneous cleanup