### PR TITLE
Fixes #20422: Allow Aggregate and Prefix to filter by family in GraphQL

### DIFF
--- a/netbox/ipam/graphql/filters.py
+++ b/netbox/ipam/graphql/filters.py
@@ -101,6 +101,13 @@ class AggregateFilter(ContactFilterMixin, TenancyFilterMixin, PrimaryModelFilter
             q |= Q(**{f"{prefix}prefix__net_contains": query})
         return q
 
+    def family(
+        self,
+        value: Annotated['IPAddressFamilyEnum', strawberry.lazy('ipam.graphql.enums')],
+        prefix,
+    ) -> Q:
+        return Q(**{f"{prefix}prefix__family": value.value})
+
 
 @strawberry_django.filter_type(models.FHRPGroup, lookups=True)
 class FHRPGroupFilter(PrimaryModelFilterMixin):
@@ -291,6 +298,14 @@ class PrefixFilter(ContactFilterMixin, ScopedFilterMixin, TenancyFilterMixin, Pr
                 continue
             q |= Q(**{f"{prefix}prefix__net_contains": query})
         return q
+
+    @strawberry_django.filter_field()
+    def family(
+        self,
+        value: Annotated['IPAddressFamilyEnum', strawberry.lazy('ipam.graphql.enums')],
+        prefix,
+    ) -> Q:
+        return Q(**{f"{prefix}prefix__family": value.value})
 
 
 @strawberry_django.filter_type(models.RIR, lookups=True)

--- a/netbox/ipam/graphql/filters.py
+++ b/netbox/ipam/graphql/filters.py
@@ -101,6 +101,7 @@ class AggregateFilter(ContactFilterMixin, TenancyFilterMixin, PrimaryModelFilter
             q |= Q(**{f"{prefix}prefix__net_contains": query})
         return q
 
+    @strawberry_django.filter_field()
     def family(
         self,
         value: Annotated['IPAddressFamilyEnum', strawberry.lazy('ipam.graphql.enums')],


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20422

This allows `AggregateFilter` and `PrefixFilter` to filter by their family similar with `IPAddressFilter`.
I've tested the following queries manually:

```graphql
aggregate_v6: aggregate_list(filters: {family: FAMILY_6}) {
    prefix
}
prefixes_v4: prefix_list(filters: {family: FAMILY_4}) {
    prefix
    role {
      name
    }
    vrf {
      name
    }
    vlan {
      vid
    }
}
```