### PR TITLE
Fixes #20653: Add `object_type_id` filter for Jobs

### DIFF
--- a/netbox/core/api/serializers_/jobs.py
+++ b/netbox/core/api/serializers_/jobs.py
@@ -1,8 +1,13 @@
+from drf_spectacular.utils import extend_schema_field
+from rest_framework import serializers
+
 from core.choices import *
 from core.models import Job
+from netbox.api.exceptions import SerializerNotFound
 from netbox.api.fields import ChoiceField, ContentTypeField
 from netbox.api.serializers import BaseModelSerializer
 from users.api.serializers_.users import UserSerializer
+from utilities.api import get_serializer_for_model
 
 __all__ = (
     'JobSerializer',
@@ -18,11 +23,28 @@ class JobSerializer(BaseModelSerializer):
     object_type = ContentTypeField(
         read_only=True
     )
+    object = serializers.SerializerMethodField(
+        read_only=True
+    )
 
     class Meta:
         model = Job
         fields = [
-            'id', 'url', 'display_url', 'display', 'object_type', 'object_id', 'name', 'status', 'created', 'scheduled',
-            'interval', 'started', 'completed', 'user', 'data', 'error', 'job_id', 'log_entries',
+            'id', 'url', 'display_url', 'display', 'object_type', 'object_id', 'object', 'name', 'status', 'created',
+            'scheduled', 'interval', 'started', 'completed', 'user', 'data', 'error', 'job_id', 'log_entries',
         ]
         brief_fields = ('url', 'created', 'completed', 'user', 'status')
+
+    @extend_schema_field(serializers.JSONField(allow_null=True))
+    def get_object(self, obj):
+        """
+        Serialize a nested representation of the object.
+        """
+        if obj.object is None:
+            return None
+        try:
+            serializer = get_serializer_for_model(obj.object)
+        except SerializerNotFound:
+            return obj.object_repr
+        context = {'request': self.context['request']}
+        return serializer(obj.object, nested=True, context=context).data

--- a/netbox/core/filtersets.py
+++ b/netbox/core/filtersets.py
@@ -80,6 +80,10 @@ class JobFilterSet(BaseFilterSet):
         method='search',
         label=_('Search'),
     )
+    object_type_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=ObjectType.objects.with_feature('jobs'),
+        field_name='object_type_id',
+    )
     object_type = ContentTypeFilter()
     created = django_filters.DateTimeFilter()
     created__before = django_filters.DateTimeFilter(
@@ -124,7 +128,7 @@ class JobFilterSet(BaseFilterSet):
 
     class Meta:
         model = Job
-        fields = ('id', 'object_type', 'object_id', 'name', 'interval', 'status', 'user', 'job_id')
+        fields = ('id', 'object_type', 'object_type_id', 'object_id', 'name', 'interval', 'status', 'user', 'job_id')
 
     def search(self, queryset, name, value):
         if not value.strip():

--- a/netbox/core/forms/filtersets.py
+++ b/netbox/core/forms/filtersets.py
@@ -70,13 +70,13 @@ class JobFilterForm(SavedFiltersMixin, FilterForm):
     model = Job
     fieldsets = (
         FieldSet('q', 'filter_id'),
-        FieldSet('object_type', 'status', name=_('Attributes')),
+        FieldSet('object_type_id', 'status', name=_('Attributes')),
         FieldSet(
             'created__before', 'created__after', 'scheduled__before', 'scheduled__after', 'started__before',
             'started__after', 'completed__before', 'completed__after', 'user', name=_('Creation')
         ),
     )
-    object_type = ContentTypeChoiceField(
+    object_type_id = ContentTypeChoiceField(
         label=_('Object Type'),
         queryset=ObjectType.objects.with_feature('jobs'),
         required=False,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20653

<!--
    Please include a summary of the proposed changes below.
-->

#### Summary
Fix Jobs list returning empty results when filtering by **Object Type** by introducing a proper `object_type_id` filter and exposing it in the Jobs filter form/fieldsets.

#### Changes
- Add `object_type_id` to the Jobs FilterSet.
- Update the Jobs filter form and fieldsets to include it.
- No model/schema changes or migrations.
