### PR TITLE
Fixes #21354: Fix Swagger-UI generating wrong URLs when BASE_PATH is set

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -773,7 +773,7 @@ SPECTACULAR_SETTINGS = {
     'COMPONENT_SPLIT_REQUEST': True,
     'REDOC_DIST': 'SIDECAR',
     'SERVERS': [{
-        'url': BASE_PATH,
+        'url': '',
         'description': 'NetBox',
     }],
     'SWAGGER_UI_DIST': 'SIDECAR',


### PR DESCRIPTION
## Fixes

Closes #21354

## Summary

When `BASE_PATH` is configured (e.g., `v4.4.7`), Swagger-UI generates incorrect request URLs with the base path duplicated multiple times:

```
https://netbox.server.com/v4.4.7/api/schema/v4.4.7/v4.4.7/api/circuits/...
```

**Root cause:** The `SPECTACULAR_SETTINGS['SERVERS']` url was set to `BASE_PATH` (e.g., `v4.4.7/`). However, drf-spectacular already includes the `BASE_PATH` prefix in the schema paths since all URL patterns are wrapped under `path(settings.BASE_PATH, include(_patterns))`. Swagger-UI resolves the relative server URL against the document URL and then appends the path, causing the prefix to appear multiple times.

**Fix:** Replace `'url': BASE_PATH` with `'url': ''` in the `SERVERS` configuration. An empty string causes Swagger-UI to resolve paths relative to the current document, and since the schema paths are already absolute (e.g., `/v4.4.7/api/circuits/...`), they resolve correctly to the server root.

This is a no-op for the default case (no `BASE_PATH`), since `BASE_PATH` already evaluates to `''` when unset.