### PR TITLE
Closes #19751: Disable occupied Module Bays in form dropdowns

### DIFF
--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -755,7 +755,10 @@ class ModuleForm(ModuleCommonForm, NetBoxModelForm):
         queryset=ModuleBay.objects.all(),
         query_params={
             'device_id': '$device'
-        }
+        },
+        context={
+            'disabled': 'installed_module',
+        },
     )
     module_type = DynamicModelChoiceField(
         label=_('Module type'),


### PR DESCRIPTION
### Fixes: #19751

Implements the occupied‑bay UI behavior without adding a private `_occupied` field to the API.

Update the `module_bay` form field to use context with `disabled_indicator: 'installed_module'` so occupied bays are disabled in dropdowns

**Notes**
- Backward compatible; no database or migration changes
- Keeps the REST surface clean while providing the needed UI parity
