### PR TITLE
Closes #20297: add additional coaxial cable type choices

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1736,6 +1736,15 @@ class CableTypeChoices(ChoiceSet):
 
     # Copper - Coaxial
     TYPE_COAXIAL = 'coaxial'
+    TYPE_RG_6 = 'rg-6'
+    TYPE_RG_8 = 'rg-8'
+    TYPE_RG_11 = 'rg-11'
+    TYPE_RG_59 = 'rg-59'
+    TYPE_RG_62 = 'rg-62'
+    TYPE_RG_213 = 'rg-213'
+    TYPE_LMR_100 = 'lmr-100'
+    TYPE_LMR_200 = 'lmr-200'
+    TYPE_LMR_400 = 'lmr-400'
 
     # Fiber Optic - Multimode
     TYPE_MMF = 'mmf'
@@ -1785,6 +1794,15 @@ class CableTypeChoices(ChoiceSet):
             _('Copper - Coaxial'),
             (
                 (TYPE_COAXIAL, 'Coaxial'),
+                (TYPE_RG_6, 'RG-6'),
+                (TYPE_RG_8, 'RG-8'),
+                (TYPE_RG_11, 'RG-11'),
+                (TYPE_RG_59, 'RG-59'),
+                (TYPE_RG_62, 'RG-62'),
+                (TYPE_RG_213, 'RG-213'),
+                (TYPE_LMR_100, 'LMR-100'),
+                (TYPE_LMR_200, 'LMR-200'),
+                (TYPE_LMR_400, 'LMR-400'),
             ),
         ),
         (


### PR DESCRIPTION
### Fixes: #20297

Introduces several additional `Copper - Coaxial` cable types proposed in https://github.com/netbox-community/netbox/issues/20297. These are intended to be used where applicable, with the existing `Coaxial` type used in more general cases (similar to how mmf is implemented). 
