### PR TITLE
Fixes #19918: Resolve {module} placeholders in nested module bay labels

### DIFF
--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -681,8 +681,8 @@ class ModuleBayTemplate(ModularComponentTemplateModel):
 
     def instantiate(self, **kwargs):
         return self.component_model(
-            name=self.name,
-            label=self.label,
+            name=self.resolve_name(kwargs.get('module')),
+            label=self.resolve_label(kwargs.get('module')),
             position=self.position,
             **kwargs
         )

--- a/netbox/dcim/models/modules.py
+++ b/netbox/dcim/models/modules.py
@@ -7,7 +7,6 @@ from django.utils.translation import gettext_lazy as _
 from jsonschema.exceptions import ValidationError as JSONValidationError
 
 from dcim.choices import *
-from dcim.constants import MODULE_TOKEN
 from dcim.utils import update_interface_bridges
 from extras.models import ConfigContextModel, CustomField
 from netbox.models import PrimaryModel
@@ -331,7 +330,6 @@ class Module(PrimaryModel, ConfigContextModel):
             else:
                 # ModuleBays must be saved individually for MPTT
                 for instance in create_instances:
-                    instance.name = instance.name.replace(MODULE_TOKEN, str(self.module_bay.position))
                     instance.save()
 
             update_fields = ['module']


### PR DESCRIPTION
### Fixes: #19918

`ModuleBayTemplate.instantiate()` now calls `resolve_name()` and `resolve_label()` to properly resolve `{module}` placeholders, making it consistent with other modular components like InterfaceTemplate.

When a module with nested module bays is installed (e.g., a module with SFP bays in position "A"), the nested bay labels now correctly show "A-21" instead of "{module}-21".

This also removes the inconsistent fix from #17436 which only handled name resolution post-instantiation. The proper resolution now happens during instantiation using the existing resolve methods.