### PR TITLE
Closes #20516: Add `ranges_to_string_list` and render VLAN Group VID ranges with `ArrayColumn`

### DIFF
--- a/netbox/ipam/models/vlans.py
+++ b/netbox/ipam/models/vlans.py
@@ -10,9 +10,9 @@ from django.utils.translation import gettext_lazy as _
 from dcim.models import Interface, Site, SiteGroup
 from ipam.choices import *
 from ipam.constants import *
-from ipam.querysets import VLANQuerySet, VLANGroupQuerySet
+from ipam.querysets import VLANGroupQuerySet, VLANQuerySet
 from netbox.models import OrganizationalModel, PrimaryModel, NetBoxModel
-from utilities.data import check_ranges_overlap, ranges_to_string
+from utilities.data import check_ranges_overlap, ranges_to_string, ranges_to_string_list
 from virtualization.models import VMInterface
 
 __all__ = (
@@ -165,7 +165,17 @@ class VLANGroup(OrganizationalModel):
         return VLAN.objects.filter(group=self).order_by('vid')
 
     @property
+    def vid_ranges_items(self):
+        """
+        Property that converts VID ranges to a list of string representations.
+        """
+        return ranges_to_string_list(self.vid_ranges)
+
+    @property
     def vid_ranges_list(self):
+        """
+        Property that converts VID ranges into a string representation.
+        """
         return ranges_to_string(self.vid_ranges)
 
 

--- a/netbox/ipam/tables/vlans.py
+++ b/netbox/ipam/tables/vlans.py
@@ -41,7 +41,8 @@ class VLANGroupTable(TenancyColumnsMixin, NetBoxTable):
         linkify=True,
         orderable=False
     )
-    vid_ranges_list = tables.Column(
+    vid_ranges_list = columns.ArrayColumn(
+        accessor='vid_ranges_items',
         verbose_name=_('VID Ranges'),
         orderable=False
     )

--- a/netbox/templates/ipam/vlangroup.html
+++ b/netbox/templates/ipam/vlangroup.html
@@ -40,7 +40,7 @@
         </tr>
         <tr>
           <th scope="row">{% trans "VLAN IDs" %}</th>
-          <td>{{ object.vid_ranges_list }}</td>
+          <td>{{ object.vid_ranges_items|join:", " }}</td>
         </tr>
         <tr>
           <th scope="row">Utilization</th>

--- a/netbox/utilities/tests/test_data.py
+++ b/netbox/utilities/tests/test_data.py
@@ -1,7 +1,11 @@
 from django.db.backends.postgresql.psycopg_any import NumericRange
 from django.test import TestCase
-
-from utilities.data import check_ranges_overlap, ranges_to_string, string_to_ranges
+from utilities.data import (
+    check_ranges_overlap,
+    ranges_to_string,
+    ranges_to_string_list,
+    string_to_ranges,
+)
 
 
 class RangeFunctionsTestCase(TestCase):
@@ -47,14 +51,26 @@ class RangeFunctionsTestCase(TestCase):
             ])
         )
 
+    def test_ranges_to_string_list(self):
+        self.assertEqual(
+            ranges_to_string_list([
+                NumericRange(10, 20),    # 10-19
+                NumericRange(30, 40),    # 30-39
+                NumericRange(50, 51),    # 50-50
+                NumericRange(100, 200),  # 100-199
+            ]),
+            ['10-19', '30-39', '50', '100-199']
+        )
+
     def test_ranges_to_string(self):
         self.assertEqual(
             ranges_to_string([
                 NumericRange(10, 20),    # 10-19
                 NumericRange(30, 40),    # 30-39
+                NumericRange(50, 51),    # 50-50
                 NumericRange(100, 200),  # 100-199
             ]),
-            '10-19,30-39,100-199'
+            '10-19,30-39,50,100-199'
         )
 
     def test_string_to_ranges(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20516

<!--
    Please include a summary of the proposed changes below.
-->

**Summary**
- Add `ranges_to_string_list(ranges) -> list[str]`, which formats numeric ranges as human‑readable strings (e.g., `["1-5", "8", "10-12"]`).
- Refactor `ranges_to_string(ranges)` to delegate to the new helper:
  ```py
  if not ranges:
      return ''
  return ','.join(ranges_to_string_list(ranges))
  ```
  This preserves the existing output (comma‑separated with **no spaces**) while enabling callers to control separators when needed.
- Improve VLAN Group rendering by switching the table column to use a list accessor with `ArrayColumn`, yielding `", "` spacing in the UI without changing underlying data or the string helper’s behavior.

**Implementation notes**
- `ranges_to_string` remains fully backward‑compatible in both signature and output.
- VLAN Group table uses a list accessor (e.g., `vid_ranges_items`) with `ArrayColumn`, while keeping the existing `vid_ranges_list` string property available to avoid breaking saved table configs.

**Testing**
- Add unit tests covering:
  - Singleton ranges (`"8"`) vs. hyphen ranges (`"1-5"`)
  - `ranges_to_string_list()`

**Backwards compatibility**
- No breaking changes. Existing uses of `ranges_to_string()` and `VLANGroup.vid_ranges_list` continue to work as before.
