### PR TITLE
Fixes #20329: Fix `InconsistentMigrationHistory` exception when upgrading from v4.3

### DIFF
--- a/netbox/users/migrations/0005_alter_user_table.py
+++ b/netbox/users/migrations/0005_alter_user_table.py
@@ -24,9 +24,8 @@ def update_content_types(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ('core', '0018_concrete_objecttype'),
-        ('extras', '0117_move_objectchange'),
         ('users', '0002_squashed_0004'),
+        ('extras', '0113_customfield_rename_object_type'),
     ]
 
     operations = [


### PR DESCRIPTION
### Fixes: #20329

This reverts the change made in PR #20314 in an attempt to resolve bug #20290.