### PR TITLE
Fixes #19702: add NotificationGroup.event_rules GenericRelation

### DIFF
--- a/netbox/extras/models/notifications.py
+++ b/netbox/extras/models/notifications.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 
 from django.conf import settings
-from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.urls import reverse
@@ -143,6 +143,12 @@ class NotificationGroup(ChangeLoggedModel):
         verbose_name=_('users'),
         blank=True,
         related_name='notification_groups'
+    )
+    event_rules = GenericRelation(
+        to='extras.EventRule',
+        content_type_field='action_object_type',
+        object_id_field='action_object_id',
+        related_query_name='+'
     )
 
     objects = RestrictedQuerySet.as_manager()


### PR DESCRIPTION
### Fixes: #19702

The collector we use to notify users about dependent objects that will be deleted does handle GFKs. However, a GenericRelation must be set up on the other end.

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->

<!--
    Please include a summary of the proposed changes below.
-->
