### PR TITLE
Fixes #20755: Scope `ProviderFilterSet.search()` to Provider Fields

### DIFF
--- a/netbox/circuits/filtersets.py
+++ b/netbox/circuits/filtersets.py
@@ -89,8 +89,6 @@ class ProviderFilterSet(NetBoxModelFilterSet, ContactModelFilterSet):
         return queryset.filter(
             Q(name__icontains=value) |
             Q(description__icontains=value) |
-            Q(accounts__account__icontains=value) |
-            Q(accounts__name__icontains=value) |
             Q(comments__icontains=value)
         )
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20755

Stop traversing the related `ProviderAccount` in `ProviderFilterSet.search()`.  
Including related models in NetBox `search()` methods can cause duplicate results, unexpected matches, and unnecessary joins.
