### PR TITLE
Fixes #19677 - Call none() when VRF is None in IPAddress and Prefix `filter_present_in_vrf`filters

### DIFF
--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -449,7 +449,7 @@ class PrefixFilterSet(NetBoxModelFilterSet, ScopedFilterSet, TenancyFilterSet, C
     @extend_schema_field(OpenApiTypes.STR)
     def filter_present_in_vrf(self, queryset, name, vrf):
         if vrf is None:
-            return queryset.none
+            return queryset.none()
         return queryset.filter(
             Q(vrf=vrf) |
             Q(vrf__export_targets__in=vrf.import_targets.all())
@@ -729,7 +729,7 @@ class IPAddressFilterSet(NetBoxModelFilterSet, TenancyFilterSet, ContactModelFil
     @extend_schema_field(OpenApiTypes.STR)
     def filter_present_in_vrf(self, queryset, name, vrf):
         if vrf is None:
-            return queryset.none
+            return queryset.none()
         return queryset.filter(
             Q(vrf=vrf) |
             Q(vrf__export_targets__in=vrf.import_targets.all())


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19677 - IPAM FilterSet: filter_present_in_vrf method returns queryset.none instead of calling it when VRF is None

Ensures the `queryset.none()` method is called properly with parentheses. This fixes a potential issue where the method would not execute as intended, improving the stability and correctness of the filter logic.
