### PR TITLE
Fixes #21011: Avoid updating database when loading active ConfigRevision

### DIFF
--- a/netbox/core/models/config.py
+++ b/netbox/core/models/config.py
@@ -63,16 +63,20 @@ class ConfigRevision(models.Model):
             return reverse('core:config')  # Default config view
         return reverse('core:configrevision', args=[self.pk])
 
-    def activate(self):
+    def activate(self, update_db=True):
         """
         Cache the configuration data.
+
+        Parameters:
+            update_db: Mark the ConfigRevision as active in the database (default: True)
         """
         cache.set('config', self.data, None)
         cache.set('config_version', self.pk, None)
 
-        # Set all instances of ConfigRevision to false and set this instance to true
-        ConfigRevision.objects.all().update(active=False)
-        ConfigRevision.objects.filter(pk=self.pk).update(active=True)
+        if update_db:
+            # Set all instances of ConfigRevision to false and set this instance to true
+            ConfigRevision.objects.all().update(active=False)
+            ConfigRevision.objects.filter(pk=self.pk).update(active=True)
 
     activate.alters_data = True
 

--- a/netbox/netbox/config/__init__.py
+++ b/netbox/netbox/config/__init__.py
@@ -80,22 +80,21 @@ class Config:
         try:
             # Enforce the creation date as the ordering parameter
             revision = ConfigRevision.objects.get(active=True)
-            logger.debug(f"Loaded active configuration revision #{revision.pk}")
+            logger.debug(f"Loaded active configuration revision (#{revision.pk})")
         except (ConfigRevision.DoesNotExist, ConfigRevision.MultipleObjectsReturned):
-            logger.debug("No active configuration revision found - falling back to most recent")
             revision = ConfigRevision.objects.order_by('-created').first()
             if revision is None:
-                logger.debug("No previous configuration found in database; proceeding with default values")
+                logger.debug("No configuration found in database; proceeding with default values")
                 return
-            logger.debug(f"Using fallback configuration revision #{revision.pk}")
+            logger.debug(f"No active configuration revision found; falling back to most recent (#{revision.pk})")
         except DatabaseError:
             # The database may not be available yet (e.g. when running a management command)
             logger.warning("Skipping config initialization (database unavailable)")
             return
 
-        revision.activate()
-        logger.debug("Filled cache with data from latest ConfigRevision")
+        revision.activate(update_db=False)
         self._populate_from_cache()
+        logger.debug("Filled cache with data from latest ConfigRevision")
 
 
 class ConfigItem:


### PR DESCRIPTION
### Fixes: #21011

- Add an `update_db` parameter to the `activate()` method on ConfigRevision
  - Set this to False when loading the active revision from the database
- Miscellaneous cleanup of debug messages