### PR TITLE
Fixes #21175: Use `gettext_lazy` in data.py for stable migrations

### DIFF
--- a/netbox/core/models/data.py
+++ b/netbox/core/models/data.py
@@ -12,7 +12,7 @@ from django.core.validators import RegexValidator
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
-from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy as _
 
 from netbox.constants import CENSOR_TOKEN, CENSOR_TOKEN_CHANGED
 from netbox.models import PrimaryModel
@@ -128,7 +128,9 @@ class DataSource(JobsMixin, PrimaryModel):
         # Ensure URL scheme matches selected type
         if self.backend_class.is_local and self.url_scheme not in ('file', ''):
             raise ValidationError({
-                'source_url': "URLs for local sources must start with file:// (or specify no scheme)"
+                'source_url': _("URLs for local sources must start with {scheme} (or specify no scheme)").format(
+                    scheme='file://'
+                )
             })
 
     def save(self, *args, **kwargs):


### PR DESCRIPTION
### Fixes: #21175

This PR replaces `gettext()` with `gettext_lazy()` in `core/data.py` so translated validator/validation messages are not evaluated at import time.
This prevents locale-dependent model serialization, which can lead Django to report false-positive “pending migration” warnings when `DEFAULT_LANGUAGE` is set to a non-English locale.

It also updates one missing `ValidationError` message to be properly translatable and safe to format.

Reproducer and background discussion: https://github.com/netbox-community/netbox/discussions/21108
