### PR TITLE
Fix single {module} token rejection at nested module bay depth

### DIFF
--- a/netbox/dcim/api/serializers_/devices.py
+++ b/netbox/dcim/api/serializers_/devices.py
@@ -6,8 +6,9 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from dcim.choices import *
-from dcim.constants import MACADDRESS_ASSIGNMENT_MODELS
+from dcim.constants import MACADDRESS_ASSIGNMENT_MODELS, MODULE_TOKEN
 from dcim.models import Device, DeviceBay, MACAddress, Module, VirtualDeviceContext
+from dcim.utils import get_module_bay_positions, resolve_module_placeholder
 from extras.api.serializers_.configtemplates import ConfigTemplateSerializer
 from ipam.api.serializers_.ip import IPAddressSerializer
 from netbox.api.fields import ChoiceField, ContentTypeField, RelatedObjectCountField
@@ -158,6 +159,60 @@ class ModuleSerializer(PrimaryModelSerializer):
             'asset_tag', 'description', 'owner', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
         brief_fields = ('id', 'url', 'display', 'device', 'module_bay', 'module_type', 'description')
+
+    def validate(self, data):
+        data = super().validate(data)
+
+        if self.nested:
+            return data
+
+        # Skip validation for existing modules (updates)
+        if self.instance is not None:
+            return data
+
+        module_bay = data.get('module_bay')
+        module_type = data.get('module_type')
+        device = data.get('device')
+
+        if not all((module_bay, module_type, device)):
+            return data
+
+        positions = get_module_bay_positions(module_bay)
+
+        for templates, component_attribute in [
+            ("consoleporttemplates", "consoleports"),
+            ("consoleserverporttemplates", "consoleserverports"),
+            ("interfacetemplates", "interfaces"),
+            ("powerporttemplates", "powerports"),
+            ("poweroutlettemplates", "poweroutlets"),
+            ("rearporttemplates", "rearports"),
+            ("frontporttemplates", "frontports"),
+        ]:
+            installed_components = {
+                component.name: component for component in getattr(device, component_attribute).all()
+            }
+
+            for template in getattr(module_type, templates).all():
+                resolved_name = template.name
+                if MODULE_TOKEN in template.name:
+                    if not module_bay.position:
+                        raise serializers.ValidationError(
+                            _("Cannot install module with placeholder values in a module bay with no position defined.")
+                        )
+                    try:
+                        resolved_name = resolve_module_placeholder(template.name, positions)
+                    except ValueError as e:
+                        raise serializers.ValidationError(str(e))
+
+                if resolved_name in installed_components:
+                    raise serializers.ValidationError(
+                        _("A {model} named {name} already exists").format(
+                            model=template.component_model.__name__,
+                            name=resolved_name
+                        )
+                    )
+
+        return data
 
 
 class MACAddressSerializer(PrimaryModelSerializer):

--- a/netbox/dcim/forms/common.py
+++ b/netbox/dcim/forms/common.py
@@ -126,18 +126,21 @@ class ModuleCommonForm(forms.Form):
                             _("Cannot install module with placeholder values in a module bay with no position defined.")
                         )
 
-                    if len(module_bays) != template.name.count(MODULE_TOKEN):
+                    token_count = template.name.count(MODULE_TOKEN)
+                    if token_count == 1:
+                        resolved_name = resolved_name.replace(MODULE_TOKEN, module_bays[-1].position)
+                    elif token_count == len(module_bays):
+                        for mb in module_bays:
+                            resolved_name = resolved_name.replace(MODULE_TOKEN, mb.position, 1)
+                    else:
                         raise forms.ValidationError(
                             _(
                                 "Cannot install module with placeholder values in a module bay tree {level} in tree "
                                 "but {tokens} placeholders given."
                             ).format(
-                                level=len(module_bays), tokens=template.name.count(MODULE_TOKEN)
+                                level=len(module_bays), tokens=token_count
                             )
                         )
-
-                    for module_bay in module_bays:
-                        resolved_name = resolved_name.replace(MODULE_TOKEN, module_bay.position, 1)
 
                 existing_item = installed_components.get(resolved_name)
 

--- a/netbox/dcim/forms/common.py
+++ b/netbox/dcim/forms/common.py
@@ -3,6 +3,7 @@ from django.utils.translation import gettext_lazy as _
 
 from dcim.choices import *
 from dcim.constants import *
+from dcim.utils import get_module_bay_positions, resolve_module_placeholder
 from utilities.forms import get_field_value
 
 __all__ = (
@@ -70,18 +71,6 @@ class InterfaceCommonForm(forms.Form):
 
 class ModuleCommonForm(forms.Form):
 
-    def _get_module_bay_tree(self, module_bay):
-        module_bays = []
-        while module_bay:
-            module_bays.append(module_bay)
-            if module_bay.module:
-                module_bay = module_bay.module.module_bay
-            else:
-                module_bay = None
-
-        module_bays.reverse()
-        return module_bays
-
     def clean(self):
         super().clean()
 
@@ -100,7 +89,7 @@ class ModuleCommonForm(forms.Form):
             self.instance._disable_replication = True
             return
 
-        module_bays = self._get_module_bay_tree(module_bay)
+        positions = get_module_bay_positions(module_bay)
 
         for templates, component_attribute in [
                 ("consoleporttemplates", "consoleports"),
@@ -119,28 +108,16 @@ class ModuleCommonForm(forms.Form):
             # Get the templates for the module type.
             for template in getattr(module_type, templates).all():
                 resolved_name = template.name
-                # Installing modules with placeholders require that the bay has a position value
                 if MODULE_TOKEN in template.name:
                     if not module_bay.position:
                         raise forms.ValidationError(
                             _("Cannot install module with placeholder values in a module bay with no position defined.")
                         )
 
-                    token_count = template.name.count(MODULE_TOKEN)
-                    if token_count == 1:
-                        resolved_name = resolved_name.replace(MODULE_TOKEN, module_bays[-1].position)
-                    elif token_count == len(module_bays):
-                        for mb in module_bays:
-                            resolved_name = resolved_name.replace(MODULE_TOKEN, mb.position, 1)
-                    else:
-                        raise forms.ValidationError(
-                            _(
-                                "Cannot install module with placeholder values in a module bay tree {level} in tree "
-                                "but {tokens} placeholders given."
-                            ).format(
-                                level=len(module_bays), tokens=token_count
-                            )
-                        )
+                    try:
+                        resolved_name = resolve_module_placeholder(template.name, positions)
+                    except ValueError as e:
+                        raise forms.ValidationError(str(e))
 
                 existing_item = installed_components.get(resolved_name)
 

--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -9,6 +9,7 @@ from dcim.choices import *
 from dcim.constants import *
 from dcim.models.base import PortMappingBase
 from dcim.models.mixins import InterfaceValidationMixin
+from dcim.utils import get_module_bay_positions, resolve_module_placeholder
 from netbox.models import ChangeLoggedModel
 from utilities.fields import ColorField, NaturalOrderingField
 from utilities.mptt import TreeManager
@@ -165,34 +166,15 @@ class ModularComponentTemplateModel(ComponentTemplateModel):
                 _("A component template must be associated with either a device type or a module type.")
             )
 
-    def _get_module_tree(self, module):
-        modules = []
-        while module:
-            modules.append(module)
-            if module.module_bay:
-                module = module.module_bay.module
-            else:
-                module = None
-
-        modules.reverse()
-        return modules
-
-    def _resolve_module_placeholder(self, value, module):
-        if MODULE_TOKEN not in value or not module:
-            return value
-        modules = self._get_module_tree(module)
-        token_count = value.count(MODULE_TOKEN)
-        if token_count == 1:
-            return value.replace(MODULE_TOKEN, modules[-1].module_bay.position)
-        for m in modules:
-            value = value.replace(MODULE_TOKEN, m.module_bay.position, 1)
-        return value
-
     def resolve_name(self, module):
-        return self._resolve_module_placeholder(self.name, module)
+        if MODULE_TOKEN not in self.name or not module:
+            return self.name
+        return resolve_module_placeholder(self.name, get_module_bay_positions(module.module_bay))
 
     def resolve_label(self, module):
-        return self._resolve_module_placeholder(self.label, module)
+        if MODULE_TOKEN not in self.label or not module:
+            return self.label
+        return resolve_module_placeholder(self.label, get_module_bay_positions(module.module_bay))
 
 
 class ConsolePortTemplate(ModularComponentTemplateModel):
@@ -723,7 +705,9 @@ class ModuleBayTemplate(ModularComponentTemplateModel):
         verbose_name_plural = _('module bay templates')
 
     def resolve_position(self, module):
-        return self._resolve_module_placeholder(self.position, module)
+        if MODULE_TOKEN not in self.position or not module:
+            return self.position
+        return resolve_module_placeholder(self.position, get_module_bay_positions(module.module_bay))
 
     def instantiate(self, **kwargs):
         return self.component_model(

--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -181,6 +181,9 @@ class ModularComponentTemplateModel(ComponentTemplateModel):
         if MODULE_TOKEN not in value or not module:
             return value
         modules = self._get_module_tree(module)
+        token_count = value.count(MODULE_TOKEN)
+        if token_count == 1:
+            return value.replace(MODULE_TOKEN, modules[-1].module_bay.position)
         for m in modules:
             value = value.replace(MODULE_TOKEN, m.module_bay.position, 1)
         return value

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -893,6 +893,77 @@ class ModuleBayTestCase(TestCase):
         nested_bay = module.modulebays.get(name='Sub-bay 1-1')
         self.assertEqual(nested_bay.position, '1-1')
 
+    @tag('regression')  # #20474
+    def test_single_module_token_at_nested_depth(self):
+        """
+        A module type with a single {module} token should install at depth > 1
+        without raising a token count mismatch error, resolving to the immediate
+        parent bay's position.
+        """
+        manufacturer = Manufacturer.objects.first()
+        site = Site.objects.first()
+        device_role = DeviceRole.objects.first()
+
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model='Chassis with Rear Card',
+            slug='chassis-with-rear-card'
+        )
+        ModuleBayTemplate.objects.create(
+            device_type=device_type,
+            name='Rear card slot',
+            position='1'
+        )
+
+        rear_card_type = ModuleType.objects.create(
+            manufacturer=manufacturer,
+            model='Rear Card'
+        )
+        ModuleBayTemplate.objects.create(
+            module_type=rear_card_type,
+            name='SFP slot 1',
+            position='1'
+        )
+        ModuleBayTemplate.objects.create(
+            module_type=rear_card_type,
+            name='SFP slot 2',
+            position='2'
+        )
+
+        sfp_type = ModuleType.objects.create(
+            manufacturer=manufacturer,
+            model='SFP Module'
+        )
+        InterfaceTemplate.objects.create(
+            module_type=sfp_type,
+            name='SFP {module}',
+            type=InterfaceTypeChoices.TYPE_10GE_SFP_PLUS
+        )
+
+        device = Device.objects.create(
+            name='Test Chassis',
+            device_type=device_type,
+            role=device_role,
+            site=site
+        )
+
+        rear_card_bay = device.modulebays.get(name='Rear card slot')
+        rear_card = Module.objects.create(
+            device=device,
+            module_bay=rear_card_bay,
+            module_type=rear_card_type
+        )
+
+        sfp_bay = rear_card.modulebays.get(name='SFP slot 2')
+        sfp_module = Module.objects.create(
+            device=device,
+            module_bay=sfp_bay,
+            module_type=sfp_type
+        )
+
+        interface = sfp_module.interfaces.first()
+        self.assertEqual(interface.name, 'SFP 2')
+
     @tag('regression')  # #20912
     def test_module_bay_parent_cleared_when_module_removed(self):
         """Test that the parent field is properly cleared when a module bay's module assignment is removed"""

--- a/netbox/dcim/utils.py
+++ b/netbox/dcim/utils.py
@@ -3,6 +3,9 @@ from collections import defaultdict
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
 from django.db import router, transaction
+from django.utils.translation import gettext as _
+
+from dcim.constants import MODULE_TOKEN
 
 
 def compile_path_node(ct_id, object_id):
@@ -31,6 +34,51 @@ def path_node_to_object(repr):
     ct_id, object_id = decompile_path_node(repr)
     ct = ContentType.objects.get_for_id(ct_id)
     return ct.model_class().objects.filter(pk=object_id).first()
+
+
+def get_module_bay_positions(module_bay):
+    """
+    Given a module bay, traverse up the module hierarchy and return
+    a list of bay position strings from root to leaf.
+    """
+    positions = []
+    while module_bay:
+        positions.append(module_bay.position)
+        if module_bay.module:
+            module_bay = module_bay.module.module_bay
+        else:
+            module_bay = None
+    positions.reverse()
+    return positions
+
+
+def resolve_module_placeholder(value, positions):
+    """
+    Resolve {module} placeholder tokens in a string using the given
+    list of module bay positions (ordered root to leaf).
+
+    A single {module} token resolves to the leaf (immediate parent) bay's position.
+    Multiple tokens must match the tree depth and resolve level-by-level.
+
+    Returns the resolved string.
+    Raises ValueError if token count is greater than 1 and doesn't match tree depth.
+    """
+    if MODULE_TOKEN not in value:
+        return value
+
+    token_count = value.count(MODULE_TOKEN)
+    if token_count == 1:
+        return value.replace(MODULE_TOKEN, positions[-1])
+    if token_count == len(positions):
+        for pos in positions:
+            value = value.replace(MODULE_TOKEN, pos, 1)
+        return value
+    raise ValueError(
+        _("Cannot install module with placeholder values in a module bay tree "
+          "{level} levels deep but {tokens} placeholders given.").format(
+            level=len(positions), tokens=token_count
+        )
+    )
 
 
 def create_cablepaths(objects):


### PR DESCRIPTION
### Fixes: #20474

## Summary

Fixes a bug where installing a module type with a single `{module}` placeholder into a nested module bay (depth > 1) was rejected with: *"Cannot install module with placeholder values in a module bay tree 2 in tree but 1 placeholders given."*

- A single `{module}` token now resolves to the immediate parent bay's position regardless of nesting depth
- Multi-token `{module}` behavior is unchanged (token count must still match tree depth)
- Refactors `resolve_name()` and `resolve_label()` into a shared `_resolve_module_placeholder()` helper to eliminate duplication

## Changes

| File | Change |
|------|--------|
| `dcim/forms/common.py` | Single `{module}` token resolves to parent bay position instead of erroring; multi-token validation unchanged |
| `dcim/models/device_component_templates.py` | Consolidated `resolve_name()`/`resolve_label()` into shared `_resolve_module_placeholder()` with same single-token logic |
| `dcim/tests/test_models.py` | Regression test: single `{module}` SFP module installs at depth 2 and resolves to parent position |

## Testing

All existing dcim model and form tests pass (59 tests). Added one regression test that reproduces the exact scenario from #20474:

1. Create a chassis with a rear card slot (depth 1)
2. Install a rear card module with SFP slots (depth 2)
3. Install an SFP module type with `SFP {module}` interface template into depth 2
4. Verify the interface resolves to `SFP 2` (parent bay position) instead of raising a `ValidationError`