### PR TITLE
Fixes #18878: Automatically assign a designated primary MAC address upon creation of a new interface

### DIFF
--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -632,10 +632,17 @@ class BaseInterface(models.Model):
             })
 
         # Check that the primary MAC address (if any) is assigned to this interface
-        if self.primary_mac_address and self.primary_mac_address.assigned_object != self:
+        if (
+                self.primary_mac_address and
+                self.primary_mac_address.assigned_object is not None and
+                self.primary_mac_address.assigned_object != self
+        ):
             raise ValidationError({
-                'primary_mac_address': _("MAC address {mac_address} is not assigned to this interface.").format(
-                    mac_address=self.primary_mac_address
+                'primary_mac_address': _(
+                    "MAC address {mac_address} is assigned to a different interface ({interface})."
+                ).format(
+                    mac_address=self.primary_mac_address,
+                    interface=self.primary_mac_address.assigned_object,
                 )
             })
 


### PR DESCRIPTION
### Fixes: #18878

- Loosen the validation logic on BaseInterface to only raise an error if the designated primary MAC address is assigned to a _different_ interface
- Introduce the `update_mac_address_interface()` signal handler to automatically assign the primary MAC address (if any) to a new interface immediately following its creation
