### PR TITLE
Fixes #19502: Improve upgrade instructions

### DIFF
--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -122,7 +122,7 @@ sudo cp /opt/netbox-$OLDVER/gunicorn.py /opt/netbox/
 
 ### Option B: Check Out a Git Release
 
-This guide assumes that NetBox is installed at `/opt/netbox`. First, determine the latest release either by visiting our [releases page](https://github.com/netbox-community/netbox/releases) or by running the following command:
+This guide assumes that NetBox is installed in `/opt/netbox`. First, determine the latest release either by visiting our [releases page](https://github.com/netbox-community/netbox/releases) or by running the following command:
 
 ```
 git ls-remote --tags https://github.com/netbox-community/netbox.git \
@@ -134,7 +134,9 @@ git ls-remote --tags https://github.com/netbox-community/netbox.git \
 Check out the desired release by specifying its tag. For example:
 
 ```
-sudo git checkout v4.2.7
+cd /opt/netbox && \
+sudo git fetch && \
+sudo git checkout v2.4.7
 ```
 
 ## 4. Run the Upgrade Script

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -136,7 +136,7 @@ Check out the desired release by specifying its tag. For example:
 ```
 cd /opt/netbox && \
 sudo git fetch && \
-sudo git checkout v2.4.7
+sudo git checkout v4.2.7
 ```
 
 ## 4. Run the Upgrade Script


### PR DESCRIPTION
### Fixes: #19502

* Explicitly change the directory so the user doesn't have to do this manually (any users not using the default installation directory should notice and adapt accordingly)
* Use "git fetch" to prevent ```error: pathspec 'v4.3.1' did not match any file(s) known to git```. This seems to be a common problem ([1](https://github.com/netbox-community/netbox/discussions/12224), [2](https://github.com/netbox-community/netbox/discussions/9125), [3](https://www.reddit.com/r/Netbox/comments/1k9qruy/cannot_upgrade_from_git/)).
