### PR TITLE
Fixes #21960: Allow cable trace to continue through multi-position FrontPorts without position context

### DIFF
--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -936,6 +936,7 @@ class CablePath(models.Model):
                 break
 
             if isinstance(remote_terminations[0], FrontPort):
+
                 # Follow FrontPorts to their corresponding RearPorts
                 if remote_terminations[0].positions > 1 and position_stack:
                     positions = position_stack.pop()
@@ -943,15 +944,44 @@ class CablePath(models.Model):
                     for rt in remote_terminations:
                         q_filter |= Q(front_port=rt, front_port_position__in=positions)
                     port_mappings = PortMapping.objects.filter(q_filter)
-                elif remote_terminations[0].positions > 1:
-                    is_split = True
-                    logger.debug(
-                        'Encountered front port mapped to multiple rear ports but position stack is empty; aborting '
-                        'trace.'
-                    )
-                    break
                 else:
                     port_mappings = PortMapping.objects.filter(front_port__in=remote_terminations)
+
+                    # For multi-position FrontPorts with no positional context, check whether
+                    # all mapped RearPorts converge on the same remote parent (device/module).
+                    # If they diverge to different parents the split is genuinely ambiguous;
+                    # if they share a parent the split is convergent and safe to follow.
+                    if any(rt.positions > 1 for rt in remote_terminations):
+                        if not port_mappings:
+                            break
+                        rear_ports = [m.rear_port for m in port_mappings]
+                        termination_type = ObjectType.objects.get_for_model(rear_ports[0])
+                        local_cts = CableTermination.objects.filter(
+                            termination_type=termination_type,
+                            termination_id__in=[rp.pk for rp in rear_ports]
+                        )
+
+                        q_filter = Q()
+                        for lct in local_cts:
+                            far_end = 'A' if lct.cable_end == 'B' else 'B'
+                            q_filter |= Q(cable=lct.cable, cable_end=far_end)
+
+                        if q_filter:
+                            far_end_cts = CableTermination.objects.filter(q_filter).prefetch_related('termination')
+                            far_end_parents = set()
+                            for ct in far_end_cts:
+                                t = ct.termination
+                                far_end_parents.add(
+                                    ('module', t.module_id) if getattr(t, 'module_id', None)
+                                    else ('device', getattr(t, 'device_id', None))
+                                )
+                            if len(far_end_parents) > 1:
+                                is_split = True
+                                logger.debug(
+                                    'Multi-position FrontPort maps to RearPorts connected to different '
+                                    'remote parents; divergent path, aborting trace.'
+                                )
+                                break
                 if not port_mappings:
                     break
 

--- a/netbox/dcim/tests/test_cablepaths.py
+++ b/netbox/dcim/tests/test_cablepaths.py
@@ -2608,6 +2608,7 @@ class LegacyCablePathTests(CablePathTestCase):
         self.assertPathIsSet(interface2, path2)
 
     def test_224_single_path_via_multiple_pass_throughs_with_breakouts(self):
+
         """
         [IF1] --C1-- [FP1] [RP1] --C2-- [IF3]
         [IF2]        [FP2] [RP2]        [IF4]
@@ -2667,6 +2668,145 @@ class LegacyCablePathTests(CablePathTestCase):
             is_active=True
         )
         self.assertEqual(CablePath.objects.count(), 2)
+
+    def test_225_duplex_single_front_port_cross_connect_two_devices(self):
+
+        """
+        Duplex QSFP model on device B: one multi-position front port maps to two rear ports that cross-connect to a
+        peer (device A) where two strands converge on one interface. Regression for convergent paths without cable
+        position context at the duplex front port.
+        """
+        device_a = self.device
+        device_b = Device.objects.create(
+            site=self.site,
+            device_type=self.device.device_type,
+            role=self.device.role,
+            name='Router B',
+        )
+        if_a = Interface.objects.create(device=device_a, name='ce0')
+        if_b = Interface.objects.create(device=device_b, name='ce0')
+
+        rp_a_tx = RearPort.objects.create(device=device_a, name='ce0-TX', positions=1)
+        rp_a_rx = RearPort.objects.create(device=device_a, name='ce0-RX', positions=1)
+        fp_a_tx = FrontPort.objects.create(device=device_a, name='ce0-tx', positions=1)
+        fp_a_rx = FrontPort.objects.create(device=device_a, name='ce0-rx', positions=1)
+
+        rp_b_tx = RearPort.objects.create(device=device_b, name='ce0-TX', positions=1)
+        rp_b_rx = RearPort.objects.create(device=device_b, name='ce0-RX', positions=1)
+        fp_b_ce0 = FrontPort.objects.create(device=device_b, name='ce0', positions=2)
+
+        PortMapping.objects.bulk_create([
+            PortMapping(
+                device=device_a,
+                front_port=fp_a_tx,
+                front_port_position=1,
+                rear_port=rp_a_tx,
+                rear_port_position=1,
+            ),
+            PortMapping(
+                device=device_a,
+                front_port=fp_a_rx,
+                front_port_position=1,
+                rear_port=rp_a_rx,
+                rear_port_position=1,
+            ),
+            PortMapping(
+                device=device_b,
+                front_port=fp_b_ce0,
+                front_port_position=1,
+                rear_port=rp_b_tx,
+                rear_port_position=1,
+            ),
+            PortMapping(
+                device=device_b,
+                front_port=fp_b_ce0,
+                front_port_position=2,
+                rear_port=rp_b_rx,
+                rear_port_position=1,
+            ),
+        ])
+
+        cable_a_mod = Cable(a_terminations=[if_a], b_terminations=[fp_a_tx, fp_a_rx])
+        cable_a_mod.save()
+        cable_b_mod = Cable(a_terminations=[if_b], b_terminations=[fp_b_ce0])
+        cable_b_mod.save()
+
+        Cable(a_terminations=[rp_a_tx], b_terminations=[rp_b_rx]).save()
+        Cable(a_terminations=[rp_a_rx], b_terminations=[rp_b_tx]).save()
+
+        if_a.refresh_from_db()
+        if_b.refresh_from_db()
+
+        self.assertTrue(if_b._path.is_complete)
+        self.assertEqual(len(if_b.connected_endpoints), 1)
+        self.assertEqual(if_b.connected_endpoints[0].pk, if_a.pk)
+
+        self.assertTrue(if_a._path.is_complete)
+        self.assertEqual(len(if_a.connected_endpoints), 1)
+        self.assertEqual(if_a.connected_endpoints[0].pk, if_b.pk)
+
+    def test_226_divergent_multi_position_front_port_remains_split(self):
+        """
+        A multi-position FrontPort whose positions map to RearPorts on *different*
+        parent devices must still be flagged as a split path.
+
+        This ensures the convergent-path fix (test_225) does not accidentally allow
+        divergent paths through with is_split=False.
+        """
+        device_a = self.device
+        device_b = Device.objects.create(
+            site=self.site,
+            device_type=self.device.device_type,
+            role=self.device.role,
+            name='Router B',
+        )
+        device_c = Device.objects.create(
+            site=self.site,
+            device_type=self.device.device_type,
+            role=self.device.role,
+            name='Router C',
+        )
+
+        if_b = Interface.objects.create(device=device_b, name='ce0')
+
+        # Device B: one duplex front port, two rear ports
+        fp_b = FrontPort.objects.create(device=device_b, name='ce0', positions=2)
+        rp_b_1 = RearPort.objects.create(device=device_b, name='ce0-1', positions=1)
+        rp_b_2 = RearPort.objects.create(device=device_b, name='ce0-2', positions=1)
+
+        # Device A and C each have a single rear port
+        rp_a = RearPort.objects.create(device=device_a, name='rp0', positions=1)
+        rp_c = RearPort.objects.create(device=device_c, name='rp0', positions=1)
+
+        PortMapping.objects.bulk_create([
+            PortMapping(
+                device=device_b,
+                front_port=fp_b,
+                front_port_position=1,
+                rear_port=rp_b_1,
+                rear_port_position=1,
+            ),
+            PortMapping(
+                device=device_b,
+                front_port=fp_b,
+                front_port_position=2,
+                rear_port=rp_b_2,
+                rear_port_position=1,
+            ),
+        ])
+
+        # if_b → fp_b (duplex)
+        Cable(a_terminations=[if_b], b_terminations=[fp_b]).save()
+
+        # Each strand goes to a *different* device → genuinely divergent
+        Cable(a_terminations=[rp_b_1], b_terminations=[rp_a]).save()
+        Cable(a_terminations=[rp_b_2], b_terminations=[rp_c]).save()
+
+        if_b.refresh_from_db()
+        path = if_b._path
+
+        self.assertTrue(path.is_split)
+        self.assertFalse(path.is_complete)
 
     def test_301_create_path_via_existing_cable(self):
         """


### PR DESCRIPTION
### Fixes: #21960

When tracing encounters a multi-position FrontPort with an empty position_stack, instead of aborting unconditionally, perform a one-hop lookahead: inspect what each mapped RearPort is cabled to on the far end and check whether all far-end terminations share the same parent device/module.

- If they share a parent, the split is convergent (all strands lead to the same endpoint) and traversal continues correctly.
- If they diverge to different parents, the path is genuinely ambiguous and is flagged as is_split=True.

The existing abort behavior for multi-position RearPorts is preserved unchanged.

Tests added:
- test_225: convergent duplex QSFP model resolves connected_endpoints in both directions.
- test_226: divergent multi-position FrontPort still flags is_split=True.