### PR TITLE
#20175 Fix Grammatical Error Related To Capitalization

### DIFF
--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -89,7 +89,7 @@ The following condition will evaluate as true:
 ```
 
 !!! note "Evaluating static choice fields"
-    Pay close attention when evaluating static choice fields, such as the `status` field above. These fields typically render as a dictionary specifying both the field's raw value (`value`) and its human-friendly label (`label`). be sure to specify on which of these you want to match.
+    Pay close attention when evaluating static choice fields, such as the `status` field above. These fields typically render as a dictionary specifying both the field's raw value (`value`) and its human-friendly label (`label`). Be sure to specify on which of these you want to match.
 
 ## Condition Sets
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20175 

<!--
    Please include a summary of the proposed changes below.
-->
Fixes that a B in the word be needs to be capitalized if the word before it ends with a period