### PR TITLE
Fixes #21814: Correct display of custom script "last run" time

### DIFF
--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -467,7 +467,7 @@ class JobsMixin(models.Model):
         """
         Return a list of the most recent jobs for this instance.
         """
-        return self.jobs.filter(status__in=JobStatusChoices.TERMINAL_STATE_CHOICES).order_by('-created').defer('data')
+        return self.jobs.filter(status__in=JobStatusChoices.TERMINAL_STATE_CHOICES).order_by('-started').defer('data')
 
 
 class JournalingMixin(models.Model):

--- a/netbox/templates/extras/inc/script_list_content.html
+++ b/netbox/templates/extras/inc/script_list_content.html
@@ -54,7 +54,7 @@
                     <td>{{ script.python_class.description|markdown|placeholder }}</td>
                     {% if last_job %}
                       <td>
-                        <a href="{% url 'extras:script_result' job_pk=last_job.pk %}">{{ last_job.created|isodatetime }}</a>
+                        <a href="{% url 'extras:script_result' job_pk=last_job.pk %}">{{ last_job.started|isodatetime }}</a>
                       </td>
                       <td>
                         {% badge last_job.get_status_display last_job.get_status_color %}


### PR DESCRIPTION
### Fixes: #21814

- `get_latest_jobs()` now orders by `-started` instead of `created`, so the most recently executed job surfaces first.               
- The "Last run" link text now shows `last_job.started` instead of `last_job.created`.