### PR TITLE
fix regression from #14329

### DIFF
--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -279,8 +279,8 @@ class ObjectChangeView(generic.ObjectView):
                 exclude=['last_updated'],
             )
         else:
-            diff_added = None
-            diff_removed = None
+            diff_added = {}
+            diff_removed = {}
 
         return {
             'diff_added': diff_added,


### PR DESCRIPTION
Fixes regression for viewing created changelog diffs introduced in #14329, scenario is simple:

1. create an object (like site)
2. view the changelog for the create
