### PR TITLE
Fixes #20560: Fix VLAN disambiguation in prefix bulk import

### DIFF
--- a/netbox/ipam/forms/bulk_import.py
+++ b/netbox/ipam/forms/bulk_import.py
@@ -230,10 +230,6 @@ class PrefixImportForm(ScopedImportForm, NetBoxModelImportForm):
             query |= Q(**{
                 f"site__{self.fields['vlan_site'].to_field_name}": vlan_site
             })
-            # Don't Forget to include VLANs without a site in the filter
-            query |= Q(**{
-                f"site__{self.fields['vlan_site'].to_field_name}__isnull": True
-            })
 
         if vlan_group:
             query &= Q(**{


### PR DESCRIPTION
### Fixes: #20560

When `vlan_site` is specified during prefix bulk import, the form should only match VLANs at that specific site. The previous implementation included VLANs with `NULL` site (global VLANs), which caused "multiple objects were found" errors when both a global VLAN and site-specific VLAN existed with the same vid.

- Removed NULL site inclusion from `PrefixImportForm.__init__` 
- Added regression tests for disambiguation between site-specific VLANs and between global/site-specific VLANs
- Completes the fix started in PR #18844 which added the `vlan_site` field but inadvertently carried forward the NULL inclusion bug