### PR TITLE
Fixes #20238 - Fix Outside IP field in Tunnel Termination bulk import form

### DIFF
--- a/netbox/vpn/forms/bulk_import.py
+++ b/netbox/vpn/forms/bulk_import.py
@@ -107,7 +107,7 @@ class TunnelTerminationImportForm(NetBoxModelImportForm):
         label=_('Outside IP'),
         queryset=IPAddress.objects.all(),
         required=False,
-        to_field_name='name'
+        to_field_name='address'
     )
 
     class Meta:


### PR DESCRIPTION
### Fixes: #20238

Changes the `to_field_name` from `name` to `address` for the `outside_ip` selector in the VPN **Tunnel Termination** bulk import form. This aligns with how other IP references are resolved and fixes the import error:

> `outside_ip: "name" is an invalid accessor field name.`

After this change, imports like the example below work as expected:

```text
tunnel role outside_ip virtual_machine termination
tunnel peer 1.1.1.1/32 vm int0
```

This ensures proper mapping and validation of IP addresses during bulk import.
