### PR TITLE
Add support for DynamicModelMultipleChoiceField in custom fields filterset forms.

### DIFF
--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -593,7 +593,7 @@ class CustomField(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMo
                 'required': required,
                 'initial': initial,
             }
-            if not for_csv_import and not for_filterset_form:
+            if not for_csv_import:
                 kwargs['query_params'] = self.related_object_filter
                 kwargs['selector'] = True
 
@@ -608,7 +608,7 @@ class CustomField(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMo
                 'required': required,
                 'initial': initial,
             }
-            if not for_csv_import and not for_filterset_form:
+            if not for_csv_import:
                 kwargs['query_params'] = self.related_object_filter
                 kwargs['selector'] = True
 

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -582,13 +582,18 @@ class CustomField(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMo
         # Object
         elif self.type == CustomFieldTypeChoices.TYPE_OBJECT:
             model = self.related_object_type.model_class()
-            field_class = CSVModelChoiceField if for_csv_import else DynamicModelChoiceField
+            if for_csv_import:
+                field_class = CSVModelChoiceField
+            elif for_filterset_form:
+                field_class = DynamicModelMultipleChoiceField
+            else:
+                field_class = DynamicModelChoiceField
             kwargs = {
                 'queryset': model.objects.all(),
                 'required': required,
                 'initial': initial,
             }
-            if not for_csv_import:
+            if not for_csv_import and not for_filterset_form:
                 kwargs['query_params'] = self.related_object_filter
                 kwargs['selector'] = True
 
@@ -603,7 +608,7 @@ class CustomField(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMo
                 'required': required,
                 'initial': initial,
             }
-            if not for_csv_import:
+            if not for_csv_import and not for_filterset_form:
                 kwargs['query_params'] = self.related_object_filter
                 kwargs['selector'] = True
 


### PR DESCRIPTION

<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Closes: #21854

<!--
    Please include a summary of the proposed changes below.
-->

In the method `_get_form_field` of the class `NetBoxModelFilterSetForm`, the attribute `for_filterset_form` is [passed](https://github.com/miaow2/netbox/blob/main/netbox/netbox/forms/filtersets.py#L48) for rendering custom fields filter forms. 
But the condition for `for_filterset_form` is [missing](https://github.com/miaow2/netbox/blob/main/netbox/extras/models/customfields.py#L585) for object custom fields, and `DynamicModelChoiceField` is rendered, and the user can't choose several objects for filtering.
I have added this condition.
Also added condition `not for_filterset_form` to disable the selector button, because it does not work in filter forms.