### PR TITLE
Fixes #19465: Fix ability to clear assigned prefix scope in UI

### DIFF
--- a/netbox/dcim/forms/mixins.py
+++ b/netbox/dcim/forms/mixins.py
@@ -66,6 +66,10 @@ class ScopedForm(forms.Form):
             if self.instance and scope_type_id != self.instance.scope_type_id:
                 self.initial['scope'] = None
 
+        else:
+            # Clear the initial scope value if scope_type is not set
+            self.initial['scope'] = None
+
 
 class ScopedBulkEditForm(forms.Form):
     scope_type = ContentTypeChoiceField(


### PR DESCRIPTION
### Fixes: #19465

When editing an existing instance, its scope (if set) is passed as initial data. Because the `scope` field is disabled in the UI form when no scope type is selected, its value does not get nullified when submitting the form.