### PR TITLE
Fixes #19432 - Update PostgreSQL Version in Programming Error Message

### DIFF
--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -53,6 +53,7 @@ If a new Django release is adopted or other major dependencies (Python, PostgreS
 
 * Update the installation guide (`docs/installation/index.md`) with the new minimum versions.
 * Update the upgrade guide (`docs/installation/upgrading.md`) for the current version accordingly.
+* Update the minimum PostgreSQL version in the programming error template (`netbox/templates/exceptions/programming_error.html`).
 
 ### Manually Perform a New Install
 

--- a/netbox/templates/exceptions/programming_error.html
+++ b/netbox/templates/exceptions/programming_error.html
@@ -17,7 +17,7 @@
     <i class="mdi mdi-alert"></i>
     <strong>{% trans "Unsupported PostgreSQL version" %}.</strong>
     {% blocktrans trimmed %}
-      Ensure that PostgreSQL version 12 or later is in use. You can check this by connecting to the database using
+      Ensure that PostgreSQL version 14 or later is in use. You can check this by connecting to the database using
       NetBox's credentials and issuing a query for <code>SELECT VERSION()</code>.
     {% endblocktrans %}
   </p>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19432 - Server error mentioning wrong PostgreSQL requirement

This PR updates the programming error message to reflect the correct minimum PostgreSQL version requirement (14 or later), aligning with the changes introduced in v4.3.0.

Additionally, it adds a step to the release checklist to ensure the minimum PostgreSQL version in the programming error template is kept up to date.
