### PR TITLE
Closes #19945: Create DecimalVar class for custom script input

### DIFF
--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -275,6 +275,15 @@ Stores a numeric integer. Options include:
 * `min_value` - Minimum value
 * `max_value` - Maximum value
 
+### DecimalVar
+
+Stores a numeric decimal. Options include:
+
+* `min_value` - Minimum value
+* `max_value` - Maximum value
+* `max_digits` - Maximum number of digits, including decimal places
+* `decimal_places` - Number of decimal places
+
 ### BooleanVar
 
 A true/false flag. This field has no options beyond the defaults listed above.

--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -31,6 +31,7 @@ __all__ = (
     'DateTimeVar',
     'FileVar',
     'IntegerVar',
+    'DecimalVar',
     'IPAddressVar',
     'IPAddressWithMaskVar',
     'IPNetworkVar',
@@ -133,6 +134,26 @@ class IntegerVar(ScriptVariable):
             self.field_attrs['min_value'] = min_value
         if max_value:
             self.field_attrs['max_value'] = max_value
+
+
+class DecimalVar(ScriptVariable):
+    """
+    Decimal representation. Can enforce minimum/maximum values, maximum digits and decimal places.
+    """
+    form_field = forms.DecimalField
+
+    def __init__(self, min_value=None, max_value=None, max_digits=None, decimal_places=None, *args, **kwargs,):
+        super().__init__(*args, **kwargs)
+
+        # Optional constraints
+        if min_value:
+            self.field_attrs["min_value"] = min_value
+        if max_value:
+            self.field_attrs["max_value"] = max_value
+        if max_digits:
+            self.field_attrs["max_digits"] = max_digits
+        if decimal_places:
+            self.field_attrs["decimal_places"] = decimal_places
 
 
 class BooleanVar(ScriptVariable):

--- a/netbox/extras/tests/test_scripts.py
+++ b/netbox/extras/tests/test_scripts.py
@@ -2,6 +2,7 @@ import logging
 import tempfile
 from datetime import date, datetime, timezone
 
+from decimal import Decimal
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from netaddr import IPAddress, IPNetwork
@@ -137,6 +138,54 @@ class ScriptVariablesTest(TestCase):
         form = TestScript().as_form(data, None)
         self.assertTrue(form.is_valid())
         self.assertEqual(form.cleaned_data['var1'], data['var1'])
+
+    def test_decimalvar(self):
+
+        class TestScript(Script):
+
+            var1 = DecimalVar(
+                min_value=-100.500,
+                max_value=100.500,
+                max_digits=6,
+                decimal_places=3,
+                required=False
+            )
+
+            var2 = DecimalVar(
+                max_digits=3,
+                decimal_places=1,
+                required=False
+            )
+
+        # Validate min_value enforcement
+        data = {'var1': -100.501}
+        form = TestScript().as_form(data, None)
+        self.assertFalse(form.is_valid())
+        self.assertIn('var1', form.errors)
+
+        # Validate max_value enforcement
+        data = {'var1': 100.501}
+        form = TestScript().as_form(data, None)
+        self.assertFalse(form.is_valid())
+        self.assertIn('var1', form.errors)
+
+        # Validate max_digits enforcement
+        data = {'var2': 123.4}
+        form = TestScript().as_form(data, None)
+        self.assertFalse(form.is_valid())
+        self.assertIn('var2', form.errors)
+
+        # Validate decimal_places
+        data = {'var2': 1.23}
+        form = TestScript().as_form(data, None)
+        self.assertFalse(form.is_valid())
+        self.assertIn('var2', form.errors)
+
+        # Validate valid data
+        data = {'var1': '50.123'}
+        form = TestScript().as_form(data, None)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data['var1'], Decimal(data['var1']))
 
     def test_booleanvar(self):
 

--- a/netbox/extras/tests/test_scripts.py
+++ b/netbox/extras/tests/test_scripts.py
@@ -1,8 +1,8 @@
 import logging
 import tempfile
 from datetime import date, datetime, timezone
-
 from decimal import Decimal
+
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase
 from netaddr import IPAddress, IPNetwork


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19945

<!--
    Please include a summary of the proposed changes below.
-->
- Adds a new class called `DecimalVar` to `netbox/extras/scripts.py` to take in decimal input from a form. DecimalVar takes the same arguments as `django.forms.DecimalField`: `min_value`, `max_value`, `max_digits` and `decimal_places`.

- Adds 5 new tests to `netbox/extras/tests/test_scripts.py`. One to isolate each of the four parameters and one to validate valid data. Two objects are created with different parameters because `max_value` will always be hit before `max_digits` can come into play so they have to be tested separately (e.g. if `max_value = 999` but `max_digits = 4`, you can't test `max_digits` because a value of `1000` is already invalid).

- Adds DecimalVar to custom script documentation.