### PR TITLE
Fixes #19434 - Add 2.5 Gbps and 5 Gbps options to InterfaceSpeedChoices

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1238,6 +1238,8 @@ class InterfaceSpeedChoices(ChoiceSet):
         (10000, '10 Mbps'),
         (100000, '100 Mbps'),
         (1000000, '1 Gbps'),
+        (2500000, '2.5 Gbps'),
+        (5000000, '5 Gbps'),
         (10000000, '10 Gbps'),
         (25000000, '25 Gbps'),
         (40000000, '40 Gbps'),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19434 2.5GBASE-T and 5GBASE-T speeds support on Interfaces

Extend `InterfaceSpeedChoices` to include 2.5 Gbps and 5 Gbps values.
