### PR TITLE
Closes #21420: Improve query performance of ContentTypeFilter

### DIFF
--- a/netbox/utilities/filters.py
+++ b/netbox/utilities/filters.py
@@ -165,12 +165,12 @@ class ContentTypeFilter(django_filters.CharFilter):
 
         try:
             app_label, model = value.lower().split('.')
-        except ValueError:
+            content_type = ContentType.objects.get_by_natural_key(app_label, model)
+        except (ValueError, ContentType.DoesNotExist):
             return qs.none()
         return qs.filter(
             **{
-                f'{self.field_name}__app_label': app_label,
-                f'{self.field_name}__model': model
+                f'{self.field_name}': content_type,
             }
         )
 


### PR DESCRIPTION
### Fixes: #21420

This change improves the performance of `ContentTypeFilter` by resolving the `ContentType` up front using `ContentType.objects.get_by_natural_key(<app_label>, <model>)` and then filtering directly on the FK value. This avoids an unnecessary `INNER JOIN` to `django_content_type` that occurs when filtering via `__app_label`/`__model`.

Behavior remains the same for valid values, and invalid or unknown content types still return `qs.none()`.

Thanks for taking the time to review this PR!
