### PR TITLE
Closes #21168: Fix Application Service cloning to preserve parent object

### DIFF
--- a/netbox/ipam/models/services.py
+++ b/netbox/ipam/models/services.py
@@ -87,7 +87,9 @@ class Service(ContactsMixin, ServiceBase, PrimaryModel):
         help_text=_("The specific IP addresses (if any) to which this application service is bound")
     )
 
-    clone_fields = ['protocol', 'ports', 'description', 'parent', 'ipaddresses', ]
+    clone_fields = (
+        'protocol', 'ports', 'description', 'parent_object_type', 'parent_object_id', 'ipaddresses',
+    )
 
     class Meta:
         indexes = (


### PR DESCRIPTION
### Fixes: #21168

Thanks for taking the time to review this PR!

When creating multiple application services from a parent object context, the parent fields are pre-filled on the initial form, but clicking **Create & Add another** clears them. This makes adding several services to the same parent unnecessarily repetitive.

This change adds `parent_object_type` and `parent_object_id` to the service form’s `clone_fields`, so the parent context is preserved between consecutive creations and object cloning behaves more consistently for models that reference a parent object.