### PR TITLE
Fixes #19599: Prevent exception when sorting user's recent activity

### DIFF
--- a/netbox/account/views.py
+++ b/netbox/account/views.py
@@ -191,11 +191,7 @@ class ProfileView(LoginRequiredMixin, View):
     def get(self, request):
 
         # Compile changelog table
-        changelog = ObjectChange.objects.valid_models().restrict(request.user, 'view').filter(
-            user=request.user
-        ).prefetch_related(
-            'changed_object_type'
-        )[:20]
+        changelog = ObjectChange.objects.valid_models().restrict(request.user, 'view').filter(user=request.user)[:20]
         changelog_table = ObjectChangeTable(changelog)
         changelog_table.orderable = False
         changelog_table.configure(request)

--- a/netbox/account/views.py
+++ b/netbox/account/views.py
@@ -197,6 +197,7 @@ class ProfileView(LoginRequiredMixin, View):
             'changed_object_type'
         )[:20]
         changelog_table = ObjectChangeTable(changelog)
+        changelog_table.orderable = False
         changelog_table.configure(request)
 
         return render(request, self.template_name, {

--- a/netbox/templates/account/profile.html
+++ b/netbox/templates/account/profile.html
@@ -65,7 +65,14 @@
     <div class="row">
       <div class="col-md-12">
         <div class="card">
-          <h2 class="card-header text-center">{% trans "Recent Activity" %}</h2>
+          <h2 class="card-header text-center">
+            {% trans "Recent Activity" %}
+            <div class="card-actions">
+              <a href="{% url 'core:objectchange_list' %}?user_id={{ request.user.pk }}" class="btn btn-ghost-primary btn-sm">
+                <i class="mdi mdi-arrow-right-thick" aria-hidden="true"></i> {% trans "View All" %}
+              </a>
+            </div>
+          </h2>
           <div class="table-responsive">
             {% render_table changelog_table 'inc/table.html' %}
           </div>

--- a/netbox/templates/account/profile.html
+++ b/netbox/templates/account/profile.html
@@ -1,12 +1,10 @@
 {% extends 'account/base.html' %}
-{% load helpers %}
-{% load render_table from django_tables2 %}
 {% load i18n %}
 
 {% block title %}{% trans "User Profile" %}{% endblock %}
 
 {% block content %}
-  <div class="row mb-3">
+  <div class="row">
     <div class="col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "Account Details" %}</h2>
@@ -64,19 +62,7 @@
   {% if perms.core.view_objectchange %}
     <div class="row">
       <div class="col-md-12">
-        <div class="card">
-          <h2 class="card-header text-center">
-            {% trans "Recent Activity" %}
-            <div class="card-actions">
-              <a href="{% url 'core:objectchange_list' %}?user_id={{ request.user.pk }}" class="btn btn-ghost-primary btn-sm">
-                <i class="mdi mdi-arrow-right-thick" aria-hidden="true"></i> {% trans "View All" %}
-              </a>
-            </div>
-          </h2>
-          <div class="table-responsive">
-            {% render_table changelog_table 'inc/table.html' %}
-          </div>
-        </div>
+        {% include 'users/inc/user_activity.html' with user=user table=changelog_table %}
       </div>
     </div>
   {% endif %}

--- a/netbox/templates/users/inc/user_activity.html
+++ b/netbox/templates/users/inc/user_activity.html
@@ -1,0 +1,16 @@
+{% load i18n %}
+{% load render_table from django_tables2 %}
+
+<div class="card">
+  <h2 class="card-header text-center">
+    {% trans "Recent Activity" %}
+    <div class="card-actions">
+      <a href="{% url 'core:objectchange_list' %}?user_id={{ user.pk }}" class="btn btn-ghost-primary btn-sm">
+        <i class="mdi mdi-arrow-right-thick" aria-hidden="true"></i> {% trans "View All" %}
+      </a>
+    </div>
+  </h2>
+  <div class="table-responsive">
+    {% render_table table 'inc/table.html' %}
+  </div>
+</div>

--- a/netbox/templates/users/user.html
+++ b/netbox/templates/users/user.html
@@ -1,14 +1,12 @@
 {% extends 'generic/object.html' %}
 {% load i18n %}
-{% load helpers %}
-{% load render_table from django_tables2 %}
 
 {% block title %}{% trans "User" %} {{ object.username }}{% endblock %}
 
 {% block subtitle %}{% endblock %}
 
 {% block content %}
-  <div class="row mb-3">
+  <div class="row">
     <div class="col-md-6">
       <div class="card">
         <h2 class="card-header">{% trans "User" %}</h2>
@@ -74,12 +72,7 @@
   {% if perms.core.view_objectchange %}
     <div class="row">
       <div class="col-md-12">
-        <div class="card">
-          <h2 class="text-center">{% trans "Recent Activity" %}</h2>
-          <div class="card-body table-responsive">
-            {% render_table changelog_table 'inc/table.html' %}
-          </div>
-        </div>
+        {% include 'users/inc/user_activity.html' with user=object table=changelog_table %}
       </div>
     </div>
   {% endif %}

--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -75,8 +75,9 @@ class UserView(generic.ObjectView):
     template_name = 'users/user.html'
 
     def get_extra_context(self, request, instance):
-        changelog = ObjectChange.objects.restrict(request.user, 'view').filter(user=instance)[:20]
+        changelog = ObjectChange.objects.valid_models().restrict(request.user, 'view').filter(user=instance)[:20]
         changelog_table = ObjectChangeTable(changelog)
+        changelog_table.orderable = False
         changelog_table.configure(request)
 
         return {


### PR DESCRIPTION
### Fixes: #19599

- Established a shared template for displaying a user's change history
- Disable ordering on the user's changelog table
- Add a link to filtered results from the global changelog