### PR TITLE
Fixes #20197: Correct validation for virtual chassis parent interface

### DIFF
--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -872,14 +872,14 @@ class Interface(ModularComponentModel, BaseInterface, CabledObjectModel, PathEnd
                         "The selected parent interface ({interface}) belongs to a different device ({device})"
                     ).format(interface=self.parent, device=self.parent.device)
                 })
-            elif self.parent.device.virtual_chassis != self.parent.virtual_chassis:
+            elif self.parent.device.virtual_chassis != self.device.virtual_chassis:
                 raise ValidationError({
                     'parent': _(
                         "The selected parent interface ({interface}) belongs to {device}, which is not part of "
                         "virtual chassis {virtual_chassis}."
                     ).format(
                         interface=self.parent,
-                        device=self.parent_device,
+                        device=self.parent.device,
                         virtual_chassis=self.device.virtual_chassis
                     )
                 })
@@ -890,7 +890,7 @@ class Interface(ModularComponentModel, BaseInterface, CabledObjectModel, PathEnd
         if self.pk and self.bridge_id == self.pk:
             raise ValidationError({'bridge': _("An interface cannot be bridged to itself.")})
 
-        # A bridged interface belong to the same device or virtual chassis
+        # A bridged interface belongs to the same device or virtual chassis
         if self.bridge and self.bridge.device != self.device:
             if self.device.virtual_chassis is None:
                 raise ValidationError({


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to NetBox! Please note that our contribution policy requires that a feature request or bug report be approved and assigned prior to opening a pull request. This helps avoid waste time and effort on a proposed change that we might not be able to accept. IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED TO YOU, IT WILL BE CLOSED AUTOMATICALLY. Please specify your assigned issue number on the line below. --> 

### Fixes: #20197

**Summary**  
Fixes an `AttributeError` during parent interface validation by checking the VC on **devices** (use `self.device.virtual_chassis` and `self.parent.device.virtual_chassis`). This allows a parent on another member of the same VC and rejects mismatches.

Thanks @elipsion for the STR and for pointing out the incorrect reference.
