### PR TITLE
Closes #21887: Deprecate support for legacy view actions

### DIFF
--- a/netbox/netbox/views/generic/mixins.py
+++ b/netbox/netbox/views/generic/mixins.py
@@ -9,7 +9,7 @@ __all__ = (
     'TableMixin',
 )
 
-# TODO: Remove in NetBox v4.5
+# TODO: Remove in NetBox v4.7
 LEGACY_ACTIONS = {
     'add': object_actions.AddObject,
     'edit': object_actions.EditObject,
@@ -33,13 +33,21 @@ class ActionsMixin:
     """
     actions = tuple()
 
-    # TODO: Remove in NetBox v4.5
+    # TODO: Remove in NetBox v4.7
     def _convert_legacy_actions(self):
         """
         Convert a legacy dictionary mapping action name to required permissions to a list of ObjectAction subclasses.
         """
         if type(self.actions) is not dict:
             return
+
+        import warnings
+        warnings.warn(
+            f"{self.__class__.__name__}.actions is defined as a dictionary, which is deprecated and will be removed "
+            "in NetBox v4.7. Define actions as a list of ObjectAction subclasses instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
         actions = []
         for name in self.actions.keys():
@@ -56,7 +64,7 @@ class ActionsMixin:
         """
         model = model or self.queryset.model
 
-        # TODO: Remove in NetBox v4.5
+        # TODO: Remove in NetBox v4.7
         # Handle legacy action sets
         self._convert_legacy_actions()
 


### PR DESCRIPTION
### Closes: #21887

Raise a deprecation warning for any view which inherits from ActionsMixin and declares `actions` as a dictionary mapping.