### PR TITLE
Fixes: #19901 - Make module_bay recursion check on Module.clean tolerant of unset module.module_bay

### DIFF
--- a/netbox/dcim/models/modules.py
+++ b/netbox/dcim/models/modules.py
@@ -259,11 +259,13 @@ class Module(TrackingModelMixin, PrimaryModel, ConfigContextModel):
         module_bays = []
         modules = []
         while module:
-            if module.pk in modules or module.module_bay.pk in module_bays:
+            module_module_bay = getattr(module, "module_bay", None)
+            if module.pk in modules or (module_module_bay and module_module_bay.pk in module_bays):
                 raise ValidationError(_("A module bay cannot belong to a module installed within it."))
             modules.append(module.pk)
-            module_bays.append(module.module_bay.pk)
-            module = module.module_bay.module if module.module_bay else None
+            if module_module_bay:
+                module_bays.append(module_module_bay.pk)
+            module = module_module_bay.module if module_module_bay else None
 
     def save(self, *args, **kwargs):
         is_new = self.pk is None


### PR DESCRIPTION
### Fixes: #19901 

In the `clean` method of `Module`, we have a recursion check that presumes that the attribute `module_bay` has been set on the `self` object. If this attribute is missing, we throw a "Module has no module_bay" error, which is misleading and unhelpful.

This issue manifests when importing a module to a device that has no name, but this seems to be a red herring, as it can also occur on devices with names. It is a side effect of the recursion check not properly handling cases where `module.module_bay` is unset.

This change fixes the issue by skipping iterations in the recursion check where `module.module_bay` is unset.

**Note** that it does not directly address the reported issue in #19901, that an error is thrown when bulk-importing Modules to a Device whose name is null. For these cases, the workaround (and expected usage) is to use `device.id` as the bulk import field rather than the name; and with this fix a more helpful snackbar validation error is produced instead of an unhandled Server Error:

<img width="880" height="750" alt="Screenshot 2026-01-06 at 10 01 53 PM" src="https://github.com/user-attachments/assets/7ae539d3-8d24-4140-8c78-5f1b9a8c48cd" />
