### PR TITLE
Fixes #19764: docs/administration replicating netbox - wrong table name

### DIFF
--- a/docs/administration/replicating-netbox.md
+++ b/docs/administration/replicating-netbox.md
@@ -18,10 +18,10 @@ pg_dump --username netbox --password --host localhost netbox > netbox.sql
 !!! note
     You may need to change the username, host, and/or database in the command above to match your installation.
 
-When replicating a production database for development purposes, you may find it convenient to exclude changelog data, which can easily account for the bulk of a database's size. To do this, exclude the `extras_objectchange` table data from the export. The table will still be included in the output file, but will not be populated with any data.
+When replicating a production database for development purposes, you may find it convenient to exclude changelog data, which can easily account for the bulk of a database's size. To do this, exclude the `core_objectchange` table data from the export. The table will still be included in the output file, but will not be populated with any data.
 
 ```no-highlight
-pg_dump ... --exclude-table-data=extras_objectchange netbox > netbox.sql
+pg_dump ... --exclude-table-data=core_objectchange netbox > netbox.sql
 ```
 
 ### Load an Exported Database


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes #19764: docs/administration replicating netbox - wrong table name

<!--
    Please include a summary of the proposed changes below.
-->
The changes made update the docs to reference the correct table for objectchange. These changes are represented in the codebase in migration 0117_move_objectchange.py.

Changes made:
- Changed the table name: extras_objectchange to core_objectchange in text and in code snippet.