### PR TITLE
Fixes: #19228 - Fix ordered_scripts to only return ordered list of script objects

### DIFF
--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -123,7 +123,7 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
         ordered = [
             script_objects.pop(sc) for sc in self.module_scripts.keys() if sc in script_objects
         ]
-        ordered.extend(script_objects.items())
+        ordered.extend(script_objects.values())
         return ordered
 
     @property


### PR DESCRIPTION
### Fixes: #19228 - Fix ordered_scripts to only return ordered list of script objects

* Modify ordered_scripts to only return `Script` objects and not a list of `Script` objects and tuples of `Script` names and `Script` objects