### PR TITLE
Closes #17151: Use ColoredLabelColumn for Type Column in Circuits Table

### DIFF
--- a/netbox/circuits/tables/circuits.py
+++ b/netbox/circuits/tables/circuits.py
@@ -61,9 +61,8 @@ class CircuitTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
         linkify=True,
         verbose_name=_('Account')
     )
-    type = tables.Column(
+    type = columns.ColoredLabelColumn(
         verbose_name=_('Type'),
-        linkify=True
     )
     status = columns.ChoiceFieldColumn()
     termination_a = columns.TemplateColumn(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #17151 add color backgrounds for circuit type

This PR updates the `type` column in the Circuits table to use `ColoredLabelColumn`, which applies the configured color for each Circuit Type as a background. This improves visual clarity and consistency with how Rack Roles are displayed.

As part of this change, the now-redundant `linkify=True` attribute has been removed from the column definition, since `ColoredLabelColumn` already provides clickable labels by default.