### PR TITLE
Closes #19898: Remove legacy /api/extras/object-types/ endpoint

### DIFF
--- a/netbox/core/tests/test_api.py
+++ b/netbox/core/tests/test_api.py
@@ -107,14 +107,14 @@ class ObjectTypeTest(APITestCase):
     def test_list_objects(self):
         object_type_count = ObjectType.objects.count()
 
-        response = self.client.get(reverse('extras-api:objecttype-list'), **self.header)
+        response = self.client.get(reverse('core-api:objecttype-list'), **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], object_type_count)
 
     def test_get_object(self):
         object_type = ObjectType.objects.first()
 
-        url = reverse('extras-api:objecttype-detail', kwargs={'pk': object_type.pk})
+        url = reverse('core-api:objecttype-detail', kwargs={'pk': object_type.pk})
         self.assertHttpStatus(self.client.get(url, **self.header), status.HTTP_200_OK)
 
 

--- a/netbox/extras/api/urls.py
+++ b/netbox/extras/api/urls.py
@@ -1,9 +1,7 @@
 from django.urls import include, path
 
-from core.api.views import ObjectTypeViewSet
 from netbox.api.routers import NetBoxRouter
 from . import views
-
 
 router = NetBoxRouter()
 router.APIRootView = views.ExtrasRootView
@@ -28,9 +26,6 @@ router.register('config-contexts', views.ConfigContextViewSet)
 router.register('config-context-profiles', views.ConfigContextProfileViewSet)
 router.register('config-templates', views.ConfigTemplateViewSet)
 router.register('scripts', views.ScriptViewSet, basename='script')
-
-# TODO: Remove in NetBox v4.5
-router.register('object-types', ObjectTypeViewSet)
 
 app_name = 'extras-api'
 urlpatterns = [


### PR DESCRIPTION
### Closes: #19898

This endpoint was moved to `/api/core/object-types/` under FR #19829 in NetBox v4.4.