### PR TITLE
Fixes #20030: Fix height of object list action buttons & others

### DIFF
--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -237,7 +237,11 @@ class ActionsColumn(tables.Column):
     :param split_actions: When True, converts the actions dropdown menu into a split button with first action as the
         direct button link and icon (default: True)
     """
-    attrs = {'td': {'class': 'text-end text-nowrap noprint'}}
+    attrs = {
+        'td': {
+            'class': 'text-end text-nowrap noprint p-1'
+        }
+    }
     empty_values = ()
     actions = {
         'edit': ActionsItem('Edit', 'pencil', 'change', 'warning'),

--- a/netbox/templates/circuits/inc/circuit_termination.html
+++ b/netbox/templates/circuits/inc/circuit_termination.html
@@ -4,22 +4,22 @@
 <div class="card">
     <h2 class="card-header d-flex justify-content-between">
       {% blocktrans %}Termination{% endblocktrans %} {{ side }}
-      <div>
+      <div class="card-actions">
         {% if not termination and perms.circuits.add_circuittermination %}
-            <a href="{% url 'circuits:circuittermination_add' %}?circuit={{ object.pk }}&term_side={{ side }}&return_url={{ object.get_absolute_url }}" class="btn btn-success lh-1">
+            <a href="{% url 'circuits:circuittermination_add' %}?circuit={{ object.pk }}&term_side={{ side }}&return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-ghost-primary">
                 <span class="mdi mdi-plus-thick" aria-hidden="true"></span> {% trans "Add" %}
             </a>
         {% endif %}
         {% if termination and perms.circuits.change_circuittermination %}
-            <a href="{% url 'circuits:circuittermination_edit' pk=termination.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-warning lh-1">
+            <a href="{% url 'circuits:circuittermination_edit' pk=termination.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-ghost-warning">
                 <span class="mdi mdi-pencil" aria-hidden="true"></span> {% trans "Edit" %}
             </a>
-            <a href="{% url 'circuits:circuit_terminations_swap' pk=object.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-primary lh-1">
+            <a href="{% url 'circuits:circuit_terminations_swap' pk=object.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-ghost-primary">
                 <span class="mdi mdi-swap-vertical" aria-hidden="true"></span> {% trans "Swap" %}
             </a>
         {% endif %}
         {% if termination and perms.circuits.delete_circuittermination %}
-            <a href="{% url 'circuits:circuittermination_delete' pk=termination.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-danger lh-1">
+            <a href="{% url 'circuits:circuittermination_delete' pk=termination.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-ghost-danger">
                 <span class="mdi mdi-trash-can-outline" aria-hidden="true"></span> {% trans "Delete" %}
             </a>
         {% endif %}

--- a/netbox/templates/circuits/inc/circuit_termination_fields.html
+++ b/netbox/templates/circuits/inc/circuit_termination_fields.html
@@ -29,16 +29,16 @@
           {{ peer|linkify }}{% if not forloop.last %},{% endif %}
         {% endfor %}
         <div class="mt-1">
-          <a href="{% url 'circuits:circuittermination_trace' pk=termination.pk %}" class="btn btn-primary lh-1" title="{% trans "Trace" %}">
+          <a href="{% url 'circuits:circuittermination_trace' pk=termination.pk %}" class="btn btn-sm btn-primary" title="{% trans "Trace" %}">
             <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i> {% trans "Trace" %}
           </a>
           {% if perms.dcim.change_cable %}
-            <a href="{% url 'dcim:cable_edit' pk=termination.cable.pk %}?return_url={{ termination.circuit.get_absolute_url }}" title="{% trans "Edit cable" %}" class="btn btn-warning lh-1">
+            <a href="{% url 'dcim:cable_edit' pk=termination.cable.pk %}?return_url={{ termination.circuit.get_absolute_url }}" title="{% trans "Edit cable" %}" class="btn btn-sm btn-warning">
               <i class="mdi mdi-ethernet-cable" aria-hidden="true"></i> {% trans "Edit" %}
             </a>
           {% endif %}
           {% if perms.dcim.delete_cable %}
-            <a href="{% url 'dcim:cable_delete' pk=termination.cable.pk %}?return_url={{ termination.circuit.get_absolute_url }}" title="{% trans "Remove cable" %}" class="btn btn-danger lh-1">
+            <a href="{% url 'dcim:cable_delete' pk=termination.cable.pk %}?return_url={{ termination.circuit.get_absolute_url }}" title="{% trans "Remove cable" %}" class="btn btn-sm btn-danger">
               <i class="mdi mdi-ethernet-cable-off" aria-hidden="true"></i> {% trans "Disconnect" %}
             </a>
           {% endif %}

--- a/netbox/templates/dcim/frontport.html
+++ b/netbox/templates/dcim/frontport.html
@@ -77,7 +77,7 @@
                             <th scope="row">{% trans "Cable" %}</th>
                             <td>
                                 {{ object.cable|linkify }}
-                                <a href="{% url 'dcim:frontport_trace' pk=object.pk %}" class="btn btn-primary lh-1" title="{% trans "Trace" %}">
+                                <a href="{% url 'dcim:frontport_trace' pk=object.pk %}" class="btn btn-sm btn-primary" title="{% trans "Trace" %}">
                                     <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
                                 </a>
                             </td>

--- a/netbox/templates/dcim/inc/cable_termination.html
+++ b/netbox/templates/dcim/inc/cable_termination.html
@@ -24,7 +24,7 @@
             <i class="mdi mdi-chevron-right" aria-hidden="true"></i>
             {{ term|linkify }}
             {% with trace_url=term|viewname:"trace" %}
-              <a href="{% url trace_url pk=term.pk %}" class="btn btn-primary lh-1" title="{% trans "Trace" %}">
+              <a href="{% url trace_url pk=term.pk %}" class="btn btn-sm btn-primary" title="{% trans "Trace" %}">
                 <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
               </a>
             {% endwith %}
@@ -48,7 +48,7 @@
           {% for term in terminations %}
             {{ term|linkify }}
             {% with trace_url=term|viewname:"trace" %}
-              <a href="{% url trace_url pk=term.pk %}" class="btn btn-primary lh-1" title="{% trans "Trace" %}">
+              <a href="{% url trace_url pk=term.pk %}" class="btn btn-sm btn-primary" title="{% trans "Trace" %}">
                 <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
               </a>
             {% endwith %}
@@ -68,7 +68,7 @@
           {% for term in terminations %}
             {{ term.circuit|linkify }} ({{ term }})
             {% with trace_url=term|viewname:"trace" %}
-              <a href="{% url trace_url pk=term.pk %}" class="btn btn-primary lh-1" title="{% trans "Trace" %}">
+              <a href="{% url trace_url pk=term.pk %}" class="btn btn-sm btn-primary" title="{% trans "Trace" %}">
                 <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
               </a>
             {% endwith %}

--- a/netbox/templates/dcim/inc/connection_endpoints.html
+++ b/netbox/templates/dcim/inc/connection_endpoints.html
@@ -4,7 +4,7 @@
     <th scope="row">{% trans "Cable" %}</th>
     <td>
       {{ object.cable|linkify }}
-      <a href="{% url trace_url pk=object.pk %}" class="btn btn-primary lh-1" title="{% trans "Trace" %}">
+      <a href="{% url trace_url pk=object.pk %}" class="btn btn-sm btn-primary" title="{% trans "Trace" %}">
         <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
       </a>
     </td>

--- a/netbox/templates/dcim/inc/panels/inventory_items.html
+++ b/netbox/templates/dcim/inc/panels/inventory_items.html
@@ -29,12 +29,12 @@
           <td>{{ item.role|linkify|placeholder }}</td>
           <td class="text-end d-print-none">
             {% if perms.dcim.change_inventoryitem %}
-              <a href="{% url 'dcim:inventoryitem_edit' pk=item.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-warning lh-1" title="{% trans "Edit" %}">
+              <a href="{% url 'dcim:inventoryitem_edit' pk=item.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-warning" title="{% trans "Edit" %}">
                 <i class="mdi mdi-pencil" aria-hidden="true"></i>
               </a>
             {% endif %}
             {% if perms.ipam.delete_inventoryitem %}
-              <a href="{% url 'dcim:inventoryitem_delete' pk=item.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-danger lh-1" title="{% trans "Delete" %}">
+              <a href="{% url 'dcim:inventoryitem_delete' pk=item.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-danger" title="{% trans "Delete" %}">
                 <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i>
               </a>
             {% endif %}

--- a/netbox/templates/dcim/interface.html
+++ b/netbox/templates/dcim/interface.html
@@ -208,7 +208,7 @@
                 <th scope="row">{% trans "Wireless Link" %}</th>
                 <td>
                   {{ object.wireless_link|linkify }}
-                  <a href="{% url 'dcim:interface_trace' pk=object.pk %}" class="btn btn-primary lh-1" title="{% trans "Trace" %}">
+                  <a href="{% url 'dcim:interface_trace' pk=object.pk %}" class="btn btn-sm btn-primary" title="{% trans "Trace" %}">
                     <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
                   </a>
                 </td>

--- a/netbox/templates/dcim/rearport.html
+++ b/netbox/templates/dcim/rearport.html
@@ -73,7 +73,7 @@
                             <th scope="row">{% trans "Cable" %}</th>
                             <td>
                                 {{ object.cable|linkify }}
-                                <a href="{% url 'dcim:rearport_trace' pk=object.pk %}" class="btn btn-primary lh-1" title="{% trans "Trace" %}">
+                                <a href="{% url 'dcim:rearport_trace' pk=object.pk %}" class="btn btn-sm btn-primary" title="{% trans "Trace" %}">
                                     <i class="mdi mdi-transit-connection-variant" aria-hidden="true"></i>
                                 </a>
                             </td>

--- a/netbox/templates/extras/htmx/script_result.html
+++ b/netbox/templates/extras/htmx/script_result.html
@@ -57,7 +57,7 @@
           {% trans "Output" %}
           {% if job.completed %}
             <div>
-              <a href="?export=output" class="btn btn-primary lh-1" role="button">
+              <a href="?export=output" class="btn btn-sm btn-primary" role="button">
                 <i class="mdi mdi-download" aria-hidden="true"></i> {% trans "Download" %}
               </a>
             </div>

--- a/netbox/templates/extras/object_render_config.html
+++ b/netbox/templates/extras/object_render_config.html
@@ -54,11 +54,11 @@
           <div class="card">
             <h2 class="card-header d-flex justify-content-between">
               {% trans "Rendered Config" %}
-              <div>
-                {% copy_content "rendered_config" %}
-                <a href="?export=True" class="btn btn-primary lh-1" role="button">
+              <div class="card-actions">
+                <a href="?export=True" class="btn btn-sm btn-ghost-primary" role="button">
                   <i class="mdi mdi-download" aria-hidden="true"></i> {% trans "Download" %}
                 </a>
+                {% copy_content "rendered_config" %}
               </div>
             </h2>
             <pre class="card-body" id="rendered_config">{{ rendered_config }}</pre>

--- a/netbox/templates/ipam/inc/panels/fhrp_groups.html
+++ b/netbox/templates/ipam/inc/panels/fhrp_groups.html
@@ -40,12 +40,12 @@
           <td>{{ assignment.priority }}</td>
           <td class="text-end d-print-none">
             {% if perms.ipam.change_fhrpgroupassignment %}
-              <a href="{% url 'ipam:fhrpgroupassignment_edit' pk=assignment.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-warning lh-1" title="{% trans "Edit" %}">
+              <a href="{% url 'ipam:fhrpgroupassignment_edit' pk=assignment.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-warning" title="{% trans "Edit" %}">
                 <i class="mdi mdi-pencil" aria-hidden="true"></i>
               </a>
             {% endif %}
             {% if perms.ipam.delete_fhrpgroupassignment %}
-              <a href="{% url 'ipam:fhrpgroupassignment_delete' pk=assignment.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-danger lh-1" title="{% trans "Delete" %}">
+              <a href="{% url 'ipam:fhrpgroupassignment_delete' pk=assignment.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-danger" title="{% trans "Delete" %}">
                 <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i>
               </a>
             {% endif %}


### PR DESCRIPTION
### Fixes: #20030

- Reduce padding on table cells which hold action buttons
- Replace the `lh-1` CSS class with `btn-sm` on various buttons
- Convert solid color buttons within card headers to `btn-ghost-*`