### PR TITLE
Fixes #20371: Add Power Port Type (Molex Micro-Fit 2x3)

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -461,6 +461,7 @@ class PowerPortTypeChoices(ChoiceSet):
     # Molex
     TYPE_MOLEX_MICRO_FIT_1X2 = 'molex-micro-fit-1x2'
     TYPE_MOLEX_MICRO_FIT_2X2 = 'molex-micro-fit-2x2'
+    TYPE_MOLEX_MICRO_FIT_2X3 = 'molex-micro-fit-2x3'
     TYPE_MOLEX_MICRO_FIT_2X4 = 'molex-micro-fit-2x4'
     # Direct current (DC)
     TYPE_DC = 'dc-terminal'
@@ -588,6 +589,7 @@ class PowerPortTypeChoices(ChoiceSet):
         ('Molex', (
             (TYPE_MOLEX_MICRO_FIT_1X2, 'Molex Micro-Fit 1x2'),
             (TYPE_MOLEX_MICRO_FIT_2X2, 'Molex Micro-Fit 2x2'),
+            (TYPE_MOLEX_MICRO_FIT_2X3, 'Molex Micro-Fit 2x3'),
             (TYPE_MOLEX_MICRO_FIT_2X4, 'Molex Micro-Fit 2x4'),
         )),
         ('DC', (
@@ -710,6 +712,7 @@ class PowerOutletTypeChoices(ChoiceSet):
     # Molex
     TYPE_MOLEX_MICRO_FIT_1X2 = 'molex-micro-fit-1x2'
     TYPE_MOLEX_MICRO_FIT_2X2 = 'molex-micro-fit-2x2'
+    TYPE_MOLEX_MICRO_FIT_2X3 = 'molex-micro-fit-2x3'
     TYPE_MOLEX_MICRO_FIT_2X4 = 'molex-micro-fit-2x4'
     # Direct current (DC)
     TYPE_DC = 'dc-terminal'
@@ -831,6 +834,7 @@ class PowerOutletTypeChoices(ChoiceSet):
         ('Molex', (
             (TYPE_MOLEX_MICRO_FIT_1X2, 'Molex Micro-Fit 1x2'),
             (TYPE_MOLEX_MICRO_FIT_2X2, 'Molex Micro-Fit 2x2'),
+            (TYPE_MOLEX_MICRO_FIT_2X3, 'Molex Micro-Fit 2x3'),
             (TYPE_MOLEX_MICRO_FIT_2X4, 'Molex Micro-Fit 2x4'),
         )),
         ('DC', (


### PR DESCRIPTION
Fixes: https://github.com/netbox-community/netbox/issues/20371
- Add Molex Micro-Fit 2x3 on PowerPortTypeChoices and PowerOutletTypeChoices