### PR TITLE
Fixes #19869: Display peer connections for LAG member interfaces

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -27,6 +27,7 @@ __all__ = (
     'DeviceTable',
     'FrontPortTable',
     'InterfaceTable',
+    'InterfaceLAGMemberTable',
     'InventoryItemRoleTable',
     'InventoryItemTable',
     'MACAddressTable',
@@ -687,6 +688,33 @@ class InterfaceTable(BaseInterfaceTable, ModularDeviceComponentTable, PathEndpoi
             'qinq_svlan', 'inventory_items', 'created', 'last_updated', 'vlan_translation_policy'
         )
         default_columns = ('pk', 'name', 'device', 'label', 'enabled', 'type', 'description')
+
+
+class InterfaceLAGMemberTable(PathEndpointTable, NetBoxTable):
+    parent = tables.Column(
+        verbose_name=_('Parent'),
+        accessor=Accessor('device'),
+        linkify=True,
+    )
+    name = tables.Column(
+        verbose_name=_('Name'),
+        linkify=True,
+        order_by=('_name',),
+    )
+    connection = columns.TemplateColumn(
+        accessor='connected_endpoints',
+        template_code=INTERFACE_LAG_MEMBERS_LINKTERMINATION,
+        verbose_name=_('Peer'),
+        orderable=False,
+    )
+    tags = columns.TagColumn(
+        url_name='dcim:interface_list'
+    )
+
+    class Meta(NetBoxTable.Meta):
+        model = models.Interface
+        fields = ('pk', 'parent', 'name', 'type', 'connection')
+        default_columns = ('pk', 'parent', 'name', 'type', 'connection')
 
 
 class DeviceInterfaceTable(InterfaceTable):

--- a/netbox/dcim/tables/template_code.py
+++ b/netbox/dcim/tables/template_code.py
@@ -24,6 +24,24 @@ INTERFACE_LINKTERMINATION = """
 {% else %}""" + LINKTERMINATION + """{% endif %}
 """
 
+INTERFACE_LAG_MEMBERS_LINKTERMINATION = """
+{% for termination in value %}
+  {% if termination.parent_object %}
+    <a href="{{ termination.parent_object.get_absolute_url }}">{{ termination.parent_object }}</a>
+    <i class="mdi mdi-chevron-right"></i>
+  {% endif %}
+  <a href="{{ termination.get_absolute_url }}">{{ termination }}</a>
+  {% if termination.lag %}
+    <i class="mdi mdi-chevron-right"></i>
+    <a href="{{ termination.lag.get_absolute_url }}">{{ termination.lag }}</a>
+    <span class="text-muted">(LAG)</span>
+  {% endif %}
+  {% if not forloop.last %}<br />{% endif %}
+{% empty %}
+  {{ ''|placeholder }}
+{% endfor %}
+"""
+
 CABLE_LENGTH = """
 {% load helpers %}
 {% if record.length %}{{ record.length|floatformat:"-2" }} {{ record.length_unit }}{% endif %}

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -3135,6 +3135,14 @@ class InterfaceView(generic.ObjectView):
         )
         child_interfaces_table.configure(request)
 
+        # Get LAG interfaces
+        lag_interfaces = Interface.objects.restrict(request.user, 'view').filter(lag=instance)
+        lag_interfaces_table = tables.InterfaceLAGMemberTable(
+            lag_interfaces,
+            orderable=False
+        )
+        lag_interfaces_table.configure(request)
+
         # Get assigned VLANs and annotate whether each is tagged or untagged
         vlans = []
         if instance.untagged_vlan is not None:
@@ -3164,6 +3172,7 @@ class InterfaceView(generic.ObjectView):
             'bridge_interfaces': bridge_interfaces,
             'bridge_interfaces_table': bridge_interfaces_table,
             'child_interfaces_table': child_interfaces_table,
+            'lag_interfaces_table': lag_interfaces_table,
             'vlan_table': vlan_table,
             'vlan_translation_table': vlan_translation_table,
         }

--- a/netbox/templates/dcim/interface.html
+++ b/netbox/templates/dcim/interface.html
@@ -370,33 +370,6 @@
           </table>
         </div>
       {% endif %}
-      {% if object.is_lag %}
-        <div class="card">
-          <h2 class="card-header">{% trans "LAG Members" %}</h2>
-          <table class="table table-hover">
-            <thead>
-              <tr>
-                <th>{% trans "Parent" %}</th>
-                <th>{% trans "Interface" %}</th>
-                <th>{% trans "Type" %}</th>
-              </tr>
-            </thead>
-            <tbody>
-              {% for member in object.member_interfaces.all %}
-                <tr>
-                  <td>{{ member.device|linkify }}</td>
-                  <td>{{ member|linkify }}</td>
-                  <td>{{ member.get_type_display }}</td>
-                </tr>
-              {% empty %}
-                <tr>
-                  <td colspan="3" class="text-muted">{% trans "No member interfaces" %}</td>
-                </tr>
-              {% endfor %}
-            </tbody>
-          </table>
-        </div>
-      {% endif %}
       {% include 'ipam/inc/panels/fhrp_groups.html' %}
       {% include 'dcim/inc/panels/inventory_items.html' %}
       {% plugin_right_page object %}
@@ -441,6 +414,13 @@
       {% include 'inc/panel_table.html' with table=vlan_table heading="VLANs" %}
     </div>
   </div>
+  {% if object.is_lag %}
+    <div class="row mb-3">
+      <div class="col col-md-12">
+        {% include 'inc/panel_table.html' with table=lag_interfaces_table heading="LAG Members" %}
+      </div>
+    </div>
+  {% endif %}
   {% if object.vlan_translation_policy %}
     <div class="row mb-3">
       <div class="col col-md-12">


### PR DESCRIPTION
### Fixes: #19869

This PR enhances the **LAG Members** section on a LAG interface detail view by surfacing basic connectivity information for each member.

#### Summary of changes
- Introduces `InterfaceLAGMemberTable` for the LAG Members panel.
- Displays each member’s **parent device**, **interface name/type**, and a **Peer** column.
- The **Peer** column renders the member’s connected endpoint(s) and, when applicable, also shows the peer-side **LAG** to provide quick context for aggregated links.