### PR TITLE
Fixes #19806: Introduce JobFailed exception to allow marking background jobs as failed

### DIFF
--- a/docs/features/background-jobs.md
+++ b/docs/features/background-jobs.md
@@ -2,9 +2,9 @@
 
 NetBox includes the ability to execute certain functions as background tasks. These include:
 
-* [Report](../customization/reports.md) execution
 * [Custom script](../customization/custom-scripts.md) execution
 * Synchronization of [remote data sources](../integrations/synchronized-data.md)
+* Housekeeping tasks
 
 Additionally, NetBox plugins can enqueue their own background tasks. This is accomplished using the [Job model](../models/core/job.md). Background tasks are executed by the `rqworker` process(es).
 

--- a/docs/plugins/development/background-jobs.md
+++ b/docs/plugins/development/background-jobs.md
@@ -15,7 +15,6 @@ A background job implements a basic [Job](../../models/core/job.md) executor for
 ```python title="jobs.py"
 from netbox.jobs import JobRunner
 
-
 class MyTestJob(JobRunner):
     class Meta:
         name = "My Test Job"
@@ -24,6 +23,8 @@ class MyTestJob(JobRunner):
         obj = self.job.object
         # your logic goes here
 ```
+
+Completed jobs will have their status updated to "completed" by default, or "errored" if an unhandled exception was raised by the `run()` method. To intentionally mark a job as failed, raise the `core.exceptions.JobFailed` exception. (Note that "failed" differs from "errored" in that a failure may be expected under certain conditions, whereas an error is not.)
 
 You can schedule the background job from within your code (e.g. from a model's `save()` method or a view) by calling `MyTestJob.enqueue()`. This method passes through all arguments to `Job.enqueue()`. However, no `name` argument must be passed, as the background job name will be used instead.
 

--- a/netbox/core/exceptions.py
+++ b/netbox/core/exceptions.py
@@ -1,9 +1,19 @@
 from django.core.exceptions import ImproperlyConfigured
 
-
-class SyncError(Exception):
-    pass
+__all__ = (
+    'IncompatiblePluginError',
+    'JobFailed',
+    'SyncError',
+)
 
 
 class IncompatiblePluginError(ImproperlyConfigured):
+    pass
+
+
+class JobFailed(Exception):
+    pass
+
+
+class SyncError(Exception):
     pass

--- a/netbox/core/models/jobs.py
+++ b/netbox/core/models/jobs.py
@@ -187,15 +187,14 @@ class Job(models.Model):
         """
         Mark the job as completed, optionally specifying a particular termination status.
         """
-        valid_statuses = JobStatusChoices.TERMINAL_STATE_CHOICES
-        if status not in valid_statuses:
+        if status not in JobStatusChoices.TERMINAL_STATE_CHOICES:
             raise ValueError(
                 _("Invalid status for job termination. Choices are: {choices}").format(
-                    choices=', '.join(valid_statuses)
+                    choices=', '.join(JobStatusChoices.TERMINAL_STATE_CHOICES)
                 )
             )
 
-        # Mark the job as completed
+        # Set the job's status and completion time
         self.status = status
         if error:
             self.error = error


### PR DESCRIPTION
### Fixes: #19806

- Introduce the `JobFailed` exception
- Add the `test_handle_failed()` test
- Update development documentation