### PR TITLE
Fixes: #19221 - Add truncate_middle filter for middle-ellipsis on long filenames

### DIFF
--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -43,7 +43,7 @@ IMAGEATTACHMENT_IMAGE = """
   <a href="{{ record.image.url }}" target="_blank" class="image-preview" data-bs-placement="top">
     <i class="mdi mdi-image"></i></a>
 {% endif %}
-<a href="{{ record.get_absolute_url }}">{{ record }}</a>
+<a href="{{ record.get_absolute_url }}">{{ record.filename|truncate_middle:16 }}</a>
 """
 
 NOTIFICATION_ICON = """

--- a/netbox/utilities/templatetags/builtins/filters.py
+++ b/netbox/utilities/templatetags/builtins/filters.py
@@ -260,8 +260,8 @@ def truncate_middle(value, length):
         return value
 
     # Calculate split points for the two parts
-    half_len = (length - 3) // 2  # 3 for the '...'
+    half_len = (length - 1) // 2  # 1 for the ellipsis
     first_part = value[:half_len]
-    second_part = value[len(value) - (length - 3 - half_len):]
+    second_part = value[len(value) - (length - 1 - half_len):]
 
     return mark_safe(f"{first_part}&hellip;{second_part}")

--- a/netbox/utilities/templatetags/builtins/filters.py
+++ b/netbox/utilities/templatetags/builtins/filters.py
@@ -252,3 +252,16 @@ def isodatetime(value, spec='seconds'):
     else:
         return ''
     return mark_safe(f'<span title="{naturaltime(value)}">{text}</span>')
+
+
+@register.filter
+def truncate_middle(value, length):
+    if len(value) <= length:
+        return value
+
+    # Calculate split points for the two parts
+    half_len = (length - 3) // 2  # 3 for the '...'
+    first_part = value[:half_len]
+    second_part = value[len(value) - (length - 3 - half_len):]
+
+    return mark_safe(f"{first_part}&hellip;{second_part}")


### PR DESCRIPTION
### Fixes: #19221

<img width="632" height="256" alt="Screenshot 2026-01-21 at 7 45 41 PM" src="https://github.com/user-attachments/assets/0bba62cb-3c81-4ec0-9f83-e84a67d12623" />

This behavior is accomplished using a new filter, `truncate_middle`, which in this case is hard-coded to 16 characters overall length.

A CSS-based/front-end solution would probably be more optimal for responsiveness reasons, but it would be a lot more involved and awkward.
