### PR TITLE
Fixes #21913: Restore plugin template extension support on declarative-layout detail views

### DIFF
--- a/netbox/core/views.py
+++ b/netbox/core/views.py
@@ -192,6 +192,12 @@ class DataFileView(generic.ObjectView):
             layout.Column(
                 panels.DataFilePanel(),
                 panels.DataFileContentPanel(),
+                PluginContentPanel('left_page'),
+            ),
+        ),
+        layout.Row(
+            layout.Column(
+                PluginContentPanel('full_width_page'),
             ),
         ),
     )
@@ -253,6 +259,12 @@ class JobLogView(generic.ObjectView):
         layout.Row(
             layout.Column(
                 ContextTablePanel('table', title=_('Log Entries')),
+                PluginContentPanel('left_page'),
+            ),
+        ),
+        layout.Row(
+            layout.Column(
+                PluginContentPanel('full_width_page'),
             ),
         ),
     )
@@ -393,6 +405,12 @@ class ConfigRevisionView(generic.ObjectView):
             layout.Column(
                 TemplatePanel('core/panels/configrevision_data.html'),
                 TemplatePanel('core/panels/configrevision_comment.html'),
+                PluginContentPanel('left_page'),
+            ),
+        ),
+        layout.Row(
+            layout.Column(
+                PluginContentPanel('full_width_page'),
             ),
         ),
     )

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -16,6 +16,7 @@ from netbox.ui.panels import (
     CommentsPanel,
     ContextTablePanel,
     ObjectsTablePanel,
+    PluginContentPanel,
     RelatedObjectsPanel,
     TemplatePanel,
 )
@@ -55,11 +56,13 @@ class VRFView(GetRelatedModelsMixin, generic.ObjectView):
             layout.Column(
                 panels.VRFPanel(),
                 TagsPanel(),
+                PluginContentPanel('left_page'),
             ),
             layout.Column(
                 RelatedObjectsPanel(),
                 CustomFieldsPanel(),
                 CommentsPanel(),
+                PluginContentPanel('right_page'),
             ),
         ),
         layout.Row(
@@ -68,6 +71,11 @@ class VRFView(GetRelatedModelsMixin, generic.ObjectView):
             ),
             layout.Column(
                 ContextTablePanel('export_targets_table', title=_('Export route targets')),
+            ),
+        ),
+        layout.Row(
+            layout.Column(
+                PluginContentPanel('full_width_page'),
             ),
         ),
     )
@@ -169,10 +177,12 @@ class RouteTargetView(generic.ObjectView):
             layout.Column(
                 panels.RouteTargetPanel(),
                 TagsPanel(),
+                PluginContentPanel('left_page'),
             ),
             layout.Column(
                 CustomFieldsPanel(),
                 CommentsPanel(),
+                PluginContentPanel('right_page'),
             ),
         ),
         layout.Row(
@@ -205,6 +215,11 @@ class RouteTargetView(generic.ObjectView):
                     filters={'export_target_id': lambda ctx: ctx['object'].pk},
                     title=_('Exporting L2VPNs'),
                 ),
+            ),
+        ),
+        layout.Row(
+            layout.Column(
+                PluginContentPanel('full_width_page'),
             ),
         ),
     )


### PR DESCRIPTION
### Fixes: #21913

This change adds the `PluginContentPanel` slots (`left_page`, `right_page`, and `full_width_page`) to the `DataFile`, `JobResult`, `ConfigRevision`, `VRF`, and `RouteTarget` detail views.

This restores consistent plugin content injection support for these declarative-layout object pages and brings them in line with other detail views.