### PR TITLE
Closes #20092: Clean up `mkdocs` warnings

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -106,7 +106,11 @@ mkdocs-material
 
 # Introspection for embedded code
 # https://github.com/mkdocstrings/mkdocstrings/blob/main/CHANGELOG.md
-mkdocstrings[python]
+mkdocstrings
+
+# Python handler for mkdocstrings
+# https://github.com/mkdocstrings/python/blob/main/CHANGELOG.md
+mkdocstrings-python
 
 # Library for manipulating IP prefixes and addresses
 # https://github.com/netaddr/netaddr/blob/master/CHANGELOG.rst

--- a/docs/plugins/development/models.md
+++ b/docs/plugins/development/models.md
@@ -24,7 +24,7 @@ Every model includes by default a numeric primary key. This value is generated a
 
 ## Enabling NetBox Features
 
-Plugin models can leverage certain [model features](../development/models.md#features-matrix) (such as tags, custom fields, event rules, etc.) by inheriting from NetBox's `NetBoxModel` class. This class performs two crucial functions:
+Plugin models can leverage certain [model features](../../development/models.md#features-matrix) (such as tags, custom fields, event rules, etc.) by inheriting from NetBox's `NetBoxModel` class. This class performs two crucial functions:
 
 1. Apply any fields, methods, and/or attributes necessary to the operation of these features
 2. Register the model with NetBox as utilizing these features

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,8 @@ plugins:
         python:
           paths: ["netbox"]
           options:
+            docstring_options:
+              warn_missing_types: false
             heading_level: 3
             members_order: source
             show_root_heading: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -24,7 +24,8 @@ Jinja2==3.1.6
 jsonschema==4.25.0
 Markdown==3.8.2
 mkdocs-material==9.6.16
-mkdocstrings[python]==0.30.0
+mkdocstrings==0.30.0
+mkdocstrings-python==1.18.2
 netaddr==1.3.0
 nh3==0.3.0
 Pillow==11.3.0


### PR DESCRIPTION
### Closes: #20092

* Split `mkdocstrings-python` into explicit dependency to force updates
* Suppress `griffe` warnings for missing type annotations in docstrings
* Fix an invalid link