### PR TITLE
Fix {module} placeholder resolution in module bay position field

### DIFF
--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -191,9 +191,6 @@ class ModularComponentTemplateModel(ComponentTemplateModel):
     def resolve_label(self, module):
         return self._resolve_module_placeholder(self.label, module)
 
-    def resolve_position(self, module):
-        return self._resolve_module_placeholder(self.position, module)
-
 
 class ConsolePortTemplate(ModularComponentTemplateModel):
     """
@@ -721,6 +718,9 @@ class ModuleBayTemplate(ModularComponentTemplateModel):
     class Meta(ModularComponentTemplateModel.Meta):
         verbose_name = _('module bay template')
         verbose_name_plural = _('module bay templates')
+
+    def resolve_position(self, module):
+        return self._resolve_module_placeholder(self.position, module)
 
     def instantiate(self, **kwargs):
         return self.component_model(

--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -177,29 +177,22 @@ class ModularComponentTemplateModel(ComponentTemplateModel):
         modules.reverse()
         return modules
 
-    def resolve_name(self, module):
-        if MODULE_TOKEN not in self.name:
-            return self.name
+    def _resolve_module_placeholder(self, value, module):
+        if MODULE_TOKEN not in value or not module:
+            return value
+        modules = self._get_module_tree(module)
+        for m in modules:
+            value = value.replace(MODULE_TOKEN, m.module_bay.position, 1)
+        return value
 
-        if module:
-            modules = self._get_module_tree(module)
-            name = self.name
-            for module in modules:
-                name = name.replace(MODULE_TOKEN, module.module_bay.position, 1)
-            return name
-        return self.name
+    def resolve_name(self, module):
+        return self._resolve_module_placeholder(self.name, module)
 
     def resolve_label(self, module):
-        if MODULE_TOKEN not in self.label:
-            return self.label
+        return self._resolve_module_placeholder(self.label, module)
 
-        if module:
-            modules = self._get_module_tree(module)
-            label = self.label
-            for module in modules:
-                label = label.replace(MODULE_TOKEN, module.module_bay.position, 1)
-            return label
-        return self.label
+    def resolve_position(self, module):
+        return self._resolve_module_placeholder(self.position, module)
 
 
 class ConsolePortTemplate(ModularComponentTemplateModel):
@@ -733,7 +726,7 @@ class ModuleBayTemplate(ModularComponentTemplateModel):
         return self.component_model(
             name=self.resolve_name(kwargs.get('module')),
             label=self.resolve_label(kwargs.get('module')),
-            position=self.position,
+            position=self.resolve_position(kwargs.get('module')),
             **kwargs
         )
     instantiate.do_not_call_in_templates = True

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -849,6 +849,50 @@ class ModuleBayTestCase(TestCase):
         nested_bay = module.modulebays.get(name='SFP A-21')
         self.assertEqual(nested_bay.label, 'A-21')
 
+    @tag('regression')  # #20467
+    def test_nested_module_bay_position_resolution(self):
+        """Test that {module} in a module bay template's position field is resolved when the module is installed."""
+        manufacturer = Manufacturer.objects.first()
+        site = Site.objects.first()
+        device_role = DeviceRole.objects.first()
+
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer,
+            model='Device with Position Test',
+            slug='device-with-position-test'
+        )
+        ModuleBayTemplate.objects.create(
+            device_type=device_type,
+            name='Slot 1',
+            position='1'
+        )
+
+        module_type = ModuleType.objects.create(
+            manufacturer=manufacturer,
+            model='Module with Position Placeholder'
+        )
+        ModuleBayTemplate.objects.create(
+            module_type=module_type,
+            name='Sub-bay {module}-1',
+            position='{module}-1'
+        )
+
+        device = Device.objects.create(
+            name='Position Test Device',
+            device_type=device_type,
+            role=device_role,
+            site=site
+        )
+        module_bay = device.modulebays.get(name='Slot 1')
+        module = Module.objects.create(
+            device=device,
+            module_bay=module_bay,
+            module_type=module_type
+        )
+
+        nested_bay = module.modulebays.get(name='Sub-bay 1-1')
+        self.assertEqual(nested_bay.position, '1-1')
+
     @tag('regression')  # #20912
     def test_module_bay_parent_cleared_when_module_removed(self):
         """Test that the parent field is properly cleared when a module bay's module assignment is removed"""


### PR DESCRIPTION
### Fixes: #20467

## Summary

Fixes a bug where the `{module}` placeholder in a `ModuleBayTemplate`'s position field was not being resolved when a module was installed, leaving the literal string `{module}` in the position value.

The `{module}` placeholder already worked correctly in the `name` and `label` fields — this brings `position` into parity.

## Changes

| File | Change |
|------|--------|
| `dcim/models/device_component_templates.py` | Add `resolve_position()` method; consolidate shared resolution logic into `_resolve_module_placeholder()` to eliminate duplication across `resolve_name`, `resolve_label`, and `resolve_position` |
| `dcim/tests/test_models.py` | Regression test: module bay template with `position='{module}-1'` resolves to `1-1` when installed under a parent bay with position `1` |

## Testing

All existing dcim model and form tests pass (60 tests). Added one regression test that verifies:

1. Create a device type with a module bay (position `1`)
2. Create a module type with a sub-bay template using `position='{module}-1'`
3. Install the module — verify the sub-bay's position resolves to `1-1`