### PR TITLE
Fixes #20859: Handle dashboard widget exceptions

### DIFF
--- a/netbox/extras/dashboard/widgets.py
+++ b/netbox/extras/dashboard/widgets.py
@@ -209,7 +209,10 @@ class ObjectCountsWidget(DashboardWidget):
                     url = get_action_url(model, action='list')
                 except NoReverseMatch:
                     url = None
-                qs = model.objects.restrict(request.user, 'view')
+                try:
+                    qs = model.objects.restrict(request.user, 'view')
+                except AttributeError:
+                    qs = model.objects.all()
                 # Apply any specified filters
                 if url and (filters := self.config.get('filters')):
                     params = dict_to_querydict(filters)

--- a/netbox/extras/templatetags/dashboard.py
+++ b/netbox/extras/templatetags/dashboard.py
@@ -1,4 +1,6 @@
 from django import template
+from django.utils.safestring import mark_safe
+from django.utils.translation import gettext as _
 
 
 register = template.Library()
@@ -8,4 +10,16 @@ register = template.Library()
 def render_widget(context, widget):
     request = context['request']
 
-    return widget.render(request)
+    try:
+        return widget.render(request)
+    except Exception as e:
+        message1 = _('An error was encountered when attempting to render this widget:')
+        message2 = _('Please try reconfiguring the widget, or remove it from your dashboard.')
+        return mark_safe(f"""
+            <p>
+              <span class="text-danger"><i class="mdi mdi-alert"></i></span>
+              {message1}
+            </p>
+            <p class="font-monospace ps-3">{e}</p>
+            <p>{message2}</p>
+        """)


### PR DESCRIPTION
### Fixes: #20859

- Fix the root issue in ObjectCountsWidget
- Ensure that any exceptions raised when rendering a widget are caught and handled cleanly to preserve dashboard integrity