### PR TITLE
Fixes #20217: Fix '0 VLANs available' in the VLANs table in VLAN Groups

### DIFF
--- a/netbox/ipam/utils.py
+++ b/netbox/ipam/utils.py
@@ -164,11 +164,11 @@ def available_vlans_from_range(vlans, vlan_group, vid_range):
         prev_vid = vlan.vid
 
     # Annotate any remaining available VLANs
-    if prev_vid < max_vid:
+    if prev_vid < max_vid and (available := max_vid - prev_vid - 1) > 0:
         new_vlans.append({
             'vid': prev_vid + 1,
             'vlan_group': vlan_group,
-            'available': max_vid - prev_vid - 1,
+            'available': available,
         })
 
     return new_vlans

--- a/netbox/ipam/utils.py
+++ b/netbox/ipam/utils.py
@@ -164,11 +164,11 @@ def available_vlans_from_range(vlans, vlan_group, vid_range):
         prev_vid = vlan.vid
 
     # Annotate any remaining available VLANs
-    if prev_vid < max_vid and (available := max_vid - prev_vid - 1) > 0:
+    if prev_vid < max_vid - 1:
         new_vlans.append({
             'vid': prev_vid + 1,
             'vlan_group': vlan_group,
-            'available': available,
+            'available': max_vid - prev_vid - 1,
         })
 
     return new_vlans


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20217 

Fixes an issue where the VLANs table under a VLAN Group will display a clickable `0 VLANs available` button when the final VLAN in the range is in use.