### PR TITLE
Fixes #21233: UI Add horizontal padding to Release info section in Navigation menu

### DIFF
--- a/netbox/templates/base/layout.html
+++ b/netbox/templates/base/layout.html
@@ -53,7 +53,7 @@ Blocks:
           {% nav %}
 
           {# Release info #}
-          <div class="text-muted text-center fs-5 my-3">
+          <div class="text-muted text-center fs-5 my-3 px-3">
             {{ settings.RELEASE.name }}
             {% if not settings.RELEASE.features.commercial and not settings.ISOLATED_DEPLOYMENT %}
               <div>


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #21233

<!--
    Please include a summary of the proposed changes below.
-->

This pull request is to enhance the layout of the release information div in layout.html by adding padding. 

When users input a lengthy version string for the release information, the padding will help ensure that the text is properly displayed. The addition of `px-3` will provide 16px of padding, consistent with the spacing of other elements in the template.

<img width="914" height="798" alt="image" src="https://github.com/user-attachments/assets/f410792b-75f3-4150-9ac9-c9d2e4ff3df7" />

<img width="990" height="912" alt="image" src="https://github.com/user-attachments/assets/fbc5671d-6e1c-4fd0-aa71-6ba4174564aa" />


Thanks for the review!