### PR TITLE
Fixes #19464: Fix bulk editing of inventory items from device view

### DIFF
--- a/netbox/dcim/forms/bulk_edit.py
+++ b/netbox/dcim/forms/bulk_edit.py
@@ -1779,6 +1779,13 @@ class InventoryItemBulkEditForm(
     )
     nullable_fields = ('label', 'role', 'manufacturer', 'part_id', 'description')
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Remove parent device passed as context to avoid conflicts with the actual device field
+        # on this form (see bug #19464)
+        self.initial.pop('device', None)
+
 
 #
 # Device component roles


### PR DESCRIPTION
### Fixes: #19464

Remove the `device` initial data after instantiating the form to avoid flagging the actual `device` field as having changed data. (Ultimately we need to figure out a better way to pass contextual data under BulkEditView, but this suffices for now.)