### PR TITLE
19555 fix script API validation for scheduled_at

### DIFF
--- a/netbox/extras/api/serializers_/scripts.py
+++ b/netbox/extras/api/serializers_/scripts.py
@@ -66,11 +66,11 @@ class ScriptInputSerializer(serializers.Serializer):
     interval = serializers.IntegerField(required=False, allow_null=True)
 
     def validate_schedule_at(self, value):
-        if value and not self.context['script'].scheduling_enabled:
+        if value and not self.context['script'].python_class.scheduling_enabled:
             raise serializers.ValidationError(_("Scheduling is not enabled for this script."))
         return value
 
     def validate_interval(self, value):
-        if value and not self.context['script'].scheduling_enabled:
+        if value and not self.context['script'].python_class.scheduling_enabled:
             raise serializers.ValidationError(_("Scheduling is not enabled for this script."))
         return value

--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -270,7 +270,7 @@ class ScriptViewSet(ModelViewSet):
             module_name, script_name = pk.split('.', maxsplit=1)
         except ValueError:
             raise Http404
-        print(f"module_name: {module_name} script_name: {script_name}")
+
         return get_object_or_404(self.queryset, module__file_path=f'{module_name}.py', name=script_name)
 
     def retrieve(self, request, pk):

--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -270,6 +270,7 @@ class ScriptViewSet(ModelViewSet):
             module_name, script_name = pk.split('.', maxsplit=1)
         except ValueError:
             raise Http404
+        print(f"module_name: {module_name} script_name: {script_name}")
         return get_object_or_404(self.queryset, module__file_path=f'{module_name}.py', name=script_name)
 
     def retrieve(self, request, pk):


### PR DESCRIPTION
### Fixes: #19555 

Fixes verification check on Script API call when using schedule_at or interval.  Note: If testing this will probably run into #19529 which also affects script calling via API.