### PR TITLE
Fixes #19309: N+1 problem on /interfaces, /ip-addresses and /prefixes requests

### DIFF
--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -455,6 +455,7 @@ class InterfaceViewSet(PathEndpointMixin, NetBoxModelViewSet):
                 Interface.objects.select_related("device", "cable"),
             ],
         ),
+        'virtual_circuit_termination',
         'l2vpn_terminations',  # Referenced by InterfaceSerializer.l2vpn_termination
         'ip_addresses',  # Referenced by Interface.count_ipaddresses()
         'fhrp_group_assignments',  # Referenced by Interface.count_fhrp_groups()

--- a/netbox/ipam/api/views.py
+++ b/netbox/ipam/api/views.py
@@ -81,9 +81,7 @@ class RoleViewSet(NetBoxModelViewSet):
 
 
 class PrefixViewSet(NetBoxModelViewSet):
-    queryset = Prefix.objects.prefetch_related(
-        "scope",
-    ).all()
+    queryset = Prefix.objects.prefetch_related("scope")
     serializer_class = serializers.PrefixSerializer
     filterset_class = filtersets.PrefixFilterSet
 
@@ -111,7 +109,7 @@ class IPAddressViewSet(NetBoxModelViewSet):
                 Interface.objects.select_related("device"),
             ],
         ),
-    ).all()
+    )
     serializer_class = serializers.IPAddressSerializer
     filterset_class = filtersets.IPAddressFilterSet
 

--- a/netbox/ipam/api/views.py
+++ b/netbox/ipam/api/views.py
@@ -23,6 +23,7 @@ from netbox.api.viewsets.mixins import ObjectValidationMixin
 from netbox.config import get_config
 from netbox.constants import ADVISORY_LOCK_KEYS
 from utilities.api import get_serializer_for_model
+from virtualization.models import VMInterface
 from . import serializers
 
 
@@ -106,7 +107,10 @@ class IPAddressViewSet(NetBoxModelViewSet):
         GenericPrefetch(
             "assigned_object",
             [
-                Interface.objects.select_related("device"),
+                # serializers are taken according to IPADDRESS_ASSIGNMENT_MODELS
+                FHRPGroup.objects.all(),
+                Interface.objects.select_related("cable", "device"),
+                VMInterface.objects.select_related("virtual_machine"),
             ],
         ),
     )


### PR DESCRIPTION
### Fixes: #19309
In case of requesting `/interfaces`, `/ip-addresses` and `/prefixes` some of the fields are selected separately for each model. We should prefetch them.
