### PR TITLE
Closes #19668: Remove obsolete docs publication step from release checklist

### DIFF
--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -192,15 +192,3 @@ Create a [new release](https://github.com/netbox-community/netbox/releases/new) 
 * **Description:** Copy from the pull request body, then promote the `###` headers to `##` ones
 
 Once created, the release will become available for users to install.
-
-### Update the Public Documentation
-
-After a release has been published, the public NetBox documentation needs to be updated. This is accomplished by running two actions on the [netboxlabs-docs](https://github.com/netboxlabs/netboxlabs-docs) repository.
-
-First, run the `build-site` action, by navigating to Actions > build-site > Run workflow. This process compiles the documentation along with an overlay for integration with the documentation portal at <https://netboxlabs.com/docs>. The job should take about two minutes.
-
-Once the documentation files have been compiled, they must be published by running the `deploy-kinsta` action. Select the desired deployment environment (staging or production) and specify `latest` as the deploy tag.
-
-Clear the CDN cache from the [Kinsta](https://my.kinsta.com/) portal. Navigate to _Sites_ / _NetBox Labs_ / _Live_, select _Cache_ in the left-nav, click the _Clear Cache_ button, and confirm the clear operation.
-
-Finally, verify that the documentation at <https://netboxlabs.com/docs/netbox/en/stable/> has been updated.


### PR DESCRIPTION
### Closes: #19668
