### PR TITLE
Fixes #19610: FieldError when sorting Tunnel Termination on tenant

### DIFF
--- a/netbox/vpn/tables/tunnels.py
+++ b/netbox/vpn/tables/tunnels.py
@@ -73,7 +73,7 @@ class TunnelTable(TenancyColumnsMixin, NetBoxTable):
         default_columns = ('pk', 'name', 'group', 'status', 'encapsulation', 'tenant', 'terminations_count')
 
 
-class TunnelTerminationTable(TenancyColumnsMixin, NetBoxTable):
+class TunnelTerminationTable(NetBoxTable):
     tunnel = tables.Column(
         verbose_name=_('Tunnel'),
         linkify=True

--- a/netbox/vpn/tests/test_tables.py
+++ b/netbox/vpn/tests/test_tables.py
@@ -1,0 +1,26 @@
+from django.test import RequestFactory, tag, TestCase
+
+from vpn.models import TunnelTermination
+from vpn.tables import TunnelTerminationTable
+
+
+@tag('regression')
+class TunnelTerminationTableTest(TestCase):
+    def test_every_orderable_field_does_not_throw_exception(self):
+        terminations = TunnelTermination.objects.all()
+        fake_request = RequestFactory().get("/")
+        disallowed = {
+            'actions',
+            'termination',  # TODO: remove this when #19600 is merged
+        }
+
+        orderable_columns = [
+            column.name for column in TunnelTerminationTable(terminations).columns
+            if column.orderable and column.name not in disallowed
+        ]
+
+        for col in orderable_columns:
+            for dir in ('-', ''):
+                table = TunnelTerminationTable(terminations)
+                table.order_by = f'{dir}{col}'
+                table.as_html(fake_request)

--- a/netbox/vpn/tests/test_tables.py
+++ b/netbox/vpn/tests/test_tables.py
@@ -9,10 +9,7 @@ class TunnelTerminationTableTest(TestCase):
     def test_every_orderable_field_does_not_throw_exception(self):
         terminations = TunnelTermination.objects.all()
         fake_request = RequestFactory().get("/")
-        disallowed = {
-            'actions',
-            'termination',  # TODO: remove this when #19600 is merged
-        }
+        disallowed = {'actions'}
 
         orderable_columns = [
             column.name for column in TunnelTerminationTable(terminations).columns


### PR DESCRIPTION
### Fixes: #19610

It turns out that the `TunnelTermination` model doesn't implement the tenancy "protocol", in that there are no foreign keys to a tenant or tenant group. It looks like `TenancyColumnsMixin` was added to `TunnelTerminationTable` by mistake in completing #9816.

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->


<!--
    Please include a summary of the proposed changes below.
-->
