### PR TITLE
Add a GenericRelation "mac_addresses" to BaseInterface

### DIFF
--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -618,6 +618,12 @@ class BaseInterface(models.Model):
         null=True,
         verbose_name=_('primary MAC address')
     )
+    mac_addresses = GenericRelation(
+        to='dcim.MACAddress',
+        content_type_field='assigned_object_type',
+        object_id_field='assigned_object_id',
+        related_query_name='interface',
+    )
 
     class Meta:
         abstract = True


### PR DESCRIPTION
### Fixes: #19720

Adds a `GenericRelation` to `BaseInterface` providing a reverse lookup `interface` which can be used in `MACAddress` queries against the `assigned_object` field (a GFK to `Interface` or `VMInterface`), for example in permissions:

<img width="793" height="669" alt="Screenshot 2025-10-02 at 10 04 44 PM" src="https://github.com/user-attachments/assets/9230b102-d7ba-4c34-ab0a-93e09f338039" />

Note that this lookup will be called `interface` regardless of whether the target object is an `Interface` or a `VMInterface`.
