### PR TITLE
Fixes #21579: Display 'add script' button only if user has sufficient permission

### DIFF
--- a/netbox/templates/extras/script_list.html
+++ b/netbox/templates/extras/script_list.html
@@ -15,7 +15,7 @@
 {% endblock tabs %}
 
 {% block controls %}
-  {% if perms.extras.add_scriptmodule %}
+  {% if perms.core.add_managedfile and perms.extras.add_scriptmodule %}
     {% add_button model %}
   {% endif %}
 {% endblock controls %}

--- a/netbox/templates/extras/script_list.html
+++ b/netbox/templates/extras/script_list.html
@@ -15,7 +15,9 @@
 {% endblock tabs %}
 
 {% block controls %}
-  {% add_button model %}
+  {% if perms.extras.add_scriptmodule %}
+    {% add_button model %}
+  {% endif %}
 {% endblock controls %}
 
 {% block content %}


### PR DESCRIPTION
### Fixes: #21579
