### PR TITLE
Closes #17222: Improve visibility of notifications icon

### DIFF
--- a/netbox/templates/htmx/notifications.html
+++ b/netbox/templates/htmx/notifications.html
@@ -15,14 +15,14 @@
           <div class="d-block text-secondary fs-5">{{ notification.event }} {{ notification.created|timesince }} {% trans "ago" %}</div>
         </div>
         <div class="col-auto">
-          <a href="#" hx-get="{% url 'extras:notification_dismiss' pk=notification.pk %}" hx-target="closest .notifications" class="list-group-item-actions text-secondary" title="{% trans "Dismiss" %}">
+          <a href="#" hx-get="{% url 'extras:notification_dismiss' pk=notification.pk %}" hx-target="closest .notifications" class="list-group-item-actions text-red" title="{% trans "Dismiss" %}">
             <i class="mdi mdi-close"></i>
           </a>
         </div>
       </div>
     </div>
   {% empty %}
-    <div class="dropdown-item text-muted">
+    <div class="dropdown-item disabled">
       {% trans "No unread notifications" %}
     </div>
   {% endfor %}

--- a/netbox/templates/inc/light_toggle.html
+++ b/netbox/templates/inc/light_toggle.html
@@ -1,10 +1,10 @@
 {% load i18n %}
 
 <div class="d-flex ms-2">
-  <button class="btn color-mode-toggle hide-theme-dark" title="{% trans "Enable dark mode" %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
+  <button class="nav-link color-mode-toggle hide-theme-dark fs-2 p-0 text-secondary" title="{% trans "Enable dark mode" %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
     <i class="mdi mdi-lightbulb"></i>
   </button>
-  <button class="btn color-mode-toggle hide-theme-light" title="{% trans "Enable light mode" %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
+  <button class="nav-link color-mode-toggle hide-theme-light fs-2 p-0 text-secondary" title="{% trans "Enable light mode" %}" data-bs-toggle="tooltip" data-bs-placement="bottom">
     <i class="mdi mdi-lightbulb-on"></i>
   </button>
 </div>

--- a/netbox/templates/inc/notification_bell.html
+++ b/netbox/templates/inc/notification_bell.html
@@ -1,6 +1,7 @@
 {% if notifications %}
   <span class="text-primary" id="notifications-alert" hx-swap-oob="true">
-    <i class="mdi mdi-bell-badge"></i>
+    <i class="mdi mdi-bell-ring"></i>
+    <span class="badge bg-red"></span>
   </span>
 {% else %}
   <span class="text-muted" id="notifications-alert" hx-swap-oob="true">

--- a/netbox/templates/inc/user_menu.html
+++ b/netbox/templates/inc/user_menu.html
@@ -12,9 +12,9 @@
   {# Notifications #}
   {% with notifications=request.user.notifications.unread.exists %}
     <div class="dropdown">
-      <a href="#" class="nav-link px-1" data-bs-toggle="dropdown" hx-get="{% url 'extras:notifications' %}" hx-target="next .notifications" aria-label="{% trans "Notifications" %}">
+      <button class="nav-link fs-2 p-0" data-bs-toggle="dropdown" hx-get="{% url 'extras:notifications' %}" hx-target="next .notifications" aria-label="{% trans "Notifications" %}">
         {% include 'inc/notification_bell.html' %}
-      </a>
+      </button>
       <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow notifications"></div>
     </div>
   {% endwith %}


### PR DESCRIPTION
### Closes: #17222

- Use the `bell-ring` icon for active notifications
- Attach a separate red badge to the active icon
- Increase font size and standardize buttons for color mode & notifications icons
- Misc other cosmetic tweaks to the notifications menu

Before:
<img width="162" height="52" alt="screenshot1" src="https://github.com/user-attachments/assets/493a1ab7-c219-46c1-894f-f350e9f4dbae" />
After:
<img width="162" height="52" alt="screenshot2" src="https://github.com/user-attachments/assets/cea2cd87-0109-4643-89be-863fa4db48dc" />

