### PR TITLE
#21409: Disable `CHANGELOG_RETAIN_CREATE_LAST_UPDATE` by default

### DIFF
--- a/docs/configuration/miscellaneous.md
+++ b/docs/configuration/miscellaneous.md
@@ -77,7 +77,7 @@ This data enables the project maintainers to estimate how many NetBox deployment
 
 !!! tip "Dynamic Configuration Parameter"
 
-Default: `True`
+Default: `False`
 
 When pruning expired changelog entries (per `CHANGELOG_RETENTION`), retain each non-deleted object's original `create`
 change record and its most recent `update` change record. If an object has a `delete` change record, its changelog
@@ -87,10 +87,6 @@ entries are pruned normally according to `CHANGELOG_RETENTION`.
     For objects without a `delete` change record, the original `create` record and most recent `update` record are
     exempt from pruning. All other changelog records (including intermediate `update` records and all `delete` records)
     remain subject to pruning per `CHANGELOG_RETENTION`.
-
-!!! warning
-    This setting is enabled by default. Upgrading deployments that rely on complete pruning of expired changelog entries
-    should explicitly set `CHANGELOG_RETAIN_CREATE_LAST_UPDATE = False` to preserve the previous behavior.
 
 ---
 

--- a/netbox/netbox/config/parameters.py
+++ b/netbox/netbox/config/parameters.py
@@ -186,7 +186,7 @@ PARAMS = (
     ConfigParam(
         name='CHANGELOG_RETAIN_CREATE_LAST_UPDATE',
         label=_('Retain create & last update changelog records'),
-        default=True,
+        default=False,
         description=_(
             "Retain each object's create record and most recent update record when pruning expired changelog entries "
             "(excluding objects with a delete record)."


### PR DESCRIPTION
This modifies the default state of the `CHANGELOG_RETAIN_CREATE_LAST_UPDATE` configuration parameter introduced for NetBox v4.6 under #21409, restoring the original default behavior of deleting _all_ changelog records older than the configured expiration time.

While this is a very useful feature, we should avoid enabling it by default as it has implications e.g. for the size of a deployment's change log and may lead to unexpected behavior for those unaware of the new functionality.