### PR TITLE
Closes #15492: Add support for cloning ObjectPermission objects

### DIFF
--- a/netbox/users/models/permissions.py
+++ b/netbox/users/models/permissions.py
@@ -3,6 +3,7 @@ from django.db import models
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
+from netbox.models.features import CloningMixin
 from utilities.querysets import RestrictedQuerySet
 
 __all__ = (
@@ -10,7 +11,7 @@ __all__ = (
 )
 
 
-class ObjectPermission(models.Model):
+class ObjectPermission(CloningMixin, models.Model):
     """
     A mapping of view, add, change, and/or delete permission for users and/or groups to an arbitrary set of objects
     identified by ORM query parameters.
@@ -41,6 +42,10 @@ class ObjectPermission(models.Model):
         null=True,
         verbose_name=_('constraints'),
         help_text=_("Queryset filter matching the applicable objects of the selected type(s)")
+    )
+
+    clone_fields = (
+        'description', 'enabled', 'object_types', 'actions', 'constraints',
     )
 
     objects = RestrictedQuerySet.as_manager()


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to NetBox! Please note that our contribution policy requires that a feature request or bug report be approved and assigned prior to opening a pull request. This helps avoid waste time and effort on a proposed change that we might not be able to accept. IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED TO YOU, IT WILL BE CLOSED AUTOMATICALLY. Please specify your assigned issue number on the line below. -->

### Fixes: #15492

**Summary**
Add a **Clone** action to **Admin → Authentication → Permissions**. Clicking **Clone** opens the create form pre‑populated from an existing permission (name cleared), making it quick to duplicate rules without re‑entering object types, actions, and constraints.

**Implementation**
- Enable cloning for `ObjectPermission` via `CloningMixin`.
- Add a **Clone** button to the permission detail view.
- Provide `initial` form data from the source permission, including `constraints`.