### PR TITLE
Fixes #21580: Hide VM Add Components dropdown without change permission

### DIFF
--- a/netbox/templates/virtualization/virtualmachine/base.html
+++ b/netbox/templates/virtualization/virtualmachine/base.html
@@ -16,23 +16,23 @@
 {% endblock %}
 
 {% block extra_controls %}
-
-  <div class="dropdown">
+  {% if perms.virtualization.change_virtualmachine %}
+    <div class="dropdown">
       <button id="add-components" type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-          <i class="mdi mdi-plus-thick" aria-hidden="true"></i> {% trans "Add Components" %}
+        <i class="mdi mdi-plus-thick" aria-hidden="true"></i> {% trans "Add Components" %}
       </button>
       <ul class="dropdown-menu" aria-labeled-by="add-components">
-          {% if perms.virtualization.add_vminterface %}
-            <li><a class="dropdown-item"  href="{% url 'virtualization:vminterface_add' %}?virtual_machine={{ object.pk }}&return_url={% url 'virtualization:virtualmachine_interfaces' pk=object.pk %}">
-              {% trans "Interfaces" %}
-            </a></li>
-          {% endif %}
-          {% if perms.virtualization.add_virtualdisk %}
-            <li><a class="dropdown-item"  href="{% url 'virtualization:virtualdisk_add' %}?virtual_machine={{ object.pk }}&return_url={% url 'virtualization:virtualmachine_disks' pk=object.pk %}">
-              {% trans "Virtual Disks" %}
-            </a></li>
-          {% endif %}
+        {% if perms.virtualization.add_vminterface %}
+          <li><a class="dropdown-item"  href="{% url 'virtualization:vminterface_add' %}?virtual_machine={{ object.pk }}&return_url={% url 'virtualization:virtualmachine_interfaces' pk=object.pk %}">
+            {% trans "Interfaces" %}
+          </a></li>
+        {% endif %}
+        {% if perms.virtualization.add_virtualdisk %}
+          <li><a class="dropdown-item"  href="{% url 'virtualization:virtualdisk_add' %}?virtual_machine={{ object.pk }}&return_url={% url 'virtualization:virtualmachine_disks' pk=object.pk %}">
+            {% trans "Virtual Disks" %}
+          </a></li>
+        {% endif %}
       </ul>
-  </div>
-
+    </div>
+  {% endif %}
 {% endblock %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #21580

<!--
    Please include a summary of the proposed changes below.
-->
Wrap the VirtualMachine "Add Components" dropdown in a `virtualization.change_virtualmachine` permission check to match Device behavior and prevent users without change permission from seeing component add actions.
