### PR TITLE
Fixes #20840: Remove unused `airflow` from RackType UI

### DIFF
--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -278,11 +278,6 @@ class RackBaseFilterForm(NetBoxModelFilterSetForm):
             choices=BOOLEAN_WITH_BLANK_CHOICES
         )
     )
-    airflow = forms.MultipleChoiceField(
-        label=_('Airflow'),
-        choices=add_blank_choice(RackAirflowChoices),
-        required=False
-    )
     weight = forms.DecimalField(
         label=_('Weight'),
         required=False,
@@ -380,6 +375,11 @@ class RackFilterForm(TenancyFilterForm, ContactModelFilterForm, RackBaseFilterFo
             'manufacturer_id': '$manufacturer_id'
         },
         label=_('Rack type')
+    )
+    airflow = forms.MultipleChoiceField(
+        label=_('Airflow'),
+        choices=add_blank_choice(RackAirflowChoices),
+        required=False
     )
     serial = forms.CharField(
         label=_('Serial'),

--- a/netbox/dcim/tables/racks.py
+++ b/netbox/dcim/tables/racks.py
@@ -100,7 +100,7 @@ class RackTypeTable(NetBoxTable):
         model = RackType
         fields = (
             'pk', 'id', 'model', 'manufacturer', 'form_factor', 'u_height', 'starting_unit', 'width', 'outer_width',
-            'outer_height', 'outer_depth', 'mounting_depth', 'airflow', 'weight', 'max_weight', 'description',
+            'outer_height', 'outer_depth', 'mounting_depth', 'weight', 'max_weight', 'description',
             'comments', 'instance_count', 'tags', 'created', 'last_updated',
         )
         default_columns = (

--- a/netbox/templates/dcim/racktype.html
+++ b/netbox/templates/dcim/racktype.html
@@ -24,10 +24,6 @@
             <th scope="row">{% trans "Description" %}</th>
             <td>{{ object.description|placeholder }}</td>
           </tr>
-          <tr>
-            <th scope="row">{% trans "Airflow" %}</th>
-            <td>{{ object.get_airflow_display|placeholder }}</td>
-          </tr>
         </table>
       </div>
       {% include 'dcim/inc/panels/racktype_dimensions.html' %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20840

`RackType` does not define an `airflow` field; however, the **Rack Types** list exposed an **Airflow** column and the detail view template attempted to render it. The FilterForm correctly omits this field because it is not included in the `RackTypeFilterSet`.

**This PR:**
- Removes **Airflow** from the RackType table configuration.
- Removes the `airflow` row from the RackType detail view template.

UI-only cleanup; no database or API changes.
