### PR TITLE
Fixes #19321: Reduce redundant database queries during bulk creation of devices

### DIFF
--- a/netbox/utilities/prefetch.py
+++ b/netbox/utilities/prefetch.py
@@ -1,0 +1,34 @@
+from django.contrib.contenttypes.fields import GenericRelation
+from django.db.models import ManyToManyField
+from django.db.models.fields.related import ForeignObjectRel
+from taggit.managers import TaggableManager
+
+__all__ = (
+    'get_prefetchable_fields',
+)
+
+
+def get_prefetchable_fields(model):
+    """
+    Return a list containing the names of all fields on the given model which support prefetching.
+    """
+    field_names = []
+
+    for field in model._meta.get_fields():
+        # Forward relations (e.g. ManyToManyFields)
+        if isinstance(field, ManyToManyField):
+            field_names.append(field.name)
+
+        # Reverse relations (e.g. reverse ForeignKeys, reverse M2M)
+        elif isinstance(field, ForeignObjectRel):
+            field_names.append(field.get_accessor_name())
+
+        # Generic relations
+        elif isinstance(field, GenericRelation):
+            field_names.append(field.name)
+
+        # Tags
+        elif isinstance(field, TaggableManager):
+            field_names.append(field.name)
+
+    return field_names

--- a/netbox/utilities/tests/test_prefetch.py
+++ b/netbox/utilities/tests/test_prefetch.py
@@ -1,0 +1,17 @@
+from circuits.models import Circuit, Provider
+from utilities.prefetch import get_prefetchable_fields
+from utilities.testing.base import TestCase
+
+
+class GetPrefetchableFieldsTest(TestCase):
+    """
+    Verify the operation of get_prefetchable_fields()
+    """
+    def test_get_prefetchable_fields(self):
+        field_names = get_prefetchable_fields(Provider)
+        self.assertIn('asns', field_names)  # ManyToManyField
+        self.assertIn('circuits', field_names)  # Reverse relation
+        self.assertIn('tags', field_names)  # Tags
+
+        field_names = get_prefetchable_fields(Circuit)
+        self.assertIn('group_assignments', field_names)  # Generic relation


### PR DESCRIPTION
### Fixes: #19321

- Introduce the `get_prefetchable_fields()` utility function
- Call `prefetch_related_objects()` on newly-created components when instantiating a component template, to prefetch related objects before creating their search & changelog records during `post_save`