### PR TITLE
Fixes #21214: Clean up AutoSyncRecord when detaching from DataSource

### DIFF
--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -569,7 +569,6 @@ class SyncedDataMixin(models.Model):
             )
         else:
             AutoSyncRecord.objects.filter(
-                datafile=self.data_file,
                 object_type=object_type,
                 object_id=self.pk
             ).delete()
@@ -582,7 +581,6 @@ class SyncedDataMixin(models.Model):
         # Delete AutoSyncRecord
         object_type = ObjectType.objects.get_for_model(self)
         AutoSyncRecord.objects.filter(
-            datafile=self.data_file,
             object_type=object_type,
             object_id=self.pk
         ).delete()


### PR DESCRIPTION
When a synced object (e.g., `ConfigTemplate`) is detached from a `DataSource`, the `clean()` method sets `data_file` to `None` before `save()` is called. The previous code attempted to delete the `AutoSyncRecord` by filtering with `datafile=self.data_file`, which in this case is `None`, so it never matched the existing record and left a stale `AutoSyncRecord` behind.

This caused subsequent DataSource sync jobs to fail when trying to sync objects that no longer had a valid `data_file`. The fix removes the `datafile` filter from the delete query and relies on the existing `UniqueConstraint` on `(object_type, object_id)` to correctly identify and delete the associated `AutoSyncRecord`.

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #21214

<!--
    Please include a summary of the proposed changes below.
-->

### Summary

- Update `SyncedDataMixin.save()` and `.delete()` to delete `AutoSyncRecord` instances by `(object_type, object_id)` only.
- Remove the `datafile=self.data_file` filter, which could be `None` after `clean()` has cleared `data_file` when detaching from a `DataSource`.
- Ensure that stale `AutoSyncRecord` rows are cleaned up when a synced object is detached, allowing subsequent DataSource syncs to proceed without errors.