### PR TITLE
Fixes #21704: Add port mappings to DeviceType & ModuleType YAML export

### DIFF
--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -557,7 +557,7 @@ class PortTemplateMapping(PortMappingBase):
             'rear_port_position': self.rear_port_position,
         }
 
-        
+
 class FrontPortTemplate(ModularComponentTemplateModel):
     """
     Template for a pass-through port on the front of a new Device.

--- a/netbox/dcim/models/device_component_templates.py
+++ b/netbox/dcim/models/device_component_templates.py
@@ -549,7 +549,15 @@ class PortTemplateMapping(PortMappingBase):
         self.module_type = self.front_port.module_type
         super().save(*args, **kwargs)
 
+    def to_yaml(self):
+        return {
+            'front_port': self.front_port.name,
+            'front_port_position': self.front_port_position,
+            'rear_port': self.rear_port.name,
+            'rear_port_position': self.rear_port_position,
+        }
 
+        
 class FrontPortTemplate(ModularComponentTemplateModel):
     """
     Template for a pass-through port on the front of a new Device.

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -277,18 +277,12 @@ class DeviceType(ImageAttachmentsMixin, PrimaryModel, WeightMixin):
             ]
 
         # Port mappings
-        port_mappings = []
+        port_mapping_data = [
+            c.to_yaml() for c in self.port_mappings.all()
+        ]
 
-        for mapping in self.port_mappings.all():
-            port_mappings.append({
-                'front_port': mapping.front_port.name,
-                'front_port_position': mapping.front_port_position,
-                'rear_port': mapping.rear_port.name,
-                'rear_port_position': mapping.rear_port_position,
-            })
-
-        if port_mappings:
-            data['port-mappings'] = port_mappings
+        if port_mapping_data:
+            data['port-mappings'] = port_mapping_data
 
         if self.modulebaytemplates.exists():
             data['module-bays'] = [

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -289,7 +289,7 @@ class DeviceType(ImageAttachmentsMixin, PrimaryModel, WeightMixin):
 
         if port_mappings:
             data['port-mappings'] = port_mappings
-                
+
         if self.modulebaytemplates.exists():
             data['module-bays'] = [
                 c.to_yaml() for c in self.modulebaytemplates.all()

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -275,6 +275,21 @@ class DeviceType(ImageAttachmentsMixin, PrimaryModel, WeightMixin):
             data['rear-ports'] = [
                 c.to_yaml() for c in self.rearporttemplates.all()
             ]
+
+        # Port mappings
+        port_mappings = []
+
+        for mapping in self.port_mappings.all():
+            port_mappings.append({
+                'front_port': mapping.front_port.name,
+                'front_port_position': mapping.front_port_position,
+                'rear_port': mapping.rear_port.name,
+                'rear_port_position': mapping.rear_port_position,
+            })
+
+        if port_mappings:
+            data['port-mappings'] = port_mappings
+                
         if self.modulebaytemplates.exists():
             data['module-bays'] = [
                 c.to_yaml() for c in self.modulebaytemplates.all()

--- a/netbox/dcim/models/modules.py
+++ b/netbox/dcim/models/modules.py
@@ -192,6 +192,14 @@ class ModuleType(ImageAttachmentsMixin, PrimaryModel, WeightMixin):
                 c.to_yaml() for c in self.rearporttemplates.all()
             ]
 
+        # Port mappings
+        port_mapping_data = [
+            c.to_yaml() for c in self.port_mappings.all()
+        ]
+
+        if port_mapping_data:
+            data['port-mappings'] = port_mapping_data
+
         return yaml.dump(dict(data), sort_keys=False)
 
 


### PR DESCRIPTION
### Fixes: #21704

#### Summary

This fixes the bug where the **Device-type YAML export is missing port mappings**.  

- Added logic in `DeviceType.to_yaml()` to export `port-mappings` with front/rear port names and positions.
