### PR TITLE
Virtual Machine Resources Use Decimal MB/GB Instead of Binary MiB/GiB

### DIFF
--- a/netbox/virtualization/forms/model_forms.py
+++ b/netbox/virtualization/forms/model_forms.py
@@ -221,7 +221,7 @@ class VirtualMachineForm(TenancyForm, PrimaryModelForm):
         FieldSet('site', 'cluster', 'device', name=_('Site/Cluster')),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
         FieldSet('platform', 'primary_ip4', 'primary_ip6', 'config_template', name=_('Management')),
-        FieldSet('vcpus', 'memory', 'disk', name=_('Resources')),
+        FieldSet('vcpus', 'memory', 'disk', name=_('Resources (MiB)')),
         FieldSet('local_context_data', name=_('Config Context')),
     )
 
@@ -393,7 +393,7 @@ class VMInterfaceForm(InterfaceCommonForm, VMComponentForm):
 class VirtualDiskForm(VMComponentForm):
 
     fieldsets = (
-        FieldSet('virtual_machine', 'name', 'size', 'description', 'tags', name=_('Disk')),
+        FieldSet('virtual_machine', 'name', 'size', 'description', 'tags', name=_('Disk (GiB)')),
     )
 
     class Meta:

--- a/netbox/virtualization/models/virtualmachines.py
+++ b/netbox/virtualization/models/virtualmachines.py
@@ -121,12 +121,12 @@ class VirtualMachine(ContactsMixin, ImageAttachmentsMixin, RenderConfigMixin, Co
     memory = models.PositiveIntegerField(
         blank=True,
         null=True,
-        verbose_name=_('memory (MB)')
+        verbose_name=_('Memory (MiB)')
     )
     disk = models.PositiveIntegerField(
         blank=True,
         null=True,
-        verbose_name=_('disk (MB)')
+        verbose_name=_('Disk (GiB)')
     )
     serial = models.CharField(
         verbose_name=_('serial number'),

--- a/netbox/virtualization/tables/virtualmachines.py
+++ b/netbox/virtualization/tables/virtualmachines.py
@@ -100,10 +100,11 @@ class VirtualMachineTable(TenancyColumnsMixin, ContactsColumnMixin, PrimaryModel
 
     def render_memory(self, value):
         return f"{value} MiB"
-    
+
 #
 # VM components
 #
+
 
 class VMInterfaceTable(BaseInterfaceTable):
     virtual_machine = tables.Column(

--- a/netbox/virtualization/tables/virtualmachines.py
+++ b/netbox/virtualization/tables/virtualmachines.py
@@ -78,8 +78,11 @@ class VirtualMachineTable(TenancyColumnsMixin, ContactsColumnMixin, PrimaryModel
         linkify=True
     )
     disk = tables.Column(
-        verbose_name=_('Disk'),
+        verbose_name=_('Disk (GiB)'),
     )
+    memory = tables.Column(
+        verbose_name=_('Memory (MiB)'),
+     )
 
     class Meta(PrimaryModelTable.Meta):
         model = VirtualMachine
@@ -93,9 +96,11 @@ class VirtualMachineTable(TenancyColumnsMixin, ContactsColumnMixin, PrimaryModel
         )
 
     def render_disk(self, value):
-        return humanize_disk_megabytes(value)
+        return f"{value} GiB"
 
-
+    def render_memory(self, value):
+        return f"{value} MiB"
+    
 #
 # VM components
 #
@@ -166,7 +171,7 @@ class VirtualDiskTable(NetBoxTable):
         linkify=True
     )
     size = tables.Column(
-        verbose_name=_('Size')
+       verbose_name=_('Size (GiB)')
     )
     tags = columns.TagColumn(
         url_name='virtualization:virtualdisk_list'


### PR DESCRIPTION
### Fixes: #21095 
This change would primarily affect display and input handling in the VM resources UI, without changing the underlying numeric values unless binary units are adopted.