### PR TITLE
closes 20774: used gettext_lazy instead  gettext

### DIFF
--- a/netbox/core/object_actions.py
+++ b/netbox/core/object_actions.py
@@ -1,4 +1,4 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from netbox.object_actions import ObjectAction
 

--- a/netbox/dcim/object_actions.py
+++ b/netbox/dcim/object_actions.py
@@ -1,4 +1,4 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from netbox.object_actions import ObjectAction
 

--- a/netbox/netbox/object_actions.py
+++ b/netbox/netbox/object_actions.py
@@ -1,6 +1,6 @@
 from django.template import loader
 from django.urls.exceptions import NoReverseMatch
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from core.models import ObjectType
 from extras.models import ExportTemplate

--- a/netbox/virtualization/object_actions.py
+++ b/netbox/virtualization/object_actions.py
@@ -1,4 +1,4 @@
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from netbox.object_actions import ObjectAction
 


### PR DESCRIPTION
### Fixes: #20774

The function for translating action button labels has been replaced
