### PR TITLE
Fixes #20243: Prevent scheduled system jobs from re-running multiple times

### DIFF
--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.functional import classproperty
+from django.utils import timezone
 from django_pglocks import advisory_lock
 from rq.timeouts import JobTimeoutException
 
@@ -113,7 +114,11 @@ class JobRunner(ABC):
         # If the executed job is a periodic job, schedule its next execution at the specified interval.
         finally:
             if job.interval:
-                new_scheduled_time = (job.scheduled or job.started) + timedelta(minutes=job.interval)
+                # Determine the new scheduled time. Cannot be earlier than one minute in the future.
+                new_scheduled_time = max([
+                    (job.scheduled or job.started) + timedelta(minutes=job.interval),
+                    timezone.now() + timedelta(minutes=1)
+                ])
                 if job.object and getattr(job.object, "python_class", None):
                     kwargs["job_timeout"] = job.object.python_class.job_timeout
                 cls.enqueue(

--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -115,10 +115,10 @@ class JobRunner(ABC):
         finally:
             if job.interval:
                 # Determine the new scheduled time. Cannot be earlier than one minute in the future.
-                new_scheduled_time = max([
+                new_scheduled_time = max(
                     (job.scheduled or job.started) + timedelta(minutes=job.interval),
                     timezone.now() + timedelta(minutes=1)
-                ])
+                )
                 if job.object and getattr(job.object, "python_class", None):
                     kwargs["job_timeout"] = job.object.python_class.job_timeout
                 cls.enqueue(


### PR DESCRIPTION
### Fixes: #20243

When determining the new scheduled time for a job with an interval, ensure that it is at least one minute into the future.