### PR TITLE
Fixes #19911: Fix `redirect_url` support for bulk operations

### DIFF
--- a/netbox/netbox/object_actions.py
+++ b/netbox/netbox/object_actions.py
@@ -1,3 +1,4 @@
+from django.template import loader
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.translation import gettext as _
@@ -27,12 +28,14 @@ class ObjectAction:
     Params:
         name: The action name appended to the module for view resolution
         label: Human-friendly label for the rendered button
+        template_name: Name of the HTML template which renders the button
         multi: Set to True if this action is performed by selecting multiple objects (i.e. using a table)
         permissions_required: The set of permissions a user must have to perform the action
         url_kwargs: The set of URL keyword arguments to pass when resolving the view's URL
     """
     name = ''
     label = None
+    template_name = None
     multi = False
     permissions_required = set()
     url_kwargs = []
@@ -49,11 +52,13 @@ class ObjectAction:
             return
 
     @classmethod
-    def get_context(cls, context, obj):
-        return {
+    def render(cls, obj, **kwargs):
+        context = {
             'url': cls.get_url(obj),
             'label': cls.label,
+            **kwargs,
         }
+        return loader.render_to_string(cls.template_name, context)
 
 
 class AddObject(ObjectAction):

--- a/netbox/templates/core/buttons/bulk_sync.html
+++ b/netbox/templates/core/buttons/bulk_sync.html
@@ -1,3 +1,3 @@
-<button type="submit" name="_sync" {% formaction %}="{{ url }}" class="btn btn-primary">
+<button type="submit" name="_sync" {% formaction %}="{{ url }}{% if return_url %}?return_url={{ return_url }}{% endif %}" class="btn btn-primary">
   <i class="mdi mdi-sync" aria-hidden="true"></i> {{ label }}
 </button>

--- a/netbox/templates/dcim/buttons/bulk_disconnect.html
+++ b/netbox/templates/dcim/buttons/bulk_disconnect.html
@@ -1,3 +1,3 @@
-<button type="submit" name="_disconnect" {% formaction %}="{{ url }}" class="btn btn-red">
+<button type="submit" name="_disconnect" {% formaction %}="{{ url }}{% if return_url %}?return_url={{ return_url }}{% endif %}" class="btn btn-red">
   <i class="mdi mdi-ethernet-cable-off" aria-hidden="true"></i> {{ label }}
 </button>

--- a/netbox/templates/generic/object_children.html
+++ b/netbox/templates/generic/object_children.html
@@ -35,7 +35,7 @@ Context:
         </div>
         <div class="d-print-none mt-2">
             {% block bulk_controls %}
-              {% action_buttons actions model multi=True %}
+              {% action_buttons actions model multi=True return_url=request.path %}
               {% block bulk_extra_controls %}{% endblock %}
             {% endblock bulk_controls %}
         </div>

--- a/netbox/utilities/templates/buttons/bulk_delete.html
+++ b/netbox/utilities/templates/buttons/bulk_delete.html
@@ -1,3 +1,3 @@
-<button type="submit" name="_delete" {% formaction %}="{{ url }}" class="btn btn-red">
+<button type="submit" name="_delete" {% formaction %}="{{ url }}{% if return_url %}?return_url={{ return_url }}{% endif %}" class="btn btn-red">
   <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i> {{ label }}
 </button>

--- a/netbox/utilities/templates/buttons/bulk_edit.html
+++ b/netbox/utilities/templates/buttons/bulk_edit.html
@@ -1,3 +1,3 @@
-<button type="submit" name="_edit" {% formaction %}="{{ url }}" class="btn btn-yellow">
+<button type="submit" name="_edit" {% formaction %}="{{ url }}{% if return_url %}?return_url={{ return_url }}{% endif %}" class="btn btn-yellow">
   <i class="mdi mdi-pencil" aria-hidden="true"></i> {{ label }}
 </button>

--- a/netbox/utilities/templates/buttons/bulk_rename.html
+++ b/netbox/utilities/templates/buttons/bulk_rename.html
@@ -1,5 +1,5 @@
 {% if url %}
-  <button type="submit" name="_rename" {% formaction %}="{{ url }}" class="btn btn-yellow">
+  <button type="submit" name="_rename" {% formaction %}="{{ url }}{% if return_url %}?return_url={{ return_url }}{% endif %}" class="btn btn-yellow">
     <i class="mdi mdi-pencil" aria-hidden="true"></i> {{ label }}
   </button>
 {% endif %}

--- a/netbox/utilities/templatetags/buttons.py
+++ b/netbox/utilities/templatetags/buttons.py
@@ -1,6 +1,5 @@
 from django import template
 from django.contrib.contenttypes.models import ContentType
-from django.template import loader
 from django.urls import NoReverseMatch, reverse
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
@@ -29,11 +28,10 @@ __all__ = (
 register = template.Library()
 
 
-@register.simple_tag(takes_context=True)
-def action_buttons(context, actions, obj, multi=False):
+@register.simple_tag
+def action_buttons(actions, obj, multi=False, **kwargs):
     buttons = [
-        loader.render_to_string(action.template_name, action.get_context(context, obj))
-        for action in actions if action.multi == multi
+        action.render(obj, **kwargs) for action in actions if action.multi == multi
     ]
     return mark_safe(''.join(buttons))
 


### PR DESCRIPTION
### Fixes: #19911

- Move the template rendering logic to a `render()` method on the ObjectAction class
- Extend `action_buttons` template tag to support passing arbitrary keyword arguments
- Extend bulk operation button templates to attach a return URL parameter to the target URL if one was given
