### PR TITLE
Fix #19910: Add conditional to hide internet dependent links in an isolated deployment

### DIFF
--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -199,21 +199,19 @@ Blocks:
                   </li>
 
                 {# Community links #}
-                {% else %}
-                  {% if not settings.ISOLATED_DEPLOYMENT %}
-                    {# GitHub #}
-                    <li class="list-inline-item">
-                      <a href="https://github.com/netbox-community/netbox" target="_blank" class="link-secondary" rel="noopener" aria-label="{% trans "Source Code" %}">
-                        <i title="{% trans "Source Code" %}" class="mdi mdi-github text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
-                      </a>
-                    </li>
-                    {# NetDev Slack #}
-                    <li class="list-inline-item">
-                      <a href="https://netdev.chat" target="_blank" class="link-secondary" rel="noopener" aria-label="{% trans "Community" %}">
-                        <i title="{% trans "Community" %}" class="mdi mdi-slack text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
-                      </a>
-                    </li>
-                  {% endif %}
+                {% elif not settings.ISOLATED_DEPLOYMENT %}                  
+                  {# GitHub #}
+                  <li class="list-inline-item">
+                    <a href="https://github.com/netbox-community/netbox" target="_blank" class="link-secondary" rel="noopener" aria-label="{% trans "Source Code" %}">
+                      <i title="{% trans "Source Code" %}" class="mdi mdi-github text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
+                    </a>
+                  </li>
+                  {# NetDev Slack #}
+                  <li class="list-inline-item">
+                    <a href="https://netdev.chat" target="_blank" class="link-secondary" rel="noopener" aria-label="{% trans "Community" %}">
+                      <i title="{% trans "Community" %}" class="mdi mdi-slack text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
+                    </a>
+                  </li>                  
                 {% endif %}
               {% endblock footer_links %}
             </ul>

--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -200,19 +200,19 @@ Blocks:
 
                 {# Community links #}
                 {% else %}
-                {% if not settings.ISOLATED_DEPLOYMENT %}
-                  {# GitHub #}
-                  <li class="list-inline-item">
-                    <a href="https://github.com/netbox-community/netbox" target="_blank" class="link-secondary" rel="noopener" aria-label="{% trans "Source Code" %}">
-                      <i title="{% trans "Source Code" %}" class="mdi mdi-github text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
-                    </a>
-                  </li>
-                  {# NetDev Slack #}
-                  <li class="list-inline-item">
-                    <a href="https://netdev.chat" target="_blank" class="link-secondary" rel="noopener" aria-label="{% trans "Community" %}">
-                      <i title="{% trans "Community" %}" class="mdi mdi-slack text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
-                    </a>
-                  </li>
+                  {% if not settings.ISOLATED_DEPLOYMENT %}
+                    {# GitHub #}
+                    <li class="list-inline-item">
+                      <a href="https://github.com/netbox-community/netbox" target="_blank" class="link-secondary" rel="noopener" aria-label="{% trans "Source Code" %}">
+                        <i title="{% trans "Source Code" %}" class="mdi mdi-github text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
+                      </a>
+                    </li>
+                    {# NetDev Slack #}
+                    <li class="list-inline-item">
+                      <a href="https://netdev.chat" target="_blank" class="link-secondary" rel="noopener" aria-label="{% trans "Community" %}">
+                        <i title="{% trans "Community" %}" class="mdi mdi-slack text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
+                      </a>
+                    </li>
                   {% endif %}
                 {% endif %}
               {% endblock footer_links %}

--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -55,7 +55,7 @@ Blocks:
           {# Release info #}
           <div class="text-muted text-center fs-5 my-3">
             {{ settings.RELEASE.name }}
-            {% if not settings.RELEASE.features.commercial %}
+            {% if not settings.RELEASE.features.commercial and not settings.ISOLATED_DEPLOYMENT %}
               <div>
                 <a href="https://netboxlabs.com/netbox-cloud/" class="text-muted">{% trans "Get" %} Cloud</a> |
                 <a href="https://netboxlabs.com/netbox-enterprise/" class="text-muted">{% trans "Get" %} Enterprise</a>
@@ -184,7 +184,7 @@ Blocks:
                 {% endif %}
 
                 {# Commercial links #}
-                {% if settings.RELEASE.features.commercial %}
+                {% if settings.RELEASE.features.commercial and not settings.ISOLATED_DEPLOYMENT %}
                   {# LinkedIn #}
                   <li class="list-inline-item">
                     <a href="https://www.linkedin.com/company/netboxlabs/" target="_blank" class="link-secondary" rel="noopener" aria-label="LinkedIn">
@@ -200,6 +200,7 @@ Blocks:
 
                 {# Community links #}
                 {% else %}
+                {% if not settings.ISOLATED_DEPLOYMENT %}
                   {# GitHub #}
                   <li class="list-inline-item">
                     <a href="https://github.com/netbox-community/netbox" target="_blank" class="link-secondary" rel="noopener" aria-label="{% trans "Source Code" %}">
@@ -212,6 +213,7 @@ Blocks:
                       <i title="{% trans "Community" %}" class="mdi mdi-slack text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
                     </a>
                   </li>
+                  {% endif %}
                 {% endif %}
               {% endblock footer_links %}
             </ul>

--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -199,7 +199,7 @@ Blocks:
                   </li>
 
                 {# Community links #}
-                {% elif not settings.ISOLATED_DEPLOYMENT %}                  
+                {% elif not settings.ISOLATED_DEPLOYMENT %}
                   {# GitHub #}
                   <li class="list-inline-item">
                     <a href="https://github.com/netbox-community/netbox" target="_blank" class="link-secondary" rel="noopener" aria-label="{% trans "Source Code" %}">
@@ -211,7 +211,7 @@ Blocks:
                     <a href="https://netdev.chat" target="_blank" class="link-secondary" rel="noopener" aria-label="{% trans "Community" %}">
                       <i title="{% trans "Community" %}" class="mdi mdi-slack text-primary" data-bs-placement="top" data-bs-toggle="tooltip"></i>
                     </a>
-                  </li>                  
+                  </li>
                 {% endif %}
               {% endblock footer_links %}
             </ul>


### PR DESCRIPTION
### Fixes: #19910

In the base template, add conditionals on internet links to hide them when the setting ISOLATED_DEPLOYMENT is set to True.