### PR TITLE
Closes #21300: Cache model-specific custom field lookups for the duration of a request

### DIFF
--- a/netbox/extras/api/customfields.py
+++ b/netbox/extras/api/customfields.py
@@ -23,12 +23,9 @@ class CustomFieldDefaultValues:
     def __call__(self, serializer_field):
         self.model = serializer_field.parent.Meta.model
 
-        # Retrieve the CustomFields for the parent model
-        fields = CustomField.objects.get_for_model(self.model)
-
-        # Populate the default value for each CustomField
+        # Populate the default value for each CustomField on the model
         value = {}
-        for field in fields:
+        for field in CustomField.objects.get_for_model(self.model):
             if field.default is not None:
                 value[field.name] = field.default
             else:

--- a/netbox/extras/api/customfields.py
+++ b/netbox/extras/api/customfields.py
@@ -4,7 +4,6 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework.fields import Field
 from rest_framework.serializers import ValidationError
 
-from core.models import ObjectType
 from extras.choices import CustomFieldTypeChoices
 from extras.constants import CUSTOMFIELD_EMPTY_VALUES
 from extras.models import CustomField
@@ -25,8 +24,7 @@ class CustomFieldDefaultValues:
         self.model = serializer_field.parent.Meta.model
 
         # Retrieve the CustomFields for the parent model
-        object_type = ObjectType.objects.get_for_model(self.model)
-        fields = CustomField.objects.filter(object_types=object_type)
+        fields = CustomField.objects.get_for_model(self.model)
 
         # Populate the default value for each CustomField
         value = {}
@@ -47,8 +45,7 @@ class CustomFieldsDataField(Field):
         Cache CustomFields assigned to this model to avoid redundant database queries
         """
         if not hasattr(self, '_custom_fields'):
-            object_type = ObjectType.objects.get_for_model(self.parent.Meta.model)
-            self._custom_fields = CustomField.objects.filter(object_types=object_type)
+            self._custom_fields = CustomField.objects.get_for_model(self.parent.Meta.model)
         return self._custom_fields
 
     def to_representation(self, obj):

--- a/netbox/netbox/filtersets.py
+++ b/netbox/netbox/filtersets.py
@@ -306,11 +306,10 @@ class NetBoxModelFilterSet(ChangeLoggedModelFilterSet):
         super().__init__(*args, **kwargs)
 
         # Dynamically add a Filter for each CustomField applicable to the parent model
-        custom_fields = CustomField.objects.filter(
-            object_types=ContentType.objects.get_for_model(self._meta.model)
-        ).exclude(
-            filter_logic=CustomFieldFilterLogicChoices.FILTER_DISABLED
-        )
+        custom_fields = [
+            cf for cf in CustomField.objects.get_for_model(self._meta.model)
+            if cf.filter_logic != CustomFieldFilterLogicChoices.FILTER_DISABLED
+        ]
 
         custom_field_filters = {}
         for custom_field in custom_fields:

--- a/netbox/netbox/filtersets.py
+++ b/netbox/netbox/filtersets.py
@@ -305,17 +305,13 @@ class NetBoxModelFilterSet(ChangeLoggedModelFilterSet):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # Dynamically add a Filter for each CustomField applicable to the parent model
-        custom_fields = [
-            cf for cf in CustomField.objects.get_for_model(self._meta.model)
-            if cf.filter_logic != CustomFieldFilterLogicChoices.FILTER_DISABLED
-        ]
-
         custom_field_filters = {}
-        for custom_field in custom_fields:
-            filter_name = f'cf_{custom_field.name}'
-            filter_instance = custom_field.to_filter()
-            if filter_instance:
+        for custom_field in CustomField.objects.get_for_model(self._meta.model):
+            if custom_field.filter_logic == CustomFieldFilterLogicChoices.FILTER_DISABLED:
+                # Skip disabled fields
+                continue
+            if filter_instance := custom_field.to_filter():
+                filter_name = f'cf_{custom_field.name}'
                 custom_field_filters[filter_name] = filter_instance
 
                 # Add relevant additional lookups

--- a/netbox/netbox/forms/bulk_import.py
+++ b/netbox/netbox/forms/bulk_import.py
@@ -31,10 +31,10 @@ class NetBoxModelImportForm(CSVModelForm, NetBoxModelForm):
     )
 
     def _get_custom_fields(self, content_type):
-        return CustomField.objects.filter(
-            object_types=content_type,
-            ui_editable=CustomFieldUIEditableChoices.YES
-        )
+        return [
+            cf for cf in CustomField.objects.get_for_model(content_type.model_class())
+            if cf.ui_editable == CustomFieldUIEditableChoices.YES
+        ]
 
     def _get_form_field(self, customfield):
         return customfield.to_form_field(for_csv_import=True)

--- a/netbox/netbox/forms/bulk_import.py
+++ b/netbox/netbox/forms/bulk_import.py
@@ -31,6 +31,7 @@ class NetBoxModelImportForm(CSVModelForm, NetBoxModelForm):
     )
 
     def _get_custom_fields(self, content_type):
+        # Return only custom fields that are editable in the UI
         return [
             cf for cf in CustomField.objects.get_for_model(content_type.model_class())
             if cf.ui_editable == CustomFieldUIEditableChoices.YES

--- a/netbox/netbox/forms/filtersets.py
+++ b/netbox/netbox/forms/filtersets.py
@@ -34,6 +34,7 @@ class NetBoxModelFilterSetForm(FilterModifierMixin, CustomFieldsMixin, SavedFilt
     selector_fields = ('filter_id', 'q')
 
     def _get_custom_fields(self, content_type):
+        # Return only non-hidden custom fields for which filtering is enabled (excluding JSON fields)
         return [
             cf for cf in super()._get_custom_fields(content_type) if (
                 cf.filter_logic != CustomFieldFilterLogicChoices.FILTER_DISABLED and

--- a/netbox/netbox/forms/filtersets.py
+++ b/netbox/netbox/forms/filtersets.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.db.models import Q
 from django.utils.translation import gettext_lazy as _
 
 from extras.choices import *
@@ -35,10 +34,12 @@ class NetBoxModelFilterSetForm(FilterModifierMixin, CustomFieldsMixin, SavedFilt
     selector_fields = ('filter_id', 'q')
 
     def _get_custom_fields(self, content_type):
-        return super()._get_custom_fields(content_type).exclude(
-            Q(filter_logic=CustomFieldFilterLogicChoices.FILTER_DISABLED) |
-            Q(type=CustomFieldTypeChoices.TYPE_JSON)
-        )
+        return [
+            cf for cf in super()._get_custom_fields(content_type) if (
+                cf.filter_logic != CustomFieldFilterLogicChoices.FILTER_DISABLED and
+                cf.type != CustomFieldTypeChoices.TYPE_JSON
+            )
+        ]
 
     def _get_form_field(self, customfield):
         return customfield.to_form_field(

--- a/netbox/netbox/forms/mixins.py
+++ b/netbox/netbox/forms/mixins.py
@@ -65,6 +65,7 @@ class CustomFieldsMixin:
         return ObjectType.objects.get_for_model(self.model)
 
     def _get_custom_fields(self, content_type):
+        # Return only custom fields that are not hidden from the UI
         return [
             cf for cf in CustomField.objects.get_for_model(content_type.model_class())
             if cf.ui_editable != CustomFieldUIEditableChoices.HIDDEN

--- a/netbox/netbox/forms/mixins.py
+++ b/netbox/netbox/forms/mixins.py
@@ -65,9 +65,10 @@ class CustomFieldsMixin:
         return ObjectType.objects.get_for_model(self.model)
 
     def _get_custom_fields(self, content_type):
-        return CustomField.objects.filter(object_types=content_type).exclude(
-            ui_editable=CustomFieldUIEditableChoices.HIDDEN
-        )
+        return [
+            cf for cf in CustomField.objects.get_for_model(content_type.model_class())
+            if cf.ui_editable != CustomFieldUIEditableChoices.HIDDEN
+        ]
 
     def _get_form_field(self, customfield):
         return customfield.to_form_field()

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -321,7 +321,7 @@ class CustomFieldsMixin(models.Model):
     def save(self, *args, **kwargs):
         from extras.models import CustomField
 
-        # Populate default values if omitted
+        # Populate default values for custom fields not already present in the object data
         for cf in CustomField.objects.get_for_model(self):
             if cf.name not in self.custom_field_data and cf.default is not None:
                 self.custom_field_data[cf.name] = cf.default

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -319,9 +319,11 @@ class CustomFieldsMixin(models.Model):
                 raise ValidationError(_("Missing required custom field '{name}'.").format(name=cf.name))
 
     def save(self, *args, **kwargs):
+        from extras.models import CustomField
+
         # Populate default values if omitted
-        for cf in self.custom_fields.filter(default__isnull=False):
-            if cf.name not in self.custom_field_data:
+        for cf in CustomField.objects.get_for_model(self):
+            if cf.name not in self.custom_field_data and cf.default is not None:
                 self.custom_field_data[cf.name] = cf.default
 
         super().save(*args, **kwargs)

--- a/netbox/netbox/search/backends.py
+++ b/netbox/netbox/search/backends.py
@@ -208,9 +208,12 @@ class CachedValueSearchBackend(SearchBackend):
                     except KeyError:
                         break
 
-                # Prefetch any associated custom fields
+                # Prefetch any associated custom fields (excluding those with a zero search weight)
                 object_type = ObjectType.objects.get_for_model(indexer.model)
-                custom_fields = CustomField.objects.filter(object_types=object_type).exclude(search_weight=0)
+                custom_fields = [
+                    cf for cf in CustomField.objects.get_for_model(indexer.model)
+                    if cf.search_weight > 0
+                ]
 
             # Wipe out any previously cached values for the object
             if remove_existing:

--- a/netbox/netbox/search/backends.py
+++ b/netbox/netbox/search/backends.py
@@ -187,7 +187,6 @@ class CachedValueSearchBackend(SearchBackend):
         return ret
 
     def cache(self, instances, indexer=None, remove_existing=True):
-        object_type = None
         custom_fields = None
 
         # Convert a single instance to an iterable
@@ -209,7 +208,6 @@ class CachedValueSearchBackend(SearchBackend):
                         break
 
                 # Prefetch any associated custom fields (excluding those with a zero search weight)
-                object_type = ObjectType.objects.get_for_model(indexer.model)
                 custom_fields = [
                     cf for cf in CustomField.objects.get_for_model(indexer.model)
                     if cf.search_weight > 0
@@ -220,6 +218,7 @@ class CachedValueSearchBackend(SearchBackend):
                 self.remove(instance)
 
             # Generate cache data
+            object_type = ObjectType.objects.get_for_model(indexer.model)
             for field in indexer.to_cache(instance, custom_fields=custom_fields):
                 buffer.append(
                     CachedValue(

--- a/netbox/netbox/tables/tables.py
+++ b/netbox/netbox/tables/tables.py
@@ -244,9 +244,10 @@ class NetBoxTable(BaseTable):
 
         # Add custom field & custom link columns
         object_type = ObjectType.objects.get_for_model(self._meta.model)
-        custom_fields = CustomField.objects.filter(
-            object_types=object_type
-        ).exclude(ui_visible=CustomFieldUIVisibleChoices.HIDDEN)
+        custom_fields = [
+            cf for cf in CustomField.objects.get_for_model(self._meta.model)
+            if cf.ui_visible != CustomFieldUIVisibleChoices.HIDDEN
+        ]
         extra_columns.extend([
             (f'cf_{cf.name}', columns.CustomFieldColumn(cf)) for cf in custom_fields
         ])

--- a/netbox/netbox/tables/tables.py
+++ b/netbox/netbox/tables/tables.py
@@ -242,8 +242,7 @@ class NetBoxTable(BaseTable):
                 (name, deepcopy(column)) for name, column in registered_columns.items()
             ])
 
-        # Add custom field & custom link columns
-        object_type = ObjectType.objects.get_for_model(self._meta.model)
+        # Add columns for custom fields
         custom_fields = [
             cf for cf in CustomField.objects.get_for_model(self._meta.model)
             if cf.ui_visible != CustomFieldUIVisibleChoices.HIDDEN
@@ -251,6 +250,9 @@ class NetBoxTable(BaseTable):
         extra_columns.extend([
             (f'cf_{cf.name}', columns.CustomFieldColumn(cf)) for cf in custom_fields
         ])
+
+        # Add columns for custom links
+        object_type = ObjectType.objects.get_for_model(self._meta.model)
         custom_links = CustomLink.objects.filter(object_types=object_type, enabled=True)
         extra_columns.extend([
             (f'cl_{cl.name}', columns.CustomLinkColumn(cl)) for cl in custom_links

--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -5,7 +5,6 @@ from copy import deepcopy
 
 from django.contrib import messages
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRel
-from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import FieldDoesNotExist, ObjectDoesNotExist, ValidationError
 from django.db import IntegrityError, router, transaction
 from django.db.models import ManyToManyField, ProtectedError, RestrictedError
@@ -485,10 +484,10 @@ class BulkImportView(GetReturnURLMixin, BaseMultiObjectView):
                 instance = self.queryset.model()
 
                 # For newly created objects, apply any default custom field values
-                custom_fields = CustomField.objects.filter(
-                    object_types=ContentType.objects.get_for_model(self.queryset.model),
-                    ui_editable=CustomFieldUIEditableChoices.YES
-                )
+                custom_fields = [
+                    cf for cf in CustomField.objects.get_for_model(self.queryset.model)
+                    if cf.ui_editable == CustomFieldUIEditableChoices.YES
+                ]
                 for cf in custom_fields:
                     field_name = f'cf_{cf.name}'
                     if field_name not in record:

--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -483,12 +483,11 @@ class BulkImportView(GetReturnURLMixin, BaseMultiObjectView):
             else:
                 instance = self.queryset.model()
 
-                # For newly created objects, apply any default custom field values
-                custom_fields = [
-                    cf for cf in CustomField.objects.get_for_model(self.queryset.model)
-                    if cf.ui_editable == CustomFieldUIEditableChoices.YES
-                ]
-                for cf in custom_fields:
+                # For newly created objects, apply any default values for custom fields
+                for cf in CustomField.objects.get_for_model(self.queryset.model):
+                    if cf.ui_editable != CustomFieldUIEditableChoices.YES:
+                        # Skip custom fields which are not editable via the UI
+                        continue
                     field_name = f'cf_{cf.name}'
                     if field_name not in record:
                         record[field_name] = cf.default


### PR DESCRIPTION
### Closes: #21300

- Cache the results of the `get_for_model()` method on CustomFieldManager (same approach as #21259)
- Replace various calls to `CustomField.objects.filter(object_types=object_type)` with `get_for_model()` to enable caching