### PR TITLE
Closes #21075: Rename L2VPN-Terminations menu entry

### DIFF
--- a/netbox/netbox/navigation/menu.py
+++ b/netbox/netbox/navigation/menu.py
@@ -232,7 +232,7 @@ VPN_MENU = Menu(
             label=_('L2VPNs'),
             items=(
                 get_model_item('vpn', 'l2vpn', _('L2VPNs')),
-                get_model_item('vpn', 'l2vpntermination', _('Terminations')),
+                get_model_item('vpn', 'l2vpntermination', _('L2VPN Terminations')),
             ),
         ),
         MenuGroup(


### PR DESCRIPTION
Simply edited one line in menu.py in order to rename "Terminations" into "L2VPN Terminations".

Closes #21075