### PR TITLE
Fixes #20365: Fix schema and field definitions for OpenAPI

### DIFF
--- a/netbox/core/api/serializers_/tasks.py
+++ b/netbox/core/api/serializers_/tasks.py
@@ -13,7 +13,7 @@ class BackgroundTaskSerializer(serializers.Serializer):
     url = serializers.HyperlinkedIdentityField(
         view_name='core-api:rqtask-detail',
         lookup_field='id',
-        lookup_url_kwarg='pk'
+        lookup_url_kwarg='id'
     )
     description = serializers.CharField()
     origin = serializers.CharField()

--- a/netbox/dcim/fields.py
+++ b/netbox/dcim/fields.py
@@ -26,13 +26,16 @@ class eui64_unix_expanded_uppercase(eui64_unix_expanded):
 #
 
 class MACAddressField(models.Field):
-    description = "PostgreSQL MAC Address field"
+    description = 'PostgreSQL MAC Address field'
 
     def python_type(self):
         return EUI
 
     def from_db_value(self, value, expression, connection):
         return self.to_python(value)
+
+    def get_internal_type(self):
+        return 'CharField'
 
     def to_python(self, value):
         if value is None:
@@ -54,13 +57,16 @@ class MACAddressField(models.Field):
 
 
 class WWNField(models.Field):
-    description = "World Wide Name field"
+    description = 'World Wide Name field'
 
     def python_type(self):
         return EUI
 
     def from_db_value(self, value, expression, connection):
         return self.to_python(value)
+
+    def get_internal_type(self):
+        return 'CharField'
 
     def to_python(self, value):
         if value is None:

--- a/netbox/extras/api/serializers_/customfields.py
+++ b/netbox/extras/api/serializers_/customfields.py
@@ -26,6 +26,7 @@ class CustomFieldChoiceSetSerializer(ChangeLogMessageSerializer, ValidatedModelS
             max_length=2
         )
     )
+    choices_count = serializers.IntegerField(read_only=True)
 
     class Meta:
         model = CustomFieldChoiceSet

--- a/netbox/ipam/fields.py
+++ b/netbox/ipam/fields.py
@@ -26,6 +26,9 @@ class BaseIPField(models.Field):
     def from_db_value(self, value, expression, connection):
         return self.to_python(value)
 
+    def get_internal_type(self):
+        return 'CharField'
+
     def to_python(self, value):
         if not value:
             return value
@@ -57,7 +60,7 @@ class IPNetworkField(BaseIPField):
     """
     IP prefix (network and mask)
     """
-    description = "PostgreSQL CIDR field"
+    description = 'PostgreSQL CIDR field'
     default_validators = [validators.prefix_validator]
 
     def db_type(self, connection):
@@ -83,7 +86,7 @@ class IPAddressField(BaseIPField):
     """
     IP address (host address and mask)
     """
-    description = "PostgreSQL INET field"
+    description = 'PostgreSQL INET field'
 
     def db_type(self, connection):
         return 'inet'
@@ -110,7 +113,7 @@ IPAddressField.register_lookup(lookups.Inet)
 
 
 class ASNField(models.BigIntegerField):
-    description = "32-bit ASN field"
+    description = '32-bit ASN field'
     default_validators = [
         MinValueValidator(BGP_ASN_MIN),
         MaxValueValidator(BGP_ASN_MAX),

--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -354,13 +354,13 @@ class PrefixFilterSet(NetBoxModelFilterSet, ScopedFilterSet, TenancyFilterSet, C
     vlan_group_id = django_filters.ModelMultipleChoiceFilter(
         field_name='vlan__group',
         queryset=VLANGroup.objects.all(),
-        to_field_name="id",
+        to_field_name='id',
         label=_('VLAN Group (ID)'),
     )
     vlan_group = django_filters.ModelMultipleChoiceFilter(
         field_name='vlan__group__slug',
         queryset=VLANGroup.objects.all(),
-        to_field_name="slug",
+        to_field_name='slug',
         label=_('VLAN Group (slug)'),
     )
     vlan_id = django_filters.ModelMultipleChoiceFilter(
@@ -695,12 +695,12 @@ class IPAddressFilterSet(NetBoxModelFilterSet, TenancyFilterSet, ContactModelFil
         return queryset.filter(q)
 
     def parse_inet_addresses(self, value):
-        '''
+        """
         Parse networks or IP addresses and cast to a format
         acceptable by the Postgres inet type.
 
         Skips invalid values.
-        '''
+        """
         parsed = []
         for addr in value:
             if netaddr.valid_ipv4(addr) or netaddr.valid_ipv6(addr):
@@ -718,7 +718,7 @@ class IPAddressFilterSet(NetBoxModelFilterSet, TenancyFilterSet, ContactModelFil
         # as argument. If they are all invalid,
         # we return an empty queryset
         value = self.parse_inet_addresses(value)
-        if (len(value) == 0):
+        if len(value) == 0:
             return queryset.none()
 
         try:
@@ -1079,6 +1079,7 @@ class VLANFilterSet(NetBoxModelFilterSet, TenancyFilterSet):
     def get_for_virtualmachine(self, queryset, name, value):
         return queryset.get_for_virtualmachine(value)
 
+    @extend_schema_field(OpenApiTypes.INT)
     def filter_interface_id(self, queryset, name, value):
         if value is None:
             return queryset.none()
@@ -1087,6 +1088,7 @@ class VLANFilterSet(NetBoxModelFilterSet, TenancyFilterSet):
             Q(interfaces_as_untagged=value)
         ).distinct()
 
+    @extend_schema_field(OpenApiTypes.INT)
     def filter_vminterface_id(self, queryset, name, value):
         if value is None:
             return queryset.none()


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20365

- Implement `get_internal_type()` on custom fields for Django introspection.
- Annotate `id`/`name` path params and add explicit `operation_id`s for queues/workers/tasks
- Provide `get_serializer_class()` and `get_serializer_context()` on the RQ base viewset