### PR TITLE
Fixes #19851: Fix `WirelessLANImportForm` has no field `scope`, improve validation

### DIFF
--- a/netbox/dcim/forms/mixins.py
+++ b/netbox/dcim/forms/mixins.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.contrib.contenttypes.models import ContentType
-from django.core.exceptions import ObjectDoesNotExist
+from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.utils.translation import gettext_lazy as _
 
 from dcim.constants import LOCATION_SCOPE_TYPES
@@ -48,8 +48,17 @@ class ScopedForm(forms.Form):
     def clean(self):
         super().clean()
 
+        scope = self.cleaned_data.get('scope')
+        scope_type = self.cleaned_data.get('scope_type')
+        if scope_type and not scope:
+            raise ValidationError({
+                'scope_id': _(
+                    "Please select a {scope_type}."
+                ).format(scope_type=scope_type.model_class()._meta.model_name)
+            })
+
         # Assign the selected scope (if any)
-        self.instance.scope = self.cleaned_data.get('scope')
+        self.instance.scope = scope
 
     def _set_scoped_values(self):
         if scope_type_id := get_field_value(self, 'scope_type'):
@@ -107,3 +116,15 @@ class ScopedImportForm(forms.Form):
         required=False,
         label=_('Scope type (app & model)')
     )
+
+    def clean(self):
+        super().clean()
+
+        scope_id = self.cleaned_data.get('scope_id')
+        scope_type = self.cleaned_data.get('scope_type')
+        if scope_type and not scope_id:
+            raise ValidationError({
+                'scope_id': _(
+                    "Please select a {scope_type}."
+                ).format(scope_type=scope_type.model_class()._meta.model_name)
+            })

--- a/netbox/dcim/forms/mixins.py
+++ b/netbox/dcim/forms/mixins.py
@@ -52,7 +52,7 @@ class ScopedForm(forms.Form):
         scope_type = self.cleaned_data.get('scope_type')
         if scope_type and not scope:
             raise ValidationError({
-                'scope_id': _(
+                'scope': _(
                     "Please select a {scope_type}."
                 ).format(scope_type=scope_type.model_class()._meta.model_name)
             })

--- a/netbox/dcim/models/mixins.py
+++ b/netbox/dcim/models/mixins.py
@@ -87,11 +87,9 @@ class CachedScopeMixin(models.Model):
     def clean(self):
         if self.scope_type and not (self.scope or self.scope_id):
             scope_type = self.scope_type.model_class()
-            raise ValidationError({
-                'scope': _(
-                    "Please select a {scope_type}."
-                ).format(scope_type=scope_type._meta.model_name)
-            })
+            raise ValidationError(
+                _("Please select a {scope_type}.").format(scope_type=scope_type._meta.model_name)
+            )
         super().clean()
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19851
- Changes `CachedScopeMixin.clean()` to raise non-field specific `ValidationError`
- Adds field-specific `ValidationError` to `ScopedForm.clean()` and `ScopedImportForm.clean()`

I contemplated creating a re-usable `ScopeRequiredError` exception that sub-classes `ValidataionError` and handles the messaging, to avoid code duplication. Happy to change that if the reviewer disagrees with the decision not to.

<!--
    Please include a summary of the proposed changes below.
-->
