### PR TITLE
Fixes #19988: `has_feature()` should gracefully handle invalid ContentTypes

### DIFF
--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -679,10 +679,14 @@ def has_feature(model_or_ct, feature):
         ot = model_or_ct
     # If a ContentType was passed, resolve its model class
     elif type(model_or_ct) is ContentType:
-        ot = ObjectType.objects.get_for_model(model_or_ct.model_class())
+        model_class = model_or_ct.model_class()
+        ot = ObjectType.objects.get_for_model(model_class) if model_class else None
     # For anything else, look up the ObjectType
     else:
         ot = ObjectType.objects.get_for_model(model_or_ct)
+    # ObjectType is invalid/deleted
+    if ot is None:
+        return False
     return feature in ot.features
 
 


### PR DESCRIPTION
### Fixes: #19988

- Extend the logic inside `has_feature()` to return False if the model class for a given ContentType cannot be resolved