### PR TITLE
Closes #22114: Split CI into conditional jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,12 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE.md'
       - 'contrib/**'
-      - 'docs/**'
       - 'netbox/translations/**'
   pull_request:
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE.md'
       - 'contrib/**'
-      - 'docs/**'
       - 'netbox/translations/**'
 
 permissions:
@@ -26,22 +24,68 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
+
+  # Detect which areas of the codebase changed so downstream jobs can be skipped
+  # when their inputs haven't changed. Jobs that don't match any filter are shown
+  # as "skipped" in GitHub's check list, which satisfies required-status-checks.
+  changes:
+    name: Detect changed files
+    runs-on: ubuntu-latest
+    outputs:
+      python: ${{ steps.filter.outputs.python }}
+      frontend: ${{ steps.filter.outputs.frontend }}
+      docs: ${{ steps.filter.outputs.docs }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+        id: filter
+        with:
+          filters: |
+            python:
+              - 'netbox/**/*.py'
+              - 'requirements*.txt'
+              - 'pyproject.toml'
+            frontend:
+              - 'netbox/project-static/src/**'
+              - 'netbox/project-static/styles/**'
+              - 'netbox/project-static/*.js'
+              - 'netbox/project-static/package.json'
+              - 'netbox/project-static/yarn.lock'
+              - 'netbox/project-static/tsconfig.json'
+            docs:
+              - 'docs/**'
+              - 'mkdocs.yml'
+
+  lint:
+    name: Lint (Python)
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Check Python linting & PEP8 compliance
+        uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
+        with:
+          version: "0.15.10"
+          args: "check --output-format=github"
+          src: "netbox/"
+
+  test:
     name: >-
-      Tests (Python ${{ matrix.python-version }},
-      Node ${{ matrix.node-version }}${{ matrix.coverage && ', coverage' || '' }})
+      Tests (Python ${{ matrix.python-version }}${{ matrix.coverage && ', coverage' || '' }})
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     env:
       NETBOX_CONFIGURATION: netbox.configuration_testing
     strategy:
       matrix:
         python-version: ['3.12', '3.13', '3.14']
-        node-version: ['20.x']
         include:
           - coverage: false
           # Run coverage only once, using the Python 3.14 job.
           - python-version: '3.14'
-            node-version: '20.x'
             coverage: true
     services:
       redis:
@@ -62,72 +106,90 @@ jobs:
           - 5432:5432
 
     steps:
-    - name: Check out repo
-      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-    - name: Check Python linting & PEP8 compliance
-      uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
-      with:
-        version: "0.15.10"
-        args: "check --output-format=github"
-        src: "netbox/"
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
 
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
-      with:
-        python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install coverage tblib
 
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
-      with:
-        node-version: ${{ matrix.node-version }}
+      - name: Check for missing migrations
+        run: python netbox/manage.py makemigrations --check
 
-    - name: Install Yarn Package Manager
-      run: npm install -g yarn
+      - name: Run tests
+        if: ${{ ! matrix.coverage }}
+        run: python netbox/manage.py test netbox/ --parallel
 
-    - name: Setup Node.js with Yarn Caching
-      uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
-      with:
-        node-version: ${{ matrix.node-version }}
-        cache: yarn
-        cache-dependency-path: netbox/project-static/yarn.lock
+      - name: Run tests with coverage
+        if: ${{ matrix.coverage }}
+        run: coverage run netbox/manage.py test netbox/ --parallel
 
-    - name: Install Frontend Dependencies
-      run: yarn --cwd netbox/project-static
+      - name: Combine coverage data
+        if: ${{ matrix.coverage }}
+        run: coverage combine
 
-    - name: Install dependencies & set up configuration
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install coverage tblib
+      - name: Show coverage report
+        if: ${{ matrix.coverage }}
+        run: coverage report
 
-    - name: Build documentation
-      run: zensical build
+  frontend:
+    name: Frontend
+    needs: changes
+    if: needs.changes.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-    - name: Collect static files
-      run: python netbox/manage.py collectstatic --no-input
+      - name: Use Node.js 20.x
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: '20.x'
 
-    - name: Check for missing migrations
-      run: python netbox/manage.py makemigrations --check
+      - name: Install Yarn Package Manager
+        run: npm install -g yarn
 
-    - name: Check UI ESLint, TypeScript, and Prettier Compliance
-      run: yarn --cwd netbox/project-static validate
+      - name: Setup Node.js with Yarn Caching
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6.3.0
+        with:
+          node-version: '20.x'
+          cache: yarn
+          cache-dependency-path: netbox/project-static/yarn.lock
 
-    - name: Validate Static Asset Integrity
-      run: scripts/verify-bundles.sh
+      - name: Install Frontend Dependencies
+        run: yarn --cwd netbox/project-static
 
-    - name: Run tests
-      if: ${{ ! matrix.coverage }}
-      run: python netbox/manage.py test netbox/ --parallel
+      - name: Check UI ESLint, TypeScript, and Prettier Compliance
+        run: yarn --cwd netbox/project-static validate
 
-    - name: Run tests with coverage
-      if: ${{ matrix.coverage }}
-      run: coverage run netbox/manage.py test netbox/ --parallel
+      - name: Validate Static Asset Integrity
+        run: scripts/verify-bundles.sh
 
-    - name: Combine coverage data
-      if: ${{ matrix.coverage }}
-      run: coverage combine
+  docs:
+    name: Documentation
+    needs: changes
+    if: needs.changes.outputs.docs == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-    - name: Show coverage report
-      if: ${{ matrix.coverage }}
-      run: coverage report
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Build documentation
+        run: zensical build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
   lint:
     name: Lint (Python)
     needs: changes
-    if: needs.changes.outputs.python == 'true'
+    if: needs.changes.result == 'success' && needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -75,7 +75,7 @@ jobs:
     name: >-
       Tests (Python ${{ matrix.python-version }}${{ matrix.coverage && ', coverage' || '' }})
     needs: changes
-    if: needs.changes.outputs.python == 'true'
+    if: needs.changes.result == 'success' && needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     env:
       NETBOX_CONFIGURATION: netbox.configuration_testing
@@ -142,7 +142,7 @@ jobs:
   frontend:
     name: Frontend
     needs: changes
-    if: needs.changes.outputs.frontend == 'true'
+    if: needs.changes.result == 'success' && needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
@@ -175,7 +175,7 @@ jobs:
   docs:
     name: Documentation
     needs: changes
-    if: needs.changes.outputs.docs == 'true'
+    if: needs.changes.result == 'success' && needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,11 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       docs: ${{ steps.filter.outputs.docs }}
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36  # v3.0.2
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Detect changed files
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4.0.1
         id: filter
         with:
           filters: |
@@ -46,12 +49,7 @@ jobs:
               - 'requirements*.txt'
               - 'pyproject.toml'
             frontend:
-              - 'netbox/project-static/src/**'
-              - 'netbox/project-static/styles/**'
-              - 'netbox/project-static/*.js'
-              - 'netbox/project-static/package.json'
-              - 'netbox/project-static/yarn.lock'
-              - 'netbox/project-static/tsconfig.json'
+              - 'netbox/project-static/**'
             docs:
               - 'docs/**'
               - 'mkdocs.yml'
@@ -62,7 +60,8 @@ jobs:
     if: needs.changes.result == 'success' && needs.changes.outputs.python == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+      - name: Check out repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Check Python linting & PEP8 compliance
         uses: astral-sh/ruff-action@0ce1b0bf8b818ef400413f810f8a11cdbda0034b  # v4.0.0
@@ -166,8 +165,11 @@ jobs:
       - name: Install Frontend Dependencies
         run: yarn --cwd netbox/project-static
 
-      - name: Check UI ESLint, TypeScript, and Prettier Compliance
+      - name: Validate TypeScript and run ESLint
         run: yarn --cwd netbox/project-static validate
+
+      - name: Validate formatting
+        run: yarn --cwd netbox/project-static validate:formatting
 
       - name: Validate Static Asset Integrity
         run: scripts/verify-bundles.sh


### PR DESCRIPTION
## Fixes #22114

- `paths-ignore`: Removed `docs/**` so docs-only pushes now trigger the workflow (and the docs job runs).
- New jobs:
  - `changes`: Always runs; uses `dorny/paths-filter@v3.0.2` (pinned SHA de90cc6f) to output three booleans — python, frontend, docs — based on which paths changed.
  - `lint`: Runs Ruff only, gated on python == 'true'. No Node, no services, no matrix.
  - `frontend`: Runs ESLint/TypeScript/Prettier validation and bundle integrity check, gated on frontend == 'true'.
  - `docs`: Installs dependencies and runs `zensical build`, gated on docs == 'true'. This was previously impossible — doc-only PRs never triggered CI before.
  - `test` (replaces `build`): Retains the 3-version Python matrix and coverage on 3.14. Stripped of everything test-irrelevant: Node/Yarn setup, zensical build, collectstatic, and frontend validation. Only `pip install`, migration check, and `manage.py test`.
