### PR TITLE
Closes: #21284 -  Add deprecation note to webhooks documentation

### DIFF
--- a/docs/integrations/webhooks.md
+++ b/docs/integrations/webhooks.md
@@ -31,6 +31,11 @@ The following data is available as context for Jinja2 templates:
 * `data` - A detailed representation of the object in its current state. This is typically equivalent to the model's representation in NetBox's REST API.
 * `snapshots` - Minimal "snapshots" of the object state both before and after the change was made; provided as a dictionary with keys named `prechange` and `postchange`. These are not as extensive as the fully serialized representation, but contain enough information to convey what has changed.
 
+!!! warning "Deprecation of legacy fields"
+    The "request_id" and "username" fields in the webhook payload above are deprecated and should no longer be used. Support for them will be removed in NetBox v4.7.0.
+
+    Use `request.user.username` and `request.request_id` from the `request` object included in the callback context instead.
+
 ### Default Request Body
 
 If no body template is specified, the request body will be populated with a JSON object containing the context data. For example, a newly created site might appear as follows:

--- a/docs/models/extras/webhook.md
+++ b/docs/models/extras/webhook.md
@@ -88,3 +88,8 @@ The following context variables are available in to the text and link templates.
 | `request_id` | The unique request ID                              |
 | `data`       | A complete serialized representation of the object |
 | `snapshots`  | Pre- and post-change snapshots of the object       |
+
+!!! warning "Deprecation of legacy fields"
+    The "request_id" and "username" fields in the webhook payload above are deprecated and should no longer be used. Support for them will be removed in NetBox v4.7.0.
+
+    Use `request.user.username` and `request.request_id` from the `request` object included in the callback context instead.

--- a/docs/plugins/development/webhooks.md
+++ b/docs/plugins/development/webhooks.md
@@ -43,6 +43,9 @@ The resulting webhook payload will look like the following:
 }
 ```
 
+!!! note "Deprecation of legacy fields"
+    The "request_id" and "username" fields in the webhook payload above are deprecated and should no longer be used. Support for them will be removed in a future release.
+
 !!! note "Consider namespacing webhook data"
     The data returned from all webhook callbacks will be compiled into a single `context` dictionary. Any existing keys within this dictionary will be overwritten by subsequent callbacks which include those keys. To avoid collisions with webhook data provided by other plugins, consider namespacing your plugin's data within a nested dictionary as such:
     

--- a/docs/plugins/development/webhooks.md
+++ b/docs/plugins/development/webhooks.md
@@ -43,8 +43,10 @@ The resulting webhook payload will look like the following:
 }
 ```
 
-!!! note "Deprecation of legacy fields"
+!!! warning "Deprecation of legacy fields"
     The "request_id" and "username" fields in the webhook payload above are deprecated and should no longer be used. Support for them will be removed in a future release.
+
+    Use `request.user.username` and `request.request_id` from the `request` object included in the callback context instead.
 
 !!! note "Consider namespacing webhook data"
     The data returned from all webhook callbacks will be compiled into a single `context` dictionary. Any existing keys within this dictionary will be overwritten by subsequent callbacks which include those keys. To avoid collisions with webhook data provided by other plugins, consider namespacing your plugin's data within a nested dictionary as such:

--- a/docs/plugins/development/webhooks.md
+++ b/docs/plugins/development/webhooks.md
@@ -44,7 +44,7 @@ The resulting webhook payload will look like the following:
 ```
 
 !!! warning "Deprecation of legacy fields"
-    The "request_id" and "username" fields in the webhook payload above are deprecated and should no longer be used. Support for them will be removed in a future release.
+    The "request_id" and "username" fields in the webhook payload above are deprecated and should no longer be used. Support for them will be removed in NetBox v4.7.0.
 
     Use `request.user.username` and `request.request_id` from the `request` object included in the callback context instead.
 

--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -102,8 +102,8 @@ def enqueue_event(queue, instance, request, event_type):
             request=request,
             user=request.user,
             # Legacy request attributes for backward compatibility
-            username=request.user.username,
-            request_id=request.id,
+            username=request.user.username,  # DEPRECATED, will be removed in NetBox v4.7.0
+            request_id=request.id,           # DEPRECATED, will be removed in NetBox v4.7.0
         )
     # Force serialization of objects prior to them actually being deleted
     if event_type == OBJECT_DELETED:


### PR DESCRIPTION
### Closes: #21284

Adds a deprecation note to the webhooks documentation.
