### PR TITLE
Add Edit/Delete/Changelog buttons to IP Ranges

### DIFF
--- a/netbox/ipam/tables/ip.py
+++ b/netbox/ipam/tables/ip.py
@@ -280,6 +280,10 @@ class IPRangeTable(TenancyColumnsMixin, ContactsColumnMixin, PrimaryModelTable):
     tags = columns.TagColumn(
         url_name='ipam:iprange_list'
     )
+    
+    actions = columns.ActionsColumn(
+        extra_buttons=IPADDRESS_COPY_BUTTON
+    )
 
     class Meta(PrimaryModelTable.Meta):
         model = IPRange
@@ -355,6 +359,7 @@ class IPAddressTable(TenancyColumnsMixin, ContactsColumnMixin, PrimaryModelTable
         fields = (
             'pk', 'id', 'address', 'vrf', 'status', 'role', 'tenant', 'tenant_group', 'nat_inside', 'nat_outside',
             'assigned', 'dns_name', 'description', 'comments', 'contacts', 'tags', 'created', 'last_updated',
+            'actions',
         )
         default_columns = (
             'pk', 'address', 'vrf', 'status', 'role', 'tenant', 'assigned', 'dns_name', 'description',
@@ -366,10 +371,13 @@ class IPAddressTable(TenancyColumnsMixin, ContactsColumnMixin, PrimaryModelTable
 
 class AnnotatedIPAddressTable(IPAddressTable):
     address = tables.TemplateColumn(
-        template_code=IPADDRESS_LINK,
+        template_code=ANNOTATED_IPADDRESS_LINK
         verbose_name=_('IP Address')
     )
-
+    actions = columns.ActionsColumn(
+        actions=('edit', 'delete'),
+        extra_buttons=IPADDRESS_COPY_BUTTON
+    )
     class Meta(IPAddressTable.Meta):
         pass
 

--- a/netbox/ipam/tables/template_code.py
+++ b/netbox/ipam/tables/template_code.py
@@ -38,6 +38,18 @@ IPADDRESS_LINK = """
 {% endif %}
 """
 
+ANNOTATED_IPADDRESS_LINK = """
+{% if record.address %}
+  <a href="{{ record.get_absolute_url }}" id="ipaddress_{{ record.pk}}">{{ record.address.ip }}</a>/{{ record.address.prefix_length }}
+{% elif record.start_address %}
+  <a href="{{ record.get_absolute_url }}">{{ record }}</a>
+{% elif perms.ipam.add_ipaddress %}
+  <a href="{% url 'ipam:ipaddress_add' %}?address={{ record.first_ip }}{% if object.vrf %}&vrf={{ object.vrf.pk }}{% endif %}{% if object.tenant %}&tenant={{ object.tenant.pk }}{% endif %}&return_url={% url 'ipam:prefix_ipaddresses' pk=object.pk %}" class="btn btn-sm btn-success">{{ record.title }}</a>
+{% else %}
+  {{ record.title }}
+{% endif %}
+"""
+
 IPADDRESS_COPY_BUTTON = """
 {% if record.address %}
   {% copy_content record.pk prefix="ipaddress_" %}


### PR DESCRIPTION
Fix: https://github.com/netbox-community/netbox/issues/21054

When looking at the IP address-level usage of a prefix, the IP Addresses list is the one that provides the best possible view for the used/available IPs, provided that the IP ranges are created with "Marked Populated" flag to signal the usage of the IP addresses within the range objects. At that point it would be natural to be able to also directly edit/delete the IP ranges and not just the IP addresses, if there are needs to modify the IP range objects.

