### PR TITLE
Fixes #19744: Add accessor for is_loaded in TemplateColumn

### DIFF
--- a/netbox/core/tables/plugins.py
+++ b/netbox/core/tables/plugins.py
@@ -61,6 +61,7 @@ class CatalogPluginTable(BaseTable):
         verbose_name=_('Local')
     )
     is_installed = columns.TemplateColumn(
+        accessor=tables.A('is_loaded'),
         verbose_name=_('Active'),
         template_code=PLUGIN_IS_INSTALLED
     )


### PR DESCRIPTION
### Fixes: #19744

**Summary**  
Fix sorting for the **Active** column on **Admin → Plugins**.

**Change**  
Add `accessor=tables.A('is_loaded')` to the Active `TemplateColumn` so django‑tables2 orders by the boolean value rather than the rendered HTML.

**Result**  
Clicking **Active** now correctly toggles:
- **Ascending:** inactive → active  
- **Descending:** active → inactive

