### PR TITLE
Closes #19095: Introduce support for Python 3.13 & 3.14

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/02-bug_report.yaml
@@ -36,6 +36,8 @@ body:
       description: What version of Python are you currently running?
       options:
         - "3.12"
+        - "3.13"
+        - "3.14"
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       NETBOX_CONFIGURATION: netbox.configuration_testing
     strategy:
       matrix:
-        python-version: ['3.12', '3.13', '3.14']
+        python-version: ['3.12', '3.13']
         node-version: ['20.x']
     services:
       redis:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
       NETBOX_CONFIGURATION: netbox.configuration_testing
     strategy:
       matrix:
-        python-version: ['3.12']
+        python-version: ['3.12', '3.13', '3.14']
         node-version: ['20.x']
     services:
       redis:

--- a/docs/installation/3-netbox.md
+++ b/docs/installation/3-netbox.md
@@ -238,7 +238,7 @@ sudo /opt/netbox/upgrade.sh
 Note that **Python 3.12 or later is required** for NetBox v4.5 and later releases. If the default Python installation on your server is set to a lesser version,  pass the path to the supported installation as an environment variable named `PYTHON`. (Note that the environment variable must be passed _after_ the `sudo` command.)
 
 ```no-highlight
-sudo PYTHON=/usr/bin/python3.10 /opt/netbox/upgrade.sh
+sudo PYTHON=/usr/bin/python3.12 /opt/netbox/upgrade.sh
 ```
 
 !!! note

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -27,7 +27,7 @@ The following sections detail how to set up a new instance of NetBox:
 
 | Dependency | Supported Versions |
 |------------|--------------------|
-| Python     | 3.12+              |
+| Python     | 3.12, 3.13, 3.14   |
 | PostgreSQL | 14+                |
 | Redis      | 4.0+               |
 

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -19,7 +19,7 @@ NetBox requires the following dependencies:
 
 | Dependency | Supported Versions |
 |------------|--------------------|
-| Python     | 3.10, 3.11, 3.12   |
+| Python     | 3.12, 3.13, 3.14   |
 | PostgreSQL | 14+                |
 | Redis      | 4.0+               |
 
@@ -27,6 +27,7 @@ NetBox requires the following dependencies:
 
 | NetBox Version | Python min | Python max | PostgreSQL min | Redis min |                                       Documentation                                       |
 |:--------------:|:----------:|:----------:|:--------------:|:---------:|:-----------------------------------------------------------------------------------------:|
+|      4.5       |    3.12    |    3.14    |       14       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.5.0/docs/installation/index.md) |
 |      4.4       |    3.10    |    3.12    |       14       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.4.0/docs/installation/index.md) |
 |      4.3       |    3.10    |    3.12    |       14       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.3.0/docs/installation/index.md) |
 |      4.2       |    3.10    |    3.12    |       13       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.2.0/docs/installation/index.md) |
@@ -130,7 +131,7 @@ sudo ./upgrade.sh
     If the default version of Python is not at least 3.10, you'll need to pass the path to a supported Python version as an environment variable when calling the upgrade script. For example:
 
     ```no-highlight
-    sudo PYTHON=/usr/bin/python3.10 ./upgrade.sh
+    sudo PYTHON=/usr/bin/python3.12 ./upgrade.sh
     ```
 
 !!! note

--- a/docs/plugins/development/index.md
+++ b/docs/plugins/development/index.md
@@ -173,12 +173,12 @@ classifiers=[
     'Intended Audience :: Developers',
     'Natural Language :: English',
     "Programming Language :: Python :: 3 :: Only",
-    'Programming Language :: Python :: 3.10',
-    'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
+    'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: 3.14',
 ]
 
-requires-python = ">=3.10.0"
+requires-python = ">=3.12.0"
 
 ```
 
@@ -195,7 +195,7 @@ python3 -m venv ~/.virtualenvs/my_plugin
 You can make NetBox available within this environment by creating a path file pointing to its location. This will add NetBox to the Python path upon activation. (Be sure to adjust the command below to specify your actual virtual environment path, Python version, and NetBox installation.)
 
 ```shell
-echo /opt/netbox/netbox > $VENV/lib/python3.10/site-packages/netbox.pth
+echo /opt/netbox/netbox > $VENV/lib/python3.12/site-packages/netbox.pth
 ```
 
 ## Development Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ classifiers = [
     "Programming Language :: Python",
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
 ]
 
 [project.urls]
@@ -26,7 +28,7 @@ Issues = "https://github.com/netbox-community/netbox/issues"
 
 [tool.black]
 line-length = 120
-target_version = ['py312']
+target_version = ['py312', 'py313', 'py314']
 skip-string-normalization = true
 
 [tool.isort]


### PR DESCRIPTION
### Closes: #19095

- Add Python 3.13 & 3.14 as supported Python versions in the documentation
- Add Python 3.13 to the CI matrix (holding off on 3.14 until final release)
- Update the packaging to denote Python 3.13 & 3.14
- Remove obsolete references to Python 3.10 & 3.11