### PR TITLE
Closes #21228: Add image attachments support to RackType model

### DIFF
--- a/netbox/dcim/graphql/filters.py
+++ b/netbox/dcim/graphql/filters.py
@@ -889,7 +889,7 @@ class PowerPortTemplateFilter(ModularComponentTemplateFilterMixin, ChangeLoggedM
 
 
 @strawberry_django.filter_type(models.RackType, lookups=True)
-class RackTypeFilter(RackFilterMixin, WeightFilterMixin, PrimaryModelFilter):
+class RackTypeFilter(ImageAttachmentFilterMixin, RackFilterMixin, WeightFilterMixin, PrimaryModelFilter):
     form_factor: BaseFilterLookup[Annotated['RackFormFactorEnum', strawberry.lazy('dcim.graphql.enums')]] | None = (
         strawberry_django.filter_field()
     )

--- a/netbox/dcim/graphql/types.py
+++ b/netbox/dcim/graphql/types.py
@@ -734,7 +734,7 @@ class PowerPortTemplateType(ModularComponentTemplateType):
     filters=RackTypeFilter,
     pagination=True
 )
-class RackTypeType(PrimaryObjectType):
+class RackTypeType(ImageAttachmentsMixin, PrimaryObjectType):
     rack_count: BigInt
     manufacturer: Annotated["ManufacturerType", strawberry.lazy('dcim.graphql.types')]
 

--- a/netbox/dcim/models/racks.py
+++ b/netbox/dcim/models/racks.py
@@ -122,7 +122,7 @@ class RackBase(WeightMixin, PrimaryModel):
         abstract = True
 
 
-class RackType(RackBase):
+class RackType(ImageAttachmentsMixin, RackBase):
     """
     Devices are housed within Racks. Each rack has a defined height measured in rack units, and a front and rear face.
     Each Rack is assigned to a Site and (optionally) a Location.

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -880,6 +880,7 @@ class RackTypeView(GetRelatedModelsMixin, generic.ObjectView):
             panels.RackWeightPanel(title=_('Weight'), exclude=['total_weight']),
             CustomFieldsPanel(),
             RelatedObjectsPanel(),
+            ImageAttachmentsPanel(),
         ],
     )
 


### PR DESCRIPTION
## Summary

Enable image attachments for the RackType model, similar to other models like DeviceType, ModuleType, Site, and Location.

### Changes:
- Add `ImageAttachmentsMixin` to `RackType` model
- Add `ImageAttachmentsMixin` to `RackTypeType` GraphQL type  
- Add `ImageAttachmentFilterMixin` to `RackTypeFilter` GraphQL filter

Fixes #21228