### PR TITLE
Fixes #21749: Prevent sorting on unsupported Provider, Member, and Action Object columns

### DIFF
--- a/netbox/circuits/tables/circuits.py
+++ b/netbox/circuits/tables/circuits.py
@@ -190,14 +190,16 @@ class CircuitGroupAssignmentTable(NetBoxTable):
     provider = tables.Column(
         accessor='member__provider',
         verbose_name=_('Provider'),
-        linkify=True
+        orderable=False,
+        linkify=True,
     )
     member_type = columns.ContentTypeColumn(
         verbose_name=_('Type')
     )
     member = tables.Column(
         verbose_name=_('Circuit'),
-        linkify=True
+        orderable=False,
+        linkify=True,
     )
     priority = tables.Column(
         verbose_name=_('Priority'),

--- a/netbox/circuits/tests/test_tables.py
+++ b/netbox/circuits/tests/test_tables.py
@@ -1,23 +1,48 @@
 from django.test import RequestFactory, TestCase, tag
 
-from circuits.models import CircuitTermination
-from circuits.tables import CircuitTerminationTable
+from circuits.models import CircuitGroupAssignment, CircuitTermination
+from circuits.tables import CircuitGroupAssignmentTable, CircuitTerminationTable
 
 
 @tag('regression')
 class CircuitTerminationTableTest(TestCase):
     def test_every_orderable_field_does_not_throw_exception(self):
         terminations = CircuitTermination.objects.all()
-        disallowed = {'actions', }
+        disallowed = {
+            'actions',
+        }
 
         orderable_columns = [
-            column.name for column in CircuitTerminationTable(terminations).columns
+            column.name
+            for column in CircuitTerminationTable(terminations).columns
             if column.orderable and column.name not in disallowed
         ]
-        fake_request = RequestFactory().get("/")
+        fake_request = RequestFactory().get('/')
 
         for col in orderable_columns:
-            for dir in ('-', ''):
+            for direction in ('-', ''):
                 table = CircuitTerminationTable(terminations)
-                table.order_by = f'{dir}{col}'
+                table.order_by = f'{direction}{col}'
+                table.as_html(fake_request)
+
+
+@tag('regression')
+class CircuitGroupAssignmentTableTest(TestCase):
+    def test_every_orderable_field_does_not_throw_exception(self):
+        assignment = CircuitGroupAssignment.objects.all()
+        disallowed = {
+            'actions',
+        }
+
+        orderable_columns = [
+            column.name
+            for column in CircuitGroupAssignmentTable(assignment).columns
+            if column.orderable and column.name not in disallowed
+        ]
+        fake_request = RequestFactory().get('/')
+
+        for col in orderable_columns:
+            for direction in ('-', ''):
+                table = CircuitGroupAssignmentTable(assignment)
+                table.order_by = f'{direction}{col}'
                 table.as_html(fake_request)

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -510,8 +510,9 @@ class EventRuleTable(NetBoxTable):
         verbose_name=_('Type'),
     )
     action_object = tables.Column(
-        linkify=True,
         verbose_name=_('Object'),
+        orderable=False,
+        linkify=True,
     )
     object_types = columns.ContentTypesColumn(
         verbose_name=_('Object Types'),

--- a/netbox/extras/tests/test_tables.py
+++ b/netbox/extras/tests/test_tables.py
@@ -1,0 +1,24 @@
+from django.test import RequestFactory, TestCase, tag
+
+from extras.models import EventRule
+from extras.tables import EventRuleTable
+
+
+@tag('regression')
+class EventRuleTableTest(TestCase):
+    def test_every_orderable_field_does_not_throw_exception(self):
+        rule = EventRule.objects.all()
+        disallowed = {
+            'actions',
+        }
+
+        orderable_columns = [
+            column.name for column in EventRuleTable(rule).columns if column.orderable and column.name not in disallowed
+        ]
+        fake_request = RequestFactory().get('/')
+
+        for col in orderable_columns:
+            for direction in ('-', ''):
+                table = EventRuleTable(rule)
+                table.order_by = f'{direction}{col}'
+                table.as_html(fake_request)


### PR DESCRIPTION
### Fixes: #21749

Mark the `provider`, `member`, and `action_object` table columns as non-orderable.

These columns rely on complex accessors that do not map cleanly to database ordering, which can cause table rendering errors when sorting is applied. Marking them as non-orderable fixes the immediate issue while keeping this change focused on the bug itself.

Broader table-ordering test coverage will be handled separately as housekeeping work.