### PR TITLE
Fixes #19397: Fix filtering IP ranges by role in GraphQL API

### DIFF
--- a/netbox/ipam/graphql/filters.py
+++ b/netbox/ipam/graphql/filters.py
@@ -168,9 +168,7 @@ class IPRangeFilter(ContactFilterMixin, TenancyFilterMixin, PrimaryModelFilterMi
     status: Annotated['IPRangeStatusEnum', strawberry.lazy('ipam.graphql.enums')] | None = (
         strawberry_django.filter_field()
     )
-    role: Annotated['IPAddressRoleEnum', strawberry.lazy('ipam.graphql.enums')] | None = (
-        strawberry_django.filter_field()
-    )
+    role: Annotated['RoleFilter', strawberry.lazy('ipam.graphql.filters')] | None = strawberry_django.filter_field()
     mark_utilized: FilterLookup[bool] | None = strawberry_django.filter_field()
 
     @strawberry_django.filter_field()


### PR DESCRIPTION
### Fixes: #19397

- Correct the `role` filter definition under IPRangeFilter