### PR TITLE
Closes #19535 - Add Project Stanza to pyproject toml

### DIFF
--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -54,6 +54,7 @@ If a new Django release is adopted or other major dependencies (Python, PostgreS
 * Update the installation guide (`docs/installation/index.md`) with the new minimum versions.
 * Update the upgrade guide (`docs/installation/upgrading.md`) for the current version accordingly.
 * Update the minimum PostgreSQL version in the programming error template (`netbox/templates/exceptions/programming_error.html`).
+* Update the minimum and supported Python versions in the project metadata file (`pyproject.toml`)
 
 ### Manually Perform a New Install
 

--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -166,7 +166,7 @@ Then, compile these portable (`.po`) files for use in the application:
 
 ### Update Version and Changelog
 
-* Update the version number and date in `netbox/release.yaml`. Add or remove the designation (e.g. `beta1`) if applicable.
+* Update the version number and date in `netbox/release.yaml` and `pyproject.toml`. Add or remove the designation (e.g. `beta1`) if applicable.
 * Update the example version numbers in the feature request and bug report templates under `.github/ISSUE_TEMPLATES/`.
 * Add a section for this release at the top of the changelog page for the minor version (e.g. `docs/release-notes/version-4.2.md`) listing all relevant changes made in this release.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 [project.urls]
 Homepage = "https://netboxlabs.com/products/netbox/"
 Documentation = "https://netboxlabs.com/docs/netbox/"
-Repository = "https://github.com/netbox-community/netbox"
+Source = "https://github.com/netbox-community/netbox"
 Issues = "https://github.com/netbox-community/netbox/issues"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,38 +4,35 @@
 [project]
 name = "netbox"
 version = "4.3.1"
+requires-python = ">=3.10"
 authors = [
     { name = "NetBox Community" }
 ]
-description = """\
-NetBox exists to empower network engineers. Since its release in 2016, it has become the go-to solution for modeling\
- and documenting network infrastructure for thousands of organizations worldwide. As a successor to legacy IPAM and\
- DCIM applications, NetBox provides a cohesive, extensive, and accessible data model for all things networked.\
- By providing a single robust user interface and programmable APIs for everything from cable maps to device\
- configurations, NetBox serves as the central source of truth for the modern network.
-"""
+maintainers = [
+    { name = "NetBox Community" }
+]
+description = "The premier source of truth powering network automation."
 readme = "README.md"
-license = { file = "LICENSE.txt" }
-
+license = "Apache-2.0"
+license-files = ["LICENSE.txt"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Framework :: Django",
     "Intended Audience :: Developers",
     "Intended Audience :: System Administrators",
-    "License :: OSI Approved :: Apache Software License",
     "Natural Language :: English",
-    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
 
-requires-python = ">=3.10"
 
 [project.urls]
 Homepage = "https://netboxlabs.com/products/netbox/"
-Source = "https://github.com/netbox-community/netbox"
 Documentation = "https://netboxlabs.com/docs/netbox/"
+Repository = "https://github.com/netbox-community/netbox"
 Issues = "https://github.com/netbox-community/netbox/issues"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,43 @@
 # See PEP 518 for the spec of this file
 # https://www.python.org/dev/peps/pep-0518/
 
+[project]
+name = "netbox"
+version = "4.3.1"
+authors = [
+    { name = "NetBox Community" }
+]
+description = """\
+NetBox exists to empower network engineers. Since its release in 2016, it has become the go-to solution for modeling\
+ and documenting network infrastructure for thousands of organizations worldwide. As a successor to legacy IPAM and\
+ DCIM applications, NetBox provides a cohesive, extensive, and accessible data model for all things networked.\
+ By providing a single robust user interface and programmable APIs for everything from cable maps to device\
+ configurations, NetBox serves as the central source of truth for the modern network.
+"""
+readme = "README.md"
+license = { file = "LICENSE.txt" }
+
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Framework :: Django",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: Apache Software License",
+    "Natural Language :: English",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+]
+
+requires-python = ">=3.10"
+
+[project.urls]
+Homepage = "https://netboxlabs.com/products/netbox/"
+Source = "https://github.com/netbox-community/netbox"
+Documentation = "https://netboxlabs.com/docs/netbox/"
+Issues = "https://github.com/netbox-community/netbox/issues"
+
 [tool.black]
 line-length = 120
 target_version = ['py310', 'py311', 'py312']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
     "Intended Audience :: System Administrators",
     "Natural Language :: English",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19535 - Update pyproject.toml with a [project] stanza

This PR adds a `[project]` section to `pyproject.toml` to improve compatibility with tools like [`uv`](https://github.com/astral-sh/uv), which rely on PEP 621-compliant metadata.

The section includes basic project metadata such as name, version, description, license, authors, and relevant URLs. This is primarily intended to help users who wish to manage their virtual environments using `uv`, which otherwise fails without a `[project]` table.

The version field is currently maintained manually to match the main NetBox version. Dynamic versioning was considered but isn't suitable here, as we're not building NetBox as a Python package.

Let me know if any adjustments are needed!
