### PR TITLE
Closes #21001: Annotate plugin filterset registration in v4.5 release notes

### DIFF
--- a/docs/release-notes/version-4.5.md
+++ b/docs/release-notes/version-4.5.md
@@ -22,7 +22,7 @@
 
 #### Lookup Modifiers in Filter Forms ([#7604](https://github.com/netbox-community/netbox/issues/7604))
 
-Most object list filters within the UI have been extended to include optional lookup modifiers to support more complex queries. For instance, filters for numeric values now include a dropdown where a user can select "less than," "greater than," or "not" in addition to the default equivalency match. The specific modifiers available depend on the type of each filter.
+Most object list filters within the UI have been extended to include optional lookup modifiers to support more complex queries. For instance, filters for numeric values now include a dropdown where a user can select "less than," "greater than," or "not" in addition to the default equivalency match. The specific modifiers available depend on the type of each filter. Plugins can register their own filtersets using the `register_filterset()` decorator to enable this new functionality.
 
 (Note that this feature does not introduce any new filters. Rather, it makes available in the UI filters which already exist.)
 


### PR DESCRIPTION
### Closes: #21001

Plugin support foe filterset registration was implemented under #7604, but we never explicitly mention it in the v4.5 release notes.