### PR TITLE
Closes #19889: Drop support for Python 3.10 & 3.11

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/02-bug_report.yaml
@@ -35,8 +35,6 @@ body:
       label: Python Version
       description: What version of Python are you currently running?
       options:
-        - "3.10"
-        - "3.11"
         - "3.12"
     validations:
       required: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       NETBOX_CONFIGURATION: netbox.configuration_testing
     strategy:
       matrix:
-        python-version: ['3.10', '3.11', '3.12']
+        python-version: ['3.12']
         node-version: ['20.x']
     services:
       redis:

--- a/docs/development/getting-started.md
+++ b/docs/development/getting-started.md
@@ -7,7 +7,7 @@ Getting started with NetBox development is pretty straightforward, and should fe
 * A Linux system or compatible environment
 * A PostgreSQL server, which can be installed locally [per the documentation](../installation/1-postgresql.md)
 * A Redis server, which can also be [installed locally](../installation/2-redis.md)
-* Python 3.10 or later
+* Python 3.12 or later
 
 ### 1. Fork the Repo
 

--- a/docs/installation/3-netbox.md
+++ b/docs/installation/3-netbox.md
@@ -6,8 +6,8 @@ This section of the documentation discusses installing and configuring the NetBo
 
 Begin by installing all system packages required by NetBox and its dependencies.
 
-!!! warning "Python 3.10 or later required"
-    NetBox supports Python 3.10, 3.11, and 3.12.
+!!! warning "Python 3.12 or later required"
+    NetBox supports only Python 3.12 or later.
 
 ```no-highlight
 sudo apt install -y python3 python3-pip python3-venv python3-dev \
@@ -15,7 +15,7 @@ build-essential libxml2-dev libxslt1-dev libffi-dev libpq-dev \
 libssl-dev zlib1g-dev
 ```
 
-Before continuing, check that your installed Python version is at least 3.10:
+Before continuing, check that your installed Python version is at least 3.12:
 
 ```no-highlight
 python3 -V
@@ -235,7 +235,7 @@ Once NetBox has been configured, we're ready to proceed with the actual installa
 sudo /opt/netbox/upgrade.sh
 ```
 
-Note that **Python 3.10 or later is required** for NetBox v4.0 and later releases. If the default Python installation on your server is set to a lesser version,  pass the path to the supported installation as an environment variable named `PYTHON`. (Note that the environment variable must be passed _after_ the `sudo` command.)
+Note that **Python 3.12 or later is required** for NetBox v4.5 and later releases. If the default Python installation on your server is set to a lesser version,  pass the path to the supported installation as an environment variable named `PYTHON`. (Note that the environment variable must be passed _after_ the `sudo` command.)
 
 ```no-highlight
 sudo PYTHON=/usr/bin/python3.10 /opt/netbox/upgrade.sh

--- a/docs/installation/4a-gunicorn.md
+++ b/docs/installation/4a-gunicorn.md
@@ -60,6 +60,3 @@ You should see output similar to the following:
     If the NetBox service fails to start, issue the command `journalctl -eu netbox` to check for log messages that may indicate the problem.
 
 Once you've verified that the WSGI workers are up and running, move on to HTTP server setup.
-
-!!! note
-    There is a bug in the current stable release of gunicorn (v21.2.0) where automatic restarts of the worker processes can result in 502 errors under heavy load. (See [gunicorn bug #3038](https://github.com/benoitc/gunicorn/issues/3038) for more detail.) Users who encounter this issue may opt to downgrade to an earlier, unaffected release of gunicorn (`pip install gunicorn==20.1.0`). Note, however, that this earlier release does not officially support Python 3.11.

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -27,7 +27,7 @@ The following sections detail how to set up a new instance of NetBox:
 
 | Dependency | Supported Versions |
 |------------|--------------------|
-| Python     | 3.10, 3.11, 3.12   |
+| Python     | 3.12+              |
 | PostgreSQL | 14+                |
 | Redis      | 4.0+               |
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -31,9 +31,9 @@ VERSION = RELEASE.full_version  # Retained for backward compatibility
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Validate Python version
-if sys.version_info < (3, 10):
+if sys.version_info < (3, 12):
     raise RuntimeError(
-        f"NetBox requires Python 3.10 or later. (Currently installed: Python {platform.python_version()})"
+        f"NetBox requires Python 3.12 or later. (Currently installed: Python {platform.python_version()})"
     )
 
 #

--- a/netbox/utilities/datetime.py
+++ b/netbox/utilities/datetime.py
@@ -20,9 +20,4 @@ def datetime_from_timestamp(value):
     """
     Convert an ISO 8601 or RFC 3339 timestamp to a datetime object.
     """
-    # Work around UTC issue for Python < 3.11; see
-    # https://docs.python.org/3/library/datetime.html#datetime.datetime.fromisoformat
-    # TODO: Remove this once Python 3.10 is no longer supported
-    if type(value) is str and value.endswith('Z'):
-        value = f'{value[:-1]}+00:00'
     return datetime.datetime.fromisoformat(value)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@
 [project]
 name = "netbox"
 version = "4.4.0"
-requires-python = ">=3.10"
+requires-python = ">=3.12"
 description = "The premier source of truth powering network automation."
 readme = "README.md"
 license = "Apache-2.0"
@@ -15,8 +15,6 @@ classifiers = [
     "Natural Language :: English",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
 ]
 
@@ -28,7 +26,7 @@ Issues = "https://github.com/netbox-community/netbox/issues"
 
 [tool.black]
 line-length = 120
-target_version = ['py310', 'py311', 'py312']
+target_version = ['py312']
 skip-string-normalization = true
 
 [tool.isort]

--- a/upgrade.sh
+++ b/upgrade.sh
@@ -4,7 +4,7 @@
 
 # This script will invoke Python with the value of the PYTHON environment
 # variable (if set), or fall back to "python3". Note that NetBox v4.0+ requires
-# Python 3.10 or later.
+# Python 3.12 or later.
 
 # Parse arguments
 if [[ "$1" == "--readonly" ]]; then
@@ -22,15 +22,15 @@ VIRTUALENV="$(pwd -P)/venv"
 PYTHON="${PYTHON:-python3}"
 
 # Validate the minimum required Python version
-COMMAND="${PYTHON} -c 'import sys; exit(1 if sys.version_info < (3, 10) else 0)'"
+COMMAND="${PYTHON} -c 'import sys; exit(1 if sys.version_info < (3, 12) else 0)'"
 PYTHON_VERSION=$(eval "${PYTHON} -V")
 eval $COMMAND || {
   echo "--------------------------------------------------------------------"
   echo "ERROR: Unsupported Python version: ${PYTHON_VERSION}. NetBox requires"
-  echo "Python 3.10 or later. To specify an alternate Python executable, set"
+  echo "Python 3.12 or later. To specify an alternate Python executable, set"
   echo "the PYTHON environment variable. For example:"
   echo ""
-  echo "  sudo PYTHON=/usr/bin/python3.10 ./upgrade.sh"
+  echo "  sudo PYTHON=/usr/bin/python3.12 ./upgrade.sh"
   echo ""
   echo "To show your current Python version: ${PYTHON} -V"
   echo "--------------------------------------------------------------------"


### PR DESCRIPTION
### Closes: #19889

- Drop support for Python 3.10 & 3.11 in documentation
- Remove Python 3.10 & 3.11 from the CI matrix
- Enforce a minimum Python version of 3.12 in upgrade script & `settings.py`
- Remove a hack in `datetime_from_timestamp()` to accommodate Python 3.10