### PR TITLE
Closes #20341: Drop legacy `django_admin_log` table

### DIFF
--- a/netbox/users/migrations/0012_drop_django_admin_log_table.py
+++ b/netbox/users/migrations/0012_drop_django_admin_log_table.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('users', '0011_concrete_objecttype'),
+    ]
+
+    operations = [
+        # Django admin UI was removed in NetBox v4.0
+        # Older installations may still have the old `django_admin_log` table in place
+        # Drop the obsolete table if it exists. This is a no-op on fresh or already-clean DBs.
+        migrations.RunSQL(
+            sql='DROP TABLE IF EXISTS "django_admin_log";',
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+        # Clean up a potential leftover sequence in older DBs
+        migrations.RunSQL(
+            sql='DROP SEQUENCE IF EXISTS "django_admin_log_id_seq";',
+            reverse_sql=migrations.RunSQL.noop,
+        ),
+    ]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20341

Older installations may still have the legacy django_admin_log table from the Django admin UI. These records can hold a foreign key to existing users and block their deletion. This PR adds a simple migration that drops the table (and its sequence) if they exist, unblocking user deletions on upgraded deployments.

Refs #20338

- Drop legacy `django_admin_log` via raw SQL (`DROP TABLE IF EXISTS`).
- Also drop leftover sequence (`DROP SEQUENCE IF EXISTS`).
- Reverse is a no‑op; no models changed.

---

### Testing

Verified end‑to‑end:

1. Install fresh NetBox **v3.7.8** (with Django Admin UI).
2. Create a superuser and a user **user1** with staff & superuser status.
3. Log in as **user1** and open Django Admin.
4. Create a `django_admin_log` entry by creating a “nonce” with random values.
5. Upgrade to NetBox **v4.3.7**.
6. Try to delete **user1** → FK error reproduced.
7. Upgrade to NetBox **v4.4.0** and apply this migration.
8. Delete **user1** successfully (no error).