### PR TITLE
Fixes #21020: Fix object filtering for image attachments panel

### DIFF
--- a/netbox/extras/ui/panels.py
+++ b/netbox/extras/ui/panels.py
@@ -51,7 +51,14 @@ class ImageAttachmentsPanel(panels.ObjectsTablePanel):
     ]
 
     def __init__(self, **kwargs):
-        super().__init__('extras.imageattachment', **kwargs)
+        super().__init__(
+            'extras.imageattachment',
+            filters={
+                'object_type_id': lambda ctx: ContentType.objects.get_for_model(ctx['object']).pk,
+                'object_id': lambda ctx: ctx['object'].pk,
+            },
+            **kwargs,
+        )
 
 
 class TagsPanel(panels.ObjectPanel):


### PR DESCRIPTION
### Fixes: #21020

Apply object type & ID filters for image attachments panel