### PR TITLE
Fixes #21825: Fix sorting for multiple incorrectly configured table columns

### DIFF
--- a/netbox/circuits/tables/virtual_circuits.py
+++ b/netbox/circuits/tables/virtual_circuits.py
@@ -95,6 +95,7 @@ class VirtualCircuitTerminationTable(NetBoxTable):
         verbose_name=_('Provider network')
     )
     provider_account = tables.Column(
+        accessor=tables.A('virtual_circuit__provider_account'),
         linkify=True,
         verbose_name=_('Account')
     )
@@ -112,7 +113,7 @@ class VirtualCircuitTerminationTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = VirtualCircuitTermination
         fields = (
-            'pk', 'id', 'virtual_circuit', 'provider', 'provider_network', 'provider_account', 'role', 'interfaces',
+            'pk', 'id', 'virtual_circuit', 'provider', 'provider_network', 'provider_account', 'role', 'interface',
             'description', 'created', 'last_updated', 'actions',
         )
         default_columns = (

--- a/netbox/core/tables/config.py
+++ b/netbox/core/tables/config.py
@@ -19,6 +19,7 @@ REVISION_BUTTONS = """
 class ConfigRevisionTable(NetBoxTable):
     is_active = columns.BooleanColumn(
         verbose_name=_('Is Active'),
+        accessor='active',
         false_mark=None
     )
     actions = columns.ActionsColumn(

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -1149,7 +1149,7 @@ class VirtualDeviceContextTable(TenancyColumnsMixin, PrimaryModelTable):
     )
     device = tables.Column(
         verbose_name=_('Device'),
-        order_by=('device___name',),
+        order_by=('device__name',),
         linkify=True
     )
     status = columns.ChoiceFieldColumn(

--- a/netbox/dcim/tables/modules.py
+++ b/netbox/dcim/tables/modules.py
@@ -56,7 +56,9 @@ class ModuleTypeTable(PrimaryModelTable):
         template_code=WEIGHT,
         order_by=('_abs_weight', 'weight_unit')
     )
-    attributes = columns.DictColumn()
+    attributes = columns.DictColumn(
+        orderable=False,
+    )
     module_count = columns.LinkedCountColumn(
         viewname='dcim:module_list',
         url_params={'module_type_id': 'pk'},

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -417,6 +417,7 @@ class NotificationTable(NetBoxTable):
     icon = columns.TemplateColumn(
         template_code=NOTIFICATION_ICON,
         accessor=tables.A('event'),
+        orderable=False,
         attrs={
             'td': {'class': 'w-1'},
             'th': {'class': 'w-1'},
@@ -479,8 +480,8 @@ class WebhookTable(NetBoxTable):
         verbose_name=_('Name'),
         linkify=True
     )
-    ssl_validation = columns.BooleanColumn(
-        verbose_name=_('SSL Validation')
+    ssl_verification = columns.BooleanColumn(
+        verbose_name=_('SSL Verification'),
     )
     owner = tables.Column(
         linkify=True,

--- a/netbox/ipam/tables/vlans.py
+++ b/netbox/ipam/tables/vlans.py
@@ -247,6 +247,6 @@ class VLANTranslationRuleTable(NetBoxTable):
     class Meta(NetBoxTable.Meta):
         model = VLANTranslationRule
         fields = (
-            'pk', 'id', 'name', 'policy', 'local_vid', 'remote_vid', 'description', 'tags', 'created', 'last_updated',
+            'pk', 'id', 'policy', 'local_vid', 'remote_vid', 'description', 'tags', 'created', 'last_updated',
         )
         default_columns = ('pk', 'policy', 'local_vid', 'remote_vid', 'description')

--- a/netbox/vpn/tables/tunnels.py
+++ b/netbox/vpn/tables/tunnels.py
@@ -66,7 +66,7 @@ class TunnelTable(TenancyColumnsMixin, ContactsColumnMixin, PrimaryModelTable):
         model = Tunnel
         fields = (
             'pk', 'id', 'name', 'group', 'status', 'encapsulation', 'ipsec_profile', 'tenant', 'tenant_group',
-            'tunnel_id', 'termination_count', 'description', 'contacts', 'comments', 'tags', 'created',
+            'tunnel_id', 'terminations_count', 'description', 'contacts', 'comments', 'tags', 'created',
             'last_updated',
         )
         default_columns = ('pk', 'name', 'group', 'status', 'encapsulation', 'tenant', 'terminations_count')


### PR DESCRIPTION
### Fixes: #21825

This PR fixes several broken sortable columns caused by incorrect accessors, invalid field references, and columns being marked sortable when sorting is not actually supported.

It updates the affected table definitions by correcting accessor paths and field names, removing the deprecated `name` field from `VLANTranslationRule`, and marking computed or template-only columns as non-orderable where needed.

Related test coverage is being handled as part of #21766, so this PR focuses on the fixes themselves.