### PR TITLE
Fixes #20390: Fix styling of pagination dropdown menu

### DIFF
--- a/netbox/templates/inc/paginator.html
+++ b/netbox/templates/inc/paginator.html
@@ -79,21 +79,23 @@
     {# /Showing #}
 
     {# Pagination options #}
-    <nav class="text-end" aria-label="{% trans "Pagination options" %}">
+    <nav aria-label="{% trans "Pagination options" %}">
       {% if page %}
-        <div class="dropdown">
+        <div class="dropdown dropdown-menu-end">
           <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
             {% trans "Per Page" %}
           </button>
-          <div class="dropdown-menu">
+          <ul class="dropdown-menu">
             {% for n in page.paginator.get_page_lengths %}
-              {% if htmx %}
-                <a href="#" hx-get="{{ table.htmx_url }}{% querystring request per_page=n %}" class="dropdown-item">{{ n }}</a>
-              {% else %}
-                <a href="{% querystring request per_page=n %}" class="dropdown-item">{{ n }}</a>
-              {% endif %}
+              <li>
+                {% if htmx %}
+                  <a href="#" hx-get="{{ table.htmx_url }}{% querystring request per_page=n %}" class="dropdown-item">{{ n }}</a>
+                {% else %}
+                  <a href="{% querystring request per_page=n %}" class="dropdown-item">{{ n }}</a>
+                {% endif %}
+              </li>
             {% endfor %}
-          </div>
+          </ul>
         </div>
       {% endif %}
     </nav>


### PR DESCRIPTION
### Fixes: #20390

Prevent the dropdown menu from consuming all horizontal space.

<img width="254" height="309" alt="screenshot" src="https://github.com/user-attachments/assets/75323340-abaa-418c-9b56-d9f1bdf3b578" />
