### PR TITLE
Remove backward compatibility shim for OptionalLimitOffsetPagination

### DIFF
--- a/netbox/netbox/api/pagination.py
+++ b/netbox/netbox/api/pagination.py
@@ -1,5 +1,3 @@
-import warnings
-
 from django.db.models import QuerySet
 from django.utils.translation import gettext_lazy as _
 from rest_framework.exceptions import ValidationError
@@ -222,15 +220,3 @@ class LimitOffsetListPagination(LimitOffsetPagination):
             self.display_page_controls = True
 
         return data[self.offset:self.offset + self.limit]
-
-
-# TODO: Remove in NetBox v4.7.0
-def __getattr__(name):
-    if name == 'OptionalLimitOffsetPagination':
-        warnings.warn(
-            "OptionalLimitOffsetPagination has been renamed to NetBoxPagination. "
-            "OptionalLimitOffsetPagination will be removed in NetBox v4.7.0.",
-            DeprecationWarning,
-        )
-        return NetBoxPagination
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/netbox/netbox/tests/test_api.py
+++ b/netbox/netbox/tests/test_api.py
@@ -46,7 +46,7 @@ class AppTest(APITestCase):
         self.assertEqual(response.data['id'], self.user.pk)
 
 
-class OptionalLimitOffsetPaginationTest(TestCase):
+class NetBoxPaginationTest(TestCase):
 
     def setUp(self):
         self.paginator = NetBoxPagination()


### PR DESCRIPTION
## Summary

Closes #22052

Removes the deprecated `OptionalLimitOffsetPagination` backward compatibility shim from `netbox/api/pagination.py`. This alias (pointing to `NetBoxPagination`) was scheduled for removal in v4.7.0.

Changes:
- Remove `__getattr__` shim that returned `NetBoxPagination` when `OptionalLimitOffsetPagination` was accessed
- Remove unused `import warnings` from `pagination.py`
- Rename test class `OptionalLimitOffsetPaginationTest` → `NetBoxPaginationTest` to reflect the current class name

🤖 Generated with [Claude Code](https://claude.com/claude-code)