### PR TITLE
Fixes #19667: Fix TypeError exception when creating a new module profile type with no schema

### DIFF
--- a/netbox/dcim/models/modules.py
+++ b/netbox/dcim/models/modules.py
@@ -144,7 +144,7 @@ class ModuleType(ImageAttachmentsMixin, PrimaryModel, WeightMixin):
         super().clean()
 
         # Validate any attributes against the assigned profile's schema
-        if self.profile:
+        if self.profile and self.profile.schema:
             try:
                 jsonschema.validate(self.attribute_data, schema=self.profile.schema)
             except JSONValidationError as e:


### PR DESCRIPTION
### Fixes: #19667

Attempt to validate the JSON schema only if one has been defined.