### PR TITLE
Closes #22150: Run collectstatic before Python tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 # Add concurrency group to control job running
 concurrency:
@@ -124,6 +125,11 @@ jobs:
 
       - name: Check for missing migrations
         run: python netbox/manage.py makemigrations --check
+
+      # Copy frontend-generated files into STATIC_ROOT before SVG rendering
+      # tests read their CSS directly.
+      - name: Collect static files
+        run: python netbox/manage.py collectstatic --no-input
 
       - name: Run tests
         if: ${{ ! matrix.coverage }}


### PR DESCRIPTION
### Fixes: #22150

Run `collectstatic` before the Python test suite so committed static assets are available under `STATIC_ROOT`.

Some SVG rendering code reads CSS files such as `rack_elevation.css` and `cable_trace.css` directly from `STATIC_ROOT`. These files already ship with NetBox under `project-static/dist/`, but after the recent CI split the Python test job no longer prepares collected static files before running the tests.

This keeps the application code unchanged and avoids making the Python test matrix depend on frontend build artifacts.