### PR TITLE
Closes #19965: Expand Prometheus metrics

### DIFF
--- a/docs/integrations/prometheus-metrics.md
+++ b/docs/integrations/prometheus-metrics.md
@@ -11,6 +11,8 @@ NetBox makes use of the [django-prometheus](https://github.com/korfuri/django-pr
 - Per model insert, update, and delete counters
 - Per view request counters
 - Per view request latency histograms
+- REST API requests (by endpoint & method)
+- GraphQL API requests
 - Request body size histograms
 - Response body size histograms
 - Response code counters

--- a/netbox/netbox/metrics.py
+++ b/netbox/netbox/metrics.py
@@ -25,7 +25,7 @@ class Metrics(middleware.Metrics):
         )
         self.rest_api_requests_by_view_method = self.register_metric(
             Counter,
-            "django_http_requests_total_by_view_method",
+            "rest_api_requests_total_by_view_method",
             "Count of REST API requests by view & method",
             ["view", "method"],
             namespace=NAMESPACE,

--- a/netbox/netbox/metrics.py
+++ b/netbox/netbox/metrics.py
@@ -30,3 +30,11 @@ class Metrics(middleware.Metrics):
             ["view", "method"],
             namespace=NAMESPACE,
         )
+
+        # GraphQL API metrics
+        self.graphql_api_requests = self.register_metric(
+            Counter,
+            "graphql_api_requests_total",
+            "Count of total GraphQL API requests",
+            namespace=NAMESPACE,
+        )

--- a/netbox/netbox/metrics.py
+++ b/netbox/netbox/metrics.py
@@ -1,0 +1,32 @@
+from django_prometheus.conf import NAMESPACE
+from django_prometheus import middleware
+from prometheus_client import Counter
+
+__all__ = (
+    'Metrics',
+)
+
+
+class Metrics(middleware.Metrics):
+    """
+    Expand the stock Metrics class from django_prometheus to add our own counters.
+    """
+
+    def register(self):
+        super().register()
+
+        # REST API metrics
+        self.rest_api_requests = self.register_metric(
+            Counter,
+            "rest_api_requests_total_by_method",
+            "Count of total REST API requests by method",
+            ["method"],
+            namespace=NAMESPACE,
+        )
+        self.rest_api_requests_by_view_method = self.register_metric(
+            Counter,
+            "django_http_requests_total_by_view_method",
+            "Count of REST API requests by view & method",
+            ["view", "method"],
+            namespace=NAMESPACE,
+        )

--- a/netbox/netbox/middleware.py
+++ b/netbox/netbox/middleware.py
@@ -13,7 +13,7 @@ from django_prometheus import middleware
 from netbox.config import clear_config, get_config
 from netbox.metrics import Metrics
 from netbox.views import handler_500
-from utilities.api import is_api_request
+from utilities.api import is_api_request, is_graphql_request
 from utilities.error_handlers import handle_rest_api_exception
 from utilities.request import apply_request_processors
 
@@ -200,6 +200,10 @@ class PrometheusAfterMiddleware(middleware.PrometheusAfterMiddleware):
             name = self._get_view_name(request)
             self.label_metric(self.metrics.rest_api_requests, request, method=method).inc()
             self.label_metric(self.metrics.rest_api_requests_by_view_method, request, method=method, view=name).inc()
+
+        # Increment GraphQL API request counters
+        elif is_graphql_request(request):
+            self.metrics.graphql_api_requests.inc()
 
         return response
 

--- a/netbox/netbox/middleware.py
+++ b/netbox/netbox/middleware.py
@@ -8,8 +8,10 @@ from django.core.exceptions import ImproperlyConfigured
 from django.db import connection, ProgrammingError
 from django.db.utils import InternalError
 from django.http import Http404, HttpResponseRedirect
+from django_prometheus import middleware
 
 from netbox.config import clear_config, get_config
+from netbox.metrics import Metrics
 from netbox.views import handler_500
 from utilities.api import is_api_request
 from utilities.error_handlers import handle_rest_api_exception
@@ -18,6 +20,8 @@ from utilities.request import apply_request_processors
 __all__ = (
     'CoreMiddleware',
     'MaintenanceModeMiddleware',
+    'PrometheusAfterMiddleware',
+    'PrometheusBeforeMiddleware',
     'RemoteUserMiddleware',
 )
 
@@ -178,6 +182,26 @@ class RemoteUserMiddleware(RemoteUserMiddleware_):
             groups = []
         logger.debug(f"Groups are {groups}")
         return groups
+
+
+class PrometheusBeforeMiddleware(middleware.PrometheusBeforeMiddleware):
+    metrics_cls = Metrics
+
+
+class PrometheusAfterMiddleware(middleware.PrometheusAfterMiddleware):
+    metrics_cls = Metrics
+
+    def process_response(self, request, response):
+        response = super().process_response(request, response)
+
+        # Increment REST API request counters
+        if is_api_request(request):
+            method = self._method(request)
+            name = self._get_view_name(request)
+            self.label_metric(self.metrics.rest_api_requests, request, method=method).inc()
+            self.label_metric(self.metrics.rest_api_requests_by_view_method, request, method=method, view=name).inc()
+
+        return response
 
 
 class MaintenanceModeMiddleware:

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -471,9 +471,9 @@ if DEBUG:
 if METRICS_ENABLED:
     # If metrics are enabled, add the before & after Prometheus middleware
     MIDDLEWARE = [
-        'django_prometheus.middleware.PrometheusBeforeMiddleware',
+        'netbox.middleware.PrometheusBeforeMiddleware',
         *MIDDLEWARE,
-        'django_prometheus.middleware.PrometheusAfterMiddleware',
+        'netbox.middleware.PrometheusAfterMiddleware',
     ]
 
 # URLs

--- a/netbox/utilities/api.py
+++ b/netbox/utilities/api.py
@@ -23,6 +23,7 @@ __all__ = (
     'get_serializer_for_model',
     'get_view_name',
     'is_api_request',
+    'is_graphql_request',
 )
 
 
@@ -58,6 +59,13 @@ def is_api_request(request):
     """
     api_path = reverse('api-root')
     return request.path_info.startswith(api_path) and request.content_type == HTTP_CONTENT_TYPE_JSON
+
+
+def is_graphql_request(request):
+    """
+    Return True of the request is being made via the GraphQL API.
+    """
+    return request.path_info == reverse('graphql') and request.content_type == HTTP_CONTENT_TYPE_JSON
 
 
 def get_view_name(view):


### PR DESCRIPTION
### Closes: #19965

- Introduce `is_graphql_request()` utility function
- Subclass `Metrics` to add REST & GraphQL API request counters
- Create subclasses of the stock before & after middleware
- Extend PrometheusAfterMiddleware to increase counters for REST & GraphQL API requests