### PR TITLE
Fixes #21115: Include attribute_data in ModuleType YAML export

### DIFF
--- a/netbox/dcim/models/modules.py
+++ b/netbox/dcim/models/modules.py
@@ -155,6 +155,8 @@ class ModuleType(ImageAttachmentsMixin, PrimaryModel, WeightMixin):
             'description': self.description,
             'weight': float(self.weight) if self.weight is not None else None,
             'weight_unit': self.weight_unit,
+            'airflow': self.airflow,
+            'attribute_data': self.attribute_data,
             'comments': self.comments,
         }
 


### PR DESCRIPTION
Fixes #21115 

## Summary

This PR fixes an issue where custom JSON properties defined in module type profiles were not being included in YAML exports of module types. The `to_yaml()` method was missing both the `airflow` field and the `attribute_data` field which contains the custom properties.

## Changes Made

- Added `airflow` field to `ModuleType.to_yaml()` method
- Added `attribute_data` field to `ModuleType.to_yaml()` method

## Problem

When exporting a module type with custom properties defined via a module type profile schema (e.g., `u_generation` in the example from the issue), these properties were not included in the YAML export output, even though they were properly stored in the `attribute_data` JSONField.

## Solution

The fix adds both missing fields to the YAML export:
- `airflow`: The airflow direction field (consistent with how `DeviceType.to_yaml()` handles it)
- `attribute_data`: The JSON field containing all custom properties from the profile schema

This ensures complete round-trip export/import functionality, as `ModuleTypeImportForm` already supports importing `attribute_data`.

## Testing

- Verified that `attribute_data` is properly exported in YAML format
- Confirmed consistency with existing `DeviceType.to_yaml()` implementation
- Ensured compatibility with existing import functionality