### PR TITLE
Fixes #21658: Fix OpenAPI schema for available-prefixes endpoint request body

### DIFF
--- a/netbox/ipam/api/views.py
+++ b/netbox/ipam/api/views.py
@@ -392,7 +392,7 @@ class AvailablePrefixesView(AvailableObjectsView):
     @extend_schema(
         methods=["post"],
         responses={201: serializers.PrefixSerializer(many=True)},
-        request=serializers.PrefixSerializer(many=True),
+        request=serializers.PrefixLengthSerializer(many=True),
     )
     def post(self, request, pk):
         return super().post(request, pk)


### PR DESCRIPTION
### Fixes: #21658

## Summary

The `available-prefixes` endpoint correctly validates input using `PrefixLengthSerializer`, which expects a `prefix_length` field.

However, the OpenAPI schema incorrectly documents the request body using `PrefixSerializer`, which leads to a mismatch between the API documentation and the actual behavior.

This change updates the OpenAPI schema to use `PrefixLengthSerializer`, aligning the documentation with the implemented API behavior.

