### PR TITLE
Fixes #19520: restore ability to set Prefix.scope via API

### DIFF
--- a/netbox/dcim/models/mixins.py
+++ b/netbox/dcim/models/mixins.py
@@ -85,7 +85,7 @@ class CachedScopeMixin(models.Model):
         abstract = True
 
     def clean(self):
-        if self.scope_type and not self.scope:
+        if self.scope_type and not (self.scope or self.scope_id):
             scope_type = self.scope_type.model_class()
             raise ValidationError({
                 'scope': _(


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19520


It turned out that the `.prefetch_related('scope')` on the `PrefixViewSet.queryset` attribute was causing `scope` to not be set on the prefix instance being changed--even though `scope_id` _was_ set--causing the check in `CachedScopeMixin.clean()` to fail. I only found this when comparing the behavior of API endpoints for other models that make use of the `CachedScopeMixin` model mixin.
<!--
    Please include a summary of the proposed changes below.
-->
