### PR TITLE
Fixes #20750: Normalize actions in cloned objects init

### DIFF
--- a/netbox/users/forms/model_forms.py
+++ b/netbox/users/forms/model_forms.py
@@ -372,6 +372,9 @@ class ObjectPermissionForm(forms.ModelForm):
         elif self.initial:
             # Handle cloned objects - actions come from initial data (URL parameters)
             if 'actions' in self.initial:
+                # Normalize actions to a list of strings
+                if isinstance(self.initial['actions'], str):
+                    self.initial['actions'] = [self.initial['actions']]
                 if cloned_actions := self.initial['actions']:
                     for action in ['view', 'add', 'change', 'delete']:
                         if action in cloned_actions:


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20750

<!--
    Please include a summary of the proposed changes below.
-->
Normalize `actions` to a list of strings when initializing cloned `ObjectPermission` forms.
Prevents `AttributeError` caused by single action values being passed as a string instead of a list.
