### PR TITLE
Fixes #19687 - Treat cellular interface type as not connectable

### DIFF
--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -53,6 +53,11 @@ WIRELESS_IFACE_TYPES = [
     InterfaceTypeChoices.TYPE_802151,
     InterfaceTypeChoices.TYPE_802154,
     InterfaceTypeChoices.TYPE_OTHER_WIRELESS,
+    InterfaceTypeChoices.TYPE_GSM,
+    InterfaceTypeChoices.TYPE_CDMA,
+    InterfaceTypeChoices.TYPE_LTE,
+    InterfaceTypeChoices.TYPE_4G,
+    InterfaceTypeChoices.TYPE_5G,
 ]
 
 NONCONNECTABLE_IFACE_TYPES = VIRTUAL_IFACE_TYPES + WIRELESS_IFACE_TYPES

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -954,6 +954,7 @@ class CableTestCase(TestCase):
         with self.assertRaises(ValidationError):
             cable.clean()
 
+    @tag('regression')
     def test_cable_cannot_terminate_to_a_cellular_interface(self):
         """
         A cable cannot terminate to a cellular interface

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -954,6 +954,18 @@ class CableTestCase(TestCase):
         with self.assertRaises(ValidationError):
             cable.clean()
 
+    def test_cable_cannot_terminate_to_a_cellular_interface(self):
+        """
+        A cable cannot terminate to a cellular interface
+        """
+        device1 = Device.objects.get(name='TestDevice1')
+        interface2 = Interface.objects.get(device__name='TestDevice2', name='eth0')
+
+        cellular_interface = Interface(device=device1, name="W1", type=InterfaceTypeChoices.TYPE_LTE)
+        cable = Cable(a_terminations=[interface2], b_terminations=[cellular_interface])
+        with self.assertRaises(ValidationError):
+            cable.clean()
+
 
 class VirtualDeviceContextTestCase(TestCase):
 


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19687

<!--
    Please include a summary of the proposed changes below.
-->
Add cellular interface types to WIRELESS_IFACE_TYPES const
Add cable termination test for cellular interface