### PR TITLE
Fixes #21518: Ensure proper display of decimal custom fields with a zero value

### DIFF
--- a/netbox/utilities/templates/builtins/customfield_value.html
+++ b/netbox/utilities/templates/builtins/customfield_value.html
@@ -2,6 +2,8 @@
 {% load i18n %}
 {% if customfield.type == 'integer' and value is not None %}
   {{ value }}
+{% elif customfield.type == 'decimal' and value is not None %}
+  {{ value }}
 {% elif customfield.type == 'longtext' and value %}
   {{ value|markdown }}
 {% elif customfield.type == 'boolean' and value == True %}


### PR DESCRIPTION
### Fixes: #21518

Display all non-null values for custom decimal fields.