### PR TITLE
Closes: #18989 Add and display references to "Virtual circuits" from Provider view

### DIFF
--- a/netbox/circuits/views.py
+++ b/netbox/circuits/views.py
@@ -36,7 +36,19 @@ class ProviderView(GetRelatedModelsMixin, generic.ObjectView):
 
     def get_extra_context(self, request, instance):
         return {
-            'related_models': self.get_related_models(request, instance),
+            'related_models': self.get_related_models(
+                request,
+                instance,
+                omit=(),
+                extra=(
+                    (
+                        VirtualCircuit.objects.restrict(request.user, 'view').filter(
+                            provider_network__provider=instance
+                        ),
+                        'provider_id',
+                    ),
+                ),
+                ),
         }
 
 


### PR DESCRIPTION
### Closes: #18989 Add and display references to "Virtual circuits" from Provider view

- Add VirtualCircuits reference to `ProviderView` `get_related_models` extras.