### PR TITLE
Closes #19499 - Add WirelessLink Bulk Import Support by Device and Interface Names

### DIFF
--- a/netbox/wireless/models.py
+++ b/netbox/wireless/models.py
@@ -198,13 +198,13 @@ class WirelessLink(WirelessAuthenticationBase, DistanceMixin, PrimaryModel):
         super().clean()
 
         # Validate interface types
-        if self.interface_a.type not in WIRELESS_IFACE_TYPES:
+        if hasattr(self, "interface_a") and self.interface_a.type not in WIRELESS_IFACE_TYPES:
             raise ValidationError({
                 'interface_a': _(
                     "{type} is not a wireless interface."
                 ).format(type=self.interface_a.get_type_display())
             })
-        if self.interface_b.type not in WIRELESS_IFACE_TYPES:
+        if hasattr(self, "interface_b") and self.interface_b.type not in WIRELESS_IFACE_TYPES:
             raise ValidationError({
                 'interface_b': _(
                     "{type} is not a wireless interface."

--- a/netbox/wireless/tests/test_views.py
+++ b/netbox/wireless/tests/test_views.py
@@ -198,10 +198,10 @@ class WirelessLinkTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         }
 
         cls.csv_data = (
-            "interface_a,interface_b,status,tenant",
-            f"{interfaces[6].pk},{interfaces[7].pk},connected,{tenants[0].name}",
-            f"{interfaces[8].pk},{interfaces[9].pk},connected,{tenants[1].name}",
-            f"{interfaces[10].pk},{interfaces[11].pk},connected,{tenants[2].name}",
+            "device_a,interface_a,device_b,interface_b,status,tenant",
+            f"{interfaces[6].device.name},{interfaces[6].name},{interfaces[7].device.name},{interfaces[7].name},connected,{tenants[0].name}",
+            f"{interfaces[8].device.name},{interfaces[8].name},{interfaces[9].device.name},{interfaces[9].name},connected,{tenants[1].name}",
+            f"{interfaces[10].device.name},{interfaces[10].name},{interfaces[11].device.name},{interfaces[11].name},connected,{tenants[2].name}",
         )
 
         cls.csv_update_data = (


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19499 - Wireless Link Bulk Import-Device/interface

* Enhances the WirelessLink bulk import form to support specifying site and device for both terminations (A and B), with dynamic queryset filtering based on selection. Also allows interfaces to be referenced by name (instead of ID) during import, improving usability for CSV workflows.
* Modifies the CSV data structure in WirelessLink test cases to include device names alongside interface names for both terminations.
