### PR TITLE
Fixes #20475: Collapse singleton VLAN IDs in VLANGroup display

### DIFF
--- a/netbox/utilities/data.py
+++ b/netbox/utilities/data.py
@@ -137,8 +137,17 @@ def check_ranges_overlap(ranges):
 
 def ranges_to_string(ranges):
     """
-    Generate a human-friendly string from a set of ranges. Intended for use with ArrayField. For example:
-        [[1, 100)], [200, 300)] => "1-99,200-299"
+    Converts a list of ranges into a string representation.
+
+    This function takes a list of range objects and produces a string
+    representation of those ranges. Each range is represented as a
+    hyphen-separated pair of lower and upper bounds, with inclusive or
+    exclusive bounds adjusted accordingly. If the lower and upper bounds
+    of a range are the same, only the single value is added to the string.
+    Intended for use with ArrayField.
+
+    Example:
+        [NumericRange(1, 5), NumericRange(8, 9), NumericRange(10, 12)] => "1-5,8,10-12"
     """
     if not ranges:
         return ''
@@ -146,7 +155,7 @@ def ranges_to_string(ranges):
     for r in ranges:
         lower = r.lower if r.lower_inc else r.lower + 1
         upper = r.upper if r.upper_inc else r.upper - 1
-        output.append(f'{lower}-{upper}')
+        output.append(f"{lower}-{upper}" if lower != upper else str(lower))
     return ','.join(output)
 
 


### PR DESCRIPTION
<!-- Thank you for your interest in contributing to NetBox! Please note that our contribution policy requires that a feature request or bug report be approved and assigned prior to opening a pull request. This helps avoid waste time and effort on a proposed change that we might not be able to accept. IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED TO YOU, IT WILL BE CLOSED AUTOMATICALLY. Please specify your assigned issue number on the line below. -->

### Fixes: #20475

<!-- Please include a summary of the proposed changes below. -->

**Summary**  
Collapse singleton VLAN ID ranges when rendering/storing display strings.  
Input `1-5,10,20-30` remains `1-5,10,20-30` instead of `1-5,10-10,20-30`.

**Implementation**  
Update `utilities.ranges_to_string()` to emit a bare integer when `start == end`.  

**Before → After**  
`1-5,10-10,20-30` → `1-5,10,20-30`