### PR TITLE
19380 call configure on  embedded tables

### DIFF
--- a/netbox/account/views.py
+++ b/netbox/account/views.py
@@ -197,6 +197,7 @@ class ProfileView(LoginRequiredMixin, View):
             'changed_object_type'
         )[:20]
         changelog_table = ObjectChangeTable(changelog)
+        changelog_table.configure(request)
 
         return render(request, self.template_name, {
             'changelog_table': changelog_table,

--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -223,6 +223,7 @@ class ObjectChangeView(generic.ObjectView):
             data=related_changes[:50],
             orderable=False
         )
+        related_changes_table.configure(request)
 
         objectchanges = ObjectChange.objects.valid_models().restrict(request.user, 'view').filter(
             changed_object_type=instance.changed_object_type,

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -2826,6 +2826,7 @@ class InterfaceView(generic.ObjectView):
             data=vlans,
             orderable=False
         )
+        vlan_table.configure(request)
 
         # Get VLAN translation rules
         vlan_translation_table = None
@@ -2834,6 +2835,7 @@ class InterfaceView(generic.ObjectView):
                 data=instance.vlan_translation_policy.rules.all(),
                 orderable=False
             )
+            vlan_translation_table.configure(request)
 
         return {
             'vdc_table': vdc_table,

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -2793,6 +2793,7 @@ class InterfaceView(generic.ObjectView):
             ),
             orderable=False
         )
+        vdc_table.configure(request)
 
         # Get bridge interfaces
         bridge_interfaces = Interface.objects.restrict(request.user, 'view').filter(bridge=instance)
@@ -2801,6 +2802,7 @@ class InterfaceView(generic.ObjectView):
             exclude=('device', 'parent'),
             orderable=False
         )
+        bridge_interfaces_table.configure(request)
 
         # Get child interfaces
         child_interfaces = Interface.objects.restrict(request.user, 'view').filter(parent=instance)
@@ -2809,6 +2811,7 @@ class InterfaceView(generic.ObjectView):
             exclude=('device', 'parent'),
             orderable=False
         )
+        child_interfaces_table.configure(request)
 
         # Get assigned VLANs and annotate whether each is tagged or untagged
         vlans = []

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -46,6 +46,7 @@ class VRFView(GetRelatedModelsMixin, generic.ObjectView):
             orderable=False
         )
         import_targets_table.configure(request)
+
         export_targets_table = tables.RouteTargetTable(
             instance.export_targets.all(),
             orderable=False
@@ -895,6 +896,7 @@ class IPAddressAssignView(generic.ObjectView):
             # Limit to 100 results
             addresses = filtersets.IPAddressFilterSet(request.POST, addresses).qs[:100]
             table = tables.IPAddressAssignTable(addresses)
+            table.configure(request)
 
         return render(request, 'ipam/ipaddress_assign.html', {
             'form': form,
@@ -1060,6 +1062,8 @@ class VLANTranslationPolicyView(GetRelatedModelsMixin, generic.ObjectView):
             data=instance.rules.all(),
             orderable=False
         )
+        vlan_translation_table.configure(request)
+
         return {
             'vlan_translation_table': vlan_translation_table,
         }

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -45,10 +45,12 @@ class VRFView(GetRelatedModelsMixin, generic.ObjectView):
             instance.import_targets.all(),
             orderable=False
         )
+        import_targets_table.configure(request)
         export_targets_table = tables.RouteTargetTable(
             instance.export_targets.all(),
             orderable=False
         )
+        export_targets_table.configure(request)
 
         return {
             'related_models': self.get_related_models(request, instance, omit=[Interface, VMInterface]),
@@ -530,6 +532,7 @@ class PrefixView(generic.ObjectView):
             exclude=('vrf', 'utilization'),
             orderable=False
         )
+        parent_prefix_table.configure(request)
 
         # Duplicate prefixes table
         duplicate_prefixes = Prefix.objects.restrict(request.user, 'view').filter(
@@ -544,6 +547,7 @@ class PrefixView(generic.ObjectView):
             exclude=('vrf', 'utilization'),
             orderable=False
         )
+        duplicate_prefix_table.configure(request)
 
         return {
             'aggregate': aggregate,
@@ -709,6 +713,7 @@ class IPRangeView(generic.ObjectView):
             exclude=('vrf', 'utilization'),
             orderable=False
         )
+        parent_prefixes_table.configure(request)
 
         return {
             'parent_prefixes_table': parent_prefixes_table,
@@ -796,6 +801,7 @@ class IPAddressView(generic.ObjectView):
             exclude=('vrf', 'utilization'),
             orderable=False
         )
+        parent_prefixes_table.configure(request)
 
         # Duplicate IPs table
         duplicate_ips = IPAddress.objects.restrict(request.user, 'view').filter(
@@ -811,6 +817,7 @@ class IPAddressView(generic.ObjectView):
             duplicate_ips = duplicate_ips.exclude(role=IPAddressRoleChoices.ROLE_ANYCAST)
         # Limit to a maximum of 10 duplicates displayed here
         duplicate_ips_table = tables.IPAddressTable(duplicate_ips[:10], orderable=False)
+        duplicate_ips_table.configure(request)
 
         return {
             'parent_prefixes_table': parent_prefixes_table,
@@ -1170,6 +1177,7 @@ class FHRPGroupView(GetRelatedModelsMixin, generic.ObjectView):
             data=FHRPGroupAssignment.objects.restrict(request.user, 'view').filter(group=instance),
             orderable=False
         )
+        members_table.configure(request)
         members_table.columns.hide('group')
 
         return {
@@ -1289,6 +1297,7 @@ class VLANView(generic.ObjectView):
             'vrf', 'scope', 'role', 'tenant'
         )
         prefix_table = tables.PrefixTable(list(prefixes), exclude=('vlan', 'utilization'), orderable=False)
+        prefix_table.configure(request)
 
         return {
             'prefix_table': prefix_table,

--- a/netbox/netbox/views/misc.py
+++ b/netbox/netbox/views/misc.py
@@ -100,6 +100,7 @@ class SearchView(ConditionalLoginRequiredMixin, View):
                 highlight = form.cleaned_data['q']
 
         table = SearchTable(results, highlight=highlight)
+        table.configure(request)
 
         # Paginate the table results
         RequestConfig(request, {

--- a/netbox/netbox/views/misc.py
+++ b/netbox/netbox/views/misc.py
@@ -100,7 +100,6 @@ class SearchView(ConditionalLoginRequiredMixin, View):
                 highlight = form.cleaned_data['q']
 
         table = SearchTable(results, highlight=highlight)
-        table.configure(request)
 
         # Paginate the table results
         RequestConfig(request, {

--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -77,6 +77,7 @@ class UserView(generic.ObjectView):
     def get_extra_context(self, request, instance):
         changelog = ObjectChange.objects.restrict(request.user, 'view').filter(user=instance)[:20]
         changelog_table = ObjectChangeTable(changelog)
+        changelog_table.configure(request)
 
         return {
             'changelog_table': changelog_table,

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -505,6 +505,7 @@ class VMInterfaceView(generic.ObjectView):
             exclude=('virtual_machine',),
             orderable=False
         )
+        child_interfaces_tables.configure(request)
 
         # Get VLAN translation rules
         vlan_translation_table = None

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -350,6 +350,7 @@ class ClusterRemoveDevicesView(generic.ObjectEditView):
 
         selected_objects = Device.objects.filter(pk__in=form.initial['pk'])
         device_table = DeviceTable(list(selected_objects), orderable=False)
+        device_table.configure(request)
 
         return render(request, self.template_name, {
             'form': form,
@@ -514,6 +515,7 @@ class VMInterfaceView(generic.ObjectView):
                 data=instance.vlan_translation_policy.rules.all(),
                 orderable=False
             )
+            vlan_translation_table.configure(request)
 
         # Get assigned VLANs and annotate whether each is tagged or untagged
         vlans = []
@@ -528,6 +530,7 @@ class VMInterfaceView(generic.ObjectView):
             data=vlans,
             orderable=False
         )
+        vlan_table.configure(request)
 
         return {
             'child_interfaces_table': child_interfaces_tables,

--- a/netbox/vpn/views.py
+++ b/netbox/vpn/views.py
@@ -452,10 +452,12 @@ class L2VPNView(generic.ObjectView):
             instance.import_targets.prefetch_related('tenant'),
             orderable=False
         )
+        import_targets_table.configure(request)
         export_targets_table = RouteTargetTable(
             instance.export_targets.prefetch_related('tenant'),
             orderable=False
         )
+        export_targets_table.configure(request)
 
         return {
             'import_targets_table': import_targets_table,


### PR DESCRIPTION
### Fixes: #19380 

Due to changes .configure needs to be called on tables when they are instantiated in views to set default columns, there were a bunch of missing ones. Here are the views changed:

ObjectChangeView
InterfaceView
VRFView
PrefixView
IPRangeView
IPAddressView
FHRPGroupView
VLANView
VMInterfaceView
ProfileView
IPAddressAssignView
VLANTranslationPolicyView
UserView
ClusterRemoveDevicesView
VMInterfaceView
L2VPNView
