### PR TITLE
Closes #20820: Add Object Type Filter to CustomField

### DIFF
--- a/netbox/extras/forms/filtersets.py
+++ b/netbox/extras/forms/filtersets.py
@@ -42,17 +42,20 @@ class CustomFieldFilterForm(SavedFiltersMixin, FilterForm):
     model = CustomField
     fieldsets = (
         FieldSet('q', 'filter_id'),
-        FieldSet(
-            'type', 'related_object_type_id', 'group_name', 'weight', 'required', 'unique', 'choice_set_id',
-            name=_('Attributes')
-        ),
+        FieldSet('object_type_id', 'type', 'group_name', 'weight', 'required', 'unique', name=_('Attributes')),
+        FieldSet('choice_set_id', 'related_object_type_id', name=_('Type Options')),
         FieldSet('ui_visible', 'ui_editable', 'is_cloneable', name=_('Behavior')),
         FieldSet('validation_minimum', 'validation_maximum', 'validation_regex', name=_('Validation')),
     )
-    related_object_type_id = ContentTypeMultipleChoiceField(
+    object_type_id = ContentTypeMultipleChoiceField(
         queryset=ObjectType.objects.with_feature('custom_fields'),
         required=False,
-        label=_('Related object type')
+        label=_('Object types'),
+    )
+    related_object_type_id = ContentTypeMultipleChoiceField(
+        queryset=ObjectType.objects.public(),
+        required=False,
+        label=_('Related object type'),
     )
     type = forms.MultipleChoiceField(
         choices=CustomFieldTypeChoices,


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20820

Add `object_type_id` to the CustomField filter form to filter by assigned object types. Move type‑specific controls into a new “Type Options” FieldSet (`choice_set_id`, `related_object_type_id`). This clarifies the difference between a field’s assigned `ObjectType` and its related `ObjectType` (for `object` fields), improving discoverability and consistency.

UI only; no API or database changes.
