### PR TITLE
#19561 fix changelog table on profile page

### DIFF
--- a/netbox/account/views.py
+++ b/netbox/account/views.py
@@ -195,7 +195,7 @@ class ProfileView(LoginRequiredMixin, View):
             user=request.user
         ).prefetch_related(
             'changed_object_type'
-        )[:20]
+        )
         changelog_table = ObjectChangeTable(changelog)
         changelog_table.configure(request)
 

--- a/netbox/templates/account/profile.html
+++ b/netbox/templates/account/profile.html
@@ -68,6 +68,7 @@
           <h2 class="card-header text-center">{% trans "Recent Activity" %}</h2>
           <div class="table-responsive">
             {% render_table changelog_table 'inc/table.html' %}
+            {% include 'inc/paginator.html' with paginator=changelog_table.paginator page=changelog_table.page %}
           </div>
         </div>
       </div>

--- a/netbox/templates/users/user.html
+++ b/netbox/templates/users/user.html
@@ -78,6 +78,7 @@
           <h2 class="text-center">{% trans "Recent Activity" %}</h2>
           <div class="card-body table-responsive">
             {% render_table changelog_table 'inc/table.html' %}
+            {% include 'inc/paginator.html' with paginator=changelog_table.paginator page=changelog_table.page %}
           </div>
         </div>
       </div>

--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -75,7 +75,7 @@ class UserView(generic.ObjectView):
     template_name = 'users/user.html'
 
     def get_extra_context(self, request, instance):
-        changelog = ObjectChange.objects.restrict(request.user, 'view').filter(user=instance)[:20]
+        changelog = ObjectChange.objects.restrict(request.user, 'view').filter(user=instance)
         changelog_table = ObjectChangeTable(changelog)
         changelog_table.configure(request)
 


### PR DESCRIPTION
### Fixes: #19561

Removes the split from the queryset for the changelog on the profile page, I don't see any reason to keep it there.  Added the pagination so can get all the info. 
![Monosnap User Profile | NetBox 2025-05-22 14-33-01](https://github.com/user-attachments/assets/7c8130e5-fb9a-463b-986e-364b7d758d6e)
