### PR TITLE
Fixes #21486: Fix event rule webhooks for scripts executed via `runscript`

### DIFF
--- a/netbox/extras/management/commands/runscript.py
+++ b/netbox/extras/management/commands/runscript.py
@@ -81,7 +81,7 @@ class Command(BaseCommand):
                     logger.error(f'\t{field}: {error.get("message")}')
             raise CommandError()
 
-        # Remove extra fields from ScriptForm before passng data to script
+        # Remove extra fields from ScriptForm before passing data to script
         form.cleaned_data.pop('_schedule_at')
         form.cleaned_data.pop('_interval')
         form.cleaned_data.pop('_commit')
@@ -94,10 +94,12 @@ class Command(BaseCommand):
             data=form.cleaned_data,
             request=NetBoxFakeRequest({
                 'META': {},
+                'COOKIES': {},
                 'POST': data,
                 'GET': {},
                 'FILES': {},
                 'user': user,
+                'method': 'POST',
                 'path': '',
                 'id': uuid.uuid4()
             }),


### PR DESCRIPTION
### Fixes: #21486

Populate `COOKIES` and set `method` to `POST` on the `NetBoxFakeRequest` created by the `runscript` management command.

This makes the fake request behave more like a real Django request and avoids errors during event rule and webhook processing when scripts are run via CLI or scheduled jobs.