### PR TITLE
Fixes #20154: Restore missing `changelog_message` field on several forms

### DIFF
--- a/netbox/templates/dcim/device_edit.html
+++ b/netbox/templates/dcim/device_edit.html
@@ -117,4 +117,9 @@
       {% render_field form.comments %}
     </div>
 
+    {# Meta fields #}
+    <div class="bg-primary-subtle border border-primary rounded-1 pt-3 px-3 mb-3">
+      {% render_field form.changelog_message %}
+    </div>
+
 {% endblock %}

--- a/netbox/templates/dcim/htmx/cable_edit.html
+++ b/netbox/templates/dcim/htmx/cable_edit.html
@@ -87,9 +87,12 @@
   </div>
 {% endif %}
 
-{% if form.comments %}
-  <div class="field-group mb-5">
-    <h2 class="text-center">{% trans "Comments" %}</h2>
-    {% render_field form.comments %}
-  </div>
-{% endif %}
+<div class="field-group mb-5">
+  <h2 class="text-center">{% trans "Comments" %}</h2>
+  {% render_field form.comments %}
+</div>
+
+{# Meta fields #}
+<div class="bg-primary-subtle border border-primary rounded-1 pt-3 px-3 mb-3">
+  {% render_field form.changelog_message %}
+</div>

--- a/netbox/templates/ipam/vlan_edit.html
+++ b/netbox/templates/ipam/vlan_edit.html
@@ -77,4 +77,9 @@
   <div class="field-group my-5">
     {% render_field form.comments %}
   </div>
+
+  {# Meta fields #}
+  <div class="bg-primary-subtle border border-primary rounded-1 pt-3 px-3 mb-3">
+    {% render_field form.changelog_message %}
+  </div>
 {% endblock %}


### PR DESCRIPTION
### Fixes: #20154

Add the `changelog_message` field to the add/edit form templates for the following models:

- dcim.Cable
- dcim.Device
- ipam.VLAN