### PR TITLE
Add post_raw_create signal hook for running post-save logic after raw object creation

### DIFF
--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -167,13 +167,13 @@ def retrace_cable_paths(instance, **kwargs):
 
 
 @receiver(post_save, sender=Cable)
-def retrace_cable_paths_on_update_dependencies(sender, instance, update_dependencies=False, **kwargs):
+def retrace_cable_paths_on_raw_create(sender, instance, post_raw_create=False, **kwargs):
     """
     Trigger cable path retracing for a Cable instance when dependencies need to be
-    recalculated. Callers should fire post_save with update_dependencies=True after
+    recalculated. Callers should fire post_save with post_raw_create=True after
     all CableTerminations are in place.
     """
-    if not update_dependencies:
+    if not post_raw_create:
         return
     instance._terminations_modified = True
     trace_paths.send(Cable, instance=instance, created=True)

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -4,6 +4,8 @@ from django.db.models import Q
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
+from netbox.signals import post_raw_create
+
 from dcim.choices import CableEndChoices, LinkStatusChoices
 from ipam.models import Prefix
 from virtualization.models import Cluster, VMInterface
@@ -164,6 +166,23 @@ def retrace_cable_paths(instance, **kwargs):
     """
     for cablepath in CablePath.objects.filter(_nodes__contains=instance):
         cablepath.retrace()
+
+
+@receiver(post_raw_create, sender=Cable)
+def retrace_cable_paths_after_raw_create(sender, pks, **kwargs):
+    """
+    When Cables are created via a raw save, the normal Cable.save() path is bypassed,
+    so trace_paths is never sent. Retrace paths for all newly created cables once their
+    CableTerminations have been applied.
+    """
+    logger = logging.getLogger('netbox.dcim.cable')
+    for cable in Cable.objects.filter(pk__in=pks):
+        cable._terminations_modified = True
+        try:
+            trace_paths.send(Cable, instance=cable, created=True)
+            logger.debug(f"Retraced cable paths for Cable {cable.pk}")
+        except Exception as e:
+            logger.warning(f"Failed to retrace cable paths for Cable {cable.pk}: {e}")
 
 
 @receiver((post_delete, post_save), sender=PortMapping)

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -167,12 +167,13 @@ def retrace_cable_paths(instance, **kwargs):
 
 
 @receiver(post_save, sender=Cable)
-def retrace_cable_paths_on_raw_create(sender, instance, post_raw_create=False, **kwargs):
+def retrace_cable_paths_on_raw_create(sender, instance, raw=False, **kwargs):
     """
     Trigger cable path retracing for a Cable instance when dependencies need to be
     recalculated. Callers should fire post_save with post_raw_create=True after
     all CableTerminations are in place.
     """
+    post_raw_create = kwargs.get('post_raw_create', False)
     if not post_raw_create:
         return
     instance._terminations_modified = True

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -177,11 +177,8 @@ def retrace_cable_paths_after_raw_create(sender, pks, **kwargs):
     logger = logging.getLogger('netbox.dcim.cable')
     for cable in Cable.objects.filter(pk__in=pks):
         cable._terminations_modified = True
-        try:
-            trace_paths.send(Cable, instance=cable, created=True)
-            logger.debug(f"Retraced cable paths for Cable {cable.pk}")
-        except Exception as e:
-            logger.warning(f"Failed to retrace cable paths for Cable {cable.pk}: {e}")
+        trace_paths.send(Cable, instance=cable, created=True)
+        logger.debug(f"Retraced cable paths for Cable {cable.pk}")
 
 
 @receiver((post_delete, post_save), sender=PortMapping)

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -4,10 +4,9 @@ from django.db.models import Q
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
-from netbox.signals import post_raw_create
-
 from dcim.choices import CableEndChoices, LinkStatusChoices
 from ipam.models import Prefix
+from netbox.signals import post_raw_create
 from virtualization.models import Cluster, VMInterface
 from wireless.models import WirelessLAN
 

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -6,7 +6,6 @@ from django.dispatch import receiver
 
 from dcim.choices import CableEndChoices, LinkStatusChoices
 from ipam.models import Prefix
-from netbox.signals import post_raw_create
 from virtualization.models import Cluster, VMInterface
 from wireless.models import WirelessLAN
 
@@ -167,25 +166,17 @@ def retrace_cable_paths(instance, **kwargs):
         cablepath.retrace()
 
 
-@receiver(post_raw_create, sender=Cable)
-def retrace_cable_paths_after_raw_create(sender, pks, **kwargs):
+@receiver(post_save, sender=Cable)
+def retrace_cable_paths_on_update_dependencies(sender, instance, update_dependencies=False, **kwargs):
     """
-    When Cables are created via a raw save, the normal Cable.save() path is bypassed,
-    so trace_paths is never sent. Retrace paths for all newly created cables.
-
-    Callers must only send this signal after all CableTerminations for the given cables
-    have been applied. If a cable has no terminations, update_connected_endpoints will
-    find empty termination lists and skip path creation — so this is safe to call even
-    if terminations are absent, but path tracing will have no effect.
-
-    Note: raw=False (the default) is intentional here — we explicitly want
-    update_connected_endpoints to run, unlike during fixture loading (raw=True).
+    Trigger cable path retracing for a Cable instance when dependencies need to be
+    recalculated. Callers should fire post_save with update_dependencies=True after
+    all CableTerminations are in place.
     """
-    logger = logging.getLogger('netbox.dcim.cable')
-    for cable in Cable.objects.filter(pk__in=pks):
-        cable._terminations_modified = True
-        trace_paths.send(Cable, instance=cable, created=True)
-        logger.debug(f"Retraced cable paths for Cable {cable.pk}")
+    if not update_dependencies:
+        return
+    instance._terminations_modified = True
+    trace_paths.send(Cable, instance=instance, created=True)
 
 
 @receiver((post_delete, post_save), sender=PortMapping)

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -171,8 +171,15 @@ def retrace_cable_paths(instance, **kwargs):
 def retrace_cable_paths_after_raw_create(sender, pks, **kwargs):
     """
     When Cables are created via a raw save, the normal Cable.save() path is bypassed,
-    so trace_paths is never sent. Retrace paths for all newly created cables once their
-    CableTerminations have been applied.
+    so trace_paths is never sent. Retrace paths for all newly created cables.
+
+    Callers must only send this signal after all CableTerminations for the given cables
+    have been applied. If a cable has no terminations, update_connected_endpoints will
+    find empty termination lists and skip path creation — so this is safe to call even
+    if terminations are absent, but path tracing will have no effect.
+
+    Note: raw=False (the default) is intentional here — we explicitly want
+    update_connected_endpoints to run, unlike during fixture loading (raw=True).
     """
     logger = logging.getLogger('netbox.dcim.cable')
     for cable in Cable.objects.filter(pk__in=pks):

--- a/netbox/netbox/signals.py
+++ b/netbox/netbox/signals.py
@@ -3,9 +3,3 @@ from django.dispatch import Signal
 # Signals that a model has completed its clean() method
 post_clean = Signal()
 
-# Sent after objects of a given model are created via raw save.
-# Expected call signature: post_raw_create.send(sender=MyModel, pks=[...])
-# Provides: pks (list) - PKs of the newly created objects.
-# Callers must ensure all related objects (e.g. M2M, dependent rows) are in place
-# before sending, as receivers may query related data to perform post-create work.
-post_raw_create = Signal()

--- a/netbox/netbox/signals.py
+++ b/netbox/netbox/signals.py
@@ -6,4 +6,6 @@ post_clean = Signal()
 # Sent after objects of a given model are created via raw save.
 # Expected call signature: post_raw_create.send(sender=MyModel, pks=[...])
 # Provides: pks (list) - PKs of the newly created objects.
+# Callers must ensure all related objects (e.g. M2M, dependent rows) are in place
+# before sending, as receivers may query related data to perform post-create work.
 post_raw_create = Signal()

--- a/netbox/netbox/signals.py
+++ b/netbox/netbox/signals.py
@@ -4,5 +4,6 @@ from django.dispatch import Signal
 post_clean = Signal()
 
 # Sent after objects of a given model are created via raw save.
-# Provides pks (list) of the created objects.
+# Expected call signature: post_raw_create.send(sender=MyModel, pks=[...])
+# Provides: pks (list) - PKs of the newly created objects.
 post_raw_create = Signal()

--- a/netbox/netbox/signals.py
+++ b/netbox/netbox/signals.py
@@ -2,3 +2,7 @@ from django.dispatch import Signal
 
 # Signals that a model has completed its clean() method
 post_clean = Signal()
+
+# Sent after objects of a given model are created via raw save.
+# Provides pks (list) of the created objects.
+post_raw_create = Signal()

--- a/netbox/netbox/signals.py
+++ b/netbox/netbox/signals.py
@@ -2,4 +2,3 @@ from django.dispatch import Signal
 
 # Signals that a model has completed its clean() method
 post_clean = Signal()
-


### PR DESCRIPTION
### Fixes: #21879 

Triggers cable path retracing after a Cable is created outside the normal save() path (e.g., via bulk_create()). Callers must dispatch Django's built-in post_save signal with post_raw_create=True after all CableTermination records are in place. Without the flag the handler is a no-op, so normal saves are unaffected.

We need a new parameter on the signal-handler instead of using raw=True. Using a handler gated on raw=True would fire at exactly the wrong time. Django sets raw=True during loaddata and fixture imports - scenarios where the database is being populated in dependency order and CableTermination records for a given cable may not exist yet.