### PR TITLE
Fixes #21320: Prevent Rack validation errors when site or optional fields are missing during import

### DIFF
--- a/netbox/dcim/models/racks.py
+++ b/netbox/dcim/models/racks.py
@@ -373,7 +373,7 @@ class Rack(ContactsMixin, ImageAttachmentsMixin, TrackingModelMixin, RackBase):
         super().clean()
 
         # Validate location/site assignment
-        if self.site and self.location and self.location.site != self.site:
+        if self.site_id and self.location_id and self.location.site_id != self.site_id:
             raise ValidationError(_("Assigned location must belong to parent site ({site}).").format(site=self.site))
 
         # Validate outer dimensions and unit


### PR DESCRIPTION
### Fixes: #21320

This PR prevents an uncaught exception during Rack direct import/validation when the `site` relation isn’t set (e.g. due to missing/incorrect CSV headers), which previously could raise `RelatedObjectDoesNotExist`.

#### Summary of changes
- Update Rack validation to use the FK ID fields (`site_id` / `location_id`) instead of accessing related objects directly.
- Avoid triggering related-object lookups during validation, ensuring we return normal, user-facing validation errors rather than a backend exception.
- Aligns the validation logic with Django’s underlying foreign key fields and behavior when relations are unset.

Thanks again to @cpt-kernel-afk for the report and sample CSVs, and to @jnovinger for the review/suggestion to use FK IDs here.
