### PR TITLE
Fixes #20610: Correct VLAN ID range calculation logic

### DIFF
--- a/netbox/ipam/migrations/0083_vlangroup_populate_total_vlan_ids.py
+++ b/netbox/ipam/migrations/0083_vlangroup_populate_total_vlan_ids.py
@@ -1,0 +1,27 @@
+from django.db import migrations
+
+
+def populate_vlangroup_total_vlan_ids(apps, schema_editor):
+    VLANGroup = apps.get_model('ipam', 'VLANGroup')
+    db_alias = schema_editor.connection.alias
+
+    vlan_groups = VLANGroup.objects.using(db_alias).only('id', 'vid_ranges')
+    for group in vlan_groups:
+        total_vlan_ids = 0
+        if group.vid_ranges:
+            for r in group.vid_ranges:
+                # Half-open [lo, hi): length is (hi - lo).
+                if r is not None and r.lower is not None and r.upper is not None:
+                    total_vlan_ids += r.upper - r.lower
+        group._total_vlan_ids = total_vlan_ids
+    VLANGroup.objects.using(db_alias).bulk_update(vlan_groups, ['_total_vlan_ids'], batch_size=100)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('ipam', '0082_add_prefix_network_containment_indexes'),
+    ]
+
+    operations = [
+        migrations.RunPython(populate_vlangroup_total_vlan_ids, migrations.RunPython.noop),
+    ]

--- a/netbox/ipam/models/vlans.py
+++ b/netbox/ipam/models/vlans.py
@@ -132,7 +132,8 @@ class VLANGroup(OrganizationalModel):
     def save(self, *args, **kwargs):
         self._total_vlan_ids = 0
         for vid_range in self.vid_ranges:
-            self._total_vlan_ids += vid_range.upper - vid_range.lower + 1
+            # VID range is inclusive on lower-bound, exclusive on upper-bound
+            self._total_vlan_ids += vid_range.upper - vid_range.lower
 
         super().save(*args, **kwargs)
 

--- a/netbox/ipam/tests/test_models.py
+++ b/netbox/ipam/tests/test_models.py
@@ -661,6 +661,10 @@ class TestVLANGroup(TestCase):
         vlangroup.full_clean()
         vlangroup.save()
 
+    def test_total_vlan_ids(self):
+        vlangroup = VLANGroup.objects.first()
+        self.assertEqual(vlangroup._total_vlan_ids, 100)
+
 
 class TestVLAN(TestCase):
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20610

<!--
    Please include a summary of the proposed changes below.
-->
Correct an off‑by‑one in `VLANGroup._total_vlan_ids` by computing lengths with half‑open `[lo, hi)` semantics during `save()`. Removes the `+1`, adds a test and includes a data migration to backfill existing `_total_vlan_ids`.

No schema changes.
