### PR TITLE
#20378 fix delete of DataSource

### DIFF
--- a/netbox/core/models/files.py
+++ b/netbox/core/models/files.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.core.files.storage import storages
-from django.urls import reverse
 from django.utils.translation import gettext as _
 
 from ..choices import ManagedFileRootPathChoices
@@ -63,9 +62,6 @@ class ManagedFile(SyncedDataMixin, models.Model):
 
     def __str__(self):
         return self.name
-
-    def get_absolute_url(self):
-        return reverse('core:managedfile', args=[self.pk])
 
     @property
     def name(self):


### PR DESCRIPTION
### Fixes: #20378 

`core:managedfile` is not a valid url so this function is not getting hit regardless.  The error handler already handles objects without this method gracefully. and the correct error message is returned

<img width="741" height="822" alt="Monosnap ads | NetBox 2025-11-06 16-00-11" src="https://github.com/user-attachments/assets/e21850e6-7e08-4294-8dba-2e9bc598d5a2" />
