### PR TITLE
Fixes: #19669 & #18396 - Allow Token Authentication against Media view

### DIFF
--- a/netbox/netbox/views/misc.py
+++ b/netbox/netbox/views/misc.py
@@ -20,7 +20,7 @@ from netbox.search.backends import search_backend
 from netbox.tables import SearchTable
 from utilities.htmx import htmx_partial
 from utilities.paginator import EnhancedPaginator, get_paginate_count
-from utilities.views import ConditionalLoginRequiredMixin
+from utilities.views import ConditionalLoginRequiredMixin, TokenConditionalLoginRequiredMixin
 
 __all__ = (
     'HomeView',
@@ -119,7 +119,7 @@ class SearchView(ConditionalLoginRequiredMixin, View):
         })
 
 
-class MediaView(ConditionalLoginRequiredMixin, View):
+class MediaView(TokenConditionalLoginRequiredMixin, View):
     """
     Wrap Django's serve() view to enforce LOGIN_REQUIRED for static media.
     """

--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -6,7 +6,6 @@ from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.translation import gettext_lazy as _
-from rest_framework.exceptions import AuthenticationFailed
 
 from netbox.api.authentication import TokenAuthentication
 from netbox.plugins import PluginConfig
@@ -47,12 +46,9 @@ class TokenConditionalLoginRequiredMixin(ConditionalLoginRequiredMixin):
         # Attempt to authenticate the user using a DRF token, if provided
         if settings.LOGIN_REQUIRED and not request.user.is_authenticated:
             authenticator = TokenAuthentication()
-            try:
-                auth_info = authenticator.authenticate(request)
-                if auth_info is not None:
-                    request.user = auth_info[0]  # User object
-            except AuthenticationFailed:
-                pass
+            auth_info = authenticator.authenticate(request)
+            if auth_info is not None:
+                request.user = auth_info[0]  # User object
 
         return super().dispatch(request, *args, **kwargs)
 

--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -6,7 +6,9 @@ from django.core.exceptions import ImproperlyConfigured
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.translation import gettext_lazy as _
+from rest_framework.exceptions import AuthenticationFailed
 
+from netbox.api.authentication import TokenAuthentication
 from netbox.plugins import PluginConfig
 from netbox.registry import registry
 from utilities.relations import get_related_models
@@ -19,6 +21,7 @@ __all__ = (
     'GetRelatedModelsMixin',
     'GetReturnURLMixin',
     'ObjectPermissionRequiredMixin',
+    'TokenConditionalLoginRequiredMixin',
     'ViewTab',
     'get_viewname',
     'register_model_view',
@@ -36,6 +39,21 @@ class ConditionalLoginRequiredMixin(AccessMixin):
     def dispatch(self, request, *args, **kwargs):
         if settings.LOGIN_REQUIRED and not request.user.is_authenticated:
             return self.handle_no_permission()
+        return super().dispatch(request, *args, **kwargs)
+
+
+class TokenConditionalLoginRequiredMixin(ConditionalLoginRequiredMixin):
+    def dispatch(self, request, *args, **kwargs):
+        # Attempt to authenticate the user using a DRF token, if provided
+        if settings.LOGIN_REQUIRED and not request.user.is_authenticated:
+            authenticator = TokenAuthentication()
+            try:
+                auth_info = authenticator.authenticate(request)
+                if auth_info is not None:
+                    request.user = auth_info[0]  # User object
+            except AuthenticationFailed:
+                pass
+
         return super().dispatch(request, *args, **kwargs)
 
 

--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -49,10 +49,7 @@ class TokenConditionalLoginRequiredMixin(ConditionalLoginRequiredMixin):
             auth_info = authenticator.authenticate(request)
             if auth_info is not None:
                 request.user = auth_info[0]  # User object
-                try:
-                    request.auth = auth_info[1]
-                except IndexError:
-                    pass
+                request.auth = auth_info[1]
 
         return super().dispatch(request, *args, **kwargs)
 

--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -49,6 +49,10 @@ class TokenConditionalLoginRequiredMixin(ConditionalLoginRequiredMixin):
             auth_info = authenticator.authenticate(request)
             if auth_info is not None:
                 request.user = auth_info[0]  # User object
+                try:
+                    request.auth = auth_info[1]
+                except IndexError:
+                    pass
 
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
### Fixes: #19669 & #18396 - Allow Token Authentication against Media view

* Add reusable `TokenConditionalLoginRequiredMixin` (inheriting from `ConditionalLoginRequiredMixin`)
* Change MediaView to utilize new Mixin