### PR TITLE
Fixes #21178: Use localized “millimeters” for rack mounting depth (follow-up)

### DIFF
--- a/netbox/dcim/ui/panels.py
+++ b/netbox/dcim/ui/panels.py
@@ -31,7 +31,7 @@ class RackDimensionsPanel(panels.ObjectAttributesPanel):
     outer_width = attrs.NumericAttr('outer_width', unit_accessor='get_outer_unit_display')
     outer_height = attrs.NumericAttr('outer_height', unit_accessor='get_outer_unit_display')
     outer_depth = attrs.NumericAttr('outer_depth', unit_accessor='get_outer_unit_display')
-    mounting_depth = attrs.TextAttr('mounting_depth', format_string='{} mm')
+    mounting_depth = attrs.TextAttr('mounting_depth', format_string=_('{} millimeters'))
 
 
 class RackNumberingPanel(panels.ObjectAttributesPanel):


### PR DESCRIPTION
### Fixes: #21178

This is a follow-up to #21183.

Updates the rack `mounting_depth` display to match the other dimension fields by using the full unit label (“millimeters”) instead of “mm”. The label is now built using `gettext_lazy` to ensure it remains localizable for internationalization.