### PR TITLE
Fixes #19486: Cards in Console Server Port page are rendered incorrectly

### DIFF
--- a/netbox/templates/dcim/consoleserverport.html
+++ b/netbox/templates/dcim/consoleserverport.html
@@ -53,7 +53,6 @@
         <div class="col col-12 col-md-6">
           <div class="card">
             <h2 class="card-header">{% trans "Connection" %}</h2>
-            <div class="card-body">
             {% if object.mark_connected %}
               <div class="card-body">
                 <span class="text-success"><i class="mdi mdi-check-bold"></i></span>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19486 

<!--
    Please include a summary of the proposed changes below.
-->

- Fixed visual anomaly in Console Server Port page where cards were inadvertently rendered inside of each other.