### PR TITLE
Fixes #19985: Fix ordering of migrations under `dcim` app

### DIFF
--- a/netbox/dcim/migrations/0208_devicerole_uniqueness.py
+++ b/netbox/dcim/migrations/0208_devicerole_uniqueness.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dcim', '0209_interface_tx_power_negative'),
+        ('dcim', '0207_remove_redundant_indexes'),
         ('extras', '0129_fix_script_paths'),
     ]
 

--- a/netbox/dcim/migrations/0209_platform_manufacturer_uniqueness.py
+++ b/netbox/dcim/migrations/0209_platform_manufacturer_uniqueness.py
@@ -4,7 +4,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dcim', '0207_remove_redundant_indexes'),
+        ('dcim', '0208_devicerole_uniqueness'),
         ('extras', '0129_fix_script_paths'),
     ]
 

--- a/netbox/dcim/migrations/0210_interface_tx_power_negative.py
+++ b/netbox/dcim/migrations/0210_interface_tx_power_negative.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dcim', '0208_platform_manufacturer_uniqueness'),
+        ('dcim', '0209_platform_manufacturer_uniqueness'),
     ]
 
     operations = [


### PR DESCRIPTION
### Fixes: #19985

Correct the ordering of migrations, ensuring that `0208_devicerole_uniqueness` is restored to its original state.