### PR TITLE
Fixes: #19466. Remove unnecessary saving

### DIFF
--- a/netbox/ipam/signals.py
+++ b/netbox/ipam/signals.py
@@ -54,6 +54,9 @@ def clear_primary_ip(instance, **kwargs):
     """
     When an IPAddress is deleted, trigger save() on any Devices/VirtualMachines for which it was a primary IP.
     """
+    origin = kwargs.get('origin')
+    if isinstance(origin, (Device, VirtualMachine)) and origin.primary_ip4 == instance:
+        return
     field_name = f'primary_ip{instance.family}'
     if device := Device.objects.filter(**{field_name: instance}).first():
         device.snapshot()


### PR DESCRIPTION
Before the main signal code, a check is made of the initiator of the deletion process. If this is a device or a virtual machine, then further operation of the signal is interrupted.
