### PR TITLE
Closes #20808: Show occupying device in rack position selector

### DIFF
--- a/netbox/dcim/api/serializers_/rackunits.py
+++ b/netbox/dcim/api/serializers_/rackunits.py
@@ -1,6 +1,7 @@
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
+from django.utils.translation import gettext as _
 
 from dcim.choices import *
 from netbox.api.fields import ChoiceField
@@ -25,7 +26,17 @@ class RackUnitSerializer(serializers.Serializer):
     device = DeviceSerializer(nested=True, read_only=True)
     occupied = serializers.BooleanField(read_only=True)
     display = serializers.SerializerMethodField(read_only=True)
+    description = serializers.SerializerMethodField(read_only=True)
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_display(self, obj):
-        return obj['name']
+        display = obj['name']
+        if obj['occupied'] and (device := obj['device']):
+            return _('{rack_unit} - {device}').format(rack_unit=display, device=device)
+
+        return display
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_description(self, obj):
+        if obj['occupied'] and (device := obj['device']):
+            return str(device.device_type)

--- a/netbox/dcim/api/serializers_/rackunits.py
+++ b/netbox/dcim/api/serializers_/rackunits.py
@@ -1,4 +1,3 @@
-from django.utils.translation import gettext as _
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
@@ -26,20 +25,12 @@ class RackUnitSerializer(serializers.Serializer):
     device = DeviceSerializer(nested=True, read_only=True)
     occupied = serializers.BooleanField(read_only=True)
     display = serializers.SerializerMethodField(read_only=True)
-    device_display = serializers.SerializerMethodField(read_only=True)
-    device_type = serializers.SerializerMethodField(read_only=True)
+    description = serializers.SerializerMethodField(read_only=True)
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_display(self, obj):
         return obj['name']
 
-    @extend_schema_field(OpenApiTypes.STR)
-    def get_device_display(self, obj):
-        if obj['occupied'] and (device := obj['device']):
-            return _('{rack_unit} - {device}').format(rack_unit=obj['name'], device=device)
-        return obj['name']
-
-    @extend_schema_field(OpenApiTypes.STR)
-    def get_device_type(self, obj):
-        if obj['occupied'] and (device := obj['device']):
-            return str(device.device_type)
+    @extend_schema_field(OpenApiTypes.STR)  
+    def get_description(self, obj):  
+        return f'{obj["device"]}' if obj['device'] else None  

--- a/netbox/dcim/api/serializers_/rackunits.py
+++ b/netbox/dcim/api/serializers_/rackunits.py
@@ -1,7 +1,7 @@
+from django.utils.translation import gettext as _
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
-from django.utils.translation import gettext as _
 
 from dcim.choices import *
 from netbox.api.fields import ChoiceField
@@ -26,17 +26,19 @@ class RackUnitSerializer(serializers.Serializer):
     device = DeviceSerializer(nested=True, read_only=True)
     occupied = serializers.BooleanField(read_only=True)
     display = serializers.SerializerMethodField(read_only=True)
-    description = serializers.SerializerMethodField(read_only=True)
+    device_display = serializers.SerializerMethodField(read_only=True)
+    device_type = serializers.SerializerMethodField(read_only=True)
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_display(self, obj):
-        display = obj['name']
-        if obj['occupied'] and (device := obj['device']):
-            return _('{rack_unit} - {device}').format(rack_unit=display, device=device)
-
-        return display
+        return obj['name']
 
     @extend_schema_field(OpenApiTypes.STR)
-    def get_description(self, obj):
+    def get_device_display(self, obj):
+        if obj['occupied'] and (device := obj['device']):
+            return _('{rack_unit} - {device}').format(rack_unit=obj['name'], device=device)
+
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_device_type(self, obj):
         if obj['occupied'] and (device := obj['device']):
             return str(device.device_type)

--- a/netbox/dcim/api/serializers_/rackunits.py
+++ b/netbox/dcim/api/serializers_/rackunits.py
@@ -31,6 +31,6 @@ class RackUnitSerializer(serializers.Serializer):
     def get_display(self, obj):
         return obj['name']
 
-    @extend_schema_field(OpenApiTypes.STR)  
-    def get_description(self, obj):  
-        return f'{obj["device"]}' if obj['device'] else None  
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_description(self, obj):
+        return f'{obj["device"]}' if obj['device'] else None

--- a/netbox/dcim/api/serializers_/rackunits.py
+++ b/netbox/dcim/api/serializers_/rackunits.py
@@ -37,6 +37,7 @@ class RackUnitSerializer(serializers.Serializer):
     def get_device_display(self, obj):
         if obj['occupied'] and (device := obj['device']):
             return _('{rack_unit} - {device}').format(rack_unit=obj['name'], device=device)
+        return obj['name']
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_device_type(self, obj):

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -590,8 +590,6 @@ class DeviceForm(TenancyForm, PrimaryModelForm):
             api_url='/api/dcim/racks/{{rack}}/elevation/',
             attrs={
                 'ts-disabled-field': 'device',
-                'ts-label-field': 'device_display',
-                'ts-description-field': 'device_type',
                 'data-dynamic-params': '[{"fieldName":"face","queryParam":"face"}]'
             },
         )

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -590,6 +590,8 @@ class DeviceForm(TenancyForm, PrimaryModelForm):
             api_url='/api/dcim/racks/{{rack}}/elevation/',
             attrs={
                 'ts-disabled-field': 'device',
+                'ts-label-field': 'device_display',
+                'ts-description-field': 'device_type',
                 'data-dynamic-params': '[{"fieldName":"face","queryParam":"face"}]'
             },
         )

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -451,32 +451,32 @@ class RackTest(APIViewTestCases.APIViewTestCase):
         response = self.client.get(f'{url}?q=U10', **self.header)
         self.assertEqual(response.data['count'], 2)
 
-    def test_get_rack_elevation_display_includes_occupying_device(self):
+    def test_get_rack_elevation_description_is_occupying_device_name(self):
         """
         Verify occupied rack units include the occupying device in their display label.
         """
         rack = Rack.objects.first()
+        self.add_permissions('dcim.view_rack', 'dcim.view_device')
+        url = reverse('dcim-api:rack-elevation', kwargs={'pk': rack.pk})
+
         device = create_test_device(
             name='Device A',
             site=rack.site,
             rack=rack,
-            position=10,
+            position=40,
             face=DeviceFaceChoices.FACE_FRONT,
         )
 
-        self.add_permissions('dcim.view_rack', 'dcim.view_device')
-        url = reverse('dcim-api:rack-elevation', kwargs={'pk': rack.pk})
+        # Retrieve all units
         response = self.client.get(url, **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
 
-        occupied_unit = next(unit for unit in response.data['results'] if unit['name'] == 'U10')
-        unoccupied_unit = next(unit for unit in response.data['results'] if unit['name'] == 'U11')
-
+        occupied_unit = next(unit for unit in response.data['results'] if unit['name'] == 'U40')
         self.assertEqual(occupied_unit['device']['id'], device.pk)
-        self.assertEqual(occupied_unit['display'], 'U10')
         self.assertEqual(occupied_unit['description'], f'{device}')
-        self.assertEqual(unoccupied_unit['device'], None)
-        self.assertEqual(unoccupied_unit['display'], 'U11')
+
+        unoccupied_unit = next(unit for unit in response.data['results'] if unit['name'] == 'U39')
+        self.assertEqual(occupied_unit['device'], None)
         self.assertEqual(unoccupied_unit['description'], None)
 
     def test_get_rack_elevation_svg(self):

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -474,12 +474,10 @@ class RackTest(APIViewTestCases.APIViewTestCase):
 
         self.assertEqual(occupied_unit['device']['id'], device.pk)
         self.assertEqual(occupied_unit['display'], 'U10')
-        self.assertEqual(occupied_unit['device_display'], f'U10 - {device}')
-        self.assertEqual(occupied_unit['device_type'], str(device.device_type))
+        self.assertEqual(occupied_unit['description'], f'{device}')
         self.assertEqual(unoccupied_unit['device'], None)
         self.assertEqual(unoccupied_unit['display'], 'U11')
-        self.assertEqual(unoccupied_unit['device_display'], None)
-        self.assertEqual(unoccupied_unit['device_type'], None)
+        self.assertEqual(unoccupied_unit['description'], None)
 
     def test_get_rack_elevation_svg(self):
         """

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -473,9 +473,13 @@ class RackTest(APIViewTestCases.APIViewTestCase):
         unoccupied_unit = next(unit for unit in response.data['results'] if unit['name'] == 'U11')
 
         self.assertEqual(occupied_unit['device']['id'], device.pk)
-        self.assertEqual(occupied_unit['display'], f'U10 - {device}')
-        self.assertEqual(occupied_unit['description'], str(device.device_type))
+        self.assertEqual(occupied_unit['display'], 'U10')
+        self.assertEqual(occupied_unit['device_display'], f'U10 - {device}')
+        self.assertEqual(occupied_unit['device_type'], str(device.device_type))
+        self.assertEqual(unoccupied_unit['device'], None)
         self.assertEqual(unoccupied_unit['display'], 'U11')
+        self.assertEqual(unoccupied_unit['device_display'], None)
+        self.assertEqual(unoccupied_unit['device_type'], None)
 
     def test_get_rack_elevation_svg(self):
         """

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -476,7 +476,7 @@ class RackTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(occupied_unit['description'], f'{device}')
 
         unoccupied_unit = next(unit for unit in response.data['results'] if unit['name'] == 'U39')
-        self.assertEqual(occupied_unit['device'], None)
+        self.assertEqual(unoccupied_unit['device'], None)
         self.assertEqual(unoccupied_unit['description'], None)
 
     def test_get_rack_elevation_svg(self):

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -451,6 +451,32 @@ class RackTest(APIViewTestCases.APIViewTestCase):
         response = self.client.get(f'{url}?q=U10', **self.header)
         self.assertEqual(response.data['count'], 2)
 
+    def test_get_rack_elevation_display_includes_occupying_device(self):
+        """
+        Verify occupied rack units include the occupying device in their display label.
+        """
+        rack = Rack.objects.first()
+        device = create_test_device(
+            name='Device A',
+            site=rack.site,
+            rack=rack,
+            position=10,
+            face=DeviceFaceChoices.FACE_FRONT,
+        )
+
+        self.add_permissions('dcim.view_rack', 'dcim.view_device')
+        url = reverse('dcim-api:rack-elevation', kwargs={'pk': rack.pk})
+        response = self.client.get(url, **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
+        occupied_unit = next(unit for unit in response.data['results'] if unit['name'] == 'U10')
+        unoccupied_unit = next(unit for unit in response.data['results'] if unit['name'] == 'U11')
+
+        self.assertEqual(occupied_unit['device']['id'], device.pk)
+        self.assertEqual(occupied_unit['display'], f'U10 - {device}')
+        self.assertEqual(occupied_unit['description'], str(device.device_type))
+        self.assertEqual(unoccupied_unit['display'], 'U11')
+
     def test_get_rack_elevation_svg(self):
         """
         GET a single rack elevation in SVG format.

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -453,7 +453,7 @@ class RackTest(APIViewTestCases.APIViewTestCase):
 
     def test_get_rack_elevation_description_is_occupying_device_name(self):
         """
-        Verify occupied rack units include the occupying device in their display label.
+        Verify occupied rack units include the occupying device in their description.
         """
         rack = Rack.objects.first()
         self.add_permissions('dcim.view_rack', 'dcim.view_device')


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #20808 

<!--
    Please include a summary of the proposed changes below.
-->

Added the name and device type of the racked device inside the device rack position select.

<img width="861" height="302" alt="image" src="https://github.com/user-attachments/assets/cfe735eb-e6c0-4ecb-983c-392c27916f61" />
