### PR TITLE
Fixes: #20412: linkify cluster type

### DIFF
--- a/netbox/templates/virtualization/virtualmachine.html
+++ b/netbox/templates/virtualization/virtualmachine.html
@@ -108,7 +108,9 @@
                 </tr>
                 <tr>
                     <th scope="row">{% trans "Cluster Type" %}</th>
-                    <td>{{ object.cluster.type }}</td>
+                    <td>
+                        {{ object.cluster.type|linkify|placeholder }}
+                    </td>
                 </tr>
                 <tr>
                     <th scope="row">{% trans "Device" %}</th>


### PR DESCRIPTION
### Fixes: #20412

- Added linkify function to cluster type on the virtual machine overview page.