### PR TITLE
Closes #22118: Collect coverage from parallel test workers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,12 +122,12 @@ jobs:
 
     - name: Run tests with coverage
       if: ${{ matrix.coverage }}
-      run: >-
-        coverage run --source="netbox/"
-        netbox/manage.py test netbox/ --parallel
+      run: coverage run netbox/manage.py test netbox/ --parallel
+
+    - name: Combine coverage data
+      if: ${{ matrix.coverage }}
+      run: coverage combine
 
     - name: Show coverage report
       if: ${{ matrix.coverage }}
-      run: >-
-        coverage report --skip-covered
-        --omit '*/migrations/*,*/tests/*'
+      run: coverage report

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,19 @@ Documentation = "https://netboxlabs.com/docs/netbox/"
 Source = "https://github.com/netbox-community/netbox"
 Issues = "https://github.com/netbox-community/netbox/issues"
 
+[tool.coverage.run]
+source = ["netbox/"]
+concurrency = ["multiprocessing"]
+parallel = true
+sigterm = true
+
+[tool.coverage.report]
+skip_covered = true
+omit = [
+    "*/migrations/*",
+    "*/tests/*",
+]
+
 [tool.pyright]
 include = ["netbox"]
 exclude = [


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #22118

<!--
    Please include a summary of the proposed changes below.
-->
Configure coverage.py to collect data from Django's parallel test workers.

The coverage job currently runs the Django test suite with `--parallel`, which uses worker processes. This change adds coverage.py multiprocessing configuration, moves the measured source/report settings into `pyproject.toml`, and combines the per-process coverage data before generating the report.

This keeps the faster parallel test run while making the remaining coverage job more accurate.