### PR TITLE
Closes #21890: Deprecate the `models` registry key

### DIFF
--- a/docs/development/application-registry.md
+++ b/docs/development/application-registry.md
@@ -32,6 +32,9 @@ Core model features are listed in the [features matrix](./models.md#features-mat
 
 ### `models`
 
+!!! warning "Deprecated"
+    Usage of this key has been deprecated and will be removed in NetBox v4.7. Use `ObjectType.objects.public()` to find registered models.
+
 This key lists all models which have been registered in NetBox which are not designated for private use. (Setting `_netbox_private` to True on a model excludes it from this list.) As with individual features under `model_features`, models are organized by app label.
 
 ### `plugins`

--- a/netbox/netbox/models/features.py
+++ b/netbox/netbox/models/features.py
@@ -723,10 +723,10 @@ def register_models(*models):
     for model in models:
         app_label, model_name = model._meta.label_lower.split('.')
 
-        # TODO: Remove in NetBox v4.5
-        # Register public models
+        # TODO: Remove in NetBox v4.7
+        # Register public models (access the underlying dict directly to avoid triggering the deprecation warning)
         if not getattr(model, '_netbox_private', False):
-            registry['models'][app_label].add(model_name)
+            dict.__getitem__(registry, 'models')[app_label].add(model_name)
 
         # Register applicable feature views for the model
         if issubclass(model, ContactsMixin):

--- a/netbox/netbox/registry.py
+++ b/netbox/netbox/registry.py
@@ -9,6 +9,15 @@ class Registry(dict):
     removed (though the value of each key is mutable).
     """
     def __getitem__(self, key):
+        # TODO: Remove in NetBox v4.7
+        if key == 'models':
+            import warnings
+            warnings.warn(
+                'The "models" registry key is deprecated and will be removed in NetBox v4.7. Registered models can be '
+                'obtained by calling ObjectType.objects.public().',
+                DeprecationWarning,
+                stacklevel=2,
+            )
         try:
             return super().__getitem__(key)
         except KeyError:
@@ -30,6 +39,7 @@ registry = Registry({
     'filtersets': dict(),
     'model_actions': collections.defaultdict(set),
     'model_features': dict(),
+    # TODO: Remove in NetBox v4.7
     'models': collections.defaultdict(set),
     'plugins': dict(),
     'request_processors': list(),


### PR DESCRIPTION
### Closes: #21890

Raise a DeprecationWarning on access to `registry['models']`