### PR TITLE
Fixes #21810: Prevent errors when viewing Device pages for Virtual Chassis Members

### DIFF
--- a/netbox/dcim/ui/panels.py
+++ b/netbox/dcim/ui/panels.py
@@ -420,14 +420,23 @@ class VirtualChassisMembersPanel(panels.ObjectPanel):
     """
     A panel which lists all members of a virtual chassis.
     """
+
     template_name = 'dcim/panels/virtual_chassis_members.html'
     title = _('Virtual Chassis Members')
     actions = [
         actions.AddObject(
             'dcim.device',
             url_params={
-                'site': lambda ctx: ctx['object'].master.site_id if ctx['object'].master else '',
-                'rack': lambda ctx: ctx['object'].master.rack_id if ctx['object'].master else '',
+                'site': lambda ctx: (
+                    ctx['virtual_chassis'].master.site_id
+                    if ctx['virtual_chassis'] and ctx['virtual_chassis'].master_id
+                    else ''
+                ),
+                'rack': lambda ctx: (
+                    ctx['virtual_chassis'].master.rack_id
+                    if ctx['virtual_chassis'] and ctx['virtual_chassis'].master_id
+                    else ''
+                ),
             },
         ),
     ]


### PR DESCRIPTION
### Fixes: #21810

This fixes a regression in the device detail view introduced during the UI layout migration.

`VirtualChassisMembersPanel` was building its add-device action from `ctx['object']`, but on the device view `object` is a `Device`, not a `VirtualChassis`. This change uses the panel's `virtual_chassis` context instead and checks for `master_id` before populating the default site and rack parameters, preventing an `AttributeError` when viewing a virtual chassis member that is not the master.