### PR TITLE
Fixes #20052: improve logging for faulty scripts

### DIFF
--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -137,7 +137,7 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
             module = self.get_module()
         except Exception as e:
             self.error = e
-            logger.debug(f"Failed to load script: {self.python_name} error: {e}")
+            logger.error(f"Failed to load script: {self.python_name} error: {e}")
             module = None
 
         scripts = {}

--- a/netbox/templates/extras/inc/script_list_content.html
+++ b/netbox/templates/extras/inc/script_list_content.html
@@ -121,6 +121,7 @@
           <div class="alert alert-warning" role="alert">
             <i class="mdi mdi-alert"></i>
             {% blocktrans with module=module.name %}Could not load scripts from module {{ module }}{% endblocktrans %}
+            {% if module.error %}<code>{{ module.error }}</code>{% endif %}
           </div>
         </div>
       {% endif %}


### PR DESCRIPTION
### Fixes: #20052

When a custom script is faulty (i.e missing import or syntax error), the error is now logged at error level and also displayed in the UI.
<img width="841" height="268" alt="Screenshot 2026-01-24 at 18 51 18" src="https://github.com/user-attachments/assets/488a71d6-2f5e-4f80-947e-366ac9a752f9" />

