### PR TITLE
Closes #21896: Update create-github-app-token and add-and-commit for Node.js 24 compatibility

### DIFF
--- a/.github/workflows/update-translation-strings.yml
+++ b/.github/workflows/update-translation-strings.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Create app token
-      uses: actions/create-github-app-token@v1
+      uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
       id: app-token
       with:
         app-id: 1076524
@@ -48,7 +48,7 @@ jobs:
       run: python netbox/manage.py makemessages -l ${{ env.LOCALE }}
 
     - name: Commit changes
-      uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
+      uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321 # v10.0.0
       with:
         add: 'netbox/translations/'
         default_author: github_actions


### PR DESCRIPTION
### Fixes: #21896

This PR updates `actions/create-github-app-token` from `v1` to `v3.1.1` and `EndBug/add-and-commit` from `v9.1.4` to `v10.0.0`, pinning both actions to their full commit SHAs.

This is a small housekeeping change to keep the workflow aligned with the Node.js 24 update effort and to improve supply chain security.