### PR TITLE
#17571 - Remove HTMX navigation

### DIFF
--- a/docs/features/user-preferences.md
+++ b/docs/features/user-preferences.md
@@ -34,9 +34,6 @@ Sets the default number of rows displayed on paginated tables.
 ### Paginator placement
 Controls where pagination controls are rendered relative to a table.
 
-### HTMX navigation (experimental)
-Enables partial‑page navigation for supported views. Disable this preference if unexpected behavior is observed.
-
 ### Striped table rows
 Toggles alternating row backgrounds on tables.
 

--- a/netbox/netbox/context_processors.py
+++ b/netbox/netbox/context_processors.py
@@ -28,7 +28,6 @@ def preferences(request):
     user_preferences = request.user.config if request.user.is_authenticated else {}
     return {
         'preferences': user_preferences,
-        'htmx_navigation': user_preferences.get('ui.htmx_navigation', False) == 'true'
     }
 
 

--- a/netbox/netbox/preferences.py
+++ b/netbox/netbox/preferences.py
@@ -26,16 +26,6 @@ def get_csv_delimiters():
 PREFERENCES = {
 
     # User interface
-    'ui.htmx_navigation': UserPreference(
-        label=_('HTMX Navigation'),
-        choices=(
-            ('', _('Disabled')),
-            ('true', _('Enabled')),
-        ),
-        description=_('Enable dynamic UI navigation'),
-        default=False,
-        warning=_('Experimental feature')
-    ),
     'locale.language': UserPreference(
         label=_('Language'),
         choices=(

--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -95,7 +95,7 @@ Blocks:
 
     {# Page content #}
     <div class="page-wrapper">
-      <div id="page-content" {% htmx_boost %}>
+      <div id="page-content">
 
       {# Page header #}
       {% block header %}

--- a/netbox/templates/inc/user_menu.html
+++ b/netbox/templates/inc/user_menu.html
@@ -33,7 +33,7 @@
         </div>
       </div>
     </a>
-    <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow" {% htmx_boost %}>
+    <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow">
       <a href="{% url 'account:profile' %}" class="dropdown-item">
         <i class="mdi mdi-account"></i> {% trans "Profile" %}
       </a>

--- a/netbox/users/forms/model_forms.py
+++ b/netbox/users/forms/model_forms.py
@@ -61,8 +61,7 @@ class UserConfigFormMetaclass(forms.models.ModelFormMetaclass):
 class UserConfigForm(forms.ModelForm, metaclass=UserConfigFormMetaclass):
     fieldsets = (
         FieldSet(
-            'locale.language', 'pagination.per_page', 'pagination.placement', 'ui.htmx_navigation',
-            'ui.tables.striping',
+            'locale.language', 'pagination.per_page', 'pagination.placement', 'ui.tables.striping',
             name=_('User Interface')
         ),
         FieldSet('data_format', 'csv_delimiter', name=_('Miscellaneous')),

--- a/netbox/utilities/templates/navigation/menu.html
+++ b/netbox/utilities/templates/navigation/menu.html
@@ -2,7 +2,7 @@
 {% load i18n %}
 {% load navigation %}
 
-<ul class="navbar-nav pt-lg-2" {% htmx_boost %}>
+<ul class="navbar-nav pt-lg-2">
   <li class="nav-item d-block d-lg-none">
     <form action="{% url 'search' %}" method="get" autocomplete="off" novalidate>
       <div class="input-group mb-1 mt-2">

--- a/netbox/utilities/templatetags/builtins/tags.py
+++ b/netbox/utilities/templatetags/builtins/tags.py
@@ -1,5 +1,4 @@
 from django import template
-from django.utils.safestring import mark_safe
 
 from extras.choices import CustomFieldTypeChoices
 from utilities.querydict import dict_to_querydict
@@ -121,9 +120,7 @@ def htmx_table(context, viewname, return_url=None, **kwargs):
 @register.simple_tag(takes_context=True)
 def formaction(context):
     """
-    Replace the 'formaction' attribute on an HTML element with the appropriate HTMX attributes
-    if HTMX navigation is enabled (per the user's preferences).
+    A hook for overriding the 'formaction' attribute on an HTML element, for example to replace
+    with 'hx-push-url="true" hx-post' for HTMX navigation.
     """
-    if context.get('htmx_navigation', False):
-        return mark_safe('hx-push-url="true" hx-post')
     return 'formaction'

--- a/netbox/utilities/templatetags/buttons.py
+++ b/netbox/utilities/templatetags/buttons.py
@@ -226,7 +226,6 @@ def bulk_edit_button(context, model, action='bulk_edit', query_params=None):
     return {
         'label': _('Edit Selected'),
         'url': url,
-        'htmx_navigation': context.get('htmx_navigation'),
     }
 
 
@@ -243,5 +242,4 @@ def bulk_delete_button(context, model, action='bulk_delete', query_params=None):
     return {
         'label': _('Delete Selected'),
         'url': url,
-        'htmx_navigation': context.get('htmx_navigation'),
     }

--- a/netbox/utilities/templatetags/navigation.py
+++ b/netbox/utilities/templatetags/navigation.py
@@ -1,11 +1,9 @@
 from django import template
-from django.utils.safestring import mark_safe
 
 from netbox.navigation.menu import MENUS
 
 __all__ = (
     'nav',
-    'htmx_boost',
 )
 
 
@@ -43,30 +41,4 @@ def nav(context):
 
     return {
         'nav_items': nav_items,
-        'htmx_navigation': context['htmx_navigation']
     }
-
-
-@register.simple_tag(takes_context=True)
-def htmx_boost(context, target='#page-content', select='#page-content'):
-    """
-    Renders the HTML attributes needed to effect HTMX boosting within an element if
-    HTMX navigation is enabled for the request. The target and select parameters are
-    rendered as `hx-target` and `hx-select`, respectively. For example:
-
-        <div id="page-content" {% htmx_boost %}>
-
-    If HTMX navigation is not enabled, the tag renders no content.
-    """
-    if not context.get('htmx_navigation', False):
-        return ''
-    hx_params = {
-        'hx-boost': 'true',
-        'hx-target': target,
-        'hx-select': select,
-        'hx-swap': 'outerHTML show:window:top',
-    }
-    htmx_params = ' '.join([
-        f'{k}="{v}"' for k, v in hx_params.items()
-    ])
-    return mark_safe(htmx_params)


### PR DESCRIPTION
### Closes: #17571

Removes experimental HTMX navigation.

Note: this leaves in place the `{% formaction %}` template tag as a hook for later customization, rather than removing all usages of it from templates.

Also does not remove existing non-experimental HTMX usages in forms, notifications, etc.
