### PR TITLE
Fixes #21064: Ensures that extra choices preserve nested colons

### DIFF
--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -189,22 +189,22 @@ class CustomFieldChoiceSetForm(ChangelogMessageMixin, forms.ModelForm):
         # if standardize these, we can simplify this code
 
         # Convert extra_choices Array Field from model to CharField for form
-        if 'extra_choices' in self.initial and self.initial['extra_choices']:
-            extra_choices = self.initial['extra_choices']
+        if extra_choices := self.initial.get('extra_choices', None):
             if isinstance(extra_choices, str):
                 extra_choices = [extra_choices]
-            choices = ""
+            choices = []
             for choice in extra_choices:
                 # Setup choices in Add Another use case
                 if isinstance(choice, str):
                     choice_str = ":".join(choice.replace("'", "").replace(" ", "")[1:-1].split(","))
-                    choices += choice_str + "\n"
+                    choices.append(choice_str)
                 # Setup choices in Edit use case
                 elif isinstance(choice, list):
-                    choice_str = ":".join(choice)
-                    choices += choice_str + "\n"
+                    value = choice[0].replace(':', '\\:')
+                    label = choice[1].replace(':', '\\:')
+                    choices.append(f'{value}:{label}')
 
-            self.initial['extra_choices'] = choices
+            self.initial['extra_choices'] = '\n'.join(choices)
 
     def clean_extra_choices(self):
         data = []


### PR DESCRIPTION
### Fixes: #21064

PR #14469 changed the separator from comma to colon. During review, Jeremy requested escape support, noting that colons would need escaping unlike commas. PR #14470 added the escape/unescape logic using the `(?<!\\):` regex pattern two days later. However, PR #18631 rewrote the `__init__` method to fix #17796 (an `IndexError` when using "Create & Add Another") and inadvertently removed the re-escaping logic, leaving only the parsing side intact.

The fix is to re-escape colons in both value and label before joining them, ensuring proper round-trip handling when editing existing choice sets.

