### PR TITLE
Allow REDIS KWARGS to be set in configuration.py

### DIFF
--- a/docs/configuration/required-parameters.md
+++ b/docs/configuration/required-parameters.md
@@ -200,6 +200,48 @@ REDIS = {
 !!! note
     It is permissible to use Sentinel for only one database and not the other.
 
+### SSL Configuration
+
+If you need to configure SSL/TLS for Redis beyond the basic `SSL`, `CA_CERT_PATH`, and `INSECURE_SKIP_TLS_VERIFY` options (for example, client certificates, a specific TLS version, or custom ciphers), you can pass additional parameters via the `KWARGS` key in either the `tasks` or `caching` subsection.
+
+NetBox already maps `CA_CERT_PATH` to `ssl_ca_certs` and (for caching) `INSECURE_SKIP_TLS_VERIFY` to `ssl_cert_reqs`; only add `KWARGS` when you need to override or extend those settings (for example, to supply client certificates or restrict TLS version or ciphers).
+
+* `KWARGS` - Optional dictionary of additional SSL/TLS (or other) parameters passed to the Redis client. These are passed directly to the underlying Redis client: for `tasks` to [redis-py](https://redis-py.readthedocs.io/en/stable/connections.html), and for `caching` to the [django-redis](https://github.com/jazzband/django-redis#configure-as-cache-backend) connection pool.
+
+Example:
+
+```python
+REDIS = {
+    'tasks': {
+        'HOST': 'redis.example.com',
+        'PORT': 1234,
+        'SSL': True,
+        'CA_CERT_PATH': '/etc/ssl/certs/ca.crt',
+        'KWARGS': {
+            'ssl_certfile': '/path/to/client-cert.pem',
+            'ssl_keyfile': '/path/to/client-key.pem',
+            'ssl_min_version': ssl.TLSVersion.TLSv1_2,
+            'ssl_ciphers': 'HIGH:!aNULL',
+        },
+    },
+    'caching': {
+        'HOST': 'redis.example.com',
+        'PORT': 1234,
+        'SSL': True,
+        'CA_CERT_PATH': '/etc/ssl/certs/ca.crt',
+        'KWARGS': {
+            'ssl_certfile': '/path/to/client-cert.pem',
+            'ssl_keyfile': '/path/to/client-key.pem',
+            'ssl_min_version': ssl.TLSVersion.TLSv1_2,
+            'ssl_ciphers': 'HIGH:!aNULL',
+        },
+    }
+}
+```
+
+!!! note
+    If you use `ssl.TLSVersion` in your configuration (e.g. `ssl_min_version`), add `import ssl` at the top of your configuration file.
+
 ---
 
 ## SECRET_KEY

--- a/netbox/netbox/configuration_example.py
+++ b/netbox/netbox/configuration_example.py
@@ -43,6 +43,16 @@ REDIS = {
         # 'INSECURE_SKIP_TLS_VERIFY': False,
         # Set a path to a certificate authority, typically used with a self signed certificate.
         # 'CA_CERT_PATH': '/etc/ssl/certs/ca.crt',
+        # Advanced Redis client parameters (SSL/TLS, timeouts, etc.)
+        # Passed directly to redis-py. See: https://redis-py.readthedocs.io/en/stable/connections.html
+        # NOTE: The CA_CERT_PATH setting above is already mapped to 'ssl_ca_certs' in KWARGS.
+        #       Only override these parameters in KWARGS if you have a specific reason to do so.
+        # 'KWARGS': {
+        #     'ssl_certfile': '/path/to/client-cert.pem',
+        #     'ssl_keyfile': '/path/to/client-key.pem',
+        #     'ssl_min_version': ssl.TLSVersion.TLSv1_2,
+        #     'ssl_ciphers': 'HIGH:!aNULL',
+        # },
     },
     'caching': {
         'HOST': 'localhost',
@@ -59,6 +69,17 @@ REDIS = {
         # 'INSECURE_SKIP_TLS_VERIFY': False,
         # Set a path to a certificate authority, typically used with a self signed certificate.
         # 'CA_CERT_PATH': '/etc/ssl/certs/ca.crt',
+        # Advanced Redis client parameters (SSL/TLS, timeouts, etc.)
+        # Passed directly to Redis connection pool. See: https://github.com/jazzband/django-redis#configure-as-cache-backend
+        # NOTE: The INSECURE_SKIP_TLS_VERIFY setting above is already mapped to 'ssl_cert_reqs' and
+        #       CA_CERT_PATH is mapped to 'ssl_ca_certs' in KWARGS. Only override these parameters
+        #       in KWARGS if you have a specific reason to do so.
+        # 'KWARGS': {
+        #     'ssl_certfile': '/path/to/client-cert.pem',
+        #     'ssl_keyfile': '/path/to/client-key.pem',
+        #     'ssl_min_version': ssl.TLSVersion.TLSv1_2,
+        #     'ssl_ciphers': 'HIGH:!aNULL',
+        # },
     }
 }
 

--- a/netbox/netbox/configuration_example.py
+++ b/netbox/netbox/configuration_example.py
@@ -43,16 +43,6 @@ REDIS = {
         # 'INSECURE_SKIP_TLS_VERIFY': False,
         # Set a path to a certificate authority, typically used with a self signed certificate.
         # 'CA_CERT_PATH': '/etc/ssl/certs/ca.crt',
-        # Advanced Redis client parameters (SSL/TLS, timeouts, etc.)
-        # Passed directly to redis-py. See: https://redis-py.readthedocs.io/en/stable/connections.html
-        # NOTE: The CA_CERT_PATH setting above is already mapped to 'ssl_ca_certs' in KWARGS.
-        #       Only override these parameters in KWARGS if you have a specific reason to do so.
-        # 'KWARGS': {
-        #     'ssl_certfile': '/path/to/client-cert.pem',
-        #     'ssl_keyfile': '/path/to/client-key.pem',
-        #     'ssl_min_version': ssl.TLSVersion.TLSv1_2,
-        #     'ssl_ciphers': 'HIGH:!aNULL',
-        # },
     },
     'caching': {
         'HOST': 'localhost',
@@ -69,17 +59,6 @@ REDIS = {
         # 'INSECURE_SKIP_TLS_VERIFY': False,
         # Set a path to a certificate authority, typically used with a self signed certificate.
         # 'CA_CERT_PATH': '/etc/ssl/certs/ca.crt',
-        # Advanced Redis client parameters (SSL/TLS, timeouts, etc.)
-        # Passed directly to Redis connection pool. See: https://github.com/jazzband/django-redis#configure-as-cache-backend
-        # NOTE: The INSECURE_SKIP_TLS_VERIFY setting above is already mapped to 'ssl_cert_reqs' and
-        #       CA_CERT_PATH is mapped to 'ssl_ca_certs' in KWARGS. Only override these parameters
-        #       in KWARGS if you have a specific reason to do so.
-        # 'KWARGS': {
-        #     'ssl_certfile': '/path/to/client-cert.pem',
-        #     'ssl_keyfile': '/path/to/client-key.pem',
-        #     'ssl_min_version': ssl.TLSVersion.TLSv1_2,
-        #     'ssl_ciphers': 'HIGH:!aNULL',
-        # },
     }
 }
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -819,8 +819,6 @@ RQ_PARAMS.update({
     'PASSWORD': TASKS_REDIS_PASSWORD,
     'DEFAULT_TIMEOUT': RQ_DEFAULT_TIMEOUT,
 })
-
-# Backwards compatibility: map existing SSL parameters
 if TASKS_REDIS_CA_CERT_PATH:
     RQ_PARAMS.setdefault('REDIS_CLIENT_KWARGS', {})
     RQ_PARAMS['REDIS_CLIENT_KWARGS']['ssl_ca_certs'] = TASKS_REDIS_CA_CERT_PATH

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -410,7 +410,7 @@ if CACHING_REDIS_CA_CERT_PATH:
     CACHES['default']['OPTIONS'].setdefault('CONNECTION_POOL_KWARGS', {})
     CACHES['default']['OPTIONS']['CONNECTION_POOL_KWARGS']['ssl_ca_certs'] = CACHING_REDIS_CA_CERT_PATH
 
-# Merge in KWARGS for additional parameters (additive, can override existing)
+# Merge in KWARGS for additional parameters
 caching_redis_kwargs = REDIS['caching'].get('KWARGS')
 if caching_redis_kwargs:
     CACHES['default']['OPTIONS'].setdefault('CONNECTION_POOL_KWARGS', {})
@@ -827,7 +827,7 @@ if TASKS_REDIS_CA_CERT_PATH:
     RQ_PARAMS.setdefault('REDIS_CLIENT_KWARGS', {})
     RQ_PARAMS['REDIS_CLIENT_KWARGS']['ssl_ca_certs'] = TASKS_REDIS_CA_CERT_PATH
 
-# Merge in KWARGS for additional parameters (additive, can override existing)
+# Merge in KWARGS for additional parameters
 tasks_redis_kwargs = TASKS_REDIS.get('KWARGS')
 if tasks_redis_kwargs:
     RQ_PARAMS.setdefault('REDIS_CLIENT_KWARGS', {})

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -409,8 +409,7 @@ if CACHING_REDIS_CA_CERT_PATH:
     CACHES['default']['OPTIONS']['CONNECTION_POOL_KWARGS']['ssl_ca_certs'] = CACHING_REDIS_CA_CERT_PATH
 
 # Merge in KWARGS for additional parameters
-caching_redis_kwargs = REDIS['caching'].get('KWARGS')
-if caching_redis_kwargs:
+if caching_redis_kwargs := REDIS['caching'].get('KWARGS'):
     CACHES['default']['OPTIONS'].setdefault('CONNECTION_POOL_KWARGS', {})
     CACHES['default']['OPTIONS']['CONNECTION_POOL_KWARGS'].update(caching_redis_kwargs)
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -823,8 +823,7 @@ if TASKS_REDIS_CA_CERT_PATH:
     RQ_PARAMS['REDIS_CLIENT_KWARGS']['ssl_ca_certs'] = TASKS_REDIS_CA_CERT_PATH
 
 # Merge in KWARGS for additional parameters
-tasks_redis_kwargs = TASKS_REDIS.get('KWARGS')
-if tasks_redis_kwargs:
+if tasks_redis_kwargs := TASKS_REDIS.get('KWARGS'):
     RQ_PARAMS.setdefault('REDIS_CLIENT_KWARGS', {})
     RQ_PARAMS['REDIS_CLIENT_KWARGS'].update(tasks_redis_kwargs)
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -401,8 +401,6 @@ if CACHING_REDIS_SENTINELS:
     CACHES['default']['LOCATION'] = f'{CACHING_REDIS_PROTO}://{CACHING_REDIS_SENTINEL_SERVICE}/{CACHING_REDIS_DATABASE}'
     CACHES['default']['OPTIONS']['CLIENT_CLASS'] = 'django_redis.client.SentinelClient'
     CACHES['default']['OPTIONS']['SENTINELS'] = CACHING_REDIS_SENTINELS
-
-# Backwards compatibility: map existing SSL parameters
 if CACHING_REDIS_SKIP_TLS_VERIFY:
     CACHES['default']['OPTIONS'].setdefault('CONNECTION_POOL_KWARGS', {})
     CACHES['default']['OPTIONS']['CONNECTION_POOL_KWARGS']['ssl_cert_reqs'] = False


### PR DESCRIPTION
### Fixes: #21240 

Adds a KWARGS to REDIS['tasks'] and REDIS['caching'] that gets passed to django-rq and django-redis to allow more flexibility in configuration like setting ssl options.  All current settings options still work so completely backwards compatible.

```
REDIS = {
    'tasks': {
        'KWARGS': {
        #     'ssl_certfile': '/path/to/client-cert.pem',
        #     'ssl_keyfile': '/path/to/client-key.pem',
        #     'ssl_min_version': ssl.TLSVersion.TLSv1_2,
        #     'ssl_ciphers': 'HIGH:!aNULL',
        },
    },
    'caching': {
        'KWARGS': {
        #     'ssl_certfile': '/path/to/client-cert.pem',
        #     'ssl_keyfile': '/path/to/client-key.pem',
        #     'ssl_min_version': ssl.TLSVersion.TLSv1_2,
        #     'ssl_ciphers': 'HIGH:!aNULL',
        },
    }
}
```