### PR TITLE
Fixes #21869: Remove redundant ScriptModule class synchronization on save

### DIFF
--- a/netbox/extras/models/scripts.py
+++ b/netbox/extras/models/scripts.py
@@ -5,8 +5,6 @@ from functools import cached_property
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import models
 from django.db.models import Q
-from django.db.models.signals import post_save
-from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
@@ -188,9 +186,7 @@ class ScriptModule(PythonModuleMixin, JobsMixin, ManagedFile):
     def save(self, *args, **kwargs):
         self.file_root = ManagedFileRootPathChoices.SCRIPTS
         super().save(*args, **kwargs)
+
+        # Sync script classes after the module has been saved. This is the
+        # single intended synchronization path for ScriptModule saves.
         self.sync_classes()
-
-
-@receiver(post_save, sender=ScriptModule)
-def script_module_post_save_handler(instance, created, **kwargs):
-    instance.sync_classes()


### PR DESCRIPTION
### Fixes: #21869

This PR removes the `post_save` signal handler that calls `ScriptModule.sync_classes()`, leaving the existing explicit call in `ScriptModule.save()` as the single synchronization path.

Since `save()` already performs the sync after the model has been written, the additional signal-based call is redundant. Removing it avoids duplicate work during a single save and keeps the behavior a bit simpler and easier to follow.