### PR TITLE
Fixes #21410: Expand Ruff exclusions and standardize formatting settings

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,16 +1,58 @@
+# Ruff configuration
+####################
+
 exclude = [
-    "netbox/project-static/**"
+    ".eggs",
+    ".git",
+    ".pyenv",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    ".vscode",
+    "__pypackages__",
+    "_build",
+    "build",
+    "dist",
+    "netbox/project-static/**",
+    "node_modules",
+    "site-packages",
+    "venv",
 ]
+
+# Enforce line length and indent-width
 line-length = 120
+indent-width = 4
+
+# Ignores anything in .gitignore
+respect-gitignore = true
+
+# Always generate Python 3.12-compatible code
 target-version = "py312"
 
 [lint]
-extend-select = ["E1", "E2", "E3", "E501", "W"]
-ignore = ["F403", "F405"]
+extend-select = [
+    "E1",    # pycodestyle errors: indentation-related (e.g., unexpected/missing indent)
+    "E2",    # pycodestyle errors: whitespace-related (e.g., missing whitespace, extra spaces)
+    "E3",    # pycodestyle errors: blank lines / spacing around definitions
+    "E501",  # pycodestyle: line too long (enforced with `line-length` above)
+    "W",     # pycodestyle warnings (various style warnings, often whitespace/newlines)
+]
+ignore = [
+    "F403",  # pyflakes: `from ... import *` used; unable to detect undefined names
+    "F405",  # pyflakes: name may be undefined or defined from star imports
+    "UP032", # pyupgrade: prefer f-strings over `str.format(...)`
+]
 preview = true
 
 [lint.per-file-ignores]
 "template_code.py" = ["E501"]
 
 [format]
+# Use single quotes for strings.
 quote-style = "single"
+
+# Indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Enforce UNIX line ending
+line-ending = "lf"


### PR DESCRIPTION
### Fixes: #21410

This PR tightens up our Ruff defaults to better match the repository’s layout and existing style conventions.

- Expands `exclude` to skip common virtualenv/cache/build directories (and `netbox/project-static/**`)
- Sets `indent-width = 4` at the top level
- Enables `respect-gitignore = true` so Ruff follows the repo’s ignore rules
- Aligns formatter defaults (`indent-style = "space"`, `line-ending = "lf"`, `quote-style = "single"`)
- Adds comments to make the intent of each setting easier to follow

No functional code changes are intended.
Thanks for review!