### PR TITLE
Remove backward compatibility shim for ExpandableIPAddressField

### DIFF
--- a/netbox/utilities/forms/fields/expandable.py
+++ b/netbox/utilities/forms/fields/expandable.py
@@ -1,5 +1,4 @@
 import re
-import warnings
 
 import netaddr
 from django import forms
@@ -71,15 +70,3 @@ class ExpandableIPNetworkField(forms.CharField):
         if family == 6 and re.search(IP6_EXPANSION_PATTERN, value):
             return list(expand_ipnetwork_pattern(value.lower(), 6))
         return [value]
-
-
-# TODO: Remove in NetBox v4.7.0
-def __getattr__(name):
-    if name == 'ExpandableIPAddressField':
-        warnings.warn(
-            "ExpandableIPAddressField has been renamed to ExpandableIPNetworkField. "
-            "ExpandableIPAddressField will be removed in NetBox v4.7.0.",
-            DeprecationWarning,
-        )
-        return ExpandableIPNetworkField
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

Closes #22053

Removes the deprecated `ExpandableIPAddressField` backward compatibility shim from `utilities/forms/fields/expandable.py`. This alias (pointing to `ExpandableIPNetworkField`) was scheduled for removal in v4.7.0.

Changes:
- Remove `__getattr__` shim that returned `ExpandableIPNetworkField` when `ExpandableIPAddressField` was accessed
- Remove unused `import warnings` from `expandable.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)