### PR TITLE
Closes #21110: Support for cursor-based pagination in GraphQL API

### DIFF
--- a/docs/integrations/graphql-api.md
+++ b/docs/integrations/graphql-api.md
@@ -137,6 +137,8 @@ The GraphQL API supports two types of pagination. Offset-based pagination operat
 
 The alternative approach is cursor-based pagination, which operates using absolute (rather than relative) primary key values. (These are the numeric IDs assigned to each object in the database.) When using cursor-based pagination, the response will contain records with a primary key greater than or equal to the specified start value, up to the maximum number of results. This strategy requires keeping track of the last seen primary key from each response when paginating through data, but is extremely performant. The cursor is specified by passing the starting object ID via the `start` parameter.
 
+To ensure consistent ordering, objects will always be ordered by their primary keys when cursor-based pagination is used.
+
 !!! note "Cursor-based pagination was introduced in NetBox v4.5.2."
 
 Both pagination strategies support passing an optional `limit` parameter. In both approaches, this specifies the maximum number of objects to include in the response. If no limit is specified, a default value of 100 is used.

--- a/docs/integrations/graphql-api.md
+++ b/docs/integrations/graphql-api.md
@@ -133,23 +133,65 @@ The field "class_type" is an easy way to distinguish what type of object it is w
 
 ## Pagination
 
-Queries can be paginated by specifying pagination in the query and supplying an offset and optionaly a limit in the query.  If no limit is given, a default of 100 is used.  Queries are not paginated unless requested in the query. An example paginated query is shown below:
+The GraphQL API supports two types of pagination. Offset-based pagination operates using an offset relative to the first record in a set, specified by the `offset` parameter. For example, the response to a request specifying an offset of 100 will contain the 101st and later matching records. Offset-based pagination feels very natural, but its performance can suffer when dealing with large data sets due to the overhead involved in calculating the relative offset.
+
+The alternative approach is cursor-based pagination, which operates using absolute (rather than relative) primary key values. (These are the numeric IDs assigned to each object in the database.) When using cursor-based pagination, the response will contain records with a primary key greater than or equal to the specified start value, up to the maximum number of results. This strategy requires keeping track of the last seen primary key from each response when paginating through data, but is extremely performant. The cursor is specified by passing the starting object ID via the `start` parameter.
+
+!!! note "Cursor-based pagination was introduced in NetBox v4.5.2."
+
+Both pagination strategies support passing an optional `limit` parameter. In both approaches, this specifies the maximum number of objects to include in the response. If no limit is specified, a default value of 100 is used.
+
+### Offset Pagination
+
+The first page will have an `offset` of zero, or the `offset` parameter will be omitted:
 
 ```
 query {
-  device_list(pagination: { offset: 0, limit: 20 }) {
+  device_list(pagination: {offset: 0, limit: 20}) {
     id
   }
 }
 ```
 
+The second page will have an offset equal to the size of the first page. If the number of records is less than the specified limit, there are no more records to process. For example, if a request specifies a `limit` of 20 but returns only 13 records, we can conclude that this is the final page of records.
+
+```
+query {
+  device_list(pagination: {offset: 20, limit: 20}) {
+    id
+  }
+}
+```
+
+### Cursor Pagination
+
+Set the `start` value to zero to fetch the first page. Note that if the `start` parameter is omitted, offset-based pagination will be used by default.
+
+```
+query {
+  device_list(pagination: {start: 0, limit: 20}) {
+    id
+  }
+}
+```
+
+To determine the `start` value for the next page, add 1 to the primary key (`id`) of the last record in the previous page.
+
+For example, if the ID of the last record in the previous response was 123, we would specify a `start` value of 124:
+
+```
+query {
+  device_list(pagination: {start: 124, limit: 20}) {
+    id
+  }
+}
+```
+
+This will return up to 20 records with an ID greater than or equal to 124.
+
 ## Authentication
 
-NetBox's GraphQL API uses the same API authentication tokens as its REST API. Authentication tokens are included with requests by attaching an `Authorization` HTTP header in the following form:
-
-```
-Authorization: Token $TOKEN
-```
+NetBox's GraphQL API uses the same API authentication tokens as its REST API. See the [REST API authentication](./rest-api.md#authentication) documentation for further detail.
 
 ## Disabling the GraphQL API
 

--- a/netbox/netbox/graphql/pagination.py
+++ b/netbox/netbox/graphql/pagination.py
@@ -35,6 +35,9 @@ def apply_pagination(
     Replacement for the `apply_pagination()` method on StrawberryDjangoField to support cursor-based pagination.
     """
     if pagination is not None:
+        if pagination.start and pagination.offset:
+            raise ValueError('Cannot specify both `start` and `offset` in pagination.')
+
         if pagination.start not in (None, UNSET):
             # Filter the queryset to include only records with a primary key greater than or equal to the start value,
             # and force ordering by primary key to ensure consistent pagination across all records.

--- a/netbox/netbox/graphql/pagination.py
+++ b/netbox/netbox/graphql/pagination.py
@@ -34,16 +34,17 @@ def apply_pagination(
     """
     Replacement for the `apply_pagination()` method on StrawberryDjangoField to support cursor-based pagination.
     """
-    if pagination is not None:
-        if pagination.start and pagination.offset:
+    if pagination is not None and pagination.start not in (None, UNSET):
+        if pagination.offset:
             raise ValueError('Cannot specify both `start` and `offset` in pagination.')
+        if pagination.start < 0:
+            raise ValueError('`start` must be greater than or equal to zero.')
 
-        if pagination.start not in (None, UNSET):
-            # Filter the queryset to include only records with a primary key greater than or equal to the start value,
-            # and force ordering by primary key to ensure consistent pagination across all records.
-            queryset = queryset.filter(pk__gte=pagination.start).order_by('pk')
+        # Filter the queryset to include only records with a primary key greater than or equal to the start value,
+        # and force ordering by primary key to ensure consistent pagination across all records.
+        queryset = queryset.filter(pk__gte=pagination.start).order_by('pk')
 
-            # Ignore `offset` when `start` is set
-            pagination.offset = 0
+        # Ignore `offset` when `start` is set
+        pagination.offset = 0
 
     return apply(pagination, queryset, related_field_id=related_field_id)

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -12,10 +12,13 @@ from django.core.validators import URLValidator
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
 from rest_framework.utils import field_mapping
+from strawberry_django import pagination
+from strawberry_django.fields.field import StrawberryDjangoField
 
 from core.exceptions import IncompatiblePluginError
 from netbox.config import PARAMS as CONFIG_PARAMS
 from netbox.constants import RQ_QUEUE_DEFAULT, RQ_QUEUE_HIGH, RQ_QUEUE_LOW
+from netbox.graphql.pagination import OffsetPaginationInput, apply_pagination
 from netbox.plugins import PluginConfig
 from netbox.registry import registry
 import storages.utils  # type: ignore
@@ -32,6 +35,12 @@ from .monkey import get_unique_validators
 # TODO: Remove this once #20547 has been implemented
 # Override DRF's get_unique_validators() function with our own (see bug #19302)
 field_mapping.get_unique_validators = get_unique_validators
+
+# Override strawberry-django's OffsetPaginationInput class to add the `start` parameter
+pagination.OffsetPaginationInput = OffsetPaginationInput
+
+# Patch StrawberryDjangoField to use our custom `apply_pagination()` method with support for cursor-based pagination
+StrawberryDjangoField.apply_pagination = apply_pagination
 
 
 #


### PR DESCRIPTION
### Closes: #21110

- Monkey-patch a custom `OffsetPaginationInput` class to support a `start` pagination parameter
- Monkey-patch a customized `apply_pagination()` function to replace the stock method on `StrawberryDjangoField`
- Add tests for both offset- and cursor-based pagination
- Update the pagination docs for GraphQL
    - Also tidy up `test_graphql_filter_objects()`