### PR TITLE
Fixes #19665: Fix incorrect field reference in WirelessLink validation

### DIFF
--- a/netbox/wireless/models.py
+++ b/netbox/wireless/models.py
@@ -206,7 +206,7 @@ class WirelessLink(WirelessAuthenticationBase, DistanceMixin, PrimaryModel):
             })
         if self.interface_b.type not in WIRELESS_IFACE_TYPES:
             raise ValidationError({
-                'interface_a': _(
+                'interface_b': _(
                     "{type} is not a wireless interface."
                 ).format(type=self.interface_b.get_type_display())
             })


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19665 – WirelessLink model validation references wrong field

This PR corrects a validation error in the `WirelessLink` model where the error message incorrectly referenced `interface_a` instead of `interface_b`. The fix ensures that validation errors are associated with the correct field, improving the accuracy of user feedback.
