### PR TITLE
Fixes #19376: Fix FieldDoesNotExist exception when global search results include a contact

### DIFF
--- a/netbox/tenancy/search.py
+++ b/netbox/tenancy/search.py
@@ -15,7 +15,7 @@ class ContactIndex(SearchIndex):
         ('description', 500),
         ('comments', 5000),
     )
-    display_attrs = ('group', 'title', 'phone', 'email', 'description')
+    display_attrs = ('title', 'phone', 'email', 'description')
 
 
 @register_search


### PR DESCRIPTION
### Fixes: #19376

 Remove `group` from the object attributes list, as this is now a many-to-many relationship.