### PR TITLE
Fixes #21709: Use `@register_search` in plugin search docs

### DIFF
--- a/docs/plugins/development/search.md
+++ b/docs/plugins/development/search.md
@@ -1,12 +1,14 @@
 # Search
 
-Plugins can define and register their own models to extend NetBox's core search functionality. Typically, a plugin will include a file named `search.py`, which holds all search indexes for its models (see the example below).
+Plugins can define and register their own models to extend NetBox's core search functionality. Typically, a plugin will include a file named `search.py`, which holds all search indexes for its models.
 
-```python
+```python title="search.py"
 # search.py
-from netbox.search import SearchIndex
+from netbox.search import SearchIndex, register_search
+
 from .models import MyModel
 
+@register_search
 class MyModelIndex(SearchIndex):
     model = MyModel
     fields = (
@@ -17,15 +19,11 @@ class MyModelIndex(SearchIndex):
     display_attrs = ('site', 'device', 'status', 'description')
 ```
 
-Fields listed in `display_attrs` will not be cached for search, but will be displayed alongside the object when it appears in global search results. This is helpful for conveying to the user additional information about an object.
+Decorate each `SearchIndex` subclass with `@register_search` to register it with NetBox. When using the default `search.py` module, no additional `indexes = [...]` list is required.
 
-To register one or more indexes with NetBox, define a list named `indexes` at the end of this file:
-
-```python
-indexes = [MyModelIndex]
-```
+Fields listed in `display_attrs` are not cached for matching, but they are displayed alongside the object in global search results to provide additional context.
 
 !!! tip
-    The path to the list of search indexes can be modified by setting `search_indexes` in the PluginConfig instance.
+    The legacy `indexes = [...]` list remains supported via `PluginConfig.search_indexes` for backward compatibility and custom loading patterns.
 
 ::: netbox.search.SearchIndex


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #21709

<!--
    Please include a summary of the proposed changes below.
-->
Align the plugin search example with the recommended registration pattern used in the general search documentation and NetBox core.

Replace the legacy `indexes = [...]` example with decorator-based registration to make the preferred approach clearer for plugin authors.