### PR TITLE
Fixes #20290: Fix ordering of migrations to support upgrading from v3.7

### DIFF
--- a/netbox/users/migrations/0005_alter_user_table.py
+++ b/netbox/users/migrations/0005_alter_user_table.py
@@ -24,8 +24,9 @@ def update_content_types(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
+        ('core', '0018_concrete_objecttype'),
+        ('extras', '0117_move_objectchange'),
         ('users', '0002_squashed_0004'),
-        ('extras', '0113_customfield_rename_object_type'),
     ]
 
     operations = [


### PR DESCRIPTION
### Fixes: #20290

Reorders migrations to avoid an `UndefinedTable` exception when upgrading directly to NetBox v4.4 from v3.7.

Thanks to @pheus for [identifying the fix](https://github.com/netbox-community/netbox/issues/20290#issuecomment-3263602845)!