### PR TITLE
Closes: #18215 Add script results view to script job history

### DIFF
--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -5,6 +5,8 @@ from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
 from extras.models import *
+from core.tables import JobTable
+from core.models import Job
 from netbox.constants import EMPTY_TABLE_TEXT
 from netbox.events import get_event_text
 from netbox.tables import BaseTable, NetBoxTable, columns
@@ -26,6 +28,7 @@ __all__ = (
     'SavedFilterTable',
     'ReportResultsTable',
     'ScriptResultsTable',
+    'ScriptJobTable',
     'SubscriptionTable',
     'TaggedItemTable',
     'TagTable',
@@ -636,6 +639,23 @@ class ScriptResultsTable(BaseTable):
 
     def render_url(self, value):
         return format_html("<a href='{}'>{}</a>", value, value)
+
+
+class ScriptJobTable(JobTable):
+    id = tables.TemplateColumn(
+        template_code="""<a href="{% url 'extras:script_result' job_pk=record.pk %}">{{ record.id }}</a>""",
+        verbose_name=_('ID'),
+    )
+
+    class Meta(NetBoxTable.Meta):
+        model = Job
+        fields = (
+            'pk', 'id', 'object_type', 'object', 'name', 'status', 'created', 'scheduled', 'interval', 'started',
+            'completed', 'user', 'error', 'job_id',
+        )
+        default_columns = (
+            'pk', 'id', 'object_type', 'object', 'name', 'status', 'created', 'started', 'completed', 'user',
+        )
 
 
 class ReportResultsTable(BaseTable):

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -15,7 +15,6 @@ from jinja2.exceptions import TemplateError
 from core.choices import ManagedFileRootPathChoices
 from core.forms import ManagedFileForm
 from core.models import Job
-from core.tables import JobTable
 from dcim.models import Device, DeviceRole, Platform
 from extras.choices import LogLevelChoices
 from extras.dashboard.forms import DashboardWidgetAddForm, DashboardWidgetForm
@@ -36,7 +35,7 @@ from virtualization.models import VirtualMachine
 from . import filtersets, forms, tables
 from .constants import LOG_LEVEL_RANK
 from .models import *
-from .tables import ReportResultsTable, ScriptResultsTable
+from .tables import ReportResultsTable, ScriptResultsTable, ScriptJobTable
 
 
 #
@@ -1351,7 +1350,7 @@ class ScriptJobsView(BaseScriptView):
     def get(self, request, **kwargs):
         script = self.get_object(**kwargs)
 
-        jobs_table = JobTable(
+        jobs_table = ScriptJobTable(
             data=script.jobs.all(),
             orderable=False,
             user=request.user


### PR DESCRIPTION
### Closes: #18215 Add script results view to script job history

- Created a `ScriptJobTable` from `JobTable` 
- Added that table in `ScriptJobsView` 


Observations:

IMO that approach makes the behaivour more natural, and similar to the previous versions like in `3.6.x`, but it should be more intuitive if the tab name changes to `Results` or a new column with a button icon linking for the results. 