### PR TITLE
Fixes #21117: Avoid exception when attempting to create v2 token without `API_TOKEN_PEPPERS` defined

### DIFF
--- a/netbox/users/models/tokens.py
+++ b/netbox/users/models/tokens.py
@@ -213,6 +213,9 @@ class Token(models.Model):
     def clean(self):
         super().clean()
 
+        if self.version == TokenVersionChoices.V2 and not settings.API_TOKEN_PEPPERS:
+            raise ValidationError(_("Unable to save v2 tokens: API_TOKEN_PEPPERS is not defined."))
+
         if self._state.adding:
             if self.pepper_id is not None and self.pepper_id not in settings.API_TOKEN_PEPPERS:
                 raise ValidationError(_(

--- a/netbox/users/tests/test_models.py
+++ b/netbox/users/tests/test_models.py
@@ -1,9 +1,10 @@
 from datetime import timedelta
 
 from django.core.exceptions import ValidationError
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 
+from users.choices import TokenVersionChoices
 from users.models import User, Token
 from utilities.testing import create_test_user
 
@@ -93,6 +94,15 @@ class TokenTest(TestCase):
 
         token.refresh_from_db()
         self.assertEqual(token.description, 'New Description')
+
+    @override_settings(API_TOKEN_PEPPERS={})
+    def test_v2_without_peppers_configured(self):
+        """
+        Attempting to save a v2 token without API_TOKEN_PEPPERS defined should raise a ValidationError.
+        """
+        token = Token(version=TokenVersionChoices.V2)
+        with self.assertRaises(ValidationError):
+            token.clean()
 
 
 class UserConfigTest(TestCase):


### PR DESCRIPTION
### Fixes: #21117

Extend `clean()` on the Token model to check that `API_TOKEN_PEPPERS` is defined.

I initially attempted to disable the v2 choice in the form field when peppers are not defined but it would require implementing a custom widget, which didn't seem worth the effort given that we want to encourage users to adopt v2 tokens ASAP.