### PR TITLE
Fixes #19281: Fix service template creation form

### DIFF
--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -840,6 +840,7 @@ class ServiceCreateForm(ServiceForm):
         # Fields which may be populated from a ServiceTemplate are not required
         for field in ('name', 'protocol', 'ports'):
             self.fields[field].required = False
+            self.fields[field].widget.is_required = False
 
     def clean(self):
         super().clean()


### PR DESCRIPTION
### Fixes: #19281

Mark the widget for the `protocol` form field as not required.