### PR TITLE
Closes #21702: Include originating HTTP request in outbound webhook context data

### DIFF
--- a/docs/models/extras/webhook.md
+++ b/docs/models/extras/webhook.md
@@ -90,4 +90,4 @@ The following context variables are available to the text and link templates.
 | `snapshots`   | Pre- and post-change snapshots of the object         |
 
 !!! warning "Deprecation of legacy fields"
-    The `request_id` and `username` fields in the webhook payload above are deprecated and should no longer be used. Support for them will be removed in NetBox v4.7.0. Use `request.user.username` and `request.request_id` from the `request` object included in the callback context instead.
+    The `request_id` and `username` fields in the webhook payload above are deprecated and should no longer be used. Support for them will be removed in NetBox v4.7.0. Use `request.user` and `request.id` from the `request` object included in the callback context instead. (Note that `request` is populated in the context only when the webhook is associated with a triggering request.)

--- a/netbox/extras/tests/test_event_rules.py
+++ b/netbox/extras/tests/test_event_rules.py
@@ -345,6 +345,7 @@ class EventRuleTest(APITestCase):
 
     def test_send_webhook(self):
         request_id = uuid.uuid4()
+        url_path = reverse('dcim:site_add')
 
         def dummy_send(_, request, **kwargs):
             """
@@ -372,12 +373,13 @@ class EventRuleTest(APITestCase):
             self.assertEqual(body['context']['foo'], 123)  # From netbox.tests.dummy_plugin
             self.assertEqual(body['request']['id'], str(request_id))
             self.assertEqual(body['request']['method'], 'GET')
+            self.assertEqual(body['request']['path'], url_path)
             self.assertEqual(body['request']['user'], 'testuser')
 
             return HttpResponse()
 
         # Create a dummy request
-        request = RequestFactory().get(reverse('dcim:site_add'))
+        request = RequestFactory().get(url_path)
         request.id = request_id
         request.user = self.user
 

--- a/netbox/extras/tests/test_event_rules.py
+++ b/netbox/extras/tests/test_event_rules.py
@@ -370,6 +370,9 @@ class EventRuleTest(APITestCase):
             self.assertEqual(body['data']['name'], 'Site 1')
             self.assertEqual(body['data']['foo'], 1)
             self.assertEqual(body['context']['foo'], 123)  # From netbox.tests.dummy_plugin
+            self.assertEqual(body['request']['id'], str(request_id))
+            self.assertEqual(body['request']['method'], 'GET')
+            self.assertEqual(body['request']['user'], 'testuser')
 
             return HttpResponse()
 

--- a/netbox/extras/webhooks.py
+++ b/netbox/extras/webhooks.py
@@ -57,6 +57,13 @@ def send_webhook(event_rule, object_type, event_type, data, timestamp, username,
         'request_id': request.id if request else None,
         'data': data,
     }
+    if request:
+        context['request'] = {
+            'id': str(request.id) if request.id else None,
+            'method': request.method,
+            'path': request.path,
+            'user': str(request.user),
+        }
     if snapshots:
         context.update({
             'snapshots': snapshots


### PR DESCRIPTION
### Closes: #21702

Adds a `request` key to the webhook data if a request is associated with the origination of the webhook.

Note: We're not attaching a complete representation of the request in the interest of both security and brevity.