### PR TITLE
Closes #21682: Update ruff-action to v4.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,9 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
     - name: Check Python linting & PEP8 compliance
-      uses: astral-sh/ruff-action@4919ec5cf1f49eff0871dbcea0da843445b837e6 # v3.6.1
+      uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
       with:
-        version: "0.15.2"
+        version: "0.15.10"
         args: "check --output-format=github"
         src: "netbox/"
 


### PR DESCRIPTION
### Fixes: #21682

This PR updates `astral-sh/ruff-action` to the newly available Node.js 24-compatible release and bumps the Ruff version used in CI. This completes the remaining Ruff-related follow-up from the earlier GitHub Actions housekeeping work and keeps the linting workflow aligned with GitHub Actions' move away from Node 20.

Specifically, this PR:
- updates `astral-sh/ruff-action` from `v3.6.1` to `v4.0.0`
- bumps `ruff` from `0.15.2` to `0.15.10`

This change is limited to the linting workflow and does not affect the Node.js version used for CI testing.