### PR TITLE
Fixes #21150: Correct Dynamic Configuration menu path in documentation

### DIFF
--- a/docs/configuration/index.md
+++ b/docs/configuration/index.md
@@ -15,7 +15,7 @@ Some configuration parameters may alternatively be defined either in `configurat
 
 ## Dynamic Configuration Parameters
 
-Some configuration parameters are primarily controlled via NetBox's admin interface (under Admin > Extras > Configuration Revisions). These are noted where applicable in the documentation. These settings may also be overridden in `configuration.py` to prevent them from being modified via the UI. A complete list of supported parameters is provided below:
+Some configuration parameters are primarily controlled via NetBox's admin interface (under Admin > System > Configuration History). These are noted where applicable in the documentation. These settings may also be overridden in `configuration.py` to prevent them from being modified via the UI. A complete list of supported parameters is provided below:
 
 * [`ALLOWED_URL_SCHEMES`](./security.md#allowed_url_schemes)
 * [`BANNER_BOTTOM`](./miscellaneous.md#banner_bottom)


### PR DESCRIPTION
Fixes #21150 

## Summary

This PR corrects an inaccurate menu path reference in the Dynamic Configuration Parameters documentation section. The documentation incorrectly stated that configuration parameters are controlled via "Admin > Extras > Configuration Revisions", when the actual location is "Admin > System > Configuration History".

## Changes Made

- Updated menu path in `docs/configuration/index.md` from "Admin > Extras > Configuration Revisions" to "Admin > System > Configuration History"

## Problem

The documentation referenced a non-existent menu path, which could confuse users trying to locate the Configuration History interface in NetBox's admin interface.

## Solution

Corrected the menu path to match the actual location in the NetBox admin interface, which is under Admin > System > Configuration History (as defined in `netbox/navigation/menu.py`).

## Impact

- Users can now correctly navigate to the Configuration History interface
- Documentation accurately reflects the current NetBox UI structure