### PR TITLE
Fixes 20822: add auto sync enabled property for configtemplates

### DIFF
--- a/netbox/extras/api/serializers_/configtemplates.py
+++ b/netbox/extras/api/serializers_/configtemplates.py
@@ -23,6 +23,6 @@ class ConfigTemplateSerializer(ChangeLogMessageSerializer, TaggableModelSerializ
         fields = [
             'id', 'url', 'display_url', 'display', 'name', 'description', 'environment_params', 'template_code',
             'mime_type', 'file_name', 'file_extension', 'as_attachment', 'data_source', 'data_path', 'data_file',
-            'data_synced', 'tags', 'created', 'last_updated',
+            'auto_sync_enabled', 'data_synced', 'tags', 'created', 'last_updated',
         ]
         brief_fields = ('id', 'url', 'display', 'name', 'description')

--- a/netbox/extras/forms/bulk_edit.py
+++ b/netbox/extras/forms/bulk_edit.py
@@ -398,8 +398,12 @@ class ConfigTemplateBulkEditForm(ChangelogMessageMixin, BulkEditForm):
         required=False,
         widget=BulkEditNullBooleanSelect()
     )
-
-    nullable_fields = ('description', 'mime_type', 'file_name', 'file_extension')
+    auto_sync_enabled = forms.NullBooleanField(
+        label=_('Auto sync enabled'),
+        required=False,
+        widget=BulkEditNullBooleanSelect()
+    )
+    nullable_fields = ('description', 'mime_type', 'file_name', 'file_extension', 'auto_sync_enabled',)
 
 
 class ImageAttachmentBulkEditForm(ChangelogMessageMixin, BulkEditForm):

--- a/netbox/extras/forms/filtersets.py
+++ b/netbox/extras/forms/filtersets.py
@@ -476,7 +476,7 @@ class ConfigTemplateFilterForm(SavedFiltersMixin, FilterForm):
     model = ConfigTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('data_source_id', 'data_file_id', name=_('Data')),
+        FieldSet('data_source_id', 'data_file_id', 'auto_sync_enabled', name=_('Data')),
         FieldSet('mime_type', 'file_name', 'file_extension', 'as_attachment', name=_('Rendering'))
     )
     data_source_id = DynamicModelMultipleChoiceField(
@@ -491,6 +491,13 @@ class ConfigTemplateFilterForm(SavedFiltersMixin, FilterForm):
         query_params={
             'source_id': '$data_source_id'
         }
+    )
+    auto_sync_enabled = forms.NullBooleanField(
+        label=_('Auto sync enabled'),
+        required=False,
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        )
     )
     tag = TagFilterField(ConfigTemplate)
     mime_type = forms.CharField(

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -632,6 +632,10 @@ class ConfigTemplateTable(NetBoxTable):
         orderable=False,
         verbose_name=_('Synced')
     )
+    auto_sync_enabled = columns.BooleanColumn(
+        verbose_name=_('Auto Sync Enabled'),
+        orderable=False,
+    )
     mime_type = tables.Column(
         verbose_name=_('MIME Type')
     )

--- a/netbox/templates/extras/configtemplate.html
+++ b/netbox/templates/extras/configtemplate.html
@@ -62,6 +62,10 @@
             <th scope="row">{% trans "Data Synced" %}</th>
             <td>{{ object.data_synced|placeholder }}</td>
           </tr>
+          <tr>
+            <th scope="row">{% trans "Auto Sync Enabled" %}</th>
+            <td>{% checkmark object.auto_sync_enabled %}</td>
+          </tr>
         </table>
       </div>
       {% include 'inc/panels/tags.html' %}


### PR DESCRIPTION
### Fixes: #20822

```auto_sync_enabled``` property for configTemplates was ignored by API, bulk edit & view forms. Even though this attribute existed, it was only possible to view it through the edit form.

This FR fixes the issue by implementing the missing property on the related objects.
