### PR TITLE
Fixes #19622: Allow loading graphql query from URL in GraphiQL

### DIFF
--- a/netbox/templates/graphql/graphiql.html
+++ b/netbox/templates/graphql/graphiql.html
@@ -88,6 +88,21 @@
 #
 `;
 
+      let sharedQuery;
+      const hashArgs = new URLSearchParams(window.location.hash.substring(1));
+      if (hashArgs.has('query')) {
+        sharedQuery = hashArgs.get('query');
+        // reset url to not motivate copying of stale URL
+        hashArgs.delete('query');
+        let remainingHash = "";
+        if (hashArgs.size !== 0) {
+          remainingHash = `#${hashArgs.toString()}`;
+        }
+        history.pushState("", document.title,
+          window.location.pathname + window.location.search + remainingHash
+        );
+      }
+
       const fetchURL = window.location.href;
 
       function httpUrlToWebSockeUrl(url) {
@@ -123,6 +138,8 @@
           defaultEditorToolsVisibility: true,
           plugins: [explorerPlugin],
           inputValueDeprecation: true,
+          defaultQuery: EXAMPLE_QUERY,
+          query: sharedQuery,
         }),
       );
     </script>


### PR DESCRIPTION
### Fixes: #19622

This adds the ability to populate the query in the built-in GraphQL IDE (GraphiQL) using a parameter specified in the URL hash (aka fragment).

E.g.

```
https://<your netbox>/graphql/#query=%7Bdevice_list%28filters%3A%7Binterfaces%3A%7Bip_addresses%3A%7Bfamily%3AFAMILY_6%7D%7D%7D%29%7Binterfaces%7Bip_addresses%7Baddress%20family%7Blabel%7D%7D%7D%7D%7D
```

I considered adding a button to copy this kind of url to the UI, but the project setup for GraphiQL (the UI component) is pretty outdated and doesn't easily allow modifications.