### PR TITLE
Fixes #20342: Override create_superuser to drop is_staff

### DIFF
--- a/netbox/users/models/users.py
+++ b/netbox/users/models/users.py
@@ -77,9 +77,13 @@ class UserManager(DjangoUserManager.from_queryset(RestrictedQuerySet)):
         extra_fields.setdefault('is_superuser', False)
         return self._create_user(username, email, password, **extra_fields)
 
+    create_user.alters_data = True
+
     async def acreate_user(self, username, email=None, password=None, **extra_fields):
         extra_fields.setdefault('is_superuser', False)
         return await self._acreate_user(username, email, password, **extra_fields)
+
+    acreate_user.alters_data = True
 
     def create_superuser(self, username, email=None, password=None, **extra_fields):
         extra_fields.setdefault('is_superuser', True)
@@ -89,6 +93,8 @@ class UserManager(DjangoUserManager.from_queryset(RestrictedQuerySet)):
 
         return self._create_user(username, email, password, **extra_fields)
 
+    create_superuser.alters_data = True
+
     async def acreate_superuser(self, username, email=None, password=None, **extra_fields):
         extra_fields.setdefault('is_superuser', True)
 
@@ -96,6 +102,8 @@ class UserManager(DjangoUserManager.from_queryset(RestrictedQuerySet)):
             raise ValueError('Superuser must have is_superuser=True.')
 
         return await self._acreate_user(username, email, password, **extra_fields)
+
+    acreate_superuser.alters_data = True
 
 
 class User(AbstractBaseUser, PermissionsMixin):

--- a/netbox/users/models/users.py
+++ b/netbox/users/models/users.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import (
     GroupManager as DjangoGroupManager,
     Permission,
     PermissionsMixin,
-    UserManager as DjangoUserManager
+    UserManager as DjangoUserManager,
 )
 from django.contrib.auth.validators import UnicodeUsernameValidator
 from django.core.exceptions import ValidationError
@@ -74,8 +74,28 @@ class Group(models.Model):
 class UserManager(DjangoUserManager.from_queryset(RestrictedQuerySet)):
 
     def create_user(self, username, email=None, password=None, **extra_fields):
-        extra_fields.setdefault("is_superuser", False)
+        extra_fields.setdefault('is_superuser', False)
         return self._create_user(username, email, password, **extra_fields)
+
+    async def acreate_user(self, username, email=None, password=None, **extra_fields):
+        extra_fields.setdefault('is_superuser', False)
+        return await self._acreate_user(username, email, password, **extra_fields)
+
+    def create_superuser(self, username, email=None, password=None, **extra_fields):
+        extra_fields.setdefault('is_superuser', True)
+
+        if extra_fields.get('is_superuser') is not True:
+            raise ValueError('Superuser must have is_superuser=True.')
+
+        return self._create_user(username, email, password, **extra_fields)
+
+    async def acreate_superuser(self, username, email=None, password=None, **extra_fields):
+        extra_fields.setdefault('is_superuser', True)
+
+        if extra_fields.get('is_superuser') is not True:
+            raise ValueError('Superuser must have is_superuser=True.')
+
+        return await self._acreate_user(username, email, password, **extra_fields)
 
 
 class User(AbstractBaseUser, PermissionsMixin):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20342

Override `UserManager.create_superuser()` to strip `is_staff` from `extra_fields` and enforce `is_superuser=True`, fixing the `TypeError` during `createsuperuser` with the custom `User` model.
