### PR TITLE
Closes #20115: Support the use of ArrayColumn for plugin tables

### DIFF
--- a/docs/plugins/development/tables.md
+++ b/docs/plugins/development/tables.md
@@ -51,6 +51,10 @@ This will automatically apply any user-specific preferences for the table. (If u
 
 The table column classes listed below are supported for use in plugins. These classes can be imported from `netbox.tables.columns`.
 
+::: netbox.tables.ArrayColumn
+    options:
+      members: false
+
 ::: netbox.tables.BooleanColumn
     options:
       members: false

--- a/docs/release-notes/version-4.4.md
+++ b/docs/release-notes/version-4.4.md
@@ -39,6 +39,7 @@ A new ConfigContextProfile model has been introduced to support JSON schema vali
 * [#19945](https://github.com/netbox-community/netbox/issues/19945) - Introduce a new custom script variable to represent decimal values
 * [#19965](https://github.com/netbox-community/netbox/issues/19965) - Add REST & GraphQL API request counters to the Prometheus metrics exporter
 * [#20029](https://github.com/netbox-community/netbox/issues/20029) - Include complete representation of object type in webhook payload data
+* [#20115](https://github.com/netbox-community/netbox/issues/20115) - Support the use of ArrayColumn for plugin tables
 
 ### Plugins
 


### PR DESCRIPTION
### Closes: #20115

Add `ArrayColumn` to the set of supported table column classes for plugins