### PR TITLE
Fixes #20969: Fix FrontPortTemplateFilterSet rear_port_id queryset

### DIFF
--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -875,7 +875,7 @@ class FrontPortTemplateFilterSet(ChangeLoggedModelFilterSet, ModularDeviceTypeCo
         null_value=None
     )
     rear_port_id = django_filters.ModelMultipleChoiceFilter(
-        queryset=RearPort.objects.all()
+        queryset=RearPortTemplate.objects.all()
     )
 
     class Meta:


### PR DESCRIPTION
### Fixes: #20969

- Modified `FrontPortTemplateFilterSet rear_port_id` queryset to filter using `FrontPortTemplate`s instead of `FrontPort`s