### PR TITLE
Fixes #17319: Arrange device and module type fields behind tab in com…

### DIFF
--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -899,7 +899,7 @@ class ComponentTemplateForm(forms.ModelForm):
 class ModularComponentTemplateForm(ComponentTemplateForm):
     device_type = DynamicModelChoiceField(
         label=_('Device type'),
-        queryset=DeviceType.objects.all().all(),
+        queryset=DeviceType.objects.all(),
         required=False,
         context={
             'parent': 'manufacturer',
@@ -912,6 +912,16 @@ class ModularComponentTemplateForm(ComponentTemplateForm):
         context={
             'parent': 'manufacturer',
         }
+    )
+
+    fieldsets = (
+        FieldSet(
+            TabbedGroups(
+                FieldSet('device_type', name=_('Device Type')),
+                FieldSet('module_type', name=_('Module Type')),
+            ),
+            'name', 'label', 'type', 'description'
+        ),
     )
 
     def __init__(self, *args, **kwargs):
@@ -930,10 +940,6 @@ class ModularComponentTemplateForm(ComponentTemplateForm):
 
 
 class ConsolePortTemplateForm(ModularComponentTemplateForm):
-    fieldsets = (
-        FieldSet('device_type', 'module_type', 'name', 'label', 'type', 'description'),
-    )
-
     class Meta:
         model = ConsolePortTemplate
         fields = [
@@ -942,10 +948,6 @@ class ConsolePortTemplateForm(ModularComponentTemplateForm):
 
 
 class ConsoleServerPortTemplateForm(ModularComponentTemplateForm):
-    fieldsets = (
-        FieldSet('device_type', 'module_type', 'name', 'label', 'type', 'description'),
-    )
-
     class Meta:
         model = ConsoleServerPortTemplate
         fields = [
@@ -956,7 +958,11 @@ class ConsoleServerPortTemplateForm(ModularComponentTemplateForm):
 class PowerPortTemplateForm(ModularComponentTemplateForm):
     fieldsets = (
         FieldSet(
-            'device_type', 'module_type', 'name', 'label', 'type', 'maximum_draw', 'allocated_draw', 'description',
+            TabbedGroups(
+                FieldSet('device_type', name=_('Device Type')),
+                FieldSet('module_type', name=_('Module Type')),
+            ),
+            'name', 'label', 'type', 'maximum_draw', 'allocated_draw', 'description',
         ),
     )
 
@@ -978,7 +984,13 @@ class PowerOutletTemplateForm(ModularComponentTemplateForm):
     )
 
     fieldsets = (
-        FieldSet('device_type', 'module_type', 'name', 'label', 'type', 'power_port', 'feed_leg', 'description'),
+        FieldSet(
+            TabbedGroups(
+                FieldSet('device_type', name=_('Device Type')),
+                FieldSet('module_type', name=_('Module Type')),
+            ),
+            'name', 'label', 'type', 'power_port', 'feed_leg', 'description',
+        ),
     )
 
     class Meta:
@@ -1001,7 +1013,11 @@ class InterfaceTemplateForm(ModularComponentTemplateForm):
 
     fieldsets = (
         FieldSet(
-            'device_type', 'module_type', 'name', 'label', 'type', 'enabled', 'mgmt_only', 'description', 'bridge',
+            TabbedGroups(
+                FieldSet('device_type', name=_('Device Type')),
+                FieldSet('module_type', name=_('Module Type')),
+            ),
+            'name', 'label', 'type', 'enabled', 'mgmt_only', 'description', 'bridge',
         ),
         FieldSet('poe_mode', 'poe_type', name=_('PoE')),
         FieldSet('rf_role', name=_('Wireless')),
@@ -1028,8 +1044,11 @@ class FrontPortTemplateForm(ModularComponentTemplateForm):
 
     fieldsets = (
         FieldSet(
-            'device_type', 'module_type', 'name', 'label', 'type', 'color', 'rear_port', 'rear_port_position',
-            'description',
+            TabbedGroups(
+                FieldSet('device_type', name=_('Device Type')),
+                FieldSet('module_type', name=_('Module Type')),
+            ),
+            'name', 'label', 'type', 'color', 'rear_port', 'rear_port_position', 'description',
         ),
     )
 
@@ -1043,7 +1062,13 @@ class FrontPortTemplateForm(ModularComponentTemplateForm):
 
 class RearPortTemplateForm(ModularComponentTemplateForm):
     fieldsets = (
-        FieldSet('device_type', 'module_type', 'name', 'label', 'type', 'color', 'positions', 'description'),
+        FieldSet(
+            TabbedGroups(
+                FieldSet('device_type', name=_('Device Type')),
+                FieldSet('module_type', name=_('Module Type')),
+            ),
+            'name', 'label', 'type', 'color', 'positions', 'description',
+        ),
     )
 
     class Meta:
@@ -1055,7 +1080,13 @@ class RearPortTemplateForm(ModularComponentTemplateForm):
 
 class ModuleBayTemplateForm(ModularComponentTemplateForm):
     fieldsets = (
-        FieldSet('device_type', 'module_type', 'name', 'label', 'position', 'description'),
+        FieldSet(
+            TabbedGroups(
+                FieldSet('device_type', name=_('Device Type')),
+                FieldSet('module_type', name=_('Module Type')),
+            ),
+            'name', 'label', 'position', 'description',
+        ),
     )
 
     class Meta:

--- a/netbox/dcim/forms/object_create.py
+++ b/netbox/dcim/forms/object_create.py
@@ -4,7 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from dcim.models import *
 from netbox.forms import NetBoxModelForm
 from utilities.forms.fields import DynamicModelChoiceField, DynamicModelMultipleChoiceField, ExpandableNameField
-from utilities.forms.rendering import FieldSet
+from utilities.forms.rendering import FieldSet, TabbedGroups
 from utilities.forms.widgets import APISelect
 from . import model_forms
 
@@ -118,7 +118,13 @@ class FrontPortTemplateCreateForm(ComponentCreateForm, model_forms.FrontPortTemp
 
     # Override fieldsets from FrontPortTemplateForm to omit rear_port_position
     fieldsets = (
-        FieldSet('device_type', 'module_type', 'name', 'label', 'type', 'color', 'rear_port', 'description'),
+        FieldSet(
+            TabbedGroups(
+                FieldSet('device_type', name=_('Device Type')),
+                FieldSet('module_type', name=_('Module Type')),
+            ),
+            'name', 'label', 'type', 'color', 'rear_port', 'description',
+        ),
     )
 
     class Meta(model_forms.FrontPortTemplateForm.Meta):


### PR DESCRIPTION
…ponent template forms

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #17319 
- Updates all device/module component template forms (but only those that display both fields) to arrange `device_type` and `module_type` fields in a tabbed group.
- Included module component templates forms even though the initial ticket only specified device component template forms, since most of them are shared forms.
- Contemplated creating a re-usable sub-Fieldset definition and plugging that in, but it seemed less readable plus I didn't see us doing anything like that elsewhere.

<!--
    Please include a summary of the proposed changes below.
-->
