### PR TITLE
Fixes #21412: Defer monkey-patching until after settings have been loaded

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -11,14 +11,10 @@ from django.core.exceptions import ImproperlyConfigured, ValidationError
 from django.core.validators import URLValidator
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
-from rest_framework.utils import field_mapping
-from strawberry_django import pagination
-from strawberry_django.fields.field import StrawberryDjangoField
 
 from core.exceptions import IncompatiblePluginError
 from netbox.config import PARAMS as CONFIG_PARAMS
 from netbox.constants import RQ_QUEUE_DEFAULT, RQ_QUEUE_HIGH, RQ_QUEUE_LOW
-from netbox.graphql.pagination import OffsetPaginationInput, apply_pagination
 from netbox.plugins import PluginConfig
 from netbox.registry import registry
 import storages.utils  # type: ignore
@@ -26,21 +22,6 @@ from utilities.release import load_release_data
 from utilities.security import validate_peppers
 from utilities.string import trailing_slash
 from .monkey import get_unique_validators
-
-
-#
-# Monkey-patching
-#
-
-# TODO: Remove this once #20547 has been implemented
-# Override DRF's get_unique_validators() function with our own (see bug #19302)
-field_mapping.get_unique_validators = get_unique_validators
-
-# Override strawberry-django's OffsetPaginationInput class to add the `start` parameter
-pagination.OffsetPaginationInput = OffsetPaginationInput
-
-# Patch StrawberryDjangoField to use our custom `apply_pagination()` method with support for cursor-based pagination
-StrawberryDjangoField.apply_pagination = apply_pagination
 
 
 #
@@ -967,6 +948,26 @@ for plugin_name in PLUGINS:
             EVENTS_PIPELINE.extend(events_pipeline)
         else:
             raise ImproperlyConfigured(f"events_pipline in plugin: {plugin_name} must be a list or tuple")
+
+
+#
+# Monkey-patching
+#
+
+from rest_framework.utils import field_mapping  # noqa: E402
+from strawberry_django import pagination  # noqa: E402
+from strawberry_django.fields.field import StrawberryDjangoField  # noqa: E402
+from netbox.graphql.pagination import OffsetPaginationInput, apply_pagination  # noqa: E402
+
+# TODO: Remove this once #20547 has been implemented
+# Override DRF's get_unique_validators() function with our own (see bug #19302)
+field_mapping.get_unique_validators = get_unique_validators
+
+# Override strawberry-django's OffsetPaginationInput class to add the `start` parameter
+pagination.OffsetPaginationInput = OffsetPaginationInput
+
+# Patch StrawberryDjangoField to use our custom `apply_pagination()` method with support for cursor-based pagination
+StrawberryDjangoField.apply_pagination = apply_pagination
 
 
 # UNSUPPORTED FUNCTIONALITY: Import any local overrides.


### PR DESCRIPTION
### Fixes: #21412

This moves all the imports necessary for monkey-patching to the end of the `settings` module, to avoid interfering with the loading of configuration parameters.

This fix can be tested by checking out the PR and installing & enabling netbox-changes v0.4.2
