### PR TITLE
feat(settings): Add NETBOX_COPILOT_URL configuration and URL validation

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -661,8 +661,15 @@ CENSUS_URL = 'https://census.netbox.oss.netboxlabs.com/api/v1/'
 # NetBox Copilot
 #
 
-NETBOX_COPILOT_URL = 'https://static.copilot.netboxlabs.ai/load.js'
+NETBOX_COPILOT_URL = getattr(configuration, 'NETBOX_COPILOT_URL', 'https://static.copilot.netboxlabs.ai/load.js')
 
+if NETBOX_COPILOT_URL:
+    try:
+        URLValidator()(NETBOX_COPILOT_URL)
+    except ValidationError:
+        raise ImproperlyConfigured(
+            "NETBOX_COPILOT_URL must be a valid URL. Example: https://static.copilot.netboxlabs.ai/load.js"
+        )
 
 #
 # Django social auth


### PR DESCRIPTION
This pull request updates the configuration for the NetBox Copilot integration to allow dynamic configuration of the Copilot URL and to enforce validation for its format. The main change is to make the Copilot URL configurable via the `configuration` object and to ensure that any provided URL is valid.

Configuration improvements:

* Updated the assignment of `NETBOX_COPILOT_URL` in `settings.py` to use the value from `configuration.NETBOX_COPILOT_URL` if present, falling back to the default URL otherwise.
* Added validation for `NETBOX_COPILOT_URL` using Django's `URLValidator`, raising an `ImproperlyConfigured` exception if the URL is invalid.