### PR TITLE
Closes #19589: Background job for bulk operations

### DIFF
--- a/netbox/core/models/jobs.py
+++ b/netbox/core/models/jobs.py
@@ -116,7 +116,7 @@ class Job(models.Model):
         verbose_name_plural = _('jobs')
 
     def __str__(self):
-        return str(self.job_id)
+        return self.name
 
     def get_absolute_url(self):
         # TODO: Employ dynamic registration

--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -507,7 +507,11 @@ class BulkImportView(GetReturnURLMixin, BaseMultiObjectView):
             # If indicated, defer this request to a background job & redirect the user
             if form.cleaned_data['background_job']:
                 if job := process_request_as_job(self.__class__, request):
-                    messages.info(request, _("Background job enqueued: {job}").format(job=job.pk))
+                    msg = _('Created background job <a href="{url}">{job}</a>').format(
+                        url=job.get_absolute_url(),
+                        job=job
+                    )
+                    messages.info(request, mark_safe(msg))
                     return redirect(redirect_url)
 
             try:

--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -506,8 +506,12 @@ class BulkImportView(GetReturnURLMixin, BaseMultiObjectView):
 
             # If indicated, defer this request to a background job & redirect the user
             if form.cleaned_data['background_job']:
-                if job := process_request_as_job(self.__class__, request):
-                    msg = _('Created background job <a href="{url}">{job}</a>').format(
+                job_name = _('Bulk import {count} {object_type}').format(
+                    count=len(form.cleaned_data['data']),
+                    object_type=model._meta.verbose_name_plural,
+                )
+                if job := process_request_as_job(self.__class__, request, name=job_name):
+                    msg = _('Created background job {job.pk}: <a href="{url}">{job.name}</a>').format(
                         url=job.get_absolute_url(),
                         job=job
                     )

--- a/netbox/templates/generic/bulk_import.html
+++ b/netbox/templates/generic/bulk_import.html
@@ -73,7 +73,6 @@ Context:
         {% render_field form.upload_file %}
         {% render_field form.format %}
         {% render_field form.csv_delimiter %}
-        {% render_field form.background_job %}
         <div class="form-group">
           <div class="col col-md-12 text-end">
             {% if return_url %}

--- a/netbox/templates/generic/bulk_import.html
+++ b/netbox/templates/generic/bulk_import.html
@@ -50,6 +50,7 @@ Context:
           {% render_field form.data %}
           {% render_field form.format %}
           {% render_field form.csv_delimiter %}
+          {% render_field form.background_job %}
           <div class="form-group">
             <div class="col col-md-12 text-end">
               {% if return_url %}
@@ -72,6 +73,7 @@ Context:
         {% render_field form.upload_file %}
         {% render_field form.format %}
         {% render_field form.csv_delimiter %}
+        {% render_field form.background_job %}
         <div class="form-group">
           <div class="col col-md-12 text-end">
             {% if return_url %}
@@ -94,6 +96,7 @@ Context:
         {% render_field form.data_file %}
         {% render_field form.format %}
         {% render_field form.csv_delimiter %}
+        {% render_field form.background_job %}
         <div class="form-group">
           <div class="col col-md-12 text-end">
             {% if return_url %}

--- a/netbox/utilities/forms/bulk_import.py
+++ b/netbox/utilities/forms/bulk_import.py
@@ -37,6 +37,11 @@ class BulkImportForm(SyncedDataMixin, forms.Form):
         help_text=_("The character which delimits CSV fields. Applies only to CSV format."),
         required=False
     )
+    background_job = forms.BooleanField(
+        label=_('Background job'),
+        help_text=_("Enqueue a background job to complete the bulk import/update."),
+        required=False,
+    )
 
     data_field = 'data'
 

--- a/netbox/utilities/jobs.py
+++ b/netbox/utilities/jobs.py
@@ -1,0 +1,45 @@
+from dataclasses import dataclass
+from typing import List
+
+from netbox.jobs import AsyncViewJob
+from utilities.request import copy_safe_request
+
+__all__ = (
+    'AsyncJobData',
+    'is_background_request',
+    'process_request_as_job',
+)
+
+
+@dataclass
+class AsyncJobData:
+    log: List[str]
+    errors: List[str]
+
+
+def is_background_request(request):
+    """
+    Return True if the request is being processed as a background job.
+    """
+    return getattr(request, '_background', False)
+
+
+def process_request_as_job(view, request):
+    """
+    Process a request using a view as a background job.
+    """
+
+    # Check that the request that is not already being processed as a background job (would be a loop)
+    if is_background_request(request):
+        return
+
+    # Create a serializable copy of the original request
+    request_copy = copy_safe_request(request)
+    request_copy._background = True
+
+    # Enqueue a job to perform the work in the background
+    return AsyncViewJob.enqueue(
+        user=request.user,
+        view_cls=view,
+        request=request_copy,
+    )

--- a/netbox/utilities/jobs.py
+++ b/netbox/utilities/jobs.py
@@ -24,7 +24,7 @@ def is_background_request(request):
     return getattr(request, '_background', False)
 
 
-def process_request_as_job(view, request):
+def process_request_as_job(view, request, name=None):
     """
     Process a request using a view as a background job.
     """
@@ -39,6 +39,7 @@ def process_request_as_job(view, request):
 
     # Enqueue a job to perform the work in the background
     return AsyncViewJob.enqueue(
+        name=name,
         user=request.user,
         view_cls=view,
         request=request_copy,


### PR DESCRIPTION
### Closes: #19589

- Introduce AsyncViewJob to handle the background execution of arbitrary views
- Introduce the `apply_request_processors()` utility context manager for applying request processors
- Extend BulkImportView to support execution via a background job
- Add the `background_job` checkbox to BulkImportForm
- The string representation of a job now shows its name (rather than its task ID)