### PR TITLE
Fixes #21380: Fix display of the background workers list on small screens

### DIFF
--- a/netbox/templates/core/rq_queue_list.html
+++ b/netbox/templates/core/rq_queue_list.html
@@ -28,7 +28,7 @@
     </div>
   </div>
 
-  <div class="card">
+  <div class="card table-responsive">
     {% render_table table %}
   </div>
 {% endblock content %}


### PR DESCRIPTION
### Fixes: #21380

Wrap the table in a `.table-responsive` to enable horizontal scrolling within the table body.