### PR TITLE
Fixes #20688: Change log level for missing config revision

### DIFF
--- a/netbox/netbox/config/__init__.py
+++ b/netbox/netbox/config/__init__.py
@@ -82,7 +82,7 @@ class Config:
             revision = ConfigRevision.objects.get(active=True)
             logger.debug(f"Loaded active configuration revision #{revision.pk}")
         except (ConfigRevision.DoesNotExist, ConfigRevision.MultipleObjectsReturned):
-            logger.warning("No active configuration revision found - falling back to most recent")
+            logger.debug("No active configuration revision found - falling back to most recent")
             revision = ConfigRevision.objects.order_by('-created').first()
             if revision is None:
                 logger.debug("No previous configuration found in database; proceeding with default values")


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20688

<!--
    Please include a summary of the proposed changes below.
-->
Update the log level from `warning` to `debug` when no active configuration revision is found. This prevents unnecessary warnings in normal operation scenarios, improving log clarity and relevance.
