### PR TITLE
Closes #21356: Implement ETag support for REST API

### DIFF
--- a/netbox/netbox/api/viewsets/__init__.py
+++ b/netbox/netbox/api/viewsets/__init__.py
@@ -36,15 +36,17 @@ HTTP_ACTIONS = {
 
 class ETagMixin:
     """
-    Adds ETag header support to ViewSets. Generates ETags from `last_updated`
-    (or `created` if unavailable).
+    Adds ETag header support to ViewSets. Generates weak ETags (W/ prefix per
+    RFC 7232 §2.1) from `last_updated` (or `created` if unavailable). Weak ETags
+    are appropriate here because the tag is derived from a modification timestamp
+    rather than a hash of the serialized payload.
     """
 
     @staticmethod
     def _get_etag(obj):
-        """Return a quoted ETag string for the given object, or None."""
+        """Return a weak ETag string for the given object, or None."""
         if ts := getattr(obj, 'last_updated', None) or getattr(obj, 'created', None):
-            return f'"{ts.isoformat()}"'
+            return f'W/"{ts.isoformat()}"'
         return None
 
     def retrieve(self, request, *args, **kwargs):

--- a/netbox/netbox/api/viewsets/__init__.py
+++ b/netbox/netbox/api/viewsets/__init__.py
@@ -13,7 +13,7 @@ from rest_framework.viewsets import GenericViewSet
 from netbox.api.serializers.features import ChangeLogMessageSerializer
 from netbox.constants import ADVISORY_LOCK_KEYS
 from utilities.api import get_annotations_for_serializer, get_prefetches_for_serializer
-from utilities.exceptions import AbortRequest
+from utilities.exceptions import AbortRequest, PreconditionFailed
 from utilities.query import reapply_model_ordering
 
 from . import mixins
@@ -48,6 +48,20 @@ class ETagMixin:
         if ts := getattr(obj, 'last_updated', None) or getattr(obj, 'created', None):
             return f'W/"{ts.isoformat()}"'
         return None
+
+    @staticmethod
+    def _get_if_match(request):
+        """Return the list of If-Match header values (if specified)."""
+        if (if_match := request.META.get('HTTP_IF_MATCH')) and if_match != '*':
+            return [e.strip() for e in if_match.split(',')]
+        return []
+
+    def _validate_etag(self, request, instance):
+        """Validate the request's ETag"""
+        if provided := self._get_if_match(request):
+            current_etag = self._get_etag(instance)
+            if current_etag and current_etag not in provided:
+                raise PreconditionFailed()
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()
@@ -246,11 +260,7 @@ class NetBoxModelViewSet(
         instance = self.get_object_with_snapshot()
 
         # Enforce If-Match precondition (RFC 9110 §13.1.1)
-        if (if_match := request.META.get('HTTP_IF_MATCH')) and if_match != '*':
-            current_etag = self._get_etag(instance)
-            provided = [e.strip() for e in if_match.split(',')]
-            if current_etag and current_etag not in provided:
-                return Response(status=status.HTTP_412_PRECONDITION_FAILED)
+        self._validate_etag(self.request, instance)
 
         serializer = self.get_serializer(instance, data=request.data, partial=partial)
         serializer.is_valid(raise_exception=True)
@@ -277,6 +287,11 @@ class NetBoxModelViewSet(
         # Enforce object-level permissions on save()
         try:
             with transaction.atomic(using=router.db_for_write(model)):
+                # Re-check the If-Match ETag under a row-level lock to close the TOCTOU window
+                # between the initial check in update() and the actual write.
+                if self._get_if_match(self.request):
+                    locked = model.objects.select_for_update().get(pk=serializer.instance.pk)
+                    self._validate_etag(self.request, locked)
                 instance = serializer.save()
                 self._validate_objects(instance)
         except ObjectDoesNotExist:

--- a/netbox/netbox/api/viewsets/__init__.py
+++ b/netbox/netbox/api/viewsets/__init__.py
@@ -61,7 +61,13 @@ class ETagMixin:
         if provided := self._get_if_match(request):
             current_etag = self._get_etag(instance)
             if current_etag and current_etag not in provided:
-                raise PreconditionFailed()
+                raise PreconditionFailed(etag=current_etag)
+
+    def handle_exception(self, exc):
+        response = super().handle_exception(exc)
+        if isinstance(exc, PreconditionFailed) and exc.etag:
+            response['ETag'] = exc.etag
+        return response
 
     def retrieve(self, request, *args, **kwargs):
         instance = self.get_object()

--- a/netbox/netbox/api/viewsets/__init__.py
+++ b/netbox/netbox/api/viewsets/__init__.py
@@ -308,6 +308,9 @@ class NetBoxModelViewSet(
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object_with_snapshot()
 
+        # Enforce If-Match precondition (RFC 9110 §13.1.1)
+        self._validate_etag(request, instance)
+
         # Attach changelog message (if any)
         serializer = ChangeLogMessageSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -322,7 +325,16 @@ class NetBoxModelViewSet(
         logger = logging.getLogger(f'netbox.api.views.{self.__class__.__name__}')
         logger.info(f"Deleting {model._meta.verbose_name} {instance} (PK: {instance.pk})")
 
-        return super().perform_destroy(instance)
+        try:
+            with transaction.atomic(using=router.db_for_write(model)):
+                # Re-check the If-Match ETag under a row-level lock to close the TOCTOU window
+                # between the initial check in destroy() and the actual delete.
+                if self._get_if_match(self.request):
+                    locked = model.objects.select_for_update().get(pk=instance.pk)
+                    self._validate_etag(self.request, locked)
+                super().perform_destroy(instance)
+        except ObjectDoesNotExist:
+            raise PermissionDenied()
 
 
 class MPTTLockedMixin:

--- a/netbox/utilities/exceptions.py
+++ b/netbox/utilities/exceptions.py
@@ -6,6 +6,7 @@ __all__ = (
     'AbortScript',
     'AbortTransaction',
     'PermissionsViolation',
+    'PreconditionFailed',
     'RQWorkerNotRunningException',
 )
 
@@ -38,6 +39,15 @@ class PermissionsViolation(Exception):
     allowed permissions.
     """
     message = "Operation failed due to object-level permissions violation"
+
+
+class PreconditionFailed(APIException):
+    """
+    Raised when an If-Match precondition is not satisfied (HTTP 412).
+    """
+    status_code = status.HTTP_412_PRECONDITION_FAILED
+    default_detail = 'Precondition failed.'
+    default_code = 'precondition_failed'
 
 
 class RQWorkerNotRunningException(APIException):

--- a/netbox/utilities/exceptions.py
+++ b/netbox/utilities/exceptions.py
@@ -44,10 +44,15 @@ class PermissionsViolation(Exception):
 class PreconditionFailed(APIException):
     """
     Raised when an If-Match precondition is not satisfied (HTTP 412).
+    Optionally carries the current ETag so it can be included in the response.
     """
     status_code = status.HTTP_412_PRECONDITION_FAILED
     default_detail = 'Precondition failed.'
     default_code = 'precondition_failed'
+
+    def __init__(self, detail=None, code=None, etag=None):
+        super().__init__(detail=detail, code=code)
+        self.etag = etag
 
 
 class RQWorkerNotRunningException(APIException):


### PR DESCRIPTION
### Closes: #21356

#### `netbox/netbox/api/viewsets/__init__.py`

  1. ETagMixin class (new, lines 37–56): Static helper `_get_etag()` returns a quoted ISO 8601 ETag derived from last_updated (falling back to created). The retrieve() override appends the ETag header to detail responses.
  2. NetBoxReadOnlyModelViewSet and NetBoxModelViewSet: ETagMixin added as the first base class, giving its `retrieve()` priority in the MRO over DRF's `RetrieveModelMixin.retrieve()`.
  3. `update()`: Added an If-Match precondition check per RFC 9110 §13.1.1 — if the header is present and not *, it compares against the current ETag and returns 412 Precondition Failed on mismatch. The response now includes a
  fresh ETag reflecting the updated last_updated value.
  4. `create()`: Single-object creation responses now include an ETag header. Bulk creation responses do not (no single canonical object).

#### `netbox/utilities/testing/api.py`

  1. `test_get_object()`: After the 200 OK assertion, verifies that ChangeLoggingMixin models return an ETag header.
  2. `test_update_object_with_etag()` (new method): End-to-end test that verifies correct-ETag PATCH returns 200 with a changed ETag, and stale-ETag PATCH returns 412.

