### PR TITLE
Closes #19262: Remove FHRP IP prefix constraint

### DIFF
--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -804,6 +804,7 @@ class FHRPGroupFilterSet(NetBoxModelFilterSet):
             return queryset
         return queryset.filter(
             Q(description__icontains=value) |
+            Q(group_id__contains=value) |
             Q(name__icontains=value)
         )
 

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -580,13 +580,6 @@ class FHRPGroupAssignmentForm(forms.ModelForm):
         model = FHRPGroupAssignment
         fields = ('group', 'priority')
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        ipaddresses = self.instance.interface.ip_addresses.all()
-        for ipaddress in ipaddresses:
-            self.fields['group'].widget.add_query_param('related_ip', ipaddress.pk)
-
     def clean_group(self):
         group = self.cleaned_data['group']
 


### PR DESCRIPTION
### Fixes: #19262

- Lift the “same prefix” requirement when assigning FHRP groups to interfaces.
- Remove `FHRPGroupAssignmentForm.__init__` filtering; show all groups regardless of VIP subnet.
- Add `group_id` to the `q` filter for matching by group ID (per maintainer feedback).

**Reason:** NAT/shared VIP subnets mean interface IP and VIP prefixes can differ; type‑ahead search keeps selection manageable.
