### PR TITLE
Fixes: #20098 - Handle empty object_types field in Tag bulk import

### DIFF
--- a/netbox/utilities/forms/fields/csv.py
+++ b/netbox/utilities/forms/fields/csv.py
@@ -120,4 +120,6 @@ class CSVMultipleContentTypeField(forms.ModelMultipleChoiceField):
                 app_label, model = name.split('.')
                 ct_filter |= Q(app_label=app_label, model=model)
             return list(ContentType.objects.filter(ct_filter).values_list('pk', flat=True))
-        return object_type_identifier(value)
+        if value:
+            return object_type_identifier(value)
+        return None

--- a/netbox/utilities/forms/fields/csv.py
+++ b/netbox/utilities/forms/fields/csv.py
@@ -114,12 +114,12 @@ class CSVMultipleContentTypeField(forms.ModelMultipleChoiceField):
 
     # TODO: Improve validation of selected ContentTypes
     def prepare_value(self, value):
+        if not value:
+            return None
         if type(value) is str:
             ct_filter = Q()
             for name in value.split(','):
                 app_label, model = name.split('.')
                 ct_filter |= Q(app_label=app_label, model=model)
             return list(ContentType.objects.filter(ct_filter).values_list('pk', flat=True))
-        if value:
-            return object_type_identifier(value)
-        return None
+        return object_type_identifier(value)


### PR DESCRIPTION
### Fixes: #20098

Handles the case in `CSVMultipleContentTypeField.prepare_value` where `value` is null (which only occurs in Tag bulk import, where the `object_types` field is optional).