### PR TITLE
Closes #19408: Enable export templates for physical & virtual circuit terminations

### DIFF
--- a/netbox/circuits/models/circuits.py
+++ b/netbox/circuits/models/circuits.py
@@ -6,7 +6,6 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 from circuits.choices import *
-from circuits.constants import *
 from dcim.models import CabledObjectModel
 from netbox.models import ChangeLoggedModel, OrganizationalModel, PrimaryModel
 from netbox.models.mixins import DistanceMixin
@@ -231,6 +230,7 @@ class CircuitGroupAssignment(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin,
 class CircuitTermination(
     CustomFieldsMixin,
     CustomLinksMixin,
+    ExportTemplatesMixin,
     TagsMixin,
     ChangeLoggedModel,
     CabledObjectModel

--- a/netbox/circuits/models/virtual_circuits.py
+++ b/netbox/circuits/models/virtual_circuits.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from circuits.choices import *
 from netbox.models import ChangeLoggedModel, PrimaryModel
-from netbox.models.features import CustomFieldsMixin, CustomLinksMixin, TagsMixin
+from netbox.models.features import CustomFieldsMixin, CustomLinksMixin, ExportTemplatesMixin, TagsMixin
 from .base import BaseCircuitType
 
 __all__ = (
@@ -121,6 +121,7 @@ class VirtualCircuit(PrimaryModel):
 class VirtualCircuitTermination(
     CustomFieldsMixin,
     CustomLinksMixin,
+    ExportTemplatesMixin,
     TagsMixin,
     ChangeLoggedModel
 ):


### PR DESCRIPTION
### Closes: #19408

Note: You must run `manage.py migrate` to update the supported features for the CircuitTermination and VirtualCircuitTermination models.