### PR TITLE
DRAFT: 14884 Make script running from UI and EventRules consistent in passing params

### DIFF
--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -143,6 +143,11 @@ def process_event_rules(event_rules, object_type, event_type, data, username=Non
                     form.cleaned_data.pop('_commit')
                     event_data.update(form.cleaned_data)
                 else:
+                    logger.error(
+                        _("Processing event rule {event_rule} failed - Cannot validate script form: {errors}").format(
+                            event_rule=event_rule, errors=form.errors
+                        )
+                    )
                     continue
 
             # Enqueue a Job to record the script's execution


### PR DESCRIPTION
### Fixes: #14884 

This makes parameter passing consistent between running a script from the UI and running one from an EventRule.   To see add the following script:

```python
from extras.scripts import Script, ObjectVar
from ipam.models import IPAddress

class BranchTesting(Script):

    ip_address = ObjectVar(
        model=IPAddress,
        description='IP Address to test',
        required=True,
    )

    def run(self, data, commit):
        return f"data is {data}"
```

Run it in the UI, select an IP Address and then inspect the job data and you should see

```
{
    "log": [],
    "output": "data is {'ip_address': <IPAddress: 172.16.0.1/24>}",
    "tests": {}
}
```

Now set up an Event Rule:
    **Object types:** DCIM > Site
    **Event types:** Object created, Object updated
    **Action type:** Script
    **Script:** <script file from above>
    **Action data:** {"ip_address": 3}

(Modify `ip_address` to one in your data). Then go and modify a site and check the output from the new job data and you should see something like:

```
{
    "log": [],
    "output": "data is {'ip_address': <IPAddress: 172.16.0.1/24>, 'id': 24, 'url': '/api/dcim/sites/24/', 'display_url': '/dcim/sites/24/', 'display': 'Butler Communications', 'name': 'Butler Communications', 'slug': 'ncsu-128', 'status': {'value': 'active', 'label': 'Active'}, 'region': {'id': 40, 'url': '/api/dcim/regions/40/', 'display': 'North Carolina', 'name': 'North Carolina', 'slug': 'us-nc', 'description': '', 'site_count': 0, '_depth': 2}, 'group': None, 'tenant': {'id': 13, 'url': '/api/tenancy/tenants/13/', 'display': 'NC State University', 'name': 'NC State University', 'slug': 'nc-state', 'description': ''}, 'facility': 'BUT', 'time_zone': None, 'description': 'asdf', 'physical_address': '3210 Faucette Dr., Raleigh, NC 27607', 'shipping_address': '', 'latitude': None, 'longitude': None, 'comments': '', 'asns': [], 'tags': [{'id': 7, 'url': '/api/extras/tags/7/', 'display_url': '/extras/tags/7/', 'display': 'Golf', 'name': 'Golf', 'slug': 'golf', 'color': '673ab7'}, {'id': 12, 'url': '/api/extras/tags/12/', 'display_url': '/extras/tags/12/', 'display': 'Lima', 'name': 'Lima', 'slug': 'lima', 'color': '009688'}, {'id': 24, 'url': '/api/extras/tags/24/', 'display_url': '/extras/tags/24/', 'display': 'X-ray', 'name': 'X-ray', 'slug': 'x-ray', 'color': '9e9e9e'}], 'custom_fields': {}, 'created': '2021-04-02T00:00:00Z', 'last_updated': '2025-10-15T21:17:43.035621Z'}",
    "tests": {}
}
```

The only part of this second data to check in the `ip_address` as the rest of the data is the Site that triggered the EventRule. Previously `ip_address` would show `3` (whatever was in action_data), now it de-references it to the correct object just like running it from the UI does.

Note: Moved this to v4.5 milestone as this will be a breaking change from older scripts being run via EventRules.
