### PR TITLE
Closes #19523: Add instance count filter to Module and Device Types

### DIFF
--- a/netbox/dcim/api/serializers_/devicetypes.py
+++ b/netbox/dcim/api/serializers_/devicetypes.py
@@ -45,8 +45,9 @@ class DeviceTypeSerializer(NetBoxModelSerializer):
     device_bay_template_count = serializers.IntegerField(read_only=True)
     module_bay_template_count = serializers.IntegerField(read_only=True)
     inventory_item_template_count = serializers.IntegerField(read_only=True)
+    instance_count = serializers.IntegerField(read_only=True)
 
-    # Related object counts
+    # Related object counts (TODO: Remove in v4.5)
     device_count = RelatedObjectCountField('instances')
 
     class Meta:
@@ -58,7 +59,7 @@ class DeviceTypeSerializer(NetBoxModelSerializer):
             'created', 'last_updated', 'device_count', 'console_port_template_count',
             'console_server_port_template_count', 'power_port_template_count', 'power_outlet_template_count',
             'interface_template_count', 'front_port_template_count', 'rear_port_template_count',
-            'device_bay_template_count', 'module_bay_template_count', 'inventory_item_template_count',
+            'device_bay_template_count', 'module_bay_template_count', 'inventory_item_template_count', 'instance_count',
         ]
         brief_fields = ('id', 'url', 'display', 'manufacturer', 'model', 'slug', 'description', 'device_count')
 
@@ -101,11 +102,14 @@ class ModuleTypeSerializer(NetBoxModelSerializer):
         allow_null=True
     )
 
+    # Counter fields
+    instance_count = serializers.IntegerField(read_only=True)
+
     class Meta:
         model = ModuleType
         fields = [
             'id', 'url', 'display_url', 'display', 'profile', 'manufacturer', 'model', 'part_number', 'airflow',
             'weight', 'weight_unit', 'description', 'attributes', 'comments', 'tags', 'custom_fields', 'created',
-            'last_updated',
+            'last_updated', 'instance_count',
         ]
         brief_fields = ('id', 'url', 'display', 'profile', 'manufacturer', 'model', 'description')

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -20,6 +20,7 @@ from netbox.api.viewsets import NetBoxModelViewSet, MPTTLockedMixin
 from netbox.api.viewsets.mixins import SequentialBulkCreatesMixin
 from utilities.api import get_serializer_for_model
 from utilities.query_functions import CollateAsChar
+from utilities.query import count_related
 from virtualization.models import VirtualMachine
 from . import serializers
 from .exceptions import MissingFilterException
@@ -266,7 +267,9 @@ class ManufacturerViewSet(NetBoxModelViewSet):
 #
 
 class DeviceTypeViewSet(NetBoxModelViewSet):
-    queryset = DeviceType.objects.all()
+    queryset = DeviceType.objects.annotate(instance_count=count_related(Device, 'device_type')).prefetch_related(
+        'manufacturer', 'default_platform'
+    )
     serializer_class = serializers.DeviceTypeSerializer
     filterset_class = filtersets.DeviceTypeFilterSet
 
@@ -278,7 +281,7 @@ class ModuleTypeProfileViewSet(NetBoxModelViewSet):
 
 
 class ModuleTypeViewSet(NetBoxModelViewSet):
-    queryset = ModuleType.objects.all()
+    queryset = ModuleType.objects.annotate(instance_count=count_related(Module, 'module_type'))
     serializer_class = serializers.ModuleTypeSerializer
     filterset_class = filtersets.ModuleTypeFilterSet
 

--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -18,8 +18,8 @@ from tenancy.filtersets import TenancyFilterSet, ContactModelFilterSet
 from tenancy.models import *
 from users.models import User
 from utilities.filters import (
-    ContentTypeFilter, MultiValueCharFilter, MultiValueMACAddressFilter, MultiValueNumberFilter, MultiValueWWNFilter,
-    NumericArrayFilter, TreeNodeMultipleChoiceFilter,
+    AnnotatedCountFilter, ContentTypeFilter, MultiValueCharFilter, MultiValueMACAddressFilter, MultiValueNumberFilter,
+    MultiValueWWNFilter, NumericArrayFilter, TreeNodeMultipleChoiceFilter,
 )
 from virtualization.models import Cluster, ClusterGroup, VMInterface, VirtualMachine
 from vpn.models import L2VPN
@@ -608,6 +608,10 @@ class DeviceTypeFilterSet(NetBoxModelFilterSet):
         method='_inventory_items',
         label=_('Has inventory items'),
     )
+    instance_count = AnnotatedCountFilter(
+        field_name='instance_count',
+        label=_('Instance count'),
+    )
 
     class Meta:
         model = DeviceType
@@ -742,6 +746,10 @@ class ModuleTypeFilterSet(AttributeFiltersMixin, NetBoxModelFilterSet):
     pass_through_ports = django_filters.BooleanFilter(
         method='_pass_through_ports',
         label=_('Has pass-through ports'),
+    )
+    instance_count = AnnotatedCountFilter(
+        field_name='instance_count',
+        label=_('Instance count'),
     )
 
     class Meta:

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -485,7 +485,8 @@ class DeviceTypeFilterForm(NetBoxModelFilterSetForm):
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet(
-            'manufacturer_id', 'default_platform_id', 'part_number', 'subdevice_role', 'airflow', name=_('Hardware')
+            'manufacturer_id', 'default_platform_id', 'part_number', 'instance_count',
+            'subdevice_role', 'airflow', name=_('Hardware')
         ),
         FieldSet('has_front_image', 'has_rear_image', name=_('Images')),
         FieldSet(
@@ -508,6 +509,11 @@ class DeviceTypeFilterForm(NetBoxModelFilterSetForm):
     part_number = forms.CharField(
         label=_('Part number'),
         required=False
+    )
+    instance_count = forms.IntegerField(
+        label=_('Instance count'),
+        required=False,
+        min_value=0,
     )
     subdevice_role = forms.MultipleChoiceField(
         label=_('Subdevice role'),
@@ -620,7 +626,8 @@ class ModuleTypeFilterForm(NetBoxModelFilterSetForm):
     model = ModuleType
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('profile_id', 'manufacturer_id', 'part_number', 'airflow', name=_('Hardware')),
+        FieldSet('profile_id', 'manufacturer_id', 'part_number', 'instance_count',
+            'airflow', name=_('Hardware')),
         FieldSet(
             'console_ports', 'console_server_ports', 'power_ports', 'power_outlets', 'interfaces',
             'pass_through_ports', name=_('Components')
@@ -641,6 +648,11 @@ class ModuleTypeFilterForm(NetBoxModelFilterSetForm):
     part_number = forms.CharField(
         label=_('Part number'),
         required=False
+    )
+    instance_count = forms.IntegerField(
+        label=_('Instance count'),
+        required=False,
+        min_value=0,
     )
     console_ports = forms.NullBooleanField(
         required=False,

--- a/netbox/utilities/filters.py
+++ b/netbox/utilities/filters.py
@@ -7,6 +7,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 
 __all__ = (
+    'AnnotatedCountFilter',
     'ContentTypeFilter',
     'MultiValueArrayFilter',
     'MultiValueCharFilter',
@@ -54,6 +55,19 @@ def multivalue_field_factory(field_class):
 #
 # Filters
 #
+
+@extend_schema_field(OpenApiTypes.INT32)
+class AnnotatedCountFilter(django_filters.NumberFilter):
+    """
+    A filter for annotated count fields that supports automatic lookup generation
+    while bypassing model field validation. Used for filtering on counts that are
+    added via queryset annotations (e.g., instance_count).
+    """
+
+    def __init__(self, *args, **kwargs):
+        self._is_annotated = True
+        super().__init__(*args, **kwargs)
+
 
 @extend_schema_field(OpenApiTypes.STR)
 class MultiValueCharFilter(django_filters.MultipleChoiceFilter):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19523

**Summary**  

Add filters to quickly find used/unused types and query by count:
- `has_instances` (bool) — **UI**, **REST**, **GraphQL**
- `instance_count` (int with `=, gt, gte, lt, lte, range`) — **REST**, **GraphQL**

**Implementation**
- `DeviceTypeFilterSet` & `ModuleTypeFilterSet`: add `has_instances` and `instance_count` using `count_related()`; a single method handles integer lookups.
- GraphQL: Strawberry filters via `@filter_field`; annotate `instance_count` and delegate lookups with `process_filters(prefix="…instance_count__")`.
- REST examples:
  - `/api/dcim/device-types/?has_instances=true`
  - `/api/dcim/device-types/?instance_count__gte=10`
  - `/api/dcim/module-types/?has_instances=false`
- Tests: filterset tests for boolean & numeric cases.
