### PR TITLE
Closes #20675: Enable NetBox Copilot integration

### DIFF
--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -53,6 +53,16 @@ Sets content for the top banner in the user interface.
 
 ---
 
+## COPILOT_ENABLED
+
+!!! tip "Dynamic Configuration Parameter"
+
+Default: `True`
+
+Enables or disables the [NetBox Copilot](https://netboxlabs.com/docs/copilot/) agent globally. When enabled, users can opt to toggle the agent individually.
+
+---
+
 ## CENSUS_REPORTING_ENABLED
 
 Default: `True`

--- a/docs/development/user-preferences.md
+++ b/docs/development/user-preferences.md
@@ -6,10 +6,14 @@ For end‑user guidance on resetting saved table layouts, see [Features > User P
 
 ## Available Preferences
 
-| Name                     | Description                                                   |
-|--------------------------|---------------------------------------------------------------|
-| data_format              | Preferred format when rendering raw data (JSON or YAML)       |
-| pagination.per_page      | The number of items to display per page of a paginated table  |
-| pagination.placement     | Where to display the paginator controls relative to the table |
-| tables.${table}.columns  | The ordered list of columns to display when viewing the table |
-| tables.${table}.ordering | A list of column names by which the table should be ordered   |
+| Name                       | Description                                                   |
+|----------------------------|---------------------------------------------------------------|
+| `csv_delimiter`            | The delimiting character used when exporting CSV data         |
+| `data_format`              | Preferred format when rendering raw data (JSON or YAML)       |
+| `locale.language`          | The language selected for UI translation                      |
+| `pagination.per_page`      | The number of items to display per page of a paginated table  |
+| `pagination.placement`     | Where to display the paginator controls relative to the table |
+| `tables.${table}.columns`  | The ordered list of columns to display when viewing the table |
+| `tables.${table}.ordering` | A list of column names by which the table should be ordered   |
+| `ui.copilot_enabled`       | Toggles the NetBox Copilot AI agent                           |
+| `ui.tables.striping`       | Toggles visual striping of tables in the UI                   |

--- a/netbox/core/forms/model_forms.py
+++ b/netbox/core/forms/model_forms.py
@@ -166,8 +166,8 @@ class ConfigRevisionForm(forms.ModelForm, metaclass=ConfigFormMetaclass):
         FieldSet('CUSTOM_VALIDATORS', 'PROTECTION_RULES', name=_('Validation')),
         FieldSet('DEFAULT_USER_PREFERENCES', name=_('User Preferences')),
         FieldSet(
-            'MAINTENANCE_MODE', 'GRAPHQL_ENABLED', 'CHANGELOG_RETENTION', 'JOB_RETENTION', 'MAPS_URL',
-            name=_('Miscellaneous')
+            'MAINTENANCE_MODE', 'COPILOT_ENABLED', 'GRAPHQL_ENABLED', 'CHANGELOG_RETENTION', 'JOB_RETENTION',
+            'MAPS_URL', name=_('Miscellaneous'),
         ),
         FieldSet('comment', name=_('Config Revision'))
     )

--- a/netbox/netbox/config/parameters.py
+++ b/netbox/netbox/config/parameters.py
@@ -184,6 +184,15 @@ PARAMS = (
         field=forms.BooleanField
     ),
     ConfigParam(
+        name='COPILOT_ENABLED',
+        label=_('NetBox Copilot enabled'),
+        default=True,
+        description=_(
+            "Enable the NetBox Copilot AI agent globally. If enabled, users can toggle the agent individually."
+        ),
+        field=forms.BooleanField
+    ),
+    ConfigParam(
         name='GRAPHQL_ENABLED',
         label=_('GraphQL enabled'),
         default=True,

--- a/netbox/netbox/context_processors.py
+++ b/netbox/netbox/context_processors.py
@@ -25,10 +25,15 @@ def preferences(request):
     Adds preferences for the current user (if authenticated) to the template context.
     Example: {{ preferences|get_key:"pagination.placement" }}
     """
+    config = get_config()
     user_preferences = request.user.config if request.user.is_authenticated else {}
     return {
         'preferences': user_preferences,
-        'htmx_navigation': user_preferences.get('ui.htmx_navigation', False) == 'true'
+        'copilot_enabled': (
+            config.COPILOT_ENABLED and not django_settings.ISOLATED_DEPLOYMENT and
+            user_preferences.get('ui.copilot_enabled', False) == 'true'
+        ),
+        'htmx_navigation': user_preferences.get('ui.htmx_navigation', False) == 'true',
     }
 
 

--- a/netbox/netbox/preferences.py
+++ b/netbox/netbox/preferences.py
@@ -49,6 +49,15 @@ PREFERENCES = {
             else ''
         )
     ),
+    'ui.copilot_enabled': UserPreference(
+        label=_('NetBox Copilot'),
+        choices=(
+            ('', _('Disabled')),
+            ('true', _('Enabled')),
+        ),
+        description=_('Enable the NetBox Copilot AI agent'),
+        default=False,
+    ),
     'pagination.per_page': UserPreference(
         label=_('Page length'),
         choices=get_page_lengths(),

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -654,6 +654,13 @@ CENSUS_URL = 'https://census.netbox.oss.netboxlabs.com/api/v1/'
 
 
 #
+# NetBox Copilot
+#
+
+NETBOX_COPILOT_URL = 'https://static.copilot.netboxlabs.ai/load.js'
+
+
+#
 # Django social auth
 #
 

--- a/netbox/templates/base/base.html
+++ b/netbox/templates/base/base.html
@@ -69,6 +69,9 @@
     {% block layout %}{% endblock %}
 
     {# Additional Javascript #}
+    {% if copilot_enabled and request.user.is_authenticated %}
+      <script src="{{ settings.NETBOX_COPILOT_URL }}" defer></script>
+    {% endif %}
     {% block javascript %}{% endblock %}
 
     {# User messages #}

--- a/netbox/templates/core/inc/config_data.html
+++ b/netbox/templates/core/inc/config_data.html
@@ -130,6 +130,10 @@
     <td>{% checkmark config.MAINTENANCE_MODE %}</td>
   </tr>
   <tr>
+    <th scope="row" class="ps-3">{% trans "NetBox Copilot enabled" %}</th>
+    <td>{% checkmark config.COPILOT_ENABLED %}</td>
+  </tr>
+  <tr>
     <th scope="row" class="ps-3">{% trans "GraphQL enabled" %}</th>
     <td>{% checkmark config.GRAPHQL_ENABLED %}</td>
   </tr>


### PR DESCRIPTION
### Closes: #20675

- Introduce the `NETBOX_COPILOT_URL` setting
- Introduce the `COPILOT_ENABLED` dynamic configuration parameter to toggle Copilot globally
- Introduce the `ui.copilot_enabled` user preference to allow users to opt-in to the agent individually
- Add `copilot_enabled` as a template context variable
- Load the external Copilot agent when enabled