### PR TITLE
Fixes #20933: Fix writable data_file assignment for ConfigContext and ConfigContextProfile via the REST API

### DIFF
--- a/netbox/core/api/serializers_/data.py
+++ b/netbox/core/api/serializers_/data.py
@@ -44,3 +44,4 @@ class DataFileSerializer(NetBoxModelSerializer):
             'id', 'url', 'display_url', 'display', 'source', 'path', 'last_updated', 'size', 'hash',
         ]
         brief_fields = ('id', 'url', 'display', 'path')
+        read_only_fields = ['path', 'last_updated', 'size', 'hash']

--- a/netbox/extras/api/serializers_/configcontexts.py
+++ b/netbox/extras/api/serializers_/configcontexts.py
@@ -28,7 +28,7 @@ class ConfigContextProfileSerializer(PrimaryModelSerializer):
     )
     data_file = DataFileSerializer(
         nested=True,
-        read_only=True
+        required=False
     )
 
     class Meta:
@@ -143,7 +143,7 @@ class ConfigContextSerializer(OwnerMixin, ChangeLogMessageSerializer, ValidatedM
     )
     data_file = DataFileSerializer(
         nested=True,
-        read_only=True
+        required=False
     )
 
     class Meta:


### PR DESCRIPTION
### Fixes: #20933

This PR fixes the REST API behavior for assigning a `ConfigContext` (and `ConfigContextProfile`) to a synced `DataFile`.

Previously, `data_file` was marked `read_only` on the `ConfigContext`/`ConfigContextProfile` serializers, so PATCH/POST requests would silently ignore `data_file` (and `data_path` would not persist), even though the UI supports this workflow.

Changes included:
- Removed `read_only=True` from the `data_file` field on the relevant `ConfigContext` and `ConfigContextProfile` serializers to allow setting it via the API (by ID).
- Marked the appropriate fields in `DataFileSerializer` as `read_only` (e.g. `path`, `last_updated`, `size`, `hash`) since these values are managed by the data source sync process and should not be modified through the API.
- Added API regression tests covering PATCHing `data_source` + `data_file` for both `ConfigContext` and `ConfigContextProfile`.

This brings the API in line with the UI and prevents silent no-op updates when referencing synced files.
