### PR TITLE
Closes #21369: Add lazy loading and decoding support to `ImageAttr`

### DIFF
--- a/netbox/templates/ui/attrs/image.html
+++ b/netbox/templates/ui/attrs/image.html
@@ -1,3 +1,3 @@
 <a href="{{ value.url }}">
-  <img src="{{ value.url }}" alt="{{ value.name }}" class="img-fluid" />
+  <img src="{{ value.url }}" alt="{{ value.name }}" class="img-fluid" {% if load_lazy %}loading="lazy" {% endif %} {% if decoding %}decoding="{{ decoding }}" {% endif %}/>
 </a>


### PR DESCRIPTION
### Fixes: #21369

Thanks for reviewing! This PR updates `ImageAttr` to support modern, native image performance hints in the rendered HTML.

#### Summary of changes
- Adds `load_lazy` and `decoding` parameters to `ImageAttr`
  - `load_lazy` now defaults to `True` to enable `loading="lazy"` by default
  - `decoding` can be set to `auto`, `async`, or `sync`
  - If `decoding` is not explicitly provided, it defaults to `async` when `load_lazy=True` (and is omitted otherwise)
- Updates the `ui/attrs/image.html` template to conditionally render `loading` and `decoding` attributes

#### Why
This helps reduce initial page load time and bandwidth usage on pages with many images, while still allowing explicit control over image decode behavior when needed.

References:
- `HTMLImageElement.loading`: https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/loading
- `HTMLImageElement.decoding`: https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding
