### PR TITLE
Fixes #21050: Prevent reassignment of OOB IPs

### DIFF
--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -372,8 +372,8 @@ class IPAddressForm(TenancyForm, PrimaryModelForm):
                     'virtual_machine_id': instance.assigned_object.virtual_machine.pk,
                 })
 
-        # Disable object assignment fields if the IP address is designated as primary
-        if self.initial.get('primary_for_parent'):
+        # Disable object assignment fields if the IP address is designated as primary or OOB
+        if self.initial.get('primary_for_parent') or self.initial.get('oob_for_parent'):
             self.fields['interface'].disabled = True
             self.fields['vminterface'].disabled = True
             self.fields['fhrpgroup'].disabled = True

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -940,6 +940,13 @@ class IPAddress(ContactsMixin, PrimaryModel):
                     _("Cannot reassign IP address while it is designated as the primary IP for the parent object")
                 )
 
+            # can't use is_oob_ip as self.assigned_object might be changed
+            if hasattr(original_parent, 'oob_ip') and original_parent.oob_ip_id == self.pk:
+                if parent != original_parent:
+                    raise ValidationError(
+                        _("Cannot reassign IP address while it is designated as the OOB IP for the parent object")
+                    )
+
         # Validate IP status selection
         if self.status == IPAddressStatusChoices.STATUS_SLAAC and self.family != 6:
             raise ValidationError({


### PR DESCRIPTION
### Fixes: #21050

Prevents creating stale device OOB IP references when reassigning IPs.

- Disable reassignment in the UI when an IP is designated as a primary IP or device OOB IP.
- Add model-level validation to block reassignment while an IP is set as a device’s OOB IP (covers API updates as well).

Note: No migration is included to clean up existing orphaned OOB IP references. The required logic is fairly complex (generic assignments / dependencies) and this is expected to be an edge case; remediation can be done via a one-off `nbshell` script as discussed in the issue.

Thanks for the review!