### PR TITLE
Closes #22093: Run coverage only on a single matrix entry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+---
 name: CI
 
 on:
@@ -26,6 +27,9 @@ concurrency:
 
 jobs:
   build:
+    name: >-
+      Tests (Python ${{ matrix.python-version }},
+      Node ${{ matrix.node-version }}${{ matrix.coverage && ', coverage' || '' }})
     runs-on: ubuntu-latest
     env:
       NETBOX_CONFIGURATION: netbox.configuration_testing
@@ -33,6 +37,12 @@ jobs:
       matrix:
         python-version: ['3.12', '3.13', '3.14']
         node-version: ['20.x']
+        include:
+          - coverage: false
+          # Run coverage only once, using the Python 3.14 job.
+          - python-version: '3.14'
+            node-version: '20.x'
+            coverage: true
     services:
       redis:
         image: redis
@@ -53,35 +63,35 @@ jobs:
 
     steps:
     - name: Check out repo
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
     - name: Check Python linting & PEP8 compliance
-      uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b # v4.0.0
+      uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
       with:
         version: "0.15.10"
         args: "check --output-format=github"
         src: "netbox/"
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
 
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
       with:
         node-version: ${{ matrix.node-version }}
-    
+
     - name: Install Yarn Package Manager
       run: npm install -g yarn
-    
+
     - name: Setup Node.js with Yarn Caching
-      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
       with:
         node-version: ${{ matrix.node-version }}
         cache: yarn
         cache-dependency-path: netbox/project-static/yarn.lock
-    
+
     - name: Install Frontend Dependencies
       run: yarn --cwd netbox/project-static
 
@@ -102,12 +112,22 @@ jobs:
 
     - name: Check UI ESLint, TypeScript, and Prettier Compliance
       run: yarn --cwd netbox/project-static validate
-    
+
     - name: Validate Static Asset Integrity
       run: scripts/verify-bundles.sh
 
     - name: Run tests
-      run: coverage run --source="netbox/" netbox/manage.py test netbox/ --parallel
+      if: ${{ ! matrix.coverage }}
+      run: python netbox/manage.py test netbox/ --parallel
+
+    - name: Run tests with coverage
+      if: ${{ matrix.coverage }}
+      run: >-
+        coverage run --source="netbox/"
+        netbox/manage.py test netbox/ --parallel
 
     - name: Show coverage report
-      run: coverage report --skip-covered --omit '*/migrations/*,*/tests/*'
+      if: ${{ matrix.coverage }}
+      run: >-
+        coverage report --skip-covered
+        --omit '*/migrations/*,*/tests/*'


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #22093

<!--
    Please include a summary of the proposed changes below.
-->
Add explicit CI job names showing the Python and Node versions, with the coverage job clearly marked in the GitHub Actions UI.

Run coverage only for the designated coverage matrix entry to avoid redundant coverage collection and reporting across the full test matrix.

Also add the YAML document marker and clean up trailing whitespace.