### PR TITLE
19623 show description on provider account detail view

### DIFF
--- a/netbox/templates/circuits/provideraccount.html
+++ b/netbox/templates/circuits/provideraccount.html
@@ -32,7 +32,7 @@
             <th scope="row">{% trans "Description" %}</th>
             <td>{{ object.description|placeholder }}</td>
           </tr>
-      </table>
+        </table>
       </div>
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}

--- a/netbox/templates/circuits/provideraccount.html
+++ b/netbox/templates/circuits/provideraccount.html
@@ -28,7 +28,11 @@
             <th scope="row">{% trans "Name" %}</th>
             <td>{{ object.name|placeholder }}</td>
           </tr>
-        </table>
+          <tr>
+            <th scope="row">{% trans "Description" %}</th>
+            <td>{{ object.description|placeholder }}</td>
+          </tr>
+      </table>
       </div>
       {% include 'inc/panels/tags.html' %}
       {% plugin_left_page object %}


### PR DESCRIPTION
### Fixes: #19623 

Just adds missing display of description on provider account detail page.