### PR TITLE
Closes #19545 - Suppress housekeeping cron output

### DIFF
--- a/contrib/netbox-housekeeping.sh
+++ b/contrib/netbox-housekeeping.sh
@@ -6,4 +6,16 @@
 #
 # If NetBox has been installed into a nonstandard location, update the paths
 # below.
-/opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py housekeeping
+# By default, all output is discarded. Uncomment the log lines below to enable
+# logging.
+
+# Run quietly (no log)
+# --------------------
+/opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py housekeeping > /dev/null 2>&1
+
+# Run with logging (append output to log file)
+# --------------------------------------------
+# LOGFILE="/var/log/netbox/housekeeping.log"
+# echo "[$(date)] Starting NetBox housekeeping..." >> "$LOGFILE"
+# /opt/netbox/venv/bin/python /opt/netbox/netbox/manage.py housekeeping >> "$LOGFILE" 2>&1
+# echo "[$(date)] NetBox housekeeping complete." >> "$LOGFILE"


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19545 - Housekeeping task output triggers emails via anacron

Enhances the NetBox housekeeping cron job by adding optional logging functionality. By default, the cron job now suppresses its output for quieter operation. Users can optionally direct output to a log file for monitoring or troubleshooting as needed.