### PR TITLE
FIxes #19506: Add filter forms for component templates

### DIFF
--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -24,35 +24,45 @@ __all__ = (
     'CableFilterForm',
     'ConsoleConnectionFilterForm',
     'ConsolePortFilterForm',
+    'ConsolePortTemplateFilterForm',
     'ConsoleServerPortFilterForm',
+    'ConsoleServerPortTemplateFilterForm',
     'DeviceBayFilterForm',
+    'DeviceBayTemplateFilterForm',
     'DeviceFilterForm',
     'DeviceRoleFilterForm',
     'DeviceTypeFilterForm',
     'FrontPortFilterForm',
+    'FrontPortTemplateFilterForm',
     'InterfaceConnectionFilterForm',
     'InterfaceFilterForm',
+    'InterfaceTemplateFilterForm',
     'InventoryItemFilterForm',
+    'InventoryItemTemplateFilterForm',
     'InventoryItemRoleFilterForm',
     'LocationFilterForm',
     'MACAddressFilterForm',
     'ManufacturerFilterForm',
     'ModuleFilterForm',
     'ModuleBayFilterForm',
+    'ModuleBayTemplateFilterForm',
     'ModuleTypeFilterForm',
     'ModuleTypeProfileFilterForm',
     'PlatformFilterForm',
     'PowerConnectionFilterForm',
     'PowerFeedFilterForm',
     'PowerOutletFilterForm',
+    'PowerOutletTemplateFilterForm',
     'PowerPanelFilterForm',
     'PowerPortFilterForm',
+    'PowerPortTemplateFilterForm',
     'RackFilterForm',
     'RackElevationFilterForm',
     'RackReservationFilterForm',
     'RackRoleFilterForm',
     'RackTypeFilterForm',
     'RearPortFilterForm',
+    'RearPortTemplateFilterForm',
     'RegionFilterForm',
     'SiteFilterForm',
     'SiteGroupFilterForm',
@@ -1342,6 +1352,25 @@ class ConsolePortFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
+class ConsolePortTemplateFilterForm(NetBoxModelFilterSetForm):
+    model = ConsolePortTemplate
+    fieldsets = (
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet('name', 'label', 'type', 'speed', name=_('Attributes')),
+        FieldSet('device_type_id', name=_('Device Type')),
+    )
+    type = forms.MultipleChoiceField(
+        label=_('Type'),
+        choices=ConsolePortTypeChoices,
+        required=False
+    )
+    speed = forms.MultipleChoiceField(
+        label=_('Speed'),
+        choices=ConsolePortSpeedChoices,
+        required=False
+    )
+
+
 class ConsoleServerPortFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     model = ConsoleServerPort
     fieldsets = (
@@ -1367,6 +1396,25 @@ class ConsoleServerPortFilterForm(PathEndpointFilterForm, DeviceComponentFilterF
     tag = TagFilterField(model)
 
 
+class ConsoleServerPortTemplateFilterForm(NetBoxModelFilterSetForm):
+    model = ConsoleServerPortTemplate
+    fieldsets = (
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet('name', 'label', 'type', 'speed', name=_('Attributes')),
+        FieldSet('device_type_id', name=_('Device Type')),
+    )
+    type = forms.MultipleChoiceField(
+        label=_('Type'),
+        choices=ConsolePortTypeChoices,
+        required=False
+    )
+    speed = forms.MultipleChoiceField(
+        label=_('Speed'),
+        choices=ConsolePortSpeedChoices,
+        required=False
+    )
+
+
 class PowerPortFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     model = PowerPort
     fieldsets = (
@@ -1387,6 +1435,20 @@ class PowerPortFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
+class PowerPortTemplateFilterForm(NetBoxModelFilterSetForm):
+    model = PowerPortTemplate
+    fieldsets = (
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet('name', 'label', 'type', name=_('Attributes')),
+        FieldSet('device_type_id', name=_('Device Type')),
+    )
+    type = forms.MultipleChoiceField(
+        label=_('Type'),
+        choices=PowerPortTypeChoices,
+        required=False
+    )
+
+
 class PowerOutletFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     model = PowerOutlet
     fieldsets = (
@@ -1405,6 +1467,29 @@ class PowerOutletFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
         required=False
     )
     tag = TagFilterField(model)
+    color = ColorField(
+        label=_('Color'),
+        required=False
+    )
+    status = forms.MultipleChoiceField(
+        label=_('Status'),
+        choices=PowerOutletStatusChoices,
+        required=False
+    )
+
+
+class PowerOutletTemplateFilterForm(NetBoxModelFilterSetForm):
+    model = PowerOutletTemplate
+    fieldsets = (
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet('name', 'label', 'type', 'color', 'status', name=_('Attributes')),
+        FieldSet('device_type_id', name=_('Device Type')),
+    )
+    type = forms.MultipleChoiceField(
+        label=_('Type'),
+        choices=PowerOutletTypeChoices,
+        required=False
+    )
     color = ColorField(
         label=_('Color'),
         required=False
@@ -1543,6 +1628,50 @@ class InterfaceFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
+class InterfaceTemplateFilterForm(NetBoxModelFilterSetForm):
+    model = InterfaceTemplate
+    fieldsets = (
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet('name', 'label', 'kind', 'type', 'speed', 'duplex', 'enabled', 'mgmt_only', name=_('Attributes')),
+        FieldSet('poe_mode', 'poe_type', name=_('PoE')),
+        FieldSet('rf_role', 'rf_channel', 'rf_channel_width', 'tx_power', name=_('Wireless')),
+        FieldSet('region_id', 'site_group_id', 'site_id', 'location_id', 'rack_id', name=_('Location')),
+    )
+
+    kind = forms.MultipleChoiceField(
+        label=_('Kind'),
+        choices=InterfaceKindChoices,
+        required=False
+    )
+    mgmt_only = forms.NullBooleanField(
+        label=_('Mgmt only'),
+        required=False,
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        )
+    )
+    type = forms.MultipleChoiceField(
+        label=_('Type'),
+        choices=InterfaceTypeChoices,
+        required=False
+    )
+    poe_mode = forms.MultipleChoiceField(
+        choices=InterfacePoEModeChoices,
+        required=False,
+        label=_('PoE mode')
+    )
+    poe_type = forms.MultipleChoiceField(
+        choices=InterfacePoETypeChoices,
+        required=False,
+        label=_('PoE type')
+    )
+    rf_role = forms.MultipleChoiceField(
+        choices=WirelessRoleChoices,
+        required=False,
+        label=_('Wireless role')
+    )
+
+
 class FrontPortFilterForm(CabledFilterForm, DeviceComponentFilterForm):
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
@@ -1565,6 +1694,23 @@ class FrontPortFilterForm(CabledFilterForm, DeviceComponentFilterForm):
         required=False
     )
     tag = TagFilterField(model)
+
+
+class FrontPortTemplateFilterForm(NetBoxModelFilterSetForm):
+    model = FrontPortTemplate
+    fieldsets = (
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet('name', 'label', 'type', 'color', name=_('Attributes')),
+    )
+    type = forms.MultipleChoiceField(
+        label=_('Type'),
+        choices=PortTypeChoices,
+        required=False
+    )
+    color = ColorField(
+        label=_('Color'),
+        required=False
+    )
 
 
 class RearPortFilterForm(CabledFilterForm, DeviceComponentFilterForm):
@@ -1591,6 +1737,23 @@ class RearPortFilterForm(CabledFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
+class RearPortTemplateFilterForm(NetBoxModelFilterSetForm):
+    model = RearPortTemplate
+    fieldsets = (
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet('name', 'label', 'type', 'color', name=_('Attributes')),
+    )
+    type = forms.MultipleChoiceField(
+        label=_('Type'),
+        choices=PortTypeChoices,
+        required=False
+    )
+    color = ColorField(
+        label=_('Color'),
+        required=False
+    )
+
+
 class ModuleBayFilterForm(DeviceComponentFilterForm):
     model = ModuleBay
     fieldsets = (
@@ -1609,6 +1772,31 @@ class ModuleBayFilterForm(DeviceComponentFilterForm):
     )
 
 
+class ModuleBayTemplateFilterForm(NetBoxModelFilterSetForm):
+    model = ModuleBayTemplate
+    fieldsets = (
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet('name', 'label', 'position', name=_('Attributes')),
+        FieldSet(
+            'device_type_id',
+            'module_type_id',
+            name=_('Device'),
+        ),
+    )
+
+    device_type_id = DynamicModelMultipleChoiceField(
+        queryset=DeviceType.objects.all(), required=False, label=_('Device type')
+    )
+    module_type_id = DynamicModelMultipleChoiceField(
+        queryset=ModuleType.objects.all(),
+        required=False,
+        query_params={'manufacturer_id': '$manufacturer_id'},
+        label=_('Module Type'),
+    )
+
+    position = forms.CharField(label=_('Position'), required=False)
+
+
 class DeviceBayFilterForm(DeviceComponentFilterForm):
     model = DeviceBay
     fieldsets = (
@@ -1621,6 +1809,22 @@ class DeviceBayFilterForm(DeviceComponentFilterForm):
         ),
     )
     tag = TagFilterField(model)
+
+
+class DeviceBayTemplateFilterForm(NetBoxModelFilterSetForm):
+    model = DeviceBayTemplate
+    fieldsets = (
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet('name', 'label', name=_('Attributes')),
+        FieldSet(
+            'device_type_id',
+            name=_('Device'),
+        ),
+    )
+
+    device_type_id = DynamicModelMultipleChoiceField(
+        queryset=DeviceType.objects.all(), required=False, label=_('Device type')
+    )
 
 
 class InventoryItemFilterForm(DeviceComponentFilterForm):
@@ -1668,6 +1872,37 @@ class InventoryItemFilterForm(DeviceComponentFilterForm):
         required=False
     )
     tag = TagFilterField(model)
+
+
+class InventoryItemTemplateFilterForm(NetBoxModelFilterSetForm):
+    model = InventoryItemTemplate
+    fieldsets = (
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet(
+            'name', 'label', 'status', 'role_id', 'manufacturer_id', name=_('Attributes')
+        ),
+        FieldSet(
+            'device_type_id', name=_('Device'),
+        ),
+    )
+    role_id = DynamicModelMultipleChoiceField(
+        queryset=InventoryItemRole.objects.all(),
+        required=False,
+        label=_('Role')
+    )
+    manufacturer_id = DynamicModelMultipleChoiceField(
+        queryset=Manufacturer.objects.all(),
+        required=False,
+        label=_('Manufacturer')
+    )
+    status = forms.MultipleChoiceField(
+        label=_('Status'),
+        choices=InventoryItemStatusChoices,
+        required=False
+    )
+    device_type_id = DynamicModelMultipleChoiceField(
+        queryset=DeviceType.objects.all(), required=False, label=_('Device type')
+    )
 
 
 #

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -1300,6 +1300,18 @@ class PowerFeedFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
 # Device components
 #
 
+class DeviceComponentTemplateFilterForm(NetBoxModelFilterSetForm):
+    device_type_id = DynamicModelMultipleChoiceField(
+        queryset=DeviceType.objects.all(), required=False, label=_('Device type')
+    )
+    module_type_id = DynamicModelMultipleChoiceField(
+        queryset=ModuleType.objects.all(),
+        required=False,
+        query_params={'manufacturer_id': '$manufacturer_id'},
+        label=_('Module Type'),
+    )
+
+
 class CabledFilterForm(forms.Form):
     cabled = forms.NullBooleanField(
         label=_('Cabled'),
@@ -1352,12 +1364,12 @@ class ConsolePortFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
-class ConsolePortTemplateFilterForm(NetBoxModelFilterSetForm):
+class ConsolePortTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
     model = ConsolePortTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet('name', 'label', 'type', 'speed', name=_('Attributes')),
-        FieldSet('device_type_id', name=_('Device Type')),
+        FieldSet('device_type_id', 'module_type_id', name=_('Device')),
     )
     type = forms.MultipleChoiceField(
         label=_('Type'),
@@ -1396,12 +1408,12 @@ class ConsoleServerPortFilterForm(PathEndpointFilterForm, DeviceComponentFilterF
     tag = TagFilterField(model)
 
 
-class ConsoleServerPortTemplateFilterForm(NetBoxModelFilterSetForm):
+class ConsoleServerPortTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
     model = ConsoleServerPortTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet('name', 'label', 'type', 'speed', name=_('Attributes')),
-        FieldSet('device_type_id', name=_('Device Type')),
+        FieldSet('device_type_id', 'module_type_id', name=_('Device')),
     )
     type = forms.MultipleChoiceField(
         label=_('Type'),
@@ -1435,12 +1447,12 @@ class PowerPortFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
-class PowerPortTemplateFilterForm(NetBoxModelFilterSetForm):
+class PowerPortTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
     model = PowerPortTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet('name', 'label', 'type', name=_('Attributes')),
-        FieldSet('device_type_id', name=_('Device Type')),
+        FieldSet('device_type_id', 'module_type_id', name=_('Device')),
     )
     type = forms.MultipleChoiceField(
         label=_('Type'),
@@ -1478,12 +1490,12 @@ class PowerOutletFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     )
 
 
-class PowerOutletTemplateFilterForm(NetBoxModelFilterSetForm):
+class PowerOutletTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
     model = PowerOutletTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('name', 'label', 'type', 'color', 'status', name=_('Attributes')),
-        FieldSet('device_type_id', name=_('Device Type')),
+        FieldSet('name', 'label', 'type', 'color', name=_('Attributes')),
+        FieldSet('device_type_id', 'module_type_id', name=_('Device')),
     )
     type = forms.MultipleChoiceField(
         label=_('Type'),
@@ -1492,11 +1504,6 @@ class PowerOutletTemplateFilterForm(NetBoxModelFilterSetForm):
     )
     color = ColorField(
         label=_('Color'),
-        required=False
-    )
-    status = forms.MultipleChoiceField(
-        label=_('Status'),
-        choices=PowerOutletStatusChoices,
         required=False
     )
 
@@ -1628,14 +1635,14 @@ class InterfaceFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
-class InterfaceTemplateFilterForm(NetBoxModelFilterSetForm):
+class InterfaceTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
     model = InterfaceTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet('name', 'label', 'kind', 'type', 'speed', 'duplex', 'enabled', 'mgmt_only', name=_('Attributes')),
         FieldSet('poe_mode', 'poe_type', name=_('PoE')),
         FieldSet('rf_role', 'rf_channel', 'rf_channel_width', 'tx_power', name=_('Wireless')),
-        FieldSet('region_id', 'site_group_id', 'site_id', 'location_id', 'rack_id', name=_('Location')),
+        FieldSet('device_type_id', 'module_type_id', name=_('Device')),
     )
 
     kind = forms.MultipleChoiceField(
@@ -1696,11 +1703,12 @@ class FrontPortFilterForm(CabledFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
-class FrontPortTemplateFilterForm(NetBoxModelFilterSetForm):
+class FrontPortTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
     model = FrontPortTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet('name', 'label', 'type', 'color', name=_('Attributes')),
+        FieldSet('device_type_id', 'module_type_id', name=_('Device')),
     )
     type = forms.MultipleChoiceField(
         label=_('Type'),
@@ -1737,11 +1745,12 @@ class RearPortFilterForm(CabledFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
-class RearPortTemplateFilterForm(NetBoxModelFilterSetForm):
+class RearPortTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
     model = RearPortTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet('name', 'label', 'type', 'color', name=_('Attributes')),
+        FieldSet('device_type_id', 'module_type_id', name=_('Device')),
     )
     type = forms.MultipleChoiceField(
         label=_('Type'),
@@ -1772,26 +1781,12 @@ class ModuleBayFilterForm(DeviceComponentFilterForm):
     )
 
 
-class ModuleBayTemplateFilterForm(NetBoxModelFilterSetForm):
+class ModuleBayTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
     model = ModuleBayTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet('name', 'label', 'position', name=_('Attributes')),
-        FieldSet(
-            'device_type_id',
-            'module_type_id',
-            name=_('Device'),
-        ),
-    )
-
-    device_type_id = DynamicModelMultipleChoiceField(
-        queryset=DeviceType.objects.all(), required=False, label=_('Device type')
-    )
-    module_type_id = DynamicModelMultipleChoiceField(
-        queryset=ModuleType.objects.all(),
-        required=False,
-        query_params={'manufacturer_id': '$manufacturer_id'},
-        label=_('Module Type'),
+        FieldSet('device_type_id', 'module_type_id', name=_('Device')),
     )
 
     position = forms.CharField(label=_('Position'), required=False)
@@ -1816,10 +1811,7 @@ class DeviceBayTemplateFilterForm(NetBoxModelFilterSetForm):
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet('name', 'label', name=_('Attributes')),
-        FieldSet(
-            'device_type_id',
-            name=_('Device'),
-        ),
+        FieldSet('device_type_id', name=_('Device')),
     )
 
     device_type_id = DynamicModelMultipleChoiceField(
@@ -1878,12 +1870,8 @@ class InventoryItemTemplateFilterForm(NetBoxModelFilterSetForm):
     model = InventoryItemTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet(
-            'name', 'label', 'status', 'role_id', 'manufacturer_id', name=_('Attributes')
-        ),
-        FieldSet(
-            'device_type_id', name=_('Device'),
-        ),
+        FieldSet('name', 'label', 'role_id', 'manufacturer_id', name=_('Attributes')),
+        FieldSet('device_type_id', name=_('Device')),
     )
     role_id = DynamicModelMultipleChoiceField(
         queryset=InventoryItemRole.objects.all(),
@@ -1894,11 +1882,6 @@ class InventoryItemTemplateFilterForm(NetBoxModelFilterSetForm):
         queryset=Manufacturer.objects.all(),
         required=False,
         label=_('Manufacturer')
-    )
-    status = forms.MultipleChoiceField(
-        label=_('Status'),
-        choices=InventoryItemStatusChoices,
-        required=False
     )
     device_type_id = DynamicModelMultipleChoiceField(
         queryset=DeviceType.objects.all(), required=False, label=_('Device type')

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -1302,8 +1302,13 @@ class PowerFeedFilterForm(TenancyFilterForm, NetBoxModelFilterSetForm):
 
 class DeviceComponentTemplateFilterForm(NetBoxModelFilterSetForm):
     device_type_id = DynamicModelMultipleChoiceField(
-        queryset=DeviceType.objects.all(), required=False, label=_('Device type')
+        queryset=DeviceType.objects.all(),
+        required=False,
+        label=_('Device type'),
     )
+
+
+class ModularDeviceComponentTemplateFilterForm(DeviceComponentTemplateFilterForm):
     module_type_id = DynamicModelMultipleChoiceField(
         queryset=ModuleType.objects.all(),
         required=False,
@@ -1364,21 +1369,16 @@ class ConsolePortFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
-class ConsolePortTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
+class ConsolePortTemplateFilterForm(ModularDeviceComponentTemplateFilterForm):
     model = ConsolePortTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('name', 'label', 'type', 'speed', name=_('Attributes')),
+        FieldSet('name', 'label', 'type', name=_('Attributes')),
         FieldSet('device_type_id', 'module_type_id', name=_('Device')),
     )
     type = forms.MultipleChoiceField(
         label=_('Type'),
         choices=ConsolePortTypeChoices,
-        required=False
-    )
-    speed = forms.MultipleChoiceField(
-        label=_('Speed'),
-        choices=ConsolePortSpeedChoices,
         required=False
     )
 
@@ -1408,21 +1408,16 @@ class ConsoleServerPortFilterForm(PathEndpointFilterForm, DeviceComponentFilterF
     tag = TagFilterField(model)
 
 
-class ConsoleServerPortTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
+class ConsoleServerPortTemplateFilterForm(ModularDeviceComponentTemplateFilterForm):
     model = ConsoleServerPortTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('name', 'label', 'type', 'speed', name=_('Attributes')),
+        FieldSet('name', 'label', 'type', name=_('Attributes')),
         FieldSet('device_type_id', 'module_type_id', name=_('Device')),
     )
     type = forms.MultipleChoiceField(
         label=_('Type'),
         choices=ConsolePortTypeChoices,
-        required=False
-    )
-    speed = forms.MultipleChoiceField(
-        label=_('Speed'),
-        choices=ConsolePortSpeedChoices,
         required=False
     )
 
@@ -1447,7 +1442,7 @@ class PowerPortFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
-class PowerPortTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
+class PowerPortTemplateFilterForm(ModularDeviceComponentTemplateFilterForm):
     model = PowerPortTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
@@ -1490,20 +1485,16 @@ class PowerOutletFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     )
 
 
-class PowerOutletTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
+class PowerOutletTemplateFilterForm(ModularDeviceComponentTemplateFilterForm):
     model = PowerOutletTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('name', 'label', 'type', 'color', name=_('Attributes')),
+        FieldSet('name', 'label', 'type', name=_('Attributes')),
         FieldSet('device_type_id', 'module_type_id', name=_('Device')),
     )
     type = forms.MultipleChoiceField(
         label=_('Type'),
         choices=PowerOutletTypeChoices,
-        required=False
-    )
-    color = ColorField(
-        label=_('Color'),
         required=False
     )
 
@@ -1635,32 +1626,33 @@ class InterfaceFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
-class InterfaceTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
+class InterfaceTemplateFilterForm(ModularDeviceComponentTemplateFilterForm):
     model = InterfaceTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('name', 'label', 'kind', 'type', 'speed', 'duplex', 'enabled', 'mgmt_only', name=_('Attributes')),
+        FieldSet('name', 'label', 'type', 'enabled', 'mgmt_only', name=_('Attributes')),
         FieldSet('poe_mode', 'poe_type', name=_('PoE')),
-        FieldSet('rf_role', 'rf_channel', 'rf_channel_width', 'tx_power', name=_('Wireless')),
+        FieldSet('rf_role', name=_('Wireless')),
         FieldSet('device_type_id', 'module_type_id', name=_('Device')),
-    )
-
-    kind = forms.MultipleChoiceField(
-        label=_('Kind'),
-        choices=InterfaceKindChoices,
-        required=False
-    )
-    mgmt_only = forms.NullBooleanField(
-        label=_('Mgmt only'),
-        required=False,
-        widget=forms.Select(
-            choices=BOOLEAN_WITH_BLANK_CHOICES
-        )
     )
     type = forms.MultipleChoiceField(
         label=_('Type'),
         choices=InterfaceTypeChoices,
         required=False
+    )
+    enabled = forms.NullBooleanField(
+        label=_('Enabled'),
+        required=False,
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        )
+    )
+    mgmt_only = forms.NullBooleanField(
+        label=_('Management only'),
+        required=False,
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        )
     )
     poe_mode = forms.MultipleChoiceField(
         choices=InterfacePoEModeChoices,
@@ -1703,7 +1695,7 @@ class FrontPortFilterForm(CabledFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
-class FrontPortTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
+class FrontPortTemplateFilterForm(ModularDeviceComponentTemplateFilterForm):
     model = FrontPortTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
@@ -1745,7 +1737,7 @@ class RearPortFilterForm(CabledFilterForm, DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
-class RearPortTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
+class RearPortTemplateFilterForm(ModularDeviceComponentTemplateFilterForm):
     model = RearPortTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
@@ -1781,15 +1773,17 @@ class ModuleBayFilterForm(DeviceComponentFilterForm):
     )
 
 
-class ModuleBayTemplateFilterForm(DeviceComponentTemplateFilterForm, NetBoxModelFilterSetForm):
+class ModuleBayTemplateFilterForm(ModularDeviceComponentTemplateFilterForm):
     model = ModuleBayTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet('name', 'label', 'position', name=_('Attributes')),
         FieldSet('device_type_id', 'module_type_id', name=_('Device')),
     )
-
-    position = forms.CharField(label=_('Position'), required=False)
+    position = forms.CharField(
+        label=_('Position'),
+        required=False,
+    )
 
 
 class DeviceBayFilterForm(DeviceComponentFilterForm):
@@ -1806,16 +1800,12 @@ class DeviceBayFilterForm(DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
-class DeviceBayTemplateFilterForm(NetBoxModelFilterSetForm):
+class DeviceBayTemplateFilterForm(DeviceComponentTemplateFilterForm):
     model = DeviceBayTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet('name', 'label', name=_('Attributes')),
         FieldSet('device_type_id', name=_('Device')),
-    )
-
-    device_type_id = DynamicModelMultipleChoiceField(
-        queryset=DeviceType.objects.all(), required=False, label=_('Device type')
     )
 
 
@@ -1866,7 +1856,7 @@ class InventoryItemFilterForm(DeviceComponentFilterForm):
     tag = TagFilterField(model)
 
 
-class InventoryItemTemplateFilterForm(NetBoxModelFilterSetForm):
+class InventoryItemTemplateFilterForm(DeviceComponentTemplateFilterForm):
     model = InventoryItemTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
@@ -1882,9 +1872,6 @@ class InventoryItemTemplateFilterForm(NetBoxModelFilterSetForm):
         queryset=Manufacturer.objects.all(),
         required=False,
         label=_('Manufacturer')
-    )
-    device_type_id = DynamicModelMultipleChoiceField(
-        queryset=DeviceType.objects.all(), required=False, label=_('Device type')
     )
 
 


### PR DESCRIPTION
### Fixes: #19506

This is being submitted as an alternate PR to #20996 from @callumau. I did some follow-up work but wasn't able to push my commit to the fork.

- Introduce filter forms for all device/module component templates