### PR TITLE
21277 call snapshot in ClusterAddDevicesView to correctly record ObjectChange data

### DIFF
--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -320,6 +320,7 @@ class ClusterAddDevicesView(generic.ObjectEditView):
 
                 # Assign the selected Devices to the Cluster
                 for device in Device.objects.filter(pk__in=device_pks):
+                    device.snapshot()
                     device.cluster = cluster
                     device.save()
 


### PR DESCRIPTION
### Fixes: #21277 

ClusterAddDevicesView was missing a call to snapshot() when saving updated devices.