### PR TITLE
Closes #21071: Include the request method & URL when displaying a server error

### DIFF
--- a/netbox/netbox/views/errors.py
+++ b/netbox/netbox/views/errors.py
@@ -52,6 +52,7 @@ def handler_500(request, template_name=ERROR_500_TEMPLATE_NAME):
     type_, error = sys.exc_info()[:2]
 
     return HttpResponseServerError(template.render({
+        'request': request,
         'error': error,
         'exception': str(type_),
         'netbox_version': settings.RELEASE.full_version,

--- a/netbox/templates/500.html
+++ b/netbox/templates/500.html
@@ -36,6 +36,12 @@
   {{ plugin }}: {{ version }}{% empty %}{% trans "None installed" %}{% endfor %}
 </pre>
             <p>
+              {% trans "The request which yielded the above error is shown below:" %}
+            </p>
+            <p>
+              <code>{{ request.method }} {{ request.build_absolute_uri }}</code>
+            </p>
+            <p>
               {% trans "If further assistance is required, please post to the" %} <a href="https://github.com/netbox-community/netbox/discussions">{% trans "NetBox discussion forum" %}</a> {% trans "on GitHub" %}.
             </p>
             <div class="text-end">


### PR DESCRIPTION
### Closes: #21071

- Pass the current request as template context
- Include the request method & URL in the error details
