### PR TITLE
docs(configuration): close Markdown inline code, "`" was forgotten

### DIFF
--- a/docs/configuration/security.md
+++ b/docs/configuration/security.md
@@ -92,7 +92,7 @@ If `True`, the cookie employed for cross-site request forgery (CSRF) protection 
 
 Default: `[]`
 
-Defines a list of trusted origins for unsafe (e.g. `POST`) requests. This is a pass-through to Django's [`CSRF_TRUSTED_ORIGINS`](https://docs.djangoproject.com/en/stable/ref/settings/#csrf-trusted-origins) setting. Note that each host listed must specify a scheme (e.g. `http://` or `https://).
+Defines a list of trusted origins for unsafe (e.g. `POST`) requests. This is a pass-through to Django's [`CSRF_TRUSTED_ORIGINS`](https://docs.djangoproject.com/en/stable/ref/settings/#csrf-trusted-origins) setting. Note that each host listed must specify a scheme (e.g. `http://` or `https://`).
 
 ```python
 CSRF_TRUSTED_ORIGINS = (


### PR DESCRIPTION
https://netboxlabs.com/docs/netbox/configuration/security/#csrf_trusted_origins

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20719

Replaces #20712 which was opened before I was assigned to an accepted issue.