### PR TITLE
Update choices.py: 50GBASE-CR2

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1015,6 +1015,7 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_50GE_SFP56 = '50gbase-x-sfp56'
     TYPE_40GE_QSFP_PLUS = '40gbase-x-qsfpp'
     TYPE_50GE_QSFP28 = '50gbase-x-sfp28'
+    TYPE_50GE_SFPDD = '50gbase-cr2-sfpdd'
     TYPE_100GE_CFP = '100gbase-x-cfp'
     TYPE_100GE_CFP2 = '100gbase-x-cfp2'
     TYPE_100GE_CFP4 = '100gbase-x-cfp4'
@@ -1311,6 +1312,7 @@ class InterfaceTypeChoices(ChoiceSet):
                 (TYPE_25GE_SFP28, 'SFP28 (25GE)'),
                 (TYPE_40GE_QSFP_PLUS, 'QSFP+ (40GE)'),
                 (TYPE_50GE_QSFP28, 'QSFP28 (50GE)'),
+                (TYPE_50GE_SFPDD, 'SFPDD (50GE)'),
                 (TYPE_50GE_SFP56, 'SFP56 (50GE)'),
                 (TYPE_100GE_CFP, 'CFP (100GE)'),
                 (TYPE_100GE_CFP2, 'CFP2 (100GE)'),


### PR DESCRIPTION
Added Support for the 50G SFP-DD (v1.0) Type which uses 2 x 25G NRZ Lanes: 50GBASE-CR2 This is used by LANCOM XS-6128QF Switches

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #21548

<!--
    Please include a summary of the proposed changes below.
-->
added just the two definition lines for the above mentioned speed.