### PR TITLE
Fixes #21524: Fix IndexError when serializing stale cable paths

### DIFF
--- a/netbox/dcim/api/serializers_/cables.py
+++ b/netbox/dcim/api/serializers_/cables.py
@@ -84,6 +84,9 @@ class CablePathSerializer(serializers.ModelSerializer):
     def get_path(self, obj):
         ret = []
         for nodes in obj.path_objects:
+            if not nodes:
+                # The path contains an invalid object
+                return []
             serializer = get_serializer_for_model(nodes[0])
             context = {'request': self.context['request']}
             ret.append(serializer(nodes, nested=True, many=True, context=context).data)


### PR DESCRIPTION
### Fixes: #21524

When serializing a CablePath, if any set of nodes in the path is empty, treat the entire path as invalid.