### PR TITLE
Closes #18843: use color name in cable export

### DIFF
--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -11,6 +11,7 @@ from dcim.choices import *
 from dcim.constants import *
 from dcim.fields import PathField
 from dcim.utils import decompile_path_node, object_to_path_node
+from netbox.choices import ColorChoices
 from netbox.models import ChangeLoggedModel, PrimaryModel
 from utilities.conversion import to_meters
 from utilities.exceptions import AbortRequest
@@ -154,6 +155,15 @@ class Cable(PrimaryModel):
         if not self.pk or self.b_terminations != list(value):
             self._terminations_modified = True
         self._b_terminations = value
+
+    @property
+    def color_name(self):
+        color_name = ""
+        for hex_code, label in ColorChoices.CHOICES:
+            if hex_code.lower() == self.color.lower():
+                color_name = str(label)
+
+        return color_name
 
     def clean(self):
         super().clean()

--- a/netbox/dcim/tables/cables.py
+++ b/netbox/dcim/tables/cables.py
@@ -113,6 +113,9 @@ class CableTable(TenancyColumnsMixin, NetBoxTable):
         order_by=('_abs_length')
     )
     color = columns.ColorColumn()
+    color_name = tables.Column(
+        verbose_name=_('Color Name')
+    )
     comments = columns.MarkdownColumn()
     tags = columns.TagColumn(
         url_name='dcim:cable_list'

--- a/netbox/dcim/tables/cables.py
+++ b/netbox/dcim/tables/cables.py
@@ -114,7 +114,8 @@ class CableTable(TenancyColumnsMixin, NetBoxTable):
     )
     color = columns.ColorColumn()
     color_name = tables.Column(
-        verbose_name=_('Color Name')
+        verbose_name=_('Color Name'),
+        orderable=False
     )
     comments = columns.MarkdownColumn()
     tags = columns.TagColumn(
@@ -126,7 +127,7 @@ class CableTable(TenancyColumnsMixin, NetBoxTable):
         fields = (
             'pk', 'id', 'label', 'a_terminations', 'b_terminations', 'device_a', 'device_b', 'rack_a', 'rack_b',
             'location_a', 'location_b', 'site_a', 'site_b', 'status', 'type', 'tenant', 'tenant_group', 'color',
-            'length', 'description', 'comments', 'tags', 'created', 'last_updated',
+            'color_name', 'length', 'description', 'comments', 'tags', 'created', 'last_updated',
         )
         default_columns = (
             'pk', 'id', 'label', 'a_terminations', 'b_terminations', 'status', 'type',


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Closes #18843: using color name in cable export

<!--
    Please include a summary of the proposed changes below.
-->
The changes made allow for the name of the color to be exported when exporting cables. This applies to both full table export "All data (csv)" and using custom export templates.

Changes made:
- Add a color_name property to cable model
- Add color_name to cable table