### PR TITLE
Fixes #21375: Fix VLANGroup VLAN ID range migration failing on upgrades with existing data

### DIFF
--- a/netbox/ipam/migrations/0070_vlangroup_vlan_id_ranges.py
+++ b/netbox/ipam/migrations/0070_vlangroup_vlan_id_ranges.py
@@ -13,10 +13,11 @@ def set_vid_ranges(apps, schema_editor):
     VLANGroup = apps.get_model('ipam', 'VLANGroup')
     db_alias = schema_editor.connection.alias
 
-    for group in VLANGroup.objects.using(db_alias).all():
+    vlan_groups = VLANGroup.objects.using(db_alias).only('id', 'min_vid', 'max_vid')
+    for group in vlan_groups:
         group.vid_ranges = [NumericRange(group.min_vid, group.max_vid, bounds='[]')]
         group._total_vlan_ids = group.max_vid - group.min_vid + 1
-        group.save()
+    VLANGroup.objects.using(db_alias).bulk_update(vlan_groups, ['vid_ranges', '_total_vlan_ids'], batch_size=100)
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
### Fixes: #21375

This PR updates the `ipam/migrations/0070_vlangroup_vlan_id_ranges.py` data migration to avoid calling `save()` for each existing `VLANGroup`. Instead, it calculates the VLAN ID ranges and applies the changes via `bulk_update()`.

Using `bulk_update()` prevents `post_save` handlers (notably the search cache/indexing hooks) from running during the migration, which can otherwise raise an `AttributeError` on instances lacking a `comments` attribute and abort the upgrade. It also limits the update to only the relevant fields and performs better on larger databases with many `VLANGroup` rows.

Appreciate your time reviewing this!
