### PR TITLE
#21364 update swagger endpoint for /api/extras/scripts/

### DIFF
--- a/netbox/extras/api/urls.py
+++ b/netbox/extras/api/urls.py
@@ -27,6 +27,11 @@ router.register('config-context-profiles', views.ConfigContextProfileViewSet)
 router.register('config-templates', views.ConfigTemplateViewSet)
 router.register('scripts', views.ScriptViewSet, basename='script')
 
+# Map POST to the script detail route for running scripts (without affecting the list route)
+for route in router.routes:
+    if route.name == '{basename}-detail':
+        route.mapping['post'] = 'post'
+
 app_name = 'extras-api'
 urlpatterns = [
     path('dashboard/', views.DashboardView.as_view(), name='dashboard'),

--- a/netbox/extras/api/urls.py
+++ b/netbox/extras/api/urls.py
@@ -27,11 +27,6 @@ router.register('config-context-profiles', views.ConfigContextProfileViewSet)
 router.register('config-templates', views.ConfigTemplateViewSet)
 router.register('scripts', views.ScriptViewSet, basename='script')
 
-# Map POST to the script detail route for running scripts (without affecting the list route)
-for route in router.routes:
-    if route.name == '{basename}-detail':
-        route.mapping['post'] = 'post'
-
 app_name = 'extras-api'
 urlpatterns = [
     path('dashboard/', views.DashboardView.as_view(), name='dashboard'),

--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -265,8 +265,48 @@ class ConfigTemplateViewSet(SyncedDataMixin, ConfigTemplateRenderMixin, NetBoxMo
 
 @extend_schema_view(
     create=extend_schema(exclude=True),  # Hide POST from list endpoint in Swagger
-    update=extend_schema(request=serializers.ScriptInputSerializer),
-    partial_update=extend_schema(request=serializers.ScriptInputSerializer),
+    update=extend_schema(
+        request=serializers.ScriptInputSerializer,
+        examples=[
+            OpenApiExample(
+                'Script with no variables',
+                value={'data': {}, 'commit': True},
+                request_only=True,
+            ),
+            OpenApiExample(
+                'Script with variables',
+                value={
+                    'data': {
+                        'variable_name': 'example_value',
+                        'another_variable': 123
+                    },
+                    'commit': True
+                },
+                request_only=True,
+            ),
+        ]
+    ),
+    partial_update=extend_schema(
+        request=serializers.ScriptInputSerializer,
+        examples=[
+            OpenApiExample(
+                'Script with no variables',
+                value={'data': {}, 'commit': True},
+                request_only=True,
+            ),
+            OpenApiExample(
+                'Script with variables',
+                value={
+                    'data': {
+                        'variable_name': 'example_value',
+                        'another_variable': 123
+                    },
+                    'commit': True
+                },
+                request_only=True,
+            ),
+        ]
+    ),
 )
 class ScriptViewSet(
     ListModelMixin,
@@ -334,7 +374,7 @@ class ScriptViewSet(
     )
     def post(self, request, pk):
         """
-        Run a Script (via POST) identified by its numeric PK or module & name and return the pending Job as the result
+        Run a Script identified by its numeric PK or module & name and return the pending Job as the result
         """
         script = self._get_script(pk)
 

--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -264,6 +264,7 @@ class ConfigTemplateViewSet(SyncedDataMixin, ConfigTemplateRenderMixin, NetBoxMo
 #
 
 @extend_schema_view(
+    create=extend_schema(exclude=True),  # Hide POST from list endpoint in Swagger
     update=extend_schema(request=serializers.ScriptInputSerializer),
     partial_update=extend_schema(request=serializers.ScriptInputSerializer),
 )


### PR DESCRIPTION
### Fixes: #21364 

Removed the post without script id from `/api/extras/scripts/` you can only do GET to the base one and GET/POST to `/api/extras/scripts/{id}/`

Also updated the `/api/extras/scripts/{id}/` schema output as it wasn't correctly showing the required fields for data and commit for the request body.

<img width="1283" height="395" alt="Monosnap NetBox REST API 2026-02-12 13-43-50" src="https://github.com/user-attachments/assets/e1a55e13-2021-4bff-a042-b7fb26cc5e7b" />


<img width="1286" height="874" alt="Monosnap NetBox REST API 2026-02-12 13-45-06" src="https://github.com/user-attachments/assets/229ae27c-5ad2-4a97-aecf-3d3284c8221f" />
