### PR TITLE
Closes #21865: Display debug toolbar if `INTERNAL_IPS` is empty

### DIFF
--- a/docs/configuration/development.md
+++ b/docs/configuration/development.md
@@ -6,7 +6,7 @@ Default: `False`
 
 This setting enables debugging and displays a debugging toolbar in the user interface. Debugging should be enabled only during development or troubleshooting.
 
-Note that the debugging toolbar will be displayed only for requests originating from an [internal IP address](./system.md#internal_ips), if defined. If no internal IPs are defined, the toolbar will be displayed for all requests.
+Note that the debugging toolbar will be displayed only for requests originating from [internal IP addresses](./system.md#internal_ips), if defined. If no internal IPs are defined, the toolbar will be displayed for all requests.
 
 !!! warning
     Never enable debugging on a production system, as it can expose sensitive data to unauthenticated users and impose a

--- a/docs/configuration/development.md
+++ b/docs/configuration/development.md
@@ -4,9 +4,9 @@
 
 Default: `False`
 
-This setting enables debugging. Debugging should be enabled only during development or troubleshooting. Note that only
-clients which access NetBox from a recognized [internal IP address](./system.md#internal_ips) will see debugging tools in the user
-interface.
+This setting enables debugging and displays a debugging toolbar in the user interface. Debugging should be enabled only during development or troubleshooting.
+
+Note that the debugging toolbar will be displayed only for requests originating from an [internal IP address](./system.md#internal_ips), if defined. If no internal IPs are defined, the toolbar will be displayed for all requests.
 
 !!! warning
     Never enable debugging on a production system, as it can expose sensitive data to unauthenticated users and impose a

--- a/docs/configuration/system.md
+++ b/docs/configuration/system.md
@@ -105,6 +105,13 @@ A list of IP addresses recognized as internal to the system, used to control the
 example, the debugging toolbar will be viewable only when a client is accessing NetBox from one of the listed IP
 addresses (and [`DEBUG`](./development.md#debug) is `True`).
 
+!!! info "New in NetBox v4.6"
+    Setting this parameter to an empty list will enable the toolbar for all requests provided debugging is enabled:
+
+    ```python
+    INTERNAL_IPS = []
+    ```
+
 ---
 
 ## ISOLATED_DEPLOYMENT

--- a/netbox/netbox/configuration_example.py
+++ b/netbox/netbox/configuration_example.py
@@ -154,10 +154,6 @@ EXEMPT_VIEW_PERMISSIONS = [
 #     'https': 'http://10.10.1.10:1080',
 # }
 
-# IP addresses recognized as internal to the system. The debugging toolbar will be available only to clients accessing
-# NetBox from an internal IP.
-INTERNAL_IPS = ('127.0.0.1', '::1')
-
 # Enable custom logging. Please see the Django documentation for detailed guidance on configuring custom logs:
 #   https://docs.djangoproject.com/en/stable/topics/logging/
 LOGGING = {}

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -587,6 +587,10 @@ SERIALIZATION_MODULES = {
     'json': 'utilities.serializers.json',
 }
 
+DEBUG_TOOLBAR_CONFIG = {
+    'SHOW_TOOLBAR_CALLBACK': 'utilities.debug.show_toolbar',
+}
+
 
 #
 # Permissions & authentication

--- a/netbox/utilities/debug.py
+++ b/netbox/utilities/debug.py
@@ -1,0 +1,24 @@
+from django.conf import settings
+from django.http import HttpRequest
+
+__all__ = (
+    'show_toolbar',
+)
+
+
+def show_toolbar(request: HttpRequest) -> bool:
+    """
+    Override django-debug-toolbar's default display conditions to allow for an empty INTERNAL_IPS.
+    """
+    if not settings.DEBUG:
+        return False
+
+    # If no internal IPs have been defined, enable the toolbar
+    if not settings.INTERNAL_IPS:
+        return True
+
+    # If the request is from an internal IP, enable the toolbar
+    if request.META.get('REMOTE_ADDR') in settings.INTERNAL_IPS:
+        return True
+
+    return False


### PR DESCRIPTION
### Closes: #21865

This has deviated slightly from the original proposal in the interest of preserving existing capability. Instead of ignoring `INTERNAL_IPS` entirely, we allow for it to be empty, and if so display the debug toolbar for every request (provided debugging is enabled).

- Introduce a custom `show_toolbar()` function in `utilities.debug` to return True if debugging is enabled and `INTERNAL_IPS` is falsy
- Define `DEBUG_TOOLBAR_CONFIG` in `settings.py` and configure `SHOW_TOOLBAR_CALLBACK`
- Remove `INTERNAL_IPS` from the example configuration file as it's a fairly niche parameter
- Document the new debug toolbar behavior