### PR TITLE
Fixes #21397: Fix CircuitType owner field persistence and rendering

### DIFF
--- a/netbox/circuits/forms/model_forms.py
+++ b/netbox/circuits/forms/model_forms.py
@@ -91,13 +91,13 @@ class ProviderNetworkForm(PrimaryModelForm):
 
 class CircuitTypeForm(OrganizationalModelForm):
     fieldsets = (
-        FieldSet('name', 'slug', 'color', 'description', 'owner', 'tags'),
+        FieldSet('name', 'slug', 'color', 'description', 'tags'),
     )
 
     class Meta:
         model = CircuitType
         fields = [
-            'name', 'slug', 'color', 'description', 'comments', 'tags',
+            'name', 'slug', 'color', 'description', 'owner', 'comments', 'tags',
         ]
 
 


### PR DESCRIPTION
### Fixes: #21397

This PR fixes CircuitType ownership not being saved/loaded by ensuring the `owner` field is handled consistently by `CircuitTypeForm`.

**Changes**
- Remove `owner` from the fieldset to avoid rendering it twice
- Add `owner` to `Meta.fields` so the form properly validates and persists it

Thanks for reviewing!
