### PR TITLE
19529 fix CLI running of scripts

### DIFF
--- a/netbox/extras/forms/scripts.py
+++ b/netbox/extras/forms/scripts.py
@@ -1,13 +1,8 @@
-import os
-
-from django import forms
-from django.conf import settings
-from django.core.files.storage import storages
-from django.utils.translation import gettext_lazy as _
-
 from core.choices import JobIntervalChoices
 from core.forms import ManagedFileForm
-from extras.storage import ScriptFileSystemStorage
+from django import forms
+from django.core.files.storage import storages
+from django.utils.translation import gettext_lazy as _
 from utilities.datetime import local_now
 from utilities.forms.widgets import DateTimePicker, NumberWithOptions
 
@@ -74,12 +69,7 @@ class ScriptFileForm(ManagedFileForm):
             storage = storages.create_storage(storages.backends["scripts"])
 
             filename = self.cleaned_data['upload_file'].name
-            if isinstance(storage, ScriptFileSystemStorage):
-                full_path = os.path.join(settings.SCRIPTS_ROOT, filename)
-            else:
-                full_path = filename
-
-            self.instance.file_path = full_path
+            self.instance.file_path = filename
             data = self.cleaned_data['upload_file']
             storage.save(filename, data)
 

--- a/netbox/extras/migrations/0129_fix_script_paths.py
+++ b/netbox/extras/migrations/0129_fix_script_paths.py
@@ -38,3 +38,20 @@ class Migration(migrations.Migration):
     operations = [
         migrations.RunPython(code=fix_script_paths, reverse_code=migrations.RunPython.noop),
     ]
+
+
+def oc_fix_script_paths(objectchange, reverting):
+    script_root_path = normalize(settings.SCRIPTS_ROOT)
+
+    for data in (objectchange.prechange_data, objectchange.postchange_data):
+        if data is None:
+            continue
+
+        if file_path := data.get('file_path'):
+            if file_path.startswith(script_root_path):
+                data['file_path'] = file_path[len(script_root_path):]
+
+
+objectchange_migrators = {
+    'extras.scriptmodule': oc_fix_script_paths,
+}

--- a/netbox/extras/migrations/0129_fix_script_paths.py
+++ b/netbox/extras/migrations/0129_fix_script_paths.py
@@ -23,10 +23,9 @@ def fix_script_paths(apps, schema_editor):
 
     ScriptModule = apps.get_model('extras', 'ScriptModule')
     script_root_path = normalize(settings.SCRIPTS_ROOT)
-    for script in ScriptModule.objects.all():
-        if script.file_path.startswith(script_root_path):
-            script.file_path = script.file_path[len(script_root_path):]
-            script.save()
+    for script in ScriptModule.object.filter(file_path__startswith=script_root_path):
+        script.file_path = script.file_path[len(script_root_path):]
+        script.save()
 
 
 class Migration(migrations.Migration):

--- a/netbox/extras/migrations/0129_fix_script_paths.py
+++ b/netbox/extras/migrations/0129_fix_script_paths.py
@@ -1,8 +1,13 @@
 from django.conf import settings
 from django.core.files.storage import storages
 from django.db import migrations
+from urllib.parse import urlparse
 
 from extras.storage import ScriptFileSystemStorage
+
+
+def normalize(url):
+    return url if urlparse(url).path else url + "/"
 
 
 def fix_script_paths(apps, schema_editor):
@@ -14,9 +19,10 @@ def fix_script_paths(apps, schema_editor):
         return
 
     ScriptModule = apps.get_model('extras', 'ScriptModule')
+    script_root_path = normalize(settings.SCRIPTS_ROOT)
     for script in ScriptModule.objects.all():
-        if script.file_path.startswith(settings.SCRIPTS_ROOT):
-            script.file_path = script.file_path[len(settings.SCRIPTS_ROOT):]
+        if script.file_path.startswith(script_root_path):
+            script.file_path = script.file_path[len(script_root_path):]
             script.save()
 
 

--- a/netbox/extras/migrations/0129_fix_script_paths.py
+++ b/netbox/extras/migrations/0129_fix_script_paths.py
@@ -1,0 +1,31 @@
+from django.conf import settings
+from django.core.files.storage import storages
+from django.db import migrations
+
+from extras.storage import ScriptFileSystemStorage
+
+
+def fix_script_paths(apps, schema_editor):
+    """
+    Fix script paths for scripts that had incorrect path from NB 4.3.
+    """
+    storage = storages.create_storage(storages.backends["scripts"])
+    if not isinstance(storage, ScriptFileSystemStorage):
+        return
+
+    ScriptModule = apps.get_model('extras', 'ScriptModule')
+    for script in ScriptModule.objects.all():
+        if script.file_path.startswith(settings.SCRIPTS_ROOT):
+            script.file_path = script.file_path[len(settings.SCRIPTS_ROOT):]
+            script.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('extras', '0128_tableconfig'),
+    ]
+
+    operations = [
+        migrations.RunPython(code=fix_script_paths, reverse_code=migrations.RunPython.noop),
+    ]

--- a/netbox/extras/migrations/0129_fix_script_paths.py
+++ b/netbox/extras/migrations/0129_fix_script_paths.py
@@ -23,7 +23,7 @@ def fix_script_paths(apps, schema_editor):
 
     ScriptModule = apps.get_model('extras', 'ScriptModule')
     script_root_path = normalize(settings.SCRIPTS_ROOT)
-    for script in ScriptModule.object.filter(file_path__startswith=script_root_path):
+    for script in ScriptModule.objects.filter(file_path__startswith=script_root_path):
         script.file_path = script.file_path[len(script_root_path):]
         script.save()
 

--- a/netbox/extras/migrations/0129_fix_script_paths.py
+++ b/netbox/extras/migrations/0129_fix_script_paths.py
@@ -7,7 +7,10 @@ from extras.storage import ScriptFileSystemStorage
 
 
 def normalize(url):
-    return url if urlparse(url).path else url + "/"
+    parsed_url = urlparse(url)
+    if not parsed_url.path.endswith('/'):
+        return url + '/'
+    return url
 
 
 def fix_script_paths(apps, schema_editor):


### PR DESCRIPTION
### Fixes: #19529 

In the file storage case (non Cloud storage) the full path (including SCRIPT_ROOT) was getting saved to the ManagedFile.  This issue was masked as the UI Script code handles that condition correctly, but it causes problems when running via the CLI or API.

Also includes a migration to remove the full-path if it exists in Script files, but is skipped if using Cloud storage.  Cloud storage scripts are not effected.

* tested old script - added from main git branch
* tested new script added in this git branch
* tested git data source (used: https://github.com/netbox-community/customizations - the scripts/find_orphaned_cables.py is a good one)