### PR TITLE
Fixes #19487: fix ordering issues with CircuitTerminationTable/TunnelTerminationTable configuration

### DIFF
--- a/netbox/circuits/tables/circuits.py
+++ b/netbox/circuits/tables/circuits.py
@@ -120,7 +120,8 @@ class CircuitTerminationTable(NetBoxTable):
     )
     termination = tables.Column(
         verbose_name=_('Termination Point'),
-        linkify=True
+        linkify=True,
+        orderable=False,
     )
 
     # Termination types

--- a/netbox/circuits/tables/circuits.py
+++ b/netbox/circuits/tables/circuits.py
@@ -133,7 +133,7 @@ class CircuitTerminationTable(NetBoxTable):
     site_group = tables.Column(
         verbose_name=_('Site Group'),
         linkify=True,
-        accessor='_sitegroup'
+        accessor='_site_group'
     )
     region = tables.Column(
         verbose_name=_('Region'),

--- a/netbox/circuits/tests/test_tables.py
+++ b/netbox/circuits/tests/test_tables.py
@@ -1,0 +1,23 @@
+from django.test import RequestFactory, tag, TestCase
+
+from circuits.models import CircuitTermination
+from circuits.tables import CircuitTerminationTable
+
+
+@tag('regression')
+class CircuitTerminationTableTest(TestCase):
+    def test_every_orderable_field_does_not_throw_exception(self):
+        terminations = CircuitTermination.objects.all()
+        disallowed = {'actions', }
+
+        orderable_columns = [
+            column.name for column in CircuitTerminationTable(terminations).columns
+            if column.orderable and column.name not in disallowed
+        ]
+        fake_request = RequestFactory().get("/")
+
+        for col in orderable_columns:
+            for dir in ('-', ''):
+                table = CircuitTerminationTable(terminations)
+                table.order_by = f'{dir}{col}'
+                table.as_html(fake_request)

--- a/netbox/vpn/tables/tunnels.py
+++ b/netbox/vpn/tables/tunnels.py
@@ -89,7 +89,8 @@ class TunnelTerminationTable(TenancyColumnsMixin, NetBoxTable):
     )
     termination = tables.Column(
         verbose_name=_('Tunnel interface'),
-        linkify=True
+        linkify=True,
+        orderable=False,
     )
     ip_addresses = columns.ManyToManyColumn(
         accessor=tables.A('termination__ip_addresses'),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19487

Fixes both issues mentioned in #19487:
- Sorting on CircuitTerminationTable.termination ('Termination Point' column) throws `FieldError`
- Sorting on TunnelTerminationTable.termination ('Tunnel Interface' column) throws `FieldError`
- Adds a regression test
<!--
    Please include a summary of the proposed changes below.
-->
