### PR TITLE
Fixes #19617: Inconsistent styling of Connect buttons

### DIFF
--- a/netbox/templates/circuits/inc/circuit_termination_fields.html
+++ b/netbox/templates/circuits/inc/circuit_termination_fields.html
@@ -45,7 +45,7 @@
         </div>
       {% elif perms.dcim.add_cable %}
         <div class="dropdown">
-          <button type="button" class="btn btn-success dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+          <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span> {% trans "Connect" %}
           </button>
           <ul class="dropdown-menu">

--- a/netbox/templates/dcim/consoleport.html
+++ b/netbox/templates/dcim/consoleport.html
@@ -65,7 +65,7 @@
                 {% trans "Not Connected" %}
                 {% if perms.dcim.add_cable %}
                   <div class="dropdown float-end">
-                    <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+                    <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
                       <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span> {% trans "Connect" %}
                     </button>
                     <ul class="dropdown-menu dropdown-menu-end">

--- a/netbox/templates/dcim/consoleserverport.html
+++ b/netbox/templates/dcim/consoleserverport.html
@@ -65,7 +65,7 @@
                 {% trans "Not Connected" %}
                 {% if perms.dcim.add_cable %}
                   <div class="dropdown float-end">
-                    <button type="button" class="btn btn-primary btn-sm dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+                    <button type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
                       <span class="mdi mdi-ethernet-cable" aria-hidden="true"></span> {% trans "Connect" %}
                     </button>
                     <ul class="dropdown-menu dropdown-menu-end">

--- a/netbox/templates/dcim/powerfeed.html
+++ b/netbox/templates/dcim/powerfeed.html
@@ -117,16 +117,14 @@
           {% include 'dcim/inc/connection_endpoints.html' with trace_url='dcim:powerfeed_trace' %}
         {% else %}
           <div class="card-body text-muted">
-            {% trans "Not connected" %}
-          </div>
+          {% trans "Not connected" %}
         {% endif %}
         {% if not object.mark_connected and not object.cable %}
-          <div class="card-footer">
-            {% if perms.dcim.add_cable %}
-              <a href="{% url 'dcim:cable_add' %}?a_terminations_type=dcim.powerfeed&a_terminations={{ object.pk }}&b_terminations_type=dcim.powerport&return_url={{ object.get_absolute_url }}" class="btn btn-primary float-end">
-                <i class="mdi mdi-ethernet-cable" aria-hidden="true"></i> {% trans "Connect" %}
-              </a>
-            {% endif %}
+          {% if perms.dcim.add_cable %}
+            <a href="{% url 'dcim:cable_add' %}?a_terminations_type=dcim.powerfeed&a_terminations={{ object.pk }}&b_terminations_type=dcim.powerport&return_url={{ object.get_absolute_url }}" class="btn btn-primary float-end">
+              <i class="mdi mdi-ethernet-cable" aria-hidden="true"></i> {% trans "Connect" %}
+            </a>
+          {% endif %}
           </div>
         {% endif %}
       </div>

--- a/netbox/templates/dcim/powerfeed.html
+++ b/netbox/templates/dcim/powerfeed.html
@@ -117,14 +117,12 @@
           {% include 'dcim/inc/connection_endpoints.html' with trace_url='dcim:powerfeed_trace' %}
         {% else %}
           <div class="card-body text-muted">
-          {% trans "Not connected" %}
-        {% endif %}
-        {% if not object.mark_connected and not object.cable %}
-          {% if perms.dcim.add_cable %}
-            <a href="{% url 'dcim:cable_add' %}?a_terminations_type=dcim.powerfeed&a_terminations={{ object.pk }}&b_terminations_type=dcim.powerport&return_url={{ object.get_absolute_url }}" class="btn btn-primary float-end">
-              <i class="mdi mdi-ethernet-cable" aria-hidden="true"></i> {% trans "Connect" %}
-            </a>
-          {% endif %}
+            {% trans "Not connected" %}
+            {% if perms.dcim.add_cable %}
+              <a href="{% url 'dcim:cable_add' %}?a_terminations_type=dcim.powerfeed&a_terminations={{ object.pk }}&b_terminations_type=dcim.powerport&return_url={{ object.get_absolute_url }}" class="btn btn-primary float-end">
+                <i class="mdi mdi-ethernet-cable" aria-hidden="true"></i> {% trans "Connect" %}
+              </a>
+            {% endif %}
           </div>
         {% endif %}
       </div>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19617

- Updates the styling of Connect buttons on the Circuit, Console Ports, and Console Server Port pages to make them consistent with others across the UI
- On the Power Feed page, moved the Connect button from the footer of the Connection card to the body