### PR TITLE
Closes #20608: Update User Menu icon class names for consistency

### DIFF
--- a/netbox/templates/inc/user_menu.html
+++ b/netbox/templates/inc/user_menu.html
@@ -37,23 +37,23 @@
     </a>
     <div class="dropdown-menu dropdown-menu-end dropdown-menu-arrow" {% htmx_boost %}>
       <a href="{% url 'account:profile' %}" class="dropdown-item">
-        <i class="mdi mdi-account"></i> {% trans "Profile" %}
+        <i class="dropdown-item-icon mdi mdi-account"></i> {% trans "Profile" %}
       </a>
       <a href="{% url 'account:bookmarks' %}" class="dropdown-item">
-        <i class="mdi mdi-bookmark"></i> {% trans "Bookmarks" %}
+        <i class="dropdown-item-icon mdi mdi-bookmark"></i> {% trans "Bookmarks" %}
       </a>
       <a href="{% url 'account:subscriptions' %}" class="dropdown-item">
-        <i class="mdi mdi-bell"></i> {% trans "Subscriptions" %}
+        <i class="dropdown-item-icon mdi mdi-bell"></i> {% trans "Subscriptions" %}
       </a>
       <a href="{% url 'account:preferences' %}" class="dropdown-item">
-        <i class="mdi mdi-wrench"></i> {% trans "Preferences" %}
+        <i class="dropdown-item-icon mdi mdi-wrench"></i> {% trans "Preferences" %}
       </a>
       <a href="{% url 'account:usertoken_list' %}" class="dropdown-item">
-        <i class="mdi mdi-key"></i> {% trans "API Tokens" %}
+        <i class="dropdown-item-icon mdi mdi-key"></i> {% trans "API Tokens" %}
       </a>
       <hr class="dropdown-divider" />
       <a href="{% url 'logout' %}" hx-disable="true" class="dropdown-item">
-        <i class="mdi mdi-logout-variant"></i> {% trans "Log Out" %}
+        <i class="dropdown-item-icon mdi mdi-logout-variant"></i> {% trans "Log Out" %}
       </a>
     </div>
   </div>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20608

<!--
    Please include a summary of the proposed changes below.
-->
Switch icons in the top-right User dropdown to Tabler’s `dropdown-item-icon` to standardize spacing between the icon and label. Improves readability and ensures alignment with the overall UI styling.

*Before*
<img width="178" height="235" alt="Image" src="https://github.com/user-attachments/assets/6e357260-c4d4-452e-b8a0-6e596756e767" />

*After*
<img width="178" height="235" alt="Image" src="https://github.com/user-attachments/assets/7625f8cc-a1c6-40c0-b45c-d3d5fa94a46e" />
