### PR TITLE
Closes #19461 : Add color backgrounds for virtual circuit types

### DIFF
--- a/netbox/circuits/tables/virtual_circuits.py
+++ b/netbox/circuits/tables/virtual_circuits.py
@@ -54,9 +54,8 @@ class VirtualCircuitTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable)
         linkify=True,
         verbose_name=_('Account')
     )
-    type = tables.Column(
+    type = columns.ColoredLabelColumn(
         verbose_name=_('Type'),
-        linkify=True
     )
     status = columns.ChoiceFieldColumn()
     termination_count = columns.LinkedCountColumn(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19461 

<!--
    Please include a summary of the proposed changes below.
-->

- Virtual Circuit tables will now display configured types as colored labels.