### PR TITLE
Closes #21035: Add .gitkeep to track the media directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,8 @@ yarn-error.log*
 /netbox/netbox/configuration.py
 /netbox/netbox/ldap_config.py
 /netbox/local/*
-/netbox/media
+/netbox/media/*
+!/netbox/media/.gitkeep
 /netbox/reports/*
 !/netbox/reports/__init__.py
 /netbox/scripts/*


### PR DESCRIPTION
### Fixes: #21035

This PR ensures the `netbox/media/` directory is present by default (including in release archives) by adding a `.gitkeep` file to track the directory in the repository.

To avoid tracking user-uploaded content, `.gitignore` is updated to ignore everything under `media/` except the `.gitkeep` placeholder. This aligns with the install/upgrade docs which assume the directory exists when setting permissions, and should prevent `chown` from failing on fresh installs.
