### PR TITLE
Fixes #20242: Conditionally log request.id in EventRule triggered script

### DIFF
--- a/netbox/extras/jobs.py
+++ b/netbox/extras/jobs.py
@@ -106,7 +106,7 @@ class ScriptJob(JobRunner):
 
         # Add the current request as a property of the script
         script.request = request
-        self.logger.debug(f"Request ID: {request.id}")
+        self.logger.debug(f"Request ID: {request.id if request else None}")
 
         # Execute the script. If commit is True, wrap it with the event_tracking context manager to ensure we process
         # change logging, event rules, etc.


### PR DESCRIPTION
### Fixes: #20242

- Conditionally log the `request.id` if available, otherwise indicate it is unavailable.