### PR TITLE
Closes #20700: Add ContactsColumnMixin to multiple tables

### DIFF
--- a/netbox/ipam/tables/asn.py
+++ b/netbox/ipam/tables/asn.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 
 from ipam.models import *
 from netbox.tables import NetBoxTable, columns
-from tenancy.tables import TenancyColumnsMixin
+from tenancy.tables import ContactsColumnMixin, TenancyColumnsMixin
 
 __all__ = (
     'ASNTable',
@@ -36,7 +36,7 @@ class ASNRangeTable(TenancyColumnsMixin, NetBoxTable):
         default_columns = ('pk', 'name', 'rir', 'start', 'end', 'tenant', 'asn_count', 'description')
 
 
-class ASNTable(TenancyColumnsMixin, NetBoxTable):
+class ASNTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
     asn = tables.Column(
         verbose_name=_('ASN'),
         linkify=True
@@ -76,7 +76,7 @@ class ASNTable(TenancyColumnsMixin, NetBoxTable):
         model = ASN
         fields = (
             'pk', 'asn', 'asn_asdot', 'rir', 'site_count', 'provider_count', 'tenant', 'tenant_group', 'description',
-            'comments', 'sites', 'tags', 'created', 'last_updated', 'actions',
+            'contacts', 'comments', 'sites', 'tags', 'created', 'last_updated', 'actions',
         )
         default_columns = (
             'pk', 'asn', 'rir', 'site_count', 'provider_count', 'sites', 'description', 'tenant',

--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -1,6 +1,6 @@
-from django.utils.translation import gettext_lazy as _
 import django_tables2 as tables
 from django.utils.safestring import mark_safe
+from django.utils.translation import gettext_lazy as _
 from django_tables2.utils import Accessor
 
 from ipam.models import *
@@ -58,7 +58,7 @@ class RIRTable(NetBoxTable):
 # Aggregates
 #
 
-class AggregateTable(TenancyColumnsMixin, NetBoxTable):
+class AggregateTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
     prefix = tables.Column(
         linkify=True,
         verbose_name=_('Aggregate'),
@@ -93,7 +93,7 @@ class AggregateTable(TenancyColumnsMixin, NetBoxTable):
         model = Aggregate
         fields = (
             'pk', 'id', 'prefix', 'rir', 'tenant', 'tenant_group', 'child_count', 'utilization', 'date_added',
-            'description', 'comments', 'tags', 'created', 'last_updated',
+            'description', 'contacts', 'comments', 'tags', 'created', 'last_updated',
         )
         default_columns = ('pk', 'prefix', 'rir', 'tenant', 'child_count', 'utilization', 'date_added', 'description')
 
@@ -154,7 +154,7 @@ class PrefixUtilizationColumn(columns.UtilizationColumn):
     """
 
 
-class PrefixTable(TenancyColumnsMixin, NetBoxTable):
+class PrefixTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
     prefix = columns.TemplateColumn(
         verbose_name=_('Prefix'),
         template_code=PREFIX_LINK_WITH_DEPTH,
@@ -237,8 +237,8 @@ class PrefixTable(TenancyColumnsMixin, NetBoxTable):
         model = Prefix
         fields = (
             'pk', 'id', 'prefix', 'prefix_flat', 'status', 'children', 'vrf', 'utilization', 'tenant', 'tenant_group',
-            'scope', 'scope_type', 'vlan_group', 'vlan', 'role', 'is_pool', 'mark_utilized', 'description', 'comments',
-            'tags', 'created', 'last_updated',
+            'scope', 'scope_type', 'vlan_group', 'vlan', 'role', 'is_pool', 'mark_utilized', 'description', 'contacts',
+            'comments', 'tags', 'created', 'last_updated',
         )
         default_columns = (
             'pk', 'prefix', 'status', 'children', 'vrf', 'utilization', 'tenant', 'scope', 'vlan', 'role',
@@ -252,7 +252,7 @@ class PrefixTable(TenancyColumnsMixin, NetBoxTable):
 #
 # IP ranges
 #
-class IPRangeTable(TenancyColumnsMixin, NetBoxTable):
+class IPRangeTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
     start_address = tables.Column(
         verbose_name=_('Start address'),
         linkify=True
@@ -293,8 +293,8 @@ class IPRangeTable(TenancyColumnsMixin, NetBoxTable):
         model = IPRange
         fields = (
             'pk', 'id', 'start_address', 'end_address', 'size', 'vrf', 'status', 'role', 'tenant', 'tenant_group',
-            'mark_populated', 'mark_utilized', 'utilization', 'description', 'comments', 'tags', 'created',
-            'last_updated',
+            'mark_populated', 'mark_utilized', 'utilization', 'description', 'contacts', 'comments', 'tags',
+            'created', 'last_updated',
         )
         default_columns = (
             'pk', 'start_address', 'end_address', 'size', 'vrf', 'status', 'role', 'tenant', 'description',

--- a/netbox/vpn/tables/l2vpn.py
+++ b/netbox/vpn/tables/l2vpn.py
@@ -2,7 +2,7 @@ import django_tables2 as tables
 from django.utils.translation import gettext_lazy as _
 
 from netbox.tables import NetBoxTable, columns
-from tenancy.tables import TenancyColumnsMixin
+from tenancy.tables import ContactsColumnMixin, TenancyColumnsMixin
 from vpn.models import L2VPN, L2VPNTermination
 
 __all__ = (
@@ -17,7 +17,7 @@ L2VPN_TARGETS = """
 """
 
 
-class L2VPNTable(TenancyColumnsMixin, NetBoxTable):
+class L2VPNTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
     pk = columns.ToggleColumn()
     name = tables.Column(
         verbose_name=_('Name'),
@@ -47,7 +47,7 @@ class L2VPNTable(TenancyColumnsMixin, NetBoxTable):
         model = L2VPN
         fields = (
             'pk', 'name', 'slug', 'status', 'identifier', 'type', 'import_targets', 'export_targets', 'tenant',
-            'tenant_group', 'description', 'comments', 'tags', 'created', 'last_updated',
+            'tenant_group', 'description', 'contacts', 'comments', 'tags', 'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'status', 'identifier', 'type', 'description')
 

--- a/netbox/vpn/tables/tunnels.py
+++ b/netbox/vpn/tables/tunnels.py
@@ -3,7 +3,7 @@ from django.utils.translation import gettext_lazy as _
 from django_tables2.utils import Accessor
 
 from netbox.tables import NetBoxTable, columns
-from tenancy.tables import TenancyColumnsMixin
+from tenancy.tables import ContactsColumnMixin, TenancyColumnsMixin
 from vpn.models import *
 
 __all__ = (
@@ -13,7 +13,7 @@ __all__ = (
 )
 
 
-class TunnelGroupTable(NetBoxTable):
+class TunnelGroupTable(ContactsColumnMixin, NetBoxTable):
     name = tables.Column(
         verbose_name=_('Name'),
         linkify=True
@@ -30,12 +30,13 @@ class TunnelGroupTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = TunnelGroup
         fields = (
-            'pk', 'id', 'name', 'tunnel_count', 'description', 'slug', 'tags', 'actions', 'created', 'last_updated',
+            'pk', 'id', 'name', 'tunnel_count', 'description', 'slug', 'contacts', 'tags', 'actions',
+            'created', 'last_updated',
         )
         default_columns = ('pk', 'name', 'tunnel_count', 'description')
 
 
-class TunnelTable(TenancyColumnsMixin, NetBoxTable):
+class TunnelTable(TenancyColumnsMixin, ContactsColumnMixin, NetBoxTable):
     name = tables.Column(
         verbose_name=_('Name'),
         linkify=True
@@ -68,7 +69,8 @@ class TunnelTable(TenancyColumnsMixin, NetBoxTable):
         model = Tunnel
         fields = (
             'pk', 'id', 'name', 'group', 'status', 'encapsulation', 'ipsec_profile', 'tenant', 'tenant_group',
-            'tunnel_id', 'termination_count', 'description', 'comments', 'tags', 'created', 'last_updated',
+            'tunnel_id', 'termination_count', 'description', 'contacts', 'comments', 'tags', 'created',
+            'last_updated',
         )
         default_columns = ('pk', 'name', 'group', 'status', 'encapsulation', 'tenant', 'terminations_count')
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20700

<!--
    Please include a summary of the proposed changes below.
-->
Add the `contacts` column to remaining IPAM/VPN tables via `ContactsColumnMixin` (adds `"contacts"` to default columns).

**Updated tables**
- `netbox.ipam.models.asns.ASN`
- `netbox.ipam.models.ip.Aggregate`
- `netbox.ipam.models.ip.Prefix`
- `netbox.ipam.models.ip.IPRange`
- `netbox.ipam.models.ip.IPAddress`
- `netbox.vpn.models.tunnels.TunnelGroup`
- `netbox.vpn.models.tunnels.Tunnel`
- `netbox.vpn.models.l2vpn.L2VPN`

UI-only change; no database or dependency changes.
