### PR TITLE
Closes #21455: Add SQL indexes for default ordering

### DIFF
--- a/netbox/circuits/migrations/0057_default_ordering_indexes.py
+++ b/netbox/circuits/migrations/0057_default_ordering_indexes.py
@@ -1,0 +1,35 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('circuits', '0056_gfk_indexes'),
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('dcim', '0230_interface_rf_channel_frequency_precision'),
+        ('extras', '0136_customfield_validation_schema'),
+        ('tenancy', '0023_add_mptt_tree_indexes'),
+        ('users', '0015_owner'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='circuit',
+            index=models.Index(fields=['provider', 'provider_account', 'cid'], name='circuits_ci_provide_a0c42c_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='circuitgroupassignment',
+            index=models.Index(
+                fields=['group', 'member_type', 'member_id', 'priority', 'id'], name='circuits_ci_group_i_2f8327_idx'
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='virtualcircuit',
+            index=models.Index(
+                fields=['provider_network', 'provider_account', 'cid'], name='circuits_vi_provide_989efa_idx'
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='virtualcircuittermination',
+            index=models.Index(fields=['virtual_circuit', 'role', 'id'], name='circuits_vi_virtual_4b5c0c_idx'),
+        ),
+    ]

--- a/netbox/circuits/models/circuits.py
+++ b/netbox/circuits/models/circuits.py
@@ -144,6 +144,9 @@ class Circuit(ContactsMixin, ImageAttachmentsMixin, DistanceMixin, PrimaryModel)
                 name='%(app_label)s_%(class)s_unique_provideraccount_cid'
             ),
         )
+        indexes = (
+            models.Index(fields=('provider', 'provider_account', 'cid')),  # Default ordering
+        )
         verbose_name = _('circuit')
         verbose_name_plural = _('circuits')
 
@@ -220,6 +223,9 @@ class CircuitGroupAssignment(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin,
                 fields=('member_type', 'member_id', 'group'),
                 name='%(app_label)s_%(class)s_unique_member_group'
             ),
+        )
+        indexes = (
+            models.Index(fields=('group', 'member_type', 'member_id', 'priority', 'id')),  # Default ordering
         )
         verbose_name = _('Circuit group assignment')
         verbose_name_plural = _('Circuit group assignments')

--- a/netbox/circuits/models/virtual_circuits.py
+++ b/netbox/circuits/models/virtual_circuits.py
@@ -97,6 +97,9 @@ class VirtualCircuit(ContactsMixin, PrimaryModel):
                 name='%(app_label)s_%(class)s_unique_provideraccount_cid'
             ),
         )
+        indexes = (
+            models.Index(fields=('provider_network', 'provider_account', 'cid')),  # Default ordering
+        )
         verbose_name = _('virtual circuit')
         verbose_name_plural = _('virtual circuits')
 
@@ -150,6 +153,9 @@ class VirtualCircuitTermination(
 
     class Meta:
         ordering = ['virtual_circuit', 'role', 'pk']
+        indexes = (
+            models.Index(fields=('virtual_circuit', 'role', 'id')),  # Default ordering
+        )
         verbose_name = _('virtual circuit termination')
         verbose_name_plural = _('virtual circuit terminations')
 

--- a/netbox/core/migrations/0022_default_ordering_indexes.py
+++ b/netbox/core/migrations/0022_default_ordering_indexes.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('core', '0021_job_queue_name'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='configrevision',
+            index=models.Index(fields=['-created'], name='core_config_created_ef9552_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='job',
+            index=models.Index(fields=['-created'], name='core_job_created_efa7cb_idx'),
+        ),
+    ]

--- a/netbox/core/models/config.py
+++ b/netbox/core/models/config.py
@@ -37,6 +37,9 @@ class ConfigRevision(models.Model):
 
     class Meta:
         ordering = ['-created']
+        indexes = (
+            models.Index(fields=('-created',)),  # Default ordering
+        )
         verbose_name = _('config revision')
         verbose_name_plural = _('config revisions')
         constraints = [

--- a/netbox/core/models/jobs.py
+++ b/netbox/core/models/jobs.py
@@ -133,6 +133,7 @@ class Job(models.Model):
     class Meta:
         ordering = ['-created']
         indexes = (
+            models.Index(fields=('-created',)),  # Default ordering
             models.Index(fields=('object_type', 'object_id')),
         )
         verbose_name = _('job')

--- a/netbox/dcim/migrations/0231_default_ordering_indexes.py
+++ b/netbox/dcim/migrations/0231_default_ordering_indexes.py
@@ -1,0 +1,78 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('dcim', '0230_interface_rf_channel_frequency_precision'),
+        ('extras', '0136_customfield_validation_schema'),
+        ('ipam', '0088_rename_vlangroup_total_vlan_ids'),
+        ('tenancy', '0023_add_mptt_tree_indexes'),
+        ('users', '0015_owner'),
+        ('virtualization', '0054_virtualmachinetype'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='consoleporttemplate',
+            index=models.Index(fields=['device_type', 'module_type', 'name'], name='dcim_consol_device__101ed5_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='consoleserverporttemplate',
+            index=models.Index(fields=['device_type', 'module_type', 'name'], name='dcim_consol_device__a901e6_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='device',
+            index=models.Index(fields=['name', 'id'], name='dcim_device_name_c27913_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='frontporttemplate',
+            index=models.Index(fields=['device_type', 'module_type', 'name'], name='dcim_frontp_device__ec2ffb_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='interfacetemplate',
+            index=models.Index(fields=['device_type', 'module_type', 'name'], name='dcim_interf_device__601012_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='macaddress',
+            index=models.Index(fields=['mac_address', 'id'], name='dcim_macadd_mac_add_f2662a_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='modulebaytemplate',
+            index=models.Index(fields=['device_type', 'module_type', 'name'], name='dcim_module_device__9eabad_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='moduletype',
+            index=models.Index(fields=['profile', 'manufacturer', 'model'], name='dcim_module_profile_868277_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='poweroutlettemplate',
+            index=models.Index(fields=['device_type', 'module_type', 'name'], name='dcim_powero_device__b83a8f_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='powerporttemplate',
+            index=models.Index(fields=['device_type', 'module_type', 'name'], name='dcim_powerp_device__6c25da_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='rack',
+            index=models.Index(fields=['site', 'location', 'name', 'id'], name='dcim_rack_site_id_715040_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='rackreservation',
+            index=models.Index(fields=['created', 'id'], name='dcim_rackre_created_84f02e_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='rearporttemplate',
+            index=models.Index(fields=['device_type', 'module_type', 'name'], name='dcim_rearpo_device__27f194_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='virtualchassis',
+            index=models.Index(fields=['name'], name='dcim_virtua_name_2dc5cd_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='virtualdevicecontext',
+            index=models.Index(fields=['name'], name='dcim_virtua_name_079d4d_idx'),
+        ),
+    ]

--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -143,6 +143,9 @@ class ModularComponentTemplateModel(ComponentTemplateModel):
                 name='%(app_label)s_%(class)s_unique_module_type_name'
             ),
         )
+        indexes = (
+            models.Index(fields=('device_type', 'module_type', 'name')),  # Default ordering
+        )
 
     def to_objectchange(self, action):
         objectchange = super().to_objectchange(action)

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -737,6 +737,9 @@ class Device(
 
     class Meta:
         ordering = ('name', 'pk')  # Name may be null
+        indexes = (
+            models.Index(fields=('name', 'id')),  # Default ordering
+        )
         constraints = (
             models.UniqueConstraint(
                 Lower('name'), 'site', 'tenant',
@@ -1184,6 +1187,9 @@ class VirtualChassis(PrimaryModel):
 
     class Meta:
         ordering = ['name']
+        indexes = (
+            models.Index(fields=('name',)),  # Default ordering
+        )
         verbose_name = _('virtual chassis')
         verbose_name_plural = _('virtual chassis')
 
@@ -1290,6 +1296,9 @@ class VirtualDeviceContext(PrimaryModel):
                 name='%(app_label)s_%(class)s_device_name'
             ),
         )
+        indexes = (
+            models.Index(fields=('name',)),  # Default ordering
+        )
         verbose_name = _('virtual device context')
         verbose_name_plural = _('virtual device contexts')
 
@@ -1356,6 +1365,7 @@ class MACAddress(PrimaryModel):
     class Meta:
         ordering = ('mac_address', 'pk')
         indexes = (
+            models.Index(fields=('mac_address', 'id')),  # Default ordering
             models.Index(fields=('assigned_object_type', 'assigned_object_id')),
         )
         verbose_name = _('MAC address')

--- a/netbox/dcim/models/modules.py
+++ b/netbox/dcim/models/modules.py
@@ -113,6 +113,9 @@ class ModuleType(ImageAttachmentsMixin, PrimaryModel, WeightMixin):
                 name='%(app_label)s_%(class)s_unique_manufacturer_model'
             ),
         )
+        indexes = (
+            models.Index(fields=('profile', 'manufacturer', 'model')),  # Default ordering
+        )
         verbose_name = _('module type')
         verbose_name_plural = _('module types')
 

--- a/netbox/dcim/models/racks.py
+++ b/netbox/dcim/models/racks.py
@@ -390,6 +390,9 @@ class Rack(ContactsMixin, ImageAttachmentsMixin, TrackingModelMixin, RackBase):
                 name='%(app_label)s_%(class)s_unique_location_facility_id'
             ),
         )
+        indexes = (
+            models.Index(fields=('site', 'location', 'name', 'id')),  # Default ordering
+        )
         verbose_name = _('rack')
         verbose_name_plural = _('racks')
 
@@ -738,6 +741,9 @@ class RackReservation(PrimaryModel):
 
     class Meta:
         ordering = ['created', 'pk']
+        indexes = (
+            models.Index(fields=('created', 'id')),  # Default ordering
+        )
         verbose_name = _('rack reservation')
         verbose_name_plural = _('rack reservations')
 

--- a/netbox/extras/migrations/0137_default_ordering_indexes.py
+++ b/netbox/extras/migrations/0137_default_ordering_indexes.py
@@ -1,0 +1,74 @@
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('core', '0022_default_ordering_indexes'),
+        ('dcim', '0231_default_ordering_indexes'),
+        ('extras', '0136_customfield_validation_schema'),
+        ('tenancy', '0023_add_mptt_tree_indexes'),
+        ('users', '0015_owner'),
+        ('virtualization', '0054_virtualmachinetype'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='bookmark',
+            index=models.Index(fields=['created', 'id'], name='extras_book_created_1cb4a5_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='configcontext',
+            index=models.Index(fields=['weight', 'name'], name='extras_conf_weight_ef9a81_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='configtemplate',
+            index=models.Index(fields=['name'], name='extras_conf_name_e276bf_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='customfield',
+            index=models.Index(fields=['group_name', 'weight', 'name'], name='extras_cust_group_n_40cb93_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='customlink',
+            index=models.Index(fields=['group_name', 'weight', 'name'], name='extras_cust_group_n_5a8be0_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='exporttemplate',
+            index=models.Index(fields=['name'], name='extras_expo_name_55a9af_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='imageattachment',
+            index=models.Index(fields=['name', 'id'], name='extras_imag_name_23cd9f_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='journalentry',
+            index=models.Index(fields=['-created'], name='extras_jour_created_ec0fac_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='notification',
+            index=models.Index(fields=['-created', 'id'], name='extras_noti_created_1d5146_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='savedfilter',
+            index=models.Index(fields=['weight', 'name'], name='extras_save_weight_c070c4_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='script',
+            index=models.Index(fields=['module', 'name'], name='extras_scri_module__8bd99c_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='subscription',
+            index=models.Index(fields=['-created', 'user'], name='extras_subs_created_034618_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='tableconfig',
+            index=models.Index(fields=['weight', 'name'], name='extras_tabl_weight_7c4bb6_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='tag',
+            index=models.Index(fields=['weight', 'name'], name='extras_tag_weight_d99f50_idx'),
+        ),
+    ]

--- a/netbox/extras/models/configs.py
+++ b/netbox/extras/models/configs.py
@@ -176,6 +176,9 @@ class ConfigContext(SyncedDataMixin, CloningMixin, CustomLinksMixin, OwnerMixin,
 
     class Meta:
         ordering = ['weight', 'name']
+        indexes = (
+            models.Index(fields=('weight', 'name')),  # Default ordering
+        )
         verbose_name = _('config context')
         verbose_name_plural = _('config contexts')
 
@@ -294,6 +297,9 @@ class ConfigTemplate(
 
     class Meta:
         ordering = ('name',)
+        indexes = (
+            models.Index(fields=('name',)),  # Default ordering
+        )
         verbose_name = _('config template')
         verbose_name_plural = _('config templates')
 

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -274,6 +274,9 @@ class CustomField(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMo
 
     class Meta:
         ordering = ['group_name', 'weight', 'name']
+        indexes = (
+            models.Index(fields=('group_name', 'weight', 'name')),  # Default ordering
+        )
         verbose_name = _('custom field')
         verbose_name_plural = _('custom fields')
 

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -356,6 +356,9 @@ class CustomLink(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMod
 
     class Meta:
         ordering = ['group_name', 'weight', 'name']
+        indexes = (
+            models.Index(fields=('group_name', 'weight', 'name')),  # Default ordering
+        )
         verbose_name = _('custom link')
         verbose_name_plural = _('custom links')
 
@@ -429,6 +432,9 @@ class ExportTemplate(
 
     class Meta:
         ordering = ('name',)
+        indexes = (
+            models.Index(fields=('name',)),  # Default ordering
+        )
         verbose_name = _('export template')
         verbose_name_plural = _('export templates')
 
@@ -515,6 +521,9 @@ class SavedFilter(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMo
 
     class Meta:
         ordering = ('weight', 'name')
+        indexes = (
+            models.Index(fields=('weight', 'name')),  # Default ordering
+        )
         verbose_name = _('saved filter')
         verbose_name_plural = _('saved filters')
 
@@ -597,6 +606,9 @@ class TableConfig(CloningMixin, ChangeLoggedModel):
 
     class Meta:
         ordering = ('weight', 'name')
+        indexes = (
+            models.Index(fields=('weight', 'name')),  # Default ordering
+        )
         verbose_name = _('table config')
         verbose_name_plural = _('table configs')
 
@@ -700,6 +712,7 @@ class ImageAttachment(ChangeLoggedModel):
     class Meta:
         ordering = ('name', 'pk')  # name may be non-unique
         indexes = (
+            models.Index(fields=('name', 'id')),  # Default ordering
             models.Index(fields=('object_type', 'object_id')),
         )
         verbose_name = _('image attachment')
@@ -810,6 +823,7 @@ class JournalEntry(CustomFieldsMixin, CustomLinksMixin, TagsMixin, ExportTemplat
     class Meta:
         ordering = ('-created',)
         indexes = (
+            models.Index(fields=('-created',)),  # Default ordering
             models.Index(fields=('assigned_object_type', 'assigned_object_id')),
         )
         verbose_name = _('journal entry')
@@ -865,6 +879,7 @@ class Bookmark(models.Model):
     class Meta:
         ordering = ('created', 'pk')
         indexes = (
+            models.Index(fields=('created', 'id')),  # Default ordering
             models.Index(fields=('object_type', 'object_id')),
         )
         constraints = (

--- a/netbox/extras/models/notifications.py
+++ b/netbox/extras/models/notifications.py
@@ -73,6 +73,7 @@ class Notification(models.Model):
     class Meta:
         ordering = ('-created', 'pk')
         indexes = (
+            models.Index(fields=('-created', 'id')),  # Default ordering
             models.Index(fields=('object_type', 'object_id')),
         )
         constraints = (
@@ -215,6 +216,7 @@ class Subscription(models.Model):
     class Meta:
         ordering = ('-created', 'user')
         indexes = (
+            models.Index(fields=('-created', 'user')),  # Default ordering
             models.Index(fields=('object_type', 'object_id')),
         )
         constraints = (

--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -62,6 +62,9 @@ class Script(EventRulesMixin, JobsMixin):
                 name='extras_script_unique_name_module'
             ),
         )
+        indexes = (
+            models.Index(fields=('module', 'name')),  # Default ordering
+        )
         verbose_name = _('script')
         verbose_name_plural = _('scripts')
 

--- a/netbox/extras/models/tags.py
+++ b/netbox/extras/models/tags.py
@@ -52,6 +52,9 @@ class Tag(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedModel, Tag
 
     class Meta:
         ordering = ('weight', 'name')
+        indexes = (
+            models.Index(fields=('weight', 'name')),  # Default ordering
+        )
         verbose_name = _('tag')
         verbose_name_plural = _('tags')
 

--- a/netbox/ipam/migrations/0089_default_ordering_indexes.py
+++ b/netbox/ipam/migrations/0089_default_ordering_indexes.py
@@ -1,0 +1,47 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('dcim', '0231_default_ordering_indexes'),
+        ('extras', '0137_default_ordering_indexes'),
+        ('ipam', '0088_rename_vlangroup_total_vlan_ids'),
+        ('tenancy', '0023_add_mptt_tree_indexes'),
+        ('users', '0015_owner'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='aggregate',
+            index=models.Index(fields=['prefix', 'id'], name='ipam_aggreg_prefix_89dd71_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='fhrpgroup',
+            index=models.Index(fields=['protocol', 'group_id', 'id'], name='ipam_fhrpgr_protoco_0445ae_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='fhrpgroupassignment',
+            index=models.Index(fields=['-priority', 'id'], name='ipam_fhrpgr_priorit_b76335_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='ipaddress',
+            index=models.Index(fields=['address', 'id'], name='ipam_ipaddr_address_3ddeea_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='role',
+            index=models.Index(fields=['weight', 'name'], name='ipam_role_weight_01396b_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='service',
+            index=models.Index(fields=['protocol', 'ports', 'id'], name='ipam_servic_protoco_687d13_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='vlan',
+            index=models.Index(fields=['site', 'group', 'vid', 'id'], name='ipam_vlan_site_id_985573_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='vrf',
+            index=models.Index(fields=['name', 'rd', 'id'], name='ipam_vrf_name_ec911d_idx'),
+        ),
+    ]

--- a/netbox/ipam/migrations/0089_default_ordering_indexes.py
+++ b/netbox/ipam/migrations/0089_default_ordering_indexes.py
@@ -37,6 +37,10 @@ class Migration(migrations.Migration):
             index=models.Index(fields=['protocol', 'ports', 'id'], name='ipam_servic_protoco_687d13_idx'),
         ),
         migrations.AddIndex(
+            model_name='vlangroup',
+            index=models.Index(fields=['name', 'id'], name='ipam_vlangr_name_ffa83e_idx'),
+        ),
+        migrations.AddIndex(
             model_name='vlan',
             index=models.Index(fields=['site', 'group', 'vid', 'id'], name='ipam_vlan_site_id_985573_idx'),
         ),

--- a/netbox/ipam/models/fhrp.py
+++ b/netbox/ipam/models/fhrp.py
@@ -59,6 +59,9 @@ class FHRPGroup(PrimaryModel):
 
     class Meta:
         ordering = ['protocol', 'group_id', 'pk']
+        indexes = (
+            models.Index(fields=('protocol', 'group_id', 'id')),  # Default ordering
+        )
         verbose_name = _('FHRP group')
         verbose_name_plural = _('FHRP groups')
 
@@ -105,6 +108,7 @@ class FHRPGroupAssignment(ChangeLoggedModel):
     class Meta:
         ordering = ('-priority', 'pk')
         indexes = (
+            models.Index(fields=('-priority', 'id')),  # Default ordering
             models.Index(fields=('interface_type', 'interface_id')),
         )
         constraints = (

--- a/netbox/ipam/models/ip.py
+++ b/netbox/ipam/models/ip.py
@@ -110,6 +110,9 @@ class Aggregate(ContactsMixin, GetAvailablePrefixesMixin, PrimaryModel):
 
     class Meta:
         ordering = ('prefix', 'pk')  # prefix may be non-unique
+        indexes = (
+            models.Index(fields=('prefix', 'id')),  # Default ordering
+        )
         verbose_name = _('aggregate')
         verbose_name_plural = _('aggregates')
 
@@ -200,6 +203,9 @@ class Role(OrganizationalModel):
 
     class Meta:
         ordering = ('weight', 'name')
+        indexes = (
+            models.Index(fields=('weight', 'name')),  # Default ordering
+        )
         verbose_name = _('role')
         verbose_name_plural = _('roles')
 
@@ -833,6 +839,7 @@ class IPAddress(ContactsMixin, PrimaryModel):
     class Meta:
         ordering = ('address', 'pk')  # address may be non-unique
         indexes = (
+            models.Index(fields=('address', 'id')),  # Default ordering
             models.Index(Cast(Host('address'), output_field=IPAddressField()), name='ipam_ipaddress_host'),
             models.Index(fields=('assigned_object_type', 'assigned_object_id')),
         )

--- a/netbox/ipam/models/services.py
+++ b/netbox/ipam/models/services.py
@@ -93,6 +93,7 @@ class Service(ContactsMixin, ServiceBase, PrimaryModel):
 
     class Meta:
         indexes = (
+            models.Index(fields=('protocol', 'ports', 'id')),  # Default ordering
             models.Index(fields=('parent_object_type', 'parent_object_id')),
         )
         ordering = ('protocol', 'ports', 'pk')  # (protocol, port) may be non-unique

--- a/netbox/ipam/models/vlans.py
+++ b/netbox/ipam/models/vlans.py
@@ -76,6 +76,7 @@ class VLANGroup(OrganizationalModel):
     class Meta:
         ordering = ('name', 'pk')  # Name may be non-unique
         indexes = (
+            models.Index(fields=('name', 'id')),  # Default ordering
             models.Index(fields=('scope_type', 'scope_id')),
         )
         constraints = (

--- a/netbox/ipam/models/vlans.py
+++ b/netbox/ipam/models/vlans.py
@@ -267,6 +267,9 @@ class VLAN(PrimaryModel):
 
     class Meta:
         ordering = ('site', 'group', 'vid', 'pk')  # (site, group, vid) may be non-unique
+        indexes = (
+            models.Index(fields=('site', 'group', 'vid', 'id')),  # Default ordering
+        )
         constraints = (
             models.UniqueConstraint(
                 fields=('group', 'vid'),

--- a/netbox/ipam/models/vrfs.py
+++ b/netbox/ipam/models/vrfs.py
@@ -58,6 +58,9 @@ class VRF(PrimaryModel):
 
     class Meta:
         ordering = ('name', 'rd', 'pk')  # (name, rd) may be non-unique
+        indexes = (
+            models.Index(fields=('name', 'rd', 'id')),  # Default ordering
+        )
         verbose_name = _('VRF')
         verbose_name_plural = _('VRFs')
 

--- a/netbox/tenancy/migrations/0024_default_ordering_indexes.py
+++ b/netbox/tenancy/migrations/0024_default_ordering_indexes.py
@@ -1,0 +1,21 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('extras', '0137_default_ordering_indexes'),
+        ('tenancy', '0023_add_mptt_tree_indexes'),
+        ('users', '0015_owner'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='contact',
+            index=models.Index(fields=['name'], name='tenancy_con_name_c26153_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='contactassignment',
+            index=models.Index(fields=['contact', 'priority', 'role', 'id'], name='tenancy_con_contact_23011f_idx'),
+        ),
+    ]

--- a/netbox/tenancy/models/contacts.py
+++ b/netbox/tenancy/models/contacts.py
@@ -90,6 +90,9 @@ class Contact(PrimaryModel):
 
     class Meta:
         ordering = ['name']
+        indexes = (
+            models.Index(fields=('name',)),  # Default ordering
+        )
         verbose_name = _('contact')
         verbose_name_plural = _('contacts')
 
@@ -130,6 +133,7 @@ class ContactAssignment(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, Chan
     class Meta:
         ordering = ('contact', 'priority', 'role', 'pk')
         indexes = (
+            models.Index(fields=('contact', 'priority', 'role', 'id')),  # Default ordering
             models.Index(fields=('object_type', 'object_id')),
         )
         constraints = (

--- a/netbox/users/migrations/0016_default_ordering_indexes.py
+++ b/netbox/users/migrations/0016_default_ordering_indexes.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('users', '0015_owner'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='objectpermission',
+            index=models.Index(fields=['name'], name='users_objec_name_ca707b_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='token',
+            index=models.Index(fields=['-created'], name='users_token_created_1467b4_idx'),
+        ),
+    ]

--- a/netbox/users/models/permissions.py
+++ b/netbox/users/models/permissions.py
@@ -52,6 +52,9 @@ class ObjectPermission(CloningMixin, models.Model):
 
     class Meta:
         ordering = ['name']
+        indexes = (
+            models.Index(fields=('name',)),  # Default ordering
+        )
         verbose_name = _('permission')
         verbose_name_plural = _('permissions')
 

--- a/netbox/users/models/tokens.py
+++ b/netbox/users/models/tokens.py
@@ -117,6 +117,9 @@ class Token(models.Model):
 
     class Meta:
         ordering = ('-created',)
+        indexes = (
+            models.Index(fields=('-created',)),  # Default ordering
+        )
         verbose_name = _('token')
         verbose_name_plural = _('tokens')
         constraints = [

--- a/netbox/virtualization/migrations/0055_default_ordering_indexes.py
+++ b/netbox/virtualization/migrations/0055_default_ordering_indexes.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('dcim', '0231_default_ordering_indexes'),
+        ('extras', '0137_default_ordering_indexes'),
+        ('ipam', '0089_default_ordering_indexes'),
+        ('tenancy', '0024_default_ordering_indexes'),
+        ('users', '0016_default_ordering_indexes'),
+        ('virtualization', '0054_virtualmachinetype'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='virtualmachine',
+            index=models.Index(fields=['name', 'id'], name='virtualizat_name_16033e_idx'),
+        ),
+        migrations.AddIndex(
+            model_name='virtualmachinetype',
+            index=models.Index(fields=['name'], name='virtualizat_name_6cff11_idx'),
+        ),
+    ]

--- a/netbox/virtualization/models/clusters.py
+++ b/netbox/virtualization/models/clusters.py
@@ -97,6 +97,9 @@ class Cluster(ContactsMixin, CachedScopeMixin, PrimaryModel):
 
     class Meta:
         ordering = ['name']
+        indexes = (
+            models.Index(fields=('name',)),  # Default ordering
+        )
         constraints = (
             models.UniqueConstraint(
                 fields=('group', 'name'),

--- a/netbox/virtualization/models/virtualmachines.py
+++ b/netbox/virtualization/models/virtualmachines.py
@@ -92,6 +92,9 @@ class VirtualMachineType(ImageAttachmentsMixin, PrimaryModel):
                 violation_error_message=_('Virtual machine type slug must be unique.'),
             ),
         )
+        indexes = (
+            models.Index(fields=('name',)),  # Default ordering
+        )
         verbose_name = _('virtual machine type')
         verbose_name_plural = _('virtual machine types')
 
@@ -249,6 +252,9 @@ class VirtualMachine(
 
     class Meta:
         ordering = ('name', 'pk')  # Name may be non-unique
+        indexes = (
+            models.Index(fields=('name', 'id')),  # Default ordering
+        )
         constraints = (
             models.UniqueConstraint(
                 Lower('name'), 'cluster', 'tenant',

--- a/netbox/vpn/migrations/0012_default_ordering_indexes.py
+++ b/netbox/vpn/migrations/0012_default_ordering_indexes.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('extras', '0137_default_ordering_indexes'),
+        ('ipam', '0089_default_ordering_indexes'),
+        ('vpn', '0011_add_comments_to_organizationalmodel'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='tunneltermination',
+            index=models.Index(fields=['tunnel', 'role', 'id'], name='vpn_tunnelt_tunnel__f542d3_idx'),
+        ),
+    ]

--- a/netbox/vpn/models/tunnels.py
+++ b/netbox/vpn/models/tunnels.py
@@ -145,6 +145,9 @@ class TunnelTermination(CustomFieldsMixin, CustomLinksMixin, TagsMixin, ChangeLo
                 violation_error_message=_("An object may be terminated to only one tunnel at a time.")
             ),
         )
+        indexes = (
+            models.Index(fields=('tunnel', 'role', 'id')),  # Default ordering
+        )
         verbose_name = _('tunnel termination')
         verbose_name_plural = _('tunnel terminations')
 

--- a/netbox/wireless/migrations/0019_default_ordering_indexes.py
+++ b/netbox/wireless/migrations/0019_default_ordering_indexes.py
@@ -1,0 +1,20 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('contenttypes', '0002_remove_content_type_name'),
+        ('dcim', '0231_default_ordering_indexes'),
+        ('extras', '0137_default_ordering_indexes'),
+        ('ipam', '0089_default_ordering_indexes'),
+        ('tenancy', '0024_default_ordering_indexes'),
+        ('users', '0016_default_ordering_indexes'),
+        ('wireless', '0018_add_mptt_tree_indexes'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='wirelesslan',
+            index=models.Index(fields=['ssid', 'id'], name='wireless_wi_ssid_64a9ce_idx'),
+        ),
+    ]

--- a/netbox/wireless/models.py
+++ b/netbox/wireless/models.py
@@ -118,6 +118,7 @@ class WirelessLAN(WirelessAuthenticationBase, CachedScopeMixin, PrimaryModel):
     class Meta:
         ordering = ('ssid', 'pk')
         indexes = (
+            models.Index(fields=('ssid', 'id')),  # Default ordering
             models.Index(fields=('scope_type', 'scope_id')),
         )
         verbose_name = _('wireless LAN')


### PR DESCRIPTION
### Closes: #21455

Introduce a SQL index for each model that doesn't already have one suitable for its default ordering. Skip MPTT-enabled models because they're weird.

Some anecdata from querying devices at `OFFSET 49950`:

| Without index | With index | Improvement
|---|---|---|
| ~90ms | ~21ms | 77% reduction |