### PR TITLE
Closes #16681: Introduce render_config permission for configuration rendering

### DIFF
--- a/docs/features/configuration-rendering.md
+++ b/docs/features/configuration-rendering.md
@@ -92,8 +92,8 @@ http://netbox:8000/api/extras/config-templates/123/render/ \
 ```
 
 !!! note "Permissions"
-    Rendering configuration templates via the REST API requires the `render_config` permission for the relevant object type:
+    Rendering configuration templates via the REST API requires appropriate permissions for the relevant object type:
 
     * To render a device's configuration via `/api/dcim/devices/{id}/render-config/`, assign a permission for "DCIM > Device" with the `render_config` action
     * To render a virtual machine's configuration via `/api/virtualization/virtual-machines/{id}/render-config/`, assign a permission for "Virtualization > Virtual Machine" with the `render_config` action
-    * To render a config template directly via `/api/extras/config-templates/{id}/render/`, assign a permission for "Extras > Config Template" with the `render_config` action
+    * To render a config template directly via `/api/extras/config-templates/{id}/render/`, assign a permission for "Extras > Config Template" with the `render` action

--- a/docs/features/configuration-rendering.md
+++ b/docs/features/configuration-rendering.md
@@ -90,3 +90,6 @@ http://netbox:8000/api/extras/config-templates/123/render/ \
   "bar": 123
 }'
 ```
+
+!!! note "Permissions"
+    Rendering device or virtual machine configurations via the REST API requires the `render_config` permission for the relevant object type. For example, to render a device's configuration via `/api/dcim/devices/{id}/render-config/`, a user must be assigned a permission for the "DCIM > Device" object type with the `render_config` action.

--- a/docs/features/configuration-rendering.md
+++ b/docs/features/configuration-rendering.md
@@ -94,6 +94,6 @@ http://netbox:8000/api/extras/config-templates/123/render/ \
 !!! note "Permissions"
     Rendering configuration templates via the REST API requires appropriate permissions for the relevant object type:
 
-    * To render a device's configuration via `/api/dcim/devices/{id}/render-config/`, assign a permission for "DCIM > Device" with the `render_config` action
-    * To render a virtual machine's configuration via `/api/virtualization/virtual-machines/{id}/render-config/`, assign a permission for "Virtualization > Virtual Machine" with the `render_config` action
-    * To render a config template directly via `/api/extras/config-templates/{id}/render/`, assign a permission for "Extras > Config Template" with the `render` action
+    * To render a device's configuration via `/api/dcim/devices/{id}/render-config/`, assign a permission for "DCIM > Device" with the `render_config` action.
+    * To render a virtual machine's configuration via `/api/virtualization/virtual-machines/{id}/render-config/`, assign a permission for "Virtualization > Virtual Machine" with the `render_config` action.
+    * To render a config template directly via `/api/extras/config-templates/{id}/render/`, assign a permission for "Extras > Config Template" with the `render` action.

--- a/docs/features/configuration-rendering.md
+++ b/docs/features/configuration-rendering.md
@@ -92,4 +92,8 @@ http://netbox:8000/api/extras/config-templates/123/render/ \
 ```
 
 !!! note "Permissions"
-    Rendering device or virtual machine configurations via the REST API requires the `render_config` permission for the relevant object type. For example, to render a device's configuration via `/api/dcim/devices/{id}/render-config/`, a user must be assigned a permission for the "DCIM > Device" object type with the `render_config` action.
+    Rendering configuration templates via the REST API requires the `render_config` permission for the relevant object type:
+
+    * To render a device's configuration via `/api/dcim/devices/{id}/render-config/`, assign a permission for "DCIM > Device" with the `render_config` action
+    * To render a virtual machine's configuration via `/api/virtualization/virtual-machines/{id}/render-config/`, assign a permission for "Virtualization > Virtual Machine" with the `render_config` action
+    * To render a config template directly via `/api/extras/config-templates/{id}/render/`, assign a permission for "Extras > Config Template" with the `render_config` action

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -13,7 +13,8 @@ from ipam.choices import VLANQinQRoleChoices
 from ipam.models import ASN, RIR, VLAN, VRF
 from netbox.api.serializers import GenericObjectSerializer
 from tenancy.models import Tenant
-from users.models import User
+from users.constants import TOKEN_PREFIX
+from users.models import Token, User
 from utilities.testing import APITestCase, APIViewTestCases, create_test_device, disable_logging
 from virtualization.models import Cluster, ClusterType
 from wireless.choices import WirelessChannelChoices
@@ -1485,8 +1486,8 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
         device.config_template = configtemplate
         device.save()
 
-        self.add_permissions('dcim.render_config_device', 'dcim.view_device', 'extras.view_configtemplate')
-        url = reverse('dcim-api:device-detail', kwargs={'pk': device.pk}) + 'render-config/'
+        self.add_permissions('dcim.render_config_device', 'dcim.view_device')
+        url = reverse('dcim-api:device-render-config', kwargs={'pk': device.pk})
         response = self.client.post(url, {}, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.data['content'], f'Config for device {device.name}')
@@ -1502,9 +1503,40 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
         device.save()
 
         # No permissions added - user has no render_config permission
-        url = reverse('dcim-api:device-detail', kwargs={'pk': device.pk}) + 'render-config/'
+        url = reverse('dcim-api:device-render-config', kwargs={'pk': device.pk})
         response = self.client.post(url, {}, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_404_NOT_FOUND)
+
+    def test_render_config_token_write_enabled(self):
+        configtemplate = ConfigTemplate.objects.create(
+            name='Config Template 1',
+            template_code='Config for device {{ device.name }}'
+        )
+
+        device = Device.objects.first()
+        device.config_template = configtemplate
+        device.save()
+
+        self.add_permissions('dcim.render_config_device', 'dcim.view_device')
+        url = reverse('dcim-api:device-render-config', kwargs={'pk': device.pk})
+
+        # Request without token auth should fail with PermissionDenied
+        response = self.client.post(url, {}, format='json')
+        self.assertHttpStatus(response, status.HTTP_403_FORBIDDEN)
+
+        # Create token with write_enabled=False
+        token = Token.objects.create(version=2, user=self.user, write_enabled=False)
+        token_header = f'Bearer {TOKEN_PREFIX}{token.key}.{token.token}'
+
+        # Request with write-disabled token should fail
+        response = self.client.post(url, {}, format='json', HTTP_AUTHORIZATION=token_header)
+        self.assertHttpStatus(response, status.HTTP_403_FORBIDDEN)
+
+        # Enable write and retry
+        token.write_enabled = True
+        token.save()
+        response = self.client.post(url, {}, format='json', HTTP_AUTHORIZATION=token_header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
 
 
 class ModuleTest(APIViewTestCases.APIViewTestCase):

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -1487,7 +1487,6 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
         device.save()
 
         self.add_permissions('dcim.render_config_device')
-        self.add_permissions('dcim.add_device')
         url = reverse('dcim-api:device-detail', kwargs={'pk': device.pk}) + 'render-config/'
         response = self.client.post(url, {}, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
@@ -1504,10 +1503,9 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
         device.save()
 
         # No permissions added - user has no render_config permission
-        self.add_permissions('dcim.add_device')
         url = reverse('dcim-api:device-detail', kwargs={'pk': device.pk}) + 'render-config/'
         response = self.client.post(url, {}, format='json', **self.header)
-        self.assertHttpStatus(response, status.HTTP_403_FORBIDDEN)
+        self.assertHttpStatus(response, status.HTTP_404_NOT_FOUND)
 
 
 class ModuleTest(APIViewTestCases.APIViewTestCase):

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -1306,7 +1306,6 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
     }
     user_permissions = (
         'dcim.view_site', 'dcim.view_rack', 'dcim.view_location', 'dcim.view_devicerole', 'dcim.view_devicetype',
-        'extras.view_configtemplate',
     )
 
     @classmethod
@@ -1486,7 +1485,7 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
         device.config_template = configtemplate
         device.save()
 
-        self.add_permissions('dcim.render_config_device')
+        self.add_permissions('dcim.render_config_device', 'dcim.view_device', 'extras.view_configtemplate')
         url = reverse('dcim-api:device-detail', kwargs={'pk': device.pk}) + 'render-config/'
         response = self.client.post(url, {}, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)

--- a/netbox/extras/api/mixins.py
+++ b/netbox/extras/api/mixins.py
@@ -1,3 +1,4 @@
+from django.utils.translation import gettext_lazy as _
 from jinja2.exceptions import TemplateError
 from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
@@ -76,7 +77,7 @@ class RenderConfigMixin(ConfigTemplateRenderMixin):
         # Check render_config permission
         perm = get_permission_for_model(instance, 'render_config')
         if not request.user.has_perm(perm, obj=instance):
-            raise PermissionDenied("This user does not have permission to render device configurations.")
+            raise PermissionDenied(_("This user does not have permission to render configurations for this object."))
 
         object_type = instance._meta.model_name
         configtemplate = instance.get_config_template()

--- a/netbox/extras/api/mixins.py
+++ b/netbox/extras/api/mixins.py
@@ -77,6 +77,7 @@ class RenderConfigMixin(ConfigTemplateRenderMixin):
         """
         Resolve and render the preferred ConfigTemplate for this Device.
         """
+        # Override restrict() on the default queryset to enforce the render_config & view actions
         self.queryset = self.queryset.model.objects.restrict(request.user, 'render_config').restrict(
             request.user, 'view'
         )

--- a/netbox/extras/api/mixins.py
+++ b/netbox/extras/api/mixins.py
@@ -1,7 +1,5 @@
-from django.utils.translation import gettext_lazy as _
 from jinja2.exceptions import TemplateError
 from rest_framework.decorators import action
-from rest_framework.exceptions import PermissionDenied
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.status import HTTP_400_BAD_REQUEST
@@ -90,10 +88,6 @@ class RenderConfigMixin(ConfigTemplateRenderMixin):
             return Response({
                 'error': f'No config template found for this {object_type}.'
             }, status=HTTP_400_BAD_REQUEST)
-
-        # Check view permission for ConfigTemplate
-        if not request.user.has_perm('extras.view_configtemplate', obj=configtemplate):
-            raise PermissionDenied(_("This user does not have permission to view this configuration template."))
 
         # Compile context data
         context_data = instance.get_config_context()

--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -250,6 +250,7 @@ class ConfigTemplateViewSet(SyncedDataMixin, ConfigTemplateRenderMixin, NetBoxMo
         Render a ConfigTemplate using the context data provided (if any). If the client requests "text/plain" data,
         return the raw rendered content, rather than serialized JSON.
         """
+        # Override restrict() on the default queryset to enforce the render & view actions
         self.queryset = self.queryset.model.objects.restrict(request.user, 'render').restrict(request.user, 'view')
         configtemplate = self.get_object()
 

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -858,7 +858,7 @@ class ConfigTemplateTest(APIViewTestCases.APIViewTestCase):
     def test_render(self):
         configtemplate = ConfigTemplate.objects.first()
 
-        self.add_permissions('extras.render_config_configtemplate')
+        self.add_permissions('extras.render_configtemplate', 'extras.view_configtemplate')
         url = reverse('extras-api:configtemplate-detail', kwargs={'pk': configtemplate.pk}) + 'render/'
         response = self.client.post(url, {'foo': 'bar'}, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
@@ -867,7 +867,7 @@ class ConfigTemplateTest(APIViewTestCases.APIViewTestCase):
     def test_render_without_permission(self):
         configtemplate = ConfigTemplate.objects.first()
 
-        # No permissions added - user has no render_config permission
+        # No permissions added - user has no render permission
         url = reverse('extras-api:configtemplate-detail', kwargs={'pk': configtemplate.pk}) + 'render/'
         response = self.client.post(url, {'foo': 'bar'}, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_404_NOT_FOUND)

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -12,7 +12,8 @@ from dcim.models import Device, DeviceRole, DeviceType, Manufacturer, Rack, Loca
 from extras.choices import *
 from extras.models import *
 from extras.scripts import BooleanVar, IntegerVar, Script as PythonClass, StringVar
-from users.models import Group, User
+from users.constants import TOKEN_PREFIX
+from users.models import Group, Token, User
 from utilities.testing import APITestCase, APIViewTestCases
 
 
@@ -859,7 +860,7 @@ class ConfigTemplateTest(APIViewTestCases.APIViewTestCase):
         configtemplate = ConfigTemplate.objects.first()
 
         self.add_permissions('extras.render_configtemplate', 'extras.view_configtemplate')
-        url = reverse('extras-api:configtemplate-detail', kwargs={'pk': configtemplate.pk}) + 'render/'
+        url = reverse('extras-api:configtemplate-render', kwargs={'pk': configtemplate.pk})
         response = self.client.post(url, {'foo': 'bar'}, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.data['content'], 'Foo: bar')
@@ -868,9 +869,33 @@ class ConfigTemplateTest(APIViewTestCases.APIViewTestCase):
         configtemplate = ConfigTemplate.objects.first()
 
         # No permissions added - user has no render permission
-        url = reverse('extras-api:configtemplate-detail', kwargs={'pk': configtemplate.pk}) + 'render/'
+        url = reverse('extras-api:configtemplate-render', kwargs={'pk': configtemplate.pk})
         response = self.client.post(url, {'foo': 'bar'}, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_404_NOT_FOUND)
+
+    def test_render_token_write_enabled(self):
+        configtemplate = ConfigTemplate.objects.first()
+
+        self.add_permissions('extras.render_configtemplate', 'extras.view_configtemplate')
+        url = reverse('extras-api:configtemplate-render', kwargs={'pk': configtemplate.pk})
+
+        # Request without token auth should fail with PermissionDenied
+        response = self.client.post(url, {'foo': 'bar'}, format='json')
+        self.assertHttpStatus(response, status.HTTP_403_FORBIDDEN)
+
+        # Create token with write_enabled=False
+        token = Token.objects.create(version=2, user=self.user, write_enabled=False)
+        token_header = f'Bearer {TOKEN_PREFIX}{token.key}.{token.token}'
+
+        # Request with write-disabled token should fail
+        response = self.client.post(url, {'foo': 'bar'}, format='json', HTTP_AUTHORIZATION=token_header)
+        self.assertHttpStatus(response, status.HTTP_403_FORBIDDEN)
+
+        # Enable write and retry
+        token.write_enabled = True
+        token.save()
+        response = self.client.post(url, {'foo': 'bar'}, format='json', HTTP_AUTHORIZATION=token_header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
 
 
 class ScriptTest(APITestCase):

--- a/netbox/netbox/api/authentication.py
+++ b/netbox/netbox/api/authentication.py
@@ -164,6 +164,17 @@ class TokenPermissions(DjangoObjectPermissions):
         return super().has_object_permission(request, view, obj)
 
 
+class TokenWritePermission(BasePermission):
+    """
+    Verify the token has write_enabled for unsafe methods, without requiring specific model permissions.
+    Used for custom actions that accept user data but don't map to standard CRUD operations.
+    """
+    def has_permission(self, request, view):
+        if isinstance(request.auth, Token):
+            return request.method in SAFE_METHODS or request.auth.write_enabled
+        return True
+
+
 class IsAuthenticatedOrLoginNotRequired(BasePermission):
     """
     Returns True if the user is authenticated or LOGIN_REQUIRED is False.

--- a/netbox/netbox/api/authentication.py
+++ b/netbox/netbox/api/authentication.py
@@ -169,10 +169,13 @@ class TokenWritePermission(BasePermission):
     Verify the token has write_enabled for unsafe methods, without requiring specific model permissions.
     Used for custom actions that accept user data but don't map to standard CRUD operations.
     """
+
     def has_permission(self, request, view):
-        if isinstance(request.auth, Token):
-            return request.method in SAFE_METHODS or request.auth.write_enabled
-        return True
+        if not isinstance(request.auth, Token):
+            raise exceptions.PermissionDenied(
+                "TokenWritePermission requires token authentication."
+            )
+        return bool(request.method in SAFE_METHODS or request.auth.write_enabled)
 
 
 class IsAuthenticatedOrLoginNotRequired(BasePermission):

--- a/netbox/virtualization/tests/test_api.py
+++ b/netbox/virtualization/tests/test_api.py
@@ -282,7 +282,6 @@ class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
         vm.save()
 
         self.add_permissions('virtualization.render_config_virtualmachine')
-        self.add_permissions('virtualization.add_virtualmachine')
         url = reverse('virtualization-api:virtualmachine-detail', kwargs={'pk': vm.pk}) + 'render-config/'
         response = self.client.post(url, {}, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
@@ -299,10 +298,9 @@ class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
         vm.save()
 
         # No permissions added - user has no render_config permission
-        self.add_permissions('virtualization.add_virtualmachine')
         url = reverse('virtualization-api:virtualmachine-detail', kwargs={'pk': vm.pk}) + 'render-config/'
         response = self.client.post(url, {}, format='json', **self.header)
-        self.assertHttpStatus(response, status.HTTP_403_FORBIDDEN)
+        self.assertHttpStatus(response, status.HTTP_404_NOT_FOUND)
 
 
 class VMInterfaceTest(APIViewTestCases.APIViewTestCase):

--- a/netbox/virtualization/tests/test_api.py
+++ b/netbox/virtualization/tests/test_api.py
@@ -12,6 +12,8 @@ from extras.choices import CustomFieldTypeChoices
 from extras.models import ConfigTemplate, CustomField
 from ipam.choices import VLANQinQRoleChoices
 from ipam.models import Prefix, VLAN, VRF
+from users.constants import TOKEN_PREFIX
+from users.models import Token
 from utilities.testing import (
     APITestCase, APIViewTestCases, create_test_device, create_test_virtualmachine, disable_logging,
 )
@@ -282,10 +284,9 @@ class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
         vm.save()
 
         self.add_permissions(
-            'virtualization.render_config_virtualmachine', 'virtualization.view_virtualmachine',
-            'extras.view_configtemplate'
+            'virtualization.render_config_virtualmachine', 'virtualization.view_virtualmachine'
         )
-        url = reverse('virtualization-api:virtualmachine-detail', kwargs={'pk': vm.pk}) + 'render-config/'
+        url = reverse('virtualization-api:virtualmachine-render-config', kwargs={'pk': vm.pk})
         response = self.client.post(url, {}, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(response.data['content'], f'Config for virtual machine {vm.name}')
@@ -301,9 +302,40 @@ class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
         vm.save()
 
         # No permissions added - user has no render_config permission
-        url = reverse('virtualization-api:virtualmachine-detail', kwargs={'pk': vm.pk}) + 'render-config/'
+        url = reverse('virtualization-api:virtualmachine-render-config', kwargs={'pk': vm.pk})
         response = self.client.post(url, {}, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_404_NOT_FOUND)
+
+    def test_render_config_token_write_enabled(self):
+        configtemplate = ConfigTemplate.objects.create(
+            name='Config Template 1',
+            template_code='Config for virtual machine {{ virtualmachine.name }}'
+        )
+
+        vm = VirtualMachine.objects.first()
+        vm.config_template = configtemplate
+        vm.save()
+
+        self.add_permissions('virtualization.render_config_virtualmachine', 'virtualization.view_virtualmachine')
+        url = reverse('virtualization-api:virtualmachine-render-config', kwargs={'pk': vm.pk})
+
+        # Request without token auth should fail with PermissionDenied
+        response = self.client.post(url, {}, format='json')
+        self.assertHttpStatus(response, status.HTTP_403_FORBIDDEN)
+
+        # Create token with write_enabled=False
+        token = Token.objects.create(version=2, user=self.user, write_enabled=False)
+        token_header = f'Bearer {TOKEN_PREFIX}{token.key}.{token.token}'
+
+        # Request with write-disabled token should fail
+        response = self.client.post(url, {}, format='json', HTTP_AUTHORIZATION=token_header)
+        self.assertHttpStatus(response, status.HTTP_403_FORBIDDEN)
+
+        # Enable write and retry
+        token.write_enabled = True
+        token.save()
+        response = self.client.post(url, {}, format='json', HTTP_AUTHORIZATION=token_header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
 
 
 class VMInterfaceTest(APIViewTestCases.APIViewTestCase):

--- a/netbox/virtualization/tests/test_api.py
+++ b/netbox/virtualization/tests/test_api.py
@@ -281,7 +281,10 @@ class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
         vm.config_template = configtemplate
         vm.save()
 
-        self.add_permissions('virtualization.render_config_virtualmachine')
+        self.add_permissions(
+            'virtualization.render_config_virtualmachine', 'virtualization.view_virtualmachine',
+            'extras.view_configtemplate'
+        )
         url = reverse('virtualization-api:virtualmachine-detail', kwargs={'pk': vm.pk}) + 'render-config/'
         response = self.client.post(url, {}, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)


### PR DESCRIPTION
### Closes: #16681

Add `render_config` permission action for rendering device, virtual machine, and config template configurations via the REST API.

**Changes:**
- Add permission checks to `/api/dcim/devices/{id}/render-config/`, `/api/virtualization/virtual-machines/{id}/render-config/`, and `/api/extras/config-templates/{id}/render/`
- Introduce `TokenWritePermission` to enforce token write ability independent of model permissions
- Replace POST='add' requirement with `render_config` permission
- Add test coverage and documentation

Per #16681: rendering configs requires accepting arbitrary user data (requiring write-enabled tokens), but doesn't require permission to create devices/VMs. The `render_config` permission separates these concerns.

**Note:** Optional data migration could grant `render_config` to existing users with `view` or `add` permissions to ease upgrade path. Can add if desired.