### PR TITLE
Introduce a new issue type for feature removals

### DIFF
--- a/.github/ISSUE_TEMPLATE/06-deprecation.yaml
+++ b/.github/ISSUE_TEMPLATE/06-deprecation.yaml
@@ -1,20 +1,26 @@
 ---
-name: 🗑️ Deprecation
+name: ⚠️ Deprecation
 type: Deprecation
-description: The removal of an existing feature or resource
+description: Designation of a feature or behavior that will be removed in a future release
 labels: ["netbox", "type: deprecation"]
 body:
   - type: textarea
     attributes:
-      label: Proposed Changes
+      label: Deprecated Functionality
       description: >
-        Describe in detail the proposed changes. What is being removed?
+        Describe the feature(s) and/or behavior that is being flagged for deprecation.
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Scheduled removal
+      description: In what future release will the deprecated functionality be removed?
     validations:
       required: true
   - type: textarea
     attributes:
       label: Justification
-      description: Please provide justification for the proposed change(s).
+      description: Please provide justification for the deprecation.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/07-feature_removal.yaml
+++ b/.github/ISSUE_TEMPLATE/07-feature_removal.yaml
@@ -1,0 +1,20 @@
+---
+name: 🗑️ Feature Removal
+type: Deprecation
+description: The removal of a deprecated feature or resource
+labels: ["netbox", "type: removal"]
+body:
+  - type: input
+    attributes:
+      label: Deprecation Issue
+      description: Specify the issue in which this deprecation was announced.
+      placeholder: "#1234"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Summary of Changes
+      description: >
+        List all changes necessary to remove the deprecated feature or resource.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/07-feature_removal.yaml
+++ b/.github/ISSUE_TEMPLATE/07-feature_removal.yaml
@@ -1,6 +1,6 @@
 ---
 name: 🗑️ Feature Removal
-type: Deprecation
+type: Removal
 description: The removal of a deprecated feature or resource
 labels: ["netbox", "type: removal"]
 body:


### PR DESCRIPTION
- Introduce a new issue type & label specifically for the removal of a feature
- Tweak the existing deprecation issue type to limit its scope to deprecation only

This change is being made to clearly delineate between the _deprecation_ of a feature and its actual removal from the application, which typically happens at a later point in time.