### PR TITLE
Fixes #20491: Normalize numeric range array fields for API test comparisons

### DIFF
--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -1071,14 +1071,17 @@ class VLANGroupTest(APIViewTestCases.APIViewTestCase):
         {
             'name': 'VLAN Group 4',
             'slug': 'vlan-group-4',
+            'vid_ranges': [[1, 4094]]
         },
         {
             'name': 'VLAN Group 5',
             'slug': 'vlan-group-5',
+            'vid_ranges': [[1, 4094]]
         },
         {
             'name': 'VLAN Group 6',
             'slug': 'vlan-group-6',
+            'vid_ranges': [[1, 4094]]
         },
     ]
     bulk_update_data = {


### PR DESCRIPTION
### Fixes: #20491

This PR updates the API testing utilities so that numeric range array fields are represented consistently with the API serializers.

Specifically:

- In `utilities.testing.base.model_to_dict()`, when `api=True` and the field is an `ArrayField` of a `RangeField` (e.g. `ArrayField(IntegerRangeField)`), the values are converted from psycopg's canonical half‑open ranges `[low, high)` into inclusive `[low, high]` pairs before comparison.
- This matches the behavior of `IntegerRangeSerializer(many=True, required=False)`, which exposes ranges as inclusive `[low, high]` pairs at the API boundary (for example, `VLANGroup.vid_ranges`).
- The change is limited to the test harness and does not affect runtime behavior or the public API; it only ensures that `APIViewTestCase` compares data using the same representation as the serializers.

As a small regression check, the VLAN group API test (`VLANGroupTest` in `ipam.tests.test_api`) is updated to include a `vid_ranges` value in `create_data` so that this path is exercised automatically going forward.
