### PR TITLE
Closes #21664: Update and pin GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
     steps:
     - name: Check out repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Check Python linting & PEP8 compliance
       uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
@@ -63,12 +63,12 @@ jobs:
         src: "netbox/"
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: ${{ matrix.node-version }}
     
@@ -76,7 +76,7 @@ jobs:
       run: npm install -g yarn
     
     - name: Setup Node.js with Yarn Caching
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: yarn

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,7 +26,7 @@ jobs:
       actions: read # Required for Claude to read CI results on PRs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 1
 

--- a/.github/workflows/close-incomplete-issues.yml
+++ b/.github/workflows/close-incomplete-issues.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'netbox-community/netbox'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           close-issue-message: >
             This issue is being closed as no further information has been provided. If

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'netbox-community/netbox'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v9
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           # General parameters
           operations-per-run: 200

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,13 +30,13 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
         config-file: .github/codeql/codeql-config.yml
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@b1bff81932f5cdfc8695c7752dcee935dcd061c8 # v4.33.0
       with:
         category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
           build-mode: none
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/lock-threads.yml
+++ b/.github/workflows/lock-threads.yml
@@ -19,6 +19,6 @@ jobs:
     if: github.repository == 'netbox-community/netbox'
     runs-on: ubuntu-latest
     steps:
-      - uses: dessant/lock-threads@v6.0.0
+      - uses: dessant/lock-threads@7266a7ce5c1df01b1c6db85bf8cd86c737dadbe7 # v6.0.0
         with:
           discussion-inactive-days: 180

--- a/.github/workflows/update-translation-strings.yml
+++ b/.github/workflows/update-translation-strings.yml
@@ -27,12 +27,12 @@ jobs:
         private-key: ${{ secrets.HOUSEKEEPING_SECRET_KEY }}
 
     - name: Check out repo
-      uses: actions/checkout@v4
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
           token: ${{ steps.app-token.outputs.token }}
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: 3.12
 


### PR DESCRIPTION
### Fixes: #21664

This PR updates the affected GitHub Actions for GitHub Actions' Node 20 deprecation and pins all referenced actions to full commit SHAs instead of version tags. This helps reduce supply chain risk from tag retargeting while preparing the workflows for the transition to Node 24.

The Node.js version used for CI testing is unchanged; this update only affects the GitHub Actions used by the workflows themselves.

Updated actions:
- `actions/checkout` to `v6.0.2`
- `actions/setup-python` to `v6.2.0`
- `actions/setup-node` to `v6.3.0`
- `actions/stale` to `v10.2.0`
- `github/codeql-action/init` pinned to `v4.33.0`
- `github/codeql-action/analyze` pinned to `v4.33.0`
- `dessant/lock-threads` pinned to `v6.0.0` (no version change)