### PR TITLE
Fixes: #18717 - On delete signal handling, manually save the related object in a ManyToOneRel to trigger a change record

### DIFF
--- a/netbox/core/signals.py
+++ b/netbox/core/signals.py
@@ -2,7 +2,7 @@ import logging
 
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ValidationError
-from django.db.models.fields.reverse_related import ManyToManyRel
+from django.db.models.fields.reverse_related import ManyToManyRel, ManyToOneRel
 from django.db.models.signals import m2m_changed, post_save, pre_delete
 from django.dispatch import receiver, Signal
 from django.utils.translation import gettext_lazy as _
@@ -146,8 +146,10 @@ def handle_deleted_object(sender, instance, **kwargs):
     # instance being deleted, and explicitly call .remove() on the remote M2M field to delete
     # the association. This triggers an m2m_changed signal with the `post_remove` action type
     # for the forward direction of the relationship, ensuring that the change is recorded.
+    # Similarly, for many-to-one relationships, we set the value on the related object to None
+    # and save it to trigger a change record on that object.
     for relation in instance._meta.related_objects:
-        if type(relation) is not ManyToManyRel:
+        if type(relation) not in [ManyToManyRel, ManyToOneRel]:
             continue
         related_model = relation.related_model
         related_field_name = relation.remote_field.name
@@ -157,7 +159,11 @@ def handle_deleted_object(sender, instance, **kwargs):
             continue
         for obj in related_model.objects.filter(**{related_field_name: instance.pk}):
             obj.snapshot()  # Ensure the change record includes the "before" state
-            getattr(obj, related_field_name).remove(instance)
+            if type(relation) is ManyToManyRel:
+                getattr(obj, related_field_name).remove(instance)
+            elif type(relation) is ManyToOneRel:
+                setattr(obj, related_field_name, None)
+                obj.save()
 
     # Enqueue the object for event processing
     queue = events_queue.get()

--- a/netbox/core/signals.py
+++ b/netbox/core/signals.py
@@ -161,7 +161,7 @@ def handle_deleted_object(sender, instance, **kwargs):
             obj.snapshot()  # Ensure the change record includes the "before" state
             if type(relation) is ManyToManyRel:
                 getattr(obj, related_field_name).remove(instance)
-            elif type(relation) is ManyToOneRel:
+            elif type(relation) is ManyToOneRel and relation.field.null is True:
                 setattr(obj, related_field_name, None)
                 obj.save()
 


### PR DESCRIPTION
### Fixes: #18717

The `handle_deleted_object` signal handler ensures that change records are saved for the object being deleted, but also manually triggers a `m2m_changed` signal to ensure that related objects through many-to-many relationships are also change-logged through their own signal handlers. However, we do not handle the case where the related object is linked to the deleted object through a many-to-one relationship.

This change handles `ManyToOneRel` fields in the same area of code, by resolving the related object in the same way as with M2M fields, but instead setting the related object's field value to `None` and saving, thus ensuring a change record is created for the related object.

**Note** the check on L164 which ensures the related field is `null=True`. This is primarily to ensure that unit tests pass, as without it one of the tests fails due to trying to set a non-nullable field to `None`. However I think in practice this will not happen as in the case of any FK relationship where `null=False`, trying to delete an object which is pointed to by a related object via a many-to-one relationship will be caught by object-level validation before the deleted object handler is ever called.
