### PR TITLE
Closes #5795: Use native unique constraint for VirtualMachineType slug

### DIFF
--- a/netbox/virtualization/migrations/0054_virtualmachinetype.py
+++ b/netbox/virtualization/migrations/0054_virtualmachinetype.py
@@ -30,7 +30,7 @@ class Migration(migrations.Migration):
                 ('description', models.CharField(blank=True, max_length=200)),
                 ('comments', models.TextField(blank=True)),
                 ('name', models.CharField(max_length=100)),
-                ('slug', models.SlugField(max_length=100)),
+                ('slug', models.SlugField(max_length=100, unique=True)),
                 (
                     'default_vcpus',
                     models.DecimalField(
@@ -93,14 +93,6 @@ class Migration(migrations.Migration):
                 django.db.models.functions.text.Lower('name'),
                 name='virtualization_virtualmachinetype_unique_name',
                 violation_error_message='Virtual machine type name must be unique.',
-            ),
-        ),
-        migrations.AddConstraint(
-            model_name='virtualmachinetype',
-            constraint=models.UniqueConstraint(
-                fields=('slug',),
-                name='virtualization_virtualmachinetype_unique_slug',
-                violation_error_message='Virtual machine type slug must be unique.',
             ),
         ),
     ]

--- a/netbox/virtualization/models/virtualmachines.py
+++ b/netbox/virtualization/models/virtualmachines.py
@@ -43,6 +43,7 @@ class VirtualMachineType(ImageAttachmentsMixin, PrimaryModel):
     slug = models.SlugField(
         verbose_name=_('slug'),
         max_length=100,
+        unique=True,
     )
     default_platform = models.ForeignKey(
         to='dcim.Platform',
@@ -85,11 +86,6 @@ class VirtualMachineType(ImageAttachmentsMixin, PrimaryModel):
                 Lower('name'),
                 name='%(app_label)s_%(class)s_unique_name',
                 violation_error_message=_('Virtual machine type name must be unique.'),
-            ),
-            models.UniqueConstraint(
-                fields=('slug',),
-                name='%(app_label)s_%(class)s_unique_slug',
-                violation_error_message=_('Virtual machine type slug must be unique.'),
             ),
         )
         indexes = (


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #5795 (follow-up)

<!--
    Please include a summary of the proposed changes below.
-->
Replace the UniqueConstraint on the slug field with the native `unique=True` parameter on SlugField in both the model definition and migration. This resolves a compatibility issue with `netbox_branching`, which does not handle a SlugField combined with a separate UniqueConstraint on the same field.