### PR TITLE
Preserve parent_bay during device bulk import when tags are present

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -2454,11 +2454,12 @@ class DeviceBulkImportView(generic.BulkImportView):
     model_form = forms.DeviceImportForm
 
     def save_object(self, object_form, request):
+        parent_bay = getattr(object_form.instance, 'parent_bay', None)
         obj = object_form.save()
 
         # For child devices, save the reverse relation to the parent device bay
-        if getattr(obj, 'parent_bay', None):
-            device_bay = obj.parent_bay
+        if parent_bay:
+            device_bay = parent_bay
             device_bay.installed_device = obj
             device_bay.save()
 


### PR DESCRIPTION
### Fixes: #20114

When tags are present, the `_save_m2m` method of `BaseModelForm` causes the instance to be forcibly saved via `f.save_form_data(self.instance, cleaned_data[f.name])`. However, because we detect the presence of a device's parent device bay by stashing it on the instance prior to `save`:

https://github.com/netbox-community/netbox/blob/ff97ab96c7e075571d2e33f0ac06cd741cfd4a82/netbox/dcim/forms/bulk_import.py#L730-L732

The `_save_m2m` behavior normally leaves `parent_bay` alone, but if tags are present, this intermediary `save_form_data` has the effect of regenerating the saved `obj` and clearing out the synthetic `parent_bay` attribute.

This fix ensures `parent_bay` survives this process by pulling it from the `object_form.instance` prior to calling the `save` chain, rather than assuming the result of `save` will still have `parent_bay`.