### PR TITLE
Fixes #20419: Correct action buttons for child object views

### DIFF
--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -14,9 +14,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
 from core.signals import clear_events
-from netbox.object_actions import (
-    BulkDelete, BulkEdit, BulkExport, BulkImport, CloneObject, DeleteObject, EditObject,
-)
+from netbox.object_actions import BulkDelete, BulkEdit, CloneObject, DeleteObject, EditObject
 from utilities.error_handlers import handle_protectederror
 from utilities.exceptions import AbortRequest, PermissionsViolation
 from utilities.forms import DeleteForm, restrict_form_fields
@@ -103,7 +101,7 @@ class ObjectChildrenView(ObjectView, ActionsMixin, TableMixin):
     table = None
     filterset = None
     filterset_form = None
-    actions = (BulkImport, BulkEdit, BulkExport, BulkDelete)
+    actions = (CloneObject, EditObject, DeleteObject, BulkEdit, BulkDelete)
     template_name = 'generic/object_children.html'
 
     def get_children(self, request, parent):


### PR DESCRIPTION
### Fixes: #20419

- Removes the incorrectly added `BulkImport` and `BulkExport` action buttons from `ObjectChildrenView`
- Restores the missing `CloneObject`, `EditObject`, and `DeleteObject` action buttons