### PR TITLE
Fixes #19365: Omit plugin icon from page title

### DIFF
--- a/netbox/templates/core/plugin.html
+++ b/netbox/templates/core/plugin.html
@@ -4,7 +4,7 @@
 {% load i18n %}
 {% load render_table from django_tables2 %}
 
-{% block title %}<img class="plugin-icon" src="{{ plugin.icon_url }}">&nbsp;{{ plugin.title_long }}{% endblock %}
+{% block title %}{{ plugin.title_long }}{% endblock %}
 
 {% block object_identifier %}
 {% endblock object_identifier %}


### PR DESCRIPTION
### Fixes: #19365

Omit the plugin icon from the page title