### PR TITLE
Fix nested serializer validation for PATCH requests with {"id": X} format

### DIFF
--- a/netbox/netbox/api/serializers/base.py
+++ b/netbox/netbox/api/serializers/base.py
@@ -41,6 +41,19 @@ class BaseModelSerializer(serializers.ModelSerializer):
 
         super().__init__(*args, **kwargs)
 
+    def run_validation(self, data=serializers.empty):
+        """
+        Override run_validation to skip field-level validation for nested serializers.
+        When nested=True, we only need to look up the object by ID/attrs, not validate
+        all required fields.
+        """
+        if self.nested:
+            # For nested serializers, skip field-level validation and go straight to
+            # to_internal_value which will look up the object by ID/attrs
+            return self.to_internal_value(data)
+
+        return super().run_validation(data)
+
     def to_internal_value(self, data):
 
         # If initialized as a nested serializer, we should expect to receive the attrs or PK


### PR DESCRIPTION
When a nested serializer receives {"id": X} in a PATCH request, DRF was attempting to validate it as a full object, requiring all required fields (e.g., 'name' and 'group' for Tenant). This caused validation errors like 'group and name are required' even though the nested serializer should only look up the object by ID.

The fix overrides run_validation() to skip field-level validation for nested serializers, allowing to_internal_value() to properly handle {"id": X} format by looking up the object via get_related_object_by_attrs().

Fixes issue where PATCH requests to update Site with tenant field using {"id": X} format would fail with validation errors.

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->


<!--
    Please include a summary of the proposed changes below.
-->
