### PR TITLE
Closes #20841: Add selector widget to RackType field on the Rack EditForm

### DIFF
--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -269,7 +269,8 @@ class RackForm(TenancyForm, NetBoxModelForm):
         label=_('Rack Type'),
         queryset=RackType.objects.all(),
         required=False,
-        help_text=_("Select a pre-defined rack type, or set physical characteristics below.")
+        selector=True,
+        help_text=_("Select a pre-defined rack type, or set physical characteristics below."),
     )
     comments = CommentField()
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20841

<!--
    Please include a summary of the proposed changes below.
-->
This PR configures the `RackType` field on the rack add/edit form to use the selector widget.

Using the selector widget improves usability by:

- Allowing users to search rack types instead of scrolling a long dropdown
- Making it easier to filter and choose the correct rack type (e.g. by manufacturer)
- Keeping the rack workflow consistent with other objects that already use selector modals

No model or API changes are introduced; this only updates the rack form UI.
