### PR TITLE
return_url for missing prerequisites "Add" button

### DIFF
--- a/netbox/templates/inc/missing_prerequisites.html
+++ b/netbox/templates/inc/missing_prerequisites.html
@@ -10,7 +10,7 @@
       {% endblocktrans %}
     </div>
     <div>
-      {% add_button prerequisite_model %}
+      {% add_button prerequisite_model request.path %}
     </div>
   </div>
 </div>

--- a/netbox/utilities/templates/buttons/add.html
+++ b/netbox/utilities/templates/buttons/add.html
@@ -1,6 +1,10 @@
 {% if url %}
-{% load i18n %}
-  <a href="{{ url }}" type="button" class="btn btn-primary">
-    <i class="mdi mdi-plus-thick"></i> {% trans "Add" %}
-  </a>
+    {% load i18n %}
+    {% if return_url %}
+        <a href="{{ url }}?return_url={{ return_url }}" type="button" class="btn btn-primary">
+    {% else %}
+        <a href="{{ url }}" type="button" class="btn btn-primary">
+    {% endif %}
+<i class="mdi mdi-plus-thick"></i> {% trans "Add" %}
+</a>
 {% endif %}

--- a/netbox/utilities/templatetags/buttons.py
+++ b/netbox/utilities/templatetags/buttons.py
@@ -146,7 +146,7 @@ def sync_button(instance):
 #
 
 @register.inclusion_tag('buttons/add.html')
-def add_button(model, action='add'):
+def add_button(model, return_url=None, action='add'):
     try:
         url = reverse(get_viewname(model, action))
     except NoReverseMatch:
@@ -154,6 +154,7 @@ def add_button(model, action='add'):
 
     return {
         'url': url,
+        'return_url': return_url,
     }
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19990

<!--
    Please include a summary of the proposed changes below.
-->
add optional return_url parameter to "Add" button, used in missing_prerequisites.html to return user back to initial page after adding an prerequisite object
