### PR TITLE
Fixes #20320: Include parent PK in BulkEdit context for child objects

### DIFF
--- a/netbox/netbox/tests/test_object_actions.py
+++ b/netbox/netbox/tests/test_object_actions.py
@@ -1,11 +1,10 @@
 from unittest import skipIf
 
 from django.conf import settings
-from django.test import TestCase
+from django.test import RequestFactory, TestCase
 
-from dcim.models import Device
-from netbox.object_actions import AddObject, BulkImport
-from netbox.tests.dummy_plugin.models import DummyNetBoxModel
+from dcim.models import Device, DeviceType, Manufacturer
+from netbox.object_actions import AddObject, BulkEdit, BulkImport
 
 
 class ObjectActionTest(TestCase):
@@ -20,9 +19,11 @@ class ObjectActionTest(TestCase):
         url = BulkImport.get_url(obj)
         self.assertEqual(url, '/dcim/devices/import/')
 
-    @skipIf('netbox.tests.dummy_plugin' not in settings.PLUGINS, "dummy_plugin not in settings.PLUGINS")
+    @skipIf('netbox.tests.dummy_plugin' not in settings.PLUGINS, 'dummy_plugin not in settings.PLUGINS')
     def test_get_url_plugin_model(self):
         """Test URL generation for plugin models includes plugins: namespace"""
+        from netbox.tests.dummy_plugin.models import DummyNetBoxModel
+
         obj = DummyNetBoxModel()
 
         url = AddObject.get_url(obj)
@@ -30,3 +31,29 @@ class ObjectActionTest(TestCase):
 
         url = BulkImport.get_url(obj)
         self.assertEqual(url, '/plugins/dummy-plugin/netboxmodel/import/')
+
+    def test_bulk_edit_get_context_child_object(self):
+        """
+        Test that the parent object's PK is included in the context for child objects.
+
+        Ensure that BulkEdit.get_context() correctly identifies and
+        includes the parent object's PK when rendering a child object's
+        action button.
+        """
+        manufacturer = Manufacturer.objects.create(name='Manufacturer 1', slug='manufacturer-1')
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model='Device Type 1', slug='device-type-1')
+
+        # Mock context containing the parent object (DeviceType)
+        request = RequestFactory().get('/')
+        context = {
+            'request': request,
+            'object': device_type,
+        }
+
+        # Get context for the child model (Device)
+        action_context = BulkEdit.get_context(context, Device)
+
+        # Verify that 'device_type' (the FK field name) is present in
+        # url_params with the parent's PK
+        self.assertIn('url_params', action_context)
+        self.assertEqual(action_context['url_params'].get('device_type'), device_type.pk)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20320

<!--
    Please include a summary of the proposed changes below.
-->
This PR addresses the issue where the “Related Interfaces” selectors (Parent/Bridge/LAG) are disabled when bulk-editing interfaces from an object child view (e.g. device → interfaces) in v4.4.0.

#### Summary / Rationale
When bulk actions are invoked from an object child view (e.g. `/dcim/devices/<pk>/interfaces/`), the bulk edit action URL no longer carries the parent-scoping query parameter (e.g. `device=<pk>`). Without that context, the bulk edit form can’t scope/populate the related-interface fields, leaving them grayed out.

#### Proposed Changes
- Enhance `BulkEdit.get_context()` to detect the “child view” case (presence of a parent `object` in the template context).
- When applicable, inject the parent object’s primary key into the bulk edit action URL parameters (e.g. `device=<parent.pk>` / `device_type=<parent.pk>`), while preserving any existing `request.GET` parameters (and `return_url` when present).
- Only add the parameter when it’s not already provided, to avoid altering behavior on global list views.

#### Tests Added
- Added a unit test to confirm the parent object's PK is included in `url_params` when rendering a bulk action in a child-object context:
  - `test_bulk_edit_get_context_child_object` creates a `DeviceType` parent and verifies `BulkEdit.get_context(context, Device)` injects `device_type=<parent.pk>` into `url_params` when the template context includes `object=<DeviceType>`.
- Also adjusted a plugin URL test to ensure the `@skipIf` decorator behaves correctly:
  - Moved the import of the dummy plugin model inside `test_get_url_plugin_model` so the module import doesn’t occur before the `@skipIf` condition is evaluated.

#### Notes / Open Question
I’m not 100% certain this is the preferred place to implement the fix (action context vs. view/template), but this approach keeps the change small and avoids duplicating templates.

#### How To Test
1. Go to a device → Interfaces tab.
2. Select multiple interfaces.
3. Click **Edit Selected**.
4. Confirm the Parent/Bridge/LAG fields are enabled and show relevant interface choices.
5. Confirm bulk edit from the global Interfaces list behaves as before (no unintended scoping).
6. Run the test suite (including plugin tests when `netbox.tests.dummy_plugin` is enabled) and confirm all tests pass.
