### PR TITLE
Fixes #21478: Fix GraphQL connected endpoint type resolution for Console Ports

### DIFF
--- a/netbox/dcim/graphql/gfk_mixins.py
+++ b/netbox/dcim/graphql/gfk_mixins.py
@@ -119,7 +119,7 @@ class ConnectedEndpointType:
     def resolve_type(cls, instance, info: Info):
         if type(instance) is CircuitTermination:
             return CircuitTerminationType
-        if type(instance) is ConsolePortType:
+        if type(instance) is ConsolePort:
             return ConsolePortType
         if type(instance) is ConsoleServerPort:
             return ConsoleServerPortType


### PR DESCRIPTION
### Fixes: #21478

This PR corrects a typo in `ConnectedEndpointType.resolve_type()` where `ConsolePortType` was checked instead of the `ConsolePort` model.

While GraphQL queries may still resolve correctly via fallback behavior, this makes the resolver logic consistent with the other branches and ensures `ConsolePort` instances explicitly resolve to `ConsolePortType`.