### PR TITLE
20738 update vc_position in delete not signal handler

### DIFF
--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -1169,7 +1169,7 @@ class VirtualChassis(PrimaryModel):
 
         # Clear vc_position and vc_priority on member devices BEFORE calling super().delete()
         # This must be done here because on_delete=SET_NULL executes before pre_delete signal
-        for device in members_list:
+        for device in self.members.all():
             device.vc_position = None
             device.vc_priority = None
             device.save()

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -1,6 +1,6 @@
 import logging
 
-from django.db.models.signals import post_save, post_delete, pre_delete
+from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 
 from dcim.choices import CableEndChoices, LinkStatusChoices
@@ -83,18 +83,6 @@ def assign_virtualchassis_master(instance, created, **kwargs):
         master.virtual_chassis = instance
         master.vc_position = 1
         master.save()
-
-
-@receiver(pre_delete, sender=VirtualChassis)
-def clear_virtualchassis_members(instance, **kwargs):
-    """
-    When a VirtualChassis is deleted, nullify the vc_position and vc_priority fields of its prior members.
-    """
-    devices = Device.objects.filter(virtual_chassis=instance.pk)
-    for device in devices:
-        device.vc_position = None
-        device.vc_priority = None
-        device.save()
 
 
 #


### PR DESCRIPTION
### Fixes: #20738

vc_position and vc_priority were getting set to None when a virtual chassis was deleted, however the signal handler is getting run after the set_null is already getting run meaning no devices were found in the loop and so they were never getting cleared.  Moved this to this functionality to the delete method.