### PR TITLE
Fixes #21498: serialize cabled object models for events when cables are changed

### DIFF
--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -9,6 +9,7 @@ from django_rq import get_queue
 
 from core.events import *
 from core.models import ObjectType
+from dcim.models import CabledObjectModel
 from netbox.config import get_config
 from netbox.constants import RQ_QUEUE_DEFAULT
 from netbox.models.features import has_feature
@@ -107,7 +108,12 @@ def enqueue_event(queue, instance, request, event_type):
             request_id=request.id,           # DEPRECATED, will be removed in NetBox v4.7.0
         )
     # Force serialization of objects prior to them actually being deleted
-    if event_type == OBJECT_DELETED:
+    if (
+        event_type == OBJECT_DELETED
+        # Changing cables deletes related objects such as path traces and makes them inaccessible
+        or isinstance(instance, CabledObjectModel)
+        and getattr(instance, '_prechange_snapshot', {}).get('cable') != instance.cable_id
+    ):
         queue[key]['data'] = serialize_for_event(instance)
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #21498

<!--
    Please include a summary of the proposed changes below.
-->

As reported in #21498 Netbox 4.5.2 and newer result in `CablePath.DoesNotExist` errors when cables are changed if event rules are enabled.

This MR works around this issue by serializing objects in `enqueue_event` like in Netbox 4.5.1 and before if they are instances of `dcim.models.CabledObjectModel` and the cable id differs from that in the prechange snapshot (if set).