### PR TITLE
Fixes #19379: allow standalone id in vlan-ids range list

### DIFF
--- a/netbox/utilities/data.py
+++ b/netbox/utilities/data.py
@@ -160,9 +160,19 @@ def string_to_ranges(value):
         return None
     value.replace(' ', '')  # Remove whitespace
     values = []
-    for dash_range in value.split(','):
-        if '-' not in dash_range:
+    for data in value.split(','):
+        dash_range = data.strip().split('-')
+        lower, upper = '', ''
+        if len(dash_range) == 1 and str(dash_range[0]).isdigit():
+            # Range is only a single value, which is a valid number
+            lower = dash_range[0]
+            upper = dash_range[0]
+        elif len(dash_range) == 2 and str(dash_range[0]).isdigit() and str(dash_range[1]).isdigit():
+            # The range has 2 values and both are valid number
+            lower = dash_range[0]
+            upper = dash_range[1]
+        else:
             return None
-        lower, upper = dash_range.split('-')
+
         values.append(NumericRange(int(lower), int(upper), bounds='[]'))
     return values

--- a/netbox/utilities/data.py
+++ b/netbox/utilities/data.py
@@ -162,17 +162,15 @@ def string_to_ranges(value):
     values = []
     for data in value.split(','):
         dash_range = data.strip().split('-')
-        lower, upper = '', ''
         if len(dash_range) == 1 and str(dash_range[0]).isdigit():
-            # Range is only a single value, which is a valid number
+            # Single integer value; expand to a range
             lower = dash_range[0]
             upper = dash_range[0]
         elif len(dash_range) == 2 and str(dash_range[0]).isdigit() and str(dash_range[1]).isdigit():
-            # The range has 2 values and both are valid number
+            # The range has two values and both are valid integers
             lower = dash_range[0]
             upper = dash_range[1]
         else:
             return None
-
         values.append(NumericRange(int(lower), int(upper), bounds='[]'))
     return values

--- a/netbox/utilities/forms/fields/array.py
+++ b/netbox/utilities/forms/fields/array.py
@@ -36,8 +36,9 @@ class NumericRangeArrayField(forms.CharField):
     """
     def __init__(self, *args, help_text='', **kwargs):
         if not help_text:
+            example = "<code>1-5,10,20-30</code>"
             help_text = mark_safe(
-                _("Specify one or more numeric ranges separated by commas. Example: " + "<code>1-5,20-30</code>")
+                _("Specify one or more individual values or numeric ranges separated by commas. Example: " + example)
             )
         super().__init__(*args, help_text=help_text, **kwargs)
 

--- a/netbox/utilities/forms/fields/array.py
+++ b/netbox/utilities/forms/fields/array.py
@@ -32,13 +32,14 @@ class NumericArrayField(SimpleArrayField):
 class NumericRangeArrayField(forms.CharField):
     """
     A field which allows for array of numeric ranges:
-      Example: 1-5,7-20,30-50
+      Example: 1-5,10,20-30
     """
     def __init__(self, *args, help_text='', **kwargs):
         if not help_text:
-            example = "<code>1-5,10,20-30</code>"
             help_text = mark_safe(
-                _("Specify one or more individual values or numeric ranges separated by commas. Example: " + example)
+                _(
+                    "Specify one or more individual numbers or numeric ranges separated by commas. Example: {example}"
+                ).format(example="<code>1-5,10,20-30</code>")
             )
         super().__init__(*args, help_text=help_text, **kwargs)
 

--- a/netbox/utilities/tests/test_data.py
+++ b/netbox/utilities/tests/test_data.py
@@ -78,5 +78,5 @@ class RangeFunctionsTestCase(TestCase):
 
         self.assertEqual(
             string_to_ranges('2-10, a-b'),
-            None    # Fails to convert
+            None  # Fails to convert
         )

--- a/netbox/utilities/tests/test_data.py
+++ b/netbox/utilities/tests/test_data.py
@@ -66,3 +66,17 @@ class RangeFunctionsTestCase(TestCase):
                 NumericRange(100, 199, bounds='[]'),  # 100-199
             ]
         )
+
+        self.assertEqual(
+            string_to_ranges('1-2, 5, 10-12'),
+            [
+                NumericRange(1, 2, bounds='[]'),    # 1-2
+                NumericRange(5, 5, bounds='[]'),    # 5-5
+                NumericRange(10, 12, bounds='[]'),  # 10-12
+            ]
+        )
+
+        self.assertEqual(
+            string_to_ranges('2-10, a-b'),
+            None    # Fails to convert
+        )


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes #19379: allow standalone id in vlan-ids range list

<!--
    Please include a summary of the proposed changes below.
-->

The changes made allow for VLAN id ranges to be created using both ranges, e.g. 10-15 and single numbers, e.g. 20 and any combination of these. I've also included broader test coverage and fixed a bug where the range "a-b" would previously break the UI.

Changes made:
- Changed the instructions in NumericRangeArrayField to indicate that single numbers can be given.
- Changed utility data function: string_to_ranges  (utilities/data.py line 153) so that it properly handles all of these cases.
- Improved test coverage of utilities.tests.test_data.RangeFunctionsTestCase.test_string_to_ranges
