### PR TITLE
Closes #19324: Limit CI push trigger to main and feature

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+      - feature
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/PULL_REQUEST_TEMPLATE.md'


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #19324

<!--
    Please include a summary of the proposed changes below.
-->
Restrict the CI workflow's push trigger to the main and feature branches while preserving the existing paths-ignore filters.

This avoids unnecessary push-triggered CI runs on topic branches without changing pull request workflow behavior.