### PR TITLE
Fixes #21533: Fix missing `family`/`mask_length` in API when creating IP-related objects

### DIFF
--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -159,9 +159,11 @@ class Aggregate(ContactsMixin, GetAvailablePrefixesMixin, PrimaryModel):
 
     @property
     def family(self):
-        if self.prefix:
-            return self.prefix.version
-        return None
+        if not self.prefix:
+            return None
+        if isinstance(self.prefix, str):
+            return netaddr.IPNetwork(self.prefix).version
+        return self.prefix.version
 
     @property
     def ipv6_full(self):
@@ -335,11 +337,19 @@ class Prefix(ContactsMixin, GetAvailablePrefixesMixin, CachedScopeMixin, Primary
 
     @property
     def family(self):
-        return self.prefix.version if self.prefix else None
+        if not self.prefix:
+            return None
+        if isinstance(self.prefix, str):
+            return netaddr.IPNetwork(self.prefix).version
+        return self.prefix.version
 
     @property
     def mask_length(self):
-        return self.prefix.prefixlen if self.prefix else None
+        if not self.prefix:
+            return None
+        if isinstance(self.prefix, str):
+            return netaddr.IPNetwork(self.prefix).prefixlen
+        return self.prefix.prefixlen
 
     @property
     def ipv6_full(self):
@@ -630,7 +640,11 @@ class IPRange(ContactsMixin, PrimaryModel):
 
     @property
     def family(self):
-        return self.start_address.version if self.start_address else None
+        if not self.start_address:
+            return None
+        if isinstance(self.start_address, str):
+            return netaddr.IPAddress(self.start_address.split('/')[0]).version
+        return self.start_address.version
 
     @property
     def range(self):
@@ -978,9 +992,11 @@ class IPAddress(ContactsMixin, PrimaryModel):
 
     @property
     def family(self):
-        if self.address:
-            return self.address.version
-        return None
+        if not self.address:
+            return None
+        if isinstance(self.address, str):
+            return netaddr.IPNetwork(self.address).version
+        return self.address.version
 
     @property
     def is_oob_ip(self):

--- a/netbox/ipam/tests/test_models.py
+++ b/netbox/ipam/tests/test_models.py
@@ -11,6 +11,13 @@ from utilities.data import string_to_ranges
 
 class TestAggregate(TestCase):
 
+    def test_family_string(self):
+        # Test property when prefix is a string
+        agg = Aggregate(prefix='10.0.0.0/8')
+        self.assertEqual(agg.family, 4)
+        agg_v6 = Aggregate(prefix='2001:db8::/32')
+        self.assertEqual(agg_v6.family, 6)
+
     def test_get_utilization(self):
         rir = RIR.objects.create(name='RIR 1', slug='rir-1')
         aggregate = Aggregate(prefix=IPNetwork('10.0.0.0/8'), rir=rir)
@@ -39,6 +46,13 @@ class TestAggregate(TestCase):
 
 
 class TestIPRange(TestCase):
+
+    def test_family_string(self):
+        # Test property when start_address is a string
+        ip_range = IPRange(start_address='10.0.0.1/24', end_address='10.0.0.254/24')
+        self.assertEqual(ip_range.family, 4)
+        ip_range_v6 = IPRange(start_address='2001:db8::1/64', end_address='2001:db8::ffff/64')
+        self.assertEqual(ip_range_v6.family, 6)
 
     def test_overlapping_range(self):
         iprange_192_168 = IPRange.objects.create(
@@ -89,6 +103,20 @@ class TestIPRange(TestCase):
 
 
 class TestPrefix(TestCase):
+
+    def test_family_string(self):
+        # Test property when prefix is a string
+        prefix = Prefix(prefix='10.0.0.0/8')
+        self.assertEqual(prefix.family, 4)
+        prefix_v6 = Prefix(prefix='2001:db8::/32')
+        self.assertEqual(prefix_v6.family, 6)
+
+    def test_mask_length_string(self):
+        # Test property when prefix is a string
+        prefix = Prefix(prefix='10.0.0.0/8')
+        self.assertEqual(prefix.mask_length, 8)
+        prefix_v6 = Prefix(prefix='2001:db8::/32')
+        self.assertEqual(prefix_v6.mask_length, 32)
 
     def test_get_duplicates(self):
         prefixes = Prefix.objects.bulk_create((
@@ -532,6 +560,13 @@ class TestPrefixHierarchy(TestCase):
 
 
 class TestIPAddress(TestCase):
+
+    def test_family_string(self):
+        # Test property when address is a string
+        ip = IPAddress(address='10.0.0.1/24')
+        self.assertEqual(ip.family, 4)
+        ip_v6 = IPAddress(address='2001:db8::1/64')
+        self.assertEqual(ip_v6.family, 6)
 
     def test_get_duplicates(self):
         ips = IPAddress.objects.bulk_create((


### PR DESCRIPTION
### Fixes: #21533

This PR addresses an issue where read-only calculated fields (like `family` and `mask_length`) are silently omitted from API responses when creating IP-related objects (`Prefix`, `IPAddress`, `Aggregate`, `IPRange`).

### Problem
During DRF's model instantiation and validation lifecycle, IP network fields are temporarily held as strings rather than `netaddr` objects. When the serializer attempts to build the response representation, evaluating properties like `family` raises an `AttributeError` (e.g., `'str' object has no attribute 'version'`). DRF's `Field.get_attribute()` catches this exception for read-only fields and silently ignores it by raising a `SkipField` exception, dropping the key from the API response.

### Solution
- Modified the `family` and `mask_length` properties on IP-related models to detect if the underlying value is a string and cast it to a `netaddr` object before evaluating.
- This ensures these properties can be safely evaluated at any point in the object's lifecycle, including during API validation and serialization.
- Added unit tests in `ipam.tests.test_models` to explicitly verify that the models correctly parse the IP version and mask length when instantiated with raw string inputs.
