### PR TITLE
Fixes: #19275 - Make type choice for interfaces non-required

### DIFF
--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -200,6 +200,8 @@ def form_from_model(model, fields):
     form_fields = fields_for_model(model, fields=fields)
     for field in form_fields.values():
         field.required = False
+        if field.widget and field.widget.is_required:
+            field.widget.is_required = False
 
     return type('FormFromModel', (forms.Form,), form_fields)
 


### PR DESCRIPTION
### Fixes: #19275 - Make type choice for interfaces non-required

* Alter `form_from_model` to also mark the widget itself as non-required