### PR TITLE
20683 - Remove circuit termination swap

### DIFF
--- a/netbox/circuits/urls.py
+++ b/netbox/circuits/urls.py
@@ -18,11 +18,6 @@ urlpatterns = [
     path('circuit-types/<int:pk>/', include(get_model_urls('circuits', 'circuittype'))),
 
     path('circuits/', include(get_model_urls('circuits', 'circuit', detail=False))),
-    path(
-        'circuits/<int:pk>/terminations/swap/',
-        views.CircuitSwapTerminations.as_view(),
-        name='circuit_terminations_swap'
-    ),
     path('circuits/<int:pk>/', include(get_model_urls('circuits', 'circuit'))),
 
     path('circuit-terminations/', include(get_model_urls('circuits', 'circuittermination', detail=False))),

--- a/netbox/circuits/views.py
+++ b/netbox/circuits/views.py
@@ -1,13 +1,8 @@
-from django.contrib import messages
-from django.db import router, transaction
-from django.shortcuts import get_object_or_404, redirect, render
-from django.utils.translation import gettext_lazy as _
 
 from dcim.views import PathTraceView
 from ipam.models import ASN
 from netbox.object_actions import AddObject, BulkDelete, BulkEdit, BulkExport, BulkImport
 from netbox.views import generic
-from utilities.forms import ConfirmationForm
 from utilities.query import count_related
 from utilities.views import GetRelatedModelsMixin, register_model_view
 from . import filtersets, forms, tables
@@ -371,82 +366,6 @@ class CircuitBulkDeleteView(generic.BulkDeleteView):
     )
     filterset = filtersets.CircuitFilterSet
     table = tables.CircuitTable
-
-
-class CircuitSwapTerminations(generic.ObjectEditView):
-    """
-    Swap the A and Z terminations of a circuit.
-    """
-    queryset = Circuit.objects.all()
-
-    def get(self, request, pk):
-        circuit = get_object_or_404(self.queryset, pk=pk)
-        form = ConfirmationForm()
-
-        # Circuit must have at least one termination to swap
-        if not circuit.termination_a and not circuit.termination_z:
-            messages.error(request, _(
-                "No terminations have been defined for circuit {circuit}."
-            ).format(circuit=circuit))
-            return redirect('circuits:circuit', pk=circuit.pk)
-
-        return render(request, 'circuits/circuit_terminations_swap.html', {
-            'circuit': circuit,
-            'termination_a': circuit.termination_a,
-            'termination_z': circuit.termination_z,
-            'form': form,
-            'panel_class': 'light',
-            'button_class': 'primary',
-            'return_url': circuit.get_absolute_url(),
-        })
-
-    def post(self, request, pk):
-        circuit = get_object_or_404(self.queryset, pk=pk)
-        form = ConfirmationForm(request.POST)
-
-        if form.is_valid():
-
-            termination_a = CircuitTermination.objects.filter(pk=circuit.termination_a_id).first()
-            termination_z = CircuitTermination.objects.filter(pk=circuit.termination_z_id).first()
-
-            if termination_a and termination_z:
-                # Use a placeholder to avoid an IntegrityError on the (circuit, term_side) unique constraint
-                with transaction.atomic(using=router.db_for_write(CircuitTermination)):
-                    termination_a.term_side = '_'
-                    termination_a.save()
-                    termination_z.term_side = 'A'
-                    termination_z.save()
-                    termination_a.term_side = 'Z'
-                    termination_a.save()
-                    circuit.refresh_from_db()
-                    circuit.termination_a = termination_z
-                    circuit.termination_z = termination_a
-                    circuit.save()
-            elif termination_a:
-                termination_a.term_side = 'Z'
-                termination_a.save()
-                circuit.refresh_from_db()
-                circuit.termination_a = None
-                circuit.save()
-            else:
-                termination_z.term_side = 'A'
-                termination_z.save()
-                circuit.refresh_from_db()
-                circuit.termination_z = None
-                circuit.save()
-
-            messages.success(request, _("Swapped terminations for circuit {circuit}.").format(circuit=circuit))
-            return redirect('circuits:circuit', pk=circuit.pk)
-
-        return render(request, 'circuits/circuit_terminations_swap.html', {
-            'circuit': circuit,
-            'termination_a': circuit.termination_a,
-            'termination_z': circuit.termination_z,
-            'form': form,
-            'panel_class': 'default',
-            'button_class': 'primary',
-            'return_url': circuit.get_absolute_url(),
-        })
 
 
 #

--- a/netbox/templates/circuits/inc/circuit_termination.html
+++ b/netbox/templates/circuits/inc/circuit_termination.html
@@ -14,9 +14,6 @@
             <a href="{% url 'circuits:circuittermination_edit' pk=termination.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-ghost-warning">
                 <span class="mdi mdi-pencil" aria-hidden="true"></span> {% trans "Edit" %}
             </a>
-            <a href="{% url 'circuits:circuit_terminations_swap' pk=object.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-ghost-primary">
-                <span class="mdi mdi-swap-vertical" aria-hidden="true"></span> {% trans "Swap" %}
-            </a>
         {% endif %}
         {% if termination and perms.circuits.delete_circuittermination %}
             <a href="{% url 'circuits:circuittermination_delete' pk=termination.pk %}?return_url={{ object.get_absolute_url }}" class="btn btn-sm btn-ghost-danger">


### PR DESCRIPTION
### Fixes: #20683 

Removes the circuit swap button (see screenshot) and view code.  From branching issue [#282](https://github.com/netboxlabs/netbox-branching/issues/282) The object change record sequence is unique to the swap function causing issues and this is a niche function that can be duplicated just by manually swapping the terminations with edit.
<img width="1528" height="1039" alt="Monosnap Image 2025-10-24 14-48-32" src="https://github.com/user-attachments/assets/e5e9231e-4582-4447-8d07-4e9888c7b414" />
