### PR TITLE
Fixes #20239: Prevent shared mutable state in PluginMenuItem/PluginMenuButton

### DIFF
--- a/netbox/netbox/plugins/navigation.py
+++ b/netbox/netbox/plugins/navigation.py
@@ -37,8 +37,6 @@ class PluginMenuItem:
     Alternatively, a pre-generated url can be set on the object which will be rendered literally.
     Buttons are each specified as a list of PluginMenuButton instances.
     """
-    permissions = []
-    buttons = []
     _url = None
 
     def __init__(
@@ -54,10 +52,14 @@ class PluginMenuItem:
             if type(permissions) not in (list, tuple):
                 raise TypeError(_("Permissions must be passed as a tuple or list."))
             self.permissions = permissions
+        else:
+            self.permissions = []
         if buttons is not None:
             if type(buttons) not in (list, tuple):
                 raise TypeError(_("Buttons must be passed as a tuple or list."))
             self.buttons = buttons
+        else:
+            self.buttons = []
 
     @property
     def url(self):
@@ -74,7 +76,6 @@ class PluginMenuButton:
     ButtonColorChoices.
     """
     color = ButtonColorChoices.DEFAULT
-    permissions = []
     _url = None
 
     def __init__(self, link, title, icon_class, color=None, permissions=None):
@@ -87,6 +88,8 @@ class PluginMenuButton:
             if type(permissions) not in (list, tuple):
                 raise TypeError(_("Permissions must be passed as a tuple or list."))
             self.permissions = permissions
+        else:
+            self.permissions = []
         if color is not None:
             if color not in ButtonColorChoices.values():
                 raise ValueError(_("Button color must be a choice within ButtonColorChoices."))


### PR DESCRIPTION
### Fixes: #20239

`PluginMenuItem` and `PluginMenuButton` classes used mutable class-level defaults for `permissions` and `buttons` attributes, causing permission leakage between instances when these attributes were modified without explicit parameters.

Changed to initialize these attributes as fresh lists per instance in `__init__` when not explicitly provided, following standard Python pattern for avoiding mutable default arguments.