### PR TITLE
Fixes #17676: Fix support for module bay creation when bulk importing module types

### DIFF
--- a/netbox/dcim/forms/object_import.py
+++ b/netbox/dcim/forms/object_import.py
@@ -159,7 +159,7 @@ class ModuleBayTemplateImportForm(forms.ModelForm):
     class Meta:
         model = ModuleBayTemplate
         fields = [
-            'device_type', 'name', 'label', 'position', 'description',
+            'device_type', 'module_type', 'name', 'label', 'position', 'description',
         ]
 
 

--- a/netbox/dcim/tests/test_views.py
+++ b/netbox/dcim/tests/test_views.py
@@ -1205,6 +1205,13 @@ front-ports:
   - name: Front Port 3
     type: 8p8c
     rear_port: Rear Port 3
+module-bays:
+  - name: Module Bay 1
+    position: 1
+  - name: Module Bay 2
+    position: 2
+  - name: Module Bay 3
+    position: 3
 """
 
         # Create the manufacturer
@@ -1222,6 +1229,7 @@ front-ports:
             'dcim.add_interfacetemplate',
             'dcim.add_frontporttemplate',
             'dcim.add_rearporttemplate',
+            'dcim.add_modulebaytemplate',
         )
 
         form_data = {
@@ -1275,6 +1283,11 @@ front-ports:
         self.assertEqual(fp1.name, 'Front Port 1')
         self.assertEqual(fp1.rear_port, rp1)
         self.assertEqual(fp1.rear_port_position, 1)
+
+        self.assertEqual(module_type.modulebaytemplates.count(), 3)
+        mb1 = ModuleBayTemplate.objects.first()
+        self.assertEqual(mb1.name, 'Module Bay 1')
+        self.assertEqual(mb1.position, '1')
 
     def test_export_objects(self):
         url = reverse('dcim:moduletype_list')

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1508,6 +1508,7 @@ class ModuleTypeImportView(generic.BulkImportView):
         'dcim.add_interfacetemplate',
         'dcim.add_frontporttemplate',
         'dcim.add_rearporttemplate',
+        'dcim.add_modulebaytemplate',
     ]
     queryset = ModuleType.objects.all()
     model_form = forms.ModuleTypeImportForm
@@ -1519,6 +1520,7 @@ class ModuleTypeImportView(generic.BulkImportView):
         'interfaces': forms.InterfaceTemplateImportForm,
         'rear-ports': forms.RearPortTemplateImportForm,
         'front-ports': forms.FrontPortTemplateImportForm,
+        'module-bays': forms.ModuleBayTemplateImportForm,
     }
 
     def prep_related_object_data(self, parent, data):


### PR DESCRIPTION
### Fixes: #17676

- Fix ModuleTypeImportView and ModuleBayTemplateImportForm to support module bay template assignment
- Extend bulk import test to validate module bay templates