### PR TITLE
Fix AttributeError when an AnonymousUser tries to sort a table

### DIFF
--- a/netbox/netbox/tables/tables.py
+++ b/netbox/netbox/tables/tables.py
@@ -159,7 +159,7 @@ class BaseTable(tables.Table):
         columns = None
         ordering = None
 
-        if self.prefixed_order_by_field in request.GET:
+        if request.user.is_authenticated and self.prefixed_order_by_field in request.GET:
             if request.GET[self.prefixed_order_by_field]:
                 # If an ordering has been specified as a query parameter, save it as the
                 # user's preferred ordering for this table.

--- a/netbox/netbox/tests/test_tables.py
+++ b/netbox/netbox/tests/test_tables.py
@@ -1,3 +1,4 @@
+from django.contrib.auth.models import AnonymousUser
 from django.template import Context, Template
 from django.test import RequestFactory, TestCase
 
@@ -45,6 +46,16 @@ class BaseTableTest(TestCase):
         table.configure(request)
         prefetch_lookups = table.data.data._prefetch_related_lookups
         self.assertEqual(prefetch_lookups, tuple())
+
+    def test_configure_anonymous_user_with_ordering(self):
+        """
+        Verify that table.configure() does not raise an error when an anonymous
+        user sorts a table column.
+        """
+        request = RequestFactory().get('/?sort=name')
+        request.user = AnonymousUser()
+        table = DeviceTable(Device.objects.all())
+        table.configure(request)
 
 
 class TagColumnTable(NetBoxTable):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #21784

Check if a user is logged in before trying to save table sorting preferences.

Also added a test case for this.
