### PR TITLE
Closes #21267: Normalize device height formatting in rack units (display `0U`)

### DIFF
--- a/netbox/dcim/ui/panels.py
+++ b/netbox/dcim/ui/panels.py
@@ -126,7 +126,7 @@ class DeviceDeviceTypePanel(panels.ObjectAttributesPanel):
 
     manufacturer = attrs.RelatedObjectAttr('device_type.manufacturer', linkify=True)
     model = attrs.RelatedObjectAttr('device_type', linkify=True)
-    height = attrs.TextAttr('device_type.u_height', format_string='{}U')
+    height = attrs.TemplatedAttr('device_type.u_height', template_name='dcim/devicetype/attrs/height.html')
     front_image = attrs.ImageAttr('device_type.front_image')
     rear_image = attrs.ImageAttr('device_type.rear_image')
 
@@ -143,7 +143,7 @@ class DeviceTypePanel(panels.ObjectAttributesPanel):
     part_number = attrs.TextAttr('part_number')
     default_platform = attrs.RelatedObjectAttr('default_platform', linkify=True)
     description = attrs.TextAttr('description')
-    height = attrs.TextAttr('u_height', format_string='{}U', label=_('Height'))
+    height = attrs.TemplatedAttr('u_height', template_name='dcim/devicetype/attrs/height.html')
     exclude_from_utilization = attrs.BooleanAttr('exclude_from_utilization')
     full_depth = attrs.BooleanAttr('is_full_depth')
     weight = attrs.NumericAttr('weight', unit_accessor='get_weight_unit_display')

--- a/netbox/netbox/ui/attrs.py
+++ b/netbox/netbox/ui/attrs.py
@@ -103,7 +103,7 @@ class TextAttr(ObjectAttribute):
     def get_value(self, obj):
         value = resolve_attr_path(obj, self.accessor)
         # Apply format string (if any)
-        if value and self.format_string:
+        if value is not None and value != '' and self.format_string:
             return self.format_string.format(value)
         return value
 

--- a/netbox/templates/dcim/devicetype/attrs/height.html
+++ b/netbox/templates/dcim/devicetype/attrs/height.html
@@ -1,0 +1,1 @@
+{{ value|floatformat }}U


### PR DESCRIPTION
### Fixes: #21267

This PR updates the device **Dimensions** panel to render rack unit height using `TemplatedAttr` and a dedicated template applying Django’s `floatformat` filter.

As a result, devices with a `u_height` of `0.0` now display as **`0U`** (and whole-unit values no longer show a trailing `.0`), matching the expected rack-unit presentation and avoiding ambiguity for users.

Thanks for the review!
