### PR TITLE
Closes #20131: Add selector to MACAddress model form for interface/vminterface

### DIFF
--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -1890,6 +1890,7 @@ class MACAddressForm(NetBoxModelForm):
         label=_('Interface'),
         queryset=Interface.objects.all(),
         required=False,
+        selector=True,
         context={
             'parent': 'device',
         },
@@ -1898,6 +1899,7 @@ class MACAddressForm(NetBoxModelForm):
         label=_('VM Interface'),
         queryset=VMInterface.objects.all(),
         required=False,
+        selector=True,
         context={
             'parent': 'virtual_machine',
         },


### PR DESCRIPTION
### Closes: #20131 - Add selector to the MACAddress model form

* Add `selector=True` to the MACAddress `model_form` for `interface`
* Add `selector=True` to the MACAddress `model_form` for `vminterface`


