### PR TITLE
Fixes #21202: Fix scoped form cloning clearing the Scope field when Scope Type changes

### DIFF
--- a/netbox/dcim/forms/mixins.py
+++ b/netbox/dcim/forms/mixins.py
@@ -75,7 +75,7 @@ class ScopedForm(forms.Form):
             except ObjectDoesNotExist:
                 pass
 
-            if self.instance and scope_type_id != self.instance.scope_type_id:
+            if self.instance and self.instance.pk and scope_type_id != self.instance.scope_type_id:
                 self.initial['scope'] = None
 
         else:


### PR DESCRIPTION
### Fixes: #21202

This PR adjusts `ScopedForm._set_scoped_values()` so it no longer clears `initial['scope']` during clone form initialization.

Previously, when cloning an object with scoped fields (e.g., a Prefix scoped to `Site: DC1`), the form would treat the `scope_type` mismatch like an edit and wipe the pre-filled scope on the initial GET, forcing the user to re-select it manually.

With this change, the scope is only cleared when **editing an existing object** (`instance.pk` is set) *and* the `scope_type` has actually changed.

Thanks for taking a look! This also helps unblock the follow-up fix in #21262.
