### PR TITLE
Fixes #20637: Omit inventory item serials from device search filter to improve performance

### DIFF
--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -1288,7 +1288,6 @@ class DeviceFilterSet(
             Q(name__icontains=value) |
             Q(virtual_chassis__name__icontains=value) |
             Q(serial__icontains=value.strip()) |
-            Q(inventoryitems__serial__icontains=value.strip()) |
             Q(asset_tag__icontains=value.strip()) |
             Q(description__icontains=value.strip()) |
             Q(comments__icontains=value) |


### PR DESCRIPTION
### Fixes: #20637

Avoid the very expensive many-to-many lookup matching on InventoryItem serial values. This causes an excessive delay when many inventory items have been populated in NetBox (regardless of whether they match the query).