### PR TITLE
Closes #19973: `nbshell` improvements

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -1,3 +1,7 @@
+# Shell text coloring
+# https://github.com/tartley/colorama/blob/master/CHANGELOG.rst
+colorama
+
 # The Python web framework on which NetBox is built
 # https://docs.djangoproject.com/en/stable/releases/
 Django==5.2.*

--- a/netbox/core/management/commands/nbshell.py
+++ b/netbox/core/management/commands/nbshell.py
@@ -55,11 +55,30 @@ class Command(BaseCommand):
             help='Python code to execute (instead of starting an interactive shell)',
         )
 
-    def _lsmodels(self):
-        for app, models in self.django_models.items():
-            app_name = apps.get_app_config(app).verbose_name
+    def _lsapps(self):
+        for app_label in self.django_models.keys():
+            app_name = apps.get_app_config(app_label).verbose_name
+            print(f'{app_label} - {app_name}')
+
+    def _lsmodels(self, app_label=None):
+        """
+        Return a list of all models within each app.
+
+        Args:
+            app_label: The name of a specific app
+        """
+        if app_label:
+            if app_label not in self.django_models:
+                print(f"No models listed for {app_label}")
+                return
+            app_labels = [app_label]
+        else:
+            app_labels = self.django_models.keys()  # All apps
+
+        for app_label in app_labels:
+            app_name = apps.get_app_config(app_label).verbose_name
             print(f'{app_name}:')
-            for m in models:
+            for m in self.django_models[app_label]:
                 print(f'  {m}')
 
     def get_namespace(self):
@@ -83,6 +102,7 @@ class Command(BaseCommand):
 
         return {
             **namespace,
+            'lsapps': self._lsapps,
             'lsmodels': self._lsmodels,
         }
 
@@ -111,7 +131,7 @@ class Command(BaseCommand):
             )
 
         lines.append(
-            'lsmodels() will show available models. Use help(<model>) for more info.'
+            'lsapps() & lsmodels() will show available models. Use help(<model>) for more info.'
         )
 
         return '\n'.join([

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+colorama==0.4.6
 Django==5.2.4
 django-cors-headers==4.7.0
 django-debug-toolbar==5.2.0


### PR DESCRIPTION
### Closes: #19973

- Declare `colorama` as an explicit dependency (already required by Django)
- List installed plugins in `nbshell` banner text
- Load all models and constants from plugins in addition to core apps
- Namespace all core & plugin models and constants
- Clean up obsolete references
- Implement color highlighting
- Add `lsapps()` helper function & extend `lsmodels()` to accept an app label argument