### PR TITLE
Closes #18797: Support path import for certain Jinja environment parameters

### DIFF
--- a/docs/models/extras/configtemplate.md
+++ b/docs/models/extras/configtemplate.md
@@ -24,6 +24,14 @@ Jinja2 template code, if being defined locally rather than replicated from a dat
 
 A dictionary of any additional parameters to pass when instantiating the [Jinja2 environment](https://jinja.palletsprojects.com/en/3.1.x/api/#jinja2.Environment). Jinja2 supports various optional parameters which can be used to modify its default behavior.
 
+The `undefined` and `finalize` Jinja environment parameters, which must reference a Python class or function, can define a dotted path to the desired resource. For example:
+
+```json
+{
+    "undefined": "jinja2.StrictUndefined"
+}
+```
+
 ### MIME Type
 
 !!! info "This field was introduced in NetBox v4.3."

--- a/docs/models/extras/exporttemplate.md
+++ b/docs/models/extras/exporttemplate.md
@@ -26,6 +26,14 @@ Jinja2 template code for rendering the exported data.
 
 A dictionary of any additional parameters to pass when instantiating the [Jinja2 environment](https://jinja.palletsprojects.com/en/3.1.x/api/#jinja2.Environment). Jinja2 supports various optional parameters which can be used to modify its default behavior.
 
+The `undefined` and `finalize` Jinja environment parameters, which must reference a Python class or function, can define a dotted path to the desired resource. For example:
+
+```json
+{
+    "undefined": "jinja2.StrictUndefined"
+}
+```
+
 ### MIME Type
 
 The MIME type to indicate in the response when rendering the export template (optional). Defaults to `text/plain`.

--- a/netbox/extras/constants.py
+++ b/netbox/extras/constants.py
@@ -21,6 +21,12 @@ WEBHOOK_EVENT_TYPES = {
     JOB_ERRORED: 'job_ended',
 }
 
+# Jinja environment parameters which support path imports
+JINJA_ENV_PARAMS_WITH_PATH_IMPORT = (
+    'undefined',
+    'finalize',
+)
+
 # Dashboard
 DEFAULT_DASHBOARD = [
     {


### PR DESCRIPTION
### Closes: #18797

Adds support for dotted path imports for Jinja environment params `undefined` and `finalize`, for both config templates and export templates.

- Introduce and utilize the new `get_environment_params()` method on RenderTemplateMixin
