### PR TITLE
Fixes #21481: Fix Rack detail view to display Facility ID

### DIFF
--- a/netbox/dcim/ui/panels.py
+++ b/netbox/dcim/ui/panels.py
@@ -44,7 +44,7 @@ class RackPanel(panels.ObjectAttributesPanel):
     site = attrs.RelatedObjectAttr('site', linkify=True, grouped_by='group')
     location = attrs.NestedObjectAttr('location', linkify=True)
     name = attrs.TextAttr('name')
-    facility = attrs.TextAttr('facility', label=_('Facility ID'))
+    facility_id = attrs.TextAttr('facility_id', label=_('Facility ID'))
     tenant = attrs.RelatedObjectAttr('tenant', linkify=True, grouped_by='group')
     status = attrs.ChoiceAttr('status')
     rack_type = attrs.RelatedObjectAttr('rack_type', linkify=True, grouped_by='manufacturer')


### PR DESCRIPTION
### Fixes: #21481

Updates the rack detail view to reference the correct `facility_id` model field when rendering “Facility ID”. This restores the expected behavior so racks created with a Facility ID show it properly on the rack view page.
