### PR TITLE
Bump Python version for `update-translation-strings` action

### DIFF
--- a/.github/workflows/update-translation-strings.yml
+++ b/.github/workflows/update-translation-strings.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
+        python-version: 3.12
 
     - name: Install system dependencies
       run: sudo apt install -y gettext


### PR DESCRIPTION
This action currently fails as NetBox v4.5+ requires Python 3.12 or later.