### PR TITLE
Fixes #19320 - Add Q-in-Q SVLAN to VMinterface template

### DIFF
--- a/netbox/templates/virtualization/vminterface.html
+++ b/netbox/templates/virtualization/vminterface.html
@@ -55,6 +55,12 @@
           <th scope="row">{% trans "802.1Q Mode" %}</th>
           <td>{{ object.get_mode_display|placeholder }}</td>
         </tr>
+        {% if object.mode == 'q-in-q' %}
+          <tr>
+              <th scope="row">{% trans "Q-in-Q SVLAN" %}</th>
+              <td>{{ object.qinq_svlan|linkify|placeholder }}</td>
+          </tr>
+        {% endif %}
         <tr>
           <th scope="row">{% trans "Tunnel" %}</th>
           <td>{{ object.tunnel_termination.tunnel|linkify|placeholder }}</td>


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19320

Display Q-in-Q SVLAN information for virtual machine interfaces with Q-in-Q mode enabled.

