### PR TITLE
Fixes #19322: Correct URL paths for bulk import views

### DIFF
--- a/netbox/circuits/views.py
+++ b/netbox/circuits/views.py
@@ -52,7 +52,7 @@ class ProviderDeleteView(generic.ObjectDeleteView):
     queryset = Provider.objects.all()
 
 
-@register_model_view(Provider, 'bulk_import', detail=False)
+@register_model_view(Provider, 'bulk_import', path='import', detail=False)
 class ProviderBulkImportView(generic.BulkImportView):
     queryset = Provider.objects.all()
     model_form = forms.ProviderImportForm
@@ -118,7 +118,7 @@ class ProviderAccountDeleteView(generic.ObjectDeleteView):
     queryset = ProviderAccount.objects.all()
 
 
-@register_model_view(ProviderAccount, 'bulk_import', detail=False)
+@register_model_view(ProviderAccount, 'bulk_import', path='import', detail=False)
 class ProviderAccountBulkImportView(generic.BulkImportView):
     queryset = ProviderAccount.objects.all()
     model_form = forms.ProviderAccountImportForm
@@ -197,7 +197,7 @@ class ProviderNetworkDeleteView(generic.ObjectDeleteView):
     queryset = ProviderNetwork.objects.all()
 
 
-@register_model_view(ProviderNetwork, 'bulk_import', detail=False)
+@register_model_view(ProviderNetwork, 'bulk_import', path='import', detail=False)
 class ProviderNetworkBulkImportView(generic.BulkImportView):
     queryset = ProviderNetwork.objects.all()
     model_form = forms.ProviderNetworkImportForm
@@ -254,7 +254,7 @@ class CircuitTypeDeleteView(generic.ObjectDeleteView):
     queryset = CircuitType.objects.all()
 
 
-@register_model_view(CircuitType, 'bulk_import', detail=False)
+@register_model_view(CircuitType, 'bulk_import', path='import', detail=False)
 class CircuitTypeBulkImportView(generic.BulkImportView):
     queryset = CircuitType.objects.all()
     model_form = forms.CircuitTypeImportForm
@@ -310,7 +310,7 @@ class CircuitDeleteView(generic.ObjectDeleteView):
     queryset = Circuit.objects.all()
 
 
-@register_model_view(Circuit, 'bulk_import', detail=False)
+@register_model_view(Circuit, 'bulk_import', path='import', detail=False)
 class CircuitBulkImportView(generic.BulkImportView):
     queryset = Circuit.objects.all()
     model_form = forms.CircuitImportForm
@@ -455,7 +455,7 @@ class CircuitTerminationDeleteView(generic.ObjectDeleteView):
     queryset = CircuitTermination.objects.all()
 
 
-@register_model_view(CircuitTermination, 'bulk_import', detail=False)
+@register_model_view(CircuitTermination, 'bulk_import', path='import', detail=False)
 class CircuitTerminationBulkImportView(generic.BulkImportView):
     queryset = CircuitTermination.objects.all()
     model_form = forms.CircuitTerminationImportForm
@@ -516,7 +516,7 @@ class CircuitGroupDeleteView(generic.ObjectDeleteView):
     queryset = CircuitGroup.objects.all()
 
 
-@register_model_view(CircuitGroup, 'bulk_import', detail=False)
+@register_model_view(CircuitGroup, 'bulk_import', path='import', detail=False)
 class CircuitGroupBulkImportView(generic.BulkImportView):
     queryset = CircuitGroup.objects.all()
     model_form = forms.CircuitGroupImportForm
@@ -566,7 +566,7 @@ class CircuitGroupAssignmentDeleteView(generic.ObjectDeleteView):
     queryset = CircuitGroupAssignment.objects.all()
 
 
-@register_model_view(CircuitGroupAssignment, 'bulk_import', detail=False)
+@register_model_view(CircuitGroupAssignment, 'bulk_import', path='import', detail=False)
 class CircuitGroupAssignmentBulkImportView(generic.BulkImportView):
     queryset = CircuitGroupAssignment.objects.all()
     model_form = forms.CircuitGroupAssignmentImportForm
@@ -623,7 +623,7 @@ class VirtualCircuitTypeDeleteView(generic.ObjectDeleteView):
     queryset = VirtualCircuitType.objects.all()
 
 
-@register_model_view(VirtualCircuitType, 'bulk_import', detail=False)
+@register_model_view(VirtualCircuitType, 'bulk_import', path='import', detail=False)
 class VirtualCircuitTypeBulkImportView(generic.BulkImportView):
     queryset = VirtualCircuitType.objects.all()
     model_form = forms.VirtualCircuitTypeImportForm

--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -102,7 +102,7 @@ class DataSourceDeleteView(generic.ObjectDeleteView):
     queryset = DataSource.objects.all()
 
 
-@register_model_view(DataSource, 'bulk_import', detail=False)
+@register_model_view(DataSource, 'bulk_import', path='import', detail=False)
 class DataSourceBulkImportView(generic.BulkImportView):
     queryset = DataSource.objects.all()
     model_form = forms.DataSourceImportForm

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -280,7 +280,7 @@ class RegionDeleteView(generic.ObjectDeleteView):
     queryset = Region.objects.all()
 
 
-@register_model_view(Region, 'bulk_import', detail=False)
+@register_model_view(Region, 'bulk_import', path='import', detail=False)
 class RegionBulkImportView(generic.BulkImportView):
     queryset = Region.objects.all()
     model_form = forms.RegionImportForm
@@ -411,7 +411,7 @@ class SiteGroupDeleteView(generic.ObjectDeleteView):
     queryset = SiteGroup.objects.all()
 
 
-@register_model_view(SiteGroup, 'bulk_import', detail=False)
+@register_model_view(SiteGroup, 'bulk_import', path='import', detail=False)
 class SiteGroupBulkImportView(generic.BulkImportView):
     queryset = SiteGroup.objects.all()
     model_form = forms.SiteGroupImportForm
@@ -507,7 +507,7 @@ class SiteDeleteView(generic.ObjectDeleteView):
     queryset = Site.objects.all()
 
 
-@register_model_view(Site, 'bulk_import', detail=False)
+@register_model_view(Site, 'bulk_import', path='import', detail=False)
 class SiteBulkImportView(generic.BulkImportView):
     queryset = Site.objects.all()
     model_form = forms.SiteImportForm
@@ -610,7 +610,7 @@ class LocationDeleteView(generic.ObjectDeleteView):
     queryset = Location.objects.all()
 
 
-@register_model_view(Location, 'bulk_import', detail=False)
+@register_model_view(Location, 'bulk_import', path='import', detail=False)
 class LocationBulkImportView(generic.BulkImportView):
     queryset = Location.objects.all()
     model_form = forms.LocationImportForm
@@ -684,7 +684,7 @@ class RackRoleDeleteView(generic.ObjectDeleteView):
     queryset = RackRole.objects.all()
 
 
-@register_model_view(RackRole, 'bulk_import', detail=False)
+@register_model_view(RackRole, 'bulk_import', path='import', detail=False)
 class RackRoleBulkImportView(generic.BulkImportView):
     queryset = RackRole.objects.all()
     model_form = forms.RackRoleImportForm
@@ -745,7 +745,7 @@ class RackTypeDeleteView(generic.ObjectDeleteView):
     queryset = RackType.objects.all()
 
 
-@register_model_view(RackType, 'bulk_import', detail=False)
+@register_model_view(RackType, 'bulk_import', path='import', detail=False)
 class RackTypeBulkImportView(generic.BulkImportView):
     queryset = RackType.objects.all()
     model_form = forms.RackTypeImportForm
@@ -924,7 +924,7 @@ class RackDeleteView(generic.ObjectDeleteView):
     queryset = Rack.objects.all()
 
 
-@register_model_view(Rack, 'bulk_import', detail=False)
+@register_model_view(Rack, 'bulk_import', path='import', detail=False)
 class RackBulkImportView(generic.BulkImportView):
     queryset = Rack.objects.all()
     model_form = forms.RackImportForm
@@ -986,7 +986,7 @@ class RackReservationDeleteView(generic.ObjectDeleteView):
     queryset = RackReservation.objects.all()
 
 
-@register_model_view(RackReservation, 'bulk_import', detail=False)
+@register_model_view(RackReservation, 'bulk_import', path='import', detail=False)
 class RackReservationImportView(generic.BulkImportView):
     queryset = RackReservation.objects.all()
     model_form = forms.RackReservationImportForm
@@ -1057,7 +1057,7 @@ class ManufacturerDeleteView(generic.ObjectDeleteView):
     queryset = Manufacturer.objects.all()
 
 
-@register_model_view(Manufacturer, 'bulk_import', detail=False)
+@register_model_view(Manufacturer, 'bulk_import', path='import', detail=False)
 class ManufacturerBulkImportView(generic.BulkImportView):
     queryset = Manufacturer.objects.all()
     model_form = forms.ManufacturerImportForm
@@ -1283,7 +1283,7 @@ class DeviceTypeInventoryItemsView(DeviceTypeComponentsView):
     )
 
 
-@register_model_view(DeviceType, 'bulk_import', detail=False)
+@register_model_view(DeviceType, 'bulk_import', path='import', detail=False)
 class DeviceTypeImportView(generic.BulkImportView):
     additional_permissions = [
         'dcim.add_devicetype',
@@ -1497,7 +1497,7 @@ class ModuleTypeModuleBaysView(ModuleTypeComponentsView):
     )
 
 
-@register_model_view(ModuleType, 'bulk_import', detail=False)
+@register_model_view(ModuleType, 'bulk_import', path='import', detail=False)
 class ModuleTypeImportView(generic.BulkImportView):
     additional_permissions = [
         'dcim.add_moduletype',
@@ -1995,7 +1995,7 @@ class DeviceRoleDeleteView(generic.ObjectDeleteView):
     queryset = DeviceRole.objects.all()
 
 
-@register_model_view(DeviceRole, 'bulk_import', detail=False)
+@register_model_view(DeviceRole, 'bulk_import', path='import', detail=False)
 class DeviceRoleBulkImportView(generic.BulkImportView):
     queryset = DeviceRole.objects.all()
     model_form = forms.DeviceRoleImportForm
@@ -2059,7 +2059,7 @@ class PlatformDeleteView(generic.ObjectDeleteView):
     queryset = Platform.objects.all()
 
 
-@register_model_view(Platform, 'bulk_import', detail=False)
+@register_model_view(Platform, 'bulk_import', path='import', detail=False)
 class PlatformBulkImportView(generic.BulkImportView):
     queryset = Platform.objects.all()
     model_form = forms.PlatformImportForm
@@ -2342,7 +2342,7 @@ class DeviceVirtualMachinesView(generic.ObjectChildrenView):
         return self.child_model.objects.restrict(request.user, 'view').filter(cluster=parent.cluster, device=parent)
 
 
-@register_model_view(Device, 'bulk_import', detail=False)
+@register_model_view(Device, 'bulk_import', path='import', detail=False)
 class DeviceBulkImportView(generic.BulkImportView):
     queryset = Device.objects.all()
     model_form = forms.DeviceImportForm
@@ -2420,7 +2420,7 @@ class ModuleDeleteView(generic.ObjectDeleteView):
     queryset = Module.objects.all()
 
 
-@register_model_view(Module, 'bulk_import', detail=False)
+@register_model_view(Module, 'bulk_import', path='import', detail=False)
 class ModuleBulkImportView(generic.BulkImportView):
     queryset = Module.objects.all()
     model_form = forms.ModuleImportForm
@@ -2481,7 +2481,7 @@ class ConsolePortDeleteView(generic.ObjectDeleteView):
     queryset = ConsolePort.objects.all()
 
 
-@register_model_view(ConsolePort, 'bulk_import', detail=False)
+@register_model_view(ConsolePort, 'bulk_import', path='import', detail=False)
 class ConsolePortBulkImportView(generic.BulkImportView):
     queryset = ConsolePort.objects.all()
     model_form = forms.ConsolePortImportForm
@@ -2556,7 +2556,7 @@ class ConsoleServerPortDeleteView(generic.ObjectDeleteView):
     queryset = ConsoleServerPort.objects.all()
 
 
-@register_model_view(ConsoleServerPort, 'bulk_import', detail=False)
+@register_model_view(ConsoleServerPort, 'bulk_import', path='import', detail=False)
 class ConsoleServerPortBulkImportView(generic.BulkImportView):
     queryset = ConsoleServerPort.objects.all()
     model_form = forms.ConsoleServerPortImportForm
@@ -2631,7 +2631,7 @@ class PowerPortDeleteView(generic.ObjectDeleteView):
     queryset = PowerPort.objects.all()
 
 
-@register_model_view(PowerPort, 'bulk_import', detail=False)
+@register_model_view(PowerPort, 'bulk_import', path='import', detail=False)
 class PowerPortBulkImportView(generic.BulkImportView):
     queryset = PowerPort.objects.all()
     model_form = forms.PowerPortImportForm
@@ -2706,7 +2706,7 @@ class PowerOutletDeleteView(generic.ObjectDeleteView):
     queryset = PowerOutlet.objects.all()
 
 
-@register_model_view(PowerOutlet, 'bulk_import', detail=False)
+@register_model_view(PowerOutlet, 'bulk_import', path='import', detail=False)
 class PowerOutletBulkImportView(generic.BulkImportView):
     queryset = PowerOutlet.objects.all()
     model_form = forms.PowerOutletImportForm
@@ -2838,7 +2838,7 @@ class InterfaceDeleteView(generic.ObjectDeleteView):
     queryset = Interface.objects.all()
 
 
-@register_model_view(Interface, 'bulk_import', detail=False)
+@register_model_view(Interface, 'bulk_import', path='import', detail=False)
 class InterfaceBulkImportView(generic.BulkImportView):
     queryset = Interface.objects.all()
     model_form = forms.InterfaceImportForm
@@ -2924,7 +2924,7 @@ class FrontPortDeleteView(generic.ObjectDeleteView):
     queryset = FrontPort.objects.all()
 
 
-@register_model_view(FrontPort, 'bulk_import', detail=False)
+@register_model_view(FrontPort, 'bulk_import', path='import', detail=False)
 class FrontPortBulkImportView(generic.BulkImportView):
     queryset = FrontPort.objects.all()
     model_form = forms.FrontPortImportForm
@@ -2999,7 +2999,7 @@ class RearPortDeleteView(generic.ObjectDeleteView):
     queryset = RearPort.objects.all()
 
 
-@register_model_view(RearPort, 'bulk_import', detail=False)
+@register_model_view(RearPort, 'bulk_import', path='import', detail=False)
 class RearPortBulkImportView(generic.BulkImportView):
     queryset = RearPort.objects.all()
     model_form = forms.RearPortImportForm
@@ -3074,7 +3074,7 @@ class ModuleBayDeleteView(generic.ObjectDeleteView):
     queryset = ModuleBay.objects.all()
 
 
-@register_model_view(ModuleBay, 'bulk_import', detail=False)
+@register_model_view(ModuleBay, 'bulk_import', path='import', detail=False)
 class ModuleBayBulkImportView(generic.BulkImportView):
     queryset = ModuleBay.objects.all()
     model_form = forms.ModuleBayImportForm
@@ -3221,7 +3221,7 @@ class DeviceBayDepopulateView(generic.ObjectEditView):
         })
 
 
-@register_model_view(DeviceBay, 'bulk_import', detail=False)
+@register_model_view(DeviceBay, 'bulk_import', path='import', detail=False)
 class DeviceBayBulkImportView(generic.BulkImportView):
     queryset = DeviceBay.objects.all()
     model_form = forms.DeviceBayImportForm
@@ -3287,7 +3287,7 @@ class InventoryItemDeleteView(generic.ObjectDeleteView):
     queryset = InventoryItem.objects.all()
 
 
-@register_model_view(InventoryItem, 'bulk_import', detail=False)
+@register_model_view(InventoryItem, 'bulk_import', path='import', detail=False)
 class InventoryItemBulkImportView(generic.BulkImportView):
     queryset = InventoryItem.objects.all()
     model_form = forms.InventoryItemImportForm
@@ -3368,7 +3368,7 @@ class InventoryItemRoleDeleteView(generic.ObjectDeleteView):
     queryset = InventoryItemRole.objects.all()
 
 
-@register_model_view(InventoryItemRole, 'bulk_import', detail=False)
+@register_model_view(InventoryItemRole, 'bulk_import', path='import', detail=False)
 class InventoryItemRoleBulkImportView(generic.BulkImportView):
     queryset = InventoryItemRole.objects.all()
     model_form = forms.InventoryItemRoleImportForm
@@ -3564,7 +3564,7 @@ class CableDeleteView(generic.ObjectDeleteView):
     queryset = Cable.objects.all()
 
 
-@register_model_view(Cable, 'bulk_import', detail=False)
+@register_model_view(Cable, 'bulk_import', path='import', detail=False)
 class CableBulkImportView(generic.BulkImportView):
     queryset = Cable.objects.all()
     model_form = forms.CableImportForm
@@ -3865,7 +3865,7 @@ class VirtualChassisRemoveMemberView(ObjectPermissionRequiredMixin, GetReturnURL
         })
 
 
-@register_model_view(VirtualChassis, 'bulk_import', detail=False)
+@register_model_view(VirtualChassis, 'bulk_import', path='import', detail=False)
 class VirtualChassisBulkImportView(generic.BulkImportView):
     queryset = VirtualChassis.objects.all()
     model_form = forms.VirtualChassisImportForm
@@ -3922,7 +3922,7 @@ class PowerPanelDeleteView(generic.ObjectDeleteView):
     queryset = PowerPanel.objects.all()
 
 
-@register_model_view(PowerPanel, 'bulk_import', detail=False)
+@register_model_view(PowerPanel, 'bulk_import', path='import', detail=False)
 class PowerPanelBulkImportView(generic.BulkImportView):
     queryset = PowerPanel.objects.all()
     model_form = forms.PowerPanelImportForm
@@ -3979,7 +3979,7 @@ class PowerFeedDeleteView(generic.ObjectDeleteView):
     queryset = PowerFeed.objects.all()
 
 
-@register_model_view(PowerFeed, 'bulk_import', detail=False)
+@register_model_view(PowerFeed, 'bulk_import', path='import', detail=False)
 class PowerFeedBulkImportView(generic.BulkImportView):
     queryset = PowerFeed.objects.all()
     model_form = forms.PowerFeedImportForm
@@ -4051,7 +4051,7 @@ class VirtualDeviceContextDeleteView(generic.ObjectDeleteView):
     queryset = VirtualDeviceContext.objects.all()
 
 
-@register_model_view(VirtualDeviceContext, 'bulk_import', detail=False)
+@register_model_view(VirtualDeviceContext, 'bulk_import', path='import', detail=False)
 class VirtualDeviceContextBulkImportView(generic.BulkImportView):
     queryset = VirtualDeviceContext.objects.all()
     model_form = forms.VirtualDeviceContextImportForm
@@ -4101,7 +4101,7 @@ class MACAddressDeleteView(generic.ObjectDeleteView):
     queryset = MACAddress.objects.all()
 
 
-@register_model_view(MACAddress, 'bulk_import', detail=False)
+@register_model_view(MACAddress, 'bulk_import', path='import', detail=False)
 class MACAddressBulkImportView(generic.BulkImportView):
     queryset = MACAddress.objects.all()
     model_form = forms.MACAddressImportForm

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -83,7 +83,7 @@ class CustomFieldDeleteView(generic.ObjectDeleteView):
     queryset = CustomField.objects.select_related('choice_set')
 
 
-@register_model_view(CustomField, 'bulk_import', detail=False)
+@register_model_view(CustomField, 'bulk_import', path='import', detail=False)
 class CustomFieldBulkImportView(generic.BulkImportView):
     queryset = CustomField.objects.select_related('choice_set')
     model_form = forms.CustomFieldImportForm
@@ -152,7 +152,7 @@ class CustomFieldChoiceSetDeleteView(generic.ObjectDeleteView):
     queryset = CustomFieldChoiceSet.objects.all()
 
 
-@register_model_view(CustomFieldChoiceSet, 'bulk_import', detail=False)
+@register_model_view(CustomFieldChoiceSet, 'bulk_import', path='import', detail=False)
 class CustomFieldChoiceSetBulkImportView(generic.BulkImportView):
     queryset = CustomFieldChoiceSet.objects.all()
     model_form = forms.CustomFieldChoiceSetImportForm
@@ -202,7 +202,7 @@ class CustomLinkDeleteView(generic.ObjectDeleteView):
     queryset = CustomLink.objects.all()
 
 
-@register_model_view(CustomLink, 'bulk_import', detail=False)
+@register_model_view(CustomLink, 'bulk_import', path='import', detail=False)
 class CustomLinkBulkImportView(generic.BulkImportView):
     queryset = CustomLink.objects.all()
     model_form = forms.CustomLinkImportForm
@@ -257,7 +257,7 @@ class ExportTemplateDeleteView(generic.ObjectDeleteView):
     queryset = ExportTemplate.objects.all()
 
 
-@register_model_view(ExportTemplate, 'bulk_import', detail=False)
+@register_model_view(ExportTemplate, 'bulk_import', path='import', detail=False)
 class ExportTemplateBulkImportView(generic.BulkImportView):
     queryset = ExportTemplate.objects.all()
     model_form = forms.ExportTemplateImportForm
@@ -334,7 +334,7 @@ class SavedFilterDeleteView(SavedFilterMixin, generic.ObjectDeleteView):
     queryset = SavedFilter.objects.all()
 
 
-@register_model_view(SavedFilter, 'bulk_import', detail=False)
+@register_model_view(SavedFilter, 'bulk_import', path='import', detail=False)
 class SavedFilterBulkImportView(SavedFilterMixin, generic.BulkImportView):
     queryset = SavedFilter.objects.all()
     model_form = forms.SavedFilterImportForm
@@ -415,7 +415,7 @@ class NotificationGroupDeleteView(generic.ObjectDeleteView):
     queryset = NotificationGroup.objects.all()
 
 
-@register_model_view(NotificationGroup, 'bulk_import', detail=False)
+@register_model_view(NotificationGroup, 'bulk_import', path='import', detail=False)
 class NotificationGroupBulkImportView(generic.BulkImportView):
     queryset = NotificationGroup.objects.all()
     model_form = forms.NotificationGroupImportForm
@@ -561,7 +561,7 @@ class WebhookDeleteView(generic.ObjectDeleteView):
     queryset = Webhook.objects.all()
 
 
-@register_model_view(Webhook, 'bulk_import', detail=False)
+@register_model_view(Webhook, 'bulk_import', path='import', detail=False)
 class WebhookBulkImportView(generic.BulkImportView):
     queryset = Webhook.objects.all()
     model_form = forms.WebhookImportForm
@@ -611,7 +611,7 @@ class EventRuleDeleteView(generic.ObjectDeleteView):
     queryset = EventRule.objects.all()
 
 
-@register_model_view(EventRule, 'bulk_import', detail=False)
+@register_model_view(EventRule, 'bulk_import', path='import', detail=False)
 class EventRuleBulkImportView(generic.BulkImportView):
     queryset = EventRule.objects.all()
     model_form = forms.EventRuleImportForm
@@ -684,7 +684,7 @@ class TagDeleteView(generic.ObjectDeleteView):
     queryset = Tag.objects.all()
 
 
-@register_model_view(Tag, 'bulk_import', detail=False)
+@register_model_view(Tag, 'bulk_import', path='import', detail=False)
 class TagBulkImportView(generic.BulkImportView):
     queryset = Tag.objects.all()
     model_form = forms.TagImportForm
@@ -860,7 +860,7 @@ class ConfigTemplateDeleteView(generic.ObjectDeleteView):
     queryset = ConfigTemplate.objects.all()
 
 
-@register_model_view(ConfigTemplate, 'bulk_import', detail=False)
+@register_model_view(ConfigTemplate, 'bulk_import', path='import', detail=False)
 class ConfigTemplateBulkImportView(generic.BulkImportView):
     queryset = ConfigTemplate.objects.all()
     model_form = forms.ConfigTemplateImportForm
@@ -1039,7 +1039,7 @@ class JournalEntryDeleteView(generic.ObjectDeleteView):
         return reverse(viewname, kwargs={'pk': obj.pk})
 
 
-@register_model_view(JournalEntry, 'bulk_import', detail=False)
+@register_model_view(JournalEntry, 'bulk_import', path='import', detail=False)
 class JournalEntryBulkImportView(generic.BulkImportView):
     queryset = JournalEntry.objects.all()
     model_form = forms.JournalEntryImportForm

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -70,7 +70,7 @@ class VRFDeleteView(generic.ObjectDeleteView):
     queryset = VRF.objects.all()
 
 
-@register_model_view(VRF, 'bulk_import', detail=False)
+@register_model_view(VRF, 'bulk_import', path='import', detail=False)
 class VRFBulkImportView(generic.BulkImportView):
     queryset = VRF.objects.all()
     model_form = forms.VRFImportForm
@@ -120,7 +120,7 @@ class RouteTargetDeleteView(generic.ObjectDeleteView):
     queryset = RouteTarget.objects.all()
 
 
-@register_model_view(RouteTarget, 'bulk_import', detail=False)
+@register_model_view(RouteTarget, 'bulk_import', path='import', detail=False)
 class RouteTargetBulkImportView(generic.BulkImportView):
     queryset = RouteTarget.objects.all()
     model_form = forms.RouteTargetImportForm
@@ -177,7 +177,7 @@ class RIRDeleteView(generic.ObjectDeleteView):
     queryset = RIR.objects.all()
 
 
-@register_model_view(RIR, 'bulk_import', detail=False)
+@register_model_view(RIR, 'bulk_import', path='import', detail=False)
 class RIRBulkImportView(generic.BulkImportView):
     queryset = RIR.objects.all()
     model_form = forms.RIRImportForm
@@ -252,7 +252,7 @@ class ASNRangeDeleteView(generic.ObjectDeleteView):
     queryset = ASNRange.objects.all()
 
 
-@register_model_view(ASNRange, 'bulk_import', detail=False)
+@register_model_view(ASNRange, 'bulk_import', path='import', detail=False)
 class ASNRangeBulkImportView(generic.BulkImportView):
     queryset = ASNRange.objects.all()
     model_form = forms.ASNRangeImportForm
@@ -317,7 +317,7 @@ class ASNDeleteView(generic.ObjectDeleteView):
     queryset = ASN.objects.all()
 
 
-@register_model_view(ASN, 'bulk_import', detail=False)
+@register_model_view(ASN, 'bulk_import', path='import', detail=False)
 class ASNBulkImportView(generic.BulkImportView):
     queryset = ASN.objects.all()
     model_form = forms.ASNImportForm
@@ -409,7 +409,7 @@ class AggregateDeleteView(generic.ObjectDeleteView):
     queryset = Aggregate.objects.all()
 
 
-@register_model_view(Aggregate, 'bulk_import', detail=False)
+@register_model_view(Aggregate, 'bulk_import', path='import', detail=False)
 class AggregateBulkImportView(generic.BulkImportView):
     queryset = Aggregate.objects.all()
     model_form = forms.AggregateImportForm
@@ -477,7 +477,7 @@ class RoleDeleteView(generic.ObjectDeleteView):
     queryset = Role.objects.all()
 
 
-@register_model_view(Role, 'bulk_import', detail=False)
+@register_model_view(Role, 'bulk_import', path='import', detail=False)
 class RoleBulkImportView(generic.BulkImportView):
     queryset = Role.objects.all()
     model_form = forms.RoleImportForm
@@ -663,7 +663,7 @@ class PrefixDeleteView(generic.ObjectDeleteView):
     queryset = Prefix.objects.all()
 
 
-@register_model_view(Prefix, 'bulk_import', detail=False)
+@register_model_view(Prefix, 'bulk_import', path='import', detail=False)
 class PrefixBulkImportView(generic.BulkImportView):
     queryset = Prefix.objects.all()
     model_form = forms.PrefixImportForm
@@ -757,7 +757,7 @@ class IPRangeDeleteView(generic.ObjectDeleteView):
     queryset = IPRange.objects.all()
 
 
-@register_model_view(IPRange, 'bulk_import', detail=False)
+@register_model_view(IPRange, 'bulk_import', path='import', detail=False)
 class IPRangeBulkImportView(generic.BulkImportView):
     queryset = IPRange.objects.all()
     model_form = forms.IPRangeImportForm
@@ -926,7 +926,7 @@ class IPAddressBulkCreateView(generic.BulkCreateView):
     template_name = 'ipam/ipaddress_bulk_add.html'
 
 
-@register_model_view(IPAddress, 'bulk_import', detail=False)
+@register_model_view(IPAddress, 'bulk_import', path='import', detail=False)
 class IPAddressBulkImportView(generic.BulkImportView):
     queryset = IPAddress.objects.all()
     model_form = forms.IPAddressImportForm
@@ -1004,7 +1004,7 @@ class VLANGroupDeleteView(generic.ObjectDeleteView):
     queryset = VLANGroup.objects.all()
 
 
-@register_model_view(VLANGroup, 'bulk_import', detail=False)
+@register_model_view(VLANGroup, 'bulk_import', path='import', detail=False)
 class VLANGroupBulkImportView(generic.BulkImportView):
     queryset = VLANGroup.objects.all()
     model_form = forms.VLANGroupImportForm
@@ -1091,7 +1091,7 @@ class VLANTranslationPolicyDeleteView(generic.ObjectDeleteView):
     queryset = VLANTranslationPolicy.objects.all()
 
 
-@register_model_view(VLANTranslationPolicy, 'bulk_import', detail=False)
+@register_model_view(VLANTranslationPolicy, 'bulk_import', path='import', detail=False)
 class VLANTranslationPolicyBulkImportView(generic.BulkImportView):
     queryset = VLANTranslationPolicy.objects.all()
     model_form = forms.VLANTranslationPolicyImportForm
@@ -1146,7 +1146,7 @@ class VLANTranslationRuleDeleteView(generic.ObjectDeleteView):
     queryset = VLANTranslationRule.objects.all()
 
 
-@register_model_view(VLANTranslationRule, 'bulk_import', detail=False)
+@register_model_view(VLANTranslationRule, 'bulk_import', path='import', detail=False)
 class VLANTranslationRuleBulkImportView(generic.BulkImportView):
     queryset = VLANTranslationRule.objects.all()
     model_form = forms.VLANTranslationRuleImportForm
@@ -1227,7 +1227,7 @@ class FHRPGroupDeleteView(generic.ObjectDeleteView):
     queryset = FHRPGroup.objects.all()
 
 
-@register_model_view(FHRPGroup, 'bulk_import', detail=False)
+@register_model_view(FHRPGroup, 'bulk_import', path='import', detail=False)
 class FHRPGroupBulkImportView(generic.BulkImportView):
     queryset = FHRPGroup.objects.all()
     model_form = forms.FHRPGroupImportForm
@@ -1353,7 +1353,7 @@ class VLANDeleteView(generic.ObjectDeleteView):
     queryset = VLAN.objects.all()
 
 
-@register_model_view(VLAN, 'bulk_import', detail=False)
+@register_model_view(VLAN, 'bulk_import', path='import', detail=False)
 class VLANBulkImportView(generic.BulkImportView):
     queryset = VLAN.objects.all()
     model_form = forms.VLANImportForm
@@ -1403,7 +1403,7 @@ class ServiceTemplateDeleteView(generic.ObjectDeleteView):
     queryset = ServiceTemplate.objects.all()
 
 
-@register_model_view(ServiceTemplate, 'bulk_import', detail=False)
+@register_model_view(ServiceTemplate, 'bulk_import', path='import', detail=False)
 class ServiceTemplateBulkImportView(generic.BulkImportView):
     queryset = ServiceTemplate.objects.all()
     model_form = forms.ServiceTemplateImportForm
@@ -1458,7 +1458,7 @@ class ServiceDeleteView(generic.ObjectDeleteView):
     queryset = Service.objects.all()
 
 
-@register_model_view(Service, 'bulk_import', detail=False)
+@register_model_view(Service, 'bulk_import', path='import', detail=False)
 class ServiceBulkImportView(generic.BulkImportView):
     queryset = Service.objects.all()
     model_form = forms.ServiceImportForm

--- a/netbox/tenancy/views.py
+++ b/netbox/tenancy/views.py
@@ -80,7 +80,7 @@ class TenantGroupDeleteView(generic.ObjectDeleteView):
     queryset = TenantGroup.objects.all()
 
 
-@register_model_view(TenantGroup, 'bulk_import', detail=False)
+@register_model_view(TenantGroup, 'bulk_import', path='import', detail=False)
 class TenantGroupBulkImportView(generic.BulkImportView):
     queryset = TenantGroup.objects.all()
     model_form = forms.TenantGroupImportForm
@@ -147,7 +147,7 @@ class TenantDeleteView(generic.ObjectDeleteView):
     queryset = Tenant.objects.all()
 
 
-@register_model_view(Tenant, 'bulk_import', detail=False)
+@register_model_view(Tenant, 'bulk_import', path='import', detail=False)
 class TenantBulkImportView(generic.BulkImportView):
     queryset = Tenant.objects.all()
     model_form = forms.TenantImportForm
@@ -215,7 +215,7 @@ class ContactGroupDeleteView(generic.ObjectDeleteView):
     queryset = ContactGroup.objects.all()
 
 
-@register_model_view(ContactGroup, 'bulk_import', detail=False)
+@register_model_view(ContactGroup, 'bulk_import', path='import', detail=False)
 class ContactGroupBulkImportView(generic.BulkImportView):
     queryset = ContactGroup.objects.all()
     model_form = forms.ContactGroupImportForm
@@ -282,7 +282,7 @@ class ContactRoleDeleteView(generic.ObjectDeleteView):
     queryset = ContactRole.objects.all()
 
 
-@register_model_view(ContactRole, 'bulk_import', detail=False)
+@register_model_view(ContactRole, 'bulk_import', path='import', detail=False)
 class ContactRoleBulkImportView(generic.BulkImportView):
     queryset = ContactRole.objects.all()
     model_form = forms.ContactRoleImportForm
@@ -334,7 +334,7 @@ class ContactDeleteView(generic.ObjectDeleteView):
     queryset = Contact.objects.all()
 
 
-@register_model_view(Contact, 'bulk_import', detail=False)
+@register_model_view(Contact, 'bulk_import', path='import', detail=False)
 class ContactBulkImportView(generic.BulkImportView):
     queryset = Contact.objects.all()
     model_form = forms.ContactImportForm
@@ -397,7 +397,7 @@ class ContactAssignmentEditView(generic.ObjectEditView):
         }
 
 
-@register_model_view(ContactAssignment, 'bulk_import', detail=False)
+@register_model_view(ContactAssignment, 'bulk_import', path='import', detail=False)
 class ContactAssignmentBulkImportView(generic.BulkImportView):
     queryset = ContactAssignment.objects.all()
     model_form = forms.ContactAssignmentImportForm

--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -38,7 +38,7 @@ class TokenDeleteView(generic.ObjectDeleteView):
     queryset = Token.objects.all()
 
 
-@register_model_view(Token, 'bulk_import', detail=False)
+@register_model_view(Token, 'bulk_import', path='import', detail=False)
 class TokenBulkImportView(generic.BulkImportView):
     queryset = Token.objects.all()
     model_form = forms.TokenImportForm
@@ -95,7 +95,7 @@ class UserDeleteView(generic.ObjectDeleteView):
     queryset = User.objects.all()
 
 
-@register_model_view(User, 'bulk_import', detail=False)
+@register_model_view(User, 'bulk_import', path='import', detail=False)
 class UserBulkImportView(generic.BulkImportView):
     queryset = User.objects.all()
     model_form = forms.UserImportForm
@@ -146,7 +146,7 @@ class GroupDeleteView(generic.ObjectDeleteView):
     queryset = Group.objects.all()
 
 
-@register_model_view(Group, 'bulk_import', detail=False)
+@register_model_view(Group, 'bulk_import', path='import', detail=False)
 class GroupBulkImportView(generic.BulkImportView):
     queryset = Group.objects.all()
     model_form = forms.GroupImportForm

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -59,7 +59,7 @@ class ClusterTypeDeleteView(generic.ObjectDeleteView):
     queryset = ClusterType.objects.all()
 
 
-@register_model_view(ClusterType, 'bulk_import', detail=False)
+@register_model_view(ClusterType, 'bulk_import', path='import', detail=False)
 class ClusterTypeBulkImportView(generic.BulkImportView):
     queryset = ClusterType.objects.all()
     model_form = forms.ClusterTypeImportForm
@@ -130,7 +130,7 @@ class ClusterGroupDeleteView(generic.ObjectDeleteView):
     queryset = ClusterGroup.objects.all()
 
 
-@register_model_view(ClusterGroup, 'bulk_import', detail=False)
+@register_model_view(ClusterGroup, 'bulk_import', path='import', detail=False)
 class ClusterGroupBulkImportView(generic.BulkImportView):
     queryset = ClusterGroup.objects.annotate(
         cluster_count=count_related(Cluster, 'group')
@@ -259,7 +259,7 @@ class ClusterDeleteView(generic.ObjectDeleteView):
     queryset = Cluster.objects.all()
 
 
-@register_model_view(Cluster, 'bulk_import', detail=False)
+@register_model_view(Cluster, 'bulk_import', path='import', detail=False)
 class ClusterBulkImportView(generic.BulkImportView):
     queryset = Cluster.objects.all()
     model_form = forms.ClusterImportForm
@@ -470,7 +470,7 @@ class VirtualMachineDeleteView(generic.ObjectDeleteView):
     queryset = VirtualMachine.objects.all()
 
 
-@register_model_view(VirtualMachine, 'bulk_import', detail=False)
+@register_model_view(VirtualMachine, 'bulk_import', path='import', detail=False)
 class VirtualMachineBulkImportView(generic.BulkImportView):
     queryset = VirtualMachine.objects.all()
     model_form = forms.VirtualMachineImportForm
@@ -569,7 +569,7 @@ class VMInterfaceDeleteView(generic.ObjectDeleteView):
     queryset = VMInterface.objects.all()
 
 
-@register_model_view(VMInterface, 'bulk_import', detail=False)
+@register_model_view(VMInterface, 'bulk_import', path='import', detail=False)
 class VMInterfaceBulkImportView(generic.BulkImportView):
     queryset = VMInterface.objects.all()
     model_form = forms.VMInterfaceImportForm
@@ -632,7 +632,7 @@ class VirtualDiskDeleteView(generic.ObjectDeleteView):
     queryset = VirtualDisk.objects.all()
 
 
-@register_model_view(VirtualDisk, 'bulk_import', detail=False)
+@register_model_view(VirtualDisk, 'bulk_import', path='import', detail=False)
 class VirtualDiskBulkImportView(generic.BulkImportView):
     queryset = VirtualDisk.objects.all()
     model_form = forms.VirtualDiskImportForm

--- a/netbox/vpn/views.py
+++ b/netbox/vpn/views.py
@@ -43,7 +43,7 @@ class TunnelGroupDeleteView(generic.ObjectDeleteView):
     queryset = TunnelGroup.objects.all()
 
 
-@register_model_view(TunnelGroup, 'bulk_import', detail=False)
+@register_model_view(TunnelGroup, 'bulk_import', path='import', detail=False)
 class TunnelGroupBulkImportView(generic.BulkImportView):
     queryset = TunnelGroup.objects.all()
     model_form = forms.TunnelGroupImportForm
@@ -112,7 +112,7 @@ class TunnelDeleteView(generic.ObjectDeleteView):
     queryset = Tunnel.objects.all()
 
 
-@register_model_view(Tunnel, 'bulk_import', detail=False)
+@register_model_view(Tunnel, 'bulk_import', path='import', detail=False)
 class TunnelBulkImportView(generic.BulkImportView):
     queryset = Tunnel.objects.all()
     model_form = forms.TunnelImportForm
@@ -171,7 +171,7 @@ class TunnelTerminationDeleteView(generic.ObjectDeleteView):
     queryset = TunnelTermination.objects.all()
 
 
-@register_model_view(TunnelTermination, 'bulk_import', detail=False)
+@register_model_view(TunnelTermination, 'bulk_import', path='import', detail=False)
 class TunnelTerminationBulkImportView(generic.BulkImportView):
     queryset = TunnelTermination.objects.all()
     model_form = forms.TunnelTerminationImportForm
@@ -221,7 +221,7 @@ class IKEProposalDeleteView(generic.ObjectDeleteView):
     queryset = IKEProposal.objects.all()
 
 
-@register_model_view(IKEProposal, 'bulk_import', detail=False)
+@register_model_view(IKEProposal, 'bulk_import', path='import', detail=False)
 class IKEProposalBulkImportView(generic.BulkImportView):
     queryset = IKEProposal.objects.all()
     model_form = forms.IKEProposalImportForm
@@ -271,7 +271,7 @@ class IKEPolicyDeleteView(generic.ObjectDeleteView):
     queryset = IKEPolicy.objects.all()
 
 
-@register_model_view(IKEPolicy, 'bulk_import', detail=False)
+@register_model_view(IKEPolicy, 'bulk_import', path='import', detail=False)
 class IKEPolicyBulkImportView(generic.BulkImportView):
     queryset = IKEPolicy.objects.all()
     model_form = forms.IKEPolicyImportForm
@@ -321,7 +321,7 @@ class IPSecProposalDeleteView(generic.ObjectDeleteView):
     queryset = IPSecProposal.objects.all()
 
 
-@register_model_view(IPSecProposal, 'bulk_import', detail=False)
+@register_model_view(IPSecProposal, 'bulk_import', path='import', detail=False)
 class IPSecProposalBulkImportView(generic.BulkImportView):
     queryset = IPSecProposal.objects.all()
     model_form = forms.IPSecProposalImportForm
@@ -371,7 +371,7 @@ class IPSecPolicyDeleteView(generic.ObjectDeleteView):
     queryset = IPSecPolicy.objects.all()
 
 
-@register_model_view(IPSecPolicy, 'bulk_import', detail=False)
+@register_model_view(IPSecPolicy, 'bulk_import', path='import', detail=False)
 class IPSecPolicyBulkImportView(generic.BulkImportView):
     queryset = IPSecPolicy.objects.all()
     model_form = forms.IPSecPolicyImportForm
@@ -421,7 +421,7 @@ class IPSecProfileDeleteView(generic.ObjectDeleteView):
     queryset = IPSecProfile.objects.all()
 
 
-@register_model_view(IPSecProfile, 'bulk_import', detail=False)
+@register_model_view(IPSecProfile, 'bulk_import', path='import', detail=False)
 class IPSecProfileBulkImportView(generic.BulkImportView):
     queryset = IPSecProfile.objects.all()
     model_form = forms.IPSecProfileImportForm
@@ -486,7 +486,7 @@ class L2VPNDeleteView(generic.ObjectDeleteView):
     queryset = L2VPN.objects.all()
 
 
-@register_model_view(L2VPN, 'bulk_import', detail=False)
+@register_model_view(L2VPN, 'bulk_import', path='import', detail=False)
 class L2VPNBulkImportView(generic.BulkImportView):
     queryset = L2VPN.objects.all()
     model_form = forms.L2VPNImportForm
@@ -541,7 +541,7 @@ class L2VPNTerminationDeleteView(generic.ObjectDeleteView):
     queryset = L2VPNTermination.objects.all()
 
 
-@register_model_view(L2VPNTermination, 'bulk_import', detail=False)
+@register_model_view(L2VPNTermination, 'bulk_import', path='import', detail=False)
 class L2VPNTerminationBulkImportView(generic.BulkImportView):
     queryset = L2VPNTermination.objects.all()
     model_form = forms.L2VPNTerminationImportForm

--- a/netbox/wireless/views.py
+++ b/netbox/wireless/views.py
@@ -48,7 +48,7 @@ class WirelessLANGroupDeleteView(generic.ObjectDeleteView):
     queryset = WirelessLANGroup.objects.all()
 
 
-@register_model_view(WirelessLANGroup, 'bulk_import', detail=False)
+@register_model_view(WirelessLANGroup, 'bulk_import', path='import', detail=False)
 class WirelessLANGroupBulkImportView(generic.BulkImportView):
     queryset = WirelessLANGroup.objects.all()
     model_form = forms.WirelessLANGroupImportForm
@@ -123,7 +123,7 @@ class WirelessLANDeleteView(generic.ObjectDeleteView):
     queryset = WirelessLAN.objects.all()
 
 
-@register_model_view(WirelessLAN, 'bulk_import', detail=False)
+@register_model_view(WirelessLAN, 'bulk_import', path='import', detail=False)
 class WirelessLANBulkImportView(generic.BulkImportView):
     queryset = WirelessLAN.objects.all()
     model_form = forms.WirelessLANImportForm
@@ -173,7 +173,7 @@ class WirelessLinkDeleteView(generic.ObjectDeleteView):
     queryset = WirelessLink.objects.all()
 
 
-@register_model_view(WirelessLink, 'bulk_import', detail=False)
+@register_model_view(WirelessLink, 'bulk_import', path='import', detail=False)
 class WirelessLinkBulkImportView(generic.BulkImportView):
     queryset = WirelessLink.objects.all()
     model_form = forms.WirelessLinkImportForm


### PR DESCRIPTION
### Fixes: #19322

Specify a `path` when wrapping a bulk import view with `register_model_view()`.