### PR TITLE
Improve key validation for `API_TOKEN_PEPPERS` configuration

### DIFF
--- a/netbox/utilities/security.py
+++ b/netbox/utilities/security.py
@@ -13,7 +13,10 @@ def validate_peppers(peppers):
         raise ImproperlyConfigured("API_TOKEN_PEPPERS must be a dictionary.")
     for key, pepper in peppers.items():
         if type(key) is not int:
-            raise ImproperlyConfigured(f"Invalid API_TOKEN_PEPPERS key: {key}. All keys must be integers.")
+            try:
+                key = int(key)
+            except ValueError:
+                raise ImproperlyConfigured(f"Invalid API_TOKEN_PEPPERS key: {key}. All keys must be integers.")
         if not 0 <= key <= 32767:
             raise ImproperlyConfigured(
                 f"Invalid API_TOKEN_PEPPERS key: {key}. Key values must be between 0 and 32767, inclusive."


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: https://github.com/netbox-community/netbox-chart/issues/1021

<!--
    Please include a summary of the proposed changes below.
-->

YAML is a loose format, and its dictionary key type is loose too.
In a situation where the configuration is processed by an external tool, an integer might be interpreted as a string.
When passing to NetBox, this mismatch raises the ImproperlyConfigured exception.
That being said, even the message printed is confusing (`1` being an integer):

```
django.core.exceptions.ImproperlyConfigured: Invalid API_TOKEN_PEPPERS key: 1. All keys must be integers.
```

This change keeps the requirements while accepting converted types.