### PR TITLE
Fixes #20466: Correct handling of `assigned` filter logic

### DIFF
--- a/netbox/ipam/graphql/filters.py
+++ b/netbox/ipam/graphql/filters.py
@@ -170,7 +170,7 @@ class IPAddressFilter(ContactFilterMixin, TenancyFilterMixin, PrimaryModelFilter
 
     @strawberry_django.filter_field()
     def assigned(self, value: bool, prefix) -> Q:
-        return Q(assigned_object_id__isnull=(not value))
+        return Q(**{f"{prefix}assigned_object_id__isnull": not value})
 
     @strawberry_django.filter_field()
     def parent(self, value: list[str], prefix) -> Q:


### PR DESCRIPTION
### Fixes: #20466

<!--
    Please include a summary of the proposed changes below.
-->

#### Summary

- Correct the custom GraphQL filter `IPAddressFilter.assigned` to use the nested relation `prefix` supplied by Strawberry‑Django.
- Prior behavior built a non‑prefixed `Q`, so when used under another filter (e.g., `Device → primary_ip4`), Django attempted to resolve `assigned_object_id` on the outer model and failed.
- New behavior dynamically qualifies the lookup with `prefix`, ensuring the condition targets the nested `IPAddress`.

#### Change

```diff
@strawberry_django.filter_field()
def assigned(self, value: bool, prefix) -> Q:
-    return Q(assigned_object_id__isnull=(not value))
+    return Q(**{f"{prefix}assigned_object_id__isnull": not value})
```

#### Why

Nested GraphQL queries like the example below errored due to the missing prefix; with this change they work as intended.

```graphql
query {
  device_list(filters: { primary_ip4: { assigned: true } }) {
    id
    name
    primary_ip4 { address }
  }
}
```

#### Follow‑up

- Propose a small audit for other `@strawberry_django.filter_field` methods that construct raw `Q(...)` lookups without applying `prefix`.