### PR TITLE
Closes #21499: Restore deterministic Ruff linting (match Ruff 0.15.1 preview defaults)

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -30,6 +30,10 @@ respect-gitignore = true
 target-version = "py312"
 
 [lint]
+# Pin the effective default rule set used with `preview = true` to match Ruff 0.15.1.
+# Ruff 0.15.2 changed the preview defaults, see https://github.com/astral-sh/ruff/releases/tag/0.15.2
+# Keeping this explicit makes ruff deterministic.
+select = ["E4", "E7", "E9", "F"]
 extend-select = [
     "E1",    # pycodestyle errors: indentation-related (e.g., unexpected/missing indent)
     "E2",    # pycodestyle errors: whitespace-related (e.g., missing whitespace, extra spaces)


### PR DESCRIPTION
### Fixes: #21499

This PR restores deterministic Ruff behavior by explicitly setting the legacy default `lint.select` rules used with `preview = true`, matching Ruff 0.15.1.

Ruff 0.15.2 updated the preview defaults, which caused our lint step to start failing when Ruff is installed unpinned. This change is intentionally small and focused on getting CI green again.
More details: https://github.com/astral-sh/ruff/releases/tag/0.15.2