### PR TITLE
Closes #21477: Add GraphQL Cable Termination filters for Device, Rack, Location, and Site

### DIFF
--- a/netbox/dcim/graphql/filters.py
+++ b/netbox/dcim/graphql/filters.py
@@ -141,6 +141,20 @@ class CableTerminationFilter(ChangeLoggedModelFilter):
     )
     termination_id: ID | None = strawberry_django.filter_field()
 
+    # Cached relations
+    _device: Annotated['DeviceFilter', strawberry.lazy('dcim.graphql.filters')] | None = strawberry_django.filter_field(
+        name='device'
+    )
+    _rack: Annotated['RackFilter', strawberry.lazy('dcim.graphql.filters')] | None = strawberry_django.filter_field(
+        name='rack'
+    )
+    _location: Annotated['LocationFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
+        strawberry_django.filter_field(name='location')
+    )
+    _site: Annotated['SiteFilter', strawberry.lazy('dcim.graphql.filters')] | None = strawberry_django.filter_field(
+        name='site'
+    )
+
 
 @strawberry_django.filter_type(models.ConsolePort, lookups=True)
 class ConsolePortFilter(ModularComponentFilterMixin, CabledObjectModelFilterMixin, NetBoxModelFilter):


### PR DESCRIPTION
### Fixes: #21477

This PR adds GraphQL filters for cables based on their terminations’ cached relations (Device, Rack, Location, and Site), bringing GraphQL filtering functionality to parity with the REST API and enabling more effective cable queries by termination attributes.

#### Example (NetBox demo data)

Filter cables by termination device ID `27` (with deduplication enabled):

```graphql
query MyQuery {
  cable_list(
    filters: {terminations: {device: {id: {exact: "27"}}, DISTINCT: true}}
  ) {
    id
    display
  }
}
```

#### Changes
- Expose cached termination relations (`device`, `rack`, `location`, `site`) for GraphQL filtering via `terminations`.
- Support efficient lookups by leveraging cached relations on `CableTermination`.

#### Testing
- Added a test in `dcim/tests/test_api.py` covering filtering by termination device/rack/location/site (including the case where both ends match and `DISTINCT` prevents duplicates).