### PR TITLE
Closes #20399: Add `assigned` and `primary` filters for MACAddress

### DIFF
--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -14,16 +14,16 @@ from netbox.filtersets import (
     AttributeFiltersMixin, BaseFilterSet, ChangeLoggedModelFilterSet, NestedGroupModelFilterSet, NetBoxModelFilterSet,
     OrganizationalModelFilterSet,
 )
-from tenancy.filtersets import TenancyFilterSet, ContactModelFilterSet
+from tenancy.filtersets import ContactModelFilterSet, TenancyFilterSet
 from tenancy.models import *
 from users.models import User
 from utilities.filters import (
     ContentTypeFilter, MultiValueCharFilter, MultiValueMACAddressFilter, MultiValueNumberFilter, MultiValueWWNFilter,
     NumericArrayFilter, TreeNodeMultipleChoiceFilter,
 )
-from virtualization.models import Cluster, ClusterGroup, VMInterface, VirtualMachine
+from virtualization.models import Cluster, ClusterGroup, VirtualMachine, VMInterface
 from vpn.models import L2VPN
-from wireless.choices import WirelessRoleChoices, WirelessChannelChoices
+from wireless.choices import WirelessChannelChoices, WirelessRoleChoices
 from wireless.models import WirelessLAN, WirelessLink
 from .choices import *
 from .constants import *
@@ -1807,6 +1807,14 @@ class MACAddressFilterSet(NetBoxModelFilterSet):
         queryset=VMInterface.objects.all(),
         label=_('VM interface (ID)'),
     )
+    assigned = django_filters.BooleanFilter(
+        method='filter_assigned',
+        label=_('Is assigned'),
+    )
+    primary = django_filters.BooleanFilter(
+        method='filter_primary',
+        label=_('Is primary'),
+    )
 
     class Meta:
         model = MACAddress
@@ -1842,6 +1850,29 @@ class MACAddressFilterSet(NetBoxModelFilterSet):
         return queryset.filter(
             vminterface__in=interface_ids
         )
+
+    def filter_assigned(self, queryset, name, value):
+        params = {
+            'assigned_object_type__isnull': True,
+            'assigned_object_id__isnull': True,
+        }
+        if value:
+            return queryset.exclude(**params)
+        else:
+            return queryset.filter(**params)
+
+    def filter_primary(self, queryset, name, value):
+        interface_mac_ids = Interface.objects.filter(primary_mac_address_id__isnull=False).values_list(
+            'primary_mac_address_id', flat=True
+        )
+        vminterface_mac_ids = VMInterface.objects.filter(primary_mac_address_id__isnull=False).values_list(
+            'primary_mac_address_id', flat=True
+        )
+        query = Q(pk__in=interface_mac_ids) | Q(pk__in=vminterface_mac_ids)
+        if value:
+            return queryset.filter(query)
+        else:
+            return queryset.exclude(query)
 
 
 class CommonInterfaceFilterSet(django_filters.FilterSet):

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -1676,12 +1676,16 @@ class MACAddressFilterForm(NetBoxModelFilterSetForm):
     model = MACAddress
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('mac_address', 'device_id', 'virtual_machine_id', name=_('MAC address')),
+        FieldSet('mac_address', name=_('Attributes')),
+        FieldSet(
+            'device_id', 'virtual_machine_id', 'assigned', 'primary',
+            name=_('Assignments'),
+        ),
     )
     selector_fields = ('filter_id', 'q', 'device_id', 'virtual_machine_id')
     mac_address = forms.CharField(
         required=False,
-        label=_('MAC address')
+        label=_('MAC address'),
     )
     device_id = DynamicModelMultipleChoiceField(
         queryset=Device.objects.all(),
@@ -1692,6 +1696,20 @@ class MACAddressFilterForm(NetBoxModelFilterSetForm):
         queryset=VirtualMachine.objects.all(),
         required=False,
         label=_('Assigned VM'),
+    )
+    assigned = forms.NullBooleanField(
+        required=False,
+        label=_('Assigned to an interface'),
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        ),
+    )
+    primary = forms.NullBooleanField(
+        required=False,
+        label=_('Primary MAC of an interface'),
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        ),
     )
     tag = TagFilterField(model)
 

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -1174,6 +1174,9 @@ class MACAddressTable(NetBoxTable):
         orderable=False,
         verbose_name=_('Parent')
     )
+    is_primary = columns.BooleanColumn(
+        verbose_name=_('Primary')
+    )
     tags = columns.TagColumn(
         url_name='dcim:macaddress_list'
     )
@@ -1184,7 +1187,7 @@ class MACAddressTable(NetBoxTable):
     class Meta(DeviceComponentTable.Meta):
         model = models.MACAddress
         fields = (
-            'pk', 'id', 'mac_address', 'assigned_object_parent', 'assigned_object', 'description', 'comments', 'tags',
-            'created', 'last_updated',
+            'pk', 'id', 'mac_address', 'assigned_object_parent', 'assigned_object', 'description', 'is_primary',
+            'comments', 'tags', 'created', 'last_updated',
         )
         default_columns = ('pk', 'mac_address', 'assigned_object_parent', 'assigned_object', 'description')


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20399

<!--
    Please include a summary of the proposed changes below.
-->
This PR introduces two boolean filters on `MACAddress` — **`assigned`** and **`primary`** — to improve filtering capabilities across the UI, REST, and GraphQL. It also adds an `is_primary` as a boolean column on the MAC Address table for quick visual scanning.


### Summary of Changes
- **FilterSet (REST/UI):**
  - Add `assigned` (true ⇒ MACs bound to any `Interface`/`VMInterface`; false ⇒ unassigned).
  - Add `primary` (true ⇒ MACs set as the *primary* MAC on any `Interface`/`VMInterface`; false ⇒ all others).
- **GraphQL:**
  - Wire the above filters into the GraphQL filter class to maintain parity with REST/UI.
- **UI / Tables:**
  - Add `is_primary` as a boolean column on the MAC Address table.
- **Forms:**
  - Expose the new boolean filters in the MAC Address filter form.
- **Tests:**
  - Unit tests for both `assigned` and `primary` filters (true/false cases).

### API Examples

**REST**
```text
GET /api/dcim/mac-addresses/?assigned=true
GET /api/dcim/mac-addresses/?primary=false
```

**GraphQL**
```graphql
query {
  mac_address_list(filters: { assigned: true, primary: true }) {
    id
    mac_address
  }
}
```

### Backward Compatibility
- Additive change only; no existing behavior is altered.
- No database migrations.

### Implementation Notes
- The table’s `is_primary` column is backed by a cached property to avoid repeated lookups while browsing tables.

---

### Naming Notes
These filters are currently named `assigned` and `primary` to match existing boolean filter conventions. If the project prefers `is_assigned` / `is_primary`, I’m happy to adjust.

Happy to take any naming or scope adjustments the maintainers prefer. Thanks for the review!
