### PR TITLE
Fixes #20646: Prevent cables from connecting to `marked_connected` objects

### DIFF
--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -967,6 +967,18 @@ class CableTestCase(TestCase):
         with self.assertRaises(ValidationError):
             cable.clean()
 
+    def test_cannot_cable_to_mark_connected(self):
+        """
+        Test that a cable cannot be connected to an interface marked as connected.
+        """
+        device1 = Device.objects.get(name='TestDevice1')
+        interface1 = Interface.objects.get(device__name='TestDevice2', name='eth1')
+
+        mark_connected_interface = Interface(device=device1, name='mark_connected1', mark_connected=True)
+        cable = Cable(a_terminations=[mark_connected_interface], b_terminations=[interface1])
+        with self.assertRaises(ValidationError):
+            cable.clean()
+
 
 class VirtualDeviceContextTestCase(TestCase):
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20646

<!--
    Please include a summary of the proposed changes below.
-->
Restricts creating cable terminations for endpoints flagged as **"mark connected"** to avoid the invalid state of being both virtually connected and physically cabled. The validation is implemented in `dcim.CableTermination.clean()`, ensuring consistent behavior across the UI, REST API, and CSV import. Includes a test covering the rejection case.


#### Summary of Changes
- Add a guard in `CableTermination.clean()` to raise `ValidationError` when `termination.mark_connected == True`.
- Keep the check generic so it applies to any cabled model exposing `mark_connected` (e.g., interfaces, power/power-feed ports, front/rear ports, circuit terminations).
- Add test exercising:
  - rejection when the endpoint is `mark_connected`
