### PR TITLE
Update help text for token field on API page.

### DIFF
--- a/netbox/users/forms/model_forms.py
+++ b/netbox/users/forms/model_forms.py
@@ -123,7 +123,7 @@ class UserTokenForm(forms.ModelForm):
     token = forms.CharField(
         label=_('Token'),
         help_text=_(
-            'Tokens must be at least 40 characters in length. <strong>Be sure to record your key</strong> prior to '
+            'Tokens must be at least 40 characters in length. <strong>Be sure to record your token</strong> prior to '
             'submitting this form, as it will no longer be accessible once the token has been created.'
         ),
         widget=forms.TextInput(

--- a/netbox/users/models/tokens.py
+++ b/netbox/users/models/tokens.py
@@ -69,7 +69,7 @@ class Token(models.Model):
     write_enabled = models.BooleanField(
         verbose_name=_('write enabled'),
         default=True,
-        help_text=_('Permit create/update/delete operations using this key')
+        help_text=_('Permit create/update/delete operations using this token')
     )
     # For legacy v1 tokens, this field stores the plaintext 40-char token value. Not used for v2.
     plaintext = models.CharField(


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #21105

<!--
    Please include a summary of the proposed changes below.
-->

The help text for the API token states you need to keep a copy of the key however the terminology above is Token, with new V2 bearers there is now also a key field so this could be confusing to some users.