### PR TITLE
Fixes #21952: Improve robustness of RQ worker check with heartbeat validation

### DIFF
--- a/netbox/utilities/rqworker.py
+++ b/netbox/utilities/rqworker.py
@@ -22,7 +22,22 @@ def get_workers_for_queue(queue_name):
     """
     Returns True if a worker process is currently servicing the specified queue.
     """
-    return Worker.count(get_connection(queue_name))
+    worker_count = Worker.count(get_connection(queue_name))
+    
+    if worker_count == 0:
+        return False
+    
+    connection = get_connection(queue_name)
+    for worker in Worker.all(connection):
+        worker_key = worker.key
+        last_heartbeat = connection.hget(worker_key, 'heartbeat_at')
+        if last_heartbeat is not None:
+            import time
+            heartbeat_age = time.time() - float(last_heartbeat)
+            if heartbeat_age > 60:
+                worker_count -= 1
+    
+    return worker_count > 0
 
 
 def get_rq_retry():


### PR DESCRIPTION
## Fixes: #21952

### Summary

This PR improves the robustness of the RQ worker check by validating worker heartbeat timestamps. When checking if a worker is running, the code now verifies the worker's most recent heartbeat to exclude workers that may have stopped without properly deregistering.

### Changes

- Enhanced  to check worker heartbeat timestamps
- Workers with heartbeat age exceeding 60 seconds are excluded from the count
- This provides a more reliable mechanism for determining worker aliveness

### Implementation Details

The new implementation:1. Gets the initial worker count using 
2. If workers exist, iterates through each worker's heartbeat timestamp
3. Excludes workers with stale heartbeats (>60 seconds old)
4. Returns True only if at least one worker has a recent heartbeat

### Testing

Manual testing should verify:
- Workers with recent heartbeats are correctly counted
- Workers with stale heartbeats are excluded
- System correctly reports when no healthy workers are present
