### PR TITLE
Closes #17413: Permit identical names for platforms belonging to different manufacturers

### DIFF
--- a/docs/models/dcim/platform.md
+++ b/docs/models/dcim/platform.md
@@ -10,11 +10,11 @@ The assignment of platforms to devices is an optional feature, and may be disreg
 
 ### Name
 
-A unique human-friendly name.
+A human-friendly name for the platform. Must be unique per manufacturer.
 
 ### Slug
 
-A unique URL-friendly identifier. (This value can be used for filtering.)
+A URL-friendly identifier; must be unique per manufacturer. (This value can be used for filtering.)
 
 ### Manufacturer
 

--- a/netbox/dcim/migrations/0208_platform_manufacturer_uniqueness.py
+++ b/netbox/dcim/migrations/0208_platform_manufacturer_uniqueness.py
@@ -1,0 +1,54 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dcim', '0207_remove_redundant_indexes'),
+        ('extras', '0129_fix_script_paths'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='platform',
+            name='name',
+            field=models.CharField(max_length=100),
+        ),
+        migrations.AlterField(
+            model_name='platform',
+            name='slug',
+            field=models.SlugField(max_length=100),
+        ),
+        migrations.AddConstraint(
+            model_name='platform',
+            constraint=models.UniqueConstraint(
+                fields=('manufacturer', 'name'),
+                name='dcim_platform_manufacturer_name'
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name='platform',
+            constraint=models.UniqueConstraint(
+                condition=models.Q(('manufacturer__isnull', True)),
+                fields=('name',),
+                name='dcim_platform_name',
+                violation_error_message='Platform name must be unique.'
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name='platform',
+            constraint=models.UniqueConstraint(
+                fields=('manufacturer', 'slug'),
+                name='dcim_platform_manufacturer_slug'
+            ),
+        ),
+        migrations.AddConstraint(
+            model_name='platform',
+            constraint=models.UniqueConstraint(
+                condition=models.Q(('manufacturer__isnull', True)),
+                fields=('slug',),
+                name='dcim_platform_slug',
+                violation_error_message='Platform slug must be unique.'
+            ),
+        ),
+    ]

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -415,6 +415,15 @@ class Platform(OrganizationalModel):
         null=True,
         help_text=_('Optionally limit this platform to devices of a certain manufacturer')
     )
+    # Override name & slug from OrganizationalModel to not enforce uniqueness
+    name = models.CharField(
+        verbose_name=_('name'),
+        max_length=100
+    )
+    slug = models.SlugField(
+        verbose_name=_('slug'),
+        max_length=100
+    )
     config_template = models.ForeignKey(
         to='extras.ConfigTemplate',
         on_delete=models.PROTECT,
@@ -427,6 +436,28 @@ class Platform(OrganizationalModel):
         ordering = ('name',)
         verbose_name = _('platform')
         verbose_name_plural = _('platforms')
+        constraints = (
+            models.UniqueConstraint(
+                fields=('manufacturer', 'name'),
+                name='%(app_label)s_%(class)s_manufacturer_name',
+            ),
+            models.UniqueConstraint(
+                fields=('name',),
+                name='%(app_label)s_%(class)s_name',
+                condition=Q(manufacturer__isnull=True),
+                violation_error_message=_("Platform name must be unique.")
+            ),
+            models.UniqueConstraint(
+                fields=('manufacturer', 'slug'),
+                name='%(app_label)s_%(class)s_manufacturer_slug',
+            ),
+            models.UniqueConstraint(
+                fields=('slug',),
+                name='%(app_label)s_%(class)s_slug',
+                condition=Q(manufacturer__isnull=True),
+                violation_error_message=_("Platform slug must be unique.")
+            ),
+        )
 
 
 class Device(


### PR DESCRIPTION
### Closes: #17413

Relaxes uniqueness enforcement on the `name` and `slug` fields of the Platform model, so that each must be unique only within the scope of its assigned manufacturer, if any.