### PR TITLE
Fixes #21747: Skip search caching when encountering an invalid schema during migrations

### DIFF
--- a/netbox/netbox/search/backends.py
+++ b/netbox/netbox/search/backends.py
@@ -5,7 +5,7 @@ import netaddr
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
-from django.db import OperationalError, ProgrammingError
+from django.db import ProgrammingError
 from django.db.models import F, Q, Window, prefetch_related_objects
 from django.db.models.fields.related import ForeignKey
 from django.db.models.functions import window
@@ -69,7 +69,7 @@ class SearchBackend:
         """
         try:
             self.cache(instance, remove_existing=not created)
-        except (ProgrammingError, OperationalError) as e:
+        except ProgrammingError as e:
             # The schema may be incomplete during migrations; skip caching.
             logger.warning(f"Skipping search cache update due to schema error: {e}")
             pass

--- a/netbox/netbox/search/backends.py
+++ b/netbox/netbox/search/backends.py
@@ -4,6 +4,7 @@ import netaddr
 from django.conf import settings
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ImproperlyConfigured
+from django.db import OperationalError, ProgrammingError
 from django.db.models import F, Q, Window, prefetch_related_objects
 from django.db.models.fields.related import ForeignKey
 from django.db.models.functions import window
@@ -63,7 +64,11 @@ class SearchBackend:
         """
         Receiver for the post_save signal, responsible for caching object creation/changes.
         """
-        self.cache(instance, remove_existing=not created)
+        try:
+            self.cache(instance, remove_existing=not created)
+        except (ProgrammingError, OperationalError):
+            # The schema may be incomplete during migrations; skip caching.
+            pass
 
     def removal_handler(self, sender, instance, **kwargs):
         """

--- a/netbox/netbox/search/backends.py
+++ b/netbox/netbox/search/backends.py
@@ -1,3 +1,4 @@
+import logging
 from collections import defaultdict
 
 import netaddr
@@ -24,6 +25,8 @@ from . import FieldTypes, LookupTypes, get_indexer
 
 DEFAULT_LOOKUP_TYPE = LookupTypes.PARTIAL
 MAX_RESULTS = 1000
+
+logger = logging.getLogger(__name__)
 
 
 class SearchBackend:
@@ -66,8 +69,9 @@ class SearchBackend:
         """
         try:
             self.cache(instance, remove_existing=not created)
-        except (ProgrammingError, OperationalError):
+        except (ProgrammingError, OperationalError) as e:
             # The schema may be incomplete during migrations; skip caching.
+            logger.warning(f"Skipping search cache update due to schema error: {e}")
             pass
 
     def removal_handler(self, sender, instance, **kwargs):


### PR DESCRIPTION
### Fixes: #21747

The search backend should silently capture and ignore exceptions relating to the database schema when running in a database migration.