### PR TITLE
Closes #19692: Unnecessary DB queries for API Endpoints

### DIFF
--- a/netbox/ipam/api/views.py
+++ b/netbox/ipam/api/views.py
@@ -143,7 +143,7 @@ class FHRPGroupAssignmentViewSet(NetBoxModelViewSet):
 
 
 class VLANGroupViewSet(NetBoxModelViewSet):
-    queryset = VLANGroup.objects.annotate_utilization()
+    queryset = VLANGroup.objects.annotate_utilization().prefetch_related('scope')
     serializer_class = serializers.VLANGroupSerializer
     filterset_class = filtersets.VLANGroupFilterSet
 
@@ -175,7 +175,7 @@ class ServiceTemplateViewSet(NetBoxModelViewSet):
 
 
 class ServiceViewSet(NetBoxModelViewSet):
-    queryset = Service.objects.all()
+    queryset = Service.objects.prefetch_related('parent')
     serializer_class = serializers.ServiceSerializer
     filterset_class = filtersets.ServiceFilterSet
 

--- a/netbox/virtualization/api/views.py
+++ b/netbox/virtualization/api/views.py
@@ -34,7 +34,7 @@ class ClusterGroupViewSet(NetBoxModelViewSet):
 
 
 class ClusterViewSet(NetBoxModelViewSet):
-    queryset = Cluster.objects.prefetch_related('virtual_machines').annotate(
+    queryset = Cluster.objects.prefetch_related('virtual_machines', 'scope').annotate(
         allocated_vcpus=Sum('virtual_machines__vcpus'),
         allocated_memory=Sum('virtual_machines__memory'),
         allocated_disk=Sum('virtual_machines__disk'),


### PR DESCRIPTION
### Fixes: #19692

Just adds a few prefetches for the API endpoints

- ipam/vlan-groups
- ipam/services
- virtualization/clusters