### PR TITLE
Closes #21902: Upgrade django-tables2 to v3.0

### DIFF
--- a/netbox/templates/inc/table.html
+++ b/netbox/templates/inc/table.html
@@ -6,7 +6,7 @@
       <tr>
         {% for column in table.columns %}
           {% if column.orderable %}
-            <th {{ column.attrs.th.as_html }}><a href="{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a></th>
+            <th {{ column.attrs.th.as_html }}><a href="{% querystring_replace table.prefixed_order_by_field=column.order_by_alias.next %}">{{ column.header }}</a></th>
           {% else %}
             <th {{ column.attrs.th.as_html }}>{{ column.header }}</th>
           {% endif %}

--- a/netbox/templates/inc/table_htmx.html
+++ b/netbox/templates/inc/table_htmx.html
@@ -13,14 +13,14 @@
               {% if column.is_ordered %}
                 <div class="float-end">
                   <a href="#"
-                     hx-get="{{ table.htmx_url }}{% querystring table.prefixed_order_by_field='' %}"
+                     hx-get="{{ table.htmx_url }}{% querystring_replace table.prefixed_order_by_field='' %}"
                      class="text-danger"
                      title="{% trans "Clear ordering" %}"
                   ><i class="mdi mdi-close"></i></a>
                 </div>
               {% endif %}
               <a href="#"
-                 hx-get="{{ table.htmx_url }}{% querystring table.prefixed_order_by_field=column.order_by_alias.next %}"
+                 hx-get="{{ table.htmx_url }}{% querystring_replace table.prefixed_order_by_field=column.order_by_alias.next %}"
               >{{ column.header }}</a>
             </th>
           {% else %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ django-redis==6.0.0
 django-rich==2.2.0
 django-rq==4.0.1
 django-storages==1.14.6
-django-tables2==2.8.0
+django-tables2==3.0.0
 django-taggit==6.1.0
 django-timezone-field==7.2.1
 djangorestframework==3.16.1


### PR DESCRIPTION
### Closes: #21902

- Upgrade django-tables2 to v3.0
- Adapt templates to use renamed `{% querystring_replace %}` template tag
