### PR TITLE
20878 use database routing when running script

### DIFF
--- a/netbox/extras/jobs.py
+++ b/netbox/extras/jobs.py
@@ -109,9 +109,6 @@ class ScriptJob(JobRunner):
         script.request = request
         self.logger.debug(f"Request ID: {request.id if request else None}")
 
-        # Execute the script. Always use request processors to set up the execution context (e.g. branch activation).
-        # The event_tracking context manager is one of the request processors and will be activated regardless of
-        # the commit flag, but it only records changes when commit=True.
         if commit:
             self.logger.info("Executing script (commit enabled)")
         else:

--- a/netbox/extras/jobs.py
+++ b/netbox/extras/jobs.py
@@ -8,6 +8,7 @@ from django.utils.translation import gettext as _
 from core.signals import clear_events
 from dcim.models import Device
 from extras.models import Script as ScriptModel
+from netbox.context_managers import event_tracking
 from netbox.jobs import JobRunner
 from netbox.registry import registry
 from utilities.exceptions import AbortScript, AbortTransaction
@@ -116,5 +117,7 @@ class ScriptJob(JobRunner):
 
         with ExitStack() as stack:
             for request_processor in registry['request_processors']:
+                if not commit and request_processor is event_tracking:
+                    continue
                 stack.enter_context(request_processor(request))
             self.run_script(script, request, data, commit)


### PR DESCRIPTION
### Fixes: #20878 

Two main changes were needed:
* The atomic transaction wrapping the script needs to be done on default database and also the branch database as the script could potentially modify data in either.  Device was picked as a branch aware model to get the correct db_for_write.
* The request processor code needs to be run even if not committing in order to pick up the branch processor that actually switches to the branch.   However the event_tracking request_processor needs to be skipped so it doesn't process events (like a web hook setup on data being modified).
