### PR TITLE
Fixes #20997: Enable creating permissions for the Owner model

### DIFF
--- a/netbox/users/constants.py
+++ b/netbox/users/constants.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 
 OBJECTPERMISSION_OBJECT_TYPES = Q(
     ~Q(app_label__in=['account', 'admin', 'auth', 'contenttypes', 'sessions', 'taggit', 'users']) |
-    Q(app_label='users', model__in=['objectpermission', 'token', 'group', 'user'])
+    Q(app_label='users', model__in=['objectpermission', 'token', 'group', 'user', 'owner'])
 )
 
 CONSTRAINT_TOKEN_USER = '$user'


### PR DESCRIPTION
### Fixes: #20997

- Add `users.Owner` to `OBJECTPERMISSION_OBJECT_TYPES`
