### PR TITLE
Fixes #21213: Make Tag weight field required in forms

### DIFF
--- a/netbox/extras/forms/bulk_import.py
+++ b/netbox/extras/forms/bulk_import.py
@@ -271,10 +271,6 @@ class EventRuleImportForm(OwnerCSVMixin, NetBoxModelImportForm):
 
 class TagImportForm(OwnerCSVMixin, CSVModelForm):
     slug = SlugField()
-    weight = forms.IntegerField(
-        label=_('Weight'),
-        required=False
-    )
     object_types = CSVMultipleContentTypeField(
         label=_('Object types'),
         queryset=ObjectType.objects.with_feature('tags'),

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -570,10 +570,6 @@ class TagForm(ChangelogMessageMixin, OwnerMixin, forms.ModelForm):
         queryset=ObjectType.objects.with_feature('tags'),
         required=False
     )
-    weight = forms.IntegerField(
-        label=_('Weight'),
-        required=False
-    )
 
     fieldsets = (
         FieldSet('name', 'slug', 'color', 'weight', 'description', 'object_types', name=_('Tag')),


### PR DESCRIPTION
The weight field was explicitly declared with `required=False` in `TagForm` and `TagImportForm`, allowing empty submissions that would crash with a database `IntegrityError` since the column is `NOT NULL`.

By removing the explicit field override, Django now auto-generates the form field from the model, which has `default=1000` and is required. This ensures the UI matches the database constraint and prevents invalid submissions before they reach the database.

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #21213

<!--
    Please include a summary of the proposed changes below.
-->

### Summary

- Remove the explicit `weight` field overrides from `TagForm` and `TagImportForm` that set `required=False`.
- Allow Django to use the model’s `PositiveSmallIntegerField(default=1000)` directly, making the field required at the form level.
- Align form validation with the database `NOT NULL` constraint to avoid `IntegrityError` when the weight is left empty.