### PR TITLE
Fixes #19745: properly check IP assignment to FHRPGroup

### DIFF
--- a/netbox/ipam/forms/bulk_import.py
+++ b/netbox/ipam/forms/bulk_import.py
@@ -633,7 +633,10 @@ class ServiceImportForm(NetBoxModelImportForm):
         # triggered
         parent = self.cleaned_data.get('parent')
         for ip_address in self.cleaned_data.get('ipaddresses', []):
-            if not ip_address.assigned_object or getattr(ip_address.assigned_object, 'parent_object') != parent:
+            if not (assigned := ip_address.assigned_object) or (        # no assigned object
+                (isinstance(parent, FHRPGroup) and assigned != parent)  # assigned to FHRPGroup
+                and getattr(assigned, 'parent_object') != parent        # assigned to [VM]Interface
+            ):
                 raise forms.ValidationError(
                     _("{ip} is not assigned to this parent.").format(ip=ip_address)
                 )

--- a/netbox/ipam/tests/test_views.py
+++ b/netbox/ipam/tests/test_views.py
@@ -1068,6 +1068,9 @@ class ServiceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         role = DeviceRole.objects.create(name='Device Role 1', slug='device-role-1')
         device = Device.objects.create(name='Device 1', site=site, device_type=devicetype, role=role)
         interface = Interface.objects.create(device=device, name='Interface 1', type=InterfaceTypeChoices.TYPE_VIRTUAL)
+        fhrp_group = FHRPGroup.objects.create(
+            name='Group 1', group_id=1234, protocol=FHRPGroupProtocolChoices.PROTOCOL_CARP
+        )
 
         services = (
             Service(parent=device, name='Service 1', protocol=ServiceProtocolChoices.PROTOCOL_TCP, ports=[101]),
@@ -1079,6 +1082,7 @@ class ServiceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         ip_addresses = (
             IPAddress(assigned_object=interface, address='192.0.2.1/24'),
             IPAddress(assigned_object=interface, address='192.0.2.2/24'),
+            IPAddress(assigned_object=fhrp_group, address='192.0.2.3/24'),
         )
         IPAddress.objects.bulk_create(ip_addresses)
 
@@ -1100,6 +1104,7 @@ class ServiceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             "dcim.device,Device 1,Service 1,tcp,1,192.0.2.1/24,First service",
             "dcim.device,Device 1,Service 2,tcp,2,192.0.2.2/24,Second service",
             "dcim.device,Device 1,Service 3,udp,3,,Third service",
+            "ipam.fhrpgroup,Group 1,Service 4,udp,4,192.0.2.3/24,Fourth service",
         )
 
         cls.csv_update_data = (


### PR DESCRIPTION
### Fixes: #19745

- Expands the logic in ServiceImportForm.clean() to handle properly validation of FHRPGroup assignments and maintain the existing [VM]Interface validation checks.
- Includes an extension to ServiceTestCase.csv_data to act as a regression test for this behavior.

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->

<!--
    Please include a summary of the proposed changes below.
-->
