### PR TITLE
Fixes #21181: Handle AuthenticationFailed exception on /media endpoint

### DIFF
--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -53,7 +53,7 @@ class TokenConditionalLoginRequiredMixin(ConditionalLoginRequiredMixin):
         if settings.LOGIN_REQUIRED and not request.user.is_authenticated:
             authenticator = TokenAuthentication()
             try:
-                if auth_info := authenticator.authenticate(request) is not None:
+                if (auth_info := authenticator.authenticate(request)) is not None:
                     request.user = auth_info[0]  # User object
                     request.auth = auth_info[1]
             except AuthenticationFailed:

--- a/netbox/utilities/views.py
+++ b/netbox/utilities/views.py
@@ -5,9 +5,11 @@ from django.conf import settings
 from django.contrib.auth.mixins import AccessMixin
 from django.core.exceptions import ImproperlyConfigured
 from django.db.models import QuerySet
+from django.http import HttpResponseForbidden
 from django.urls import reverse
 from django.urls.exceptions import NoReverseMatch
 from django.utils.translation import gettext_lazy as _
+from rest_framework.exceptions import AuthenticationFailed
 
 from netbox.api.authentication import TokenAuthentication
 from netbox.plugins import PluginConfig
@@ -50,10 +52,12 @@ class TokenConditionalLoginRequiredMixin(ConditionalLoginRequiredMixin):
         # Attempt to authenticate the user using a DRF token, if provided
         if settings.LOGIN_REQUIRED and not request.user.is_authenticated:
             authenticator = TokenAuthentication()
-            auth_info = authenticator.authenticate(request)
-            if auth_info is not None:
-                request.user = auth_info[0]  # User object
-                request.auth = auth_info[1]
+            try:
+                if auth_info := authenticator.authenticate(request) is not None:
+                    request.user = auth_info[0]  # User object
+                    request.auth = auth_info[1]
+            except AuthenticationFailed:
+                return HttpResponseForbidden("Invalid token")
 
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
### Fixes: #21181

Extend TokenConditionalLoginRequiredMixin to handle the AuthenticationFailed exception and return a 403 response