### PR TITLE
Fixes: #21456 - Improve config_context rendering with GraphQL

### DIFF
--- a/netbox/extras/graphql/mixins.py
+++ b/netbox/extras/graphql/mixins.py
@@ -21,6 +21,13 @@ if TYPE_CHECKING:
 @strawberry.type
 class ConfigContextMixin:
 
+    @classmethod
+    def get_queryset(cls, queryset, info: Info, **kwargs):
+        queryset = super().get_queryset(queryset, info, **kwargs)
+        if hasattr(queryset, 'annotate_config_context_data'):
+            return queryset.annotate_config_context_data()
+        return queryset
+
     @strawberry_django.field
     def config_context(self) -> strawberry.scalars.JSON:
         return self.get_config_context()

--- a/netbox/extras/graphql/mixins.py
+++ b/netbox/extras/graphql/mixins.py
@@ -24,11 +24,16 @@ class ConfigContextMixin:
     @classmethod
     def get_queryset(cls, queryset, info: Info, **kwargs):
         queryset = super().get_queryset(queryset, info, **kwargs)
-        if hasattr(queryset, 'annotate_config_context_data'):
+
+        # If `config_context` is requested, call annotate_config_context_data() on the queryset
+        selected = {f.name for f in info.selected_fields[0].selections}
+        if 'config_context' in selected and hasattr(queryset, 'annotate_config_context_data'):
             return queryset.annotate_config_context_data()
+
         return queryset
 
-    @strawberry_django.field
+    # Ensure `local_context_data` is fetched when `config_context` is requested
+    @strawberry_django.field(only=['local_context_data'])
     def config_context(self) -> strawberry.scalars.JSON:
         return self.get_config_context()
 


### PR DESCRIPTION
### Fixes: #21456

It seems that GraphQL API, unlike the REST API, does not make use of the performance improvement from using ConfigContextModelQuerySet (https://github.com/netbox-community/netbox/pull/5266). This PR adds the necessary config_context annotation to GraphQL queries that request config_context.

 It speeds up queries by a factor of >10x with a simple netbox-demo-data setup and even surpases the REST API performance (due it's much smaller overall query) when using:
```graphql
{
  device_list {
    id
    config_context
  }
}
```