### PR TITLE
Fixes #21808: Prevent errors when viewing Virtual Interfaces without a Virtual Circuit Termination

### DIFF
--- a/netbox/dcim/ui/panels.py
+++ b/netbox/dcim/ui/panels.py
@@ -532,7 +532,7 @@ class VirtualCircuitPanel(panels.ObjectPanel):
 
     def render(self, context):
         obj = context.get('object')
-        if not obj or not obj.is_virtual or not obj.virtual_circuit_termination:
+        if not obj or not obj.is_virtual or not hasattr(obj, 'virtual_circuit_termination'):
             return ''
         ctx = self.get_context(context)
         return render_to_string(self.template_name, ctx, request=ctx.get('request'))


### PR DESCRIPTION
### Fixes: #21808

This fixes a regression in the virtual interface detail view introduced during the UI layout migration.

`VirtualCircuitPanel` accessed `object.virtual_circuit_termination` directly, which can raise `RelatedObjectDoesNotExist` for virtual interfaces without a related termination. This change handles that case gracefully and skips rendering the panel when no termination exists, restoring the previous behavior and preventing a server error when opening the interface detail page.