### PR TITLE
Closes #21766: Add reusable tests for sortable table columns

### DIFF
--- a/netbox/circuits/tests/test_tables.py
+++ b/netbox/circuits/tests/test_tables.py
@@ -1,48 +1,46 @@
-from django.test import RequestFactory, TestCase, tag
-
-from circuits.models import CircuitGroupAssignment, CircuitTermination
-from circuits.tables import CircuitGroupAssignmentTable, CircuitTerminationTable
+from circuits.tables import *
+from utilities.testing import TableTestCases
 
 
-@tag('regression')
-class CircuitTerminationTableTest(TestCase):
-    def test_every_orderable_field_does_not_throw_exception(self):
-        terminations = CircuitTermination.objects.all()
-        disallowed = {
-            'actions',
-        }
-
-        orderable_columns = [
-            column.name
-            for column in CircuitTerminationTable(terminations).columns
-            if column.orderable and column.name not in disallowed
-        ]
-        fake_request = RequestFactory().get('/')
-
-        for col in orderable_columns:
-            for direction in ('-', ''):
-                table = CircuitTerminationTable(terminations)
-                table.order_by = f'{direction}{col}'
-                table.as_html(fake_request)
+class CircuitTypeTableTest(TableTestCases.StandardTableTestCase):
+    table = CircuitTypeTable
 
 
-@tag('regression')
-class CircuitGroupAssignmentTableTest(TestCase):
-    def test_every_orderable_field_does_not_throw_exception(self):
-        assignment = CircuitGroupAssignment.objects.all()
-        disallowed = {
-            'actions',
-        }
+class CircuitTableTest(TableTestCases.StandardTableTestCase):
+    table = CircuitTable
 
-        orderable_columns = [
-            column.name
-            for column in CircuitGroupAssignmentTable(assignment).columns
-            if column.orderable and column.name not in disallowed
-        ]
-        fake_request = RequestFactory().get('/')
 
-        for col in orderable_columns:
-            for direction in ('-', ''):
-                table = CircuitGroupAssignmentTable(assignment)
-                table.order_by = f'{direction}{col}'
-                table.as_html(fake_request)
+class CircuitTerminationTableTest(TableTestCases.StandardTableTestCase):
+    table = CircuitTerminationTable
+
+
+class CircuitGroupTableTest(TableTestCases.StandardTableTestCase):
+    table = CircuitGroupTable
+
+
+class CircuitGroupAssignmentTableTest(TableTestCases.StandardTableTestCase):
+    table = CircuitGroupAssignmentTable
+
+
+class ProviderTableTest(TableTestCases.StandardTableTestCase):
+    table = ProviderTable
+
+
+class ProviderAccountTableTest(TableTestCases.StandardTableTestCase):
+    table = ProviderAccountTable
+
+
+class ProviderNetworkTableTest(TableTestCases.StandardTableTestCase):
+    table = ProviderNetworkTable
+
+
+class VirtualCircuitTypeTableTest(TableTestCases.StandardTableTestCase):
+    table = VirtualCircuitTypeTable
+
+
+class VirtualCircuitTableTest(TableTestCases.StandardTableTestCase):
+    table = VirtualCircuitTable
+
+
+class VirtualCircuitTerminationTableTest(TableTestCases.StandardTableTestCase):
+    table = VirtualCircuitTerminationTable

--- a/netbox/core/tests/test_tables.py
+++ b/netbox/core/tests/test_tables.py
@@ -1,0 +1,26 @@
+from core.models import ObjectChange
+from core.tables import *
+from utilities.testing import TableTestCases
+
+
+class DataSourceTableTest(TableTestCases.StandardTableTestCase):
+    table = DataSourceTable
+
+
+class DataFileTableTest(TableTestCases.StandardTableTestCase):
+    table = DataFileTable
+
+
+class JobTableTest(TableTestCases.StandardTableTestCase):
+    table = JobTable
+
+
+class ObjectChangeTableTest(TableTestCases.StandardTableTestCase):
+    table = ObjectChangeTable
+    queryset_sources = [
+        ('ObjectChangeListView', ObjectChange.objects.valid_models()),
+    ]
+
+
+class ConfigRevisionTableTest(TableTestCases.StandardTableTestCase):
+    table = ConfigRevisionTable

--- a/netbox/dcim/tests/test_tables.py
+++ b/netbox/dcim/tests/test_tables.py
@@ -1,0 +1,204 @@
+from dcim.models import ConsolePort, Interface, PowerPort
+from dcim.tables import *
+from utilities.testing import TableTestCases
+
+#
+# Sites
+#
+
+
+class RegionTableTest(TableTestCases.StandardTableTestCase):
+    table = RegionTable
+
+
+class SiteGroupTableTest(TableTestCases.StandardTableTestCase):
+    table = SiteGroupTable
+
+
+class SiteTableTest(TableTestCases.StandardTableTestCase):
+    table = SiteTable
+
+
+class LocationTableTest(TableTestCases.StandardTableTestCase):
+    table = LocationTable
+
+
+#
+# Racks
+#
+
+class RackRoleTableTest(TableTestCases.StandardTableTestCase):
+    table = RackRoleTable
+
+
+class RackTypeTableTest(TableTestCases.StandardTableTestCase):
+    table = RackTypeTable
+
+
+class RackTableTest(TableTestCases.StandardTableTestCase):
+    table = RackTable
+
+
+class RackReservationTableTest(TableTestCases.StandardTableTestCase):
+    table = RackReservationTable
+
+
+#
+# Device types
+#
+
+class ManufacturerTableTest(TableTestCases.StandardTableTestCase):
+    table = ManufacturerTable
+
+
+class DeviceTypeTableTest(TableTestCases.StandardTableTestCase):
+    table = DeviceTypeTable
+
+
+#
+# Module types
+#
+
+class ModuleTypeProfileTableTest(TableTestCases.StandardTableTestCase):
+    table = ModuleTypeProfileTable
+
+
+class ModuleTypeTableTest(TableTestCases.StandardTableTestCase):
+    table = ModuleTypeTable
+
+
+class ModuleTableTest(TableTestCases.StandardTableTestCase):
+    table = ModuleTable
+
+
+#
+# Devices
+#
+
+class DeviceRoleTableTest(TableTestCases.StandardTableTestCase):
+    table = DeviceRoleTable
+
+
+class PlatformTableTest(TableTestCases.StandardTableTestCase):
+    table = PlatformTable
+
+
+class DeviceTableTest(TableTestCases.StandardTableTestCase):
+    table = DeviceTable
+
+
+#
+# Device components
+#
+
+class ConsolePortTableTest(TableTestCases.StandardTableTestCase):
+    table = ConsolePortTable
+
+
+class ConsoleServerPortTableTest(TableTestCases.StandardTableTestCase):
+    table = ConsoleServerPortTable
+
+
+class PowerPortTableTest(TableTestCases.StandardTableTestCase):
+    table = PowerPortTable
+
+
+class PowerOutletTableTest(TableTestCases.StandardTableTestCase):
+    table = PowerOutletTable
+
+
+class InterfaceTableTest(TableTestCases.StandardTableTestCase):
+    table = InterfaceTable
+
+
+class FrontPortTableTest(TableTestCases.StandardTableTestCase):
+    table = FrontPortTable
+
+
+class RearPortTableTest(TableTestCases.StandardTableTestCase):
+    table = RearPortTable
+
+
+class ModuleBayTableTest(TableTestCases.StandardTableTestCase):
+    table = ModuleBayTable
+
+
+class DeviceBayTableTest(TableTestCases.StandardTableTestCase):
+    table = DeviceBayTable
+
+
+class InventoryItemTableTest(TableTestCases.StandardTableTestCase):
+    table = InventoryItemTable
+
+
+class InventoryItemRoleTableTest(TableTestCases.StandardTableTestCase):
+    table = InventoryItemRoleTable
+
+
+#
+# Connections
+#
+
+class ConsoleConnectionTableTest(TableTestCases.StandardTableTestCase):
+    table = ConsoleConnectionTable
+    queryset_sources = [
+        ('ConsoleConnectionsListView', ConsolePort.objects.filter(_path__is_complete=True)),
+    ]
+
+
+class PowerConnectionTableTest(TableTestCases.StandardTableTestCase):
+    table = PowerConnectionTable
+    queryset_sources = [
+        ('PowerConnectionsListView', PowerPort.objects.filter(_path__is_complete=True)),
+    ]
+
+
+class InterfaceConnectionTableTest(TableTestCases.StandardTableTestCase):
+    table = InterfaceConnectionTable
+    queryset_sources = [
+        ('InterfaceConnectionsListView', Interface.objects.filter(_path__is_complete=True)),
+    ]
+
+
+#
+# Cables
+#
+
+class CableTableTest(TableTestCases.StandardTableTestCase):
+    table = CableTable
+
+
+#
+# Power
+#
+
+class PowerPanelTableTest(TableTestCases.StandardTableTestCase):
+    table = PowerPanelTable
+
+
+class PowerFeedTableTest(TableTestCases.StandardTableTestCase):
+    table = PowerFeedTable
+
+
+#
+# Virtual chassis
+#
+
+class VirtualChassisTableTest(TableTestCases.StandardTableTestCase):
+    table = VirtualChassisTable
+
+
+#
+# Virtual device contexts
+#
+
+class VirtualDeviceContextTableTest(TableTestCases.StandardTableTestCase):
+    table = VirtualDeviceContextTable
+
+
+#
+# MAC addresses
+#
+
+class MACAddressTableTest(TableTestCases.StandardTableTestCase):
+    table = MACAddressTable

--- a/netbox/extras/tests/test_tables.py
+++ b/netbox/extras/tests/test_tables.py
@@ -1,24 +1,93 @@
-from django.test import RequestFactory, TestCase, tag
+from extras.models import Bookmark, Notification, Subscription
+from extras.tables import *
+from utilities.testing import TableTestCases
 
-from extras.models import EventRule
-from extras.tables import EventRuleTable
+
+class CustomFieldTableTest(TableTestCases.StandardTableTestCase):
+    table = CustomFieldTable
 
 
-@tag('regression')
-class EventRuleTableTest(TestCase):
-    def test_every_orderable_field_does_not_throw_exception(self):
-        rule = EventRule.objects.all()
-        disallowed = {
-            'actions',
-        }
+class CustomFieldChoiceSetTableTest(TableTestCases.StandardTableTestCase):
+    table = CustomFieldChoiceSetTable
 
-        orderable_columns = [
-            column.name for column in EventRuleTable(rule).columns if column.orderable and column.name not in disallowed
-        ]
-        fake_request = RequestFactory().get('/')
 
-        for col in orderable_columns:
-            for direction in ('-', ''):
-                table = EventRuleTable(rule)
-                table.order_by = f'{direction}{col}'
-                table.as_html(fake_request)
+class CustomLinkTableTest(TableTestCases.StandardTableTestCase):
+    table = CustomLinkTable
+
+
+class ExportTemplateTableTest(TableTestCases.StandardTableTestCase):
+    table = ExportTemplateTable
+
+
+class SavedFilterTableTest(TableTestCases.StandardTableTestCase):
+    table = SavedFilterTable
+
+
+class TableConfigTableTest(TableTestCases.StandardTableTestCase):
+    table = TableConfigTable
+
+
+class BookmarkTableTest(TableTestCases.StandardTableTestCase):
+    table = BookmarkTable
+
+    # The list view for this table lives in account.views (not extras.views),
+    # so auto-discovery cannot find it. Provide an explicit queryset source.
+    queryset_sources = [
+        ('Bookmark.objects.all()', Bookmark.objects.all()),
+    ]
+
+
+class NotificationGroupTableTest(TableTestCases.StandardTableTestCase):
+    table = NotificationGroupTable
+
+
+class NotificationTableTest(TableTestCases.StandardTableTestCase):
+    table = NotificationTable
+
+    # The list view for this table lives in account.views (not extras.views),
+    # so auto-discovery cannot find it. Provide an explicit queryset source.
+    queryset_sources = [
+        ('Notification.objects.all()', Notification.objects.all()),
+    ]
+
+
+class SubscriptionTableTest(TableTestCases.StandardTableTestCase):
+    table = SubscriptionTable
+
+    # The list view for this table lives in account.views (not extras.views),
+    # so auto-discovery cannot find it. Provide an explicit queryset source.
+    queryset_sources = [
+        ('Subscription.objects.all()', Subscription.objects.all()),
+    ]
+
+
+class WebhookTableTest(TableTestCases.StandardTableTestCase):
+    table = WebhookTable
+
+
+class EventRuleTableTest(TableTestCases.StandardTableTestCase):
+    table = EventRuleTable
+
+
+class TagTableTest(TableTestCases.StandardTableTestCase):
+    table = TagTable
+
+
+class ConfigContextProfileTableTest(TableTestCases.StandardTableTestCase):
+    table = ConfigContextProfileTable
+
+
+class ConfigContextTableTest(TableTestCases.StandardTableTestCase):
+    table = ConfigContextTable
+
+
+class ConfigTemplateTableTest(TableTestCases.StandardTableTestCase):
+    table = ConfigTemplateTable
+
+
+class ImageAttachmentTableTest(TableTestCases.StandardTableTestCase):
+    table = ImageAttachmentTable
+
+
+class JournalEntryTableTest(TableTestCases.StandardTableTestCase):
+    table = JournalEntryTable

--- a/netbox/ipam/tests/test_tables.py
+++ b/netbox/ipam/tests/test_tables.py
@@ -1,9 +1,10 @@
 from django.test import RequestFactory, TestCase
 from netaddr import IPNetwork
 
-from ipam.models import IPAddress, IPRange, Prefix
-from ipam.tables import AnnotatedIPAddressTable
+from ipam.models import FHRPGroupAssignment, IPAddress, IPRange, Prefix
+from ipam.tables import *
 from ipam.utils import annotate_ip_space
+from utilities.testing import TableTestCases
 
 
 class AnnotatedIPAddressTableTest(TestCase):
@@ -168,3 +169,85 @@ class AnnotatedIPAddressTableTest(TestCase):
         # Pools are fully usable
         self.assertEqual(available.first_ip, '2001:db8:1::/126')
         self.assertEqual(available.size, 4)
+
+
+#
+# Table ordering tests
+#
+
+class VRFTableTest(TableTestCases.StandardTableTestCase):
+    table = VRFTable
+
+
+class RouteTargetTableTest(TableTestCases.StandardTableTestCase):
+    table = RouteTargetTable
+
+
+class RIRTableTest(TableTestCases.StandardTableTestCase):
+    table = RIRTable
+
+
+class AggregateTableTest(TableTestCases.StandardTableTestCase):
+    table = AggregateTable
+
+
+class RoleTableTest(TableTestCases.StandardTableTestCase):
+    table = RoleTable
+
+
+class PrefixTableTest(TableTestCases.StandardTableTestCase):
+    table = PrefixTable
+
+
+class IPRangeTableTest(TableTestCases.StandardTableTestCase):
+    table = IPRangeTable
+
+
+class IPAddressTableTest(TableTestCases.StandardTableTestCase):
+    table = IPAddressTable
+
+
+class FHRPGroupTableTest(TableTestCases.StandardTableTestCase):
+    table = FHRPGroupTable
+
+
+class FHRPGroupAssignmentTableTest(TableTestCases.StandardTableTestCase):
+    table = FHRPGroupAssignmentTable
+
+    # No ObjectListView exists for this table; it is only rendered inline on
+    # the FHRPGroup detail view. Provide an explicit queryset source.
+    queryset_sources = [
+        ('FHRPGroupAssignment.objects.all()', FHRPGroupAssignment.objects.all()),
+    ]
+
+
+class VLANGroupTableTest(TableTestCases.StandardTableTestCase):
+    table = VLANGroupTable
+
+
+class VLANTableTest(TableTestCases.StandardTableTestCase):
+    table = VLANTable
+
+
+class VLANTranslationPolicyTableTest(TableTestCases.StandardTableTestCase):
+    table = VLANTranslationPolicyTable
+
+
+class VLANTranslationRuleTableTest(TableTestCases.StandardTableTestCase):
+    table = VLANTranslationRuleTable
+
+
+class ASNRangeTableTest(TableTestCases.StandardTableTestCase):
+    table = ASNRangeTable
+
+
+class ASNTableTest(TableTestCases.StandardTableTestCase):
+    table = ASNTable
+
+
+class ServiceTemplateTableTest(TableTestCases.StandardTableTestCase):
+    table = ServiceTemplateTable
+
+
+class ServiceTableTest(TableTestCases.StandardTableTestCase):
+    table = ServiceTable

--- a/netbox/tenancy/tests/test_tables.py
+++ b/netbox/tenancy/tests/test_tables.py
@@ -1,0 +1,26 @@
+from tenancy.tables import *
+from utilities.testing import TableTestCases
+
+
+class TenantGroupTableTest(TableTestCases.StandardTableTestCase):
+    table = TenantGroupTable
+
+
+class TenantTableTest(TableTestCases.StandardTableTestCase):
+    table = TenantTable
+
+
+class ContactGroupTableTest(TableTestCases.StandardTableTestCase):
+    table = ContactGroupTable
+
+
+class ContactRoleTableTest(TableTestCases.StandardTableTestCase):
+    table = ContactRoleTable
+
+
+class ContactTableTest(TableTestCases.StandardTableTestCase):
+    table = ContactTable
+
+
+class ContactAssignmentTableTest(TableTestCases.StandardTableTestCase):
+    table = ContactAssignmentTable

--- a/netbox/users/tests/test_tables.py
+++ b/netbox/users/tests/test_tables.py
@@ -1,24 +1,26 @@
-from django.test import RequestFactory, TestCase, tag
-
-from users.models import Token
-from users.tables import TokenTable
+from users.tables import *
+from utilities.testing import TableTestCases
 
 
-class TokenTableTest(TestCase):
-    @tag('regression')
-    def test_every_orderable_field_does_not_throw_exception(self):
-        tokens = Token.objects.all()
-        disallowed = {'actions'}
+class TokenTableTest(TableTestCases.StandardTableTestCase):
+    table = TokenTable
 
-        orderable_columns = [
-            column.name for column in TokenTable(tokens).columns
-            if column.orderable and column.name not in disallowed
-        ]
-        fake_request = RequestFactory().get("/")
 
-        for col in orderable_columns:
-            for direction in ('-', ''):
-                with self.subTest(col=col, direction=direction):
-                    table = TokenTable(tokens)
-                    table.order_by = f'{direction}{col}'
-                    table.as_html(fake_request)
+class UserTableTest(TableTestCases.StandardTableTestCase):
+    table = UserTable
+
+
+class GroupTableTest(TableTestCases.StandardTableTestCase):
+    table = GroupTable
+
+
+class ObjectPermissionTableTest(TableTestCases.StandardTableTestCase):
+    table = ObjectPermissionTable
+
+
+class OwnerGroupTableTest(TableTestCases.StandardTableTestCase):
+    table = OwnerGroupTable
+
+
+class OwnerTableTest(TableTestCases.StandardTableTestCase):
+    table = OwnerTable

--- a/netbox/utilities/testing/__init__.py
+++ b/netbox/utilities/testing/__init__.py
@@ -1,5 +1,6 @@
 from .api import *
 from .base import *
 from .filtersets import *
+from .tables import *
 from .utils import *
 from .views import *

--- a/netbox/utilities/testing/tables.py
+++ b/netbox/utilities/testing/tables.py
@@ -1,0 +1,157 @@
+import inspect
+from importlib import import_module
+
+from django.test import RequestFactory
+
+from netbox.views import generic
+
+from .base import TestCase
+
+__all__ = (
+    "ModelTableTestCase",
+    "TableTestCases",
+)
+
+
+class ModelTableTestCase(TestCase):
+    """
+    Shared helpers for model-backed table ordering smoke tests.
+
+    Concrete subclasses should set `table` and may override `queryset_sources`,
+    `queryset_source_view_classes`, or `excluded_orderable_columns` as needed.
+    """
+    table = None
+    excluded_orderable_columns = frozenset({"actions"})
+
+    # Optional explicit override for odd cases
+    queryset_sources = None
+
+    # Only these view types are considered sortable queryset sources by default
+    queryset_source_view_classes = (generic.ObjectListView,)
+
+    @classmethod
+    def validate_table_test_case(cls):
+        """
+        Assert that the test case is correctly configured with a model-backed table.
+
+        Raises:
+            AssertionError: If ``table`` is not set or is not backed by a Django model.
+        """
+        if cls.table is None:
+            raise AssertionError(f"{cls.__name__} must define `table`")
+        if getattr(cls.table._meta, "model", None) is None:
+            raise AssertionError(f"{cls.__name__}.table must be model-backed")
+
+    def get_request(self):
+        """
+        Build a minimal ``GET`` request authenticated as the test user.
+        """
+        request = RequestFactory().get("/")
+        request.user = self.user
+        return request
+
+    def get_table(self, queryset):
+        """
+        Instantiate the table class under test with the given *queryset*.
+        """
+        return self.table(queryset)
+
+    @classmethod
+    def is_queryset_source_view(cls, view):
+        """
+        Return ``True`` if *view* is a list-style view class that declares
+        this test case's table and exposes a usable queryset.
+        """
+        model = cls.table._meta.model
+        app_label = model._meta.app_label
+
+        return (
+            inspect.isclass(view)
+            and view.__module__.startswith(f"{app_label}.views")
+            and getattr(view, "table", None) is cls.table
+            and getattr(view, "queryset", None) is not None
+            and issubclass(view, cls.queryset_source_view_classes)
+        )
+
+    @classmethod
+    def get_queryset_sources(cls):
+        """
+        Return iterable of (label, queryset) pairs to test.
+
+        The label is included in the subtest failure output.
+
+        By default, only discover list-style views that declare this table.
+        That keeps bulk edit/delete confirmation tables out of the ordering
+        smoke test.
+        """
+        if cls.queryset_sources is not None:
+            return tuple(cls.queryset_sources)
+
+        model = cls.table._meta.model
+        app_label = model._meta.app_label
+        module = import_module(f"{app_label}.views")
+
+        sources = []
+        for _, view in inspect.getmembers(module, inspect.isclass):
+            if not cls.is_queryset_source_view(view):
+                continue
+
+            queryset = view.queryset
+            if hasattr(queryset, "all"):
+                queryset = queryset.all()
+
+            sources.append((view.__name__, queryset))
+
+        if not sources:
+            raise AssertionError(
+                f"{cls.__name__} could not find any list-style queryset source for "
+                f"{cls.table.__module__}.{cls.table.__name__}; "
+                "set `queryset_sources` explicitly if needed."
+            )
+
+        return tuple(sources)
+
+    def iter_orderable_columns(self, queryset):
+        """
+        Yield the names of all orderable columns for *queryset*, excluding
+        any listed in ``excluded_orderable_columns``.
+        """
+        for column in self.get_table(queryset).columns:
+            if not column.orderable:
+                continue
+            if column.name in self.excluded_orderable_columns:
+                continue
+            yield column.name
+
+
+class TableTestCases:
+    """
+    Keep test_* methods nested to avoid unittest auto-discovering the reusable
+    base classes directly.
+    """
+
+    class StandardTableTestCase(ModelTableTestCase):
+        @classmethod
+        def setUpClass(cls):
+            super().setUpClass()
+            cls.validate_table_test_case()
+
+        def test_every_orderable_column_renders(self):
+            """
+            Verify that each declared ordering can be applied without error.
+
+            This is intentionally a smoke test. It validates ordering against
+            the configured queryset sources but does not create model
+            instances by default, so it complements rather than replaces
+            data-backed rendering tests for tables whose behavior depends on
+            populated querysets.
+            """
+            request = self.get_request()
+
+            for source_name, queryset in self.get_queryset_sources():
+                for column_name in self.iter_orderable_columns(queryset):
+                    for direction, prefix in (("asc", ""), ("desc", "-")):
+                        with self.subTest(source=source_name, column=column_name, direction=direction):
+                            table = self.get_table(queryset)
+                            table.order_by = f"{prefix}{column_name}"
+                            table.as_html(request)

--- a/netbox/virtualization/tests/test_tables.py
+++ b/netbox/virtualization/tests/test_tables.py
@@ -1,0 +1,26 @@
+from utilities.testing import TableTestCases
+from virtualization.tables import *
+
+
+class ClusterTypeTableTest(TableTestCases.StandardTableTestCase):
+    table = ClusterTypeTable
+
+
+class ClusterGroupTableTest(TableTestCases.StandardTableTestCase):
+    table = ClusterGroupTable
+
+
+class ClusterTableTest(TableTestCases.StandardTableTestCase):
+    table = ClusterTable
+
+
+class VirtualMachineTableTest(TableTestCases.StandardTableTestCase):
+    table = VirtualMachineTable
+
+
+class VMInterfaceTableTest(TableTestCases.StandardTableTestCase):
+    table = VMInterfaceTable
+
+
+class VirtualDiskTableTest(TableTestCases.StandardTableTestCase):
+    table = VirtualDiskTable

--- a/netbox/vpn/tests/test_tables.py
+++ b/netbox/vpn/tests/test_tables.py
@@ -1,23 +1,42 @@
-from django.test import RequestFactory, TestCase, tag
-
-from vpn.models import TunnelTermination
-from vpn.tables import TunnelTerminationTable
+from utilities.testing import TableTestCases
+from vpn.tables import *
 
 
-@tag('regression')
-class TunnelTerminationTableTest(TestCase):
-    def test_every_orderable_field_does_not_throw_exception(self):
-        terminations = TunnelTermination.objects.all()
-        fake_request = RequestFactory().get("/")
-        disallowed = {'actions'}
+class TunnelGroupTableTest(TableTestCases.StandardTableTestCase):
+    table = TunnelGroupTable
 
-        orderable_columns = [
-            column.name for column in TunnelTerminationTable(terminations).columns
-            if column.orderable and column.name not in disallowed
-        ]
 
-        for col in orderable_columns:
-            for dir in ('-', ''):
-                table = TunnelTerminationTable(terminations)
-                table.order_by = f'{dir}{col}'
-                table.as_html(fake_request)
+class TunnelTableTest(TableTestCases.StandardTableTestCase):
+    table = TunnelTable
+
+
+class TunnelTerminationTableTest(TableTestCases.StandardTableTestCase):
+    table = TunnelTerminationTable
+
+
+class IKEProposalTableTest(TableTestCases.StandardTableTestCase):
+    table = IKEProposalTable
+
+
+class IKEPolicyTableTest(TableTestCases.StandardTableTestCase):
+    table = IKEPolicyTable
+
+
+class IPSecProposalTableTest(TableTestCases.StandardTableTestCase):
+    table = IPSecProposalTable
+
+
+class IPSecPolicyTableTest(TableTestCases.StandardTableTestCase):
+    table = IPSecPolicyTable
+
+
+class IPSecProfileTableTest(TableTestCases.StandardTableTestCase):
+    table = IPSecProfileTable
+
+
+class L2VPNTableTest(TableTestCases.StandardTableTestCase):
+    table = L2VPNTable
+
+
+class L2VPNTerminationTableTest(TableTestCases.StandardTableTestCase):
+    table = L2VPNTerminationTable

--- a/netbox/wireless/tests/test_tables.py
+++ b/netbox/wireless/tests/test_tables.py
@@ -1,0 +1,14 @@
+from utilities.testing import TableTestCases
+from wireless.tables import *
+
+
+class WirelessLANGroupTableTest(TableTestCases.StandardTableTestCase):
+    table = WirelessLANGroupTable
+
+
+class WirelessLANTableTest(TableTestCases.StandardTableTestCase):
+    table = WirelessLANTable
+
+
+class WirelessLinkTableTest(TableTestCases.StandardTableTestCase):
+    table = WirelessLinkTable


### PR DESCRIPTION
### Fixes: #21766

Introduce `TableTestCases.OrderableColumnsTestCase`, a reusable base class for table ordering smoke tests.

The new helper discovers sortable columns from list-view querysets and verifies that each one renders without exceptions when ordered in both ascending and descending directions. This gives us a consistent way to catch unsupported ordering across model-backed tables without duplicating the same test logic in each app.

This PR also adds per-table smoke tests across circuits, core, dcim, extras, ipam, tenancy, users, virtualization, vpn, and wireless.