### PR TITLE
Fixes #21402: Prefetch device_type and manufacturer for brief mode API responses

### DIFF
--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -404,9 +404,8 @@ class DeviceViewSet(
     RenderConfigMixin,
     NetBoxModelViewSet
 ):
-    queryset = Device.objects.select_related(
+    queryset = Device.objects.prefetch_related(
         'device_type__manufacturer',  # Referenced by Device.__str__() for unnamed devices
-    ).prefetch_related(
         'parent_bay',  # Referenced by DeviceSerializer.get_parent_device()
     )
     filterset_class = filtersets.DeviceFilterSet

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -404,7 +404,9 @@ class DeviceViewSet(
     RenderConfigMixin,
     NetBoxModelViewSet
 ):
-    queryset = Device.objects.prefetch_related(
+    queryset = Device.objects.select_related(
+        'device_type__manufacturer',  # Referenced by Device.__str__() for unnamed devices
+    ).prefetch_related(
         'parent_bay',  # Referenced by DeviceSerializer.get_parent_device()
     )
     filterset_class = filtersets.DeviceFilterSet


### PR DESCRIPTION
### Fixes: #21402                                                                                                                                                               

  - Adds `select_related('device_type__manufacturer')` to `DeviceViewSet` queryset to avoid N+1 queries for unnamed devices in brief mode