### PR TITLE
Fixes #21760: Add 1C2P:2C1P breakout cable profile

### DIFF
--- a/netbox/dcim/cable_profiles.py
+++ b/netbox/dcim/cable_profiles.py
@@ -254,6 +254,21 @@ class Trunk8C4PCableProfile(BaseCableProfile):
     b_connectors = a_connectors
 
 
+class Breakout1C2Px2C1PCableProfile(BaseCableProfile):
+    a_connectors = {
+        1: 2,
+    }
+    b_connectors = {
+        1: 1,
+        2: 1,
+    }
+    _mapping = {
+        (1, 1): (1, 1),
+        (1, 2): (2, 1),
+        (2, 1): (1, 2),
+    }
+
+
 class Breakout1C4Px4C1PCableProfile(BaseCableProfile):
     a_connectors = {
         1: 4,

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1776,6 +1776,7 @@ class CableProfileChoices(ChoiceSet):
     TRUNK_4C8P = 'trunk-4c8p'
     TRUNK_8C4P = 'trunk-8c4p'
     # Breakouts
+    BREAKOUT_1C2P_2C1P = 'breakout-1c2p-2c1p'
     BREAKOUT_1C4P_4C1P = 'breakout-1c4p-4c1p'
     BREAKOUT_1C6P_6C1P = 'breakout-1c6p-6c1p'
     BREAKOUT_2C4P_8C1P_SHUFFLE = 'breakout-2c4p-8c1p-shuffle'
@@ -1815,6 +1816,7 @@ class CableProfileChoices(ChoiceSet):
         (
             _('Breakout'),
             (
+                (BREAKOUT_1C2P_2C1P, _('1C2P:2C1P breakout')),
                 (BREAKOUT_1C4P_4C1P, _('1C4P:4C1P breakout')),
                 (BREAKOUT_1C6P_6C1P, _('1C6P:6C1P breakout')),
                 (BREAKOUT_2C4P_8C1P_SHUFFLE, _('2C4P:8C1P breakout (shuffle)')),

--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -160,6 +160,7 @@ class Cable(PrimaryModel):
             CableProfileChoices.TRUNK_4C6P: cable_profiles.Trunk4C6PCableProfile,
             CableProfileChoices.TRUNK_4C8P: cable_profiles.Trunk4C8PCableProfile,
             CableProfileChoices.TRUNK_8C4P: cable_profiles.Trunk8C4PCableProfile,
+            CableProfileChoices.BREAKOUT_1C2P_2C1P: cable_profiles.Breakout1C2Px2C1PCableProfile,
             CableProfileChoices.BREAKOUT_1C4P_4C1P: cable_profiles.Breakout1C4Px4C1PCableProfile,
             CableProfileChoices.BREAKOUT_1C6P_6C1P: cable_profiles.Breakout1C6Px6C1PCableProfile,
             CableProfileChoices.BREAKOUT_2C4P_8C1P_SHUFFLE: cable_profiles.Breakout2C4Px8C1PShuffleCableProfile,


### PR DESCRIPTION
### Fixes: #21760

Adds 1 connector to 2 ports (1C2P:2C1P) breakout cable profile to allow users to choose a new breakout cable type, e.g. https://www.fs.com/eu-en/products/101800.html

This is enabled by modifying the following three files:
cable_profiles.py, choices.py, and the profile_class property in models/cables.py

Cherry-picked from #21799 (authored by @hexlibris) to cleanly target `main`.