### PR TITLE
Add Max Depth and Max Length dropdowns for child prefix pages

### DIFF
--- a/netbox/templates/ipam/aggregate/prefixes.html
+++ b/netbox/templates/ipam/aggregate/prefixes.html
@@ -3,6 +3,8 @@
 
 {% block extra_controls %}
   {% include 'ipam/inc/toggle_available.html' %}
+  {% include 'ipam/inc/max_depth.html' %}
+  {% include 'ipam/inc/max_length.html' %}  
   {% if perms.ipam.add_prefix and first_available_prefix %}
     <a href="{% url 'ipam:prefix_add' %}?prefix={{ first_available_prefix }}" class="btn btn-primary">
       <i class="mdi mdi-plus-thick" aria-hidden="true"></i> {% trans "Add Prefix" %}

--- a/netbox/templates/ipam/inc/max_depth.html
+++ b/netbox/templates/ipam/inc/max_depth.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+{% load helpers %}
+
+<div class="dropdown">
+    <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="max_depth" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+        {% trans "Max Depth" %}{% if "depth__lte" in request.GET %}: {{ request.GET.depth__lte }}{% endif %}
+    </button>
+    <ul class="dropdown-menu" aria-labelledby="max_depth">
+        {% if request.GET.depth__lte %}
+            <li>
+                <a class="dropdown-item" href="{{ request.path }}{% querystring request depth__lte=None page=1 %}">{% trans "Clear" %}</a>
+            </li>
+        {% endif %}
+        {% for i in 16|as_range %}
+            <li><a class="dropdown-item" href="{{ request.path }}{% querystring request depth__lte=i page=1 %}">
+                {{ i }} {% if request.GET.depth__lte == i %}<i class="mdi mdi-check-bold"></i>{% endif %}
+            </a></li>
+        {% endfor %}
+    </ul>
+</div>

--- a/netbox/templates/ipam/inc/max_length.html
+++ b/netbox/templates/ipam/inc/max_length.html
@@ -1,0 +1,20 @@
+{% load i18n %}
+{% load helpers %}
+
+<div class="dropdown">
+    <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="max_length" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
+        {% trans "Max Length" %}{% if "mask_length__lte" in request.GET %}: {{ request.GET.mask_length__lte }}{% endif %}
+    </button>
+    <ul class="dropdown-menu" aria-labelledby="max_length">
+        {% if request.GET.mask_length__lte %}
+            <li>
+                <a class="dropdown-item" href="{{ request.path }}{% querystring request mask_length__lte=None page=1 %}">{% trans "Clear" %}</a>
+            </li>
+        {% endif %}
+        {% for i in "4,8,12,16,20,24,28,32,40,48,56,64"|split %}
+            <li><a class="dropdown-item" href="{{ request.path }}{% querystring request mask_length__lte=i page=1 %}">
+                {{ i }} {% if request.GET.mask_length__lte == i %}<i class="mdi mdi-check-bold"></i>{% endif %}
+            </a></li>
+        {% endfor %}
+    </ul>
+</div>

--- a/netbox/templates/ipam/prefix/prefixes.html
+++ b/netbox/templates/ipam/prefix/prefixes.html
@@ -3,6 +3,8 @@
 
 {% block extra_controls %}
   {% include 'ipam/inc/toggle_available.html' %}
+  {% include 'ipam/inc/max_depth.html' %}
+  {% include 'ipam/inc/max_length.html' %}  
   {% if perms.ipam.add_prefix and first_available_prefix %}
     <a href="{% url 'ipam:prefix_add' %}?prefix={{ first_available_prefix }}&vrf={{ object.vrf.pk }}&site={{ object.site.pk }}&tenant_group={{ object.tenant.group.pk }}&tenant={{ object.tenant.pk }}" class="btn btn-primary">
       <i class="mdi mdi-plus-thick" aria-hidden="true"></i> {% trans "Add Prefix" %}

--- a/netbox/templates/ipam/prefix_list.html
+++ b/netbox/templates/ipam/prefix_list.html
@@ -6,38 +6,6 @@
     <button class="btn btn-outline-secondary toggle-depth" type="button">
         {% trans "Hide Depth Indicators" %}
     </button>
-    <div class="dropdown">
-        <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="max_depth" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-            {% trans "Max Depth" %}{% if "depth__lte" in request.GET %}: {{ request.GET.depth__lte }}{% endif %}
-        </button>
-        <ul class="dropdown-menu" aria-labelledby="max_depth">
-            {% if request.GET.depth__lte %}
-                <li>
-                    <a class="dropdown-item" href="{% url 'ipam:prefix_list' %}{% querystring request depth__lte=None page=1 %}">{% trans "Clear" %}</a>
-                </li>
-            {% endif %}
-            {% for i in 16|as_range %}
-                <li><a class="dropdown-item" href="{% url 'ipam:prefix_list' %}{% querystring request depth__lte=i page=1 %}">
-                    {{ i }} {% if request.GET.depth__lte == i %}<i class="mdi mdi-check-bold"></i>{% endif %}
-                </a></li>
-            {% endfor %}
-        </ul>
-    </div>
-    <div class="dropdown">
-        <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="max_length" data-bs-toggle="dropdown" aria-haspopup="true" aria-expanded="true">
-            {% trans "Max Length" %}{% if "mask_length__lte" in request.GET %}: {{ request.GET.mask_length__lte }}{% endif %}
-        </button>
-        <ul class="dropdown-menu" aria-labelledby="max_length">
-            {% if request.GET.mask_length__lte %}
-                <li>
-                    <a class="dropdown-item" href="{% url 'ipam:prefix_list' %}{% querystring request mask_length__lte=None page=1 %}">{% trans "Clear" %}</a>
-                </li>
-            {% endif %}
-            {% for i in "4,8,12,16,20,24,28,32,40,48,56,64"|split %}
-                <li><a class="dropdown-item" href="{% url 'ipam:prefix_list' %}{% querystring request mask_length__lte=i page=1 %}">
-                    {{ i }} {% if request.GET.mask_length__lte == i %}<i class="mdi mdi-check-bold"></i>{% endif %}
-                </a></li>
-            {% endfor %}
-        </ul>
-    </div>
+    {% include 'ipam/inc/max_depth.html' %}
+    {% include 'ipam/inc/max_length.html' %}
 {% endblock %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #21088 

<!--
    Please include a summary of the proposed changes below.
-->
This adds the max_length and max_depth drop down filters to the child "prefix" pages for both aggregates and prefixes. It achieves this by creating 2 new templates which can be then be included wherever this functionality is required. This PR also standardises the existing prefix_list template to include these new templates. 