### PR TITLE
Fixes #19839: Enable export of parent assignment for recursively nested objects

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -63,6 +63,10 @@ class DeviceRoleTable(NetBoxTable):
         verbose_name=_('Name'),
         linkify=True
     )
+    parent = tables.Column(
+        verbose_name=_('Parent'),
+        linkify=True,
+    )
     device_count = columns.LinkedCountColumn(
         viewname='dcim:device_list',
         url_params={'role_id': 'pk'},
@@ -88,8 +92,8 @@ class DeviceRoleTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = models.DeviceRole
         fields = (
-            'pk', 'id', 'name', 'device_count', 'vm_count', 'color', 'vm_role', 'config_template', 'description',
-            'slug', 'tags', 'actions', 'created', 'last_updated',
+            'pk', 'id', 'name', 'parent', 'device_count', 'vm_count', 'color', 'vm_role', 'config_template',
+            'description', 'slug', 'tags', 'actions', 'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'device_count', 'vm_count', 'color', 'vm_role', 'description')
 

--- a/netbox/dcim/tables/sites.py
+++ b/netbox/dcim/tables/sites.py
@@ -24,6 +24,10 @@ class RegionTable(ContactsColumnMixin, NetBoxTable):
         verbose_name=_('Name'),
         linkify=True
     )
+    parent = tables.Column(
+        verbose_name=_('Parent'),
+        linkify=True,
+    )
     site_count = columns.LinkedCountColumn(
         viewname='dcim:site_list',
         url_params={'region_id': 'pk'},
@@ -39,7 +43,7 @@ class RegionTable(ContactsColumnMixin, NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = Region
         fields = (
-            'pk', 'id', 'name', 'slug', 'site_count', 'description', 'comments', 'contacts', 'tags',
+            'pk', 'id', 'name', 'parent', 'slug', 'site_count', 'description', 'comments', 'contacts', 'tags',
             'created', 'last_updated', 'actions',
         )
         default_columns = ('pk', 'name', 'site_count', 'description')
@@ -53,6 +57,10 @@ class SiteGroupTable(ContactsColumnMixin, NetBoxTable):
     name = columns.MPTTColumn(
         verbose_name=_('Name'),
         linkify=True
+    )
+    parent = tables.Column(
+        verbose_name=_('Parent'),
+        linkify=True,
     )
     site_count = columns.LinkedCountColumn(
         viewname='dcim:site_list',
@@ -69,7 +77,7 @@ class SiteGroupTable(ContactsColumnMixin, NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = SiteGroup
         fields = (
-            'pk', 'id', 'name', 'slug', 'site_count', 'description', 'comments', 'contacts', 'tags',
+            'pk', 'id', 'name', 'parent', 'slug', 'site_count', 'description', 'comments', 'contacts', 'tags',
             'created', 'last_updated', 'actions',
         )
         default_columns = ('pk', 'name', 'site_count', 'description')
@@ -135,6 +143,10 @@ class LocationTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
         verbose_name=_('Name'),
         linkify=True
     )
+    parent = tables.Column(
+        verbose_name=_('Parent'),
+        linkify=True,
+    )
     site = tables.Column(
         verbose_name=_('Site'),
         linkify=True
@@ -170,8 +182,8 @@ class LocationTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = Location
         fields = (
-            'pk', 'id', 'name', 'site', 'status', 'facility', 'tenant', 'tenant_group', 'rack_count', 'device_count',
-            'description', 'slug', 'comments', 'contacts', 'tags', 'actions', 'created', 'last_updated',
+            'pk', 'id', 'name', 'parent', 'site', 'status', 'facility', 'tenant', 'tenant_group', 'rack_count',
+            'device_count', 'description', 'slug', 'comments', 'contacts', 'tags', 'actions', 'created', 'last_updated',
             'vlangroup_count',
         )
         default_columns = (

--- a/netbox/tenancy/tables/contacts.py
+++ b/netbox/tenancy/tables/contacts.py
@@ -19,6 +19,10 @@ class ContactGroupTable(NetBoxTable):
         verbose_name=_('Name'),
         linkify=True
     )
+    parent = tables.Column(
+        verbose_name=_('Parent'),
+        linkify=True,
+    )
     contact_count = columns.LinkedCountColumn(
         viewname='tenancy:contact_list',
         url_params={'group_id': 'pk'},
@@ -34,7 +38,7 @@ class ContactGroupTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = ContactGroup
         fields = (
-            'pk', 'name', 'contact_count', 'description', 'comments', 'slug', 'tags', 'created',
+            'pk', 'name', 'parent', 'contact_count', 'description', 'comments', 'slug', 'tags', 'created',
             'last_updated', 'actions',
         )
         default_columns = ('pk', 'name', 'contact_count', 'description')

--- a/netbox/tenancy/tables/tenants.py
+++ b/netbox/tenancy/tables/tenants.py
@@ -16,6 +16,10 @@ class TenantGroupTable(NetBoxTable):
         verbose_name=_('Name'),
         linkify=True
     )
+    parent = tables.Column(
+        verbose_name=_('Parent'),
+        linkify=True,
+    )
     tenant_count = columns.LinkedCountColumn(
         viewname='tenancy:tenant_list',
         url_params={'group_id': 'pk'},
@@ -31,7 +35,7 @@ class TenantGroupTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = TenantGroup
         fields = (
-            'pk', 'id', 'name', 'tenant_count', 'description', 'comments', 'slug', 'tags', 'created',
+            'pk', 'id', 'name', 'parent', 'tenant_count', 'description', 'comments', 'slug', 'tags', 'created',
             'last_updated', 'actions',
         )
         default_columns = ('pk', 'name', 'tenant_count', 'description')

--- a/netbox/wireless/tables/wirelesslan.py
+++ b/netbox/wireless/tables/wirelesslan.py
@@ -18,6 +18,10 @@ class WirelessLANGroupTable(NetBoxTable):
         verbose_name=_('Name'),
         linkify=True
     )
+    parent = tables.Column(
+        verbose_name=_('Parent'),
+        linkify=True,
+    )
     wirelesslan_count = columns.LinkedCountColumn(
         viewname='wireless:wirelesslan_list',
         url_params={'group_id': 'pk'},
@@ -33,8 +37,8 @@ class WirelessLANGroupTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = WirelessLANGroup
         fields = (
-            'pk', 'name', 'wirelesslan_count', 'slug', 'description', 'comments', 'tags', 'created', 'last_updated',
-            'actions',
+            'pk', 'name', 'parent', 'slug', 'description', 'comments', 'tags', 'wirelesslan_count', 'created',
+            'last_updated', 'actions',
         )
         default_columns = ('pk', 'name', 'wirelesslan_count', 'description')
 


### PR DESCRIPTION
### Fixes: #19839

Add a non-default `parent` table column to enable parent export for the following models:

- dcim.DeviceRole
- dcim.Location
- dcim.Region
- dcim.SiteGroup
- tenancy.ContactGroup
- tenancy.TenantGroup
- wireless.WirelessLANGroup