### PR TITLE
Fixes #20476: Prohibit changing a token's owner

### DIFF
--- a/netbox/users/api/serializers_/tokens.py
+++ b/netbox/users/api/serializers_/tokens.py
@@ -37,6 +37,15 @@ class TokenSerializer(ValidatedModelSerializer):
         read_only_fields = ('key',)
         brief_fields = ('id', 'url', 'display', 'version', 'key', 'write_enabled', 'description')
 
+    def get_fields(self):
+        fields = super().get_fields()
+
+        # Make user field read-only if updating an existing Token.
+        if self.instance is not None:
+            fields['user'].read_only = True
+
+        return fields
+
     def validate(self, data):
 
         # If the Token is being created on behalf of another user, enforce the grant_token permission.

--- a/netbox/users/forms/model_forms.py
+++ b/netbox/users/forms/model_forms.py
@@ -177,6 +177,13 @@ class TokenForm(UserTokenForm):
             'version', 'token', 'user', 'write_enabled', 'expires', 'description', 'allowed_ips',
         ]
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # If not creating a new Token, disable the user field
+        if self.instance and not self.instance._state.adding:
+            self.fields['user'].disabled = True
+
 
 class UserForm(forms.ModelForm):
     password = forms.CharField(


### PR DESCRIPTION
### Closes: #20476

- Adjust TokenSerializer so that the `user` field is set to read-only when not creating a new token
- Disable the `user` field on TokenForm when editing an existing token
- Introduce the `test_reassign_token()` API test