### PR TITLE
Closes: #21304 - Add stronger deprecation warning on use of housekeeping management command

### DIFF
--- a/netbox/extras/management/commands/housekeeping.py
+++ b/netbox/extras/management/commands/housekeeping.py
@@ -18,6 +18,7 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.stdout.write(
+            "DEPRECATION WARNING\n"
             "Running this command is no longer necessary: All housekeeping tasks\n"
             "are addressed automatically via NetBox's built-in job scheduler. It\n"
             "will be removed in a future release.",

--- a/netbox/extras/management/commands/housekeeping.py
+++ b/netbox/extras/management/commands/housekeeping.py
@@ -1,3 +1,4 @@
+import warnings
 from datetime import timedelta
 from importlib import import_module
 
@@ -17,12 +18,12 @@ class Command(BaseCommand):
     help = "Perform nightly housekeeping tasks [DEPRECATED]"
 
     def handle(self, *args, **options):
-        self.stdout.write(
-            "DEPRECATION WARNING\n"
+        warnings.warn(
+            "\n\nDEPRECATION WARNING\n"
             "Running this command is no longer necessary: All housekeeping tasks\n"
             "are addressed automatically via NetBox's built-in job scheduler. It\n"
-            "will be removed in a future release.",
-            self.style.WARNING
+            "will be removed in a future release.\n",
+            category=FutureWarning,
         )
 
         config = Config()


### PR DESCRIPTION
### Closes: #21304

The `housekeeping` command was already deprecated in that it printed a message warning the user that the command is no longer necessary and will be removed in a future release. This change strengthens it to explicitly mention `DEPRECATION WARNING` and should be included in official release notes as a warning of scheduled removal in NetBox v4.7.0.
