### PR TITLE
Closes #21302: Avoid redundant uniqueness checks in REST API serializers

### DIFF
--- a/netbox/netbox/api/serializers/base.py
+++ b/netbox/netbox/api/serializers/base.py
@@ -112,6 +112,7 @@ class ValidatedModelSerializer(BaseModelSerializer):
             for k, v in attrs.items():
                 setattr(instance, k, v)
         instance._m2m_values = m2m_values
-        instance.full_clean()
+        # Skip uniqueness validation of individual fields inside `full_clean()` (this is handled by the serializer)
+        instance.full_clean(validate_unique=False)
 
         return data


### PR DESCRIPTION
### Closes: #21302

Pass `validate_unique=False` when calling `full_clean()` on the instance. The serializer already validates fields with individual unique constraints.