### PR TITLE
#21995 Don't copy unique fields when adding another Contact

### DIFF
--- a/netbox/tenancy/models/contacts.py
+++ b/netbox/tenancy/models/contacts.py
@@ -111,7 +111,7 @@ class Contact(PrimaryModel):
     )
 
     clone_fields = (
-        'groups', 'name', 'title', 'phone', 'email', 'address', 'link',
+        'groups',
     )
 
     class Meta:


### PR DESCRIPTION
### Fixes: #21995

removes name, title, phone, email, address, and link from Contact.clone_fields, keeping only groups. Now when a user clicks "Create & Add Another", only the contact group selection carries over