### PR TITLE
docs: fix broken bookmarks link in model features table

### DIFF
--- a/docs/development/models.md
+++ b/docs/development/models.md
@@ -12,7 +12,7 @@ Depending on its classification, each NetBox model may support various features 
 
 | Feature                                                    | Feature Mixin           | Registry Key        | Description                                                                             |
 |------------------------------------------------------------|-------------------------|---------------------|-----------------------------------------------------------------------------------------|
-| [Bookmarks](../features/customization.md#bookmarks)        | `BookmarksMixin`        | `bookmarks`         | These models can be bookmarked natively in the user interface                           |
+| [Bookmarks](../features/user-preferences.md#bookmarks)     | `BookmarksMixin`        | `bookmarks`         | These models can be bookmarked natively in the user interface                           |
 | [Change logging](../features/change-logging.md)            | `ChangeLoggingMixin`    | `change_logging`    | Changes to these objects are automatically recorded in the change log                   |
 | Cloning                                                    | `CloningMixin`          | `cloning`           | Provides the `clone()` method to prepare a copy                                         |
 | [Contacts](../features/contacts.md)                        | `ContactsMixin`         | `contacts`          | Contacts can be associated with these models                                            |


### PR DESCRIPTION
## Summary
Fixes a broken documentation link in the model features table.

The bookmarks link was pointing to `../features/customization.md#bookmarks` but the bookmarks section is actually documented in `../features/user-preferences.md#bookmarks`.

## Changes
- Updated link in `docs/development/models.md` line 15 to point to the correct location

This fixes a broken anchor link that would result in a 404 when users click the Bookmarks link in the model features documentation.