### PR TITLE
Fixes #21049: Remove stale custom field data during object validation

### DIFF
--- a/netbox/extras/tests/test_customfields.py
+++ b/netbox/extras/tests/test_customfields.py
@@ -1506,18 +1506,17 @@ class CustomFieldModelTest(TestCase):
 
     def test_invalid_data(self):
         """
-        Setting custom field data for a non-applicable (or non-existent) CustomField should raise a ValidationError.
+        Any invalid or stale custom field data should be removed from the instance.
         """
         site = Site(name='Test Site', slug='test-site')
 
         # Set custom field data
         site.custom_field_data['foo'] = 'abc'
         site.custom_field_data['bar'] = 'def'
-        with self.assertRaises(ValidationError):
-            site.clean()
-
-        del site.custom_field_data['bar']
         site.clean()
+
+        self.assertIn('foo', site.custom_field_data)
+        self.assertNotIn('bar', site.custom_field_data)
 
     def test_missing_required_field(self):
         """

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -288,12 +288,13 @@ class CustomFieldsMixin(models.Model):
             cf.name: cf for cf in CustomField.objects.get_for_model(self)
         }
 
+        # Remove any stale custom field data
+        self.custom_field_data = {
+            k: v for k, v in self.custom_field_data.items() if k in custom_fields.keys()
+        }
+
         # Validate all field values
         for field_name, value in self.custom_field_data.items():
-            if field_name not in custom_fields:
-                raise ValidationError(_("Unknown field name '{name}' in custom field data.").format(
-                    name=field_name
-                ))
             try:
                 custom_fields[field_name].validate(value)
             except ValidationError as e:


### PR DESCRIPTION
### Fixes: #21049

Silently remove any stale custom field data when running `clean()` instead of raising a `ValidationError`