### PR TITLE
Closes #20172: Add `cabled` filter for DCIM interfaces in GraphQL

### DIFF
--- a/netbox/dcim/graphql/filters.py
+++ b/netbox/dcim/graphql/filters.py
@@ -551,6 +551,10 @@ class InterfaceFilter(
     )
 
     @strawberry_django.filter_field
+    def cabled(self, value: bool, prefix: str):
+        return Q(**{f'{prefix}cable__isnull': (not value)})
+
+    @strawberry_django.filter_field
     def connected(self, queryset, value: bool, prefix: str):
         if value is True:
             return queryset, Q(**{f"{prefix}_path__is_active": True})


### PR DESCRIPTION
### Fixes: #20172

This PR re-introduces a `cabled` **Boolean** filter for DCIM **Interface** objects in the GraphQL schema.

It enables callers to filter interfaces based on whether they have a cable attached:

- `cabled: true` → return only interfaces with a cable
- `cabled: false` → return only interfaces without a cable

This is particularly useful for queries that traverse cable peers, as it helps avoid returning uncabled interfaces and can reduce response size (often improving query performance).

Thanks for reviewing!
