### PR TITLE
Closes #18147: Include device & VM interfaces in VRF related objects

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -53,8 +53,26 @@ class VRFView(GetRelatedModelsMixin, generic.ObjectView):
         )
         export_targets_table.configure(request)
 
+        related_models = self.get_related_models(
+            request,
+            instance,
+            omit=(Interface, VMInterface),
+            extra=(
+                (
+                    Interface.objects.restrict(request.user, 'view').filter(vrf=instance),
+                    'vrf_id',
+                    _('Device Interfaces')
+                ),
+                (
+                    VMInterface.objects.restrict(request.user, 'view').filter(vrf=instance),
+                    'vrf_id',
+                    _('VM Interfaces')
+                ),
+            ),
+        )
+
         return {
-            'related_models': self.get_related_models(request, instance, omit=[Interface, VMInterface]),
+            'related_models': related_models,
             'import_targets_table': import_targets_table,
             'export_targets_table': export_targets_table,
         }

--- a/netbox/templates/inc/panels/related_objects.html
+++ b/netbox/templates/inc/panels/related_objects.html
@@ -7,7 +7,7 @@
     {% for related_object_count in related_models %}
       {% with viewname=related_object_count.queryset.model|validated_viewname:"list" %}
         {% if viewname is not None %}
-          <a href="{% url viewname %}?{{ filter_param }}={{ object.pk }}" class="list-group-item list-group-item-action d-flex justify-content-between">
+          <a href="{% url viewname %}?{{ related_object_count.filter_param }}={{ object.pk }}" class="list-group-item list-group-item-action d-flex justify-content-between">
             {{ related_object_count.name }}
             {% with count=related_object_count.queryset.count %}
               {% if count %}

--- a/netbox/templates/inc/panels/related_objects.html
+++ b/netbox/templates/inc/panels/related_objects.html
@@ -4,19 +4,19 @@
 <div class="card">
   <h2 class="card-header">{% trans "Related Objects" %}</h2>
   <ul class="list-group list-group-flush" role="presentation">
-    {% for qs, filter_param in related_models %}
-      {% with viewname=qs.model|validated_viewname:"list" %}
+    {% for related_object_count in related_models %}
+      {% with viewname=related_object_count.queryset.model|validated_viewname:"list" %}
         {% if viewname is not None %}
-        <a href="{% url viewname %}?{{ filter_param }}={{ object.pk }}" class="list-group-item list-group-item-action d-flex justify-content-between">
-          {{ qs.model|meta:"verbose_name_plural"|bettertitle }}
-          {% with count=qs.count %}
-            {% if count %}
-              <span class="badge text-bg-primary rounded-pill">{{ count }}</span>
-            {% else %}
-              <span class="badge text-bg-light rounded-pill">&mdash;</span>
-            {% endif %}
-          {% endwith %}
-        </a>
+          <a href="{% url viewname %}?{{ filter_param }}={{ object.pk }}" class="list-group-item list-group-item-action d-flex justify-content-between">
+            {{ related_object_count.name }}
+            {% with count=related_object_count.queryset.count %}
+              {% if count %}
+                <span class="badge text-bg-primary rounded-pill">{{ count }}</span>
+              {% else %}
+                <span class="badge text-bg-light rounded-pill">&mdash;</span>
+              {% endif %}
+            {% endwith %}
+          </a>
         {% endif %}
       {% endwith %}
     {% empty %}


### PR DESCRIPTION
### Fixes: #18147

- Introduce the RelatedObjectCount dataclass to accept an optional label
- Update the `related_objects.html` inclusion template to use RelatedObjectCount
- Extend `VRFView.get_extra_context()` to include device & VM interface counts
- Tweak the signature of `get_related_models()` to avoid passing mutable values for `omit` and `extra`