### PR TITLE
20496 make max_page_size upper bound 

### DIFF
--- a/netbox/utilities/tests/test_api.py
+++ b/netbox/utilities/tests/test_api.py
@@ -149,14 +149,13 @@ class APIPaginationTestCase(APITestCase):
     def test_default_page_size_with_small_max_page_size(self):
         response = self.client.get(self.url, format='json', **self.header)
         page_size = get_config().MAX_PAGE_SIZE
-        paginate_count = get_config().PAGINATE_COUNT
         self.assertLess(page_size, 100, "Default page size not sufficient for data set")
 
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.data['count'], 100)
-        self.assertTrue(response.data['next'].endswith(f'?limit={paginate_count}&offset={paginate_count}'))
+        self.assertTrue(response.data['next'].endswith(f'?limit={page_size}&offset={page_size}'))
         self.assertIsNone(response.data['previous'])
-        self.assertEqual(len(response.data['results']), paginate_count)
+        self.assertEqual(len(response.data['results']), page_size)
 
     def test_custom_page_size(self):
         response = self.client.get(f'{self.url}?limit=10', format='json', **self.header)


### PR DESCRIPTION
### Fixes: #20496

Refactors and fixes REST paginator checking for MAX_PAGE_SIZE, making it the upper bound.

if MAX_PAGE_SIZE is set:

* if no limit is set return min(MAX_PAGE_SIZE, PAGINATE_COUNT)
* if limit set return min(limit, MAX_PAGE_SIZE)
* if limit = 0 or None return MAX_PAGE_SIZE

if MAX_PAGE_SIZE is not set:

* if no limit is set return PAGINATE_COUNT
* if limit is set return limit
* if limit = 0 return all data

Note: The UI view overrides this if you set the pagination limit dropdown - i.e. if you select in the UI 1000 items and MAX_PAGE_SIZE=100, then 1000 items will still be returned in the view, which I think is correct.