### PR TITLE
Fixes: #21696 - Upgrade to django-rq==4.0.1

### DIFF
--- a/netbox/core/api/views.py
+++ b/netbox/core/api/views.py
@@ -2,7 +2,7 @@ from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
 from django_rq.queues import get_redis_connection
-from django_rq.settings import QUEUES_LIST
+from django_rq.settings import get_queues_list
 from django_rq.utils import get_statistics
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import OpenApiParameter, extend_schema
@@ -195,7 +195,7 @@ class BackgroundWorkerViewSet(BaseRQViewSet):
         return 'Background Workers'
 
     def get_data(self):
-        config = QUEUES_LIST[0]
+        config = get_queues_list()[0]
         return Worker.all(get_redis_connection(config['connection_config']))
 
     @extend_schema(
@@ -205,7 +205,7 @@ class BackgroundWorkerViewSet(BaseRQViewSet):
     )
     def retrieve(self, request, name):
         # all the RQ queues should use the same connection
-        config = QUEUES_LIST[0]
+        config = get_queues_list()[0]
         workers = Worker.all(get_redis_connection(config['connection_config']))
         worker = next((item for item in workers if item.name == name), None)
         if not worker:
@@ -229,7 +229,7 @@ class BackgroundTaskViewSet(BaseRQViewSet):
         return get_rq_jobs()
 
     def get_task_from_id(self, task_id):
-        config = QUEUES_LIST[0]
+        config = get_queues_list()[0]
         task = RQ_Job.fetch(task_id, connection=get_redis_connection(config['connection_config']))
         if not task:
             raise Http404

--- a/netbox/core/tests/test_views.py
+++ b/netbox/core/tests/test_views.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from django.urls import reverse
 from django.utils import timezone
 from django_rq import get_queue
-from django_rq.settings import QUEUES_MAP
+from django_rq.settings import get_queues_map
 from django_rq.workers import get_worker
 from rq.job import Job as RQ_Job
 from rq.job import JobStatus
@@ -189,7 +189,7 @@ class BackgroundTaskTestCase(TestCase):
     def test_background_tasks_list_default(self):
         queue = get_queue('default')
         queue.enqueue(self.dummy_job_default)
-        queue_index = QUEUES_MAP['default']
+        queue_index = get_queues_map()['default']
 
         response = self.client.get(reverse('core:background_task_list', args=[queue_index, 'queued']))
         self.assertEqual(response.status_code, 200)
@@ -198,7 +198,7 @@ class BackgroundTaskTestCase(TestCase):
     def test_background_tasks_list_high(self):
         queue = get_queue('high')
         queue.enqueue(self.dummy_job_high)
-        queue_index = QUEUES_MAP['high']
+        queue_index = get_queues_map()['high']
 
         response = self.client.get(reverse('core:background_task_list', args=[queue_index, 'queued']))
         self.assertEqual(response.status_code, 200)
@@ -207,7 +207,7 @@ class BackgroundTaskTestCase(TestCase):
     def test_background_tasks_list_finished(self):
         queue = get_queue('default')
         job = queue.enqueue(self.dummy_job_default)
-        queue_index = QUEUES_MAP['default']
+        queue_index = get_queues_map()['default']
 
         registry = FinishedJobRegistry(queue.name, queue.connection)
         registry.add(job, 2)
@@ -218,7 +218,7 @@ class BackgroundTaskTestCase(TestCase):
     def test_background_tasks_list_failed(self):
         queue = get_queue('default')
         job = queue.enqueue(self.dummy_job_default)
-        queue_index = QUEUES_MAP['default']
+        queue_index = get_queues_map()['default']
 
         registry = FailedJobRegistry(queue.name, queue.connection)
         registry.add(job, 2)
@@ -229,7 +229,7 @@ class BackgroundTaskTestCase(TestCase):
     def test_background_tasks_scheduled(self):
         queue = get_queue('default')
         queue.enqueue_at(datetime.now(), self.dummy_job_default)
-        queue_index = QUEUES_MAP['default']
+        queue_index = get_queues_map()['default']
 
         response = self.client.get(reverse('core:background_task_list', args=[queue_index, 'scheduled']))
         self.assertEqual(response.status_code, 200)
@@ -238,7 +238,7 @@ class BackgroundTaskTestCase(TestCase):
     def test_background_tasks_list_deferred(self):
         queue = get_queue('default')
         job = queue.enqueue(self.dummy_job_default)
-        queue_index = QUEUES_MAP['default']
+        queue_index = get_queues_map()['default']
 
         registry = DeferredJobRegistry(queue.name, queue.connection)
         registry.add(job, 2)
@@ -335,7 +335,7 @@ class BackgroundTaskTestCase(TestCase):
         worker2 = get_worker('high')
         worker2.register_birth()
 
-        queue_index = QUEUES_MAP['default']
+        queue_index = get_queues_map()['default']
         response = self.client.get(reverse('core:worker_list', args=[queue_index]))
         self.assertEqual(response.status_code, 200)
         self.assertIn(str(worker1.name), str(response.content))

--- a/netbox/core/utils.py
+++ b/netbox/core/utils.py
@@ -1,7 +1,7 @@
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 from django_rq.queues import get_queue, get_queue_by_index, get_redis_connection
-from django_rq.settings import QUEUES_LIST, get_queues_map
+from django_rq.settings import get_queues_list, get_queues_map
 from django_rq.utils import get_jobs, stop_jobs
 from rq import requeue_job
 from rq.exceptions import NoSuchJobError
@@ -31,7 +31,7 @@ def get_rq_jobs():
     """
     jobs = set()
 
-    for queue in QUEUES_LIST:
+    for queue in get_queues_list():
         queue = get_queue(queue['name'])
         jobs.update(queue.get_jobs())
 
@@ -78,7 +78,7 @@ def delete_rq_job(job_id):
     """
     Delete the specified RQ job.
     """
-    config = QUEUES_LIST[0]
+    config = get_queues_list()[0]
     try:
         job = RQ_Job.fetch(job_id, connection=get_redis_connection(config['connection_config']),)
     except NoSuchJobError:
@@ -96,7 +96,7 @@ def requeue_rq_job(job_id):
     """
     Requeue the specified RQ job.
     """
-    config = QUEUES_LIST[0]
+    config = get_queues_list()[0]
     try:
         job = RQ_Job.fetch(job_id, connection=get_redis_connection(config['connection_config']),)
     except NoSuchJobError:
@@ -112,7 +112,7 @@ def enqueue_rq_job(job_id):
     """
     Enqueue the specified RQ job.
     """
-    config = QUEUES_LIST[0]
+    config = get_queues_list()[0]
     try:
         job = RQ_Job.fetch(job_id, connection=get_redis_connection(config['connection_config']),)
     except NoSuchJobError:
@@ -144,7 +144,7 @@ def stop_rq_job(job_id):
     """
     Stop the specified RQ job.
     """
-    config = QUEUES_LIST[0]
+    config = get_queues_list()[0]
     try:
         job = RQ_Job.fetch(job_id, connection=get_redis_connection(config['connection_config']),)
     except NoSuchJobError:

--- a/netbox/core/utils.py
+++ b/netbox/core/utils.py
@@ -1,7 +1,7 @@
 from django.http import Http404
 from django.utils.translation import gettext_lazy as _
 from django_rq.queues import get_queue, get_queue_by_index, get_redis_connection
-from django_rq.settings import QUEUES_LIST, QUEUES_MAP
+from django_rq.settings import QUEUES_LIST, get_queues_map
 from django_rq.utils import get_jobs, stop_jobs
 from rq import requeue_job
 from rq.exceptions import NoSuchJobError
@@ -84,7 +84,7 @@ def delete_rq_job(job_id):
     except NoSuchJobError:
         raise Http404(_("Job {job_id} not found").format(job_id=job_id))
 
-    queue_index = QUEUES_MAP[job.origin]
+    queue_index = get_queues_map()[job.origin]
     queue = get_queue_by_index(queue_index)
 
     # Remove job id from queue and delete the actual job
@@ -102,7 +102,7 @@ def requeue_rq_job(job_id):
     except NoSuchJobError:
         raise Http404(_("Job {id} not found.").format(id=job_id))
 
-    queue_index = QUEUES_MAP[job.origin]
+    queue_index = get_queues_map()[job.origin]
     queue = get_queue_by_index(queue_index)
 
     requeue_job(job_id, connection=queue.connection, serializer=queue.serializer)
@@ -118,7 +118,7 @@ def enqueue_rq_job(job_id):
     except NoSuchJobError:
         raise Http404(_("Job {id} not found.").format(id=job_id))
 
-    queue_index = QUEUES_MAP[job.origin]
+    queue_index = get_queues_map()[job.origin]
     queue = get_queue_by_index(queue_index)
 
     try:
@@ -150,7 +150,7 @@ def stop_rq_job(job_id):
     except NoSuchJobError:
         raise Http404(_("Job {job_id} not found").format(job_id=job_id))
 
-    queue_index = QUEUES_MAP[job.origin]
+    queue_index = get_queues_map()[job.origin]
     queue = get_queue_by_index(queue_index)
 
     return stop_jobs(queue, job_id)[0]

--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -14,7 +14,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
 from django_rq.queues import get_connection, get_queue_by_index, get_redis_connection
-from django_rq.settings import QUEUES_LIST, get_queues_map
+from django_rq.settings import get_queues_list, get_queues_map
 from django_rq.utils import get_statistics
 from rq.exceptions import NoSuchJobError
 from rq.job import Job as RQ_Job
@@ -524,7 +524,7 @@ class BackgroundTaskView(BaseRQView):
 
     def get(self, request, job_id):
         # all the RQ queues should use the same connection
-        config = QUEUES_LIST[0]
+        config = get_queues_list()[0]
         try:
             job = RQ_Job.fetch(job_id, connection=get_redis_connection(config['connection_config']),)
         except NoSuchJobError:
@@ -640,7 +640,7 @@ class WorkerView(BaseRQView):
 
     def get(self, request, key):
         # all the RQ queues should use the same connection
-        config = QUEUES_LIST[0]
+        config = get_queues_list()[0]
         worker = Worker.find_by_key('rq:worker:' + key, connection=get_redis_connection(config['connection_config']))
         # Convert microseconds to milliseconds
         worker.total_working_time = worker.total_working_time / 1000

--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -14,7 +14,7 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import View
 from django_rq.queues import get_connection, get_queue_by_index, get_redis_connection
-from django_rq.settings import QUEUES_LIST, QUEUES_MAP
+from django_rq.settings import QUEUES_LIST, get_queues_map
 from django_rq.utils import get_statistics
 from rq.exceptions import NoSuchJobError
 from rq.job import Job as RQ_Job
@@ -530,7 +530,7 @@ class BackgroundTaskView(BaseRQView):
         except NoSuchJobError:
             raise Http404(_("Job {job_id} not found").format(job_id=job_id))
 
-        queue_index = QUEUES_MAP[job.origin]
+        queue_index = get_queues_map()[job.origin]
         queue = get_queue_by_index(queue_index)
 
         try:

--- a/netbox/netbox/configuration_testing.py
+++ b/netbox/netbox/configuration_testing.py
@@ -20,6 +20,10 @@ PLUGINS = [
     'netbox.tests.dummy_plugin',
 ]
 
+RQ = {
+    'COMMIT_MODE': 'auto',
+}
+
 REDIS = {
     'tasks': {
         'HOST': 'localhost',

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -168,6 +168,7 @@ REMOTE_AUTH_USER_FIRST_NAME = getattr(configuration, 'REMOTE_AUTH_USER_FIRST_NAM
 REMOTE_AUTH_USER_LAST_NAME = getattr(configuration, 'REMOTE_AUTH_USER_LAST_NAME', 'HTTP_REMOTE_USER_LAST_NAME')
 # Required by extras/migrations/0109_script_models.py
 REPORTS_ROOT = getattr(configuration, 'REPORTS_ROOT', os.path.join(BASE_DIR, 'reports')).rstrip('/')
+RQ = getattr(configuration, 'RQ', {})
 RQ_DEFAULT_TIMEOUT = getattr(configuration, 'RQ_DEFAULT_TIMEOUT', 300)
 RQ_RETRY_INTERVAL = getattr(configuration, 'RQ_RETRY_INTERVAL', 60)
 RQ_RETRY_MAX = getattr(configuration, 'RQ_RETRY_MAX', 0)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-pglocks==1.0.4
 django-prometheus==2.4.1
 django-redis==6.0.0
 django-rich==2.2.0
-django-rq==3.2.2
+django-rq==4.0.1
 django-storages==1.14.6
 django-tables2==2.8.0
 django-taggit==6.1.0


### PR DESCRIPTION
### Fixes: #21696

This PR upgrades the pinned version of django-rq to 4.0.1. It makes a few changes to queue map lookup behavior and autocommit defaults (as in recommended usage of the current API) in order to ensure unit tests pass correctly.
