### PR TITLE
Closes #21875: Allow subclasses of dict for API_TOKEN_PEPPERS

### DIFF
--- a/netbox/utilities/security.py
+++ b/netbox/utilities/security.py
@@ -9,7 +9,7 @@ def validate_peppers(peppers):
     """
     Validate the given dictionary of cryptographic peppers for type & sufficient length.
     """
-    if type(peppers) is not dict:
+    if not isinstance(peppers, dict):
         raise ImproperlyConfigured("API_TOKEN_PEPPERS must be a dictionary.")
     for key, pepper in peppers.items():
         if type(key) is not int:


### PR DESCRIPTION
### Closes: #21875

Updated `validate_peppers()` in `utilities/security.py` to use `isinstance()`
instead of `type()` validation. This allows the use of OrderedDict or other
dict subclasses in configuration.py.

E.g.:
~~~ .py
    API_TOKEN_PEPPERS = OrderedDict({
        1: "AX....",
        2: "BX....",
    })
~~~