### PR TITLE
20465 fix script re-upload

### DIFF
--- a/docs/configuration/system.md
+++ b/docs/configuration/system.md
@@ -232,6 +232,9 @@ STORAGES = {
     },
     "scripts": {
         "BACKEND": "extras.storage.ScriptFileSystemStorage",
+        "OPTIONS": {
+            "allow_overwrite": True,
+        },
     },
 }
 ```
@@ -247,6 +250,7 @@ STORAGES = {
         "OPTIONS": { 
             'access_key': 'access key', 
             'secret_key': 'secret key',
+            "allow_overwrite": True,
         }
     }, 
 }

--- a/netbox/netbox/configuration_example.py
+++ b/netbox/netbox/configuration_example.py
@@ -243,6 +243,9 @@ SESSION_FILE_PATH = None
 #     },
 #     "scripts": {
 #         "BACKEND": "extras.storage.ScriptFileSystemStorage",
+#         "OPTIONS": {
+#             "allow_overwrite": True,
+#         },
 #     },
 # }
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -291,6 +291,9 @@ DEFAULT_STORAGES = {
     },
     "scripts": {
         "BACKEND": "extras.storage.ScriptFileSystemStorage",
+        "OPTIONS": {
+            "allow_overwrite": True,
+        },
     },
 }
 STORAGES = DEFAULT_STORAGES | STORAGES


### PR DESCRIPTION
### Fixes: #20465 

Sets allow_overwrite to true for scripts custom storage. see: https://docs.djangoproject.com/en/5.2/ref/files/storage/#django.core.files.storage.FileSystemStorage.allow_overwrite

