### PR TITLE
Closes #19893: Include hostname in REST API status endpoint

### DIFF
--- a/netbox/netbox/api/views.py
+++ b/netbox/netbox/api/views.py
@@ -65,6 +65,7 @@ class StatusView(APIView):
 
         return Response({
             'django-version': DJANGO_VERSION,
+            'hostname': settings.HOSTNAME,
             'installed-apps': installed_apps,
             'netbox-version': settings.RELEASE.version,
             'netbox-full-version': settings.RELEASE.full_version,


### PR DESCRIPTION
### Closes: #19893

Include the system hostname in REST API status output.
