### PR TITLE
Closes #19231: Add bulk renaming support for all models

### DIFF
--- a/docs/plugins/development/views.md
+++ b/docs/plugins/development/views.md
@@ -64,6 +64,7 @@ Generic view classes (documented below) facilitate common operations, such as cr
 | `ObjectListView`     | View a list of objects                                 |
 | `BulkImportView`     | Import a set of new objects                            |
 | `BulkEditView`       | Edit multiple objects                                  |
+| `BulkRenameView`     | Rename multiple objects                                |
 | `BulkDeleteView`     | Delete multiple objects                                |
 
 !!! warning
@@ -168,6 +169,10 @@ Below are the class definitions for NetBox's multi-object views. These views han
         - save_object
 
 ::: netbox.views.generic.BulkEditView
+    options:
+      members: false
+
+::: netbox.views.generic.BulkRenameView
     options:
       members: false
 

--- a/netbox/circuits/views.py
+++ b/netbox/circuits/views.py
@@ -79,6 +79,11 @@ class ProviderBulkEditView(generic.BulkEditView):
     form = forms.ProviderBulkEditForm
 
 
+@register_model_view(Provider, 'bulk_rename', path='rename', detail=False)
+class ProviderBulkRenameView(generic.BulkRenameView):
+    queryset = Provider.objects.all()
+
+
 @register_model_view(Provider, 'bulk_delete', path='delete', detail=False)
 class ProviderBulkDeleteView(generic.BulkDeleteView):
     queryset = Provider.objects.annotate(
@@ -139,6 +144,11 @@ class ProviderAccountBulkEditView(generic.BulkEditView):
     filterset = filtersets.ProviderAccountFilterSet
     table = tables.ProviderAccountTable
     form = forms.ProviderAccountBulkEditForm
+
+
+@register_model_view(ProviderAccount, 'bulk_rename', path='rename', detail=False)
+class ProviderAccountBulkRenameView(generic.BulkRenameView):
+    queryset = ProviderAccount.objects.all()
 
 
 @register_model_view(ProviderAccount, 'bulk_delete', path='delete', detail=False)
@@ -212,6 +222,11 @@ class ProviderNetworkBulkEditView(generic.BulkEditView):
     form = forms.ProviderNetworkBulkEditForm
 
 
+@register_model_view(ProviderNetwork, 'bulk_rename', path='rename', detail=False)
+class ProviderNetworkBulkRenameView(generic.BulkRenameView):
+    queryset = ProviderNetwork.objects.all()
+
+
 @register_model_view(ProviderNetwork, 'bulk_delete', path='delete', detail=False)
 class ProviderNetworkBulkDeleteView(generic.BulkDeleteView):
     queryset = ProviderNetwork.objects.all()
@@ -269,6 +284,11 @@ class CircuitTypeBulkEditView(generic.BulkEditView):
     filterset = filtersets.CircuitTypeFilterSet
     table = tables.CircuitTypeTable
     form = forms.CircuitTypeBulkEditForm
+
+
+@register_model_view(CircuitType, 'bulk_rename', path='rename', detail=False)
+class CircuitTypeBulkRenameView(generic.BulkRenameView):
+    queryset = CircuitType.objects.all()
 
 
 @register_model_view(CircuitType, 'bulk_delete', path='delete', detail=False)
@@ -526,6 +546,11 @@ class CircuitGroupBulkEditView(generic.BulkEditView):
     form = forms.CircuitGroupBulkEditForm
 
 
+@register_model_view(CircuitGroup, 'bulk_rename', path='rename', detail=False)
+class CircuitGroupBulkRenameView(generic.BulkRenameView):
+    queryset = CircuitGroup.objects.all()
+
+
 @register_model_view(CircuitGroup, 'bulk_delete', path='delete', detail=False)
 class CircuitGroupBulkDeleteView(generic.BulkDeleteView):
     queryset = CircuitGroup.objects.all()
@@ -633,6 +658,11 @@ class VirtualCircuitTypeBulkEditView(generic.BulkEditView):
     filterset = filtersets.VirtualCircuitTypeFilterSet
     table = tables.VirtualCircuitTypeTable
     form = forms.VirtualCircuitTypeBulkEditForm
+
+
+@register_model_view(VirtualCircuitType, 'bulk_rename', path='rename', detail=False)
+class VirtualCircuitTypeBulkRenameView(generic.BulkRenameView):
+    queryset = VirtualCircuitType.objects.all()
 
 
 @register_model_view(VirtualCircuitType, 'bulk_delete', path='delete', detail=False)

--- a/netbox/circuits/views.py
+++ b/netbox/circuits/views.py
@@ -5,6 +5,7 @@ from django.utils.translation import gettext_lazy as _
 
 from dcim.views import PathTraceView
 from ipam.models import ASN
+from netbox.object_actions import AddObject, BulkDelete, BulkEdit, BulkExport, BulkImport
 from netbox.views import generic
 from utilities.forms import ConfirmationForm
 from utilities.query import count_related
@@ -357,6 +358,12 @@ class CircuitBulkEditView(generic.BulkEditView):
     form = forms.CircuitBulkEditForm
 
 
+@register_model_view(Circuit, 'bulk_rename', path='rename', detail=False)
+class CircuitBulkRenameView(generic.BulkRenameView):
+    queryset = Circuit.objects.all()
+    field_name = 'cid'
+
+
 @register_model_view(Circuit, 'bulk_delete', path='delete', detail=False)
 class CircuitBulkDeleteView(generic.BulkDeleteView):
     queryset = Circuit.objects.prefetch_related(
@@ -452,6 +459,7 @@ class CircuitTerminationListView(generic.ObjectListView):
     filterset = filtersets.CircuitTerminationFilterSet
     filterset_form = forms.CircuitTerminationFilterForm
     table = tables.CircuitTerminationTable
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkDelete)
 
 
 @register_model_view(CircuitTermination)
@@ -568,6 +576,7 @@ class CircuitGroupAssignmentListView(generic.ObjectListView):
     filterset = filtersets.CircuitGroupAssignmentFilterSet
     filterset_form = forms.CircuitGroupAssignmentFilterForm
     table = tables.CircuitGroupAssignmentTable
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkDelete)
 
 
 @register_model_view(CircuitGroupAssignment)
@@ -727,6 +736,12 @@ class VirtualCircuitBulkEditView(generic.BulkEditView):
     form = forms.VirtualCircuitBulkEditForm
 
 
+@register_model_view(VirtualCircuit, 'bulk_rename', path='rename', detail=False)
+class VirtualCircuitulkRenameView(generic.BulkRenameView):
+    queryset = VirtualCircuit.objects.all()
+    field_name = 'cid'
+
+
 class VirtualCircuitBulkDeleteView(generic.BulkDeleteView):
     queryset = VirtualCircuit.objects.annotate(
         termination_count=count_related(VirtualCircuitTermination, 'virtual_circuit')
@@ -744,6 +759,7 @@ class VirtualCircuitTerminationListView(generic.ObjectListView):
     filterset = filtersets.VirtualCircuitTerminationFilterSet
     filterset_form = forms.VirtualCircuitTerminationFilterForm
     table = tables.VirtualCircuitTerminationTable
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkDelete)
 
 
 @register_model_view(VirtualCircuitTermination)

--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -120,6 +120,11 @@ class DataSourceBulkEditView(generic.BulkEditView):
     form = forms.DataSourceBulkEditForm
 
 
+@register_model_view(DataSource, 'bulk_rename', path='rename', detail=False)
+class DataSourceBulkRenameView(generic.BulkRenameView):
+    queryset = DataSource.objects.all()
+
+
 @register_model_view(DataSource, 'bulk_delete', path='delete', detail=False)
 class DataSourceBulkDeleteView(generic.BulkDeleteView):
     queryset = DataSource.objects.annotate(

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -756,6 +756,12 @@ class RackTypeBulkEditView(generic.BulkEditView):
     form = forms.RackTypeBulkEditForm
 
 
+@register_model_view(RackType, 'bulk_rename', path='rename', detail=False)
+class RackTypeBulkRenameView(generic.BulkRenameView):
+    queryset = RackType.objects.all()
+    field_name = 'model'
+
+
 @register_model_view(RackType, 'bulk_delete', path='delete', detail=False)
 class RackTypeBulkDeleteView(generic.BulkDeleteView):
     queryset = RackType.objects.all()
@@ -957,6 +963,7 @@ class RackReservationListView(generic.ObjectListView):
     filterset = filtersets.RackReservationFilterSet
     filterset_form = forms.RackReservationFilterForm
     table = tables.RackReservationTable
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkDelete)
 
 
 @register_model_view(RackReservation)
@@ -1325,6 +1332,12 @@ class DeviceTypeBulkEditView(generic.BulkEditView):
     form = forms.DeviceTypeBulkEditForm
 
 
+@register_model_view(DeviceType, 'bulk_rename', path='rename', detail=False)
+class DeviceTypeBulkRenameView(generic.BulkRenameView):
+    queryset = DeviceType.objects.all()
+    field_name = 'model'
+
+
 @register_model_view(DeviceType, 'bulk_delete', path='delete', detail=False)
 class DeviceTypeBulkDeleteView(generic.BulkDeleteView):
     queryset = DeviceType.objects.annotate(
@@ -1594,6 +1607,11 @@ class ModuleTypeBulkEditView(generic.BulkEditView):
     filterset = filtersets.ModuleTypeFilterSet
     table = tables.ModuleTypeTable
     form = forms.ModuleTypeBulkEditForm
+
+
+@register_model_view(ModuleType, 'bulk_rename', path='rename', detail=False)
+class ModuleTypeBulkRenameView(generic.BulkRenameView):
+    queryset = ModuleType.objects.all()
 
 
 @register_model_view(ModuleType, 'bulk_delete', path='delete', detail=False)
@@ -2448,6 +2466,7 @@ class ModuleListView(generic.ObjectListView):
     filterset = filtersets.ModuleFilterSet
     filterset_form = forms.ModuleFilterForm
     table = tables.ModuleTable
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkDelete)
 
 
 @register_model_view(Module)
@@ -3593,6 +3612,12 @@ class CableBulkEditView(generic.BulkEditView):
     form = forms.CableBulkEditForm
 
 
+@register_model_view(Cable, 'bulk_rename', path='rename', detail=False)
+class CableBulkRenameView(generic.BulkRenameView):
+    queryset = Cable.objects.all()
+    field_name = 'label'
+
+
 @register_model_view(Cable, 'bulk_delete', path='delete', detail=False)
 class CableBulkDeleteView(generic.BulkDeleteView):
     queryset = Cable.objects.prefetch_related(
@@ -4104,6 +4129,7 @@ class MACAddressListView(generic.ObjectListView):
     filterset = filtersets.MACAddressFilterSet
     filterset_form = forms.MACAddressFilterForm
     table = tables.MACAddressTable
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkDelete)
 
 
 @register_model_view(MACAddress)

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -292,6 +292,11 @@ class RegionBulkEditView(generic.BulkEditView):
     form = forms.RegionBulkEditForm
 
 
+@register_model_view(Region, 'bulk_rename', path='rename', detail=False)
+class RegionBulkRenameView(generic.BulkRenameView):
+    queryset = Region.objects.all()
+
+
 @register_model_view(Region, 'bulk_delete', path='delete', detail=False)
 class RegionBulkDeleteView(generic.BulkDeleteView):
     queryset = Region.objects.add_related_count(
@@ -418,6 +423,11 @@ class SiteGroupBulkEditView(generic.BulkEditView):
     form = forms.SiteGroupBulkEditForm
 
 
+@register_model_view(SiteGroup, 'bulk_rename', path='rename', detail=False)
+class SiteGroupBulkRenameView(generic.BulkRenameView):
+    queryset = SiteGroup.objects.all()
+
+
 @register_model_view(SiteGroup, 'bulk_delete', path='delete', detail=False)
 class SiteGroupBulkDeleteView(generic.BulkDeleteView):
     queryset = SiteGroup.objects.add_related_count(
@@ -501,6 +511,11 @@ class SiteBulkEditView(generic.BulkEditView):
     filterset = filtersets.SiteFilterSet
     table = tables.SiteTable
     form = forms.SiteBulkEditForm
+
+
+@register_model_view(Site, 'bulk_rename', path='rename', detail=False)
+class SiteBulkRenameView(generic.BulkRenameView):
+    queryset = Site.objects.all()
 
 
 @register_model_view(Site, 'bulk_delete', path='delete', detail=False)
@@ -607,6 +622,11 @@ class LocationBulkEditView(generic.BulkEditView):
     form = forms.LocationBulkEditForm
 
 
+@register_model_view(Location, 'bulk_rename', path='rename', detail=False)
+class LocationBulkRenameView(generic.BulkRenameView):
+    queryset = Location.objects.all()
+
+
 @register_model_view(Location, 'bulk_delete', path='delete', detail=False)
 class LocationBulkDeleteView(generic.BulkDeleteView):
     queryset = Location.objects.add_related_count(
@@ -670,6 +690,11 @@ class RackRoleBulkEditView(generic.BulkEditView):
     filterset = filtersets.RackRoleFilterSet
     table = tables.RackRoleTable
     form = forms.RackRoleBulkEditForm
+
+
+@register_model_view(RackRole, 'bulk_rename', path='rename', detail=False)
+class RackRoleBulkRenameView(generic.BulkRenameView):
+    queryset = RackRole.objects.all()
 
 
 @register_model_view(RackRole, 'bulk_delete', path='delete', detail=False)
@@ -910,6 +935,11 @@ class RackBulkEditView(generic.BulkEditView):
     form = forms.RackBulkEditForm
 
 
+@register_model_view(Rack, 'bulk_rename', path='rename', detail=False)
+class RackBulkRenameView(generic.BulkRenameView):
+    queryset = Rack.objects.all()
+
+
 @register_model_view(Rack, 'bulk_delete', path='delete', detail=False)
 class RackBulkDeleteView(generic.BulkDeleteView):
     queryset = Rack.objects.all()
@@ -1041,6 +1071,11 @@ class ManufacturerBulkEditView(generic.BulkEditView):
     filterset = filtersets.ManufacturerFilterSet
     table = tables.ManufacturerTable
     form = forms.ManufacturerBulkEditForm
+
+
+@register_model_view(Manufacturer, 'bulk_rename', path='rename', detail=False)
+class ManufacturerBulkRenameView(generic.BulkRenameView):
+    queryset = Manufacturer.objects.all()
 
 
 @register_model_view(Manufacturer, 'bulk_delete', path='delete', detail=False)
@@ -1344,6 +1379,11 @@ class ModuleTypeProfileBulkEditView(generic.BulkEditView):
     filterset = filtersets.ModuleTypeProfileFilterSet
     table = tables.ModuleTypeProfileTable
     form = forms.ModuleTypeProfileBulkEditForm
+
+
+@register_model_view(ModuleTypeProfile, 'bulk_rename', path='rename', detail=False)
+class ModuleTypeProfileBulkRenameView(generic.BulkRenameView):
+    queryset = ModuleTypeProfile.objects.all()
 
 
 @register_model_view(ModuleTypeProfile, 'bulk_delete', path='delete', detail=False)
@@ -2030,6 +2070,11 @@ class DeviceRoleBulkEditView(generic.BulkEditView):
     form = forms.DeviceRoleBulkEditForm
 
 
+@register_model_view(DeviceRole, 'bulk_rename', path='rename', detail=False)
+class DeviceRoleBulkRenameView(generic.BulkRenameView):
+    queryset = DeviceRole.objects.all()
+
+
 @register_model_view(DeviceRole, 'bulk_delete', path='delete', detail=False)
 class DeviceRoleBulkDeleteView(generic.BulkDeleteView):
     queryset = DeviceRole.objects.annotate(
@@ -2089,6 +2134,11 @@ class PlatformBulkEditView(generic.BulkEditView):
     filterset = filtersets.PlatformFilterSet
     table = tables.PlatformTable
     form = forms.PlatformBulkEditForm
+
+
+@register_model_view(Platform, 'bulk_rename', path='rename', detail=False)
+class PlatformBulkRenameView(generic.BulkRenameView):
+    queryset = Platform.objects.all()
 
 
 @register_model_view(Platform, 'bulk_delete', path='delete', detail=False)
@@ -2374,16 +2424,16 @@ class DeviceBulkEditView(generic.BulkEditView):
     form = forms.DeviceBulkEditForm
 
 
-@register_model_view(Device, 'bulk_delete', path='delete', detail=False)
-class DeviceBulkDeleteView(generic.BulkDeleteView):
-    queryset = Device.objects.prefetch_related('device_type__manufacturer')
+@register_model_view(Device, 'bulk_rename', path='rename', detail=False)
+class DeviceBulkRenameView(generic.BulkRenameView):
+    queryset = Device.objects.all()
     filterset = filtersets.DeviceFilterSet
     table = tables.DeviceTable
 
 
-@register_model_view(Device, 'bulk_rename', path='rename', detail=False)
-class DeviceBulkRenameView(generic.BulkRenameView):
-    queryset = Device.objects.all()
+@register_model_view(Device, 'bulk_delete', path='delete', detail=False)
+class DeviceBulkDeleteView(generic.BulkDeleteView):
+    queryset = Device.objects.prefetch_related('device_type__manufacturer')
     filterset = filtersets.DeviceFilterSet
     table = tables.DeviceTable
 
@@ -2453,7 +2503,6 @@ class ConsolePortListView(generic.ObjectListView):
     filterset = filtersets.ConsolePortFilterSet
     filterset_form = forms.ConsolePortFilterForm
     table = tables.ConsolePortTable
-    actions = (AddObject, BulkImport, BulkEdit, BulkRename, BulkExport, BulkDelete)
 
 
 @register_model_view(ConsolePort)
@@ -2524,7 +2573,6 @@ class ConsoleServerPortListView(generic.ObjectListView):
     filterset = filtersets.ConsoleServerPortFilterSet
     filterset_form = forms.ConsoleServerPortFilterForm
     table = tables.ConsoleServerPortTable
-    actions = (AddObject, BulkImport, BulkEdit, BulkRename, BulkExport, BulkDelete)
 
 
 @register_model_view(ConsoleServerPort)
@@ -2595,7 +2643,6 @@ class PowerPortListView(generic.ObjectListView):
     filterset = filtersets.PowerPortFilterSet
     filterset_form = forms.PowerPortFilterForm
     table = tables.PowerPortTable
-    actions = (AddObject, BulkImport, BulkEdit, BulkRename, BulkExport, BulkDelete)
 
 
 @register_model_view(PowerPort)
@@ -2666,7 +2713,6 @@ class PowerOutletListView(generic.ObjectListView):
     filterset = filtersets.PowerOutletFilterSet
     filterset_form = forms.PowerOutletFilterForm
     table = tables.PowerOutletTable
-    actions = (AddObject, BulkImport, BulkEdit, BulkRename, BulkExport, BulkDelete)
 
 
 @register_model_view(PowerOutlet)
@@ -2737,7 +2783,6 @@ class InterfaceListView(generic.ObjectListView):
     filterset = filtersets.InterfaceFilterSet
     filterset_form = forms.InterfaceFilterForm
     table = tables.InterfaceTable
-    actions = (AddObject, BulkImport, BulkEdit, BulkRename, BulkExport, BulkDelete)
 
 
 @register_model_view(Interface)
@@ -2881,7 +2926,6 @@ class FrontPortListView(generic.ObjectListView):
     filterset = filtersets.FrontPortFilterSet
     filterset_form = forms.FrontPortFilterForm
     table = tables.FrontPortTable
-    actions = (AddObject, BulkImport, BulkEdit, BulkRename, BulkExport, BulkDelete)
 
 
 @register_model_view(FrontPort)
@@ -2952,7 +2996,6 @@ class RearPortListView(generic.ObjectListView):
     filterset = filtersets.RearPortFilterSet
     filterset_form = forms.RearPortFilterForm
     table = tables.RearPortTable
-    actions = (AddObject, BulkImport, BulkEdit, BulkRename, BulkExport, BulkDelete)
 
 
 @register_model_view(RearPort)
@@ -3023,7 +3066,6 @@ class ModuleBayListView(generic.ObjectListView):
     filterset = filtersets.ModuleBayFilterSet
     filterset_form = forms.ModuleBayFilterForm
     table = tables.ModuleBayTable
-    actions = (AddObject, BulkImport, BulkEdit, BulkRename, BulkExport, BulkDelete)
 
 
 @register_model_view(ModuleBay)
@@ -3085,7 +3127,6 @@ class DeviceBayListView(generic.ObjectListView):
     filterset = filtersets.DeviceBayFilterSet
     filterset_form = forms.DeviceBayFilterForm
     table = tables.DeviceBayTable
-    actions = (AddObject, BulkImport, BulkEdit, BulkRename, BulkExport, BulkDelete)
 
 
 @register_model_view(DeviceBay)
@@ -3228,7 +3269,6 @@ class InventoryItemListView(generic.ObjectListView):
     filterset = filtersets.InventoryItemFilterSet
     filterset_form = forms.InventoryItemFilterForm
     table = tables.InventoryItemTable
-    actions = (AddObject, BulkImport, BulkEdit, BulkRename, BulkExport, BulkDelete)
 
 
 @register_model_view(InventoryItem)
@@ -3349,6 +3389,11 @@ class InventoryItemRoleBulkEditView(generic.BulkEditView):
     filterset = filtersets.InventoryItemRoleFilterSet
     table = tables.InventoryItemRoleTable
     form = forms.InventoryItemRoleBulkEditForm
+
+
+@register_model_view(InventoryItemRole, 'bulk_rename', path='rename', detail=False)
+class InventoryItemRoleBulkRenameView(generic.BulkRenameView):
+    queryset = InventoryItemRole.objects.all()
 
 
 @register_model_view(InventoryItemRole, 'bulk_delete', path='delete', detail=False)
@@ -3840,6 +3885,11 @@ class VirtualChassisBulkEditView(generic.BulkEditView):
     form = forms.VirtualChassisBulkEditForm
 
 
+@register_model_view(VirtualChassis, 'bulk_rename', path='rename', detail=False)
+class VirtualChassisBulkRenameView(generic.BulkRenameView):
+    queryset = VirtualChassis.objects.all()
+
+
 @register_model_view(VirtualChassis, 'bulk_delete', path='delete', detail=False)
 class VirtualChassisBulkDeleteView(generic.BulkDeleteView):
     queryset = VirtualChassis.objects.all()
@@ -3897,6 +3947,11 @@ class PowerPanelBulkEditView(generic.BulkEditView):
     form = forms.PowerPanelBulkEditForm
 
 
+@register_model_view(PowerPanel, 'bulk_rename', path='rename', detail=False)
+class PowerPanelBulkRenameView(generic.BulkRenameView):
+    queryset = PowerPanel.objects.all()
+
+
 @register_model_view(PowerPanel, 'bulk_delete', path='delete', detail=False)
 class PowerPanelBulkDeleteView(generic.BulkDeleteView):
     queryset = PowerPanel.objects.annotate(
@@ -3949,6 +4004,11 @@ class PowerFeedBulkEditView(generic.BulkEditView):
     form = forms.PowerFeedBulkEditForm
 
 
+@register_model_view(PowerFeed, 'bulk_rename', path='rename', detail=False)
+class PowerFeedBulkRenameView(generic.BulkRenameView):
+    queryset = PowerFeed.objects.all()
+
+
 @register_model_view(PowerFeed, 'bulk_disconnect', path='disconnect', detail=False)
 class PowerFeedBulkDisconnectView(BulkDisconnectView):
     queryset = PowerFeed.objects.all()
@@ -3977,6 +4037,7 @@ class VirtualDeviceContextListView(generic.ObjectListView):
     filterset = filtersets.VirtualDeviceContextFilterSet
     filterset_form = forms.VirtualDeviceContextFilterForm
     table = tables.VirtualDeviceContextTable
+    actions = (AddObject, BulkImport, BulkEdit, BulkRename, BulkExport, BulkDelete)
 
 
 @register_model_view(VirtualDeviceContext)
@@ -4019,6 +4080,11 @@ class VirtualDeviceContextBulkEditView(generic.BulkEditView):
     filterset = filtersets.VirtualDeviceContextFilterSet
     table = tables.VirtualDeviceContextTable
     form = forms.VirtualDeviceContextBulkEditForm
+
+
+@register_model_view(VirtualDeviceContext, 'bulk_rename', path='rename', detail=False)
+class VirtualDeviceContextBulkRenameView(generic.BulkRenameView):
+    queryset = VirtualDeviceContext.objects.all()
 
 
 @register_model_view(VirtualDeviceContext, 'bulk_delete', path='delete', detail=False)

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -97,6 +97,11 @@ class CustomFieldBulkEditView(generic.BulkEditView):
     form = forms.CustomFieldBulkEditForm
 
 
+@register_model_view(CustomField, 'bulk_rename', path='rename', detail=False)
+class CustomFieldBulkRenameView(generic.BulkRenameView):
+    queryset = CustomField.objects.all()
+
+
 @register_model_view(CustomField, 'bulk_delete', path='delete', detail=False)
 class CustomFieldBulkDeleteView(generic.BulkDeleteView):
     queryset = CustomField.objects.select_related('choice_set')
@@ -166,6 +171,11 @@ class CustomFieldChoiceSetBulkEditView(generic.BulkEditView):
     form = forms.CustomFieldChoiceSetBulkEditForm
 
 
+@register_model_view(CustomFieldChoiceSet, 'bulk_rename', path='rename', detail=False)
+class CustomFieldChoiceSetBulkRenameView(generic.BulkRenameView):
+    queryset = CustomFieldChoiceSet.objects.all()
+
+
 @register_model_view(CustomFieldChoiceSet, 'bulk_delete', path='delete', detail=False)
 class CustomFieldChoiceSetBulkDeleteView(generic.BulkDeleteView):
     queryset = CustomFieldChoiceSet.objects.all()
@@ -216,6 +226,11 @@ class CustomLinkBulkEditView(generic.BulkEditView):
     form = forms.CustomLinkBulkEditForm
 
 
+@register_model_view(CustomLink, 'bulk_rename', path='rename', detail=False)
+class CustomLinkBulkRenameView(generic.BulkRenameView):
+    queryset = CustomLink.objects.all()
+
+
 @register_model_view(CustomLink, 'bulk_delete', path='delete', detail=False)
 class CustomLinkBulkDeleteView(generic.BulkDeleteView):
     queryset = CustomLink.objects.all()
@@ -233,7 +248,7 @@ class ExportTemplateListView(generic.ObjectListView):
     filterset = filtersets.ExportTemplateFilterSet
     filterset_form = forms.ExportTemplateFilterForm
     table = tables.ExportTemplateTable
-    actions = (AddObject, BulkImport, BulkSync, BulkEdit, BulkExport, BulkDelete)
+    actions = (AddObject, BulkImport, BulkSync, BulkExport, BulkEdit, BulkRename, BulkDelete)
 
 
 @register_model_view(ExportTemplate)
@@ -265,6 +280,11 @@ class ExportTemplateBulkEditView(generic.BulkEditView):
     filterset = filtersets.ExportTemplateFilterSet
     table = tables.ExportTemplateTable
     form = forms.ExportTemplateBulkEditForm
+
+
+@register_model_view(ExportTemplate, 'bulk_rename', path='rename', detail=False)
+class ExportTemplateBulkRenameView(generic.BulkRenameView):
+    queryset = ExportTemplate.objects.all()
 
 
 @register_model_view(ExportTemplate, 'bulk_delete', path='delete', detail=False)
@@ -327,6 +347,11 @@ class SavedFilterBulkEditView(SharedObjectViewMixin, generic.BulkEditView):
     form = forms.SavedFilterBulkEditForm
 
 
+@register_model_view(SavedFilter, 'bulk_rename', path='rename', detail=False)
+class SavedFilterBulkRenameView(generic.BulkRenameView):
+    queryset = SavedFilter.objects.all()
+
+
 @register_model_view(SavedFilter, 'bulk_delete', path='delete', detail=False)
 class SavedFilterBulkDeleteView(SharedObjectViewMixin, generic.BulkDeleteView):
     queryset = SavedFilter.objects.all()
@@ -344,7 +369,7 @@ class TableConfigListView(SharedObjectViewMixin, generic.ObjectListView):
     filterset = filtersets.TableConfigFilterSet
     filterset_form = forms.TableConfigFilterForm
     table = tables.TableConfigTable
-    actions = (BulkExport,)
+    actions = (BulkExport, BulkEdit, BulkRename, BulkDelete)
 
 
 @register_model_view(TableConfig)
@@ -382,6 +407,11 @@ class TableConfigBulkEditView(SharedObjectViewMixin, generic.BulkEditView):
     filterset = filtersets.TableConfigFilterSet
     table = tables.TableConfigTable
     form = forms.TableConfigBulkEditForm
+
+
+@register_model_view(TableConfig, 'bulk_rename', path='rename', detail=False)
+class TableConfigBulkRenameView(generic.BulkRenameView):
+    queryset = TableConfig.objects.all()
 
 
 @register_model_view(TableConfig, 'bulk_delete', path='delete', detail=False)
@@ -463,6 +493,11 @@ class NotificationGroupBulkEditView(generic.BulkEditView):
     filterset = filtersets.NotificationGroupFilterSet
     table = tables.NotificationGroupTable
     form = forms.NotificationGroupBulkEditForm
+
+
+@register_model_view(NotificationGroup, 'bulk_rename', path='rename', detail=False)
+class NotificationGroupBulkRenameView(generic.BulkRenameView):
+    queryset = NotificationGroup.objects.all()
 
 
 @register_model_view(NotificationGroup, 'bulk_delete', path='delete', detail=False)
@@ -611,6 +646,11 @@ class WebhookBulkEditView(generic.BulkEditView):
     form = forms.WebhookBulkEditForm
 
 
+@register_model_view(Webhook, 'bulk_rename', path='rename', detail=False)
+class WebhookBulkRenameView(generic.BulkRenameView):
+    queryset = Webhook.objects.all()
+
+
 @register_model_view(Webhook, 'bulk_delete', path='delete', detail=False)
 class WebhookBulkDeleteView(generic.BulkDeleteView):
     queryset = Webhook.objects.all()
@@ -659,6 +699,11 @@ class EventRuleBulkEditView(generic.BulkEditView):
     filterset = filtersets.EventRuleFilterSet
     table = tables.EventRuleTable
     form = forms.EventRuleBulkEditForm
+
+
+@register_model_view(EventRule, 'bulk_rename', path='rename', detail=False)
+class EventRuleBulkRenameView(generic.BulkRenameView):
+    queryset = EventRule.objects.all()
 
 
 @register_model_view(EventRule, 'bulk_delete', path='delete', detail=False)
@@ -735,6 +780,11 @@ class TagBulkEditView(generic.BulkEditView):
     form = forms.TagBulkEditForm
 
 
+@register_model_view(Tag, 'bulk_rename', path='rename', detail=False)
+class TagBulkRenameView(generic.BulkRenameView):
+    queryset = Tag.objects.all()
+
+
 @register_model_view(Tag, 'bulk_delete', path='delete', detail=False)
 class TagBulkDeleteView(generic.BulkDeleteView):
     queryset = Tag.objects.annotate(
@@ -753,7 +803,7 @@ class ConfigContextListView(generic.ObjectListView):
     filterset = filtersets.ConfigContextFilterSet
     filterset_form = forms.ConfigContextFilterForm
     table = tables.ConfigContextTable
-    actions = (AddObject, BulkSync, BulkEdit, BulkDelete)
+    actions = (AddObject, BulkSync, BulkEdit, BulkRename, BulkDelete)
 
 
 @register_model_view(ConfigContext)
@@ -814,6 +864,11 @@ class ConfigContextBulkEditView(generic.BulkEditView):
     form = forms.ConfigContextBulkEditForm
 
 
+@register_model_view(ConfigContext, 'bulk_rename', path='rename', detail=False)
+class ConfigContextBulkRenameView(generic.BulkRenameView):
+    queryset = ConfigContext.objects.all()
+
+
 @register_model_view(ConfigContext, 'bulk_delete', path='delete', detail=False)
 class ConfigContextBulkDeleteView(generic.BulkDeleteView):
     queryset = ConfigContext.objects.all()
@@ -866,7 +921,7 @@ class ConfigTemplateListView(generic.ObjectListView):
     filterset = filtersets.ConfigTemplateFilterSet
     filterset_form = forms.ConfigTemplateFilterForm
     table = tables.ConfigTemplateTable
-    actions = (AddObject, BulkImport, BulkSync, BulkEdit, BulkExport, BulkDelete)
+    actions = (AddObject, BulkImport, BulkExport, BulkSync, BulkEdit, BulkRename, BulkDelete)
 
 
 @register_model_view(ConfigTemplate)
@@ -898,6 +953,11 @@ class ConfigTemplateBulkEditView(generic.BulkEditView):
     filterset = filtersets.ConfigTemplateFilterSet
     table = tables.ConfigTemplateTable
     form = forms.ConfigTemplateBulkEditForm
+
+
+@register_model_view(ConfigTemplate, 'bulk_rename', path='rename', detail=False)
+class ConfigTemplateBulkRenameView(generic.BulkRenameView):
+    queryset = ConfigTemplate.objects.all()
 
 
 @register_model_view(ConfigTemplate, 'bulk_delete', path='delete', detail=False)

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -86,6 +86,11 @@ class VRFBulkEditView(generic.BulkEditView):
     form = forms.VRFBulkEditForm
 
 
+@register_model_view(VRF, 'bulk_rename', path='rename', detail=False)
+class VRFBulkRenameView(generic.BulkRenameView):
+    queryset = VRF.objects.all()
+
+
 @register_model_view(VRF, 'bulk_delete', path='delete', detail=False)
 class VRFBulkDeleteView(generic.BulkDeleteView):
     queryset = VRF.objects.all()
@@ -134,6 +139,11 @@ class RouteTargetBulkEditView(generic.BulkEditView):
     filterset = filtersets.RouteTargetFilterSet
     table = tables.RouteTargetTable
     form = forms.RouteTargetBulkEditForm
+
+
+@register_model_view(RouteTarget, 'bulk_rename', path='rename', detail=False)
+class RouteTargetBulkRenameView(generic.BulkRenameView):
+    queryset = RouteTarget.objects.all()
 
 
 @register_model_view(RouteTarget, 'bulk_delete', path='delete', detail=False)
@@ -193,6 +203,11 @@ class RIRBulkEditView(generic.BulkEditView):
     filterset = filtersets.RIRFilterSet
     table = tables.RIRTable
     form = forms.RIRBulkEditForm
+
+
+@register_model_view(RIR, 'bulk_rename', path='rename', detail=False)
+class RIRBulkRenameView(generic.BulkRenameView):
+    queryset = RIR.objects.all()
 
 
 @register_model_view(RIR, 'bulk_delete', path='delete', detail=False)
@@ -268,6 +283,11 @@ class ASNRangeBulkEditView(generic.BulkEditView):
     form = forms.ASNRangeBulkEditForm
 
 
+@register_model_view(ASNRange, 'bulk_rename', path='rename', detail=False)
+class ASNRangeBulkRenameView(generic.BulkRenameView):
+    queryset = ASNRange.objects.all()
+
+
 @register_model_view(ASNRange, 'bulk_delete', path='delete', detail=False)
 class ASNRangeBulkDeleteView(generic.BulkDeleteView):
     queryset = ASNRange.objects.annotate_asn_counts()
@@ -333,6 +353,11 @@ class ASNBulkEditView(generic.BulkEditView):
     filterset = filtersets.ASNFilterSet
     table = tables.ASNTable
     form = forms.ASNBulkEditForm
+
+
+@register_model_view(ASN, 'bulk_rename', path='rename', detail=False)
+class ASNBulkRenameView(generic.BulkRenameView):
+    queryset = ASN.objects.all()
 
 
 @register_model_view(ASN, 'bulk_delete', path='delete', detail=False)
@@ -486,6 +511,11 @@ class RoleBulkEditView(generic.BulkEditView):
     filterset = filtersets.RoleFilterSet
     table = tables.RoleTable
     form = forms.RoleBulkEditForm
+
+
+@register_model_view(Role, 'bulk_rename', path='rename', detail=False)
+class RoleBulkRenameView(generic.BulkRenameView):
+    queryset = Role.objects.all()
 
 
 @register_model_view(Role, 'bulk_delete', path='delete', detail=False)
@@ -766,6 +796,11 @@ class IPRangeBulkEditView(generic.BulkEditView):
     form = forms.IPRangeBulkEditForm
 
 
+@register_model_view(IPRange, 'bulk_rename', path='rename', detail=False)
+class IPRangeBulkRenameView(generic.BulkRenameView):
+    queryset = IPRange.objects.all()
+
+
 @register_model_view(IPRange, 'bulk_delete', path='delete', detail=False)
 class IPRangeBulkDeleteView(generic.BulkDeleteView):
     queryset = IPRange.objects.all()
@@ -1006,6 +1041,11 @@ class VLANGroupBulkEditView(generic.BulkEditView):
     form = forms.VLANGroupBulkEditForm
 
 
+@register_model_view(VLANGroup, 'bulk_rename', path='rename', detail=False)
+class VLANGroupBulkRenameView(generic.BulkRenameView):
+    queryset = VLANGroup.objects.all()
+
+
 @register_model_view(VLANGroup, 'bulk_delete', path='delete', detail=False)
 class VLANGroupBulkDeleteView(generic.BulkDeleteView):
     queryset = VLANGroup.objects.annotate_utilization().prefetch_related('tags')
@@ -1093,6 +1133,11 @@ class VLANTranslationPolicyBulkEditView(generic.BulkEditView):
     filterset = filtersets.VLANTranslationPolicyFilterSet
     table = tables.VLANTranslationPolicyTable
     form = forms.VLANTranslationPolicyBulkEditForm
+
+
+@register_model_view(VLANTranslationPolicy, 'bulk_rename', path='rename', detail=False)
+class VLANTranslationPolicyBulkRenameView(generic.BulkRenameView):
+    queryset = VLANTranslationPolicy.objects.all()
 
 
 @register_model_view(VLANTranslationPolicy, 'bulk_delete', path='delete', detail=False)
@@ -1244,6 +1289,11 @@ class FHRPGroupBulkEditView(generic.BulkEditView):
     form = forms.FHRPGroupBulkEditForm
 
 
+@register_model_view(FHRPGroup, 'bulk_rename', path='rename', detail=False)
+class FHRPGroupBulkRenameView(generic.BulkRenameView):
+    queryset = FHRPGroup.objects.all()
+
+
 @register_model_view(FHRPGroup, 'bulk_delete', path='delete', detail=False)
 class FHRPGroupBulkDeleteView(generic.BulkDeleteView):
     queryset = FHRPGroup.objects.all()
@@ -1371,6 +1421,11 @@ class VLANBulkEditView(generic.BulkEditView):
     form = forms.VLANBulkEditForm
 
 
+@register_model_view(VLAN, 'bulk_rename', path='rename', detail=False)
+class VLANBulkRenameView(generic.BulkRenameView):
+    queryset = VLAN.objects.all()
+
+
 @register_model_view(VLAN, 'bulk_delete', path='delete', detail=False)
 class VLANBulkDeleteView(generic.BulkDeleteView):
     queryset = VLAN.objects.all()
@@ -1419,6 +1474,11 @@ class ServiceTemplateBulkEditView(generic.BulkEditView):
     filterset = filtersets.ServiceTemplateFilterSet
     table = tables.ServiceTemplateTable
     form = forms.ServiceTemplateBulkEditForm
+
+
+@register_model_view(ServiceTemplate, 'bulk_rename', path='rename', detail=False)
+class ServiceTemplateBulkRenameView(generic.BulkRenameView):
+    queryset = ServiceTemplate.objects.all()
 
 
 @register_model_view(ServiceTemplate, 'bulk_delete', path='delete', detail=False)
@@ -1486,6 +1546,11 @@ class ServiceBulkEditView(generic.BulkEditView):
     filterset = filtersets.ServiceFilterSet
     table = tables.ServiceTable
     form = forms.ServiceBulkEditForm
+
+
+@register_model_view(Service, 'bulk_rename', path='rename', detail=False)
+class ServiceBulkRenameView(generic.BulkRenameView):
+    queryset = Service.objects.all()
 
 
 @register_model_view(Service, 'bulk_delete', path='delete', detail=False)

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -10,6 +10,7 @@ from dcim.filtersets import InterfaceFilterSet
 from dcim.forms import InterfaceFilterForm
 from dcim.models import Device, Interface, Site
 from ipam.tables import VLANTranslationRuleTable
+from netbox.object_actions import AddObject, BulkDelete, BulkEdit, BulkExport, BulkImport
 from netbox.views import generic
 from utilities.query import count_related
 from utilities.tables import get_table_ordering
@@ -381,6 +382,7 @@ class AggregateListView(generic.ObjectListView):
     filterset = filtersets.AggregateFilterSet
     filterset_form = forms.AggregateFilterForm
     table = tables.AggregateTable
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkDelete)
 
 
 @register_model_view(Aggregate)
@@ -536,6 +538,7 @@ class PrefixListView(generic.ObjectListView):
     filterset_form = forms.PrefixFilterForm
     table = tables.PrefixTable
     template_name = 'ipam/prefix_list.html'
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkDelete)
 
 
 @register_model_view(Prefix)
@@ -818,6 +821,7 @@ class IPAddressListView(generic.ObjectListView):
     filterset = filtersets.IPAddressFilterSet
     filterset_form = forms.IPAddressFilterForm
     table = tables.IPAddressTable
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkDelete)
 
 
 @register_model_view(IPAddress)
@@ -1157,6 +1161,7 @@ class VLANTranslationRuleListView(generic.ObjectListView):
     filterset = filtersets.VLANTranslationRuleFilterSet
     filterset_form = forms.VLANTranslationRuleFilterForm
     table = tables.VLANTranslationRuleTable
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkDelete)
 
 
 @register_model_view(VLANTranslationRule)

--- a/netbox/netbox/object_actions.py
+++ b/netbox/netbox/object_actions.py
@@ -1,4 +1,5 @@
 from django.urls import reverse
+from django.urls.exceptions import NoReverseMatch
 from django.utils.translation import gettext as _
 
 from core.models import ObjectType
@@ -42,7 +43,10 @@ class ObjectAction:
         kwargs = {
             kwarg: getattr(obj, kwarg) for kwarg in cls.url_kwargs
         }
-        return reverse(viewname, kwargs=kwargs)
+        try:
+            return reverse(viewname, kwargs=kwargs)
+        except NoReverseMatch:
+            return
 
     @classmethod
     def get_context(cls, context, obj):

--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -22,7 +22,7 @@ from core.models import ObjectType
 from core.signals import clear_events
 from extras.choices import CustomFieldUIEditableChoices
 from extras.models import CustomField, ExportTemplate
-from netbox.object_actions import AddObject, BulkDelete, BulkEdit, BulkExport, BulkImport
+from netbox.object_actions import AddObject, BulkDelete, BulkEdit, BulkExport, BulkImport, BulkRename
 from utilities.error_handlers import handle_protectederror
 from utilities.exceptions import AbortRequest, AbortTransaction, PermissionsViolation
 from utilities.forms import BulkRenameForm, ConfirmationForm, restrict_form_fields
@@ -61,7 +61,7 @@ class ObjectListView(BaseMultiObjectView, ActionsMixin, TableMixin):
     template_name = 'generic/object_list.html'
     filterset = None
     filterset_form = None
-    actions = (AddObject, BulkImport, BulkEdit, BulkExport, BulkDelete)
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkRename, BulkDelete)
 
     def get_required_permission(self):
         return get_permission_for_model(self.queryset.model, 'view')

--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -55,8 +55,7 @@ class ObjectListView(BaseMultiObjectView, ActionsMixin, TableMixin):
     Attributes:
         filterset: A django-filter FilterSet that is applied to the queryset
         filterset_form: The form class used to render filter options
-        actions: A mapping of supported actions to their required permissions. When adding custom actions, bulk
-            action names must be prefixed with `bulk_`. (See ActionsMixin.)
+        actions: An iterable of ObjectAction subclasses (see ActionsMixin)
     """
     template_name = 'generic/object_list.html'
     filterset = None
@@ -731,6 +730,9 @@ class BulkEditView(GetReturnURLMixin, BaseMultiObjectView):
 class BulkRenameView(GetReturnURLMixin, BaseMultiObjectView):
     """
     An extendable view for renaming objects in bulk.
+
+    Attributes:
+        field_name: The name of the object attribute for which the value is being updated (defaults to "name")
     """
     field_name = 'name'
     template_name = 'generic/bulk_rename.html'

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -47,6 +47,7 @@ class ObjectView(ActionsMixin, BaseObjectView):
 
     Attributes:
         tab: A ViewTab instance for the view
+        actions: An iterable of ObjectAction subclasses (see ActionsMixin)
     """
     tab = None
     actions = (CloneObject, EditObject, DeleteObject)
@@ -96,8 +97,7 @@ class ObjectChildrenView(ObjectView, ActionsMixin, TableMixin):
         table: The django-tables2 Table class used to render the child objects list
         filterset: A django-filter FilterSet that is applied to the queryset
         filterset_form: The form class used to render filter options
-        actions: A mapping of supported actions to their required permissions. When adding custom actions, bulk
-            action names must be prefixed with `bulk_`. (See ActionsMixin.)
+        actions: An iterable of ObjectAction subclasses (see ActionsMixin)
     """
     child_model = None
     table = None

--- a/netbox/templates/generic/bulk_rename.html
+++ b/netbox/templates/generic/bulk_rename.html
@@ -42,10 +42,12 @@ Context:
             </thead>
             <tbody>
                 {% for obj in selected_objects %}
-                    <tr{% if obj.new_name and obj.name != obj.new_name %} class="success"{% endif %}>
-                        <td>{{ obj.name }}</td>
-                        <td>{{ obj.new_name }}</td>
-                    </tr>
+                    {% with obj_name=obj|getattr:field_name %}
+                        <tr{% if obj.new_name and obj_name != obj.new_name %} class="success"{% endif %}>
+                            <td>{{ obj_name }}</td>
+                            <td>{{ obj.new_name }}</td>
+                        </tr>
+                    {% endwith %}
                 {% endfor %}
             </tbody>
         </table>

--- a/netbox/templates/htmx/table.html
+++ b/netbox/templates/htmx/table.html
@@ -27,12 +27,7 @@
   {# Update the bulk action buttons with new query parameters #}
   {% if actions %}
     <div class="bulk-action-buttons" hx-swap-oob="outerHTML:.bulk-action-buttons">
-      {% if 'bulk_edit' in actions %}
-        {% bulk_edit_button model query_params=request.GET %}
-      {% endif %}
-      {% if 'bulk_delete' in actions %}
-        {% bulk_delete_button model query_params=request.GET %}
-      {% endif %}
+      {% action_buttons actions model multi=True %}
     </div>
   {% endif %}
 {% endif %}

--- a/netbox/tenancy/views.py
+++ b/netbox/tenancy/views.py
@@ -71,6 +71,11 @@ class TenantGroupBulkEditView(generic.BulkEditView):
     form = forms.TenantGroupBulkEditForm
 
 
+@register_model_view(TenantGroup, 'bulk_rename', path='rename', detail=False)
+class TenantGroupBulkRenameView(generic.BulkRenameView):
+    queryset = TenantGroup.objects.all()
+
+
 @register_model_view(TenantGroup, 'bulk_delete', path='delete', detail=False)
 class TenantGroupBulkDeleteView(generic.BulkDeleteView):
     queryset = TenantGroup.objects.add_related_count(
@@ -130,6 +135,11 @@ class TenantBulkEditView(generic.BulkEditView):
     filterset = filtersets.TenantFilterSet
     table = tables.TenantTable
     form = forms.TenantBulkEditForm
+
+
+@register_model_view(Tenant, 'bulk_rename', path='rename', detail=False)
+class TenantBulkRenameView(generic.BulkRenameView):
+    queryset = Tenant.objects.all()
 
 
 @register_model_view(Tenant, 'bulk_delete', path='delete', detail=False)
@@ -207,6 +217,11 @@ class ContactGroupBulkEditView(generic.BulkEditView):
     form = forms.ContactGroupBulkEditForm
 
 
+@register_model_view(ContactGroup, 'bulk_rename', path='rename', detail=False)
+class ContactGroupBulkRenameView(generic.BulkRenameView):
+    queryset = ContactGroup.objects.all()
+
+
 @register_model_view(ContactGroup, 'bulk_delete', path='delete', detail=False)
 class ContactGroupBulkDeleteView(generic.BulkDeleteView):
     queryset = ContactGroup.objects.add_related_count(
@@ -266,6 +281,11 @@ class ContactRoleBulkEditView(generic.BulkEditView):
     filterset = filtersets.ContactRoleFilterSet
     table = tables.ContactRoleTable
     form = forms.ContactRoleBulkEditForm
+
+
+@register_model_view(ContactRole, 'bulk_rename', path='rename', detail=False)
+class ContactRoleBulkRenameView(generic.BulkRenameView):
+    queryset = ContactRole.objects.all()
 
 
 @register_model_view(ContactRole, 'bulk_delete', path='delete', detail=False)
@@ -329,6 +349,11 @@ class ContactBulkEditView(generic.BulkEditView):
             obj.groups.add(*form.cleaned_data['add_groups'])
         if form.cleaned_data.get('remove_groups', None):
             obj.groups.remove(*form.cleaned_data['remove_groups'])
+
+
+@register_model_view(Contact, 'bulk_rename', path='rename', detail=False)
+class ContactBulkRenameView(generic.BulkRenameView):
+    queryset = Contact.objects.all()
 
 
 @register_model_view(Contact, 'bulk_delete', path='delete', detail=False)

--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -2,7 +2,7 @@ from django.db.models import Count
 
 from core.models import ObjectChange
 from core.tables import ObjectChangeTable
-from netbox.object_actions import AddObject, BulkDelete, BulkEdit, BulkExport, BulkRename
+from netbox.object_actions import AddObject, BulkDelete, BulkEdit, BulkExport, BulkImport, BulkRename
 from netbox.views import generic
 from utilities.views import register_model_view
 from . import filtersets, forms, tables
@@ -19,6 +19,7 @@ class TokenListView(generic.ObjectListView):
     filterset = filtersets.TokenFilterSet
     filterset_form = forms.TokenFilterForm
     table = tables.TokenTable
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkDelete)
 
 
 @register_model_view(Token)
@@ -110,6 +111,12 @@ class UserBulkEditView(generic.BulkEditView):
     filterset = filtersets.UserFilterSet
     table = tables.UserTable
     form = forms.UserBulkEditForm
+
+
+@register_model_view(User, 'bulk_rename', path='rename', detail=False)
+class UserBulkRenameView(generic.BulkRenameView):
+    queryset = User.objects.all()
+    field_name = 'username'
 
 
 @register_model_view(User, 'bulk_delete', path='delete', detail=False)

--- a/netbox/users/views.py
+++ b/netbox/users/views.py
@@ -2,6 +2,7 @@ from django.db.models import Count
 
 from core.models import ObjectChange
 from core.tables import ObjectChangeTable
+from netbox.object_actions import AddObject, BulkDelete, BulkEdit, BulkExport, BulkRename
 from netbox.views import generic
 from utilities.views import register_model_view
 from . import filtersets, forms, tables
@@ -162,6 +163,11 @@ class GroupBulkEditView(generic.BulkEditView):
     form = forms.GroupBulkEditForm
 
 
+@register_model_view(Group, 'bulk_rename', path='rename', detail=False)
+class GroupBulkRenameView(generic.BulkRenameView):
+    queryset = Group.objects.all()
+
+
 @register_model_view(Group, 'bulk_delete', path='delete', detail=False)
 class GroupBulkDeleteView(generic.BulkDeleteView):
     queryset = Group.objects.annotate(users_count=Count('user')).order_by('name')
@@ -179,6 +185,7 @@ class ObjectPermissionListView(generic.ObjectListView):
     filterset = filtersets.ObjectPermissionFilterSet
     filterset_form = forms.ObjectPermissionFilterForm
     table = tables.ObjectPermissionTable
+    actions = (AddObject, BulkExport, BulkEdit, BulkRename, BulkDelete)
 
 
 @register_model_view(ObjectPermission)
@@ -205,6 +212,11 @@ class ObjectPermissionBulkEditView(generic.BulkEditView):
     filterset = filtersets.ObjectPermissionFilterSet
     table = tables.ObjectPermissionTable
     form = forms.ObjectPermissionBulkEditForm
+
+
+@register_model_view(ObjectPermission, 'bulk_rename', path='rename', detail=False)
+class ObjectPermissionBulkRenameView(generic.BulkRenameView):
+    queryset = ObjectPermission.objects.all()
 
 
 @register_model_view(ObjectPermission, 'bulk_delete', path='delete', detail=False)

--- a/netbox/utilities/templates/buttons/bulk_rename.html
+++ b/netbox/utilities/templates/buttons/bulk_rename.html
@@ -1,3 +1,5 @@
-<button type="submit" name="_rename" {% formaction %}="{{ url }}" class="btn btn-yellow">
-  <i class="mdi mdi-pencil" aria-hidden="true"></i> {{ label }}
-</button>
+{% if url %}
+  <button type="submit" name="_rename" {% formaction %}="{{ url }}" class="btn btn-yellow">
+    <i class="mdi mdi-pencil" aria-hidden="true"></i> {{ label }}
+  </button>
+{% endif %}

--- a/netbox/utilities/templatetags/builtins/filters.py
+++ b/netbox/utilities/templatetags/builtins/filters.py
@@ -22,6 +22,7 @@ __all__ = (
     'content_type',
     'content_type_id',
     'fgcolor',
+    'getattr_',
     'isodate',
     'isodatetime',
     'isotime',
@@ -86,6 +87,14 @@ def fgcolor(value, dark='000000', light='ffffff'):
     if not re.match('^[0-9a-f]{6}$', value):
         return ''
     return f'#{foreground_color(value, dark, light)}'
+
+
+@register.filter('getattr')
+def getattr_(instance, name):
+    """
+    Call getattr() on the object for the specified attribute.
+    """
+    return getattr(instance, name, None)
 
 
 @register.filter()

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -13,7 +13,9 @@ from dcim.tables import DeviceTable
 from extras.views import ObjectConfigContextView, ObjectRenderConfigView
 from ipam.models import IPAddress, VLANGroup
 from ipam.tables import InterfaceVLANTable, VLANTranslationRuleTable
-from netbox.object_actions import *
+from netbox.object_actions import (
+    AddObject, BulkDelete, BulkEdit, BulkExport, BulkImport, BulkRename, DeleteObject, EditObject,
+)
 from netbox.views import generic
 from utilities.query import count_related
 from utilities.query_functions import CollateAsChar
@@ -73,6 +75,11 @@ class ClusterTypeBulkEditView(generic.BulkEditView):
     filterset = filtersets.ClusterTypeFilterSet
     table = tables.ClusterTypeTable
     form = forms.ClusterTypeBulkEditForm
+
+
+@register_model_view(ClusterType, 'bulk_rename', path='rename', detail=False)
+class ClusterTypeBulkRenameView(generic.BulkRenameView):
+    queryset = ClusterType.objects.all()
 
 
 @register_model_view(ClusterType, 'bulk_delete', path='delete', detail=False)
@@ -146,6 +153,11 @@ class ClusterGroupBulkEditView(generic.BulkEditView):
     filterset = filtersets.ClusterGroupFilterSet
     table = tables.ClusterGroupTable
     form = forms.ClusterGroupBulkEditForm
+
+
+@register_model_view(ClusterGroup, 'bulk_rename', path='rename', detail=False)
+class ClusterGroupBulkRenameView(generic.BulkRenameView):
+    queryset = ClusterGroup.objects.all()
 
 
 @register_model_view(ClusterGroup, 'bulk_delete', path='delete', detail=False)
@@ -262,6 +274,11 @@ class ClusterBulkEditView(generic.BulkEditView):
     form = forms.ClusterBulkEditForm
 
 
+@register_model_view(Cluster, 'bulk_rename', path='rename', detail=False)
+class ClusterBulkRenameView(generic.BulkRenameView):
+    queryset = Cluster.objects.all()
+
+
 @register_model_view(Cluster, 'bulk_delete', path='delete', detail=False)
 class ClusterBulkDeleteView(generic.BulkDeleteView):
     queryset = Cluster.objects.all()
@@ -322,7 +339,7 @@ class VirtualMachineListView(generic.ObjectListView):
     filterset = filtersets.VirtualMachineFilterSet
     filterset_form = forms.VirtualMachineFilterForm
     table = tables.VirtualMachineTable
-    actions = (AddObject, BulkImport, BulkExport, BulkAddComponents, BulkEdit, BulkDelete)
+    actions = (AddObject, BulkImport, BulkExport, BulkAddComponents, BulkEdit, BulkRename, BulkDelete)
 
 
 @register_model_view(VirtualMachine)
@@ -415,6 +432,11 @@ class VirtualMachineBulkEditView(generic.BulkEditView):
     filterset = filtersets.VirtualMachineFilterSet
     table = tables.VirtualMachineTable
     form = forms.VirtualMachineBulkEditForm
+
+
+@register_model_view(VirtualMachine, 'bulk_rename', path='rename', detail=False)
+class VirtualMachineBulkRenameView(generic.BulkRenameView):
+    queryset = VirtualMachine.objects.all()
 
 
 @register_model_view(VirtualMachine, 'bulk_delete', path='delete', detail=False)

--- a/netbox/vpn/views.py
+++ b/netbox/vpn/views.py
@@ -58,6 +58,11 @@ class TunnelGroupBulkEditView(generic.BulkEditView):
     form = forms.TunnelGroupBulkEditForm
 
 
+@register_model_view(TunnelGroup, 'bulk_rename', path='rename', detail=False)
+class TunnelGroupBulkRenameView(generic.BulkRenameView):
+    queryset = TunnelGroup.objects.all()
+
+
 @register_model_view(TunnelGroup, 'bulk_delete', path='delete', detail=False)
 class TunnelGroupBulkDeleteView(generic.BulkDeleteView):
     queryset = TunnelGroup.objects.annotate(
@@ -120,6 +125,11 @@ class TunnelBulkEditView(generic.BulkEditView):
     filterset = filtersets.TunnelFilterSet
     table = tables.TunnelTable
     form = forms.TunnelBulkEditForm
+
+
+@register_model_view(Tunnel, 'bulk_rename', path='rename', detail=False)
+class TunnelBulkRenameView(generic.BulkRenameView):
+    queryset = Tunnel.objects.all()
 
 
 @register_model_view(Tunnel, 'bulk_delete', path='delete', detail=False)
@@ -224,6 +234,11 @@ class IKEProposalBulkEditView(generic.BulkEditView):
     form = forms.IKEProposalBulkEditForm
 
 
+@register_model_view(IKEProposal, 'bulk_rename', path='rename', detail=False)
+class IKEProposalBulkRenameView(generic.BulkRenameView):
+    queryset = IKEProposal.objects.all()
+
+
 @register_model_view(IKEProposal, 'bulk_delete', path='delete', detail=False)
 class IKEProposalBulkDeleteView(generic.BulkDeleteView):
     queryset = IKEProposal.objects.all()
@@ -272,6 +287,11 @@ class IKEPolicyBulkEditView(generic.BulkEditView):
     filterset = filtersets.IKEPolicyFilterSet
     table = tables.IKEPolicyTable
     form = forms.IKEPolicyBulkEditForm
+
+
+@register_model_view(IKEPolicy, 'bulk_rename', path='rename', detail=False)
+class IKEPolicyBulkRenameView(generic.BulkRenameView):
+    queryset = IKEPolicy.objects.all()
 
 
 @register_model_view(IKEPolicy, 'bulk_delete', path='delete', detail=False)
@@ -324,6 +344,11 @@ class IPSecProposalBulkEditView(generic.BulkEditView):
     form = forms.IPSecProposalBulkEditForm
 
 
+@register_model_view(IPSecProposal, 'bulk_rename', path='rename', detail=False)
+class IPSecProposalBulkRenameView(generic.BulkRenameView):
+    queryset = IPSecProposal.objects.all()
+
+
 @register_model_view(IPSecProposal, 'bulk_delete', path='delete', detail=False)
 class IPSecProposalBulkDeleteView(generic.BulkDeleteView):
     queryset = IPSecProposal.objects.all()
@@ -374,6 +399,11 @@ class IPSecPolicyBulkEditView(generic.BulkEditView):
     form = forms.IPSecPolicyBulkEditForm
 
 
+@register_model_view(IPSecPolicy, 'bulk_rename', path='rename', detail=False)
+class IPSecPolicyBulkRenameView(generic.BulkRenameView):
+    queryset = IPSecPolicy.objects.all()
+
+
 @register_model_view(IPSecPolicy, 'bulk_delete', path='delete', detail=False)
 class IPSecPolicyBulkDeleteView(generic.BulkDeleteView):
     queryset = IPSecPolicy.objects.all()
@@ -422,6 +452,11 @@ class IPSecProfileBulkEditView(generic.BulkEditView):
     filterset = filtersets.IPSecProfileFilterSet
     table = tables.IPSecProfileTable
     form = forms.IPSecProfileBulkEditForm
+
+
+@register_model_view(IPSecProfile, 'bulk_rename', path='rename', detail=False)
+class IPSecProfileBulkRenameView(generic.BulkRenameView):
+    queryset = IPSecProfile.objects.all()
 
 
 @register_model_view(IPSecProfile, 'bulk_delete', path='delete', detail=False)
@@ -489,6 +524,11 @@ class L2VPNBulkEditView(generic.BulkEditView):
     filterset = filtersets.L2VPNFilterSet
     table = tables.L2VPNTable
     form = forms.L2VPNBulkEditForm
+
+
+@register_model_view(L2VPN, 'bulk_rename', path='rename', detail=False)
+class L2VPNBulkRenameView(generic.BulkRenameView):
+    queryset = L2VPN.objects.all()
 
 
 @register_model_view(L2VPN, 'bulk_delete', path='delete', detail=False)

--- a/netbox/vpn/views.py
+++ b/netbox/vpn/views.py
@@ -1,4 +1,5 @@
 from ipam.tables import RouteTargetTable
+from netbox.object_actions import AddObject, BulkDelete, BulkEdit, BulkExport, BulkImport
 from netbox.views import generic
 from utilities.query import count_related
 from utilities.views import GetRelatedModelsMixin, register_model_view
@@ -548,6 +549,7 @@ class L2VPNTerminationListView(generic.ObjectListView):
     table = tables.L2VPNTerminationTable
     filterset = filtersets.L2VPNTerminationFilterSet
     filterset_form = forms.L2VPNTerminationFilterForm
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkDelete)
 
 
 @register_model_view(L2VPNTermination)

--- a/netbox/wireless/views.py
+++ b/netbox/wireless/views.py
@@ -68,6 +68,11 @@ class WirelessLANGroupBulkEditView(generic.BulkEditView):
     form = forms.WirelessLANGroupBulkEditForm
 
 
+@register_model_view(WirelessLANGroup, 'bulk_rename', path='rename', detail=False)
+class WirelessLANGroupBulkRenameView(generic.BulkRenameView):
+    queryset = WirelessLANGroup.objects.all()
+
+
 @register_model_view(WirelessLANGroup, 'bulk_delete', path='delete', detail=False)
 class WirelessLANGroupBulkDeleteView(generic.BulkDeleteView):
     queryset = WirelessLANGroup.objects.add_related_count(

--- a/netbox/wireless/views.py
+++ b/netbox/wireless/views.py
@@ -142,6 +142,12 @@ class WirelessLANBulkEditView(generic.BulkEditView):
     form = forms.WirelessLANBulkEditForm
 
 
+@register_model_view(WirelessLAN, 'bulk_rename', path='rename', detail=False)
+class WirelessLANBulkRenameView(generic.BulkRenameView):
+    queryset = WirelessLAN.objects.all()
+    field_name = 'ssid'
+
+
 @register_model_view(WirelessLAN, 'bulk_delete', path='delete', detail=False)
 class WirelessLANBulkDeleteView(generic.BulkDeleteView):
     queryset = WirelessLAN.objects.all()
@@ -190,6 +196,12 @@ class WirelessLinkBulkEditView(generic.BulkEditView):
     filterset = filtersets.WirelessLinkFilterSet
     table = tables.WirelessLinkTable
     form = forms.WirelessLinkBulkEditForm
+
+
+@register_model_view(WirelessLink, 'bulk_rename', path='rename', detail=False)
+class WirelessLinkBulkRenameView(generic.BulkRenameView):
+    queryset = WirelessLink.objects.all()
+    field_name = 'ssid'
 
 
 @register_model_view(WirelessLink, 'bulk_delete', path='delete', detail=False)


### PR DESCRIPTION
### Closes: #19231

- Introduce the `getattr` template filter (needed for the bulk rename template)
- Add `BulkRename` to the default set of actions on `ObjectListView`
- Introduce a subclass of `BulkRenameView` for all relevant models; disable bulk renaming for others
- Officially support BulkRenameView for plugins
- Update ObjectAction URL resolution to fail silently
