### PR TITLE
Fixes #20033: Fix exception when bulk deleting bookmarks

### DIFF
--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -849,6 +849,9 @@ class Bookmark(models.Model):
             return str(self.object)
         return super().__str__()
 
+    def get_absolute_url(self):
+        return reverse('account:bookmarks')
+
     def clean(self):
         super().clean()
 

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -317,11 +317,12 @@ class TableConfigTable(NetBoxTable):
 
 class BookmarkTable(NetBoxTable):
     object_type = columns.ContentTypeColumn(
-        verbose_name=_('Object Types'),
+        verbose_name=_('Object Type'),
     )
     object = tables.Column(
         verbose_name=_('Object'),
-        linkify=True
+        linkify=True,
+        orderable=False
     )
     actions = columns.ActionsColumn(
         actions=('delete',)


### PR DESCRIPTION
### Fixes: #20033

- Add a `get_absolute_url()` method on Bookmark
- BookmarkTable cleanup