### PR TITLE
Closes #19728: add c18 power port type

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -344,6 +344,7 @@ class PowerPortTypeChoices(ChoiceSet):
     TYPE_IEC_C8 = 'iec-60320-c8'
     TYPE_IEC_C14 = 'iec-60320-c14'
     TYPE_IEC_C16 = 'iec-60320-c16'
+    TYPE_IEC_C18 = 'iec-60320-c18'
     TYPE_IEC_C20 = 'iec-60320-c20'
     TYPE_IEC_C22 = 'iec-60320-c22'
     # IEC 60309
@@ -462,6 +463,7 @@ class PowerPortTypeChoices(ChoiceSet):
             (TYPE_IEC_C8, 'C8'),
             (TYPE_IEC_C14, 'C14'),
             (TYPE_IEC_C16, 'C16'),
+            (TYPE_IEC_C18, 'C18'),
             (TYPE_IEC_C20, 'C20'),
             (TYPE_IEC_C22, 'C22'),
         )),
@@ -599,6 +601,7 @@ class PowerOutletTypeChoices(ChoiceSet):
     TYPE_IEC_C7 = 'iec-60320-c7'
     TYPE_IEC_C13 = 'iec-60320-c13'
     TYPE_IEC_C15 = 'iec-60320-c15'
+    TYPE_IEC_C17 = 'iec-60320-c17'
     TYPE_IEC_C19 = 'iec-60320-c19'
     TYPE_IEC_C21 = 'iec-60320-c21'
     # IEC 60309
@@ -711,6 +714,7 @@ class PowerOutletTypeChoices(ChoiceSet):
             (TYPE_IEC_C7, 'C7'),
             (TYPE_IEC_C13, 'C13'),
             (TYPE_IEC_C15, 'C15'),
+            (TYPE_IEC_C17, 'C17'),
             (TYPE_IEC_C19, 'C19'),
             (TYPE_IEC_C21, 'C21'),
         )),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Closes #19728: add c18 power port type
<!--
    Please include a summary of the proposed changes below.
-->
Introduces the C17/C18 power port and power outlet pair.

Changes made:
- Add C17 to PowerOutletTypeChoices
- Add C18 to PowerPortTypeChoices