### PR TITLE
Closes #20438: Add "facility" field to bulk edit forms for Site and Location

### DIFF
--- a/netbox/dcim/forms/bulk_edit.py
+++ b/netbox/dcim/forms/bulk_edit.py
@@ -133,6 +133,11 @@ class SiteBulkEditForm(NetBoxModelBulkEditForm):
         queryset=Tenant.objects.all(),
         required=False
     )
+    facility = forms.CharField(
+        label=_('Facility'),
+        max_length=50,
+        required=False
+    )
     asns = DynamicModelMultipleChoiceField(
         queryset=ASN.objects.all(),
         label=_('ASNs'),
@@ -166,10 +171,10 @@ class SiteBulkEditForm(NetBoxModelBulkEditForm):
 
     model = Site
     fieldsets = (
-        FieldSet('status', 'region', 'group', 'tenant', 'asns', 'time_zone', 'description'),
+        FieldSet('status', 'region', 'group', 'tenant', 'facility', 'asns', 'time_zone', 'description'),
     )
     nullable_fields = (
-        'region', 'group', 'tenant', 'asns', 'time_zone', 'description', 'comments',
+        'region', 'group', 'tenant', 'facility', 'asns', 'time_zone', 'description', 'comments',
     )
 
 
@@ -198,6 +203,11 @@ class LocationBulkEditForm(NetBoxModelBulkEditForm):
         queryset=Tenant.objects.all(),
         required=False
     )
+    facility = forms.CharField(
+        label=_('Facility'),
+        max_length=50,
+        required=False
+    )
     description = forms.CharField(
         label=_('Description'),
         max_length=200,
@@ -207,9 +217,9 @@ class LocationBulkEditForm(NetBoxModelBulkEditForm):
 
     model = Location
     fieldsets = (
-        FieldSet('site', 'parent', 'status', 'tenant', 'description'),
+        FieldSet('site', 'parent', 'status', 'tenant', 'facility', 'description'),
     )
-    nullable_fields = ('parent', 'tenant', 'description', 'comments')
+    nullable_fields = ('parent', 'tenant', 'facility', 'description', 'comments')
 
 
 class RackRoleBulkEditForm(NetBoxModelBulkEditForm):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20438

Add the **facility** field to the **Location** and **Site** bulk edit forms and make it nullable/clearable.

- Users can now set or clear `facility` for multiple Locations and Sites at once.
- No database changes; `facility` already exists on the Location and Site models.
