### PR TITLE
Fixes #19472: Fix device column rendering in virtual device contexts table

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -1091,10 +1091,9 @@ class VirtualDeviceContextTable(TenancyColumnsMixin, NetBoxTable):
         verbose_name=_('Name'),
         linkify=True
     )
-    device = tables.TemplateColumn(
+    device = tables.Column(
         verbose_name=_('Device'),
         order_by=('device___name',),
-        template_code=DEVICE_LINK,
         linkify=True
     )
     status = columns.ChoiceFieldColumn(


### PR DESCRIPTION
### Fixes: #19472

The `device` column doesn't need to be a template column. Unnamed devices will be displayed as their device type.