### PR TITLE
Closes #15801: Add link peer and connection columns to `VLANDeviceTable`

### DIFF
--- a/netbox/ipam/tables/vlans.py
+++ b/netbox/ipam/tables/vlans.py
@@ -4,6 +4,7 @@ from django.utils.translation import gettext_lazy as _
 from django_tables2.utils import Accessor
 
 from dcim.models import Interface
+from dcim.tables.template_code import INTERFACE_LINKTERMINATION, LINKTERMINATION
 from ipam.models import *
 from netbox.tables import NetBoxTable, OrganizationalModelTable, PrimaryModelTable, columns
 from tenancy.tables import TenancyColumnsMixin, TenantColumn
@@ -159,11 +160,26 @@ class VLANDevicesTable(VLANMembersTable):
     actions = columns.ActionsColumn(
         actions=('edit',)
     )
+    link_peer = columns.TemplateColumn(
+        accessor='link_peers',
+        template_code=LINKTERMINATION,
+        orderable=False,
+        verbose_name=_('Link Peers'),
+    )
+
+    # Override PathEndpointTable.connection to accommodate virtual circuits
+    connection = columns.TemplateColumn(
+        accessor='_path__destinations',
+        template_code=INTERFACE_LINKTERMINATION,
+        orderable=False,
+        verbose_name=_('Connection'),
+    )
 
     class Meta(NetBoxTable.Meta):
         model = Interface
-        fields = ('device', 'name', 'tagged', 'actions')
-        exclude = ('id', )
+        fields = ('device', 'name', 'link_peer', 'connection', 'tagged', 'actions')
+        default_columns = ('device', 'name', 'connection', 'tagged', 'actions')
+        exclude = ('id',)
 
 
 class VLANVirtualMachinesTable(VLANMembersTable):


### PR DESCRIPTION
### Fixes: #15801

This PR adds the `connection` and `link_peer` columns to the VLAN **Device Interfaces** list (`VLANDeviceTable`). This makes it easier to quickly see how a VLAN is ultimately used by connected endpoints (e.g., servers, phones) without needing to mirror VLAN assignments on the endpoint interfaces.

To keep the UI consistent with the existing **Device → Interfaces** view, the same interface table templates are reused to render connection/peer context.

Thanks for reviewing!
