### PR TITLE
Fixes #19529: Properly find scripts managed by ScriptFileSystemStorage

### DIFF
--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -9,6 +9,7 @@ from django import forms
 from django.conf import settings
 from django.core.files.storage import storages
 from django.core.validators import RegexValidator
+from django.db.models import Q
 from django.utils import timezone
 from django.utils.functional import classproperty
 from django.utils.translation import gettext as _
@@ -646,6 +647,10 @@ def is_variable(obj):
 
 
 def get_module_and_script(module_name, script_name):
-    module = ScriptModule.objects.get(file_path=f'{module_name}.py')
+    path = f'{module_name}.py'
+    module = ScriptModule.objects.get(
+        Q(file_path=path) |
+        Q(file_path=os.path.join(settings.SCRIPTS_ROOT, path))
+    )
     script = module.scripts.get(name=script_name)
     return module, script


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19529
`ScriptFileSystemStorage` was introduced in #18896 and stores a full path in `Script.file_path`. This fix handles looking for scripts by relative path as well as full path.
<!--
    Please include a summary of the proposed changes below.
-->
