### PR TITLE
Fixes #22029: Recast empty string values on unique nullable fields as null

### DIFF
--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -638,11 +638,26 @@ class DeviceTestCase(TestCase):
         device2.full_clean()
         device2.save()
 
-    def test_empty_asset_tag_coerced_to_null(self):
+    def test_empty_asset_tag_coerced_to_null_on_clean(self):
         """
         An empty string assigned to a unique nullable CharField (e.g. asset_tag) must be coerced
         to None on save so that multiple objects can be saved without violating the unique
-        constraint.
+        constraint. Test that this is done on clean().
+        """
+        common_kwargs = {
+            'site': Site.objects.first(),
+            'device_type': DeviceType.objects.first(),
+            'role': DeviceRole.objects.first(),
+        }
+        device1 = Device(name='Device 1', asset_tag='', **common_kwargs)
+        device1.clean()
+        self.assertIsNone(device1.asset_tag)
+
+    def test_empty_asset_tag_coerced_to_null_on_save(self):
+        """
+        An empty string assigned to a unique nullable CharField (e.g. asset_tag) must be coerced
+        to None on save so that multiple objects can be saved without violating the unique
+        constraint. Test that this is done on save().
         """
         common_kwargs = {
             'site': Site.objects.first(),

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -638,6 +638,27 @@ class DeviceTestCase(TestCase):
         device2.full_clean()
         device2.save()
 
+    def test_empty_asset_tag_coerced_to_null(self):
+        """
+        An empty string assigned to a unique nullable CharField (e.g. asset_tag) must be coerced
+        to None on save so that multiple objects can be saved without violating the unique
+        constraint.
+        """
+        common_kwargs = {
+            'site': Site.objects.first(),
+            'device_type': DeviceType.objects.first(),
+            'role': DeviceRole.objects.first(),
+        }
+        device1 = Device(name='Device 1', asset_tag='', **common_kwargs)
+        device1.save()
+        device2 = Device(name='Device 2', asset_tag='', **common_kwargs)
+        device2.save()
+
+        device1.refresh_from_db()
+        device2.refresh_from_db()
+        self.assertIsNone(device1.asset_tag)
+        self.assertIsNone(device2.asset_tag)
+
     def test_device_label(self):
         device1 = Device(
             site=Site.objects.first(),

--- a/netbox/netbox/models/__init__.py
+++ b/netbox/netbox/models/__init__.py
@@ -66,14 +66,11 @@ class BaseModel(models.Model):
     class Meta:
         abstract = True
 
-    def clean(self):
+    def _coerce_nullable_unique_chars(self):
         """
-        Validate the model for GenericForeignKey fields to ensure that the content type and object ID exist.
+        Coerce empty strings to None on unique nullable CharFields to avoid spurious
+        uniqueness violations (PostgreSQL treats two empty strings as duplicates).
         """
-        super().clean()
-
-        # Coerce empty strings to None on unique nullable CharFields to avoid spurious
-        # uniqueness violations (PostgreSQL treats two empty strings as duplicates).
         for field in self._meta.concrete_fields:
             if (
                 isinstance(field, models.CharField)
@@ -82,6 +79,13 @@ class BaseModel(models.Model):
                 and getattr(self, field.attname, None) == ''
             ):
                 setattr(self, field.attname, None)
+
+    def clean(self):
+        """
+        Validate the model for GenericForeignKey fields to ensure that the content type and object ID exist.
+        """
+        super().clean()
+        self._coerce_nullable_unique_chars()
 
         for field in self._meta.get_fields():
             if isinstance(field, GenericForeignKey):
@@ -110,17 +114,7 @@ class BaseModel(models.Model):
                     setattr(self, field.name, obj)
 
     def save(self, *args, **kwargs):
-        # Coerce empty strings to None on unique nullable CharFields. PostgreSQL treats
-        # two empty strings as duplicates under a UNIQUE constraint, but treats NULLs as
-        # distinct -- so empty values must be stored as NULL to behave as intended.
-        for field in self._meta.concrete_fields:
-            if (
-                isinstance(field, models.CharField)
-                and field.null
-                and field.unique
-                and getattr(self, field.attname, None) == ''
-            ):
-                setattr(self, field.attname, None)
+        self._coerce_nullable_unique_chars()
         super().save(*args, **kwargs)
 
 

--- a/netbox/netbox/models/__init__.py
+++ b/netbox/netbox/models/__init__.py
@@ -58,6 +58,7 @@ class BaseModel(models.Model):
     This class provides some important overrides to Django's default functionality, such as
     - Overriding the default manager to use RestrictedQuerySet
     - Extending `clean()` to validate GenericForeignKey fields
+    - Extending `clean()` and `save()` to coerce empty strings to None on unique nullable CharFields
     """
 
     objects = RestrictedQuerySet.as_manager()
@@ -70,6 +71,17 @@ class BaseModel(models.Model):
         Validate the model for GenericForeignKey fields to ensure that the content type and object ID exist.
         """
         super().clean()
+
+        # Coerce empty strings to None on unique nullable CharFields to avoid spurious
+        # uniqueness violations (PostgreSQL treats two empty strings as duplicates).
+        for field in self._meta.concrete_fields:
+            if (
+                isinstance(field, models.CharField)
+                and field.null
+                and field.unique
+                and getattr(self, field.attname, None) == ''
+            ):
+                setattr(self, field.attname, None)
 
         for field in self._meta.get_fields():
             if isinstance(field, GenericForeignKey):
@@ -96,6 +108,20 @@ class BaseModel(models.Model):
 
                     # update the GFK field value
                     setattr(self, field.name, obj)
+
+    def save(self, *args, **kwargs):
+        # Coerce empty strings to None on unique nullable CharFields. PostgreSQL treats
+        # two empty strings as duplicates under a UNIQUE constraint, but treats NULLs as
+        # distinct -- so empty values must be stored as NULL to behave as intended.
+        for field in self._meta.concrete_fields:
+            if (
+                isinstance(field, models.CharField)
+                and field.null
+                and field.unique
+                and getattr(self, field.attname, None) == ''
+            ):
+                setattr(self, field.attname, None)
+        super().save(*args, **kwargs)
 
 
 class ChangeLoggedModel(ChangeLoggingMixin, CustomValidationMixin, EventRulesMixin, BaseModel):


### PR DESCRIPTION
### Fixes: #22029

Extends BaseModel to automatically recast empty string values on nullable CharFields as null to avoid triggering a uniqueness violation when attempting to set an "empty" value.