### PR TITLE
#21330 optimize the assignment of tags when saving an object

### DIFF
--- a/netbox/extras/managers.py
+++ b/netbox/extras/managers.py
@@ -1,0 +1,65 @@
+from django.db.models import signals
+from django.db import router
+from taggit.managers import _TaggableManager
+
+__all__ = (
+    'NetBoxTaggableManager',
+)
+
+
+class NetBoxTaggableManager(_TaggableManager):
+    """
+    Extends taggit's _TaggableManager to replace the per-tag get_or_create loop in add() with a
+    single bulk_create() call, reducing SQL queries from O(N) to O(1) when assigning tags.
+    """
+
+    def add(self, *tags, through_defaults=None, tag_kwargs=None, **kwargs):
+        self._remove_prefetched_objects()
+        if tag_kwargs is None:
+            tag_kwargs = {}
+
+        tag_objs = self._to_tag_model_instances(tags, tag_kwargs)
+        new_ids = {t.pk for t in tag_objs}
+
+        # Determine which tags are not already assigned to this object
+        vals = set(
+            self.through._default_manager.using(db)
+            .values_list("tag_id", flat=True)
+            .filter(**self._lookup_kwargs())
+        )
+        new_ids -= vals
+
+        if not new_ids:
+            return
+
+        db = router.db_for_write(self.through, instance=self.instance)
+        signals.m2m_changed.send(
+            sender=self.through,
+            action="pre_add",
+            instance=self.instance,
+            reverse=False,
+            model=self.through.tag_model(),
+            pk_set=new_ids,
+            using=db,
+        )
+
+        # Use a single bulk INSERT instead of one get_or_create per tag.
+        lookup = self._lookup_kwargs()
+        self.through._default_manager.using(db).bulk_create(
+            [
+                self.through(tag=tag, **lookup, **(through_defaults or {}))
+                for tag in tag_objs
+                if tag.pk in new_ids
+            ],
+            ignore_conflicts=True,
+        )
+
+        signals.m2m_changed.send(
+            sender=self.through,
+            action="post_add",
+            instance=self.instance,
+            reverse=False,
+            model=self.through.tag_model(),
+            pk_set=new_ids,
+            using=db,
+        )

--- a/netbox/extras/managers.py
+++ b/netbox/extras/managers.py
@@ -1,6 +1,7 @@
 from django.db import router
 from django.db.models import signals
 from taggit.managers import _TaggableManager
+from taggit.utils import require_instance_manager
 
 __all__ = (
     'NetBoxTaggableManager',

--- a/netbox/extras/managers.py
+++ b/netbox/extras/managers.py
@@ -1,5 +1,5 @@
-from django.db.models import signals
 from django.db import router
+from django.db.models import signals
 from taggit.managers import _TaggableManager
 
 __all__ = (
@@ -22,6 +22,7 @@ class NetBoxTaggableManager(_TaggableManager):
         new_ids = {t.pk for t in tag_objs}
 
         # Determine which tags are not already assigned to this object
+        db = router.db_for_write(self.through, instance=self.instance)
         vals = set(
             self.through._default_manager.using(db)
             .values_list("tag_id", flat=True)
@@ -32,7 +33,6 @@ class NetBoxTaggableManager(_TaggableManager):
         if not new_ids:
             return
 
-        db = router.db_for_write(self.through, instance=self.instance)
         signals.m2m_changed.send(
             sender=self.through,
             action="pre_add",

--- a/netbox/extras/managers.py
+++ b/netbox/extras/managers.py
@@ -26,7 +26,7 @@ class NetBoxTaggableManager(_TaggableManager):
         vals = set(
             self.through._default_manager.using(db)
             .values_list("tag_id", flat=True)
-            .filter(**self._lookup_kwargs())
+            .filter(**self._lookup_kwargs(), tag_id__in=new_ids)
         )
         new_ids -= vals
 

--- a/netbox/extras/managers.py
+++ b/netbox/extras/managers.py
@@ -29,7 +29,7 @@ class NetBoxTaggableManager(_TaggableManager):
         vals = set(
             self.through._default_manager.using(db)
             .values_list("tag_id", flat=True)
-            .filter(**(lookup), tag_id__in=new_ids)
+            .filter(**lookup, tag_id__in=new_ids)
         )
         new_ids -= vals
 

--- a/netbox/extras/managers.py
+++ b/netbox/extras/managers.py
@@ -13,20 +13,22 @@ class NetBoxTaggableManager(_TaggableManager):
     single bulk_create() call, reducing SQL queries from O(N) to O(1) when assigning tags.
     """
 
+    @require_instance_manager
     def add(self, *tags, through_defaults=None, tag_kwargs=None, **kwargs):
         self._remove_prefetched_objects()
         if tag_kwargs is None:
             tag_kwargs = {}
+        db = router.db_for_write(self.through, instance=self.instance)
 
         tag_objs = self._to_tag_model_instances(tags, tag_kwargs)
         new_ids = {t.pk for t in tag_objs}
 
         # Determine which tags are not already assigned to this object
-        db = router.db_for_write(self.through, instance=self.instance)
+        lookup = self._lookup_kwargs()
         vals = set(
             self.through._default_manager.using(db)
             .values_list("tag_id", flat=True)
-            .filter(**self._lookup_kwargs(), tag_id__in=new_ids)
+            .filter(**(lookup), tag_id__in=new_ids)
         )
         new_ids -= vals
 
@@ -44,7 +46,6 @@ class NetBoxTaggableManager(_TaggableManager):
         )
 
         # Use a single bulk INSERT instead of one get_or_create per tag.
-        lookup = self._lookup_kwargs()
         self.through._default_manager.using(db).bulk_create(
             [
                 self.through(tag=tag, **lookup, **(through_defaults or {}))

--- a/netbox/netbox/api/serializers/features.py
+++ b/netbox/netbox/api/serializers/features.py
@@ -53,8 +53,11 @@ class TaggableModelSerializer(serializers.Serializer):
 
     def _save_tags(self, instance, tags):
         if tags:
+            # Cache tags on instance so serialize_object() can reuse them without a DB query
+            instance._tags = tags
             instance.tags.set([t.name for t in tags])
         else:
+            instance._tags = []
             instance.tags.clear()
 
         return instance

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -9,6 +9,7 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
+from extras.managers import NetBoxTaggableManager
 from taggit.managers import TaggableManager
 
 from core.choices import JobStatusChoices, ObjectChangeActionChoices
@@ -487,11 +488,12 @@ class JournalingMixin(models.Model):
 class TagsMixin(models.Model):
     """
     Enables support for tag assignment. Assigned tags can be managed via the `tags` attribute,
-    which is a `TaggableManager` instance.
+    which is a `NetBoxTaggableManager` instance.
     """
     tags = TaggableManager(
         through='extras.TaggedItem',
         ordering=('weight', 'name'),
+        manager=NetBoxTaggableManager,
     )
 
     class Meta:

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -9,13 +9,13 @@ from django.db import models
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from extras.managers import NetBoxTaggableManager
 from taggit.managers import TaggableManager
 
 from core.choices import JobStatusChoices, ObjectChangeActionChoices
 from core.models import ObjectType
 from extras.choices import *
 from extras.constants import CUSTOMFIELD_EMPTY_VALUES
+from extras.managers import NetBoxTaggableManager
 from extras.utils import is_taggable
 from netbox.config import get_config
 from netbox.constants import CORE_APPS


### PR DESCRIPTION
### Fixes: #21330 

Taggit was causing N+1 queries here. Created a new NetBoxTaggableManager replacing the add function on taggit and generally follows what it does but does a single bulk-insert of all tags instead of one at a time.  Also a small optimization on the serializer.  Could probably be upstreamed into Taggit, will look at opening an optimization PR there.

Created a new site with 12 tag assignments - checking the POST Request:

main branch: 76 SQL queries
this branch: 29 SQL queries

**Note:** After adding site, with debug toolbar, go to the history menu, find the post request and choose 'switch' to that then look at SQL queries.