### PR TITLE
Closes: #18588: Relabel Service to Application Service

### DIFF
--- a/docs/features/ipam.md
+++ b/docs/features/ipam.md
@@ -62,8 +62,8 @@ VRF modeling in NetBox very closely follows what you find in real-world network 
 
 An often overlooked component of IPAM, NetBox also tracks autonomous system (AS) numbers and their assignment to sites. Both 16- and 32-bit AS numbers are supported, and like aggregates each ASN is assigned to an authoritative RIR.
 
-## Service Mapping
+## Application Service Mapping
 
 NetBox models network applications as discrete service objects associated with devices and/or virtual machines, and optionally with specific IP addresses attached to those parent objects. These can be used to catalog the applications running on your network for reference by other objects or integrated tools.
 
-To model services in NetBox, begin by creating a service template defining the name, protocol, and port number(s) on which the service listens. This template can then be easily instantiated to "attach" new services to a device or virtual machine. It's also possible to create new services by hand, without a template, however this approach can be tedious.
+To model application services in NetBox, begin by creating an application service template defining the name, protocol, and port number(s) on which the service listens. This template can then be easily instantiated to "attach" new services to a device or virtual machine. It's also possible to create new application services by hand, without a template, however this approach can be tedious.

--- a/docs/models/ipam/service.md
+++ b/docs/models/ipam/service.md
@@ -1,14 +1,18 @@
-# Services
+# Application Services
 
-A service represents a layer seven application available on a device or virtual machine. For example, a service might be created in NetBox to represent an HTTP server running on TCP/8000. Each service may optionally be further bound to one or more specific interfaces assigned to the selected device or virtual machine.
+An application service represents a layer seven application available on a device or virtual machine. For example, a service might be created in NetBox to represent an HTTP server running on TCP/8000. Each service may optionally be further bound to one or more specific interfaces assigned to the selected device or virtual machine.
 
-To aid in the efficient creation of services, users may opt to first create a [service template](./servicetemplate.md) from which service definitions can be quickly replicated.
+To aid in the efficient creation of application services, users may opt to first create an [application service template](./servicetemplate.md) from which service definitions can be quickly replicated.
+
+!!! note "Changed in NetBox v4.4"
+
+    Previously, application services were referred to simply as "services". The name has been changed in the UI to better reflect their intended use. There is no change to the name of the model or in any programmatic NetBox APIs.
 
 ## Fields
 
 ### Parent
 
-The parent object to which the service is assigned. This must be one of [Device](../dcim/device.md),
+The parent object to which the application service is assigned. This must be one of [Device](../dcim/device.md),
 [VirtualMachine](../virtualization/virtualmachine.md), or [FHRP Group](./fhrpgroup.md).
 
 !!! note "Changed in NetBox v4.3"

--- a/docs/models/ipam/servicetemplate.md
+++ b/docs/models/ipam/servicetemplate.md
@@ -1,6 +1,10 @@
-# Service Templates
+# Application Service Templates
 
-Service templates can be used to instantiate [services](./service.md) on [devices](../dcim/device.md) and [virtual machines](../virtualization/virtualmachine.md).
+Application service templates can be used to instantiate [application services](./service.md) on [devices](../dcim/device.md) and [virtual machines](../virtualization/virtualmachine.md).
+
+!!! note "Changed in NetBox v4.4"
+
+    Previously, application service templates were referred to simply as "service templates". The name has been changed in the UI to better reflect their intended use. There is no change to the name of the model or in any programmatic NetBox APIs.
 
 ## Fields
 

--- a/docs/models/virtualization/vminterface.md
+++ b/docs/models/virtualization/vminterface.md
@@ -1,6 +1,6 @@
 ## Interfaces
 
-[Virtual machine](./virtualmachine.md) interfaces behave similarly to device [interfaces](../dcim/interface.md): They can be assigned to VRFs, may have IP addresses, VLANs, and services attached to them, and so on. However, given their virtual nature, they lack properties pertaining to physical attributes. For example, VM interfaces do not have a physical type and cannot have cables attached to them.
+[Virtual machine](./virtualmachine.md) interfaces behave similarly to device [interfaces](../dcim/interface.md): They can be assigned to VRFs, may have IP addresses, VLANs, and so on. However, given their virtual nature, they lack properties pertaining to physical attributes. For example, VM interfaces do not have a physical type and cannot have cables attached to them.
 
 ## Fields
 

--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -660,7 +660,7 @@ class IPAddressFilterSet(NetBoxModelFilterSet, TenancyFilterSet, ContactModelFil
     service_id = django_filters.ModelMultipleChoiceFilter(
         field_name='services',
         queryset=Service.objects.all(),
-        label=_('Service (ID)'),
+        label=_('Application Service (ID)'),
     )
     nat_inside_id = django_filters.ModelMultipleChoiceFilter(
         field_name='nat_inside',

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -749,7 +749,7 @@ class ServiceTemplateForm(NetBoxModelForm):
     comments = CommentField()
 
     fieldsets = (
-        FieldSet('name', 'protocol', 'ports', 'description', 'tags', name=_('Service Template')),
+        FieldSet('name', 'protocol', 'ports', 'description', 'tags', name=_('Application Service Template')),
     )
 
     class Meta:
@@ -794,7 +794,7 @@ class ServiceForm(NetBoxModelForm):
         FieldSet(
             'parent_object_type', 'parent', 'name',
             InlineFields('protocol', 'ports', label=_('Port(s)')),
-            'ipaddresses', 'description', 'tags', name=_('Service')
+            'ipaddresses', 'description', 'tags', name=_('Application Service')
         ),
     )
 
@@ -836,7 +836,7 @@ class ServiceForm(NetBoxModelForm):
 
 class ServiceCreateForm(ServiceForm):
     service_template = DynamicModelChoiceField(
-        label=_('Service template'),
+        label=_('Application Service template'),
         queryset=ServiceTemplate.objects.all(),
         required=False
     )
@@ -848,7 +848,7 @@ class ServiceCreateForm(ServiceForm):
                 FieldSet('service_template', name=_('From Template')),
                 FieldSet('name', 'protocol', 'ports', name=_('Custom')),
             ),
-            'ipaddresses', 'description', 'tags', name=_('Service')
+            'ipaddresses', 'description', 'tags', name=_('Application Service')
         ),
     )
 
@@ -877,4 +877,6 @@ class ServiceCreateForm(ServiceForm):
             if not self.cleaned_data['description']:
                 self.cleaned_data['description'] = service_template.description
         elif not all(self.cleaned_data[f] for f in ('name', 'protocol', 'ports')):
-            raise forms.ValidationError(_("Must specify name, protocol, and port(s) if not using a service template."))
+            raise forms.ValidationError(
+                _("Must specify name, protocol, and port(s) if not using an application service template.")
+            )

--- a/netbox/ipam/models/services.py
+++ b/netbox/ipam/models/services.py
@@ -55,8 +55,8 @@ class ServiceTemplate(ServiceBase, PrimaryModel):
 
     class Meta:
         ordering = ('name',)
-        verbose_name = _('service template')
-        verbose_name_plural = _('service templates')
+        verbose_name = _('application service template')
+        verbose_name_plural = _('application service templates')
 
 
 class Service(ContactsMixin, ServiceBase, PrimaryModel):
@@ -94,5 +94,5 @@ class Service(ContactsMixin, ServiceBase, PrimaryModel):
             models.Index(fields=('parent_object_type', 'parent_object_id')),
         )
         ordering = ('protocol', 'ports', 'pk')  # (protocol, port) may be non-unique
-        verbose_name = _('service')
-        verbose_name_plural = _('services')
+        verbose_name = _('application service')
+        verbose_name_plural = _('application services')

--- a/netbox/ipam/models/services.py
+++ b/netbox/ipam/models/services.py
@@ -84,7 +84,7 @@ class Service(ContactsMixin, ServiceBase, PrimaryModel):
         related_name='services',
         blank=True,
         verbose_name=_('IP addresses'),
-        help_text=_("The specific IP addresses (if any) to which this service is bound")
+        help_text=_("The specific IP addresses (if any) to which this application service is bound")
     )
 
     clone_fields = ['protocol', 'ports', 'description', 'parent', 'ipaddresses', ]

--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -1162,6 +1162,7 @@ class ServiceTemplateTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    graphql_base_name = 'service_template'
 
     @classmethod
     def setUpTestData(cls):
@@ -1197,6 +1198,7 @@ class ServiceTest(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    graphql_base_name = 'service'
 
     @classmethod
     def setUpTestData(cls):

--- a/netbox/ipam/tests/test_filtersets.py
+++ b/netbox/ipam/tests/test_filtersets.py
@@ -1101,6 +1101,9 @@ class IPAddressTestCase(TestCase, ChangeLoggedFilterSetTests):
     queryset = IPAddress.objects.all()
     filterset = IPAddressFilterSet
     ignore_fields = ('fhrpgroup',)
+    filter_name_map = {
+        'application_service': 'service',
+    }
 
     @classmethod
     def setUpTestData(cls):

--- a/netbox/netbox/navigation/menu.py
+++ b/netbox/netbox/navigation/menu.py
@@ -209,8 +209,8 @@ IPAM_MENU = Menu(
             label=_('Other'),
             items=(
                 get_model_item('ipam', 'fhrpgroup', _('FHRP Groups')),
-                get_model_item('ipam', 'servicetemplate', _('Service Templates')),
-                get_model_item('ipam', 'service', _('Services')),
+                get_model_item('ipam', 'servicetemplate', _('Application Service Templates')),
+                get_model_item('ipam', 'service', _('Application Services')),
             ),
         ),
     ),

--- a/netbox/templates/dcim/device.html
+++ b/netbox/templates/dcim/device.html
@@ -305,11 +305,11 @@
             {% endif %}
             <div class="card">
               <h2 class="card-header">
-                {% trans "Services" %}
+                {% trans "Application Services" %}
                 {% if perms.ipam.add_service %}
                   <div class="card-actions">
                     <a href="{% url 'ipam:service_add' %}?parent_object_type={{ object|content_type_id }}&parent={{ object.pk }}" class="btn btn-ghost-primary btn-sm">
-                      <span class="mdi mdi-plus-thick" aria-hidden="true"></span> {% trans "Add a service" %}
+                      <span class="mdi mdi-plus-thick" aria-hidden="true"></span> {% trans "Add an application service" %}
                     </a>
                   </div>
                 {% endif %}

--- a/netbox/templates/ipam/ipaddress.html
+++ b/netbox/templates/ipam/ipaddress.html
@@ -115,7 +115,7 @@
       {% include 'inc/panel_table.html' with table=duplicate_ips_table heading='Duplicate IPs' panel_class='danger' %}
     {% endif %}
     <div class="card">
-      <h2 class="card-header">{% trans "Services" %}</h2>
+      <h2 class="card-header">{% trans "Application Services" %}</h2>
       {% htmx_table 'ipam:service_list' ip_address_id=object.pk %}
     </div>
     {% plugin_right_page object %}

--- a/netbox/templates/ipam/servicetemplate.html
+++ b/netbox/templates/ipam/servicetemplate.html
@@ -9,7 +9,7 @@
   <div class="row mb-3">
     <div class="col col-12 col-md-6">
       <div class="card">
-        <h2 class="card-header">{% trans "Service Template" %}</h2>
+        <h2 class="card-header">{% trans "Application Service Template" %}</h2>
         <table class="table table-hover attr-table">
           <tr>
             <th scope="row">{% trans "Name" %}</th>

--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -151,11 +151,11 @@
         </div>
         <div class="card">
           <h2 class="card-header">
-            {% trans "Services" %}
+            {% trans "Application Services" %}
             {% if perms.ipam.add_service %}
               <div class="card-actions">
                 <a href="{% url 'ipam:service_add' %}?parent_object_type={{ object|content_type_id }}&parent={{ object.pk }}" class="btn btn-ghost-primary btn-sm">
-                  <span class="mdi mdi-plus-thick" aria-hidden="true"></span> {% trans "Add a service" %}
+                  <span class="mdi mdi-plus-thick" aria-hidden="true"></span> {% trans "Add an application service" %}
                 </a>
               </div>
             {% endif %}


### PR DESCRIPTION
### Closes: #18588
This PR relabels the Service model to "Application Service" (and ServiceTemplate to "Application Service Template") throughout the UI to make it clearer what this model is actually for.

"Application Service" was chosen because it best describes the model's intent: to represent pretty much anything running above the transport layer (L4). This includes classic examples like SSH, HTTPS, and NTP, but also custom applications, APIs, or any other process defined by a protocol and port. The name "L7 Service" was considered, but it felt a little too restrictive and could be confusing for users who also interact with programmatic aspects of NetBox.

To ensure backward compatibility, this is a UI-only change. The underlying models, REST API endpoints, and GraphQL schema remain unchanged.
TODO:

- [x] Update Service and ServiceTemplate verbose_name and adapt test suites (django-filter, GraphQL) to assert API stability.
- [x] Rename Service and Service template in the IPAM sub-menu.
- [x] Update hardcoded labels for buttons, titles, and messages across all relevant templates, views, forms, and tables.
- [x] Update docs as necessary.
- ~~Optional: work to make sure translations exist~~ This should be covered by routine Transifex maintenance.