### PR TITLE
Fixes #21966: Fix OpenAPI schema for available-vlans endpoint request body

### DIFF
--- a/netbox/ipam/api/views.py
+++ b/netbox/ipam/api/views.py
@@ -488,7 +488,7 @@ class AvailableVLANsView(AvailableObjectsView):
     @extend_schema(
         methods=["post"],
         responses={201: serializers.VLANSerializer(many=True)},
-        request=serializers.VLANSerializer(many=True),
+        request=serializers.CreateAvailableVLANSerializer(many=True),
     )
     def post(self, request, pk):
         return super().post(request, pk)


### PR DESCRIPTION
### Fixes: #21966

This updates the OpenAPI schema for the `available-vlans` endpoint so `POST` requests use `CreateAvailableVLANSerializer` instead of `VLANSerializer`.

As a result, the documented request body now reflects the data the endpoint actually accepts and no longer suggests fields like `vid` and `group` that are populated by the endpoint itself.