### PR TITLE
Fixes #19496: Page error on config render with empty output

### DIFF
--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -966,7 +966,7 @@ class ObjectRenderConfigView(generic.ObjectView):
 
         # Render the config template
         rendered_config = None
-        error_message = None
+        error_message = ''
         if config_template := instance.get_config_template():
             try:
                 rendered_config = config_template.render(context=context_data)

--- a/netbox/templates/extras/object_render_config.html
+++ b/netbox/templates/extras/object_render_config.html
@@ -63,10 +63,14 @@
             </h2>
             <pre class="card-body" id="rendered_config">{{ rendered_config }}</pre>
           </div>
-        {% else %}
+        {% elif error_message %}
           <div class="alert alert-warning">
             <h4 class="alert-title mb-1">{% trans "Error rendering template" %}</h4>
             {% trans error_message %}
+          </div>
+        {% else %}
+          <div class="alert alert-warning">
+            <h4 class="alert-title mb-1">{% trans "Template output is empty" %}</h4>
           </div>
         {% endif %}
       {% else %}


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19496 

<!--
    Please include a summary of the proposed changes below.
-->

Update template branching to account for successful but empty template render output
Initialize error_message variable to empty string in case of other uses in template with `{% trans error_message %}` call
