### PR TITLE
Fixes #20164 - Add status field to PowerOutlet bulk create form

### DIFF
--- a/netbox/dcim/forms/bulk_create.py
+++ b/netbox/dcim/forms/bulk_create.py
@@ -69,11 +69,14 @@ class PowerPortBulkCreateForm(
 
 
 class PowerOutletBulkCreateForm(
-    form_from_model(PowerOutlet, ['type', 'color', 'feed_leg', 'mark_connected']),
+    form_from_model(PowerOutlet, ['type', 'status', 'color', 'feed_leg', 'mark_connected']),
     DeviceBulkAddComponentForm
 ):
     model = PowerOutlet
-    field_order = ('name', 'label', 'type', 'feed_leg', 'description', 'tags')
+    field_order = (
+        'name', 'label', 'type', 'status', 'color', 'feed_leg', 'mark_connected',
+        'description', 'tags',
+    )
 
 
 class InterfaceBulkCreateForm(


### PR DESCRIPTION
### Fixes: #20164

Includes the `status` field in the PowerOutlet bulk create form to allow configuration during bulk creation.

### Summary
- Add `status` to the DCIM PowerOutlet bulk create form.
- Brings bulk create in line with single-object create/edit behavior.

### Validation
1) On **Devices**, select multiple devices.
2) Click **Add Components → Power Outlets**.
3) Enter a Name pattern (e.g., `[1-9]`), choose a **Status**, and click **Create**.
4) Verify the expected outlets are created for each device with the selected status.

### Notes
- UI-only change; no model or API impact.

