### PR TITLE
Closes #22128: Deprecate v1 API tokens

### DIFF
--- a/docs/integrations/rest-api.md
+++ b/docs/integrations/rest-api.md
@@ -792,7 +792,10 @@ Additionally, a token can be set to expire at a specific time. This can be usefu
 
 #### v1 and v2 Tokens
 
-Beginning with NetBox v4.5, two versions of API token are supported, denoted as v1 and v2. Users are strongly encouraged to create only v2 tokens and to discontinue the use of v1 tokens. Support for v1 tokens will be removed in a future NetBox release.
+!!! warning "v1 Tokens Are Deprecated"
+    v1 API tokens are deprecated as of NetBox v4.6 and will be removed in NetBox v5.0. All users should migrate to v2 tokens.
+
+Beginning with NetBox v4.5, two versions of API token are supported, denoted as v1 and v2. Users are strongly encouraged to create only v2 tokens and to discontinue the use of v1 tokens.
 
 v2 API tokens offer much stronger security. The token plaintext given at creation time is hashed together with a configured [cryptographic pepper](../configuration/required-parameters.md#api_token_peppers) to generate a unique checksum. This checksum is irreversible; the token plaintext is never stored on the server and thus cannot be retrieved even with database-level access.
 

--- a/docs/models/users/token.md
+++ b/docs/models/users/token.md
@@ -2,13 +2,13 @@
 
 A token is a secret credential associated with a [user](./user.md) which authenticates requests to NetBox's REST and GraphQL APIs. A user may hold multiple tokens; each can be independently expired, restricted, or revoked.
 
-Beginning with NetBox v4.5, two token versions are supported. v2 tokens (the default for newly-created tokens) are stored only as a salted HMAC digest, and the plaintext is shown to the user only once at creation time. Legacy v1 tokens store the plaintext directly and are retained for backward compatibility; their use is discouraged. See the [REST API authentication](../../integrations/rest-api.md#authentication) documentation for the request header formats used by each version.
+Beginning with NetBox v4.5, two token versions are supported. v2 tokens (the default for newly-created tokens) are stored only as a salted HMAC digest, and the plaintext is shown to the user only once at creation time. Legacy v1 tokens store the plaintext directly; **their use is deprecated and support will be removed in NetBox v5.0.** See the [REST API authentication](../../integrations/rest-api.md#authentication) documentation for the request header formats used by each version.
 
 ## Fields
 
 ### Version
 
-Indicates whether this is a v1 (legacy) or v2 token. v2 is the default and is strongly preferred.
+Indicates whether this is a v1 (legacy) or v2 token. v2 is the default and is strongly preferred. **v1 tokens are deprecated and will be removed in NetBox v5.0.**
 
 ### User
 

--- a/netbox/templates/account/usertoken_edit.html
+++ b/netbox/templates/account/usertoken_edit.html
@@ -1,6 +1,28 @@
 {% extends 'generic/object_edit.html' %}
 {% load i18n %}
 
+{% block content %}
+  {% include 'users/inc/v1_token_warning.html' %}
+  {{ block.super }}
+{% endblock %}
+
+{% block javascript %}
+{{ block.super }}
+<script>
+  (function () {
+    const versionField = document.getElementById('id_version');
+    const v1Warning = document.getElementById('v1-deprecation-warning');
+    if (versionField && v1Warning) {
+      function updateV1Warning() {
+        v1Warning.style.display = versionField.value === '1' ? '' : 'none';
+      }
+      versionField.addEventListener('change', updateV1Warning);
+      updateV1Warning();
+    }
+  })();
+</script>
+{% endblock javascript %}
+
 {% block buttons %}
   {# Omit the "Create & Add Another" button: that flow would redirect away from the detail page before the #}
   {# one-time plaintext can be displayed, leaving the new token unrecoverable. #}

--- a/netbox/templates/users/inc/v1_token_warning.html
+++ b/netbox/templates/users/inc/v1_token_warning.html
@@ -1,0 +1,17 @@
+{% load i18n %}
+<div id="v1-deprecation-warning" class="alert alert-warning bg-warning-subtle mx-3 my-2" role="alert" style="display: none;">
+  <div class="d-flex">
+    <div>
+      <i class="mdi mdi-alert p-2"></i>
+    </div>
+    <div>
+      <h4 class="alert-title">{% trans "v1 API Tokens Are Deprecated" %}</h4>
+      <div class="text-secondary">
+        {% blocktrans trimmed %}
+          v1 API tokens are deprecated and will be removed in a future NetBox release.
+          Please use v2 tokens instead.
+        {% endblocktrans %}
+      </div>
+    </div>
+  </div>
+</div>

--- a/netbox/templates/users/token_edit.html
+++ b/netbox/templates/users/token_edit.html
@@ -5,8 +5,26 @@
   {% if not request.user.is_superuser %}
     {% include 'inc/alerts/warning.html' with title="Creating API Tokens" message="Non-superusers should generally create and modify API tokens under their user profile." %}
   {% endif %}
+  {% include 'users/inc/v1_token_warning.html' %}
   {{ block.super }}
 {% endblock %}
+
+{% block javascript %}
+{{ block.super }}
+<script>
+  (function () {
+    const versionField = document.getElementById('id_version');
+    const v1Warning = document.getElementById('v1-deprecation-warning');
+    if (versionField && v1Warning) {
+      function updateV1Warning() {
+        v1Warning.style.display = versionField.value === '1' ? '' : 'none';
+      }
+      versionField.addEventListener('change', updateV1Warning);
+      updateV1Warning();
+    }
+  })();
+</script>
+{% endblock javascript %}
 
 {% block buttons %}
   {# Omit the "Create & Add Another" button: that flow would redirect away from the detail page before the #}


### PR DESCRIPTION
Closes: #22128

## Summary

- Adds a dynamic warning banner to both the admin (`/users/tokens/add/`) and user profile (`/account/tokens/add/`) token creation forms that appears when v1 is selected from the version dropdown, and persists when editing an existing v1 token
- Updates `docs/integrations/rest-api.md` with a prominent MkDocs warning callout noting v1 tokens are deprecated since v4.6 and will be removed in v5.0
- Updates `docs/models/users/token.md` to call out the deprecation inline in the Version field descriptions

## Test plan

- [x] Create a new token via `/users/tokens/add/` — default is v2, no warning shown; switch dropdown to v1, warning appears; switch back to v2, warning disappears
- [x] Same flow via the user profile token page (`/account/tokens/add/`)
- [x] Edit an existing v1 token — warning is shown immediately (version field is disabled but JS still reads the value)
- [x] Edit an existing v2 token — no warning shown
- [x] Preview docs site (`mkdocs serve`) and confirm warning callout renders in the REST API and Token model pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)