### PR TITLE
Fixes #19396 : Set qinq_role allow_null to True

### DIFF
--- a/netbox/ipam/api/serializers_/vlans.py
+++ b/netbox/ipam/api/serializers_/vlans.py
@@ -66,7 +66,7 @@ class VLANSerializer(NetBoxModelSerializer):
     tenant = TenantSerializer(nested=True, required=False, allow_null=True)
     status = ChoiceField(choices=VLANStatusChoices, required=False)
     role = RoleSerializer(nested=True, required=False, allow_null=True)
-    qinq_role = ChoiceField(choices=VLANQinQRoleChoices, required=False)
+    qinq_role = ChoiceField(choices=VLANQinQRoleChoices, required=False, allow_null=True)
     qinq_svlan = NestedVLANSerializer(required=False, allow_null=True, default=None)
     l2vpn_termination = L2VPNTerminationSerializer(nested=True, read_only=True, allow_null=True)
 


### PR DESCRIPTION
### Fixes: #19396

- Allow vlan `qinq_role` to be set as null with the API matching the model definition.
