### PR TITLE
Fixes #20248: Tweak help text to avoid error when compiling translations

### DIFF
--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -548,7 +548,7 @@ class IPRange(ContactsMixin, PrimaryModel):
     mark_utilized = models.BooleanField(
         verbose_name=_('mark utilized'),
         default=False,
-        help_text=_("Report space as 100% utilized")
+        help_text=_("Report space as fully utilized")
     )
 
     clone_fields = (


### PR DESCRIPTION
### Fixes: #20248

Ran into issues with escaping the `%` so I took the coward's way out