### PR TITLE
Fixes #21586: Fix child Site Group "Add" action to create a Site Group (not a Region)

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -389,7 +389,7 @@ class SiteGroupView(GetRelatedModelsMixin, generic.ObjectView):
                 title=_('Child Groups'),
                 filters={'parent_id': lambda ctx: ctx['object'].pk},
                 actions=[
-                    actions.AddObject('dcim.Region', url_params={'parent': lambda ctx: ctx['object'].pk}),
+                    actions.AddObject('dcim.SiteGroup', url_params={'parent': lambda ctx: ctx['object'].pk}),
                 ],
             ),
         ]


### PR DESCRIPTION
### Fixes: #21586

This PR fixes an incorrect link target on the Site Group detail view.
Replace the incorrect `dcim.Region` reference with `dcim.SiteGroup`, so the button opens the **Add Site Group** form (instead of the **Add Region** form).

Thanks for the review!