### PR TITLE
Fixes #22031: Fix error when adding a Prefix from a VLAN with no Tenant or Site

### DIFF
--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -1636,8 +1636,11 @@ class VLANView(generic.ObjectView):
                     actions.AddObject(
                         'ipam.prefix',
                         url_params={
-                            'tenant': lambda ctx: ctx['object'].tenant.pk if ctx['object'].tenant else None,
-                            'site': lambda ctx: ctx['object'].site.pk if ctx['object'].site else None,
+                            'tenant': lambda ctx: ctx['object'].tenant_id,
+                            'scope_type': lambda ctx: (
+                                ContentType.objects.get_for_model(Site).pk if ctx['object'].site_id else None
+                            ),
+                            'scope': lambda ctx: ctx['object'].site_id,
                             'vlan': lambda ctx: ctx['object'].pk,
                         },
                         label=_('Add a Prefix'),

--- a/netbox/netbox/ui/actions.py
+++ b/netbox/netbox/ui/actions.py
@@ -92,14 +92,18 @@ class LinkAction(PanelAction):
         """
         url = reverse(self.view_name, kwargs=self.view_kwargs)
         if self.url_params:
-            # If the param value is callable, call it with the context and save the result.
-            url_params = {
-                k: v(context) if callable(v) else v for k, v in self.url_params.items()
-            }
+            url_params = {}
+            for key, value in self.url_params.items():
+                # If the param value is callable, call it with the context and save the result.
+                value = value(context) if callable(value) else value
+                # Omit parameters whose value resolved to None
+                if value is not None:
+                    url_params[key] = value
             # Set the return URL if not already set and an object is available.
             if 'return_url' not in url_params and 'object' in context:
                 url_params['return_url'] = context['object'].get_absolute_url()
-            url = f'{url}?{urlencode(url_params)}'
+            if url_params:
+                url = f'{url}?{urlencode(url_params)}'
         return url
 
     def get_context(self, context):


### PR DESCRIPTION
### Fixes: #22031

This PR fixes the "Add a Prefix" action on VLAN detail pages when optional values such as tenant or site are not set.

Previously, URL parameters that resolved to `None` were serialized into the query string as the literal value `"None"`, for example `tenant=None`. This could cause the Prefix add form to fail while trying to interpret `"None"` as an object ID.

The change updates `LinkAction.get_url()` to skip parameters that resolve to `None`, so optional parameters are simply omitted from the generated URL.

This PR also updates the VLAN-to-Prefix action to pass the Prefix scope using `scope_type` and `scope` instead of the old `site` parameter, while still preselecting the VLAN.