### PR TITLE
Fixes #20542: Add form prefix to `POST` handler in `ObjectEditView`

### DIFF
--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -281,7 +281,8 @@ class ObjectEditView(GetReturnURLMixin, BaseObjectView):
 
         obj = self.alter_object(obj, request, args, kwargs)
 
-        form = self.form(data=request.POST, files=request.FILES, instance=obj)
+        form_prefix = 'quickadd' if request.GET.get('_quickadd') else None
+        form = self.form(data=request.POST, files=request.FILES, instance=obj, prefix=form_prefix)
         restrict_form_fields(form, request.user)
 
         if form.is_valid():


### PR DESCRIPTION
Fixes: #20542 

Commit d22246688 added form prefix support to the `GET` handler to fix Markdown preview functionality in quick add modals. The form prefix allows Django to properly namespace field names and IDs when rendering forms within the quick add modal context.

However, the corresponding change was not made to the `POST` handler. This created a mismatch where form fields were rendered with the `quickadd-` prefix during `GET` requests, but the `POST` handler instantiated forms without the prefix. When users submitted quick add forms, Django looked for unprefixed field names like `address` and `status` in the `POST` data, but the actual submitted data used prefixed names like `quickadd-address` and `quickadd-status`. This caused validation to fail immediately with "This field is required" errors for all required fields, making every quick add form unusable.

The fix adds the same prefix detection logic to the `POST` handler that was added to the `GET` handler, checking for the `_quickadd` parameter in the query string and applying the `quickadd` prefix when present. This ensures consistent form field naming between rendering and validation.

A regression test has been added to `MACAddressTestCase` to verify that MAC addresses can be successfully created via the quick add modal, preventing this issue from recurring. This test should be promoted to a template test whenever it becomes possible to determine if a model should support quick-add functionality.