### PR TITLE
fix: escape exception messages in mark_safe calls and fix SQL interpolation

### DIFF
--- a/netbox/core/jobs.py
+++ b/netbox/core/jobs.py
@@ -189,6 +189,9 @@ class SystemHousekeepingJob(JobRunner):
             if 'tag_name' not in release or release.get('devrelease') or release.get('prerelease'):
                 continue
             releases.append((version.parse(release['tag_name']), release.get('html_url')))
+        if not releases:
+            self.logger.warning("No usable releases found in API response")
+            return
         latest_release = max(releases)
         self.logger.debug(f"Found {len(response.json())} releases; {len(releases)} usable")
         self.logger.info(f"Latest release: {latest_release[0]}")

--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -588,7 +588,7 @@ class SystemView(UserPassesTestMixin, View):
                 psql_version = psql_version.split('(')[0].strip()
                 cursor.execute("SELECT current_database()")
                 db_name = cursor.fetchone()[0]
-                cursor.execute(f"SELECT pg_size_pretty(pg_database_size('{db_name}'))")
+                cursor.execute("SELECT pg_size_pretty(pg_database_size(current_database()))")
                 db_size = cursor.fetchone()[0]
         except (ProgrammingError, IndexError):
             pass

--- a/netbox/extras/templatetags/custom_links.py
+++ b/netbox/extras/templatetags/custom_links.py
@@ -66,8 +66,8 @@ def custom_links(context, obj):
                         rendered['link'], rendered['link_target'], button_class, rendered['text']
                     )
             except Exception as e:
-                template_code += f'<a class="btn btn-sm btn-outline-secondary" disabled="disabled" title="{e}">' \
-                                 f'<i class="mdi mdi-alert"></i> {cl.name}</a>\n'
+                template_code += f'<a class="btn btn-sm btn-outline-secondary" disabled="disabled" title="{escape(str(e))}">' \
+                                 f'<i class="mdi mdi-alert"></i> {escape(cl.name)}</a>\n'
 
     # Add grouped links to template
     for group, links in group_names.items():
@@ -82,8 +82,8 @@ def custom_links(context, obj):
                     )
             except Exception as e:
                 links_rendered.append(
-                    f'<li><a class="dropdown-item" disabled="disabled" title="{e}"><span class="text-muted">'
-                    f'<i class="mdi mdi-alert"></i> {cl.name}</span></a></li>'
+                    f'<li><a class="dropdown-item" disabled="disabled" title="{escape(str(e))}"><span class="text-muted">'
+                    f'<i class="mdi mdi-alert"></i> {escape(cl.name)}</span></a></li>'
                 )
 
         if links_rendered:

--- a/netbox/extras/templatetags/dashboard.py
+++ b/netbox/extras/templatetags/dashboard.py
@@ -1,4 +1,5 @@
 from django import template
+from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext as _
 
@@ -19,6 +20,6 @@ def render_widget(context, widget):
               <span class="text-danger"><i class="mdi mdi-alert"></i></span>
               {message1}
             </p>
-            <p class="font-monospace ps-3">{e}</p>
+            <p class="font-monospace ps-3">{escape(str(e))}</p>
             <p>{message2}</p>
         """)

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -587,7 +587,8 @@ class CustomLinkColumn(tables.Column):
                 return mark_safe(f'<a href="{rendered["link"]}"{rendered["link_target"]}>{rendered["text"]}</a>')
         except Exception as e:
             error_text = _('Error')
-            return mark_safe(f'<span class="text-danger" title="{e}"><i class="mdi mdi-alert"></i> {error_text}</span>')
+            from django.utils.html import escape
+            return mark_safe(f'<span class="text-danger" title="{escape(str(e))}"><i class="mdi mdi-alert"></i> {error_text}</span>')
         return ''
 
     def value(self, record, table, **kwargs):

--- a/netbox/utilities/templatetags/builtins/filters.py
+++ b/netbox/utilities/templatetags/builtins/filters.py
@@ -263,4 +263,5 @@ def truncate_middle(value, length):
     first_part = value[:half_len]
     second_part = value[len(value) - (length - 1 - half_len):]
 
-    return mark_safe(f"{first_part}&hellip;{second_part}")
+    from django.utils.html import escape
+    return mark_safe(f"{escape(first_part)}&hellip;{escape(second_part)}")


### PR DESCRIPTION
Multiple XSS and security fixes:
1. truncate_middle filter: escape first_part/second_part before mark_safe
2. CustomLinkColumn.render: escape exception in title attribute
3. render_widget dashboard tag: escape exception message
4. custom_links tag: escape exception and cl.name in both ungrouped
   and grouped link error paths
5. core/views.py: use current_database() directly instead of f-string
   interpolation of db_name into SQL
6. core/jobs.py: guard max(releases) against empty list

Signed-off-by: Aprazors <Aprazors@gmail.com>