### PR TITLE
Fixes #19413: Group custom fields in filter tab

### DIFF
--- a/netbox/templates/inc/filter_list.html
+++ b/netbox/templates/inc/filter_list.html
@@ -29,11 +29,7 @@
           <div class="hr-text">
             <span>{% trans "Custom Fields" %}</span>
           </div>
-          {% for name in filter_form.custom_fields %}
-            {% with field=filter_form|get_item:name %}
-              {% render_field field %}
-            {% endwith %}
-          {% endfor %}
+          {% render_custom_fields filter_form %}
         </div>
       {% endif %}
     </div>


### PR DESCRIPTION
### Fixes: #19413

Replaced manual rendering of custom fields in the filter tab with the `render_custom_fields` template tag. This change ensures that custom fields are properly grouped, addressing the issue where they were previously displayed without their associated groups.

<!--
    Please include a summary of the proposed changes below.
-->
