### PR TITLE
Closes #21936: Deprecate `LOGIN_REQUIRED`

### DIFF
--- a/docs/configuration/security.md
+++ b/docs/configuration/security.md
@@ -161,6 +161,9 @@ Note that enabling this setting causes NetBox to update a user's session in the 
 
 ## LOGIN_REQUIRED
 
+!!! warning "Legacy Configuration Parameter"
+    The `LOGIN_REQUIRED` configuration parameter is deprecated and will be removed in NetBox v5.0. Unauthenticated access to the application will no longer be supported once this configuration parameter is removed.
+
 Default: `True`
 
 When enabled, only authenticated users are permitted to access any part of NetBox. Disabling this will allow unauthenticated users to access most areas of NetBox (but not make any changes).

--- a/docs/release-notes/version-4.6.md
+++ b/docs/release-notes/version-4.6.md
@@ -70,6 +70,7 @@ A new `start` query parameter has been introduced as an efficient alternative to
 * [#21884](https://github.com/netbox-community/netbox/issues/21884) - Deprecate the obsolete `DEFAULT_ACTION_PERMISSIONS` mapping
 * [#21887](https://github.com/netbox-community/netbox/issues/21887) - Deprecate support for legacy view actions
 * [#21890](https://github.com/netbox-community/netbox/issues/21890) - Deprecate `models` key in application registry
+* [#21936](https://github.com/netbox-community/netbox/issues/21936) - Deprecate the `LOGIN_REQUIRED` configuration parameter
 
 ### Other Changes
 

--- a/netbox/netbox/configuration_example.py
+++ b/netbox/netbox/configuration_example.py
@@ -162,9 +162,6 @@ LOGGING = {}
 # authenticated to NetBox indefinitely.
 LOGIN_PERSISTENCE = False
 
-# Setting this to False will permit unauthenticated users to access most areas of NetBox (but not make any changes).
-LOGIN_REQUIRED = True
-
 # The length of time (in seconds) for which a user will remain logged into the web UI before being prompted to
 # re-authenticate. (Default: 1209600 [14 days])
 LOGIN_TIMEOUT = None

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -243,11 +243,18 @@ for path in PROXY_ROUTERS:
         except ImportError:
             raise ImproperlyConfigured(f"Invalid path in PROXY_ROUTERS: {path}")
 
-# Warn on presence of deprecated configuration parameters
+# Warn on the presence of deprecated configuration parameters
 if not LOGIN_REQUIRED:
     warnings.warn(
         "LOGIN_REQUIRED is deprecated and will be removed in NetBox v5.0. Consider disabling this functionality in "
-        "the near future.",
+        "the near future by removing LOGIN_REQUIRED from your configuration file to avoid a breaking change when "
+        "upgrading to v5.0.",
+        DeprecationWarning,
+    )
+elif hasattr(configuration, 'LOGIN_REQUIRED'):
+    warnings.warn(
+        "LOGIN_REQUIRED is deprecated and will be removed in NetBox v5.0. This parameter can be removed from your "
+        "configuration file",
         DeprecationWarning,
     )
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -246,15 +246,14 @@ for path in PROXY_ROUTERS:
 # Warn on the presence of deprecated configuration parameters
 if not LOGIN_REQUIRED:
     warnings.warn(
-        "LOGIN_REQUIRED is deprecated and will be removed in NetBox v5.0. Consider disabling this functionality in "
-        "the near future by removing LOGIN_REQUIRED from your configuration file to avoid a breaking change when "
-        "upgrading to v5.0.",
+        "LOGIN_REQUIRED is deprecated and will be removed in NetBox v5.0. Unauthenticated access to the application "
+        "will no longer be supported. Please plan to require authentication for all users before upgrading.",
         DeprecationWarning,
     )
 elif hasattr(configuration, 'LOGIN_REQUIRED'):
     warnings.warn(
         "LOGIN_REQUIRED is deprecated and will be removed in NetBox v5.0. This parameter can be removed from your "
-        "configuration file",
+        "configuration file.",
         DeprecationWarning,
     )
 

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -243,6 +243,14 @@ for path in PROXY_ROUTERS:
         except ImportError:
             raise ImproperlyConfigured(f"Invalid path in PROXY_ROUTERS: {path}")
 
+# Warn on presence of deprecated configuration parameters
+if not LOGIN_REQUIRED:
+    warnings.warn(
+        "LOGIN_REQUIRED is deprecated and will be removed in NetBox v5.0. Consider disabling this functionality in "
+        "the near future.",
+        DeprecationWarning,
+    )
+
 
 #
 # Database
@@ -270,12 +278,14 @@ if STORAGE_BACKEND is not None:
         )
     else:
         warnings.warn(
-            "STORAGE_BACKEND is deprecated, use the new STORAGES setting instead."
+            "STORAGE_BACKEND is deprecated, use the new STORAGES setting instead.",
+            DeprecationWarning,
         )
 
 if STORAGE_CONFIG is not None:
     warnings.warn(
-        "STORAGE_CONFIG is deprecated, use the new STORAGES setting instead."
+        "STORAGE_CONFIG is deprecated, use the new STORAGES setting instead.",
+        DeprecationWarning,
     )
 
 # Default STORAGES for Django
@@ -623,7 +633,10 @@ MAINTENANCE_EXEMPT_PATHS = (
 # Warn on the presence of deprecated Sentry config parameters
 for config_param in ('SENTRY_DSN', 'SENTRY_SAMPLE_RATE', 'SENTRY_SEND_DEFAULT_PII', 'SENTRY_TRACES_SAMPLE_RATE'):
     if hasattr(configuration, config_param):
-        warnings.warn(f"{config_param} is deprecated and will be removed in NetBox v4.7. Use SENTRY_CONFIG instead.")
+        warnings.warn(
+            f"{config_param} is deprecated and will be removed in NetBox v4.7. Use SENTRY_CONFIG instead.",
+            DeprecationWarning,
+        )
 
 if SENTRY_ENABLED:
     try:


### PR DESCRIPTION
### Closes: #21936

- Document the deprecation
- Raised a DeprecationWarning if `LOGIN_REQUIRED` is true
- Update similar warnings in `settings.py` to raise a DeprecationWarning specifically