### PR TITLE
Closes #21268: Add Device Type details panel to Device view

### DIFF
--- a/netbox/dcim/ui/panels.py
+++ b/netbox/dcim/ui/panels.py
@@ -90,7 +90,6 @@ class DevicePanel(panels.ObjectAttributesPanel):
     parent_device = attrs.TemplatedAttr('parent_bay', template_name='dcim/device/attrs/parent_device.html')
     gps_coordinates = attrs.GPSCoordinatesAttr()
     tenant = attrs.RelatedObjectAttr('tenant', linkify=True, grouped_by='group')
-    device_type = attrs.RelatedObjectAttr('device_type', linkify=True, grouped_by='manufacturer')
     description = attrs.TextAttr('description')
     airflow = attrs.ChoiceAttr('airflow')
     serial = attrs.TextAttr('serial', label=_('Serial number'), style='font-monospace', copy_button=True)
@@ -122,10 +121,19 @@ class DeviceManagementPanel(panels.ObjectAttributesPanel):
     cluster = attrs.RelatedObjectAttr('cluster', linkify=True)
 
 
+class DeviceDeviceTypePanel(panels.ObjectAttributesPanel):
+    title = _('Device Type')
+
+    manufacturer = attrs.RelatedObjectAttr('device_type.manufacturer', linkify=True)
+    model = attrs.RelatedObjectAttr('device_type', linkify=True)
+    height = attrs.TextAttr('device_type.u_height', format_string='{}U')
+    front_image = attrs.ImageAttr('device_type.front_image')
+    rear_image = attrs.ImageAttr('device_type.rear_image')
+
+
 class DeviceDimensionsPanel(panels.ObjectAttributesPanel):
     title = _('Dimensions')
 
-    height = attrs.TextAttr('device_type.u_height', format_string='{}U')
     total_weight = attrs.TemplatedAttr('total_weight', template_name='dcim/device/attrs/total_weight.html')
 
 

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -2470,6 +2470,7 @@ class DeviceView(generic.ObjectView):
                 ],
             ),
             ImageAttachmentsPanel(),
+            panels.DeviceDeviceTypePanel(),
             panels.DeviceDimensionsPanel(),
             TemplatePanel('dcim/panels/device_rack_elevations.html'),
         ],


### PR DESCRIPTION
### Fixes: #21268

This PR implements the approach suggested in the issue discussion by separating **device type attributes** from **device-specific attributes** on the Device view.

#### Changes
- Adds a new `DeviceDeviceTypePanel` to the Device view.
- Moves device type information into its own panel, including:
  - Manufacturer
  - Model
  - U height
  - Front image (from the device type)
  - Rear image (from the device type)
- Improves visual organization and reduces ambiguity by explicitly grouping shared device type attributes.

Thanks for the review!
