### PR TITLE
Fixes #21358: Prevent exception when sorting by Token column

### DIFF
--- a/netbox/users/tables.py
+++ b/netbox/users/tables.py
@@ -24,6 +24,7 @@ class TokenTable(NetBoxTable):
     token = columns.TemplateColumn(
         verbose_name=_('token'),
         template_code=TOKEN,
+        orderable=False,
     )
     enabled = columns.BooleanColumn(
         verbose_name=_('Enabled')

--- a/netbox/users/tests/test_tables.py
+++ b/netbox/users/tests/test_tables.py
@@ -4,8 +4,8 @@ from users.models import Token
 from users.tables import TokenTable
 
 
-@tag('regression')
 class TokenTableTest(TestCase):
+    @tag('regression')
     def test_every_orderable_field_does_not_throw_exception(self):
         tokens = Token.objects.all()
         disallowed = {'actions'}
@@ -17,7 +17,8 @@ class TokenTableTest(TestCase):
         fake_request = RequestFactory().get("/")
 
         for col in orderable_columns:
-            for dir in ('-', ''):
-                table = TokenTable(tokens)
-                table.order_by = f'{dir}{col}'
-                table.as_html(fake_request)
+            for direction in ('-', ''):
+                with self.subTest(col=col, direction=direction):
+                    table = TokenTable(tokens)
+                    table.order_by = f'{direction}{col}'
+                    table.as_html(fake_request)

--- a/netbox/users/tests/test_tables.py
+++ b/netbox/users/tests/test_tables.py
@@ -1,0 +1,23 @@
+from django.test import RequestFactory, tag, TestCase
+
+from users.models import Token
+from users.tables import TokenTable
+
+
+@tag('regression')
+class TokenTableTest(TestCase):
+    def test_every_orderable_field_does_not_throw_exception(self):
+        tokens = Token.objects.all()
+        disallowed = {'actions'}
+
+        orderable_columns = [
+            column.name for column in TokenTable(tokens).columns
+            if column.orderable and column.name not in disallowed
+        ]
+        fake_request = RequestFactory().get("/")
+
+        for col in orderable_columns:
+            for dir in ('-', ''):
+                table = TokenTable(tokens)
+                table.order_by = f'{dir}{col}'
+                table.as_html(fake_request)


### PR DESCRIPTION
## Fixes

Closes #21358

## Summary

Clicking the "Token" column header in the API Tokens table triggers a `FieldError` because `token` is a Python property on the model, not a database field. django-tables2 attempts to pass it to Django's ORM `order_by()`, which fails.

**Changes:**

- Mark the `token` `TemplateColumn` in `TokenTable` as `orderable=False`, consistent with how other non-field columns are handled in the codebase (e.g. `can_view`, `can_add`, `can_change`, `can_delete` in `ObjectPermissionTable`)
- Add a regression test for `TokenTable` that verifies all orderable columns can be sorted without raising exceptions, following the existing pattern in `circuits/tests/test_tables.py` and `vpn/tests/test_tables.py`
