### PR TITLE
Allow filtering IP addresses by family in GraphQL

### DIFF
--- a/netbox/ipam/graphql/filters.py
+++ b/netbox/ipam/graphql/filters.py
@@ -159,6 +159,14 @@ class IPAddressFilter(ContactFilterMixin, TenancyFilterMixin, PrimaryModelFilter
                 return Q()
         return q
 
+    @strawberry_django.filter_field()
+    def family(
+        self,
+        value: Annotated['IPAddressFamilyEnum', strawberry.lazy('ipam.graphql.enums')],
+        prefix,
+    ) -> Q:
+        return Q(**{f"{prefix}address__family": value.value})
+
 
 @strawberry_django.filter_type(models.IPRange, lookups=True)
 class IPRangeFilter(ContactFilterMixin, TenancyFilterMixin, PrimaryModelFilterMixin):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19605

<!--
    Please include a summary of the proposed changes below.
-->

This adds (back) the ability to filter IP addresses by their family, similar to how the REST API or list filtering capabilities in Netbox.

I've tested two queries manually:

```gql
query simple {
  ip_address_list(filters: {family: FAMILY_6}) {
    address
    family {
      label
    }
  }
}

query complex {
  device_list(filters: {interfaces: {ip_addresses: {family: FAMILY_6}}}) {
    interfaces {
      ip_addresses {
        address
        family {
          label
        }
      }
    }
  }
}
```
