### PR TITLE
Fixes #21985: Restore missing color field on Front Port edit form

### DIFF
--- a/netbox/dcim/forms/bulk_create.py
+++ b/netbox/dcim/forms/bulk_create.py
@@ -94,7 +94,7 @@ class InterfaceBulkCreateForm(
 
 
 # class FrontPortBulkCreateForm(
-#     form_from_model(FrontPort, ['label', 'type', 'description', 'tags']),
+#     form_from_model(FrontPort, ['label', 'type', 'color', 'description', 'tags']),
 #     DeviceBulkAddComponentForm
 # ):
 #     pass

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -1166,7 +1166,7 @@ class FrontPortTemplateForm(FrontPortFormMixin, ModularComponentTemplateForm):
                 FieldSet('device_type', name=_('Device Type')),
                 FieldSet('module_type', name=_('Module Type')),
             ),
-            'name', 'label', 'type', 'positions', 'rear_ports', 'description',
+            'name', 'label', 'type', 'color', 'positions', 'rear_ports', 'description',
         ),
     )
 


### PR DESCRIPTION
### Fixes: #21985

This change adds the `color` field to `FrontPortForm`, so front port colors can be edited in the module type UI without being cleared when other changes are saved.