### PR TITLE
Closes #19627: Object change migrators

### DIFF
--- a/netbox/circuits/migrations/0047_circuittermination__termination.py
+++ b/netbox/circuits/migrations/0047_circuittermination__termination.py
@@ -52,7 +52,7 @@ class Migration(migrations.Migration):
     ]
 
 
-def oc_circuittermination_termination(objectchange, revert):
+def oc_circuittermination_termination(objectchange, reverting):
     site_ct = ContentType.objects.get_by_natural_key('dcim', 'site').pk
     provider_network_ct = ContentType.objects.get_by_natural_key('circuits', 'providernetwork').pk
     for data in (objectchange.prechange_data, objectchange.postchange_data):
@@ -68,8 +68,8 @@ def oc_circuittermination_termination(objectchange, revert):
                 'termination_type': provider_network_ct,
                 'termination_id': provider_network_id,
             })
-        data.pop('site')
-        data.pop('provider_network')
+        data.pop('site', None)
+        data.pop('provider_network', None)
 
 
 objectchange_migrators = {

--- a/netbox/circuits/migrations/0047_circuittermination__termination.py
+++ b/netbox/circuits/migrations/0047_circuittermination__termination.py
@@ -68,8 +68,6 @@ def oc_circuittermination_termination(objectchange, reverting):
                 'termination_type': provider_network_ct,
                 'termination_id': provider_network_id,
             })
-        data.pop('site', None)
-        data.pop('provider_network', None)
 
 
 objectchange_migrators = {

--- a/netbox/circuits/migrations/0048_circuitterminations_cached_relations.py
+++ b/netbox/circuits/migrations/0048_circuitterminations_cached_relations.py
@@ -86,3 +86,15 @@ class Migration(migrations.Migration):
             new_name='_provider_network',
         ),
     ]
+
+
+def oc_circuittermination_remove_fields(objectchange, reverting):
+    for data in (objectchange.prechange_data, objectchange.postchange_data):
+        if data is not None:
+            data.pop('site', None)
+            data.pop('provider_network', None)
+
+
+objectchange_migrators = {
+    'circuits.circuittermination': oc_circuittermination_remove_fields,
+}

--- a/netbox/circuits/migrations/0051_virtualcircuit_group_assignment.py
+++ b/netbox/circuits/migrations/0051_virtualcircuit_group_assignment.py
@@ -85,7 +85,7 @@ class Migration(migrations.Migration):
     ]
 
 
-def oc_circuitgroupassignment_member(objectchange, revert):
+def oc_circuitgroupassignment_member(objectchange, reverting):
     circuit_ct = ContentType.objects.get_by_natural_key('circuits', 'circuit').pk
     for data in (objectchange.prechange_data, objectchange.postchange_data):
         if data is None:
@@ -95,7 +95,7 @@ def oc_circuitgroupassignment_member(objectchange, revert):
                 'member_type': circuit_ct,
                 'member_id': circuit_id,
             })
-        data.pop('circuit')
+        data.pop('circuit', None)
 
 
 objectchange_migrators = {

--- a/netbox/circuits/migrations/0051_virtualcircuit_group_assignment.py
+++ b/netbox/circuits/migrations/0051_virtualcircuit_group_assignment.py
@@ -1,4 +1,5 @@
 import django.db.models.deletion
+from django.contrib.contenttypes.models import ContentType
 from django.db import migrations, models
 
 
@@ -82,3 +83,21 @@ class Migration(migrations.Migration):
             ),
         ),
     ]
+
+
+def oc_circuitgroupassignment_member(objectchange, revert):
+    circuit_ct = ContentType.objects.get_by_natural_key('circuits', 'circuit').pk
+    for data in (objectchange.prechange_data, objectchange.postchange_data):
+        if data is None:
+            continue
+        if circuit_id := data.get('circuit'):
+            data.update({
+                'member_type': circuit_ct,
+                'member_id': circuit_id,
+            })
+        data.pop('circuit')
+
+
+objectchange_migrators = {
+    'circuits.circuitgroupassignment': oc_circuitgroupassignment_member,
+}

--- a/netbox/dcim/migrations/0188_racktype.py
+++ b/netbox/dcim/migrations/0188_racktype.py
@@ -100,3 +100,16 @@ class Migration(migrations.Migration):
             ),
         ),
     ]
+
+
+def oc_rename_type(objectchange, reverting):
+    for data in (objectchange.prechange_data, objectchange.postchange_data):
+        if data is None:
+            continue
+        if 'type' in data:
+            data['form_factor'] = data.pop('type')
+
+
+objectchange_migrators = {
+    'dcim.rack': oc_rename_type,
+}

--- a/netbox/dcim/migrations/0200_populate_mac_addresses.py
+++ b/netbox/dcim/migrations/0200_populate_mac_addresses.py
@@ -55,11 +55,12 @@ class Migration(migrations.Migration):
     ]
 
 
-def oc_interface_primary_mac_address(objectchange, revert):
+def oc_interface_primary_mac_address(objectchange, reverting):
     MACAddress = apps.get_model('dcim', 'MACAddress')
     interface_ct = ContentType.objects.get_by_natural_key('dcim', 'interface')
 
-    if not revert:
+    # Swap data order if the change is being reverted
+    if not reverting:
         before, after = objectchange.prechange_data, objectchange.postchange_data
     else:
         before, after = objectchange.postchange_data, objectchange.prechange_data
@@ -84,8 +85,8 @@ def oc_interface_primary_mac_address(objectchange, revert):
             ).delete()
         before['primary_mac_address'] = None
 
-    before.pop('mac_address')
-    after.pop('mac_address')
+    before.pop('mac_address', None)
+    after.pop('mac_address', None)
 
 
 objectchange_migrators = {

--- a/netbox/dcim/migrations/0200_populate_mac_addresses.py
+++ b/netbox/dcim/migrations/0200_populate_mac_addresses.py
@@ -55,6 +55,7 @@ class Migration(migrations.Migration):
     ]
 
 
+# See peer migrator in virtualization.0048_populate_mac_addresses before making changes
 def oc_interface_primary_mac_address(objectchange, reverting):
     MACAddress = apps.get_model('dcim', 'MACAddress')
     interface_ct = ContentType.objects.get_by_natural_key('dcim', 'interface')

--- a/netbox/dcim/migrations/0200_populate_mac_addresses.py
+++ b/netbox/dcim/migrations/0200_populate_mac_addresses.py
@@ -15,7 +15,7 @@ def populate_mac_addresses(apps, schema_editor):
             assigned_object_type=interface_ct,
             assigned_object_id=interface.pk
         )
-        for interface in Interface.objects.filter(mac_address__isnull=False)
+        for interface in Interface.objects.using(db_alias).filter(mac_address__isnull=False)
     ]
     MACAddress.objects.using(db_alias).bulk_create(mac_addresses, batch_size=100)
 

--- a/netbox/ipam/migrations/0071_prefix_scope.py
+++ b/netbox/ipam/migrations/0071_prefix_scope.py
@@ -47,7 +47,7 @@ class Migration(migrations.Migration):
     ]
 
 
-def oc_prefix_scope(objectchange, revert):
+def oc_prefix_scope(objectchange, reverting):
     site_ct = ContentType.objects.get_by_natural_key('dcim', 'site').pk
     for data in (objectchange.prechange_data, objectchange.postchange_data):
         if data is None:
@@ -57,7 +57,7 @@ def oc_prefix_scope(objectchange, revert):
                 'scope_type': site_ct,
                 'scope_id': site_id,
             })
-        data.pop('site')
+        data.pop('site', None)
 
 
 objectchange_migrators = {

--- a/netbox/ipam/migrations/0071_prefix_scope.py
+++ b/netbox/ipam/migrations/0071_prefix_scope.py
@@ -1,4 +1,5 @@
 import django.db.models.deletion
+from django.contrib.contenttypes.models import ContentType
 from django.db import migrations, models
 
 
@@ -44,3 +45,21 @@ class Migration(migrations.Migration):
         # Copy over existing site assignments
         migrations.RunPython(code=copy_site_assignments, reverse_code=migrations.RunPython.noop),
     ]
+
+
+def oc_prefix_scope(objectchange, revert):
+    site_ct = ContentType.objects.get_by_natural_key('dcim', 'site').pk
+    for data in (objectchange.prechange_data, objectchange.postchange_data):
+        if data is None:
+            continue
+        if site_id := data.get('site'):
+            data.update({
+                'scope_type': site_ct,
+                'scope_id': site_id,
+            })
+        data.pop('site')
+
+
+objectchange_migrators = {
+    'ipam.prefix': oc_prefix_scope,
+}

--- a/netbox/ipam/migrations/0071_prefix_scope.py
+++ b/netbox/ipam/migrations/0071_prefix_scope.py
@@ -57,7 +57,6 @@ def oc_prefix_scope(objectchange, reverting):
                 'scope_type': site_ct,
                 'scope_id': site_id,
             })
-        data.pop('site', None)
 
 
 objectchange_migrators = {

--- a/netbox/ipam/migrations/0072_prefix_cached_relations.py
+++ b/netbox/ipam/migrations/0072_prefix_cached_relations.py
@@ -60,3 +60,14 @@ class Migration(migrations.Migration):
             name='site',
         ),
     ]
+
+
+def oc_prefix_remove_fields(objectchange, reverting):
+    for data in (objectchange.prechange_data, objectchange.postchange_data):
+        if data is not None:
+            data.pop('site', None)
+
+
+objectchange_migrators = {
+    'ipam.prefix': oc_prefix_remove_fields,
+}

--- a/netbox/ipam/migrations/0080_populate_service_parent.py
+++ b/netbox/ipam/migrations/0080_populate_service_parent.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.models import ContentType
 from django.db import migrations
 from django.db.models import F
 
@@ -54,3 +55,28 @@ class Migration(migrations.Migration):
                 reverse_code=repopulate_device_and_virtualmachine_relations,
             )
     ]
+
+
+def oc_service_parent(objectchange, revert):
+    device_ct = ContentType.objects.get_by_natural_key('dcim', 'device').pk
+    virtual_machine_ct = ContentType.objects.get_by_natural_key('virtualization', 'virtualmachine').pk
+    for data in (objectchange.prechange_data, objectchange.postchange_data):
+        if data is None:
+            continue
+        if device_id := data.get('device'):
+            data.update({
+                'parent_object_type': device_ct,
+                'parent_object_id': device_id,
+            })
+        elif virtual_machine_id := data.get('virtual_machine'):
+            data.update({
+                'parent_object_type': virtual_machine_ct,
+                'parent_object_id': virtual_machine_id,
+            })
+        data.pop('device')
+        data.pop('virtual_machine')
+
+
+objectchange_migrators = {
+    'ipam.service': oc_service_parent,
+}

--- a/netbox/ipam/migrations/0080_populate_service_parent.py
+++ b/netbox/ipam/migrations/0080_populate_service_parent.py
@@ -73,8 +73,6 @@ def oc_service_parent(objectchange, reverting):
                 'parent_object_type': virtual_machine_ct,
                 'parent_object_id': virtual_machine_id,
             })
-        data.pop('device', None)
-        data.pop('virtual_machine', None)
 
 
 objectchange_migrators = {

--- a/netbox/ipam/migrations/0080_populate_service_parent.py
+++ b/netbox/ipam/migrations/0080_populate_service_parent.py
@@ -57,7 +57,7 @@ class Migration(migrations.Migration):
     ]
 
 
-def oc_service_parent(objectchange, revert):
+def oc_service_parent(objectchange, reverting):
     device_ct = ContentType.objects.get_by_natural_key('dcim', 'device').pk
     virtual_machine_ct = ContentType.objects.get_by_natural_key('virtualization', 'virtualmachine').pk
     for data in (objectchange.prechange_data, objectchange.postchange_data):
@@ -73,8 +73,8 @@ def oc_service_parent(objectchange, revert):
                 'parent_object_type': virtual_machine_ct,
                 'parent_object_id': virtual_machine_id,
             })
-        data.pop('device')
-        data.pop('virtual_machine')
+        data.pop('device', None)
+        data.pop('virtual_machine', None)
 
 
 objectchange_migrators = {

--- a/netbox/ipam/migrations/0081_remove_service_device_virtual_machine_add_parent_gfk_index.py
+++ b/netbox/ipam/migrations/0081_remove_service_device_virtual_machine_add_parent_gfk_index.py
@@ -37,3 +37,15 @@ class Migration(migrations.Migration):
             ),
         ),
     ]
+
+
+def oc_service_remove_fields(objectchange, reverting):
+    for data in (objectchange.prechange_data, objectchange.postchange_data):
+        if data is not None:
+            data.pop('device', None)
+            data.pop('virtual_machine', None)
+
+
+objectchange_migrators = {
+    'ipam.service': oc_service_remove_fields,
+}

--- a/netbox/tenancy/migrations/0018_contact_groups.py
+++ b/netbox/tenancy/migrations/0018_contact_groups.py
@@ -66,3 +66,17 @@ class Migration(migrations.Migration):
             name='group',
         ),
     ]
+
+
+def oc_contact_groups(objectchange, revert):
+    for data in (objectchange.prechange_data, objectchange.postchange_data):
+        if data is None:
+            continue
+        if 'group' in data:
+            data['groups'] = [data['group']] if data['group'] else []
+            data.pop('group')
+
+
+objectchange_migrators = {
+    'tenancy.contact': oc_contact_groups,
+}

--- a/netbox/tenancy/migrations/0018_contact_groups.py
+++ b/netbox/tenancy/migrations/0018_contact_groups.py
@@ -68,13 +68,13 @@ class Migration(migrations.Migration):
     ]
 
 
-def oc_contact_groups(objectchange, revert):
+def oc_contact_groups(objectchange, reverting):
     for data in (objectchange.prechange_data, objectchange.postchange_data):
         if data is None:
             continue
-        if 'group' in data:
-            data['groups'] = [data['group']] if data['group'] else []
-            data.pop('group')
+        # Set the M2M field `groups` to a list containing the group ID
+        data['groups'] = [data['group']] if data.get('group') else []
+        data.pop('group', None)
 
 
 objectchange_migrators = {

--- a/netbox/virtualization/migrations/0044_cluster_scope.py
+++ b/netbox/virtualization/migrations/0044_cluster_scope.py
@@ -46,7 +46,7 @@ class Migration(migrations.Migration):
     ]
 
 
-def oc_cluster_scope(objectchange, revert):
+def oc_cluster_scope(objectchange, reverting):
     site_ct = ContentType.objects.get_by_natural_key('dcim', 'site').pk
     for data in (objectchange.prechange_data, objectchange.postchange_data):
         if data is None:
@@ -56,7 +56,7 @@ def oc_cluster_scope(objectchange, revert):
                 'scope_type': site_ct,
                 'scope_id': site_id,
             })
-        data.pop('site')
+        data.pop('site', None)
 
 
 objectchange_migrators = {

--- a/netbox/virtualization/migrations/0044_cluster_scope.py
+++ b/netbox/virtualization/migrations/0044_cluster_scope.py
@@ -1,4 +1,5 @@
 import django.db.models.deletion
+from django.contrib.contenttypes.models import ContentType
 from django.db import migrations, models
 
 
@@ -43,3 +44,21 @@ class Migration(migrations.Migration):
         # Copy over existing site assignments
         migrations.RunPython(code=copy_site_assignments, reverse_code=migrations.RunPython.noop),
     ]
+
+
+def oc_cluster_scope(objectchange, revert):
+    site_ct = ContentType.objects.get_by_natural_key('dcim', 'site').pk
+    for data in (objectchange.prechange_data, objectchange.postchange_data):
+        if data is None:
+            continue
+        if site_id := data.get('site'):
+            data.update({
+                'scope_type': site_ct,
+                'scope_id': site_id,
+            })
+        data.pop('site')
+
+
+objectchange_migrators = {
+    'virtualization.cluster': oc_cluster_scope,
+}

--- a/netbox/virtualization/migrations/0044_cluster_scope.py
+++ b/netbox/virtualization/migrations/0044_cluster_scope.py
@@ -56,7 +56,6 @@ def oc_cluster_scope(objectchange, reverting):
                 'scope_type': site_ct,
                 'scope_id': site_id,
             })
-        data.pop('site', None)
 
 
 objectchange_migrators = {

--- a/netbox/virtualization/migrations/0045_clusters_cached_relations.py
+++ b/netbox/virtualization/migrations/0045_clusters_cached_relations.py
@@ -87,3 +87,14 @@ class Migration(migrations.Migration):
             ),
         ),
     ]
+
+
+def oc_cluster_remove_site(objectchange, reverting):
+    for data in (objectchange.prechange_data, objectchange.postchange_data):
+        if data is not None:
+            data.pop('site', None)
+
+
+objectchange_migrators = {
+    'virtualization.cluster': oc_cluster_remove_site,
+}

--- a/netbox/virtualization/migrations/0048_populate_mac_addresses.py
+++ b/netbox/virtualization/migrations/0048_populate_mac_addresses.py
@@ -54,11 +54,12 @@ class Migration(migrations.Migration):
     ]
 
 
-def oc_vminterface_primary_mac_address(objectchange, revert):
+def oc_vminterface_primary_mac_address(objectchange, reverting):
     MACAddress = apps.get_model('dcim', 'MACAddress')
     vminterface_ct = ContentType.objects.get_by_natural_key('virtualization', 'vminterface')
 
-    if not revert:
+    # Swap data order if the change is being reverted
+    if not reverting:
         before, after = objectchange.prechange_data, objectchange.postchange_data
     else:
         before, after = objectchange.postchange_data, objectchange.prechange_data
@@ -83,8 +84,8 @@ def oc_vminterface_primary_mac_address(objectchange, revert):
             ).delete()
         before['primary_mac_address'] = None
 
-    before.pop('mac_address')
-    after.pop('mac_address')
+    before.pop('mac_address', None)
+    after.pop('mac_address', None)
 
 
 objectchange_migrators = {

--- a/netbox/virtualization/migrations/0048_populate_mac_addresses.py
+++ b/netbox/virtualization/migrations/0048_populate_mac_addresses.py
@@ -54,6 +54,7 @@ class Migration(migrations.Migration):
     ]
 
 
+# See peer migrator in dcim.0200_populate_mac_addresses before making changes
 def oc_vminterface_primary_mac_address(objectchange, reverting):
     MACAddress = apps.get_model('dcim', 'MACAddress')
     vminterface_ct = ContentType.objects.get_by_natural_key('virtualization', 'vminterface')

--- a/netbox/virtualization/migrations/0048_populate_mac_addresses.py
+++ b/netbox/virtualization/migrations/0048_populate_mac_addresses.py
@@ -1,4 +1,6 @@
 import django.db.models.deletion
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
 from django.db import migrations, models
 
 
@@ -50,3 +52,41 @@ class Migration(migrations.Migration):
             name='mac_address',
         ),
     ]
+
+
+def oc_vminterface_primary_mac_address(objectchange, revert):
+    MACAddress = apps.get_model('dcim', 'MACAddress')
+    vminterface_ct = ContentType.objects.get_by_natural_key('virtualization', 'vminterface')
+
+    if not revert:
+        before, after = objectchange.prechange_data, objectchange.postchange_data
+    else:
+        before, after = objectchange.postchange_data, objectchange.prechange_data
+
+    if after.get('mac_address') != before.get('mac_address'):
+        # Create & assign the new MACAddress (if any)
+        if after.get('mac_address'):
+            mac = MACAddress.objects.create(
+                mac_address=after['mac_address'],
+                assigned_object_type=vminterface_ct,
+                assigned_object_id=objectchange.changed_object_id,
+            )
+            after['primary_mac_address'] = mac.pk
+        else:
+            after['primary_mac_address'] = None
+        # Delete the old MACAddress (if any)
+        if before.get('mac_address'):
+            MACAddress.objects.filter(
+                mac_address=before['mac_address'],
+                assigned_object_type=vminterface_ct,
+                assigned_object_id=objectchange.changed_object_id,
+            ).delete()
+        before['primary_mac_address'] = None
+
+    before.pop('mac_address')
+    after.pop('mac_address')
+
+
+objectchange_migrators = {
+    'virtualization.vminterface': oc_vminterface_primary_mac_address,
+}


### PR DESCRIPTION
### Closes: #19627

Provide ObjectChange data migrators for schema migrations starting with NetBox v4.2.0:

* circuits.0047_circuittermination__termination
* circuits.0051_virtualcircuit_group_assignment
* dcim.0200_populate_mac_addresses
* ipam.0071_prefix_scope
* ipam.0080_populate_service_parent
* tenancy.0018_contact_groups
* virtualization.0044_cluster_scope
* virtualization.0048_populate_mac_addresses

The order of operations necessary for testing this PR in conjunction with the netbox-branching plugin as as follows.

1. Install NetBox v4.1.9 and populate some [data](https://github.com/netbox-community/netbox-demo-data/blob/master/sql/netbox-demo-v4.1.sql).
2. Install and enable [netbox-branching](https://github.com/netboxlabs/netbox-branching) by checking out the `main` branch of the repo. (We need FR [#262](https://github.com/netboxlabs/netbox-branching/issues/262) but v0.5.6 hasn't been released yet.)
3. Create branches and perform object changes to generate branch data for testing.
4. Upgrade to NetBox v4.3.1, then switch to the branch for this PR (`19627-object-change-migrators`).
5. Check out the `1-branch-migrations` branch of netbox-branching. (This emulates upgrading to v0.6.0 of the plugin.)
6. Test migrating and merging open branches that were created under NetBox v4.1.9.