### PR TITLE
Fixes #20298: Add placeholder for failed image thumbnail generation

### DIFF
--- a/netbox/templates/extras/object_imageattachments.html
+++ b/netbox/templates/extras/object_imageattachments.html
@@ -27,6 +27,16 @@
                 alt="{{ object.description|default:object.name }}"
               />
             </a>
+          {% empty %}
+            <a href="{{ object.get_absolute_url }}" class="d-block text-decoration-none" title="{{ object.name }}">
+              <div class="d-flex align-items-center justify-content-center rounded bg-light text-secondary border" style="width: 200px; height: 200px;">
+                <div class="text-center">
+                  <i class="mdi mdi-image-broken-variant display-4"></i>
+                  <div class="small mt-2 text-dark">{% trans "Thumbnail cannot be generated" %}</div>
+                  <div class="small fw-bold text-dark">{% trans "Click to view original" %}</div>
+                </div>
+              </div>
+            </a>
           {% endthumbnail %}
           <div class="text-center text-secondary text-truncate fs-5">
             {{ object }}


### PR DESCRIPTION
### Fixes: #20298

When Redis cache lacks disk persistence `sorl-thumbnail` fails to generate thumbnails, leaving only bare filename text visible. This adds an `{% empty %}` fallback block to the thumbnail template that displays a placeholder with a broken image icon and user instructions when thumbnail generation fails.

The placeholder maintains the expected 200x200px dimensions and provides:
- Broken image icon (`mdi-image-broken-variant`)
- Error message explaining the issue
- Clickable link to view the original image
- High contrast text (`text-dark`) for readability on light background

This can be tested by changing the permission on the thumbnail cache directory before adding a thumbnail, via `chmod 444 netbox/media/cache`. Just remember to change the permission back after testing.