### PR TITLE
19381 fix data file script sync

### DIFF
--- a/netbox/core/models/files.py
+++ b/netbox/core/models/files.py
@@ -88,19 +88,11 @@ class ManagedFile(SyncedDataMixin, models.Model):
     def sync_data(self):
         if self.data_file:
             self.file_path = os.path.basename(self.data_path)
-            self._write_to_disk(self.full_path, overwrite=True)
 
-    def _write_to_disk(self, path, overwrite=False):
-        """
-        Write the object's data to disk at the specified path
-        """
-        # Check whether file already exists
-        storage = self.storage
-        if storage.exists(path) and not overwrite:
-            raise FileExistsError()
+            storage = self.storage
 
-        with storage.open(path, 'wb+') as new_file:
-            new_file.write(self.data)
+            with storage.open(self.full_path, 'wb+') as new_file:
+                new_file.write(self.data_file.data)
 
     @cached_property
     def storage(self):


### PR DESCRIPTION
### Fixes: #19381 

Fix could be a one liner:
`new_file.write(self.data)` ->  `new_file.write(self.data_file.data)`

However the _write_to_disk is only ever called in sync_data if a data_file so just collapsed the function to be inline and then it can be simplified, the line `if storage.exists(path) and not overwrite:` will never evaluate to True as overwrite was always passed as True so this can be removed.

Note: This only effects the data_file path so should have no effect on S3 storage or local file storage for scripts.