### PR TITLE
Fixes #19673: Ignore custom field references when compiling table prefetches

### DIFF
--- a/netbox/netbox/tables/tables.py
+++ b/netbox/netbox/tables/tables.py
@@ -66,6 +66,9 @@ class BaseTable(tables.Table):
                 if column.visible:
                     model = getattr(self.Meta, 'model')
                     accessor = column.accessor
+                    if accessor.startswith('custom_field_data__'):
+                        # Ignore custom field references
+                        continue
                     prefetch_path = []
                     for field_name in accessor.split(accessor.SEPARATOR):
                         try:


### PR DESCRIPTION
### Fixes: #19673

Disregard columns accessors which reference custom field data when compiling the list of fields to prefetch for the table.