### PR TITLE
#21361 Expand unit tests for ObjectChange and testing asserts

### DIFF
--- a/netbox/utilities/testing/api.py
+++ b/netbox/utilities/testing/api.py
@@ -254,6 +254,7 @@ class APIViewTestCases:
                     action=ObjectChangeActionChoices.ACTION_CREATE,
                 )
                 self.assertEqual(objectchange.message, data['changelog_message'])
+                self.assertObjectChangeData(objectchange, prechange_data=None, postchange_data=True)
 
         def test_bulk_create_objects(self):
             """
@@ -307,6 +308,8 @@ class APIViewTestCases:
                 self.assertEqual(len(objectchanges), len(self.create_data))
                 for oc in objectchanges:
                     self.assertEqual(oc.message, changelog_message)
+                    self.assertIsNone(oc.prechange_data)
+                    self.assertIsNotNone(oc.postchange_data)
 
     class UpdateObjectViewTestCase(APITestCase):
         update_data = {}
@@ -366,6 +369,8 @@ class APIViewTestCases:
                 )
                 self.assertEqual(objectchange.action, ObjectChangeActionChoices.ACTION_UPDATE)
                 self.assertEqual(objectchange.message, data['changelog_message'])
+                self.assertObjectChangeData(objectchange, prechange_data=True, postchange_data=True)
+                self.assertNotEqual(objectchange.prechange_data, objectchange.postchange_data)
 
         def test_bulk_update_objects(self):
             """
@@ -416,6 +421,9 @@ class APIViewTestCases:
                 for oc in objectchanges:
                     self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_UPDATE)
                     self.assertEqual(oc.message, changelog_message)
+                    self.assertIsNotNone(oc.prechange_data)
+                    self.assertIsNotNone(oc.postchange_data)
+                    self.assertNotEqual(oc.prechange_data, oc.postchange_data)
 
     class DeleteObjectViewTestCase(APITestCase):
 
@@ -464,6 +472,7 @@ class APIViewTestCases:
                 )
                 self.assertEqual(objectchange.action, ObjectChangeActionChoices.ACTION_DELETE)
                 self.assertEqual(objectchange.message, data['changelog_message'])
+                self.assertObjectChangeData(objectchange, prechange_data=True, postchange_data=None)
 
         def test_bulk_delete_objects(self):
             """
@@ -505,6 +514,8 @@ class APIViewTestCases:
                 for oc in objectchanges:
                     self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_DELETE)
                     self.assertEqual(oc.message, changelog_message)
+                    self.assertIsNotNone(oc.prechange_data)
+                    self.assertIsNone(oc.postchange_data)
 
     class GraphQLTestCase(APITestCase):
 

--- a/netbox/utilities/testing/api.py
+++ b/netbox/utilities/testing/api.py
@@ -254,7 +254,7 @@ class APIViewTestCases:
                     action=ObjectChangeActionChoices.ACTION_CREATE,
                 )
                 self.assertObjectChange(objectchange, action=ObjectChangeActionChoices.ACTION_CREATE,
-                    message=data['changelog_message'], prechange_is_none=True, postchange_is_none=False)
+                    message=data['changelog_message'])
 
         def test_bulk_create_objects(self):
             """
@@ -308,7 +308,7 @@ class APIViewTestCases:
                 self.assertEqual(len(objectchanges), len(self.create_data))
                 for oc in objectchanges:
                     self.assertObjectChange(oc, action=ObjectChangeActionChoices.ACTION_CREATE,
-                        message=changelog_message, prechange_is_none=True, postchange_is_none=False)
+                        message=changelog_message)
 
     class UpdateObjectViewTestCase(APITestCase):
         update_data = {}
@@ -367,7 +367,7 @@ class APIViewTestCases:
                     changed_object_id=instance.pk
                 )
                 self.assertObjectChange(objectchange, action=ObjectChangeActionChoices.ACTION_UPDATE,
-                    message=data['changelog_message'], prechange_is_none=False, postchange_is_none=False)
+                    message=data['changelog_message'])
 
         def test_bulk_update_objects(self):
             """
@@ -417,7 +417,7 @@ class APIViewTestCases:
                 self.assertEqual(len(objectchanges), len(data))
                 for oc in objectchanges:
                     self.assertObjectChange(oc, action=ObjectChangeActionChoices.ACTION_UPDATE,
-                        message=changelog_message, prechange_is_none=False, postchange_is_none=False)
+                        message=changelog_message)
 
     class DeleteObjectViewTestCase(APITestCase):
 
@@ -465,7 +465,7 @@ class APIViewTestCases:
                     changed_object_id=instance.pk
                 )
                 self.assertObjectChange(objectchange, action=ObjectChangeActionChoices.ACTION_DELETE,
-                    message=data['changelog_message'], prechange_is_none=False, postchange_is_none=True)
+                    message=data['changelog_message'])
 
         def test_bulk_delete_objects(self):
             """
@@ -506,7 +506,7 @@ class APIViewTestCases:
                 self.assertEqual(len(objectchanges), len(data))
                 for oc in objectchanges:
                     self.assertObjectChange(oc, action=ObjectChangeActionChoices.ACTION_DELETE,
-                        message=changelog_message, prechange_is_none=False, postchange_is_none=True)
+                        message=changelog_message)
 
     class GraphQLTestCase(APITestCase):
 

--- a/netbox/utilities/testing/api.py
+++ b/netbox/utilities/testing/api.py
@@ -253,8 +253,8 @@ class APIViewTestCases:
                     changed_object_id=instance.pk,
                     action=ObjectChangeActionChoices.ACTION_CREATE,
                 )
-                self.assertEqual(objectchange.message, data['changelog_message'])
-                self.assertObjectChangeData(objectchange, prechange_is_none=True, postchange_is_none=False)
+                self.assertObjectChange(objectchange, action=ObjectChangeActionChoices.ACTION_CREATE,
+                    message=data['changelog_message'], prechange_is_none=True, postchange_is_none=False)
 
         def test_bulk_create_objects(self):
             """
@@ -307,8 +307,8 @@ class APIViewTestCases:
                 )
                 self.assertEqual(len(objectchanges), len(self.create_data))
                 for oc in objectchanges:
-                    self.assertEqual(oc.message, changelog_message)
-                    self.assertObjectChangeData(oc, prechange_is_none=True, postchange_is_none=False)
+                    self.assertObjectChange(oc, action=ObjectChangeActionChoices.ACTION_CREATE,
+                        message=changelog_message, prechange_is_none=True, postchange_is_none=False)
 
     class UpdateObjectViewTestCase(APITestCase):
         update_data = {}
@@ -366,10 +366,8 @@ class APIViewTestCases:
                     changed_object_type=ContentType.objects.get_for_model(instance),
                     changed_object_id=instance.pk
                 )
-                self.assertEqual(objectchange.action, ObjectChangeActionChoices.ACTION_UPDATE)
-                self.assertEqual(objectchange.message, data['changelog_message'])
-                self.assertObjectChangeData(objectchange, prechange_is_none=False, postchange_is_none=False)
-                self.assertNotEqual(objectchange.prechange_data, objectchange.postchange_data)
+                self.assertObjectChange(objectchange, action=ObjectChangeActionChoices.ACTION_UPDATE,
+                    message=data['changelog_message'], prechange_is_none=False, postchange_is_none=False)
 
         def test_bulk_update_objects(self):
             """
@@ -418,10 +416,8 @@ class APIViewTestCases:
                 )
                 self.assertEqual(len(objectchanges), len(data))
                 for oc in objectchanges:
-                    self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_UPDATE)
-                    self.assertEqual(oc.message, changelog_message)
-                    self.assertObjectChangeData(oc, prechange_is_none=False, postchange_is_none=False)
-                    self.assertNotEqual(oc.prechange_data, oc.postchange_data)
+                    self.assertObjectChange(oc, action=ObjectChangeActionChoices.ACTION_UPDATE,
+                        message=changelog_message, prechange_is_none=False, postchange_is_none=False)
 
     class DeleteObjectViewTestCase(APITestCase):
 
@@ -468,9 +464,8 @@ class APIViewTestCases:
                     changed_object_type=ContentType.objects.get_for_model(instance),
                     changed_object_id=instance.pk
                 )
-                self.assertEqual(objectchange.action, ObjectChangeActionChoices.ACTION_DELETE)
-                self.assertEqual(objectchange.message, data['changelog_message'])
-                self.assertObjectChangeData(objectchange, prechange_is_none=False, postchange_is_none=True)
+                self.assertObjectChange(objectchange, action=ObjectChangeActionChoices.ACTION_DELETE,
+                    message=data['changelog_message'], prechange_is_none=False, postchange_is_none=True)
 
         def test_bulk_delete_objects(self):
             """
@@ -510,9 +505,8 @@ class APIViewTestCases:
                 )
                 self.assertEqual(len(objectchanges), len(data))
                 for oc in objectchanges:
-                    self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_DELETE)
-                    self.assertEqual(oc.message, changelog_message)
-                    self.assertObjectChangeData(oc, prechange_is_none=False, postchange_is_none=True)
+                    self.assertObjectChange(oc, action=ObjectChangeActionChoices.ACTION_DELETE,
+                        message=changelog_message, prechange_is_none=False, postchange_is_none=True)
 
     class GraphQLTestCase(APITestCase):
 

--- a/netbox/utilities/testing/api.py
+++ b/netbox/utilities/testing/api.py
@@ -254,7 +254,7 @@ class APIViewTestCases:
                     action=ObjectChangeActionChoices.ACTION_CREATE,
                 )
                 self.assertEqual(objectchange.message, data['changelog_message'])
-                self.assertObjectChangeData(objectchange, prechange_data=None, postchange_data=True)
+                self.assertObjectChangeData(objectchange, prechange_is_none=True, postchange_is_none=False)
 
         def test_bulk_create_objects(self):
             """
@@ -308,8 +308,7 @@ class APIViewTestCases:
                 self.assertEqual(len(objectchanges), len(self.create_data))
                 for oc in objectchanges:
                     self.assertEqual(oc.message, changelog_message)
-                    self.assertIsNone(oc.prechange_data)
-                    self.assertIsNotNone(oc.postchange_data)
+                    self.assertObjectChangeData(oc, prechange_is_none=True, postchange_is_none=False)
 
     class UpdateObjectViewTestCase(APITestCase):
         update_data = {}
@@ -369,7 +368,7 @@ class APIViewTestCases:
                 )
                 self.assertEqual(objectchange.action, ObjectChangeActionChoices.ACTION_UPDATE)
                 self.assertEqual(objectchange.message, data['changelog_message'])
-                self.assertObjectChangeData(objectchange, prechange_data=True, postchange_data=True)
+                self.assertObjectChangeData(objectchange, prechange_is_none=False, postchange_is_none=False)
                 self.assertNotEqual(objectchange.prechange_data, objectchange.postchange_data)
 
         def test_bulk_update_objects(self):
@@ -421,8 +420,7 @@ class APIViewTestCases:
                 for oc in objectchanges:
                     self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_UPDATE)
                     self.assertEqual(oc.message, changelog_message)
-                    self.assertIsNotNone(oc.prechange_data)
-                    self.assertIsNotNone(oc.postchange_data)
+                    self.assertObjectChangeData(oc, prechange_is_none=False, postchange_is_none=False)
                     self.assertNotEqual(oc.prechange_data, oc.postchange_data)
 
     class DeleteObjectViewTestCase(APITestCase):
@@ -472,7 +470,7 @@ class APIViewTestCases:
                 )
                 self.assertEqual(objectchange.action, ObjectChangeActionChoices.ACTION_DELETE)
                 self.assertEqual(objectchange.message, data['changelog_message'])
-                self.assertObjectChangeData(objectchange, prechange_data=True, postchange_data=None)
+                self.assertObjectChangeData(objectchange, prechange_is_none=False, postchange_is_none=True)
 
         def test_bulk_delete_objects(self):
             """
@@ -514,8 +512,7 @@ class APIViewTestCases:
                 for oc in objectchanges:
                     self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_DELETE)
                     self.assertEqual(oc.message, changelog_message)
-                    self.assertIsNotNone(oc.prechange_data)
-                    self.assertIsNone(oc.postchange_data)
+                    self.assertObjectChangeData(oc, prechange_is_none=False, postchange_is_none=True)
 
     class GraphQLTestCase(APITestCase):
 

--- a/netbox/utilities/testing/base.py
+++ b/netbox/utilities/testing/base.py
@@ -84,26 +84,29 @@ class TestCase(_TestCase):
     # Custom assertions
     #
 
-    def assertObjectChange(self, objectchange, *, action, message=None, prechange_is_none: bool,
-                           postchange_is_none: bool):
+    def assertObjectChange(self, objectchange, *, action, message=None):
         """
         Assert that an ObjectChange record has the expected attributes. If message is provided, it will be
-        compared against objectchange.message. For UPDATE actions, also asserts that prechange_data and
-        postchange_data differ.
+        compared against objectchange.message.
         """
+        # Verify the change action (create, update, delete)
         self.assertEqual(objectchange.action, action)
+
+        # Verify the changelog message if provided
         if message is not None:
             self.assertEqual(objectchange.message, message)
-        if prechange_is_none:
-            self.assertIsNone(objectchange.prechange_data, "Expected prechange_data to be None")
-        else:
-            self.assertIsNotNone(objectchange.prechange_data, "Expected prechange_data to be populated")
-        if postchange_is_none:
-            self.assertIsNone(objectchange.postchange_data, "Expected postchange_data to be None")
-        else:
-            self.assertIsNotNone(objectchange.postchange_data, "Expected postchange_data to be populated")
-        if action == ObjectChangeActionChoices.ACTION_UPDATE:
+
+        # For creates, prechange must be absent; for updates, snapshots must differ; for deletes, postchange must be absent
+        if action == ObjectChangeActionChoices.ACTION_CREATE:
+            self.assertIsNone(objectchange.prechange_data, "Expected prechange_data to be None for a create")
+            self.assertIsNotNone(objectchange.postchange_data, "Expected postchange_data to be populated for a create")
+        elif action == ObjectChangeActionChoices.ACTION_UPDATE:
+            self.assertIsNotNone(objectchange.prechange_data, "Expected prechange_data to be populated for an update")
+            self.assertIsNotNone(objectchange.postchange_data, "Expected postchange_data to be populated for an update")
             self.assertNotEqual(objectchange.prechange_data, objectchange.postchange_data)
+        elif action == ObjectChangeActionChoices.ACTION_DELETE:
+            self.assertIsNotNone(objectchange.prechange_data, "Expected prechange_data to be populated for a delete")
+            self.assertIsNone(objectchange.postchange_data, "Expected postchange_data to be None for a delete")
 
     def assertHttpStatus(self, response, expected_status):
         """

--- a/netbox/utilities/testing/base.py
+++ b/netbox/utilities/testing/base.py
@@ -83,16 +83,16 @@ class TestCase(_TestCase):
     # Custom assertions
     #
 
-    def assertObjectChangeData(self, objectchange, prechange_data, postchange_data):
+    def assertObjectChangeData(self, objectchange, *, prechange_is_none: bool, postchange_is_none: bool):
         """
         Assert that an ObjectChange record has the expected prechange_data and postchange_data.
-        Pass None to assert the field is null; pass any non-None value to assert it is populated.
+        Set prechange_is_none=True to assert the field is null, False to assert it is populated.
         """
-        if prechange_data is None:
+        if prechange_is_none:
             self.assertIsNone(objectchange.prechange_data, "Expected prechange_data to be None")
         else:
             self.assertIsNotNone(objectchange.prechange_data, "Expected prechange_data to be populated")
-        if postchange_data is None:
+        if postchange_is_none:
             self.assertIsNone(objectchange.postchange_data, "Expected postchange_data to be None")
         else:
             self.assertIsNotNone(objectchange.postchange_data, "Expected postchange_data to be populated")

--- a/netbox/utilities/testing/base.py
+++ b/netbox/utilities/testing/base.py
@@ -84,7 +84,8 @@ class TestCase(_TestCase):
     # Custom assertions
     #
 
-    def assertObjectChange(self, objectchange, *, action, message=None, prechange_is_none: bool, postchange_is_none: bool):
+    def assertObjectChange(self, objectchange, *, action, message=None, prechange_is_none: bool,
+                           postchange_is_none: bool):
         """
         Assert that an ObjectChange record has the expected attributes. If message is provided, it will be
         compared against objectchange.message. For UPDATE actions, also asserts that prechange_data and

--- a/netbox/utilities/testing/base.py
+++ b/netbox/utilities/testing/base.py
@@ -96,7 +96,7 @@ class TestCase(_TestCase):
         if message is not None:
             self.assertEqual(objectchange.message, message)
 
-        # For creates, prechange must be absent; for updates, snapshots must differ; for deletes, postchange must be absent
+        # Verify pre/postchange data presence and integrity based on action type
         if action == ObjectChangeActionChoices.ACTION_CREATE:
             self.assertIsNone(objectchange.prechange_data, "Expected prechange_data to be None for a create")
             self.assertIsNotNone(objectchange.postchange_data, "Expected postchange_data to be populated for a create")

--- a/netbox/utilities/testing/base.py
+++ b/netbox/utilities/testing/base.py
@@ -13,8 +13,8 @@ from django.test import TestCase as _TestCase
 from netaddr import IPNetwork
 from taggit.managers import TaggableManager
 
-from core.models import ObjectType
 from core.choices import ObjectChangeActionChoices
+from core.models import ObjectType
 from users.models import ObjectPermission, User
 from utilities.data import ranges_to_string
 from utilities.object_types import object_type_identifier

--- a/netbox/utilities/testing/base.py
+++ b/netbox/utilities/testing/base.py
@@ -14,6 +14,7 @@ from netaddr import IPNetwork
 from taggit.managers import TaggableManager
 
 from core.models import ObjectType
+from extras.choices import ObjectChangeActionChoices
 from users.models import ObjectPermission, User
 from utilities.data import ranges_to_string
 from utilities.object_types import object_type_identifier
@@ -83,11 +84,15 @@ class TestCase(_TestCase):
     # Custom assertions
     #
 
-    def assertObjectChangeData(self, objectchange, *, prechange_is_none: bool, postchange_is_none: bool):
+    def assertObjectChange(self, objectchange, *, action, message=None, prechange_is_none: bool, postchange_is_none: bool):
         """
-        Assert that an ObjectChange record has the expected prechange_data and postchange_data.
-        Set prechange_is_none=True to assert the field is null, False to assert it is populated.
+        Assert that an ObjectChange record has the expected attributes. If message is provided, it will be
+        compared against objectchange.message. For UPDATE actions, also asserts that prechange_data and
+        postchange_data differ.
         """
+        self.assertEqual(objectchange.action, action)
+        if message is not None:
+            self.assertEqual(objectchange.message, message)
         if prechange_is_none:
             self.assertIsNone(objectchange.prechange_data, "Expected prechange_data to be None")
         else:
@@ -96,6 +101,8 @@ class TestCase(_TestCase):
             self.assertIsNone(objectchange.postchange_data, "Expected postchange_data to be None")
         else:
             self.assertIsNotNone(objectchange.postchange_data, "Expected postchange_data to be populated")
+        if action == ObjectChangeActionChoices.ACTION_UPDATE:
+            self.assertNotEqual(objectchange.prechange_data, objectchange.postchange_data)
 
     def assertHttpStatus(self, response, expected_status):
         """

--- a/netbox/utilities/testing/base.py
+++ b/netbox/utilities/testing/base.py
@@ -83,6 +83,20 @@ class TestCase(_TestCase):
     # Custom assertions
     #
 
+    def assertObjectChangeData(self, objectchange, prechange_data, postchange_data):
+        """
+        Assert that an ObjectChange record has the expected prechange_data and postchange_data.
+        Pass None to assert the field is null; pass any non-None value to assert it is populated.
+        """
+        if prechange_data is None:
+            self.assertIsNone(objectchange.prechange_data, "Expected prechange_data to be None")
+        else:
+            self.assertIsNotNone(objectchange.prechange_data, "Expected prechange_data to be populated")
+        if postchange_data is None:
+            self.assertIsNone(objectchange.postchange_data, "Expected postchange_data to be None")
+        else:
+            self.assertIsNotNone(objectchange.postchange_data, "Expected postchange_data to be populated")
+
     def assertHttpStatus(self, response, expected_status):
         """
         TestCase method. Provide more detail in the event of an unexpected HTTP response.

--- a/netbox/utilities/testing/base.py
+++ b/netbox/utilities/testing/base.py
@@ -14,7 +14,7 @@ from netaddr import IPNetwork
 from taggit.managers import TaggableManager
 
 from core.models import ObjectType
-from extras.choices import ObjectChangeActionChoices
+from core.choices import ObjectChangeActionChoices
 from users.models import ObjectPermission, User
 from utilities.data import ranges_to_string
 from utilities.object_types import object_type_identifier

--- a/netbox/utilities/testing/views.py
+++ b/netbox/utilities/testing/views.py
@@ -194,7 +194,7 @@ class ViewTestCases:
                 self.assertEqual(len(objectchanges), 1)
                 self.assertEqual(objectchanges[0].action, ObjectChangeActionChoices.ACTION_CREATE)
                 self.assertEqual(objectchanges[0].message, self.form_data['changelog_message'])
-                self.assertObjectChangeData(objectchanges[0], prechange_data=None, postchange_data=True)
+                self.assertObjectChangeData(objectchanges[0], prechange_is_none=True, postchange_is_none=False)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'], EXEMPT_EXCLUDE_MODELS=[])
         def test_create_object_with_constrained_permission(self):
@@ -302,7 +302,7 @@ class ViewTestCases:
                 self.assertEqual(len(objectchanges), 1)
                 self.assertEqual(objectchanges[0].action, ObjectChangeActionChoices.ACTION_UPDATE)
                 self.assertEqual(objectchanges[0].message, self.form_data['changelog_message'])
-                self.assertObjectChangeData(objectchanges[0], prechange_data=True, postchange_data=True)
+                self.assertObjectChangeData(objectchanges[0], prechange_is_none=False, postchange_is_none=False)
                 self.assertNotEqual(objectchanges[0].prechange_data, objectchanges[0].postchange_data)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'], EXEMPT_EXCLUDE_MODELS=[])
@@ -399,7 +399,7 @@ class ViewTestCases:
                 self.assertEqual(len(objectchanges), 1)
                 self.assertEqual(objectchanges[0].action, ObjectChangeActionChoices.ACTION_DELETE)
                 self.assertEqual(objectchanges[0].message, form_data['changelog_message'])
-                self.assertObjectChangeData(objectchanges[0], prechange_data=True, postchange_data=None)
+                self.assertObjectChangeData(objectchanges[0], prechange_is_none=False, postchange_is_none=True)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
         def test_delete_object_with_constrained_permission(self):
@@ -721,8 +721,7 @@ class ViewTestCases:
 
                 for oc in objectchanges:
                     self.assertEqual(oc.message, data['changelog_message'])
-                    self.assertIsNone(oc.prechange_data)
-                    self.assertIsNotNone(oc.postchange_data)
+                    self.assertObjectChangeData(oc, prechange_is_none=True, postchange_is_none=False)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
         def test_bulk_update_objects_with_permission(self):
@@ -876,8 +875,7 @@ class ViewTestCases:
                 for oc in objectchanges:
                     self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_UPDATE)
                     self.assertEqual(oc.message, data['changelog_message'])
-                    self.assertIsNotNone(oc.prechange_data)
-                    self.assertIsNotNone(oc.postchange_data)
+                    self.assertObjectChangeData(oc, prechange_is_none=False, postchange_is_none=False)
                     self.assertNotEqual(oc.prechange_data, oc.postchange_data)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'], EXEMPT_EXCLUDE_MODELS=[])
@@ -975,8 +973,7 @@ class ViewTestCases:
                 for oc in objectchanges:
                     self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_DELETE)
                     self.assertEqual(oc.message, data['changelog_message'])
-                    self.assertIsNotNone(oc.prechange_data)
-                    self.assertIsNone(oc.postchange_data)
+                    self.assertObjectChangeData(oc, prechange_is_none=False, postchange_is_none=True)
 
         def test_bulk_delete_objects_with_constrained_permission(self):
             pk_list = self._get_queryset().values_list('pk', flat=True)

--- a/netbox/utilities/testing/views.py
+++ b/netbox/utilities/testing/views.py
@@ -194,6 +194,7 @@ class ViewTestCases:
                 self.assertEqual(len(objectchanges), 1)
                 self.assertEqual(objectchanges[0].action, ObjectChangeActionChoices.ACTION_CREATE)
                 self.assertEqual(objectchanges[0].message, self.form_data['changelog_message'])
+                self.assertObjectChangeData(objectchanges[0], prechange_data=None, postchange_data=True)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'], EXEMPT_EXCLUDE_MODELS=[])
         def test_create_object_with_constrained_permission(self):
@@ -301,6 +302,8 @@ class ViewTestCases:
                 self.assertEqual(len(objectchanges), 1)
                 self.assertEqual(objectchanges[0].action, ObjectChangeActionChoices.ACTION_UPDATE)
                 self.assertEqual(objectchanges[0].message, self.form_data['changelog_message'])
+                self.assertObjectChangeData(objectchanges[0], prechange_data=True, postchange_data=True)
+                self.assertNotEqual(objectchanges[0].prechange_data, objectchanges[0].postchange_data)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'], EXEMPT_EXCLUDE_MODELS=[])
         def test_edit_object_with_constrained_permission(self):
@@ -396,6 +399,7 @@ class ViewTestCases:
                 self.assertEqual(len(objectchanges), 1)
                 self.assertEqual(objectchanges[0].action, ObjectChangeActionChoices.ACTION_DELETE)
                 self.assertEqual(objectchanges[0].message, form_data['changelog_message'])
+                self.assertObjectChangeData(objectchanges[0], prechange_data=True, postchange_data=None)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
         def test_delete_object_with_constrained_permission(self):
@@ -717,6 +721,8 @@ class ViewTestCases:
 
                 for oc in objectchanges:
                     self.assertEqual(oc.message, data['changelog_message'])
+                    self.assertIsNone(oc.prechange_data)
+                    self.assertIsNotNone(oc.postchange_data)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
         def test_bulk_update_objects_with_permission(self):
@@ -870,6 +876,9 @@ class ViewTestCases:
                 for oc in objectchanges:
                     self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_UPDATE)
                     self.assertEqual(oc.message, data['changelog_message'])
+                    self.assertIsNotNone(oc.prechange_data)
+                    self.assertIsNotNone(oc.postchange_data)
+                    self.assertNotEqual(oc.prechange_data, oc.postchange_data)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'], EXEMPT_EXCLUDE_MODELS=[])
         def test_bulk_edit_objects_with_constrained_permission(self):
@@ -966,6 +975,8 @@ class ViewTestCases:
                 for oc in objectchanges:
                     self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_DELETE)
                     self.assertEqual(oc.message, data['changelog_message'])
+                    self.assertIsNotNone(oc.prechange_data)
+                    self.assertIsNone(oc.postchange_data)
 
         def test_bulk_delete_objects_with_constrained_permission(self):
             pk_list = self._get_queryset().values_list('pk', flat=True)

--- a/netbox/utilities/testing/views.py
+++ b/netbox/utilities/testing/views.py
@@ -192,9 +192,8 @@ class ViewTestCases:
                     changed_object_id=instance.pk
                 )
                 self.assertEqual(len(objectchanges), 1)
-                self.assertEqual(objectchanges[0].action, ObjectChangeActionChoices.ACTION_CREATE)
-                self.assertEqual(objectchanges[0].message, self.form_data['changelog_message'])
-                self.assertObjectChangeData(objectchanges[0], prechange_is_none=True, postchange_is_none=False)
+                self.assertObjectChange(objectchanges[0], action=ObjectChangeActionChoices.ACTION_CREATE,
+                    message=self.form_data['changelog_message'], prechange_is_none=True, postchange_is_none=False)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'], EXEMPT_EXCLUDE_MODELS=[])
         def test_create_object_with_constrained_permission(self):
@@ -300,10 +299,8 @@ class ViewTestCases:
                     changed_object_id=instance.pk
                 )
                 self.assertEqual(len(objectchanges), 1)
-                self.assertEqual(objectchanges[0].action, ObjectChangeActionChoices.ACTION_UPDATE)
-                self.assertEqual(objectchanges[0].message, self.form_data['changelog_message'])
-                self.assertObjectChangeData(objectchanges[0], prechange_is_none=False, postchange_is_none=False)
-                self.assertNotEqual(objectchanges[0].prechange_data, objectchanges[0].postchange_data)
+                self.assertObjectChange(objectchanges[0], action=ObjectChangeActionChoices.ACTION_UPDATE,
+                    message=self.form_data['changelog_message'], prechange_is_none=False, postchange_is_none=False)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'], EXEMPT_EXCLUDE_MODELS=[])
         def test_edit_object_with_constrained_permission(self):
@@ -397,9 +394,8 @@ class ViewTestCases:
                     changed_object_id=instance.pk
                 )
                 self.assertEqual(len(objectchanges), 1)
-                self.assertEqual(objectchanges[0].action, ObjectChangeActionChoices.ACTION_DELETE)
-                self.assertEqual(objectchanges[0].message, form_data['changelog_message'])
-                self.assertObjectChangeData(objectchanges[0], prechange_is_none=False, postchange_is_none=True)
+                self.assertObjectChange(objectchanges[0], action=ObjectChangeActionChoices.ACTION_DELETE,
+                    message=form_data['changelog_message'], prechange_is_none=False, postchange_is_none=True)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
         def test_delete_object_with_constrained_permission(self):
@@ -720,8 +716,8 @@ class ViewTestCases:
                 self.assertEqual(len(objectchanges), expected_new_objects)
 
                 for oc in objectchanges:
-                    self.assertEqual(oc.message, data['changelog_message'])
-                    self.assertObjectChangeData(oc, prechange_is_none=True, postchange_is_none=False)
+                    self.assertObjectChange(oc, action=ObjectChangeActionChoices.ACTION_CREATE,
+                        message=data['changelog_message'], prechange_is_none=True, postchange_is_none=False)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
         def test_bulk_update_objects_with_permission(self):
@@ -873,10 +869,8 @@ class ViewTestCases:
                 )
                 self.assertEqual(len(objectchanges), len(pk_list))
                 for oc in objectchanges:
-                    self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_UPDATE)
-                    self.assertEqual(oc.message, data['changelog_message'])
-                    self.assertObjectChangeData(oc, prechange_is_none=False, postchange_is_none=False)
-                    self.assertNotEqual(oc.prechange_data, oc.postchange_data)
+                    self.assertObjectChange(oc, action=ObjectChangeActionChoices.ACTION_UPDATE,
+                        message=data['changelog_message'], prechange_is_none=False, postchange_is_none=False)
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'], EXEMPT_EXCLUDE_MODELS=[])
         def test_bulk_edit_objects_with_constrained_permission(self):
@@ -971,9 +965,8 @@ class ViewTestCases:
                 )
                 self.assertEqual(len(objectchanges), len(pk_list))
                 for oc in objectchanges:
-                    self.assertEqual(oc.action, ObjectChangeActionChoices.ACTION_DELETE)
-                    self.assertEqual(oc.message, data['changelog_message'])
-                    self.assertObjectChangeData(oc, prechange_is_none=False, postchange_is_none=True)
+                    self.assertObjectChange(oc, action=ObjectChangeActionChoices.ACTION_DELETE,
+                        message=data['changelog_message'], prechange_is_none=False, postchange_is_none=True)
 
         def test_bulk_delete_objects_with_constrained_permission(self):
             pk_list = self._get_queryset().values_list('pk', flat=True)

--- a/netbox/utilities/testing/views.py
+++ b/netbox/utilities/testing/views.py
@@ -193,7 +193,7 @@ class ViewTestCases:
                 )
                 self.assertEqual(len(objectchanges), 1)
                 self.assertObjectChange(objectchanges[0], action=ObjectChangeActionChoices.ACTION_CREATE,
-                    message=self.form_data['changelog_message'], prechange_is_none=True, postchange_is_none=False)
+                    message=self.form_data['changelog_message'])
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'], EXEMPT_EXCLUDE_MODELS=[])
         def test_create_object_with_constrained_permission(self):
@@ -300,7 +300,7 @@ class ViewTestCases:
                 )
                 self.assertEqual(len(objectchanges), 1)
                 self.assertObjectChange(objectchanges[0], action=ObjectChangeActionChoices.ACTION_UPDATE,
-                    message=self.form_data['changelog_message'], prechange_is_none=False, postchange_is_none=False)
+                    message=self.form_data['changelog_message'])
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'], EXEMPT_EXCLUDE_MODELS=[])
         def test_edit_object_with_constrained_permission(self):
@@ -395,7 +395,7 @@ class ViewTestCases:
                 )
                 self.assertEqual(len(objectchanges), 1)
                 self.assertObjectChange(objectchanges[0], action=ObjectChangeActionChoices.ACTION_DELETE,
-                    message=form_data['changelog_message'], prechange_is_none=False, postchange_is_none=True)
+                    message=form_data['changelog_message'])
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
         def test_delete_object_with_constrained_permission(self):
@@ -717,7 +717,7 @@ class ViewTestCases:
 
                 for oc in objectchanges:
                     self.assertObjectChange(oc, action=ObjectChangeActionChoices.ACTION_CREATE,
-                        message=data['changelog_message'], prechange_is_none=True, postchange_is_none=False)
+                        message=data['changelog_message'])
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
         def test_bulk_update_objects_with_permission(self):
@@ -870,7 +870,7 @@ class ViewTestCases:
                 self.assertEqual(len(objectchanges), len(pk_list))
                 for oc in objectchanges:
                     self.assertObjectChange(oc, action=ObjectChangeActionChoices.ACTION_UPDATE,
-                        message=data['changelog_message'], prechange_is_none=False, postchange_is_none=False)
+                        message=data['changelog_message'])
 
         @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'], EXEMPT_EXCLUDE_MODELS=[])
         def test_bulk_edit_objects_with_constrained_permission(self):
@@ -966,7 +966,7 @@ class ViewTestCases:
                 self.assertEqual(len(objectchanges), len(pk_list))
                 for oc in objectchanges:
                     self.assertObjectChange(oc, action=ObjectChangeActionChoices.ACTION_DELETE,
-                        message=data['changelog_message'], prechange_is_none=False, postchange_is_none=True)
+                        message=data['changelog_message'])
 
         def test_bulk_delete_objects_with_constrained_permission(self):
             pk_list = self._get_queryset().values_list('pk', flat=True)


### PR DESCRIPTION
### Fixes: #21361 

Adds a new assert `assertObjectChangeData` and checks this in the standard API/View test cases.  It is just extra assert so the overhead is minimal.  The new assertions added to every ObjectChange verification block across views.py and api.py check:

* **CREATE** - prechange_data is None, postchange_data is populated
* **UPDATE** - both fields are populated, and they differ from each other
* **DELETE** - prechange_data is populated, postchange_data is None

This applies to single-object operations (create, edit, delete) and bulk operations (bulk import, bulk edit, bulk delete) in both the UI view tests and API tests.

The primary bug class caught: any code path where snapshot() is not called before a modification, which would leave prechange_data = None on an UPDATE or DELETE record.