### PR TITLE
Closes #21404: Set Ruff target Python version to 3.12

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -2,7 +2,7 @@ exclude = [
     "netbox/project-static/**"
 ]
 line-length = 120
-target-version = "py310"
+target-version = "py312"
 
 [lint]
 extend-select = ["E1", "E2", "E3", "E501", "W"]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #21404

<!--
    Please include a summary of the proposed changes below.
-->
This PR updates Ruff’s configuration to align with NetBox’s supported runtime by setting `target-version` to **Python 3.12** in `ruff.toml`.

Since Python 3.12 is the project’s minimum supported version, this helps ensure Ruff validates the codebase using the same language features and syntax expectations as our actual environment.