### PR TITLE
Fixes #20865: Enforce proper min/max values for latitude & longitude

### DIFF
--- a/netbox/dcim/migrations/0216_latitude_longitude_validators.py
+++ b/netbox/dcim/migrations/0216_latitude_longitude_validators.py
@@ -1,0 +1,67 @@
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('dcim', '0215_rackreservation_status'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='device',
+            name='latitude',
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=6,
+                max_digits=8,
+                null=True,
+                validators=[
+                    django.core.validators.MinValueValidator(-90.0),
+                    django.core.validators.MaxValueValidator(90.0),
+                ],
+            ),
+        ),
+        migrations.AlterField(
+            model_name='device',
+            name='longitude',
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=6,
+                max_digits=9,
+                null=True,
+                validators=[
+                    django.core.validators.MinValueValidator(-180.0),
+                    django.core.validators.MaxValueValidator(180.0),
+                ],
+            ),
+        ),
+        migrations.AlterField(
+            model_name='site',
+            name='latitude',
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=6,
+                max_digits=8,
+                null=True,
+                validators=[
+                    django.core.validators.MinValueValidator(-90.0),
+                    django.core.validators.MaxValueValidator(90.0),
+                ],
+            ),
+        ),
+        migrations.AlterField(
+            model_name='site',
+            name='longitude',
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=6,
+                max_digits=9,
+                null=True,
+                validators=[
+                    django.core.validators.MinValueValidator(-180.0),
+                    django.core.validators.MaxValueValidator(180.0),
+                ],
+            ),
+        ),
+    ]

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -646,6 +646,7 @@ class Device(
         decimal_places=6,
         blank=True,
         null=True,
+        validators=[MinValueValidator(-90.0), MaxValueValidator(90.0)],
         help_text=_("GPS coordinate in decimal format (xx.yyyyyy)")
     )
     longitude = models.DecimalField(
@@ -654,6 +655,7 @@ class Device(
         decimal_places=6,
         blank=True,
         null=True,
+        validators=[MinValueValidator(-180.0), MaxValueValidator(180.0)],
         help_text=_("GPS coordinate in decimal format (xx.yyyyyy)")
     )
     services = GenericRelation(

--- a/netbox/dcim/models/sites.py
+++ b/netbox/dcim/models/sites.py
@@ -1,5 +1,6 @@
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
+from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 from timezone_field import TimeZoneField
@@ -210,6 +211,7 @@ class Site(ContactsMixin, ImageAttachmentsMixin, PrimaryModel):
         decimal_places=6,
         blank=True,
         null=True,
+        validators=[MinValueValidator(-90.0), MaxValueValidator(90.0)],
         help_text=_('GPS coordinate in decimal format (xx.yyyyyy)')
     )
     longitude = models.DecimalField(
@@ -218,6 +220,7 @@ class Site(ContactsMixin, ImageAttachmentsMixin, PrimaryModel):
         decimal_places=6,
         blank=True,
         null=True,
+        validators=[MinValueValidator(-180.0), MaxValueValidator(180.0)],
         help_text=_('GPS coordinate in decimal format (xx.yyyyyy)')
     )
 


### PR DESCRIPTION
### Fixes: #20865

Add minimum & maximum value validators for the `latitude` and `longitude` fields on Site and Device.