### PR TITLE
Closes #21735: Replace deprecated Strawberry scalar for `BigInt`

### DIFF
--- a/netbox/netbox/graphql/scalars.py
+++ b/netbox/netbox/graphql/scalars.py
@@ -1,10 +1,12 @@
-from typing import Union
+from typing import NewType
 
 import strawberry
 
-BigInt = strawberry.scalar(
-    Union[int, str],  # type: ignore
+BigInt = NewType('BigInt', int)
+
+BigIntScalar = strawberry.scalar(
+    name='BigInt',
     serialize=lambda v: int(v),
     parse_value=lambda v: str(v),
-    description="BigInt field",
+    description='BigInt field',
 )

--- a/netbox/netbox/graphql/schema.py
+++ b/netbox/netbox/graphql/schema.py
@@ -16,6 +16,8 @@ from virtualization.graphql.schema import VirtualizationQuery
 from vpn.graphql.schema import VPNQuery
 from wireless.graphql.schema import WirelessQuery
 
+from .scalars import BigInt, BigIntScalar
+
 
 @strawberry.type
 class Query(
@@ -36,9 +38,14 @@ class Query(
 
 schema = strawberry.Schema(
     query=Query,
-    config=StrawberryConfig(auto_camel_case=False),
+    config=StrawberryConfig(
+        auto_camel_case=False,
+        scalar_map={
+            BigInt: BigIntScalar,
+        },
+    ),
     extensions=[
         DjangoOptimizerExtension(prefetch_custom_queryset=True),
         MaxAliasesLimiter(max_alias_count=settings.GRAPHQL_MAX_ALIASES),
-    ]
+    ],
 )


### PR DESCRIPTION
### Fixes: #21735

Replace the deprecated `strawberry.scalar()` class-based registration of `BigInt` with the approach recommended by Strawberry's current API.

`BigInt` is now defined as a `NewType` in `scalars.py`, and the corresponding GraphQL scalar (`BigIntScalar`) is registered via `StrawberryConfig.scalar_map` in `schema.py`. The exported name `BigInt` is unchanged, so existing field annotations throughout the codebase continue to work without modification.

This eliminates the `DeprecationWarning` that currently appears (twice) on startup when running with warnings enabled, and keeps NetBox aligned with Strawberry's supported API ahead of the eventual removal of the old pattern.