### PR TITLE
Fixes #20766: Prevent translation of code/commands in error templates

### DIFF
--- a/netbox/templates/exceptions/import_error.html
+++ b/netbox/templates/exceptions/import_error.html
@@ -8,10 +8,10 @@
   <p>
     <i class="mdi mdi-alert"></i>
     <strong>{% trans "Missing required packages" %}.</strong>
-    {% blocktrans trimmed %}
+    {% blocktrans trimmed with req_file="requirements.txt" local_req_file="local_requirements.txt" pip_cmd="pip freeze" %}
       This installation of NetBox might be missing one or more required Python packages. These packages are listed in
-      <code>requirements.txt</code> and <code>local_requirements.txt</code>, and are normally installed as part of the
-      installation or upgrade process. To verify installed packages, run <code>pip freeze</code> from the console and
+      <code>{{ req_file }}</code> and <code>{{ local_req_file }}</code>, and are normally installed as part of the
+      installation or upgrade process. To verify installed packages, run <code>{{ pip_cmd }}</code> from the console and
       compare the output to the list of required packages.
     {% endblocktrans %}
   </p>

--- a/netbox/templates/exceptions/programming_error.html
+++ b/netbox/templates/exceptions/programming_error.html
@@ -8,17 +8,17 @@
   <p>
     <i class="mdi mdi-alert"></i>
     <strong>{% trans "Database migrations missing" %}.</strong>
-    {% blocktrans trimmed %}
+    {% blocktrans trimmed with command="python3 manage.py migrate" %}
       When upgrading to a new NetBox release, the upgrade script must be run to apply any new database migrations. You
-      can run migrations manually by executing <code>python3 manage.py migrate</code> from the command line.
+      can run migrations manually by executing <code>{{ command }}</code> from the command line.
     {% endblocktrans %}
   </p>
   <p>
     <i class="mdi mdi-alert"></i>
     <strong>{% trans "Unsupported PostgreSQL version" %}.</strong>
-    {% blocktrans trimmed %}
+    {% blocktrans trimmed with sql_query="SELECT VERSION()" %}
       Ensure that PostgreSQL version 14 or later is in use. You can check this by connecting to the database using
-      NetBox's credentials and issuing a query for <code>SELECT VERSION()</code>.
+      NetBox's credentials and issuing a query for <code>{{ sql_query }}</code>.
     {% endblocktrans %}
   </p>
 {% endblock message %}

--- a/netbox/templates/media_failure.html
+++ b/netbox/templates/media_failure.html
@@ -26,8 +26,8 @@
         <p>{% trans "Check the following" %}:</p>
         <ul>
             <li class="tip">
-              {% blocktrans trimmed %}
-                <code>manage.py collectstatic</code> was run during the most recent upgrade. This installs the most
+              {% blocktrans trimmed with command="manage.py collectstatic" %}
+                <code>{{ command }}</code> was run during the most recent upgrade. This installs the most
                 recent iteration of each static file into the static root path.
               {% endblocktrans %}
             </li>


### PR DESCRIPTION
### Fixes: #20766

Use `blocktrans` 'with' clause to pass literal code/commands as variables, preventing them from being translated. This fixes issues where commands like 'manage.py collectstatic' were incorrectly translated to nonsensical strings in non-English locales.

Updated templates:
- `media_failure.html`: `manage.py collectstatic`
- `programming_error.html`: `python3 manage.py migrate`, `SELECT VERSION()`
- `import_error.html`: `requirements.txt`, `local_requirements.txt`, `pip freeze`