### PR TITLE
Fixes #22002: Enable horizontal scrolling for Context Table Panels

### DIFF
--- a/netbox/templates/ui/panels/context_table.html
+++ b/netbox/templates/ui/panels/context_table.html
@@ -2,5 +2,7 @@
 {% load render_table from django_tables2 %}
 
 {% block panel_content %}
-  {% render_table table 'inc/table.html' %}
+  <div class="table-responsive">
+    {% render_table table 'inc/table.html' %}
+  </div>
 {% endblock panel_content %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #22002

This adds a `table-responsive` wrapper around tables rendered by the `ContextTablePanel` template.

This ensures wide context tables can scroll horizontally instead of overflowing their panel, especially on smaller viewports or when many table columns are enabled. The change is scoped to the context table panel template so generic table rendering remains unchanged.

