### PR TITLE
Fixes #20134: Prevent HTMX OOB swaps in embedded tables

### DIFF
--- a/netbox/templates/htmx/table.html
+++ b/netbox/templates/htmx/table.html
@@ -17,15 +17,17 @@
 
 {% if request.htmx %}
   {# Include the updated object count for display elsewhere on the page #}
-  <div hx-swap-oob="innerHTML:.total-object-count">{{ table.rows|length }}</div>
+  {% if not table.embedded %}
+    <div hx-swap-oob="innerHTML:.total-object-count">{{ table.rows|length }}</div>
+  {% endif %}
 
   {# Include the updated "save" link for the table configuration #}
-  {% if table.config_params %}
+  {% if table.config_params and not table.embedded %}
     <a class="dropdown-item" hx-swap-oob="outerHTML:#table_save_link" href="{% url 'extras:tableconfig_add' %}?{{ table.config_params }}&return_url={{ request.path }}" id="table_save_link">Save</a>
   {% endif %}
 
   {# Update the bulk action buttons with new query parameters #}
-  {% if actions %}
+  {% if actions and not table.embedded %}
     <div class="bulk-action-buttons" hx-swap-oob="outerHTML:.bulk-action-buttons">
       {% action_buttons actions model multi=True %}
     </div>


### PR DESCRIPTION
### Fixes: #20134

The `htmx/table.html` template was unconditionally including out-of-band (OOB) swaps for UI elements that only exist on list pages, causing `htmx:oobErrorNoTarget` errors when tables were embedded on detail pages.

This change adds checks for `table.embedded` to conditionally exclude OOB swaps for `.total-object-count`, `#table_save_link`, and `.bulk-action-buttons` when rendering embedded tables.