### PR TITLE
Fixes #17976: Remove devicetype_count from nested manufacturer to correct OpenAPI schema

### DIFF
--- a/netbox/dcim/api/serializers_/manufacturers.py
+++ b/netbox/dcim/api/serializers_/manufacturers.py
@@ -20,4 +20,4 @@ class ManufacturerSerializer(NetBoxModelSerializer):
             'id', 'url', 'display_url', 'display', 'name', 'slug', 'description', 'tags', 'custom_fields',
             'created', 'last_updated', 'devicetype_count', 'inventoryitem_count', 'platform_count',
         ]
-        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description', 'devicetype_count')
+        brief_fields = ('id', 'url', 'display', 'name', 'slug', 'description')

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -531,7 +531,7 @@ class RackReservationTest(APIViewTestCases.APIViewTestCase):
 
 class ManufacturerTest(APIViewTestCases.APIViewTestCase):
     model = Manufacturer
-    brief_fields = ['description', 'devicetype_count', 'display', 'id', 'name', 'slug', 'url']
+    brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
         {
             'name': 'Manufacturer 4',


### PR DESCRIPTION
### Fixes: #17976

- Remove the `devicetype_count` field from `brief_fields` for the Manufacturer serializer

I'm not sure why this was ever included initially; it appears to be an oversight. The model's other counter fields (`inventoryitem_count` and `platform_count`) are not included.
