### PR TITLE
Fixes #19867: Retain the `per_page` URL parameter after editing an object

### DIFF
--- a/netbox/templates/generic/object_list.html
+++ b/netbox/templates/generic/object_list.html
@@ -92,7 +92,7 @@ Context:
 
         <div class="form form-horizontal">
           {% csrf_token %}
-          <input type="hidden" name="return_url" value="{% if return_url %}{{ return_url }}{% else %}{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" />
+          <input type="hidden" id="object-list-return-url" name="return_url" value="{% if return_url %}{{ return_url }}{% else %}{{ request.path }}{% if request.GET %}?{{ request.GET.urlencode }}{% endif %}{% endif %}" />
 
           {# Warn of any missing prerequisite objects #}
           {% if prerequisite_model %}

--- a/netbox/templates/htmx/table.html
+++ b/netbox/templates/htmx/table.html
@@ -32,4 +32,9 @@
       {% action_buttons actions model multi=True %}
     </div>
   {% endif %}
+
+  {# Update the return_url to reflect any changed query parameters (e.g. per_page) #}
+  {% if not table.embedded %}
+    <input type="hidden" id="object-list-return-url" name="return_url" value="{{ request.get_full_path }}" hx-swap-oob="outerHTML:#object-list-return-url" />
+  {% endif %}
 {% endif %}


### PR DESCRIPTION
### Fixes: #19867

Update `return_url` to capture any additional query parameters.