### PR TITLE
Fixes #20713: Record pre-change snapshots on VC members being added/removed

### DIFF
--- a/netbox/dcim/forms/object_create.py
+++ b/netbox/dcim/forms/object_create.py
@@ -453,6 +453,7 @@ class VirtualChassisCreateForm(NetBoxModelForm):
         if instance.pk and self.cleaned_data['members']:
             initial_position = self.cleaned_data.get('initial_position', 1)
             for i, member in enumerate(self.cleaned_data['members'], start=initial_position):
+                member.snapshot()
                 member.virtual_chassis = instance
                 member.vc_position = i
                 member.save()


### PR DESCRIPTION
### Fixes: #20713

- Call `snapshot()` on member devices before assigning/removing the virtual chassis
- Also call `snapshot()` on the virtual chassis under VirtualChassisEditView
- Clean up excessive empty lines