### PR TITLE
Fixes #22084: Fix OpenAPI schema for nullable `cable_end` values on cabled objects

### DIFF
--- a/netbox/dcim/api/serializers_/cables.py
+++ b/netbox/dcim/api/serializers_/cables.py
@@ -95,7 +95,8 @@ class CablePathSerializer(serializers.ModelSerializer):
 
 class CabledObjectSerializer(serializers.ModelSerializer):
     cable = CableSerializer(nested=True, read_only=True, allow_null=True)
-    cable_end = serializers.CharField(read_only=True)
+    # Use DRF's ChoiceField; NetBox's ChoiceField would return a value/label object.
+    cable_end = serializers.ChoiceField(choices=CableEndChoices, read_only=True, allow_null=True)
     link_peers_type = serializers.SerializerMethodField(read_only=True, allow_null=True)
     link_peers = serializers.SerializerMethodField(read_only=True)
     _occupied = serializers.SerializerMethodField(read_only=True)


### PR DESCRIPTION
### Fixes: #22084

This updates `CabledObjectSerializer` so `cable_end` is correctly represented in the generated API schema.

Uncabled objects can already return `"cable_end": null`, but the schema currently describes the field as a non-null string. This change marks the field as nullable and uses DRF’s `ChoiceField` so the schema also reflects the allowed values while preserving the existing raw `"A"` / `"B"` API output.