### PR TITLE
Closes #17183 - Add Object Types Field to Tag Bulk Import Form

### DIFF
--- a/netbox/extras/forms/bulk_import.py
+++ b/netbox/extras/forms/bulk_import.py
@@ -238,10 +238,18 @@ class TagImportForm(CSVModelForm):
         label=_('Weight'),
         required=False
     )
+    object_types = CSVMultipleContentTypeField(
+        label=_('Object types'),
+        queryset=ObjectType.objects.with_feature('tags'),
+        help_text=_("One or more assigned object types"),
+        required=False,
+    )
 
     class Meta:
         model = Tag
-        fields = ('name', 'slug', 'color', 'weight', 'description')
+        fields = (
+            'name', 'slug', 'color', 'weight', 'description', 'object_types',
+        )
 
 
 class JournalEntryImportForm(NetBoxModelImportForm):

--- a/netbox/extras/tests/test_views.py
+++ b/netbox/extras/tests/test_views.py
@@ -444,6 +444,8 @@ class TagTestCase(ViewTestCases.OrganizationalObjectViewTestCase):
     @classmethod
     def setUpTestData(cls):
 
+        site_ct = ContentType.objects.get_for_model(Site)
+
         tags = (
             Tag(name='Tag 1', slug='tag-1'),
             Tag(name='Tag 2', slug='tag-2', weight=1),
@@ -456,14 +458,15 @@ class TagTestCase(ViewTestCases.OrganizationalObjectViewTestCase):
             'slug': 'tag-x',
             'color': 'c0c0c0',
             'comments': 'Some comments',
+            'object_types': [site_ct.pk],
             'weight': 11,
         }
 
         cls.csv_data = (
-            "name,slug,color,description,weight",
-            "Tag 4,tag-4,ff0000,Fourth tag,0",
-            "Tag 5,tag-5,00ff00,Fifth tag,1111",
-            "Tag 6,tag-6,0000ff,Sixth tag,0",
+            "name,slug,color,description,object_types,weight",
+            "Tag 4,tag-4,ff0000,Fourth tag,dcim.interface,0",
+            "Tag 5,tag-5,00ff00,Fifth tag,'dcim.device,dcim.site',1111",
+            "Tag 6,tag-6,0000ff,Sixth tag,dcim.site,0",
         )
 
         cls.csv_update_data = (


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #17183 - Add the ability to assign object types to a tag for CSV import

Adds support for assigning object types to Tags during CSV import, matching the functionality available in the web UI.

### Proposed Functionality

- Adds an `object_types` field to the Tag bulk import form.
- Allows associating one or more object types with each Tag via CSV.

### Use Case

Enables users to set object type associations via CSV, which is already possible through the GUI.

### Example CSV

```csv
name,slug,color,object_types
Tag4,tag4,9e9e9e,"dcim.interface,virtualization.virtualmachine"
```

