### PR TITLE
Fixes #21651: Disable ordering on MACAddress is_primary column

### DIFF
--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -1205,7 +1205,8 @@ class MACAddressTable(PrimaryModelTable):
         verbose_name=_('Parent')
     )
     is_primary = columns.BooleanColumn(
-        verbose_name=_('Primary')
+        verbose_name=_('Primary'),
+        orderable=False,
     )
     tags = columns.TagColumn(
         url_name='dcim:macaddress_list'


### PR DESCRIPTION
### Fixes: #21651

The `is_primary` column on `MACAddressTable` is backed by a `@cached_property` on the model, not a database field. Clicking the column header to sort triggers `FieldError: Cannot resolve keyword 'is_primary' into field`. Worse, the sort preference is persisted to user config, so the list view crashes on every subsequent load.

This adds `orderable=False` to the column definition.