### PR TITLE
Fixes #19204: Use DjangoJSONEncoder for Job data

### DIFF
--- a/netbox/core/migrations/0013_job_data_encoder.py
+++ b/netbox/core/migrations/0013_job_data_encoder.py
@@ -1,0 +1,17 @@
+import django.core.serializers.json
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('core', '0012_job_object_type_optional'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='job',
+            name='data',
+            field=models.JSONField(blank=True, encoder=django.core.serializers.json.DjangoJSONEncoder, null=True),
+        ),
+    ]

--- a/netbox/core/models/jobs.py
+++ b/netbox/core/models/jobs.py
@@ -5,6 +5,7 @@ import django_rq
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.core.exceptions import ValidationError
+from django.core.serializers.json import DjangoJSONEncoder
 from django.core.validators import MinValueValidator
 from django.db import models, transaction
 from django.urls import reverse
@@ -90,8 +91,9 @@ class Job(models.Model):
     )
     data = models.JSONField(
         verbose_name=_('data'),
+        encoder=DjangoJSONEncoder,
         null=True,
-        blank=True
+        blank=True,
     )
     error = models.TextField(
         verbose_name=_('error'),


### PR DESCRIPTION
### Fixes: #19204

Use DjangoJSONEncoder for the `data` JSONField on the Job model for better serialization support