### PR TITLE
Fixes #21127: Clear _path on interfaces when removed from cable

### DIFF
--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -170,6 +170,8 @@ def nullify_connected_endpoints(instance, **kwargs):
         # Remove the deleted CableTermination if it's one of the path's originating nodes
         if instance.termination in cablepath.origins:
             cablepath.origins.remove(instance.termination)
+            # Clear _path on the removed origin to prevent stale connection display
+            model.objects.filter(pk=instance.termination_id, _path=cablepath.pk).update(_path=None)
         cablepath.retrace()
 
 

--- a/netbox/dcim/tests/test_cablepaths.py
+++ b/netbox/dcim/tests/test_cablepaths.py
@@ -2806,7 +2806,6 @@ class LegacyCablePathTests(CablePathTestCase):
         interface2 = Interface.objects.create(device=self.device, name='Interface 2')
         interface3 = Interface.objects.create(device=self.device, name='Interface 3')
 
-        # Create cables 1
         cable1 = Cable(
             a_terminations=[interface1],
             b_terminations=[interface2, interface3]
@@ -2837,6 +2836,10 @@ class LegacyCablePathTests(CablePathTestCase):
             is_complete=True,
             is_active=True
         )
+
+        # Verify _path is cleared on removed interface (#21127)
+        interface3.refresh_from_db()
+        self.assertPathIsNotSet(interface3)
 
     def test_401_exclude_midspan_devices(self):
         """


### PR DESCRIPTION
### Fixes: #21127

When editing a cable to remove an interface from the B side, the `_path` field on the removed interface was not being cleared. This caused the interface table to display stale connection info via `_path.destinations`, while the detail page showed correct (empty) info.

**Changes**:
- `dcim/signals.py`: Clear `_path` on removed origin in `nullify_connected_endpoints` signal handler
- `dcim/models/cables.py`: Add `CablePath.delete()` method to clear `_path` on origins (mirrors `save()` behavior)
- `dcim/tests/test_cablepaths.py`: Extended `test_303` to verify `_path` is cleared on removed interface