### PR TITLE
Fixes #21698: Fix validation of custom field URLs with single-digit ports

### DIFF
--- a/netbox/utilities/validators.py
+++ b/netbox/utilities/validators.py
@@ -34,7 +34,7 @@ class EnhancedURLValidator(URLValidator):
         r'^(?:[a-z0-9\.\-\+]*)://'          # Scheme (enforced separately)
         r'(?:\S+(?::\S*)?@)?'               # HTTP basic authentication
         r'(?:' + '|'.join(host_res) + ')'   # IPv4, IPv6, FQDN, or hostname
-        r'(?::\d{2,5})?'                    # Port number
+        r'(?::\d{1,5})?'                    # Port number
         r'(?:[/?#][^\s]*)?'                 # Path
         r'\Z', re.IGNORECASE)
     schemes = None


### PR DESCRIPTION
### Fixes: #21698

Update the custom field URL validation regex to allow single-digit ports by changing `\d{2,5}` to `\d{1,5}`. This fixes rejection of valid URLs such as `https://100.65.18.1:9/` and brings NetBox's behavior in line with Django's default URL validation.