### PR TITLE
Closes #20309: Add ASDOT notation support for ASN ranges

### DIFF
--- a/netbox/ipam/fields.py
+++ b/netbox/ipam/fields.py
@@ -16,6 +16,7 @@ __all__ = (
 # BGP ASN bounds
 BGP_ASN_MIN = 1
 BGP_ASN_MAX = 2**32 - 1
+BGP_ASN_ASDOT_BASE = 2**16
 
 
 class BaseIPField(models.Field):
@@ -126,3 +127,16 @@ class ASNField(models.BigIntegerField):
         }
         defaults.update(**kwargs)
         return super().formfield(**defaults)
+
+    @staticmethod
+    def to_asdot(value) -> str:
+        """
+        Return ASDOT notation for AS numbers greater than 16 bits.
+        """
+        if value is None:
+            return ''
+
+        if value >= BGP_ASN_ASDOT_BASE:
+            hi, lo = divmod(value, BGP_ASN_ASDOT_BASE)
+            return f'{hi}.{lo}'
+        return str(value)

--- a/netbox/ipam/tables/asn.py
+++ b/netbox/ipam/tables/asn.py
@@ -23,12 +23,12 @@ class ASNRangeTable(TenancyColumnsMixin, NetBoxTable):
     start_asdot = tables.Column(
         accessor=tables.A('start_asdot'),
         order_by=tables.A('start'),
-        verbose_name=_('Start ASDOT')
+        verbose_name=_('Start (ASDOT)')
     )
     end_asdot = tables.Column(
         accessor=tables.A('end_asdot'),
         order_by=tables.A('end'),
-        verbose_name=_('End ASDOT')
+        verbose_name=_('End (ASDOT)')
     )
     tags = columns.TagColumn(
         url_name='ipam:asnrange_list'

--- a/netbox/ipam/tables/asn.py
+++ b/netbox/ipam/tables/asn.py
@@ -20,6 +20,16 @@ class ASNRangeTable(TenancyColumnsMixin, NetBoxTable):
         verbose_name=_('RIR'),
         linkify=True
     )
+    start_asdot = tables.Column(
+        accessor=tables.A('start_asdot'),
+        order_by=tables.A('start'),
+        verbose_name=_('Start ASDOT')
+    )
+    end_asdot = tables.Column(
+        accessor=tables.A('end_asdot'),
+        order_by=tables.A('end'),
+        verbose_name=_('End ASDOT')
+    )
     tags = columns.TagColumn(
         url_name='ipam:asnrange_list'
     )
@@ -30,8 +40,8 @@ class ASNRangeTable(TenancyColumnsMixin, NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = ASNRange
         fields = (
-            'pk', 'name', 'slug', 'rir', 'start', 'end', 'asn_count', 'tenant', 'tenant_group', 'description', 'tags',
-            'created', 'last_updated', 'actions',
+            'pk', 'name', 'slug', 'rir', 'start', 'start_asdot', 'end', 'end_asdot', 'asn_count', 'tenant',
+            'tenant_group', 'description', 'tags', 'created', 'last_updated', 'actions',
         )
         default_columns = ('pk', 'name', 'rir', 'start', 'end', 'tenant', 'asn_count', 'description')
 

--- a/netbox/templates/ipam/asnrange.html
+++ b/netbox/templates/ipam/asnrange.html
@@ -23,7 +23,7 @@
           </tr>
           <tr>
             <th scope="row">{% trans "Range" %}</th>
-            <td>{{ object.range_as_string }}</td>
+            <td>{{ object.range_as_string_with_asdot }}</td>
           </tr>
           <tr>
             <th scope="row">{% trans "Tenant" %}</th>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20309

Introduces ASDOT notation for ASN ranges to improve readability of large AS numbers. Adds `start_asdot` and `end_asdot` properties, updates the relevant table columns, and adjusts display logic so ranges can show both ASPLAIN and ASDOT where appropriate.

#### Note

To avoid repeating the same ASDOT conversion logic (`// 65536` / `% 65536`) in multiple places, the conversion is implemented once as `ASNField.to_asdot()` and reused by the model properties. This keeps the helper IPAM-scoped while ensuring consistent formatting across all ASN consumers.

I also reordered methods/properties in `ASNRange` to follow the common NetBox model style for readability. If maintainers would prefer the simpler (more repetitive) inline conversion and/or don’t want the reordering, I’m happy to adjust.
