### PR TITLE
Closes #21303: Cache serialized post-change data on object

### DIFF
--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -53,9 +53,9 @@ def serialize_for_event(instance):
 def get_snapshots(instance, event_type):
     snapshots = {
         'prechange': getattr(instance, '_prechange_snapshot', None),
-        'postchange': None,
+        'postchange': getattr(instance, '_postchange_snapshot', None),
     }
-    if event_type != OBJECT_DELETED:
+    if snapshots['postchange'] is None and event_type != OBJECT_DELETED:
         # Use model's serialize_object() method if defined; fall back to serialize_object() utility function
         if hasattr(instance, 'serialize_object'):
             snapshots['postchange'] = instance.serialize_object()

--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -51,18 +51,26 @@ def serialize_for_event(instance):
 
 
 def get_snapshots(instance, event_type):
-    snapshots = {
-        'prechange': getattr(instance, '_prechange_snapshot', None),
-        'postchange': getattr(instance, '_postchange_snapshot', None),
-    }
-    if snapshots['postchange'] is None and event_type != OBJECT_DELETED:
-        # Use model's serialize_object() method if defined; fall back to serialize_object() utility function
-        if hasattr(instance, 'serialize_object'):
-            snapshots['postchange'] = instance.serialize_object()
-        else:
-            snapshots['postchange'] = serialize_object(instance)
+    """
+    Return a dictionary of pre- and post-change snapshots for the given instance.
+    """
+    if event_type == OBJECT_DELETED:
+        # Post-change snapshot must be empty for deleted objects
+        postchange_snapshot = None
+    elif hasattr(instance, '_postchange_snapshot'):
+        # Use the cached post-change snapshot if one is available
+        postchange_snapshot = instance._postchange_snapshot
+    elif hasattr(instance, 'serialize_object'):
+        # Use model's serialize_object() method if defined
+        postchange_snapshot = instance.serialize_object()
+    else:
+        # Fall back to the serialize_object() utility function
+        postchange_snapshot = serialize_object(instance)
 
-    return snapshots
+    return {
+        'prechange': getattr(instance, '_prechange_snapshot', None),
+        'postchange': postchange_snapshot,
+    }
 
 
 def enqueue_event(queue, instance, request, event_type):

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -125,6 +125,7 @@ class ChangeLoggingMixin(DeleteMixin, models.Model):
             objectchange.postchange_data = self._postchange_snapshot
 
         return objectchange
+    to_objectchange.alters_data = True
 
 
 class CloningMixin(models.Model):

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -121,7 +121,8 @@ class ChangeLoggingMixin(DeleteMixin, models.Model):
         if hasattr(self, '_prechange_snapshot'):
             objectchange.prechange_data = self._prechange_snapshot
         if action in (ObjectChangeActionChoices.ACTION_CREATE, ObjectChangeActionChoices.ACTION_UPDATE):
-            objectchange.postchange_data = self.serialize_object(exclude=exclude)
+            self._postchange_snapshot = self.serialize_object(exclude=exclude)
+            objectchange.postchange_data = self._postchange_snapshot
 
         return objectchange
 


### PR DESCRIPTION
### Closes: #21303

- Extend `to_objectchange()` to cache the serialized data as `_postchange_snapshot` on the instance being serialized.
- Modify `get_snapshots()` to check for cached serialized data before running serialization.