### PR TITLE
Fixes #20660: Optimize loading of custom script modules from remote storage

### DIFF
--- a/netbox/extras/models/mixins.py
+++ b/netbox/extras/models/mixins.py
@@ -30,8 +30,7 @@ class CustomStoragesLoader(importlib.abc.Loader):
         return None  # Use default module creation
 
     def exec_module(self, module):
-        storage = storages.create_storage(storages.backends["scripts"])
-        with storage.open(self.filename, 'rb') as f:
+        with storages["scripts"].open(self.filename, 'rb') as f:
             code = f.read()
         exec(code, module.__dict__)
 

--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -126,7 +126,7 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
         ordered.extend(script_objects.values())
         return ordered
 
-    @property
+    @cached_property
     def module_scripts(self):
 
         def _get_name(cls):


### PR DESCRIPTION
### Fixes: #20660

- Tweak `exec_module()` to avoid forcing the creation of a new storage connection on each call
- Convert `module_scripts` to a cached property, to avoid triggering a new fetch for each script within a module file

Some quick testing using three modules comprising five total scripts shows total rendering time for the script list view reduced from ~4.15s to ~0.80s. There is still some linear increment per script module, as each file must be fetched from remote storage, but it should be greatly reduced.