### PR TITLE
Fixes #19490: restores nesting behavior of DataSource-based ConfigTemplate

### DIFF
--- a/netbox/extras/models/mixins.py
+++ b/netbox/extras/models/mixins.py
@@ -131,7 +131,7 @@ class RenderTemplateMixin(models.Model):
         """
         context = self.get_context(context=context, queryset=queryset)
         env_params = self.environment_params or {}
-        output = render_jinja2(self.template_code, context, env_params)
+        output = render_jinja2(self.template_code, context, env_params, getattr(self, 'data_file', None))
 
         # Replace CRLF-style line terminators
         output = output.replace('\r\n', '\n')


### PR DESCRIPTION



<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19490 

The ability to render nested templates was accidentally removed with the implementation of #17653, which normalized the behavior of various Jinja2 template rendering actions.

This fix restores that behavior while retaining the normalized behavior. This fix also includes regression tests to ensure this behavior is not removed accidentally again in the future.
<!--
    Please include a summary of the proposed changes below.
-->
