### PR TITLE
Closes #19521: Clean up test suite output

### DIFF
--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -14,7 +14,7 @@ from ipam.models import ASN, RIR, VLAN, VRF
 from netbox.api.serializers import GenericObjectSerializer
 from tenancy.models import Tenant
 from users.models import User
-from utilities.testing import APITestCase, APIViewTestCases, create_test_device
+from utilities.testing import APITestCase, APIViewTestCases, create_test_device, disable_logging
 from virtualization.models import Cluster, ClusterType
 from wireless.choices import WirelessChannelChoices
 from wireless.models import WirelessLAN
@@ -1858,7 +1858,8 @@ class InterfaceTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase
 
         # Attempt to delete only the parent interface
         url = self._get_detail_url(interface1)
-        self.client.delete(url, **self.header)
+        with disable_logging():
+            self.client.delete(url, **self.header)
         self.assertEqual(device.interfaces.count(), 4)  # Parent was not deleted
 
         # Attempt to bulk delete parent & child together

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -2,7 +2,7 @@ import datetime
 
 from django.contrib.contenttypes.models import ContentType
 from django.urls import reverse
-from django.utils.timezone import make_aware
+from django.utils.timezone import make_aware, now
 from rest_framework import status
 
 from core.choices import ManagedFileRootPathChoices
@@ -991,6 +991,10 @@ class SubscriptionTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        cls.bulk_update_data = {
+            'user': users[3].pk,
+        }
+
 
 class NotificationGroupTest(APIViewTestCases.APIViewTestCase):
     model = NotificationGroup
@@ -1072,6 +1076,9 @@ class NotificationGroupTest(APIViewTestCases.APIViewTestCase):
 class NotificationTest(APIViewTestCases.APIViewTestCase):
     model = Notification
     brief_fields = ['display', 'event_type', 'id', 'object_id', 'object_type', 'read', 'url', 'user']
+    bulk_update_data = {
+        'read': now(),
+    }
 
     @classmethod
     def setUpTestData(cls):

--- a/netbox/extras/tests/test_scripts.py
+++ b/netbox/extras/tests/test_scripts.py
@@ -1,3 +1,4 @@
+import logging
 import tempfile
 from datetime import date, datetime, timezone
 
@@ -7,6 +8,7 @@ from netaddr import IPAddress, IPNetwork
 
 from dcim.models import DeviceRole
 from extras.scripts import *
+from utilities.testing import disable_logging
 
 CHOICES = (
     ('ff0000', 'Red'),
@@ -39,7 +41,8 @@ class ScriptTest(TestCase):
         datafile.write(bytes(YAML_DATA, 'UTF-8'))
         datafile.seek(0)
 
-        data = Script().load_yaml(datafile.name)
+        with disable_logging(level=logging.WARNING):
+            data = Script().load_yaml(datafile.name)
         self.assertEqual(data, {
             'Foo': 123,
             'Bar': 456,
@@ -51,7 +54,8 @@ class ScriptTest(TestCase):
         datafile.write(bytes(JSON_DATA, 'UTF-8'))
         datafile.seek(0)
 
-        data = Script().load_json(datafile.name)
+        with disable_logging(level=logging.WARNING):
+            data = Script().load_json(datafile.name)
         self.assertEqual(data, {
             'Foo': 123,
             'Bar': 456,

--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from django.urls import reverse
 from netaddr import IPNetwork
@@ -9,7 +10,7 @@ from ipam.choices import *
 from ipam.models import *
 from tenancy.models import Tenant
 from utilities.data import string_to_ranges
-from utilities.testing import APITestCase, APIViewTestCases, create_test_device, disable_warnings
+from utilities.testing import APITestCase, APIViewTestCases, create_test_device, disable_logging
 
 
 class AppTest(APITestCase):
@@ -1026,7 +1027,7 @@ class VLANTest(APIViewTestCases.APIViewTestCase):
 
         self.add_permissions('ipam.delete_vlan')
         url = reverse('ipam-api:vlan-detail', kwargs={'pk': vlan.pk})
-        with disable_warnings('netbox.api.views.ModelViewSet'):
+        with disable_logging(level=logging.WARNING):
             response = self.client.delete(url, **self.header)
 
         self.assertHttpStatus(response, status.HTTP_409_CONFLICT)

--- a/netbox/utilities/tests/test_api.py
+++ b/netbox/utilities/tests/test_api.py
@@ -1,5 +1,6 @@
 from django.test import Client, TestCase, override_settings
 from django.urls import reverse
+from drf_spectacular.drainage import GENERATOR_STATS
 from rest_framework import status
 
 from core.models import ObjectType
@@ -264,5 +265,6 @@ class APIDocsTestCase(TestCase):
         self.assertEqual(response.status_code, 200)
 
         url = reverse('schema')
-        response = self.client.get(url)
+        with GENERATOR_STATS.silence():  # Suppress schema generator warnings
+            response = self.client.get(url)
         self.assertEqual(response.status_code, 200)

--- a/netbox/virtualization/tests/test_api.py
+++ b/netbox/virtualization/tests/test_api.py
@@ -1,3 +1,5 @@
+import logging
+
 from django.test import tag
 from django.urls import reverse
 from netaddr import IPNetwork
@@ -10,7 +12,9 @@ from extras.choices import CustomFieldTypeChoices
 from extras.models import ConfigTemplate, CustomField
 from ipam.choices import VLANQinQRoleChoices
 from ipam.models import Prefix, VLAN, VRF
-from utilities.testing import APITestCase, APIViewTestCases, create_test_device, create_test_virtualmachine
+from utilities.testing import (
+    APITestCase, APIViewTestCases, create_test_device, create_test_virtualmachine, disable_logging,
+)
 from virtualization.choices import *
 from virtualization.models import *
 
@@ -402,7 +406,8 @@ class VMInterfaceTest(APIViewTestCases.APIViewTestCase):
 
         # Attempt to delete only the parent interface
         url = self._get_detail_url(interface1)
-        self.client.delete(url, **self.header)
+        with disable_logging(level=logging.WARNING):
+            self.client.delete(url, **self.header)
         self.assertEqual(virtual_machine.interfaces.count(), 4)  # Parent was not deleted
 
         # Attempt to bulk delete parent & child together


### PR DESCRIPTION
### Closes: #19521

- Suppress extraneous warnings/logging
- Add missing bulk update data to avoid skipping views