### PR TITLE
Fixes #20888: Fix warnings about non-decimal values for min/max latitude & longitude fields

### DIFF
--- a/netbox/dcim/migrations/0216_latitude_longitude_validators.py
+++ b/netbox/dcim/migrations/0216_latitude_longitude_validators.py
@@ -1,3 +1,5 @@
+import decimal
+
 import django.core.validators
 from django.db import migrations, models
 
@@ -17,8 +19,8 @@ class Migration(migrations.Migration):
                 max_digits=8,
                 null=True,
                 validators=[
-                    django.core.validators.MinValueValidator(-90.0),
-                    django.core.validators.MaxValueValidator(90.0),
+                    django.core.validators.MinValueValidator(decimal.Decimal('-90.0')),
+                    django.core.validators.MaxValueValidator(decimal.Decimal('90.0'))
                 ],
             ),
         ),
@@ -31,8 +33,8 @@ class Migration(migrations.Migration):
                 max_digits=9,
                 null=True,
                 validators=[
-                    django.core.validators.MinValueValidator(-180.0),
-                    django.core.validators.MaxValueValidator(180.0),
+                    django.core.validators.MinValueValidator(decimal.Decimal('-180.0')),
+                    django.core.validators.MaxValueValidator(decimal.Decimal('180.0'))
                 ],
             ),
         ),
@@ -45,8 +47,8 @@ class Migration(migrations.Migration):
                 max_digits=8,
                 null=True,
                 validators=[
-                    django.core.validators.MinValueValidator(-90.0),
-                    django.core.validators.MaxValueValidator(90.0),
+                    django.core.validators.MinValueValidator(decimal.Decimal('-90.0')),
+                    django.core.validators.MaxValueValidator(decimal.Decimal('90.0'))
                 ],
             ),
         ),
@@ -59,8 +61,8 @@ class Migration(migrations.Migration):
                 max_digits=9,
                 null=True,
                 validators=[
-                    django.core.validators.MinValueValidator(-180.0),
-                    django.core.validators.MaxValueValidator(180.0),
+                    django.core.validators.MinValueValidator(decimal.Decimal('-180.0')),
+                    django.core.validators.MaxValueValidator(decimal.Decimal('180.0'))
                 ],
             ),
         ),

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -646,7 +646,10 @@ class Device(
         decimal_places=6,
         blank=True,
         null=True,
-        validators=[MinValueValidator(-90.0), MaxValueValidator(90.0)],
+        validators=[
+            MinValueValidator(decimal.Decimal('-90.0')),
+            MaxValueValidator(decimal.Decimal('90.0'))
+        ],
         help_text=_("GPS coordinate in decimal format (xx.yyyyyy)")
     )
     longitude = models.DecimalField(
@@ -655,7 +658,10 @@ class Device(
         decimal_places=6,
         blank=True,
         null=True,
-        validators=[MinValueValidator(-180.0), MaxValueValidator(180.0)],
+        validators=[
+            MinValueValidator(decimal.Decimal('-180.0')),
+            MaxValueValidator(decimal.Decimal('180.0'))
+        ],
         help_text=_("GPS coordinate in decimal format (xx.yyyyyy)")
     )
     services = GenericRelation(

--- a/netbox/dcim/models/sites.py
+++ b/netbox/dcim/models/sites.py
@@ -1,3 +1,5 @@
+import decimal
+
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
 from django.core.validators import MaxValueValidator, MinValueValidator
@@ -211,7 +213,10 @@ class Site(ContactsMixin, ImageAttachmentsMixin, PrimaryModel):
         decimal_places=6,
         blank=True,
         null=True,
-        validators=[MinValueValidator(-90.0), MaxValueValidator(90.0)],
+        validators=[
+            MinValueValidator(decimal.Decimal('-90.0')),
+            MaxValueValidator(decimal.Decimal('90.0'))
+        ],
         help_text=_('GPS coordinate in decimal format (xx.yyyyyy)')
     )
     longitude = models.DecimalField(
@@ -220,7 +225,10 @@ class Site(ContactsMixin, ImageAttachmentsMixin, PrimaryModel):
         decimal_places=6,
         blank=True,
         null=True,
-        validators=[MinValueValidator(-180.0), MaxValueValidator(180.0)],
+        validators=[
+            MinValueValidator(decimal.Decimal('-180.0')),
+            MaxValueValidator(decimal.Decimal('180.0'))
+        ],
         help_text=_('GPS coordinate in decimal format (xx.yyyyyy)')
     )
 


### PR DESCRIPTION
### Fixes: #20888

Cast min/max values for validators as Decimal to avoid DRF warnings.