### PR TITLE
Closes #20096: Remove legacy `load_yaml()` & `load_json()` methods from BaseScript

### DIFF
--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -131,17 +131,6 @@ self.log_info(f"Running as user {username} (IP: {ip_address})...")
 
 For a complete list of available request parameters, please see the [Django documentation](https://docs.djangoproject.com/en/stable/ref/request-response/).
 
-## Reading Data from Files
-
-The Script class provides two convenience methods for reading data from files:
-
-* `load_yaml`
-* `load_json`
-
-These two methods will load data in YAML or JSON format, respectively, from files within the local path (i.e. `SCRIPTS_ROOT`).
-
-**Note:** These convenience methods are deprecated and will be removed in NetBox v4.4.  These only work if running scripts within the local path, they will not work if using a storage other than ScriptFileSystemStorage.
-
 ## Logging
 
 The Script object provides a set of convenient functions for recording messages at different severity levels:

--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -1,12 +1,9 @@
 import inspect
-import json
 import logging
 import os
 import re
 
-import yaml
 from django import forms
-from django.conf import settings
 from django.core.files.storage import storages
 from django.core.validators import RegexValidator
 from django.utils import timezone
@@ -488,7 +485,7 @@ class BaseScript:
         if self.fieldsets:
             fieldsets.extend(self.fieldsets)
         else:
-            fields = list(name for name, _ in self._get_vars().items())
+            fields = list(name for name, __ in self._get_vars().items())
             fieldsets.append((_('Script Data'), fields))
 
         # Append the default fieldset if defined in the Meta class
@@ -579,40 +576,6 @@ class BaseScript:
     def log_failure(self, message=None, obj=None):
         self._log(message, obj, level=LogLevelChoices.LOG_FAILURE)
         self.failed = True
-
-    #
-    # Convenience functions
-    #
-
-    def load_yaml(self, filename):
-        """
-        Return data from a YAML file
-        """
-        # TODO: DEPRECATED: Remove this method in v4.5
-        self._log(
-            _("load_yaml is deprecated and will be removed in v4.5"),
-            level=LogLevelChoices.LOG_WARNING
-        )
-        file_path = os.path.join(settings.SCRIPTS_ROOT, filename)
-        with open(file_path, 'r') as datafile:
-            data = yaml.load(datafile, Loader=yaml.SafeLoader)
-
-        return data
-
-    def load_json(self, filename):
-        """
-        Return data from a JSON file
-        """
-        # TODO: DEPRECATED: Remove this method in v4.5
-        self._log(
-            _("load_json is deprecated and will be removed in v4.5"),
-            level=LogLevelChoices.LOG_WARNING
-        )
-        file_path = os.path.join(settings.SCRIPTS_ROOT, filename)
-        with open(file_path, 'r') as datafile:
-            data = json.load(datafile)
-
-        return data
 
     #
     # Legacy Report functionality

--- a/netbox/extras/tests/test_scripts.py
+++ b/netbox/extras/tests/test_scripts.py
@@ -1,5 +1,3 @@
-import logging
-import tempfile
 from datetime import date, datetime, timezone
 from decimal import Decimal
 
@@ -9,7 +7,6 @@ from netaddr import IPAddress, IPNetwork
 
 from dcim.models import DeviceRole
 from extras.scripts import *
-from utilities.testing import disable_logging
 
 CHOICES = (
     ('ff0000', 'Red'),
@@ -33,35 +30,6 @@ JSON_DATA = """
   "Baz": ["A", "B", "C"]
 }
 """
-
-
-class ScriptTest(TestCase):
-
-    def test_load_yaml(self):
-        datafile = tempfile.NamedTemporaryFile()
-        datafile.write(bytes(YAML_DATA, 'UTF-8'))
-        datafile.seek(0)
-
-        with disable_logging(level=logging.WARNING):
-            data = Script().load_yaml(datafile.name)
-        self.assertEqual(data, {
-            'Foo': 123,
-            'Bar': 456,
-            'Baz': ['A', 'B', 'C'],
-        })
-
-    def test_load_json(self):
-        datafile = tempfile.NamedTemporaryFile()
-        datafile.write(bytes(JSON_DATA, 'UTF-8'))
-        datafile.seek(0)
-
-        with disable_logging(level=logging.WARNING):
-            data = Script().load_json(datafile.name)
-        self.assertEqual(data, {
-            'Foo': 123,
-            'Bar': 456,
-            'Baz': ['A', 'B', 'C'],
-        })
 
 
 class ScriptVariablesTest(TestCase):


### PR DESCRIPTION
### Closes: #20096

These convenience methods were deprecated in NetBox v4.3.0 under #18896.
