### PR TITLE
Fix examples for type of class Meta()

### DIFF
--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -95,7 +95,7 @@ An example fieldset definition is provided below:
 
 ```python
 class MyScript(Script):
-    class Meta:
+    class Meta(Script.Meta):
         fieldsets = (
             ('First group', ('field1', 'field2', 'field3')),
             ('Second group', ('field4', 'field5')),
@@ -510,7 +510,7 @@ from extras.scripts import *
 
 class NewBranchScript(Script):
 
-    class Meta:
+    class Meta(Script.Meta):
         name = "New Branch"
         description = "Provision a new branch site"
         field_order = ['site_name', 'switch_count', 'switch_model']


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20795 

Pylance reports an IncompatibleVariableOverride when trying to use the class Meta that does not derive from Script.Meta.

