### PR TITLE
Closes: #20930 - Add an ASNSiteSerializer to allow serialization of Site in ASNSerializer

### DIFF
--- a/netbox/ipam/api/serializers_/asns.py
+++ b/netbox/ipam/api/serializers_/asns.py
@@ -1,7 +1,8 @@
 from rest_framework import serializers
 
+from dcim.models import Site
 from ipam.models import ASN, ASNRange, RIR
-from netbox.api.fields import RelatedObjectCountField
+from netbox.api.fields import RelatedObjectCountField, SerializedPKRelatedField
 from netbox.api.serializers import OrganizationalModelSerializer, PrimaryModelSerializer
 from tenancy.api.serializers_.tenants import TenantSerializer
 
@@ -41,9 +42,27 @@ class ASNRangeSerializer(OrganizationalModelSerializer):
         brief_fields = ('id', 'url', 'display', 'name', 'description')
 
 
+class ASNSiteSerializer(PrimaryModelSerializer):
+    """
+    This serializer is meant for inclusion in ASNSerializer and is only used
+    to avoid a circular import of SiteSerializer.
+    """
+    class Meta:
+        model = Site
+        fields = ('id', 'url', 'display', 'name', 'description', 'slug')
+        brief_fields = ('id', 'url', 'display', 'name', 'description', 'slug')
+
+
 class ASNSerializer(PrimaryModelSerializer):
     rir = RIRSerializer(nested=True, required=False, allow_null=True)
     tenant = TenantSerializer(nested=True, required=False, allow_null=True)
+    sites = SerializedPKRelatedField(
+        queryset=Site.objects.all(),
+        serializer=ASNSiteSerializer,
+        nested=True,
+        required=False,
+        many=True
+    )
 
     # Related object counts
     site_count = RelatedObjectCountField('sites')
@@ -53,7 +72,7 @@ class ASNSerializer(PrimaryModelSerializer):
         model = ASN
         fields = [
             'id', 'url', 'display_url', 'display', 'asn', 'rir', 'tenant', 'description', 'owner', 'comments', 'tags',
-            'custom_fields', 'created', 'last_updated', 'site_count', 'provider_count',
+            'custom_fields', 'created', 'last_updated', 'site_count', 'provider_count', 'sites',
         ]
         brief_fields = ('id', 'url', 'display', 'asn', 'description')
 

--- a/netbox/ipam/api/serializers_/asns.py
+++ b/netbox/ipam/api/serializers_/asns.py
@@ -9,6 +9,7 @@ from tenancy.api.serializers_.tenants import TenantSerializer
 __all__ = (
     'ASNRangeSerializer',
     'ASNSerializer',
+    'ASNSiteSerializer',
     'AvailableASNSerializer',
     'RIRSerializer',
 )


### PR DESCRIPTION
### Closes: #20930

Normally, via the UI, it is possible to set the list of associated sites when creating an ASN. This is not possible currently in the API because `ASNSerializer` omits a `sites` field because of a circular import issue.

This PR resolves the circular import by creating a minimal `ASNSiteSerializer` for use in `ASNSerializer`, allowing a POST payload such as:

```
{
    "asn": 65007,
    "rir": 8,
    "sites": [24]
}
```
