### PR TITLE
#19550 Enhancement: Refactor rack elevations template for lazy loading /dcim/rack-elevations/

### DIFF
--- a/netbox/templates/dcim/inc/rack_elevation.html
+++ b/netbox/templates/dcim/inc/rack_elevation.html
@@ -4,7 +4,7 @@
     hx-get="{% url 'dcim-api:rack-elevation' pk=object.pk %}?face={{ face }}&render=svg{% if extra_params %}&{{ extra_params }}{% endif %}"
     hx-trigger="intersect"
     hx-swap="outerHTML"
-    aria-label="{% trans 'Rack elevation' %}"
+    aria-label="{% trans "Rack elevation" %}"
   >
     <div class="d-flex justify-content-center align-items-center" style="min-height: 200px; margin-left: 30px;">
       <div class="spinner-border" role="status">

--- a/netbox/templates/dcim/inc/rack_elevation.html
+++ b/netbox/templates/dcim/inc/rack_elevation.html
@@ -1,6 +1,16 @@
 {% load i18n %}
-<div style="margin-left: -30px">
-    <object data="{% url 'dcim-api:rack-elevation' pk=object.pk %}?face={{face}}&render=svg{% if extra_params %}&{{ extra_params }}{% endif %}" class="rack_elevation" aria-label="{% trans "Rack elevation" %}"></object>
+<div
+  hx-get="{% url 'dcim-api:rack-elevation' pk=object.pk %}?face={{ face }}&render=svg{% if extra_params %}&{{ extra_params }}{% endif %}"
+  hx-trigger="intersect"
+  hx-swap="innerHTML"
+  aria-label="{% trans 'Rack elevation' %}"
+  style="margin-left: -30px"
+>
+  <div class="d-flex justify-content-center align-items-center" style="min-height: 200px; margin-left: 30px;">
+    <div class="spinner-border" role="status">
+      <span class="visually-hidden">Rack Loading...</span>
+    </div>
+  </div>
 </div>
 <div class="text-center mt-3">
     <a class="btn btn-outline-primary" href="{% url 'dcim-api:rack-elevation' pk=object.pk %}?face={{face}}&render=svg{% if extra_params %}&{{ extra_params }}{% endif %}" hx-boost="false">

--- a/netbox/templates/dcim/inc/rack_elevation.html
+++ b/netbox/templates/dcim/inc/rack_elevation.html
@@ -1,14 +1,15 @@
 {% load i18n %}
-<div
-  hx-get="{% url 'dcim-api:rack-elevation' pk=object.pk %}?face={{ face }}&render=svg{% if extra_params %}&{{ extra_params }}{% endif %}"
-  hx-trigger="intersect"
-  hx-swap="innerHTML"
-  aria-label="{% trans 'Rack elevation' %}"
-  style="margin-left: -30px"
->
-  <div class="d-flex justify-content-center align-items-center" style="min-height: 200px; margin-left: 30px;">
-    <div class="spinner-border" role="status">
-      <span class="visually-hidden">Rack Loading...</span>
+<div style="margin-left: -30px">
+  <div
+    hx-get="{% url 'dcim-api:rack-elevation' pk=object.pk %}?face={{ face }}&render=svg{% if extra_params %}&{{ extra_params }}{% endif %}"
+    hx-trigger="intersect"
+    hx-swap="outerHTML"
+    aria-label="{% trans 'Rack elevation' %}"
+  >
+    <div class="d-flex justify-content-center align-items-center" style="min-height: 200px; margin-left: 30px;">
+      <div class="spinner-border" role="status">
+        <span class="visually-hidden">Rack Loading...</span>
+      </div>
     </div>
   </div>
 </div>

--- a/netbox/templates/dcim/inc/rack_elevation.html
+++ b/netbox/templates/dcim/inc/rack_elevation.html
@@ -8,7 +8,7 @@
   >
     <div class="d-flex justify-content-center align-items-center" style="min-height: 200px; margin-left: 30px;">
       <div class="spinner-border" role="status">
-        <span class="visually-hidden">Rack Loading...</span>
+        <span class="visually-hidden">{% trans "Loading..." %}</span>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Closes: #19550

The existing rack elevations template does not scale well, for e.g if the user has the pagination set 1000, the rack elevation template will try and make a rack http call for every rack when the page loads (#19550)

this PR does the following
- introduce lazy loading so that racks are only loaded once they intersect with the viewport
- spinner added to show while racks are being lazy loaded