### PR TITLE
Implement `contains` filter for IPAM prefixes and IP ranges

### DIFF
--- a/netbox/ipam/graphql/filters.py
+++ b/netbox/ipam/graphql/filters.py
@@ -222,6 +222,19 @@ class IPRangeFilter(ContactFilterMixin, TenancyFilterMixin, PrimaryModelFilterMi
                 return Q()
         return q
 
+    @strawberry_django.filter_field()
+    def contains(self, value: list[str], prefix) -> Q:
+        if not value:
+            return Q()
+        q = Q()
+        for subnet in value:
+            net = netaddr.IPNetwork(subnet.strip())
+            q |= Q(
+                start_address__host__inet__lte=str(netaddr.IPAddress(net.first)),
+                end_address__host__inet__gte=str(netaddr.IPAddress(net.last)),
+            )
+        return q
+
 
 @strawberry_django.filter_type(models.Prefix, lookups=True)
 class PrefixFilter(ContactFilterMixin, ScopedFilterMixin, TenancyFilterMixin, PrimaryModelFilterMixin):

--- a/netbox/ipam/graphql/filters.py
+++ b/netbox/ipam/graphql/filters.py
@@ -261,6 +261,7 @@ class PrefixFilter(ContactFilterMixin, ScopedFilterMixin, TenancyFilterMixin, Pr
             q |= Q(prefix__net_contains=query)
         return q
 
+
 @strawberry_django.filter_type(models.RIR, lookups=True)
 class RIRFilter(OrganizationalModelFilterMixin):
     is_private: FilterLookup[bool] | None = strawberry_django.filter_field()

--- a/netbox/ipam/graphql/filters.py
+++ b/netbox/ipam/graphql/filters.py
@@ -238,6 +238,15 @@ class PrefixFilter(ContactFilterMixin, ScopedFilterMixin, TenancyFilterMixin, Pr
     is_pool: FilterLookup[bool] | None = strawberry_django.filter_field()
     mark_utilized: FilterLookup[bool] | None = strawberry_django.filter_field()
 
+    @strawberry_django.filter_field()
+    def contains(self, value: list[str], prefix) -> Q:
+        if not value:
+            return Q()
+        q = Q()
+        for subnet in value:
+            query = str(netaddr.IPNetwork(subnet.strip()).cidr)
+            q |= Q(prefix__net_contains=query)
+        return q
 
 @strawberry_django.filter_type(models.RIR, lookups=True)
 class RIRFilter(OrganizationalModelFilterMixin):


### PR DESCRIPTION
### Fixes: #19812

This adds a `contains` filter on both Prefixes and IP Ranges.

Example queries:

```gql
query prefixes {
  prefix_list(filters: {contains: ["10.1.0.0"]}) {
    prefix
  }
}

query ipranges {
  ip_range_list(filters: {contains: ["10.2.1.0/24"]}) {
    start_address
    end_address
  }
}
```

The query will throw an error if the given subnet cannot be parsed. A missing prefixlength on the filter argument is interpreted as `/128`/`/32` (depending on the family)