### PR TITLE
Closes #20095: Remove obsolete module `core.models.contenttypes`

### DIFF
--- a/netbox/core/models/contenttypes.py
+++ b/netbox/core/models/contenttypes.py
@@ -1,3 +1,0 @@
-# TODO: Remove this module in NetBox v4.5
-# Provided for backward compatibility
-from .object_types import *


### PR DESCRIPTION
### Closes: #20095
