### PR TITLE
Fixes #20655: Disable sorting on Permission columns

### DIFF
--- a/netbox/users/tables.py
+++ b/netbox/users/tables.py
@@ -84,15 +84,19 @@ class ObjectPermissionTable(NetBoxTable):
     )
     can_view = columns.BooleanColumn(
         verbose_name=_('Can View'),
+        orderable=False,
     )
     can_add = columns.BooleanColumn(
         verbose_name=_('Can Add'),
+        orderable=False,
     )
     can_change = columns.BooleanColumn(
         verbose_name=_('Can Change'),
+        orderable=False,
     )
     can_delete = columns.BooleanColumn(
         verbose_name=_('Can Delete'),
+        orderable=False,
     )
     custom_actions = columns.ArrayColumn(
         verbose_name=_('Custom Actions'),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20655

<!--
    Please include a summary of the proposed changes below.
-->
Mark `can_view`, `can_add`, `can_change`, and `can_delete` columns in the Permissions list as `orderable=False`. Sorting by these computed flags persisted an invalid sort key which triggers a `FieldError` when loading `/users/permissions/`.