### PR TITLE
Fixes #20649: Enforce view permissions on REST API endpoint for custom scripts

### DIFF
--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -267,6 +267,14 @@ class ScriptViewSet(ModelViewSet):
     _ignore_model_permissions = True
     lookup_value_regex = '[^/]+'  # Allow dots
 
+    def initial(self, request, *args, **kwargs):
+        super().initial(request, *args, **kwargs)
+
+        # Restrict the view's QuerySet to allow only the permitted objects
+        if request.user.is_authenticated:
+            action = 'run' if request.method == 'POST' else 'view'
+            self.queryset = self.queryset.restrict(request.user, action)
+
     def _get_script(self, pk):
         # If pk is numeric, retrieve script by ID
         if pk.isnumeric():

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -894,18 +894,13 @@ class ScriptTest(APITestCase):
 
     def setUp(self):
         super().setUp()
+        self.add_permissions('extras.view_script')
 
         # Monkey-patch the Script model to return our TestScriptClass above
         Script.python_class = self.python_class
 
     def test_get_script(self):
-        module = ScriptModule.objects.get(
-            file_root=ManagedFileRootPathChoices.SCRIPTS,
-            file_path='script.py',
-        )
-        script = module.scripts.all().first()
-        url = reverse('extras-api:script-detail', kwargs={'pk': script.pk})
-        response = self.client.get(url, **self.header)
+        response = self.client.get(self.url, **self.header)
 
         self.assertEqual(response.data['name'], self.TestScriptClass.Meta.name)
         self.assertEqual(response.data['vars']['var1'], 'StringVar')


### PR DESCRIPTION
### Fixes: #20649

Override `initial()` on ScriptViewSet to call `restrict()` on the queryset
