### PR TITLE
Closes #20237 - Add search index for TunnelGroup

### DIFF
--- a/netbox/vpn/search.py
+++ b/netbox/vpn/search.py
@@ -15,6 +15,17 @@ class TunnelIndex(SearchIndex):
 
 
 @register_search
+class TunnelGroupIndex(SearchIndex):
+    model = models.TunnelGroup
+    fields = (
+        ('name', 100),
+        ('slug', 110),
+        ('description', 500),
+    )
+    display_attrs = ('description',)
+
+
+@register_search
 class IKEProposalIndex(SearchIndex):
     model = models.IKEProposal
     fields = (


### PR DESCRIPTION
### Fixes: #20237

Adds `TunnelGroupIndex` so VPN Tunnel Groups appear in the global search (parity with VLAN Groups). Indexes `name` (high weight) and `description` (lower weight). No schema or API changes.

**Tested:** Created a sample group; global search now hits on name/description and links to the object view as expected.

