### PR TITLE
Fixes #19659: Populate initial device/VM selection for "add a service" button

### DIFF
--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -826,7 +826,7 @@ class ServiceForm(NetBoxModelForm):
             except ObjectDoesNotExist:
                 pass
 
-            if self.instance and parent_object_type_id != self.instance.parent_object_type_id:
+            if self.instance and self.instance.pk and parent_object_type_id != self.instance.parent_object_type_id:
                 self.initial['parent'] = None
 
     def clean(self):

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -308,7 +308,7 @@
                 {% trans "Services" %}
                 {% if perms.ipam.add_service %}
                   <div class="card-actions">
-                    <a href="{% url 'ipam:service_add' %}?device={{ object.pk }}" class="btn btn-ghost-primary btn-sm">
+                    <a href="{% url 'ipam:service_add' %}?parent_object_type={{ object|content_type_id }}&parent={{ object.pk }}" class="btn btn-ghost-primary btn-sm">
                       <span class="mdi mdi-plus-thick" aria-hidden="true"></span> {% trans "Add a service" %}
                     </a>
                   </div>

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -154,7 +154,7 @@
             {% trans "Services" %}
             {% if perms.ipam.add_service %}
               <div class="card-actions">
-                <a href="{% url 'ipam:service_add' %}?virtual_machine={{ object.pk }}" class="btn btn-ghost-primary btn-sm">
+                <a href="{% url 'ipam:service_add' %}?parent_object_type={{ object|content_type_id }}&parent={{ object.pk }}" class="btn btn-ghost-primary btn-sm">
                   <span class="mdi mdi-plus-thick" aria-hidden="true"></span> {% trans "Add a service" %}
                 </a>
               </div>


### PR DESCRIPTION
### Fixes: #19659

- Update the URL query parameters for the "add a service" buttons
- Correct a bug in the form's initialization logic