### PR TITLE
Fixes: #19492: Add Save Button to Script Output Window

### DIFF
--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1482,31 +1482,13 @@ class ScriptResultView(TableMixin, generic.ObjectView):
         if job.completed:
             table = self.get_table(job, request, bulk_actions=False)
 
-        if job.completed and job.data:
+        if job.completed:
             # If a direct export output has been requested, return the job data content as a
             # downloadable file.
-            if request.GET.get('export') == 'output' and job.data.get('output'):
-                content = job.data['output'].encode()
+            if request.GET.get('export') == 'output':
+                content = (job.data.get("output") or "").encode()
                 response = HttpResponse(content, content_type='text')
                 filename = f"{job.object.name or 'script-output'}_{job.completed.strftime('%Y-%m-%d-%H-%M-%S')}.txt"
-                response['Content-Disposition'] = f'attachment; filename="{filename}"'
-                return response
-
-            # If a direct export log has been requested, return the job log content as a
-            # downloadable CSV file.
-            if request.GET.get('export') == 'log' and table:
-                # Filter generator for visible columns
-                def column_filter(data):
-                    for item in data:
-                        yield dict((k, v) for k, v, in item.items() if k in table.columns.names())
-                # Write a CSV to a string buffer for content
-                buf = StringIO()
-                writer = csv.DictWriter(buf, fieldnames=table.columns.names())
-                writer.writeheader()
-                writer.writerows(column_filter(table.data))
-                buf.seek(0)
-                response = HttpResponse(buf.read().encode(), content_type='text/csv')
-                filename = f"{job.object.name or 'script-log'}_{job.completed.strftime('%Y-%m-%d-%H-%M-%S')}.csv"
                 response['Content-Disposition'] = f'attachment; filename="{filename}"'
                 return response
 

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1,6 +1,3 @@
-import csv
-from io import StringIO
-
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.contenttypes.models import ContentType

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1,3 +1,6 @@
+import csv
+from io import StringIO
+
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.contenttypes.models import ContentType
@@ -1479,13 +1482,31 @@ class ScriptResultView(TableMixin, generic.ObjectView):
         if job.completed:
             table = self.get_table(job, request, bulk_actions=False)
 
-        if job.completed and job.data and job.data.get('output'):
-            # If a direct export has been requested, return the job data content as a
+        if job.completed and job.data:
+            # If a direct export output has been requested, return the job data content as a
             # downloadable file.
-            if request.GET.get('export'):
-                content = job.data.get('output')
+            if request.GET.get('export') == 'output' and job.data.get('output'):
+                content = job.data['output'].encode()
                 response = HttpResponse(content, content_type='text')
                 filename = f"{job.object.name or 'script-output'}_{job.completed.strftime('%Y-%m-%d-%H-%M-%S')}.txt"
+                response['Content-Disposition'] = f'attachment; filename="{filename}"'
+                return response
+
+            # If a direct export log has been requested, return the job log content as a
+            # downloadable CSV file.
+            if request.GET.get('export') == 'log' and table:
+                # Filter generator for visible columns
+                def column_filter(data):
+                    for item in data:
+                        yield dict((k, v) for k, v, in item.items() if k in table.columns.names())
+                # Write a CSV to a string buffer for content
+                buf = StringIO()
+                writer = csv.DictWriter(buf, fieldnames=table.columns.names())
+                writer.writeheader()
+                writer.writerows(column_filter(table.data))
+                buf.seek(0)
+                response = HttpResponse(buf.read().encode(), content_type='text/csv')
+                filename = f"{job.object.name or 'script-log'}_{job.completed.strftime('%Y-%m-%d-%H-%M-%S')}.csv"
                 response['Content-Disposition'] = f'attachment; filename="{filename}"'
                 return response
 

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1479,6 +1479,16 @@ class ScriptResultView(TableMixin, generic.ObjectView):
         if job.completed:
             table = self.get_table(job, request, bulk_actions=False)
 
+        if job.completed and job.data and job.data.get('output'):
+            # If a direct export has been requested, return the job data content as a
+            # downloadable file.
+            if request.GET.get('export'):
+                content = job.data.get('output')
+                response = HttpResponse(content, content_type='text')
+                filename = f"{job.object.name or 'script-output'}_{job.completed.strftime('%Y-%m-%d-%H-%M-%S')}.txt"
+                response['Content-Disposition'] = f'attachment; filename="{filename}"'
+                return response
+
         log_threshold = request.GET.get('log_threshold', LogLevelChoices.LOG_INFO)
         if log_threshold not in LOG_LEVEL_RANK:
             log_threshold = LogLevelChoices.LOG_INFO

--- a/netbox/templates/extras/htmx/script_result.html
+++ b/netbox/templates/extras/htmx/script_result.html
@@ -40,7 +40,14 @@
     {% if table %}
     <div class="card">
       <div class="table-responsive" id="object_list">
-        <h2 class="card-header">{% trans "Log" %}</h2>
+        <h2 class="card-header d-flex justify-content-between">
+          {% trans "Log" %}
+          <div>
+            <a href="?export=log" class="btn btn-primary lh-1" role="button">
+              <i class="mdi mdi-download" aria-hidden="true"></i> {% trans "Download" %}
+            </a>
+          </div>
+        </h2>
         <div class="htmx-container table-responsive"
           hx-get="{% url 'extras:script_result' job_pk=job.pk %}?embedded=True&log=True&log_threshold={{log_threshold}}"
           hx-target="this"
@@ -55,9 +62,9 @@
       <div class="card mb-3">
       <h2 class="card-header d-flex justify-content-between">
         {% trans "Output" %}
-        {% if job.completed and job.data and job.data.output %}
+        {% if job.data.output %}
         <div>
-          <a href="?export=True" class="btn btn-primary lh-1" role="button">
+          <a href="?export=output" class="btn btn-primary lh-1" role="button">
             <i class="mdi mdi-download" aria-hidden="true"></i> {% trans "Download" %}
           </a>
         </div>

--- a/netbox/templates/extras/htmx/script_result.html
+++ b/netbox/templates/extras/htmx/script_result.html
@@ -53,7 +53,16 @@
     {# Script output. Legacy reports will not have this. #}
     {% if 'output' in job.data %}
       <div class="card mb-3">
-      <h2 class="card-header">{% trans "Output" %}</h2>
+      <h2 class="card-header d-flex justify-content-between">
+        {% trans "Output" %}
+        {% if job.completed and job.data and job.data.output %}
+        <div>
+          <a href="?export=True" class="btn btn-primary lh-1" role="button">
+            <i class="mdi mdi-download" aria-hidden="true"></i> {% trans "Download" %}
+          </a>
+        </div>
+        {% endif %}
+      </h2>
         {% if job.data.output %}
           <pre class="card-body font-monospace">{{ job.data.output }}</pre>
         {% else %}

--- a/netbox/templates/extras/htmx/script_result.html
+++ b/netbox/templates/extras/htmx/script_result.html
@@ -42,11 +42,6 @@
       <div class="table-responsive" id="object_list">
         <h2 class="card-header d-flex justify-content-between">
           {% trans "Log" %}
-          <div>
-            <a href="?export=log" class="btn btn-primary lh-1" role="button">
-              <i class="mdi mdi-download" aria-hidden="true"></i> {% trans "Download" %}
-            </a>
-          </div>
         </h2>
         <div class="htmx-container table-responsive"
           hx-get="{% url 'extras:script_result' job_pk=job.pk %}?embedded=True&log=True&log_threshold={{log_threshold}}"
@@ -62,7 +57,7 @@
       <div class="card mb-3">
       <h2 class="card-header d-flex justify-content-between">
         {% trans "Output" %}
-        {% if job.data.output %}
+        {% if job.completed %}
         <div>
           <a href="?export=output" class="btn btn-primary lh-1" role="button">
             <i class="mdi mdi-download" aria-hidden="true"></i> {% trans "Download" %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19492: Add Save Button to Script Output Window
* Added download button to `script_result.html` template following the same model of `object_render_config.html`
* Added logic to `ScriptResultView.get` function to trigger content download when matching log or output.
    * Output export responds with the raw content of the script result
    * Log export responds with a CSV formatted content of the log table matching the visible table columns (works for both scripts and reports)

<!--
    Please include a summary of the proposed changes below.
-->
