### PR TITLE
Fixes #20587: Handle stale ContentTypes in has_feature()

### DIFF
--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -676,6 +676,8 @@ def has_feature(model_or_ct, feature):
     # If a ContentType was passed, resolve its model class and run the associated feature test
     elif type(model_or_ct) is ContentType:
         model = model_or_ct.model_class()
+        if model is None:  # Stale content type
+            return False
         try:
             test_func = registry['model_features'][feature]
         except KeyError:


### PR DESCRIPTION
### Fixes: #20587 

Fixes #20587 (and its duplicate #20588) by adding a null check when handling stale `ContentType`s in `has_feature()`.

When running `remove_stale_contenttypes` (executed by `upgrade.sh`), the management command fails with `TypeError: issubclass() arg 1 must be a class`. This occurs when deleting ContentTypes that no longer have corresponding model classes—referred to as "stale" ContentTypes. These arise when models are renamed/removed between versions or when plugins are uninstalled.

The error path:
1. Django's `pre_delete` signal fires when deleting the stale ContentType
2. `notify_object_changed()` signal handler calls `has_feature(instance, 'notifications')`
3. `has_feature()` calls `model_class()` on the ContentType, which returns `None` for stale types
4. This `None` gets passed directly to the feature test lambda: `issubclass(None, NotificationsMixin)` → TypeError

Root Cause:

Commit 5ceb6a6 (which fixed #20290) changed the ContentType code path in `has_feature()` to use direct feature registry lookups in addition to ObjectType lookups. However, this refactoring inadvertently removed the null safety check that existed in the previous implementation.

https://gist.github.com/jnovinger/35948fc653c0425a5f9b207f9b77883f is available as a reproduction script to verify this fix.