### PR TITLE
Fixes #21707: Correct Ownership field grouping on Provider Account form

### DIFF
--- a/netbox/circuits/forms/model_forms.py
+++ b/netbox/circuits/forms/model_forms.py
@@ -68,10 +68,14 @@ class ProviderAccountForm(PrimaryModelForm):
         quick_add=True
     )
 
+    fieldsets = (
+        FieldSet('provider', 'account', 'name', 'description', 'tags'),
+    )
+
     class Meta:
         model = ProviderAccount
         fields = [
-            'provider', 'name', 'account', 'description', 'owner', 'comments', 'tags',
+            'provider', 'account', 'name', 'description', 'owner', 'comments', 'tags',
         ]
 
 


### PR DESCRIPTION
### Fixes: #21707

This PR adds an explicit `fieldsets` definition to `ProviderAccountForm` and updates the `Meta.fields` ordering to match it.

The result is a more consistent Provider Account add/edit form layout, with fields rendered in the intended order and ownership-related fields grouped as expected.