### PR TITLE
Update the lock-threads workflow

### DIFF
--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -11,14 +11,14 @@ permissions:
   pull-requests: write
   discussions: write
 
+concurrency:
+  group: lock-threads
+
 jobs:
   lock:
     if: github.repository == 'netbox-community/netbox'
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@1bf7ec25051fe7c00bdd17e6a7cf3d7bfb7dc771 # v5.0.1
+      - uses: dessant/lock-threads@v6.0.0
         with:
-          issue-inactive-days: 90
-          pr-inactive-days: 30
           discussion-inactive-days: 180
-          issue-lock-reason: 'resolved'


### PR DESCRIPTION
- Update `lock-threads` to v6.0
- Assign a concurrency group
- Delete obsolete configuration