### PR TITLE
Format timestamp in script results table

### DIFF
--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -725,8 +725,9 @@ class ScriptResultsTable(BaseTable):
     index = tables.Column(
         verbose_name=_('Line')
     )
-    time = tables.Column(
-        verbose_name=_('Time')
+    time = columns.DateTimeColumn(
+        verbose_name=_('Time'),
+        timespec='seconds'
     )
     status = tables.TemplateColumn(
         template_code="""{% load log_levels %}{% log_level record.status %}""",

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.contenttypes.models import ContentType
@@ -1547,7 +1548,6 @@ class ScriptResultView(TableMixin, generic.ObjectView):
         except KeyError:
             log_threshold = LOG_LEVEL_RANK[LogLevelChoices.LOG_INFO]
         if job.data:
-
             if 'log' in job.data:
                 if 'tests' in job.data:
                     tests = job.data['tests']
@@ -1558,7 +1558,7 @@ class ScriptResultView(TableMixin, generic.ObjectView):
                         index += 1
                         result = {
                             'index': index,
-                            'time': log.get('time'),
+                            'time': datetime.fromisoformat(log.get('time')),
                             'status': log.get('status'),
                             'message': log.get('message'),
                             'object': log.get('obj'),


### PR DESCRIPTION
### Fixes: #16381

I thought about adding a try/except block in case `fromisoformat` fails to parse, but I could not think of a case where that would happen.