### PR TITLE
Closes #20981: Enhance JSON rendering for Custom Validators and Protection Rules in Config Revision View

### DIFF
--- a/netbox/templates/core/configrevision.html
+++ b/netbox/templates/core/configrevision.html
@@ -33,7 +33,7 @@
     <div class="col col-md-12">
       <div class="card">
         <h2 class="card-header">{% trans "Configuration Data" %}</h2>
-        {% include 'core/inc/config_data.html' with config=object.data %}
+        {% include 'core/inc/config_data.html' %}
       </div>
 
       <div class="card">

--- a/netbox/templates/core/inc/config_data.html
+++ b/netbox/templates/core/inc/config_data.html
@@ -95,7 +95,7 @@
   <tr>
     <th scope="row" class="ps-3">{% trans "Custom validators" %}</th>
     {% if config.CUSTOM_VALIDATORS %}
-      <td><pre>{{ config.CUSTOM_VALIDATORS }}</pre></td>
+      <td><pre class="p-0">{{ config.CUSTOM_VALIDATORS }}</pre></td>
     {% else %}
       <td>{{ ''|placeholder }}</td>
     {% endif %}
@@ -103,7 +103,7 @@
   <tr>
     <th scope="row" class="border-0 ps-3">{% trans "Protection rules" %}</th>
     {% if config.PROTECTION_RULES %}
-      <td class="border-0"><pre>{{ config.PROTECTION_RULES }}</pre></td>
+      <td class="border-0"><pre class="p-0">{{ config.PROTECTION_RULES }}</pre></td>
     {% else %}
       <td class="border-0">{{ ''|placeholder }}</td>
     {% endif %}
@@ -116,7 +116,7 @@
   <tr>
     <th scope="row" class="border-0 ps-3">{% trans "Default preferences" %}</th>
     {% if config.DEFAULT_USER_PREFERENCES %}
-      <td class="border-0"><pre>{{ config.DEFAULT_USER_PREFERENCES }}</pre></td>
+      <td class="border-0"><pre class="p-0">{{ config.DEFAULT_USER_PREFERENCES }}</pre></td>
     {% else %}
       <td class="border-0">{{ ''|placeholder }}</td>
     {% endif %}

--- a/netbox/templates/core/inc/config_data.html
+++ b/netbox/templates/core/inc/config_data.html
@@ -116,7 +116,7 @@
   <tr>
     <th scope="row" class="border-0 ps-3">{% trans "Default preferences" %}</th>
     {% if config.DEFAULT_USER_PREFERENCES %}
-      <td class="border-0"><pre>{{ config.DEFAULT_USER_PREFERENCES|json }}</pre></td>
+      <td class="border-0"><pre>{{ config.DEFAULT_USER_PREFERENCES }}</pre></td>
     {% else %}
       <td class="border-0">{{ ''|placeholder }}</td>
     {% endif %}


### PR DESCRIPTION
### Fixes: #20981

This PR harmonizes how JSON-like configuration values are displayed in the configuration revision UI.

`ConfigRevisionView.get_extra_context()` now prepares a safe, pretty-printed JSON representation for `CUSTOM_VALIDATORS`, `DEFAULT_USER_PREFERENCES` and `PROTECTION_RULES` before rendering `config_data.html`. This mirrors the behavior users already see in the global system configuration view and makes these fields consistently readable in the config history view.

Thanks for the review!
