### PR TITLE
Closes #20557: Upgrade Django to v5.2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 colorama==0.4.6
-Django==5.2.6
+Django==5.2.7
 django-cors-headers==4.9.0
 django-debug-toolbar==5.2.0
 django-filter==25.1


### PR DESCRIPTION
Closes: #20557 

Upgrade Django to v5.2.7 to address upstream vulnerability reports

https://www.djangoproject.com/weblog/2025/oct/01/security-releases/