### PR TITLE
Fixes #21497: Pin Ruff 0.15.2 and run CI via ruff-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,13 @@ jobs:
     - name: Check out repo
       uses: actions/checkout@v4
 
+    - name: Check Python linting & PEP8 compliance
+      uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
+      with:
+        version: "0.15.2"
+        args: "check --output-format=github"
+        src: "netbox/"
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
@@ -82,7 +89,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install ruff coverage tblib
+        pip install coverage tblib
 
     - name: Build documentation
       run: mkdocs build
@@ -92,9 +99,6 @@ jobs:
 
     - name: Check for missing migrations
       run: python netbox/manage.py makemigrations --check
-
-    - name: Check PEP8 compliance
-      run: ruff check netbox/
 
     - name: Check UI ESLint, TypeScript, and Prettier Compliance
       run: yarn --cwd netbox/project-static validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.14.1
+  rev: v0.15.2
   hooks:
     - id: ruff
       name: "Ruff linter"

--- a/docs/development/release-checklist.md
+++ b/docs/development/release-checklist.md
@@ -168,6 +168,14 @@ Update the static OpenAPI schema definition at `contrib/openapi.json` with the m
 ./manage.py spectacular --format openapi-json > ../contrib/openapi.json
 ```
 
+### Update Development Dependencies
+
+Keep development tooling versions consistent across the project. If you upgrade a dev-only dependency, update all places where it’s pinned so local tooling and CI run the same versions.
+
+* Ruff:
+  * `.pre-commit-config.yaml`
+  * `.github/workflows/ci.yml`
+
 ### Submit a Pull Request
 
 Commit the above changes and submit a pull request titled **"Release vX.Y.Z"** to merge the current release branch (e.g. `release-vX.Y.Z`) into `main`. Copy the documented release notes into the pull request's body.

--- a/docs/development/style-guide.md
+++ b/docs/development/style-guide.md
@@ -47,6 +47,14 @@ Wildcard imports (for example, `from .constants import *`) are acceptable under 
 
 The justification for ignoring this rule is the same as F403 above.
 
+##### [RET504](https://docs.astral.sh/ruff/rules/unnecessary-assign/): Unnecessary assign
+
+There are multiple instances where it is more readable and clearer to first assign to a variable and then return it.
+
+##### [UP032](https://docs.astral.sh/ruff/rules/f-string/): f-string
+
+For localizable strings, it is necessary to not use the `f-string` syntax, as Django's translation functions (e.g. `gettext_lazy`) require plain string literals.
+
 ### Introducing New Dependencies
 
 The introduction of a new dependency is best avoided unless it is absolutely necessary. For small features, it's generally preferable to replicate functionality within the NetBox code base rather than to introduce reliance on an external project. This reduces both the burden of tracking new releases and our exposure to outside bugs and supply chain attacks.

--- a/ruff.toml
+++ b/ruff.toml
@@ -45,6 +45,8 @@ extend-select = [
     "UP",        # pyupgrade: modernize syntax for your target Python (e.g., f-strings, built-in generics, newer stdlib idioms)
     "RUF022",    # ruff: enforce sorted `__all__` lists
 ]
+# If you add a rule to `ignore`, please also update the "Linter Exceptions" section in
+# docs/development/style-guide.md.
 ignore = [
     "F403",      # pyflakes: `from ... import *` used; unable to detect undefined names
     "F405",      # pyflakes: name may be undefined or defined from star imports


### PR DESCRIPTION
### Fixes #21497

This PR pins Ruff to **v0.15.2** in both CI and pre-commit to avoid unexpected breakages from upstream releases.

- Run Ruff in CI via `astral-sh/ruff-action` (pinned by SHA) instead of installing Ruff via `pip`
- Align `.pre-commit-config.yaml` with the same Ruff version
- Update the docs (release checklist + style guide) to document where Ruff is pinned and keep tooling versions consistent

Fixes #21472 as well.