### PR TITLE
Fixes #20234: Correct add_button return_url for prerequisite models

### DIFF
--- a/netbox/templates/inc/missing_prerequisites.html
+++ b/netbox/templates/inc/missing_prerequisites.html
@@ -10,7 +10,7 @@
       {% endblocktrans %}
     </div>
     <div>
-      {% add_button prerequisite_model request.path %}
+      {% add_button prerequisite_model return_url=request.path %}
     </div>
   </div>
 </div>


### PR DESCRIPTION
### Fixes: #20234

**Summary**  
The generic prerequisite include was passing `request.path` as the second positional argument to the `add_button` template tag. Because the tag expects `(model, action, return_url)`, this caused `request.path` to be interpreted as `action`, breaking the "+ Add" link in banners such as "Before you can add a power feed you must first create a power panel."

**Change**  
Pass the `return_url` by name so it’s bound correctly by the tag:

~~~django
{% add_button prerequisite_model return_url=request.path %}
~~~

**User impact**  
Clicking "+ Add" on any prerequisite banner now opens the correct add form and returns the user to the originating page upon completion.