### PR TITLE
Fixes #20912: Clear ModuleBay parent when module assignment removed

### DIFF
--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -1222,6 +1222,8 @@ class ModuleBay(ModularComponentModel, TrackingModelMixin, MPTTModel):
     def save(self, *args, **kwargs):
         if self.module:
             self.parent = self.module.module_bay
+        else:
+            self.parent = None
         super().save(*args, **kwargs)
 
 


### PR DESCRIPTION
### Fixes: #20912

When a ModuleBay's `module` field is cleared (returning it to device-level), the parent field was not being updated, leaving stale MPTT tree data.

The `save()` method only set parent when module was present, but failed to clear it when module was removed. Now explicitly sets parent to None when module is cleared.