### PR TITLE
Closes #21924: Add sticky bulk actions to account templates (follow-up)

### DIFF
--- a/netbox/templates/account/bookmarks.html
+++ b/netbox/templates/account/bookmarks.html
@@ -23,8 +23,10 @@
     </div>
 
     {# Form buttons #}
-    <div class="btn-list d-print-none mt-2">
-      {% bulk_delete_button model query_params=request.GET %}
+    <div class="card btn-list sticky-actions d-print-none" data-sticky-position="right" data-sticky-when="selection">
+      <div class="btn-list bulk-action-buttons">
+        {% bulk_delete_button model query_params=request.GET %}
+      </div>
     </div>
   </form>
 {% endblock %}

--- a/netbox/templates/account/notifications.html
+++ b/netbox/templates/account/notifications.html
@@ -23,8 +23,10 @@
     </div>
 
     {# Form buttons #}
-    <div class="btn-list d-print-none mt-2">
-      {% bulk_delete_button model query_params=request.GET %}
+    <div class="card btn-list sticky-actions d-print-none" data-sticky-position="right" data-sticky-when="selection">
+      <div class="btn-list bulk-action-buttons">
+        {% bulk_delete_button model query_params=request.GET %}
+      </div>
     </div>
   </form>
 {% endblock %}

--- a/netbox/templates/account/subscriptions.html
+++ b/netbox/templates/account/subscriptions.html
@@ -23,8 +23,10 @@
     </div>
 
     {# Form buttons #}
-    <div class="btn-list d-print-none mt-2">
-      {% bulk_delete_button model query_params=request.GET %}
+    <div class="card btn-list sticky-actions d-print-none" data-sticky-position="right" data-sticky-when="selection">
+      <div class="btn-list bulk-action-buttons">
+        {% bulk_delete_button model query_params=request.GET %}
+      </div>
     </div>
   </form>
 {% endblock %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #21924

<!--
    Please include a summary of the proposed changes below.
-->
Follow-up to #21924 to apply the new sticky-actions pattern to account list templates that were missed in the original refactor. This updates bookmarks, notifications, and subscriptions so their bulk delete controls use the same sticky behavior and styling as other list views.