### PR TITLE
Fixes #21254: Fix release check failure when stale `latest_release` cache can't be unpickled

### DIFF
--- a/netbox/netbox/views/misc.py
+++ b/netbox/netbox/views/misc.py
@@ -1,5 +1,6 @@
 import re
 from collections import namedtuple
+import logging
 
 from django.conf import settings
 from django.contrib import messages
@@ -28,6 +29,8 @@ __all__ = (
     'SearchView',
 )
 
+logger = logging.getLogger(f'netbox.{__name__}')
+
 Link = namedtuple('Link', ('label', 'viewname', 'permission', 'count'))
 
 
@@ -50,7 +53,14 @@ class HomeView(ConditionalLoginRequiredMixin, View):
         # Check whether a new release is available. (Only for superusers.)
         new_release = None
         if request.user.is_superuser:
-            latest_release = cache.get('latest_release')
+            # cache.get() can raise if the cached value can't be unpickled after dependency upgrades
+            try:
+                latest_release = cache.get('latest_release')
+            except Exception:
+                logger.debug("Failed to read 'latest_release' from cache; deleting key", exc_info=True)
+                cache.delete('latest_release')
+                latest_release = None
+
             if latest_release:
                 release_version, release_url = latest_release
                 if release_version > version.parse(settings.RELEASE.version):

--- a/netbox/netbox/views/misc.py
+++ b/netbox/netbox/views/misc.py
@@ -53,7 +53,7 @@ class HomeView(ConditionalLoginRequiredMixin, View):
         # Check whether a new release is available. (Only for superusers.)
         new_release = None
         if request.user.is_superuser:
-            # cache.get() can raise if the cached value can't be unpickled after dependency upgrades
+            # cache.get() can raise an exception if the cached value can't be unpickled after dependency upgrades
             try:
                 latest_release = cache.get('latest_release')
             except Exception:


### PR DESCRIPTION
### Fixes: #21254

This PR prevents a 500 on the home page when reading the `latest_release` cache entry fails to unpickle after dependency upgrades (e.g. `packaging>=26` with a value cached under `<26`).

**Summary of changes**
- Wrap `cache.get('latest_release')` in a `try/except` during the superuser release check
- On failure, log at debug level, delete the stale cache key, and continue as if no cached release is available

This keeps the UI working and allows the cache to be repopulated normally by housekeeping/release checks.