### PR TITLE
feat(core): Add queue_name parameter to Job.enqueue() method

### DIFF
--- a/netbox/core/models/jobs.py
+++ b/netbox/core/models/jobs.py
@@ -212,6 +212,7 @@ class Job(models.Model):
             schedule_at=None,
             interval=None,
             immediate=False,
+            queue_name=None,
             **kwargs
     ):
         """
@@ -235,7 +236,7 @@ class Job(models.Model):
             object_id = instance.pk
         else:
             object_type = object_id = None
-        rq_queue_name = get_queue_for_model(object_type.model if object_type else None)
+        rq_queue_name = queue_name if queue_name else get_queue_for_model(object_type.model if object_type else None)
         queue = django_rq.get_queue(rq_queue_name)
         status = JobStatusChoices.STATUS_SCHEDULED if schedule_at else JobStatusChoices.STATUS_PENDING
         job = Job(


### PR DESCRIPTION
- Added the queue_name parameter to Job.enqueue(), allowing users to specify an existing queue name.

- If queue_name is not provided, the default model queue will be used.

- This enhancement improves job scheduling flexibility by enabling targeted execution in specific queues.

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #18419 

<!--
    Please include a summary of the proposed changes below.
-->
