### PR TITLE
Fixes #19279: Fix missing status field for inventory item bulk creation

### DIFF
--- a/netbox/dcim/forms/bulk_create.py
+++ b/netbox/dcim/forms/bulk_create.py
@@ -121,11 +121,11 @@ class DeviceBayBulkCreateForm(DeviceBulkAddComponentForm):
 
 
 class InventoryItemBulkCreateForm(
-    form_from_model(InventoryItem, ['role', 'manufacturer', 'part_id', 'serial', 'asset_tag', 'discovered']),
+    form_from_model(InventoryItem, ['status', 'role', 'manufacturer', 'part_id', 'serial', 'asset_tag', 'discovered']),
     DeviceBulkAddComponentForm
 ):
     model = InventoryItem
     field_order = (
-        'name', 'label', 'role', 'manufacturer', 'part_id', 'serial', 'asset_tag', 'discovered',
+        'name', 'label', 'status', 'role', 'manufacturer', 'part_id', 'serial', 'asset_tag', 'discovered',
         'description', 'tags',
     )

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -200,6 +200,7 @@ def form_from_model(model, fields):
     form_fields = fields_for_model(model, fields=fields)
     for field in form_fields.values():
         field.required = False
+        field.widget.is_required = False
 
     return type('FormFromModel', (forms.Form,), form_fields)
 


### PR DESCRIPTION
### Fixes: #19279

- Add missing `status` field to InventoryItemBulkCreateForm
- Set widget `required` attribute within `form_from_model()`