### PR TITLE
Fixes #20844: Respect assigned object type for L2VPN terminations

### DIFF
--- a/netbox/vpn/filtersets.py
+++ b/netbox/vpn/filtersets.py
@@ -2,6 +2,7 @@ import django_filters
 from django.db.models import Q
 from django.utils.translation import gettext as _
 
+from core.models import ObjectType
 from dcim.models import Device, Interface
 from ipam.models import IPAddress, RouteTarget, VLAN
 from netbox.filtersets import NetBoxModelFilterSet, OrganizationalModelFilterSet
@@ -428,6 +429,10 @@ class L2VPNTerminationFilterSet(NetBoxModelFilterSet):
         field_name='vlan',
         queryset=VLAN.objects.all(),
         label=_('VLAN (ID)'),
+    )
+    assigned_object_type_id = django_filters.ModelMultipleChoiceFilter(
+        queryset=ObjectType.objects.all(),
+        field_name='assigned_object_type'
     )
     assigned_object_type = ContentTypeFilter()
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20844

<!--
    Please include a summary of the proposed changes below.
-->

This PR adds the `assigned_object_type_id` filter to `L2VPNTerminationFilterSet` so the "Assigned object type" filter correctly restricts L2VPN terminations by their assigned object type via the `ObjectType` model.

Thanks! 🙏

