### PR TITLE
Revert fix for #20950

### DIFF
--- a/netbox/dcim/api/serializers_/device_components.py
+++ b/netbox/dcim/api/serializers_/device_components.py
@@ -351,14 +351,14 @@ class ModuleBaySerializer(NetBoxModelSerializer):
     device = DeviceSerializer(nested=True)
     module = ModuleSerializer(
         nested=True,
-        fields=('id', 'url', 'display', 'device', 'module_bay'),
+        fields=('id', 'url', 'display'),
         required=False,
         allow_null=True,
         default=None
     )
     installed_module = ModuleSerializer(
         nested=True,
-        fields=('id', 'url', 'display', 'device', 'module_bay', 'serial', 'description'),
+        fields=('id', 'url', 'display', 'serial', 'description'),
         required=False,
         allow_null=True
     )


### PR DESCRIPTION
This reverts the change in 860db9590b8692e51cada0115d49dc1a36acf07f which adds the `device` and `module_bay` fields to the serialized representation of nested module bays. These fields are redundant to data which already exist in the API response.
