### PR TITLE
#20327: Device queries now faster when including ConfigContexts

### DIFF
--- a/netbox/extras/querysets.py
+++ b/netbox/extras/querysets.py
@@ -93,7 +93,7 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
                     _data=EmptyGroupByJSONBAgg('data', ordering=['weight', 'name'])
                 ).values("_data").order_by()
             )
-        ).distinct()
+        )
 
     def _get_config_context_filters(self):
         # Construct the set of Q objects for the specific object types
@@ -117,7 +117,7 @@ class ConfigContextModelQuerySet(RestrictedQuerySet):
                     ).values_list(
                         'tag_id',
                         flat=True
-                    )
+                    ).distinct()
                 )
             ) | Q(tags=None),
             is_active=True,


### PR DESCRIPTION
### Fixes: #20327

Move `.distinct()` from main queryset to tag subquery to eliminate performance bottleneck when querying devices with config contexts.

The `.distinct()` call on the main device queryset was causing PostgreSQL to sort all devices before pagination, resulting in 15x slower API responses for large installations (10k+ devices, 100+ config contexts).

Moving `.distinct()` to the tag subquery eliminates duplicates at their source (`GenericForeignKey` tag relationships) while preserving the fix for issues #5314 and #5387 without impacting overall query performance.

This is also likely to have positive impacts in other places that make use of these queryset methods, including:
- /api/virtualization/virtual-machines
- /dcim/devices/
- /virtualization/virtual-machines/
