### PR TITLE
Closes #21142: Enable filtering device components by site/location/rack directly via GraphQL API

### DIFF
--- a/netbox/dcim/graphql/filter_mixins.py
+++ b/netbox/dcim/graphql/filter_mixins.py
@@ -38,6 +38,15 @@ class ScopedFilterMixin:
 
 @dataclass
 class ComponentModelFilterMixin:
+    _site: Annotated['SiteFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
+        strawberry_django.filter_field(name='site')
+    )
+    _location: Annotated['SiteFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
+        strawberry_django.filter_field(name='location')
+    )
+    _rack: Annotated['SiteFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
+        strawberry_django.filter_field(name='rack')
+    )
     device: Annotated['DeviceFilter', strawberry.lazy('dcim.graphql.filters')] | None = strawberry_django.filter_field()
     device_id: ID | None = strawberry_django.filter_field()
     name: FilterLookup[str] | None = strawberry_django.filter_field()

--- a/netbox/dcim/graphql/filter_mixins.py
+++ b/netbox/dcim/graphql/filter_mixins.py
@@ -41,10 +41,10 @@ class ComponentModelFilterMixin:
     _site: Annotated['SiteFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
         strawberry_django.filter_field(name='site')
     )
-    _location: Annotated['SiteFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
+    _location: Annotated['LocationFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
         strawberry_django.filter_field(name='location')
     )
-    _rack: Annotated['SiteFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
+    _rack: Annotated['RackFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
         strawberry_django.filter_field(name='rack')
     )
     device: Annotated['DeviceFilter', strawberry.lazy('dcim.graphql.filters')] | None = strawberry_django.filter_field()


### PR DESCRIPTION
### Closes: #21142

Adds `site`, `location`, and `rack` GraphQL filters for all device components, which correspond to the denormalized fields `_site`, `_location`, and `_rack` on these models.
