### PR TITLE
Closes #20380: Introduce the `SENTRY_CONFIG` config parameter

### DIFF
--- a/docs/configuration/error-reporting.md
+++ b/docs/configuration/error-reporting.md
@@ -1,6 +1,31 @@
 # Error Reporting Settings
 
+## SENTRY_CONFIG
+
+A dictionary mapping keyword arguments to values, to be passed to `sentry_sdk.init()`. See the [Sentry Python SDK documentation](https://docs.sentry.io/platforms/python/) for more information on supported parameters.
+
+The default configuration is shown below:
+
+```python
+{
+    "sample_rate": 1.0,
+    "send_default_pii": False,
+    "traces_sample_rate": 0,
+}
+```
+
+Additionally, `http_proxy` and `https_proxy` are set to the HTTP and HTTPS proxies, respectively, configured for NetBox (if any).
+
 ## SENTRY_DSN
+
+!!! warning "This parameter will be removed in NetBox v4.5."
+    Set this using `SENTRY_CONFIG` instead:
+
+    ```
+    SENTRY_CONFIG = {
+        "dsn": "https://examplePublicKey@o0.ingest.sentry.io/0",
+    }
+    ```
 
 Default: `None`
 
@@ -25,6 +50,15 @@ Set to `True` to enable automatic error reporting via [Sentry](https://sentry.io
 
 ## SENTRY_SAMPLE_RATE
 
+!!! warning "This parameter will be removed in NetBox v4.5."
+    Set this using `SENTRY_CONFIG` instead:
+
+    ```
+    SENTRY_CONFIG = {
+        "sample_rate": 0.2,
+    }
+    ```
+
 Default: `1.0` (all)
 
 The sampling rate for errors. Must be a value between 0 (disabled) and 1.0 (report on all errors).
@@ -32,6 +66,15 @@ The sampling rate for errors. Must be a value between 0 (disabled) and 1.0 (repo
 ---
 
 ## SENTRY_SEND_DEFAULT_PII
+
+!!! warning "This parameter will be removed in NetBox v4.5."
+    Set this using `SENTRY_CONFIG` instead:
+
+    ```
+    SENTRY_CONFIG = {
+        "send_default_pii": True,
+    }
+    ```
 
 Default: `False`
 
@@ -59,6 +102,15 @@ SENTRY_TAGS = {
 ---
 
 ## SENTRY_TRACES_SAMPLE_RATE
+
+!!! warning "This parameter will be removed in NetBox v4.5."
+    Set this using `SENTRY_CONFIG` instead:
+
+    ```
+    SENTRY_CONFIG = {
+        "traces_sample_rate": 0.2,
+    }
+    ```
 
 Default: `0` (disabled)
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -176,11 +176,16 @@ SECURE_HSTS_INCLUDE_SUBDOMAINS = getattr(configuration, 'SECURE_HSTS_INCLUDE_SUB
 SECURE_HSTS_PRELOAD = getattr(configuration, 'SECURE_HSTS_PRELOAD', False)
 SECURE_HSTS_SECONDS = getattr(configuration, 'SECURE_HSTS_SECONDS', 0)
 SECURE_SSL_REDIRECT = getattr(configuration, 'SECURE_SSL_REDIRECT', False)
+SENTRY_CONFIG = getattr(configuration, 'SENTRY_CONFIG', {})
+# TODO: Remove in NetBox v4.5
 SENTRY_DSN = getattr(configuration, 'SENTRY_DSN', None)
 SENTRY_ENABLED = getattr(configuration, 'SENTRY_ENABLED', False)
+# TODO: Remove in NetBox v4.5
 SENTRY_SAMPLE_RATE = getattr(configuration, 'SENTRY_SAMPLE_RATE', 1.0)
+# TODO: Remove in NetBox v4.5
 SENTRY_SEND_DEFAULT_PII = getattr(configuration, 'SENTRY_SEND_DEFAULT_PII', False)
 SENTRY_TAGS = getattr(configuration, 'SENTRY_TAGS', {})
+# TODO: Remove in NetBox v4.5
 SENTRY_TRACES_SAMPLE_RATE = getattr(configuration, 'SENTRY_TRACES_SAMPLE_RATE', 0)
 SESSION_COOKIE_NAME = getattr(configuration, 'SESSION_COOKIE_NAME', 'sessionid')
 SESSION_COOKIE_PATH = CSRF_COOKIE_PATH
@@ -598,18 +603,29 @@ if SENTRY_ENABLED:
         import sentry_sdk
     except ModuleNotFoundError:
         raise ImproperlyConfigured("SENTRY_ENABLED is True but the sentry-sdk package is not installed.")
-    if not SENTRY_DSN:
-        raise ImproperlyConfigured("SENTRY_ENABLED is True but SENTRY_DSN has not been defined.")
+
+    # Construct default Sentry initialization parameters from legacy SENTRY_* config parameters
+    sentry_config = {
+        'dsn': SENTRY_DSN,
+        'sample_rate': SENTRY_SAMPLE_RATE,
+        'send_default_pii': SENTRY_SEND_DEFAULT_PII,
+        'traces_sample_rate': SENTRY_TRACES_SAMPLE_RATE,
+        # TODO: Support proxy routing
+        'http_proxy': HTTP_PROXIES.get('http') if HTTP_PROXIES else None,
+        'https_proxy': HTTP_PROXIES.get('https') if HTTP_PROXIES else None,
+    }
+    # Override/extend the default parameters with any provided via SENTRY_CONFIG
+    sentry_config.update(SENTRY_CONFIG)
+    # Check for a DSN
+    if not sentry_config.get('dsn'):
+        raise ImproperlyConfigured(
+            "Sentry is enabled but a DSN has not been specified. Set one under the SENTRY_CONFIG parameter."
+        )
+
     # Initialize the SDK
     sentry_sdk.init(
-        dsn=SENTRY_DSN,
         release=RELEASE.full_version,
-        sample_rate=SENTRY_SAMPLE_RATE,
-        traces_sample_rate=SENTRY_TRACES_SAMPLE_RATE,
-        send_default_pii=SENTRY_SEND_DEFAULT_PII,
-        # TODO: Support proxy routing
-        http_proxy=HTTP_PROXIES.get('http') if HTTP_PROXIES else None,
-        https_proxy=HTTP_PROXIES.get('https') if HTTP_PROXIES else None
+        **sentry_config
     )
     # Assign any configured tags
     for k, v in SENTRY_TAGS.items():


### PR DESCRIPTION
### Closes: #20380

* Introduce the `SENTRY_CONFIG` config parameter, which takes a dictionary of arbitrary keyword arguments to pass to `sentry_sdk.init()`
* Deprecate the following config parameters:
  * `SENTRY_DSN`
  * `SENTRY_SAMPLE_RATE`
  * `SENTRY_SEND_DEFAULT_PII`
  * `SENTRY_TRACES_SAMPLE_RATE`