### PR TITLE
Fix JSON serialization error in get_installed_apps()

### DIFF
--- a/netbox/utilities/apps.py
+++ b/netbox/utilities/apps.py
@@ -11,6 +11,9 @@ def get_installed_apps():
         if version := getattr(app, 'VERSION', getattr(app, '__version__', None)):
             if type(version) is tuple:
                 version = '.'.join(str(n) for n in version)
+            elif not isinstance(version, str):
+                # Skip non-serializable version types (e.g. setuptools-scm placeholders)
+                continue
             installed_apps[app_config.name] = version
     return {
         k: v for k, v in sorted(installed_apps.items())


### PR DESCRIPTION
### Fixes: #20993

### Summary

This PR adds a defensive check in `get_installed_apps()` to skip VERSION attributes that are neither tuples nor strings, preventing JSON serialization errors in the `/api/status/` endpoint.

**The Problem:**

Some packages (like `django-health-check` using `setuptools-scm`) define their `VERSION` attribute as a type placeholder at runtime rather than an actual version value:

```python
# In django-health-check's _version.py (generated by setuptools-scm)
VERSION_TUPLE: Tuple[int, int, int] = object  # This is <class 'object'> at runtime!
```

When `get_installed_apps()` encounters this, it includes `<class 'object'>` in the dictionary, which fails JSON serialization.

**The Fix:**

Add an `elif` branch to skip non-serializable version types:

```python
if type(version) is tuple:
    version = '.'.join(str(n) for n in version)
elif not isinstance(version, str):
    # Skip non-serializable version types (e.g. setuptools-scm placeholders)
    continue
```

This is a minimal, defensive change that:
- Maintains existing behavior for tuple and string versions
- Gracefully handles edge cases from third-party packages
- Has no impact on correctly-behaving packages

**Testing:**

Verified fix resolves the issue with `django-health-check` 3.20.0 installed.