### PR TITLE
Closes #19547: Add Sync button for DataSource ListView

### DIFF
--- a/netbox/core/tables/data.py
+++ b/netbox/core/tables/data.py
@@ -4,6 +4,7 @@ import django_tables2 as tables
 from core.models import *
 from netbox.tables import NetBoxTable, columns
 from .columns import BackendTypeColumn
+from .template_code import DATA_SOURCE_SYNC_BUTTON
 
 __all__ = (
     'DataFileTable',
@@ -36,6 +37,9 @@ class DataSourceTable(NetBoxTable):
     )
     tags = columns.TagColumn(
         url_name='core:datasource_list',
+    )
+    actions = columns.ActionsColumn(
+        extra_buttons=DATA_SOURCE_SYNC_BUTTON,
     )
 
     class Meta(NetBoxTable.Meta):

--- a/netbox/core/tables/template_code.py
+++ b/netbox/core/tables/template_code.py
@@ -26,3 +26,19 @@ PLUGIN_IS_INSTALLED = """
     <span class="text-muted">&mdash;</span>
 {% endif %}
 """
+
+DATA_SOURCE_SYNC_BUTTON = """
+{% load helpers %}
+{% load i18n %}
+{% if perms.core.sync_datasource %}
+    {% if record.ready_for_sync %}
+        <button class="btn btn-primary btn-sm" type="submit" formaction="{% url 'core:datasource_sync' pk=record.pk %}?return_url={{ request.get_full_path|urlencode }}" formmethod="post">
+            <i class="mdi mdi-sync" aria-hidden="true"></i> {% trans "Sync" %}
+        </button>
+    {% else %}
+        <button class="btn btn-primary btn-sm" disabled>
+            <i class="mdi mdi-sync" aria-hidden="true"></i> {% trans "Sync" %}
+        </button>
+    {% endif %}
+{% endif %}
+"""

--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -33,7 +33,13 @@ from utilities.forms import ConfirmationForm
 from utilities.htmx import htmx_partial
 from utilities.json import ConfigJSONEncoder
 from utilities.query import count_related
-from utilities.views import ContentTypePermissionRequiredMixin, GetRelatedModelsMixin, ViewTab, register_model_view
+from utilities.views import (
+    ContentTypePermissionRequiredMixin,
+    GetRelatedModelsMixin,
+    GetReturnURLMixin,
+    ViewTab,
+    register_model_view,
+)
 from . import filtersets, forms, tables
 from .jobs import SyncDataSourceJob
 from .models import *
@@ -66,7 +72,7 @@ class DataSourceView(GetRelatedModelsMixin, generic.ObjectView):
 
 
 @register_model_view(DataSource, 'sync')
-class DataSourceSyncView(BaseObjectView):
+class DataSourceSyncView(GetReturnURLMixin, BaseObjectView):
     queryset = DataSource.objects.all()
 
     def get_required_permission(self):
@@ -85,7 +91,7 @@ class DataSourceSyncView(BaseObjectView):
             request,
             _("Queued job #{id} to sync {datasource}").format(id=job.pk, datasource=datasource)
         )
-        return redirect(datasource.get_absolute_url())
+        return redirect(self.get_return_url(request, datasource))
 
 
 @register_model_view(DataSource, 'add', detail=False)


### PR DESCRIPTION
### Fixes: #19547

### Summary
Adds a **Sync** button to the Data Sources list view so a sync can be triggered directly from the table (no need to open the detail page).

### Details
- Introduces a per‑row **Sync** action in the list view.
- Visibility/enabled state respects user permissions and current job status.
- Reuses the existing sync mechanism/queue; no new API surface.

### UX
- Button sits alongside existing row actions.
- Disabled while a sync is pending or running.

### Notes
Open to feedback on approach.
