### PR TITLE
Bump Django to v5.2.6

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorama==0.4.6
-Django==5.2.5
+Django==5.2.6
 django-cors-headers==4.7.0
 django-debug-toolbar==5.2.0
 django-filter==25.1


### PR DESCRIPTION
Upgrade Django to v5.2.6 to address an upstream vulnerability report