### PR TITLE
Fixes #21173: Fix plugin menu registration order timing issue

### DIFF
--- a/netbox/netbox/navigation/menu.py
+++ b/netbox/netbox/navigation/menu.py
@@ -501,40 +501,46 @@ ADMIN_MENU = Menu(
     ),
 )
 
-MENUS = [
-    ORGANIZATION_MENU,
-    RACKS_MENU,
-    DEVICES_MENU,
-    CONNECTIONS_MENU,
-    WIRELESS_MENU,
-    IPAM_MENU,
-    VPN_MENU,
-    VIRTUALIZATION_MENU,
-    CIRCUITS_MENU,
-    POWER_MENU,
-    PROVISIONING_MENU,
-    CUSTOMIZATION_MENU,
-    OPERATIONS_MENU,
-]
-
-# Add top-level plugin menus
-for menu in registry['plugins']['menus']:
-    MENUS.append(menu)
-
-# Add the default "plugins" menu
-if registry['plugins']['menu_items']:
-
-    # Build the default plugins menu
-    groups = [
-        MenuGroup(label=label, items=items)
-        for label, items in registry['plugins']['menu_items'].items()
+def get_menus():
+    """
+    Dynamically build and return the list of navigation menus.
+    This ensures plugin menus registered during app initialization are included.
+    """
+    menus = [
+        ORGANIZATION_MENU,
+        RACKS_MENU,
+        DEVICES_MENU,
+        CONNECTIONS_MENU,
+        WIRELESS_MENU,
+        IPAM_MENU,
+        VPN_MENU,
+        VIRTUALIZATION_MENU,
+        CIRCUITS_MENU,
+        POWER_MENU,
+        PROVISIONING_MENU,
+        CUSTOMIZATION_MENU,
+        OPERATIONS_MENU,
     ]
-    plugins_menu = Menu(
-        label=_("Plugins"),
-        icon_class="mdi mdi-puzzle",
-        groups=groups
-    )
-    MENUS.append(plugins_menu)
 
-# Add the admin menu last
-MENUS.append(ADMIN_MENU)
+    # Add top-level plugin menus
+    for menu in registry['plugins']['menus']:
+        menus.append(menu)
+
+    # Add the default "plugins" menu
+    if registry['plugins']['menu_items']:
+        # Build the default plugins menu
+        groups = [
+            MenuGroup(label=label, items=items)
+            for label, items in registry['plugins']['menu_items'].items()
+        ]
+        plugins_menu = Menu(
+            label=_("Plugins"),
+            icon_class="mdi mdi-puzzle",
+            groups=groups
+        )
+        menus.append(plugins_menu)
+
+    # Add the admin menu last
+    menus.append(ADMIN_MENU)
+    
+    return menus

--- a/netbox/netbox/navigation/menu.py
+++ b/netbox/netbox/navigation/menu.py
@@ -501,6 +501,7 @@ ADMIN_MENU = Menu(
     ),
 )
 
+
 def get_menus():
     """
     Dynamically build and return the list of navigation menus.
@@ -542,5 +543,5 @@ def get_menus():
 
     # Add the admin menu last
     menus.append(ADMIN_MENU)
-    
+
     return menus

--- a/netbox/netbox/navigation/menu.py
+++ b/netbox/netbox/navigation/menu.py
@@ -1,3 +1,5 @@
+from functools import cache
+
 from django.utils.translation import gettext_lazy as _
 
 from netbox.registry import registry
@@ -502,10 +504,12 @@ ADMIN_MENU = Menu(
 )
 
 
+@cache
 def get_menus():
     """
     Dynamically build and return the list of navigation menus.
     This ensures plugin menus registered during app initialization are included.
+    The result is cached since menus don't change without a Django restart.
     """
     menus = [
         ORGANIZATION_MENU,

--- a/netbox/utilities/templatetags/navigation.py
+++ b/netbox/utilities/templatetags/navigation.py
@@ -1,6 +1,6 @@
 from django import template
 
-from netbox.navigation.menu import MENUS
+from netbox.navigation.menu import get_menus
 
 __all__ = (
     'nav',
@@ -19,7 +19,7 @@ def nav(context):
     nav_items = []
 
     # Construct the navigation menu based upon the current user's permissions
-    for menu in MENUS:
+    for menu in get_menus():
         groups = []
         for group in menu.groups:
             items = []


### PR DESCRIPTION
Fixes #21173: Fix plugin menu registration order timing issue

## Summary

This PR fixes an issue where plugin menus registered later in the Django app initialization process were not appearing in the NetBox navigation sidebar. The problem occurred because the `MENUS` list was built at module import time, before all plugins had completed their `ready()` methods.

## Problem

When multiple plugins register menus via `navigation.py` and `PluginConfig.ready()`, only the first few plugins' menus would appear in the navigation sidebar. The missing menus were properly registered in the plugin registry, but were not included in the final `MENUS` list.

**Root Cause:**
- `netbox/navigation/menu.py` was imported during Django startup (in `settings.py`)
- At import time, the `MENUS` list was built by iterating over `registry['plugins']['menus']`
- However, only the first few plugins had completed their `ready()` methods at that point
- Later plugins' menus were registered after `MENUS` was already built, so they were excluded

## Solution

Converted the static `MENUS` list to a dynamic `get_menus()` function that builds the menu list on-demand at request time (when the navigation template tag is rendered). This ensures all plugins have completed their `ready()` methods before the menus are assembled.

**Changes Made:**
- Replaced static `MENUS` list with `get_menus()` function in `netbox/navigation/menu.py`
- Updated `netbox/utilities/templatetags/navigation.py` to call `get_menus()` instead of importing `MENUS`
- Function builds the same menu structure, just dynamically at request time

## Impact

- **Fixed:** All plugin menus now appear in the navigation sidebar regardless of plugin load order
- **Backward Compatible:** No changes to plugin registration API or menu structure
- **Performance:** Negligible impact - building menu list is microseconds per request
- **No Breaking Changes:** Function returns the same list structure as before

## Testing

- Verified that all plugin menus appear in navigation sidebar
- Confirmed existing plugin menu registration continues to work
- No changes required to plugin code - existing plugins work without modification