### PR TITLE
#20875 fix updating of denormalized fields (_site, _location, _rack) for component models

### DIFF
--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -957,8 +957,7 @@ class Device(
             if cf_defaults := CustomField.objects.get_defaults_for_model(model):
                 for component in components:
                     component.custom_field_data = cf_defaults
-            # Set denormalized references (_site, _location, _rack) before bulk_create
-            # since bulk_create bypasses the save() method
+            # Set denormalized references
             for component in components:
                 component._site = self.site
                 component._location = self.location

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -33,6 +33,7 @@ from utilities.tracking import TrackingModelMixin
 from .device_components import *
 from .mixins import RenderConfigMixin
 from .modules import Module
+from ..utils import update_device_components
 
 
 __all__ = (
@@ -1012,6 +1013,8 @@ class Device(
             self._instantiate_components(self.device_type.inventoryitemtemplates.all(), bulk_create=False)
             # Interface bridges have to be set after interface instantiation
             update_interface_bridges(self, self.device_type.interfacetemplates.all())
+            # Update denormalized fields for all components
+            update_device_components(self)
 
         # Update Site and Rack assignment for any child Devices
         devices = Device.objects.filter(parent_bay__device=self)

--- a/netbox/dcim/models/modules.py
+++ b/netbox/dcim/models/modules.py
@@ -15,6 +15,7 @@ from netbox.models.mixins import WeightMixin
 from utilities.jsonschema import validate_schema
 from utilities.string import title
 from .device_components import *
+from ..utils import update_device_components
 
 __all__ = (
     'Module',
@@ -347,3 +348,5 @@ class Module(PrimaryModel, ConfigContextModel):
 
         # Interface bridges have to be set after interface instantiation
         update_interface_bridges(self.device, self.module_type.interfacetemplates, self)
+        # Update denormalized fields for all components
+        update_device_components(self.device)

--- a/netbox/dcim/models/modules.py
+++ b/netbox/dcim/models/modules.py
@@ -315,8 +315,7 @@ class Module(PrimaryModel, ConfigContextModel):
                 for component in create_instances:
                     component.custom_field_data = cf_defaults
 
-            # Set denormalized references (_site, _location, _rack) before bulk_create
-            # since bulk_create bypasses the save() method
+            # Set denormalized references
             for component in create_instances:
                 component._site = self.device.site
                 component._location = self.device.location

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -45,7 +45,6 @@ def handle_location_site_change(instance, created, **kwargs):
         PowerPanel.objects.filter(location__in=locations).update(site=instance.site)
         CableTermination.objects.filter(_location__in=locations).update(_site=instance.site)
         # Update component models for devices in these locations
-        # (since Device.objects.update() doesn't trigger post_save signals)
         for model in COMPONENT_MODELS:
             model.objects.filter(device__location__in=locations).update(_site=instance.site)
 
@@ -58,7 +57,6 @@ def handle_rack_site_change(instance, created, **kwargs):
     if not created:
         Device.objects.filter(rack=instance).update(site=instance.site, location=instance.location)
         # Update component models for devices in this rack
-        # (since Device.objects.update() doesn't trigger post_save signals)
         for model in COMPONENT_MODELS:
             model.objects.filter(device__rack=instance).update(
                 _site=instance.site,

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -61,7 +61,6 @@ def handle_rack_site_change(instance, created, **kwargs):
             model.objects.filter(device__rack=instance).update(
                 _site=instance.site,
                 _location=instance.location,
-                _rack=instance,
             )
 
 

--- a/netbox/dcim/utils.py
+++ b/netbox/dcim/utils.py
@@ -76,3 +76,36 @@ def update_interface_bridges(device, interface_templates, module=None):
             )
             interface.full_clean()
             interface.save()
+
+
+def update_device_components(device):
+    """
+    Update denormalized fields (_site, _location, _rack) for all component models
+    associated with the specified device.
+
+    :param device: Device instance whose components should be updated
+    """
+    from dcim.models import (
+        ConsolePort, ConsoleServerPort, DeviceBay, FrontPort, Interface,
+        InventoryItem, ModuleBay, PowerOutlet, PowerPort, RearPort,
+    )
+
+    COMPONENT_MODELS = (
+        ConsolePort,
+        ConsoleServerPort,
+        DeviceBay,
+        FrontPort,
+        Interface,
+        InventoryItem,
+        ModuleBay,
+        PowerOutlet,
+        PowerPort,
+        RearPort,
+    )
+
+    for model in COMPONENT_MODELS:
+        model.objects.filter(device=device).update(
+            _site=device.site,
+            _location=device.location,
+            _rack=device.rack,
+        )

--- a/netbox/dcim/utils.py
+++ b/netbox/dcim/utils.py
@@ -76,36 +76,3 @@ def update_interface_bridges(device, interface_templates, module=None):
             )
             interface.full_clean()
             interface.save()
-
-
-def update_device_components(device):
-    """
-    Update denormalized fields (_site, _location, _rack) for all component models
-    associated with the specified device.
-
-    :param device: Device instance whose components should be updated
-    """
-    from dcim.models import (
-        ConsolePort, ConsoleServerPort, DeviceBay, FrontPort, Interface,
-        InventoryItem, ModuleBay, PowerOutlet, PowerPort, RearPort,
-    )
-
-    COMPONENT_MODELS = (
-        ConsolePort,
-        ConsoleServerPort,
-        DeviceBay,
-        FrontPort,
-        Interface,
-        InventoryItem,
-        ModuleBay,
-        PowerOutlet,
-        PowerPort,
-        RearPort,
-    )
-
-    for model in COMPONENT_MODELS:
-        model.objects.filter(device=device).update(
-            _site=device.site,
-            _location=device.location,
-            _rack=device.rack,
-        )


### PR DESCRIPTION
### Fixes: #20875 

Several cases were previously missed:
* netbox/dcim/models/devices.py - when components are instantiated from the device-template and the denormalized fields were never getting updated.
* netbox/dcim/models/modules.py - when creating a module and instantiating components
* netbox/dcim/signals.py - when changing the site for a location, when changing the site for a rack

Also checked the API and it looks like the API and this should also affect those.  Bulk updates on the API do serializer.save() on each object which will cause the signal handler to run.
