### PR TITLE
Closes #19722: Extend the object types REST API endpoint

### DIFF
--- a/netbox/core/models/contenttypes.py
+++ b/netbox/core/models/contenttypes.py
@@ -1,7 +1,9 @@
 from django.contrib.contenttypes.models import ContentType, ContentTypeManager
 from django.db.models import Q
 
+from netbox.plugins import PluginConfig
 from netbox.registry import registry
+from utilities.string import title
 
 __all__ = (
     'ObjectType',
@@ -48,3 +50,30 @@ class ObjectType(ContentType):
 
     class Meta:
         proxy = True
+
+    @property
+    def app_labeled_name(self):
+        # Override ContentType's "app | model" representation style.
+        return f"{self.app_verbose_name} > {title(self.model_verbose_name)}"
+
+    @property
+    def app_verbose_name(self):
+        if model := self.model_class():
+            return model._meta.app_config.verbose_name
+
+    @property
+    def model_verbose_name(self):
+        if model := self.model_class():
+            return model._meta.verbose_name
+
+    @property
+    def model_verbose_name_plural(self):
+        if model := self.model_class():
+            return model._meta.verbose_name_plural
+        return model._meta.label
+
+    @property
+    def is_plugin_model(self):
+        if not (model := self.model_class()):
+            return  # Return null if model class is invalid
+        return isinstance(model._meta.app_config, PluginConfig)

--- a/netbox/core/models/contenttypes.py
+++ b/netbox/core/models/contenttypes.py
@@ -70,7 +70,6 @@ class ObjectType(ContentType):
     def model_verbose_name_plural(self):
         if model := self.model_class():
             return model._meta.verbose_name_plural
-        return model._meta.label
 
     @property
     def is_plugin_model(self):

--- a/netbox/extras/api/serializers_/objecttypes.py
+++ b/netbox/extras/api/serializers_/objecttypes.py
@@ -1,6 +1,8 @@
 import inspect
 
 from django.urls import NoReverseMatch, reverse
+from drf_spectacular.types import OpenApiTypes
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from core.models import ObjectType
@@ -28,6 +30,7 @@ class ObjectTypeSerializer(BaseModelSerializer):
             'is_plugin_model', 'rest_api_endpoint', 'description',
         ]
 
+    @extend_schema_field(OpenApiTypes.STR)
     def get_rest_api_endpoint(self, obj):
         if not (model := obj.model_class()):
             return
@@ -37,6 +40,7 @@ class ObjectTypeSerializer(BaseModelSerializer):
             except NoReverseMatch:
                 return
 
+    @extend_schema_field(OpenApiTypes.STR)
     def get_description(self, obj):
         if not (model := obj.model_class()):
             return

--- a/netbox/extras/api/serializers_/objecttypes.py
+++ b/netbox/extras/api/serializers_/objecttypes.py
@@ -1,7 +1,11 @@
+import inspect
+
+from django.urls import NoReverseMatch, reverse
 from rest_framework import serializers
 
 from core.models import ObjectType
 from netbox.api.serializers import BaseModelSerializer
+from utilities.views import get_viewname
 
 __all__ = (
     'ObjectTypeSerializer',
@@ -10,7 +14,30 @@ __all__ = (
 
 class ObjectTypeSerializer(BaseModelSerializer):
     url = serializers.HyperlinkedIdentityField(view_name='extras-api:objecttype-detail')
+    app_name = serializers.CharField(source='app_verbose_name', read_only=True)
+    model_name = serializers.CharField(source='model_verbose_name', read_only=True)
+    model_name_plural = serializers.CharField(source='model_verbose_name_plural', read_only=True)
+    is_plugin_model = serializers.BooleanField(read_only=True)
+    rest_api_endpoint = serializers.SerializerMethodField()
+    description = serializers.SerializerMethodField()
 
     class Meta:
         model = ObjectType
-        fields = ['id', 'url', 'display', 'app_label', 'model']
+        fields = [
+            'id', 'url', 'display', 'app_label', 'app_name', 'model', 'model_name', 'model_name_plural',
+            'is_plugin_model', 'rest_api_endpoint', 'description',
+        ]
+
+    def get_rest_api_endpoint(self, obj):
+        if not (model := obj.model_class()):
+            return
+        if viewname := get_viewname(model, action='list', rest_api=True):
+            try:
+                return reverse(viewname)
+            except NoReverseMatch:
+                return
+
+    def get_description(self, obj):
+        if not (model := obj.model_class()):
+            return
+        return inspect.getdoc(model)


### PR DESCRIPTION
### Closes: #19722

- Adds several new fields to the serialized representation of an ObjectType:
  - `app_name`: The human-friendly app name (e.g. "IPAM" instead of "ipam")
  - `model_name`: The human-friendly model name (e.g. "VRF" instead of "vrf")
  - `model_name_plural`: The plural form of `model_name`
  - `is_plugin_model`: Returns True if the model is delivered via a NetBox plugin
  - `rest_api_endpoint`: The base REST API endpoint for the model (if available)
  - `description`: The model's docstring
- Tweaks the formatting of `display` slightly for improved readability

Before:

```json
{
    "id": 74,
    "url": "http://netbox:8000/api/extras/object-types/74/",
    "display": "IPAM | VRF",
    "app_label": "ipam",
    "model": "vrf"
}
```

After:

```json
{
    "id": 74,
    "url": "http://netbox:8000/api/extras/object-types/74/",
    "display": "IPAM > VRF",
    "app_label": "ipam",
    "app_name": "IPAM",
    "model": "vrf",
    "model_name": "VRF",
    "model_name_plural": "VRFs",
    "is_plugin_model": false,
    "rest_api_endpoint": "/api/ipam/vrfs/",
    "description": "A virtual routing and forwarding (VRF) table represents a discrete..."
}
```