### PR TITLE
Closes #19134: Allow negative values for interface TX power

### DIFF
--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -1507,7 +1507,7 @@ class InterfaceFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     tx_power = forms.IntegerField(
         required=False,
         label=_('Transmit power (dBm)'),
-        min_value=0,
+        min_value=-40,
         max_value=127
     )
     vrf_id = DynamicModelMultipleChoiceField(

--- a/netbox/dcim/migrations/0209_interface_tx_power_negative.py
+++ b/netbox/dcim/migrations/0209_interface_tx_power_negative.py
@@ -1,0 +1,24 @@
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dcim', '0208_platform_manufacturer_uniqueness'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='interface',
+            name='tx_power',
+            field=models.SmallIntegerField(
+                blank=True,
+                null=True,
+                validators=[
+                    django.core.validators.MinValueValidator(-40),
+                    django.core.validators.MaxValueValidator(127)
+                ]
+            ),
+        ),
+    ]

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -719,10 +719,13 @@ class Interface(ModularComponentModel, BaseInterface, CabledObjectModel, PathEnd
         verbose_name=('channel width (MHz)'),
         help_text=_("Populated by selected channel (if set)")
     )
-    tx_power = models.PositiveSmallIntegerField(
+    tx_power = models.SmallIntegerField(
         blank=True,
         null=True,
-        validators=(MaxValueValidator(127),),
+        validators=(
+            MinValueValidator(-40),
+            MaxValueValidator(127),
+        ),
         verbose_name=_('transmit power (dBm)')
     )
     poe_mode = models.CharField(


### PR DESCRIPTION
### Closes: #19134

Support negative values down to -40 (inclusive) for `tx_power` on the Interface model.