### PR TITLE
Fixes #21947: Fix comments not being saved in the MAC Address edit form

### DIFF
--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -1974,7 +1974,7 @@ class MACAddressForm(PrimaryModelForm):
     class Meta:
         model = MACAddress
         fields = [
-            'mac_address', 'interface', 'vminterface', 'description', 'owner', 'tags',
+            'mac_address', 'interface', 'vminterface', 'description', 'owner', 'comments', 'tags',
         ]
 
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
### Fixes: #21947

This fixes an omission in `MACAddressForm` by adding the `comments` field to the form field list. As a result, comments entered for MAC addresses via the UI are now saved and can be edited as expected.