### PR TITLE
Closes #21385: Add contact assignment support to virtual circuits

### DIFF
--- a/netbox/circuits/graphql/types.py
+++ b/netbox/circuits/graphql/types.py
@@ -177,7 +177,7 @@ class VirtualCircuitTerminationType(CustomFieldsMixin, TagsMixin, ObjectType):
     filters=VirtualCircuitFilter,
     pagination=True
 )
-class VirtualCircuitType(PrimaryObjectType):
+class VirtualCircuitType(ContactsMixin, PrimaryObjectType):
     provider_network: ProviderNetworkType = strawberry_django.field(select_related=["provider_network"])
     provider_account: ProviderAccountType | None
     type: Annotated["VirtualCircuitTypeType", strawberry.lazy('circuits.graphql.types')] = strawberry_django.field(

--- a/netbox/circuits/models/virtual_circuits.py
+++ b/netbox/circuits/models/virtual_circuits.py
@@ -8,7 +8,7 @@ from django.utils.translation import gettext_lazy as _
 
 from circuits.choices import *
 from netbox.models import ChangeLoggedModel, PrimaryModel
-from netbox.models.features import CustomFieldsMixin, CustomLinksMixin, ExportTemplatesMixin, TagsMixin
+from netbox.models.features import ContactsMixin, CustomFieldsMixin, CustomLinksMixin, ExportTemplatesMixin, TagsMixin
 
 from .base import BaseCircuitType
 
@@ -30,7 +30,7 @@ class VirtualCircuitType(BaseCircuitType):
         verbose_name_plural = _('virtual circuit types')
 
 
-class VirtualCircuit(PrimaryModel):
+class VirtualCircuit(ContactsMixin, PrimaryModel):
     """
     A virtual connection between two or more endpoints, delivered across one or more physical circuits.
     """

--- a/netbox/circuits/tables/virtual_circuits.py
+++ b/netbox/circuits/tables/virtual_circuits.py
@@ -71,7 +71,7 @@ class VirtualCircuitTable(TenancyColumnsMixin, ContactsColumnMixin, PrimaryModel
         model = VirtualCircuit
         fields = (
             'pk', 'id', 'cid', 'provider', 'provider_account', 'provider_network', 'type', 'status', 'tenant',
-            'tenant_group', 'description', 'comments', 'tags', 'created', 'last_updated',
+            'tenant_group', 'description', 'comments', 'contacts', 'tags', 'created', 'last_updated',
         )
         default_columns = (
             'pk', 'cid', 'provider', 'provider_account', 'provider_network', 'type', 'status', 'tenant',


### PR DESCRIPTION
### Fixes: #21385

Adds `ContactsMixin` to the `VirtualCircuit` model and its GraphQL type, and includes the `contacts` field in the table definition.

Verified:
- UI Contacts tab appears and functions correctly
- REST API contact assignment returns 201 (was 400)
- GraphQL contacts query returns expected data