### PR TITLE
Closes #21039: Add AVIF support for image attachments

### DIFF
--- a/netbox/extras/constants.py
+++ b/netbox/extras/constants.py
@@ -4,6 +4,17 @@ from extras.choices import LogLevelChoices
 # Custom fields
 CUSTOMFIELD_EMPTY_VALUES = (None, '', [])
 
+# ImageAttachment
+IMAGE_ATTACHMENT_IMAGE_FORMATS = {
+    'avif': 'image/avif',
+    'bmp': 'image/bmp',
+    'gif': 'image/gif',
+    'jpeg': 'image/jpeg',
+    'jpg': 'image/jpeg',
+    'png': 'image/png',
+    'webp': 'image/webp',
+}
+
 # Template Export
 DEFAULT_MIME_TYPE = 'text/plain; charset=utf-8'
 

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext_lazy as _
 from core.forms.mixins import SyncedDataMixin
 from core.models import ObjectType
 from dcim.models import DeviceRole, DeviceType, Location, Platform, Region, Site, SiteGroup
+from extras.constants import IMAGE_ATTACHMENT_IMAGE_FORMATS
 from extras.choices import *
 from extras.models import *
 from netbox.events import get_event_type_choices
@@ -784,8 +785,11 @@ class ImageAttachmentForm(forms.ModelForm):
         fields = [
             'image', 'name', 'description',
         ]
-        help_texts = {
-            'name': _("If no name is specified, the file name will be used.")
+        # Explicitly set 'image/avif' to support AVIF selection in Firefox
+        widgets = {
+            'image': forms.ClearableFileInput(
+                attrs={'accept': ','.join(sorted(set(IMAGE_ATTACHMENT_IMAGE_FORMATS.values())))}
+            ),
         }
 
 

--- a/netbox/extras/utils.py
+++ b/netbox/extras/utils.py
@@ -10,6 +10,7 @@ from taggit.managers import _TaggableManager
 
 from netbox.context import current_request
 
+from .constants import IMAGE_ATTACHMENT_IMAGE_FORMATS
 from .validators import CustomValidator
 
 __all__ = (
@@ -78,7 +79,7 @@ def image_upload(instance, filename):
     """
     upload_dir = 'image-attachments'
     default_filename = 'unnamed'
-    allowed_img_extensions = ('bmp', 'gif', 'jpeg', 'jpg', 'png', 'webp')
+    allowed_img_extensions = IMAGE_ATTACHMENT_IMAGE_FORMATS.keys()
 
     # Normalize Windows paths and create a Path object.
     normalized_filename = str(filename).replace('\\', '/')


### PR DESCRIPTION
### Fixes: #21039

Preserve `.avif` extensions when uploading Image Attachments (so the attachment is served with the expected filename), and ensure AVIF files are selectable in the UI.

* Add AVIF (`.avif` / `image/avif`) to the list of acceptable image extensions used when generating attachment filenames, so the stored file keeps its extension.
* Update the image upload widget to explicitly include AVIF in the `accept` attribute (required for Firefox to offer AVIF files in the file picker).
* Manual test: upload a AVIF file as an Image Attachment and confirm it’s served at `/media/image-attachments/...avif`.

Thanks for the review!
