### PR TITLE
Fixes #20375: Preserve filter params when performing bulk operations

### DIFF
--- a/netbox/netbox/object_actions.py
+++ b/netbox/netbox/object_actions.py
@@ -51,6 +51,14 @@ class ObjectAction:
             return
 
     @classmethod
+    def get_url_params(cls, context):
+        request = context['request']
+        params = request.GET.copy()
+        if 'return_url' in context:
+            params['return_url'] = context['return_url']
+        return params
+
+    @classmethod
     def get_context(cls, context, obj):
         """
         Return any additional context data needed to render the button.
@@ -63,6 +71,7 @@ class ObjectAction:
             'perms': context['perms'],
             'request': context['request'],
             'url': cls.get_url(obj),
+            'url_params': cls.get_url_params(context),
             'label': cls.label,
             **cls.get_context(context, obj),
             **kwargs,

--- a/netbox/templates/core/buttons/bulk_sync.html
+++ b/netbox/templates/core/buttons/bulk_sync.html
@@ -1,3 +1,3 @@
-<button type="submit" name="_sync" {% formaction %}="{{ url }}{% if return_url %}?return_url={{ return_url }}{% endif %}" class="btn btn-primary">
+<button type="submit" name="_sync" {% formaction %}="{{ url }}{% if url_params %}?{{ url_params.urlencode }}{% endif %}{% endif %}" class="btn btn-primary">
   <i class="mdi mdi-sync" aria-hidden="true"></i> {{ label }}
 </button>

--- a/netbox/templates/core/buttons/bulk_sync.html
+++ b/netbox/templates/core/buttons/bulk_sync.html
@@ -1,3 +1,3 @@
-<button type="submit" name="_sync" {% formaction %}="{{ url }}{% if url_params %}?{{ url_params.urlencode }}{% endif %}{% endif %}" class="btn btn-primary">
+<button type="submit" name="_sync" {% formaction %}="{{ url }}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="btn btn-primary">
   <i class="mdi mdi-sync" aria-hidden="true"></i> {{ label }}
 </button>

--- a/netbox/templates/dcim/buttons/bulk_add_components.html
+++ b/netbox/templates/dcim/buttons/bulk_add_components.html
@@ -6,63 +6,63 @@
   <ul class="dropdown-menu">
     {% if perms.dcim.add_consoleport %}
       <li>
-        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_consoleport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="dropdown-item">
+        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_consoleport' %}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="dropdown-item">
          {% trans "Console Ports" %}
         </button>
       </li>
     {% endif %}
     {% if perms.dcim.add_consoleserverport %}
       <li>
-        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_consoleserverport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="dropdown-item ">
+        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_consoleserverport' %}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="dropdown-item ">
           {% trans "Console Server Ports" %}
         </button>
       </li>
     {% endif %}
     {% if perms.dcim.add_powerport %}
       <li>
-        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_powerport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="dropdown-item">
+        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_powerport' %}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="dropdown-item">
           {% trans "Power Ports" %}
         </button>
       </li>
     {% endif %}
     {% if perms.dcim.add_poweroutlet %}
       <li>
-        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_poweroutlet' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="dropdown-item">
+        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_poweroutlet' %}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="dropdown-item">
           {% trans "Power Outlets" %}
         </button>
       </li>
     {% endif %}
     {% if perms.dcim.add_interface %}
       <li>
-          <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_interface' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="dropdown-item">
+          <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_interface' %}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="dropdown-item">
             {% trans "Interfaces" %}
           </button>
       </li>
     {% endif %}
     {% if perms.dcim.add_rearport %}
       <li>
-        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_rearport' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="dropdown-item">
+        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_rearport' %}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="dropdown-item">
           {% trans "Rear Ports" %}
         </button>
       </li>
     {% endif %}
     {% if perms.dcim.add_devicebay %}
       <li>
-        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_devicebay' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="dropdown-item">
+        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_devicebay' %}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="dropdown-item">
           {% trans "Device Bays" %}
         </button>
       </li>
     {% endif %}
     {% if perms.dcim.add_modulebay %}
       <li>
-        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_modulebay' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="dropdown-item">
+        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_modulebay' %}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="dropdown-item">
           {% trans "Module Bays" %}
         </button>
       </li>
     {% endif %}
     {% if perms.dcim.add_inventoryitem %}
       <li>
-        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_inventoryitem' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="dropdown-item">
+        <button type="submit" {% formaction %}="{% url 'dcim:device_bulk_add_inventoryitem' %}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="dropdown-item">
           {% trans "Inventory Items" %}
         </button>
       </li>

--- a/netbox/templates/dcim/buttons/bulk_disconnect.html
+++ b/netbox/templates/dcim/buttons/bulk_disconnect.html
@@ -1,3 +1,3 @@
-<button type="submit" name="_disconnect" {% formaction %}="{{ url }}{% if return_url %}?return_url={{ return_url }}{% endif %}" class="btn btn-red">
+<button type="submit" name="_disconnect" {% formaction %}="{{ url }}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="btn btn-red">
   <i class="mdi mdi-ethernet-cable-off" aria-hidden="true"></i> {{ label }}
 </button>

--- a/netbox/templates/virtualization/buttons/bulk_add_components.html
+++ b/netbox/templates/virtualization/buttons/bulk_add_components.html
@@ -6,14 +6,14 @@
   <ul class="dropdown-menu">
     {% if perms.virtualization.add_vminterface %}
       <li>
-        <button type="submit" {% formaction %}="{% url 'virtualization:virtualmachine_bulk_add_vminterface' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="dropdown-item">
+        <button type="submit" {% formaction %}="{% url 'virtualization:virtualmachine_bulk_add_vminterface' %}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="dropdown-item">
           {% trans "Interfaces" %}
         </button>
       </li>
     {% endif %}
     {% if perms.virtualization.add_virtualdisk %}
       <li>
-        <button type="submit" {% formaction %}="{% url 'virtualization:virtualmachine_bulk_add_virtualdisk' %}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}" class="dropdown-item">
+        <button type="submit" {% formaction %}="{% url 'virtualization:virtualmachine_bulk_add_virtualdisk' %}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="dropdown-item">
           {% trans "Virtual Disks" %}
         </button>
       </li>

--- a/netbox/utilities/templates/buttons/bulk_delete.html
+++ b/netbox/utilities/templates/buttons/bulk_delete.html
@@ -1,3 +1,3 @@
-<button type="submit" name="_delete" {% formaction %}="{{ url }}{% if return_url %}?return_url={{ return_url }}{% endif %}" class="btn btn-red">
+<button type="submit" name="_delete" {% formaction %}="{{ url }}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="btn btn-red">
   <i class="mdi mdi-trash-can-outline" aria-hidden="true"></i> {{ label }}
 </button>

--- a/netbox/utilities/templates/buttons/bulk_edit.html
+++ b/netbox/utilities/templates/buttons/bulk_edit.html
@@ -1,3 +1,3 @@
-<button type="submit" name="_edit" {% formaction %}="{{ url }}{% if return_url %}?return_url={{ return_url }}{% endif %}" class="btn btn-yellow">
+<button type="submit" name="_edit" {% formaction %}="{{ url }}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="btn btn-yellow">
   <i class="mdi mdi-pencil" aria-hidden="true"></i> {{ label }}
 </button>

--- a/netbox/utilities/templates/buttons/bulk_rename.html
+++ b/netbox/utilities/templates/buttons/bulk_rename.html
@@ -1,5 +1,5 @@
 {% if url %}
-  <button type="submit" name="_rename" {% formaction %}="{{ url }}{% if return_url %}?return_url={{ return_url }}{% endif %}" class="btn btn-yellow">
+  <button type="submit" name="_rename" {% formaction %}="{{ url }}{% if url_params %}?{{ url_params.urlencode }}{% endif %}" class="btn btn-yellow">
     <i class="mdi mdi-pencil" aria-hidden="true"></i> {{ label }}
   </button>
 {% endif %}


### PR DESCRIPTION
### Fixes: #20375

- Add the `get_url_params()` method on ObjectAction to return a QueryDict of URL query parameters
- Provide this QueryDict as `url_params` in the button template context
- Update all button templates to reference `url_params`