### PR TITLE
Closes #18399: Refactor logic for marking data source syncing as queued

### DIFF
--- a/netbox/core/jobs.py
+++ b/netbox/core/jobs.py
@@ -21,6 +21,17 @@ class SyncDataSourceJob(JobRunner):
     class Meta:
         name = 'Synchronization'
 
+    @classmethod
+    def enqueue(cls, *args, **kwargs):
+        job = super().enqueue(*args, **kwargs)
+
+        # Update the DataSource's synchronization status to queued
+        if datasource := job.object:
+            datasource.status = DataSourceStatusChoices.QUEUED
+            DataSource.objects.filter(pk=datasource.pk).update(status=datasource.status)
+
+        return job
+
     def run(self, *args, **kwargs):
         datasource = DataSource.objects.get(pk=self.job.object_id)
 

--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -33,7 +33,6 @@ from utilities.json import ConfigJSONEncoder
 from utilities.query import count_related
 from utilities.views import ContentTypePermissionRequiredMixin, GetRelatedModelsMixin, register_model_view
 from . import filtersets, forms, tables
-from .choices import DataSourceStatusChoices
 from .jobs import SyncDataSourceJob
 from .models import *
 from .plugins import get_catalog_plugins, get_local_plugins
@@ -78,12 +77,8 @@ class DataSourceSyncView(BaseObjectView):
 
     def post(self, request, pk):
         datasource = get_object_or_404(self.queryset, pk=pk)
-
-        # Enqueue the sync job & update the DataSource's status
+        # Enqueue the sync job
         job = SyncDataSourceJob.enqueue(instance=datasource, user=request.user)
-        datasource.status = DataSourceStatusChoices.QUEUED
-        DataSource.objects.filter(pk=datasource.pk).update(status=datasource.status)
-
         messages.success(
             request,
             _("Queued job #{id} to sync {datasource}").format(id=job.pk, datasource=datasource)


### PR DESCRIPTION
### Closes: #18399

- Consolidate logic for updating DataSource status under the `enqueue()` method of SyncDataSourceJob
- Clean up imports within `core/api/views.py`
