### PR TITLE
Closes #22077: Move API test authentication setup to setUpTestData

### DIFF
--- a/netbox/circuits/tests/test_api.py
+++ b/netbox/circuits/tests/test_api.py
@@ -58,6 +58,8 @@ class ProviderTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class CircuitTypeTest(APIViewTestCases.APIViewTestCase):
     model = CircuitType
@@ -89,6 +91,8 @@ class CircuitTypeTest(APIViewTestCases.APIViewTestCase):
             CircuitType(name='Circuit Type 3', slug='circuit-type-3'),
         )
         CircuitType.objects.bulk_create(circuit_types)
+
+        super().setUpTestData()
 
 
 class CircuitTest(APIViewTestCases.APIViewTestCase):
@@ -154,6 +158,8 @@ class CircuitTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class CircuitTerminationTest(APIViewTestCases.APIViewTestCase):
     model = CircuitTermination
@@ -216,6 +222,8 @@ class CircuitTerminationTest(APIViewTestCases.APIViewTestCase):
             'port_speed': 123456
         }
 
+        super().setUpTestData()
+
 
 class CircuitGroupTest(APIViewTestCases.APIViewTestCase):
     model = CircuitGroup
@@ -247,6 +255,8 @@ class CircuitGroupTest(APIViewTestCases.APIViewTestCase):
                 'slug': 'circuit-group-6',
             },
         ]
+
+        super().setUpTestData()
 
 
 class ProviderAccountTest(APIViewTestCases.APIViewTestCase):
@@ -291,6 +301,8 @@ class ProviderAccountTest(APIViewTestCases.APIViewTestCase):
             'provider': providers[1].pk,
             'description': 'New description',
         }
+
+        super().setUpTestData()
 
 
 class CircuitGroupAssignmentTest(APIViewTestCases.APIViewTestCase):
@@ -367,6 +379,8 @@ class CircuitGroupAssignmentTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class ProviderNetworkTest(APIViewTestCases.APIViewTestCase):
     model = ProviderNetwork
@@ -408,6 +422,8 @@ class ProviderNetworkTest(APIViewTestCases.APIViewTestCase):
             'description': 'New description',
         }
 
+        super().setUpTestData()
+
 
 class VirtualCircuitTypeTest(APIViewTestCases.APIViewTestCase):
     model = VirtualCircuitType
@@ -439,6 +455,8 @@ class VirtualCircuitTypeTest(APIViewTestCases.APIViewTestCase):
             VirtualCircuitType(name='Virtual Circuit Type 3', slug='virtual-circuit-type-3'),
         )
         VirtualCircuitType.objects.bulk_create(virtual_circuit_types)
+
+        super().setUpTestData()
 
 
 class VirtualCircuitTest(APIViewTestCases.APIViewTestCase):
@@ -503,6 +521,8 @@ class VirtualCircuitTest(APIViewTestCases.APIViewTestCase):
                 'status': CircuitStatusChoices.STATUS_PLANNED,
             },
         ]
+
+        super().setUpTestData()
 
 
 class VirtualCircuitTerminationTest(APIViewTestCases.APIViewTestCase):
@@ -694,3 +714,5 @@ class VirtualCircuitTerminationTest(APIViewTestCases.APIViewTestCase):
                 'interface': virtual_interfaces[9].pk
             },
         ]
+
+        super().setUpTestData()

--- a/netbox/core/tests/test_api.py
+++ b/netbox/core/tests/test_api.py
@@ -61,6 +61,8 @@ class DataSourceTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class DataFileTest(
     APIViewTestCases.GetObjectViewTestCase,
@@ -103,6 +105,8 @@ class DataFileTest(
             ),
         )
         DataFile.objects.bulk_create(data_files)
+
+        super().setUpTestData()
 
 
 class ObjectTypeTest(APITestCase):

--- a/netbox/core/tests/test_changelog.py
+++ b/netbox/core/tests/test_changelog.py
@@ -63,6 +63,8 @@ class ChangeLogViewTest(ModelViewTestCase):
         cf_select.save()
         cf_select.object_types.set([site_type])
 
+        super().setUpTestData()
+
     def test_create_object(self):
         tags = create_tags('Tag 1', 'Tag 2')
         form_data = {
@@ -433,6 +435,8 @@ class ChangeLogAPITest(APITestCase):
             Tag(name='Tag 3', slug='tag-3'),
         )
         Tag.objects.bulk_create(tags)
+
+        super().setUpTestData()
 
     def test_create_object(self):
         data = {

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -106,6 +106,8 @@ class RegionTest(APIViewTestCases.APIViewTestCase):
         Region.objects.create(name='Region 2', slug='region-2', comments='what in the world is happening?')
         Region.objects.create(name='Region 3', slug='region-3')
 
+        super().setUpTestData()
+
 
 class SiteGroupTest(APIViewTestCases.APIViewTestCase):
     model = SiteGroup
@@ -138,6 +140,8 @@ class SiteGroupTest(APIViewTestCases.APIViewTestCase):
         SiteGroup.objects.create(name='Site Group 1', slug='site-group-1')
         SiteGroup.objects.create(name='Site Group 2', slug='site-group-2', comments='')
         SiteGroup.objects.create(name='Site Group 3', slug='site-group-3', comments='Hi!')
+
+        super().setUpTestData()
 
 
 class SiteTest(APIViewTestCases.APIViewTestCase):
@@ -202,6 +206,8 @@ class SiteTest(APIViewTestCases.APIViewTestCase):
                 'asns': [asns[4].pk, asns[5].pk],
             },
         ]
+
+        super().setUpTestData()
 
     def test_add_tags(self):
         """
@@ -503,6 +509,8 @@ class LocationTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class RackGroupTest(APIViewTestCases.APIViewTestCase):
     model = RackGroup
@@ -534,6 +542,8 @@ class RackGroupTest(APIViewTestCases.APIViewTestCase):
             RackGroup(name='Rack Group 3', slug='rack-group-3'),
         )
         RackGroup.objects.bulk_create(rack_groups)
+
+        super().setUpTestData()
 
 
 class RackRoleTest(APIViewTestCases.APIViewTestCase):
@@ -569,6 +579,8 @@ class RackRoleTest(APIViewTestCases.APIViewTestCase):
             RackRole(name='Rack Role 3', slug='rack-role-3', color='0000ff'),
         )
         RackRole.objects.bulk_create(rack_roles)
+
+        super().setUpTestData()
 
 
 class RackTypeTest(APIViewTestCases.APIViewTestCase):
@@ -629,6 +641,8 @@ class RackTypeTest(APIViewTestCases.APIViewTestCase):
                 'form_factor': RackFormFactorChoices.TYPE_CABINET,
             },
         ]
+
+        super().setUpTestData()
 
 
 class RackTest(APIViewTestCases.APIViewTestCase):
@@ -695,6 +709,8 @@ class RackTest(APIViewTestCases.APIViewTestCase):
                 'role': rack_roles[1].pk,
             },
         ]
+
+        super().setUpTestData()
 
     def test_get_rack_elevation(self):
         """
@@ -794,6 +810,8 @@ class RackReservationTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
     def test_unit_count(self):
         """unit_count should reflect the number of units in the reservation."""
         url = reverse('dcim-api:rackreservation-list')
@@ -834,6 +852,8 @@ class ManufacturerTest(APIViewTestCases.APIViewTestCase):
             Manufacturer(name='Manufacturer 3', slug='manufacturer-3'),
         )
         Manufacturer.objects.bulk_create(manufacturers)
+
+        super().setUpTestData()
 
 
 class DeviceTypeTest(APIViewTestCases.APIViewTestCase):
@@ -881,6 +901,8 @@ class DeviceTypeTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class ModuleTypeTest(APIViewTestCases.APIViewTestCase):
     model = ModuleType
@@ -920,6 +942,8 @@ class ModuleTypeTest(APIViewTestCases.APIViewTestCase):
                 'model': 'Module Type 6',
             },
         ]
+
+        super().setUpTestData()
 
 
 class ModuleTypeProfileTest(APIViewTestCases.APIViewTestCase):
@@ -985,6 +1009,8 @@ class ModuleTypeProfileTest(APIViewTestCases.APIViewTestCase):
         )
         ModuleTypeProfile.objects.bulk_create(module_type_profiles)
 
+        super().setUpTestData()
+
 
 class ConsolePortTemplateTest(APIViewTestCases.APIViewTestCase):
     model = ConsolePortTemplate
@@ -1028,6 +1054,8 @@ class ConsolePortTemplateTest(APIViewTestCases.APIViewTestCase):
                 'name': 'Console Port Template 7',
             },
         ]
+
+        super().setUpTestData()
 
 
 class ConsoleServerPortTemplateTest(APIViewTestCases.APIViewTestCase):
@@ -1073,6 +1101,8 @@ class ConsoleServerPortTemplateTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class PowerPortTemplateTest(APIViewTestCases.APIViewTestCase):
     model = PowerPortTemplate
@@ -1116,6 +1146,8 @@ class PowerPortTemplateTest(APIViewTestCases.APIViewTestCase):
                 'name': 'Power Port Template 7',
             },
         ]
+
+        super().setUpTestData()
 
 
 class PowerOutletTemplateTest(APIViewTestCases.APIViewTestCase):
@@ -1175,6 +1207,8 @@ class PowerOutletTemplateTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class InterfaceTemplateTest(APIViewTestCases.APIViewTestCase):
     model = InterfaceTemplate
@@ -1222,6 +1256,8 @@ class InterfaceTemplateTest(APIViewTestCases.APIViewTestCase):
                 'type': '1000base-t',
             },
         ]
+
+        super().setUpTestData()
 
 
 class FrontPortTemplateTest(APIViewTestCases.APIViewTestCase):
@@ -1324,6 +1360,8 @@ class FrontPortTemplateTest(APIViewTestCases.APIViewTestCase):
                 },
             ],
         }
+
+        super().setUpTestData()
 
     def test_update_object(self):
         super().test_update_object()
@@ -1441,6 +1479,8 @@ class RearPortTemplateTest(APIViewTestCases.APIViewTestCase):
             ],
         }
 
+        super().setUpTestData()
+
     def test_update_object(self):
         super().test_update_object()
 
@@ -1498,6 +1538,8 @@ class ModuleBayTemplateTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class DeviceBayTemplateTest(APIViewTestCases.APIViewTestCase):
     model = DeviceBayTemplate
@@ -1539,6 +1581,8 @@ class DeviceBayTemplateTest(APIViewTestCases.APIViewTestCase):
                 'name': 'Device Bay Template 6',
             },
         ]
+
+        super().setUpTestData()
 
 
 class InventoryItemTemplateTest(APIViewTestCases.APIViewTestCase):
@@ -1600,6 +1644,8 @@ class InventoryItemTemplateTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class DeviceRoleTest(APIViewTestCases.APIViewTestCase):
     model = DeviceRole
@@ -1633,6 +1679,8 @@ class DeviceRoleTest(APIViewTestCases.APIViewTestCase):
         DeviceRole.objects.create(name='Device Role 1', slug='device-role-1', color='ff0000')
         DeviceRole.objects.create(name='Device Role 2', slug='device-role-2', color='00ff00')
         DeviceRole.objects.create(name='Device Role 3', slug='device-role-3', color='0000ff')
+
+        super().setUpTestData()
 
 
 class PlatformTest(APIViewTestCases.APIViewTestCase):
@@ -1668,6 +1716,8 @@ class PlatformTest(APIViewTestCases.APIViewTestCase):
         )
         for platform in platforms:
             platform.save()
+
+        super().setUpTestData()
 
 
 class DeviceTest(APIViewTestCases.APIViewTestCase):
@@ -1775,6 +1825,8 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
                 'cluster': clusters[1].pk,
             },
         ]
+
+        super().setUpTestData()
 
     def test_config_context_included_by_default_in_list_view(self):
         """
@@ -2092,6 +2144,8 @@ class ModuleTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
     def test_replicate_components(self):
         """
         Installing a module with replicate_components=True (the default) should create
@@ -2397,6 +2451,8 @@ class ConsolePortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCa
             },
         ]
 
+        super().setUpTestData()
+
 
 class ConsoleServerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = ConsoleServerPort
@@ -2440,6 +2496,8 @@ class ConsoleServerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIView
             },
         ]
 
+        super().setUpTestData()
+
 
 class PowerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = PowerPort
@@ -2479,6 +2537,8 @@ class PowerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase
                 'name': 'Power Port 6',
             },
         ]
+
+        super().setUpTestData()
 
 
 class PowerOutletTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
@@ -2528,6 +2588,8 @@ class PowerOutletTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCa
                 'power_port': None,
             },
         ]
+
+        super().setUpTestData()
 
 
 class InterfaceTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
@@ -2641,6 +2703,8 @@ class InterfaceTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase
                 'qinq_svlan': vlans[3].pk,
             },
         ]
+
+        super().setUpTestData()
 
     def _perform_interface_test_with_invalid_data(self, mode: str = None, invalid_data: dict = {}):
         device = Device.objects.first()
@@ -2827,6 +2891,8 @@ class FrontPortTest(APIViewTestCases.APIViewTestCase):
             ],
         }
 
+        super().setUpTestData()
+
     def test_update_object(self):
         super().test_update_object()
 
@@ -2941,6 +3007,8 @@ class RearPortTest(APIViewTestCases.APIViewTestCase):
             ],
         }
 
+        super().setUpTestData()
+
     def test_update_object(self):
         super().test_update_object()
 
@@ -3015,6 +3083,8 @@ class ModuleBayTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class DeviceBayTest(APIViewTestCases.APIViewTestCase):
     model = DeviceBay
@@ -3078,6 +3148,8 @@ class DeviceBayTest(APIViewTestCases.APIViewTestCase):
                 'installed_device': devices[3].pk,
             },
         ]
+
+        super().setUpTestData()
 
 
 class InventoryItemTest(APIViewTestCases.APIViewTestCase):
@@ -3146,6 +3218,8 @@ class InventoryItemTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class InventoryItemRoleTest(APIViewTestCases.APIViewTestCase):
     model = InventoryItemRole
@@ -3181,6 +3255,8 @@ class InventoryItemRoleTest(APIViewTestCases.APIViewTestCase):
         )
         InventoryItemRole.objects.bulk_create(roles)
 
+        super().setUpTestData()
+
 
 class CableBundleTest(APIViewTestCases.APIViewTestCase):
     model = CableBundle
@@ -3202,6 +3278,8 @@ class CableBundleTest(APIViewTestCases.APIViewTestCase):
             CableBundle(name='Cable Bundle 3'),
         )
         CableBundle.objects.bulk_create(cable_bundles)
+
+        super().setUpTestData()
 
     def test_cable_count(self):
         """cable_count annotation is returned correctly in the API response."""
@@ -3323,6 +3401,8 @@ class CableTest(APIViewTestCases.APIViewTestCase):
                 # No profile (legacy behavior)
             },
         ]
+
+        super().setUpTestData()
 
     def test_graphql_cable_termination_cached_filters(self):
         """
@@ -3473,6 +3553,8 @@ class CableTerminationTest(
         for cable in cables:
             cable.save()
 
+        super().setUpTestData()
+
 
 class ConnectedDeviceTest(APITestCase):
 
@@ -3496,6 +3578,8 @@ class ConnectedDeviceTest(APITestCase):
 
         cable = Cable(a_terminations=[interfaces[0]], b_terminations=[interfaces[1]])
         cable.save()
+
+        super().setUpTestData()
 
     @override_settings(EXEMPT_VIEW_PERMISSIONS=['*'])
     def test_get_connected_device(self):
@@ -3591,6 +3675,8 @@ class VirtualChassisTest(APIViewTestCases.APIViewTestCase):
             'master': None
         }
 
+        super().setUpTestData()
+
 
 class PowerPanelTest(APIViewTestCases.APIViewTestCase):
     model = PowerPanel
@@ -3640,6 +3726,8 @@ class PowerPanelTest(APIViewTestCases.APIViewTestCase):
             'site': sites[1].pk,
             'location': locations[3].pk
         }
+
+        super().setUpTestData()
 
 
 class PowerFeedTest(APIViewTestCases.APIViewTestCase):
@@ -3697,6 +3785,8 @@ class PowerFeedTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class VirtualDeviceContextTest(APIViewTestCases.APIViewTestCase):
     model = VirtualDeviceContext
@@ -3751,6 +3841,8 @@ class VirtualDeviceContextTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class MACAddressTest(APIViewTestCases.APIViewTestCase):
     model = MACAddress
@@ -3793,3 +3885,5 @@ class MACAddressTest(APIViewTestCases.APIViewTestCase):
                 'mac_address': '00:00:00:00:00:06',
             },
         ]
+
+        super().setUpTestData()

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -73,6 +73,8 @@ class WebhookTest(APIViewTestCases.APIViewTestCase):
         )
         Webhook.objects.bulk_create(webhooks)
 
+        super().setUpTestData()
+
 
 class EventRuleTest(APIViewTestCases.APIViewTestCase):
     model = EventRule
@@ -151,6 +153,8 @@ class EventRuleTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class CustomFieldTest(APIViewTestCases.APIViewTestCase):
     model = CustomField
@@ -202,6 +206,8 @@ class CustomFieldTest(APIViewTestCases.APIViewTestCase):
         CustomField.objects.bulk_create(custom_fields)
         for cf in custom_fields:
             cf.object_types.add(site_ct)
+
+        super().setUpTestData()
 
 
 class CustomFieldChoiceSetTest(APIViewTestCases.APIViewTestCase):
@@ -274,6 +280,8 @@ class CustomFieldChoiceSetTest(APIViewTestCases.APIViewTestCase):
             ),
         )
         CustomFieldChoiceSet.objects.bulk_create(choice_sets)
+
+        super().setUpTestData()
 
     def test_invalid_choice_items(self):
         """
@@ -384,6 +392,8 @@ class CustomLinkTest(APIViewTestCases.APIViewTestCase):
         for i, custom_link in enumerate(custom_links):
             custom_link.object_types.set([site_type])
 
+        super().setUpTestData()
+
 
 class SavedFilterTest(APIViewTestCases.APIViewTestCase):
     model = SavedFilter
@@ -457,6 +467,8 @@ class SavedFilterTest(APIViewTestCases.APIViewTestCase):
         for i, savedfilter in enumerate(saved_filters):
             savedfilter.object_types.set([site_type])
 
+        super().setUpTestData()
+
 
 class BookmarkTest(
     APIViewTestCases.GetObjectViewTestCase,
@@ -478,6 +490,8 @@ class BookmarkTest(
             Site(name='Site 6', slug='site-6'),
         )
         Site.objects.bulk_create(sites)
+
+        super().setUpTestData()
 
     def setUp(self):
         super().setUp()
@@ -559,6 +573,8 @@ class ExportTemplateTest(APIViewTestCases.APIViewTestCase):
         for et in export_templates:
             et.object_types.set([device_object_type])
 
+        super().setUpTestData()
+
 
 class TagTest(APIViewTestCases.APIViewTestCase):
     model = Tag
@@ -592,6 +608,8 @@ class TagTest(APIViewTestCases.APIViewTestCase):
         )
         Tag.objects.bulk_create(tags)
 
+        super().setUpTestData()
+
 
 class TaggedItemTest(
     APIViewTestCases.GetObjectViewTestCase,
@@ -619,6 +637,8 @@ class TaggedItemTest(
         sites[0].tags.set([tags[0], tags[1]])
         sites[1].tags.set([tags[1], tags[2]])
         sites[2].tags.set([tags[2], tags[0]])
+
+        super().setUpTestData()
 
 
 # TODO: Standardize to APIViewTestCase (needs create & update tests)
@@ -664,6 +684,8 @@ class ImageAttachmentTest(
             )
         )
         ImageAttachment.objects.bulk_create(image_attachments)
+
+        super().setUpTestData()
 
 
 class JournalEntryTest(APIViewTestCases.APIViewTestCase):
@@ -714,6 +736,8 @@ class JournalEntryTest(APIViewTestCases.APIViewTestCase):
                 'comments': 'Third entry',
             },
         ]
+
+        super().setUpTestData()
 
 
 class ConfigContextProfileTest(APIViewTestCases.APIViewTestCase):
@@ -778,6 +802,8 @@ class ConfigContextProfileTest(APIViewTestCases.APIViewTestCase):
             ),
         )
         ConfigContextProfile.objects.bulk_create(profiles)
+
+        super().setUpTestData()
 
     def test_update_data_source_and_data_file(self):
         """
@@ -855,6 +881,8 @@ class ConfigContextTest(APIViewTestCases.APIViewTestCase):
             ConfigContext(name='Config Context 3', weight=300, data={'baz': 789}),
         )
         ConfigContext.objects.bulk_create(config_contexts)
+
+        super().setUpTestData()
 
     def test_render_configcontext_for_object(self):
         """
@@ -994,6 +1022,8 @@ class ConfigTemplateTest(APIViewTestCases.APIViewTestCase):
         )
         ConfigTemplate.objects.bulk_create(config_templates)
 
+        super().setUpTestData()
+
     def test_render(self):
         configtemplate = ConfigTemplate.objects.first()
 
@@ -1071,6 +1101,8 @@ class ScriptTest(APITestCase):
             is_executable=True,
         )
         cls.url = reverse('extras-api:script-detail', kwargs={'pk': script.pk})
+
+        super().setUpTestData()
 
     @property
     def python_class(self):
@@ -1180,6 +1212,8 @@ class CreatedUpdatedFilterTest(APITestCase):
             last_updated=make_aware(datetime.datetime(2001, 2, 3, 1, 2, 3, 4)),
             created=make_aware(datetime.datetime(2001, 2, 3))
         )
+
+        super().setUpTestData()
 
     def test_get_rack_created(self):
         rack2 = Rack.objects.get(name='Rack 2')
@@ -1294,6 +1328,8 @@ class SubscriptionTest(APIViewTestCases.APIViewTestCase):
             'user': users[3].pk,
         }
 
+        super().setUpTestData()
+
 
 class NotificationGroupTest(APIViewTestCases.APIViewTestCase):
     model = NotificationGroup
@@ -1371,6 +1407,8 @@ class NotificationGroupTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class NotificationTest(APIViewTestCases.APIViewTestCase):
     model = Notification
@@ -1434,6 +1472,8 @@ class NotificationTest(APIViewTestCases.APIViewTestCase):
                 'event_type': OBJECT_DELETED,
             },
         ]
+
+        super().setUpTestData()
 
 
 class ScriptModuleTest(APITestCase):

--- a/netbox/extras/tests/test_customfields.py
+++ b/netbox/extras/tests/test_customfields.py
@@ -32,6 +32,8 @@ class CustomFieldTest(TestCase):
 
         cls.object_type = ObjectType.objects.get_for_model(Site)
 
+        super().setUpTestData()
+
     def test_invalid_name(self):
         """
         Try creating a CustomField with an invalid name.
@@ -898,6 +900,8 @@ class CustomFieldAPITest(APITestCase):
             custom_fields[12].name: [vlans[2].pk, vlans[3].pk],
         }
         sites[1].save()
+
+        super().setUpTestData()
 
     def test_get_custom_fields(self):
         TYPES = {

--- a/netbox/extras/tests/test_event_rules.py
+++ b/netbox/extras/tests/test_event_rules.py
@@ -82,6 +82,8 @@ class EventRuleTest(APITestCase):
             Tag(name='Baz', slug='baz'),
         ))
 
+        super().setUpTestData()
+
     def test_eventrule_conditions(self):
         """
         Test evaluation of EventRule conditions.

--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -79,6 +79,8 @@ class ASNRangeTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
     def test_list_available_asns(self):
         """
         Test retrieval of all available ASNs within a parent range.
@@ -199,6 +201,8 @@ class ASNTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class VRFTest(APIViewTestCases.APIViewTestCase):
     model = VRF
@@ -231,6 +235,8 @@ class VRFTest(APIViewTestCases.APIViewTestCase):
         )
         VRF.objects.bulk_create(vrfs)
 
+        super().setUpTestData()
+
 
 class RouteTargetTest(APIViewTestCases.APIViewTestCase):
     model = RouteTarget
@@ -259,6 +265,8 @@ class RouteTargetTest(APIViewTestCases.APIViewTestCase):
             RouteTarget(name='65000:1003'),
         )
         RouteTarget.objects.bulk_create(route_targets)
+
+        super().setUpTestData()
 
 
 class RIRTest(APIViewTestCases.APIViewTestCase):
@@ -291,6 +299,8 @@ class RIRTest(APIViewTestCases.APIViewTestCase):
             RIR(name='RIR 3', slug='rir-3'),
         )
         RIR.objects.bulk_create(rirs)
+
+        super().setUpTestData()
 
 
 class AggregateTest(APIViewTestCases.APIViewTestCase):
@@ -330,6 +340,8 @@ class AggregateTest(APIViewTestCases.APIViewTestCase):
                 'rir': rirs[1].pk,
             },
         ]
+
+        super().setUpTestData()
 
     @tag('regression')
     def test_graphql_aggregate_prefix_exact(self):
@@ -423,6 +435,8 @@ class RoleTest(APIViewTestCases.APIViewTestCase):
         )
         ASN.objects.bulk_create(asns)
 
+        super().setUpTestData()
+
 
 class PrefixTest(APIViewTestCases.APIViewTestCase):
     model = Prefix
@@ -451,6 +465,8 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
             Prefix(prefix=IPNetwork('192.168.3.0/24')),
         )
         Prefix.objects.bulk_create(prefixes)
+
+        super().setUpTestData()
 
     @tag('regression')
     def test_clean_validates_scope(self):
@@ -695,6 +711,8 @@ class IPRangeTest(APIViewTestCases.APIViewTestCase):
         )
         IPRange.objects.bulk_create(ip_ranges)
 
+        super().setUpTestData()
+
     def test_list_available_ips(self):
         """
         Test retrieval of all available IP addresses within a parent IP range.
@@ -852,6 +870,8 @@ class IPAddressTest(APIViewTestCases.APIViewTestCase):
             IPAddress(address=IPNetwork('192.168.0.3/24')),
         )
         IPAddress.objects.bulk_create(ip_addresses)
+
+        super().setUpTestData()
 
     def test_assign_object(self):
         """
@@ -1027,6 +1047,8 @@ class FHRPGroupTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class FHRPGroupAssignmentTest(APIViewTestCases.APIViewTestCase):
     model = FHRPGroupAssignment
@@ -1107,6 +1129,8 @@ class FHRPGroupAssignmentTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class VLANGroupTest(APIViewTestCases.APIViewTestCase):
     model = VLANGroup
@@ -1141,6 +1165,8 @@ class VLANGroupTest(APIViewTestCases.APIViewTestCase):
             VLANGroup(name='VLAN Group 3', slug='vlan-group-3'),
         )
         VLANGroup.objects.bulk_create(vlan_groups)
+
+        super().setUpTestData()
 
     def test_list_available_vlans(self):
         """
@@ -1279,6 +1305,8 @@ class VLANTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
     def test_delete_vlan_with_prefix(self):
         """
         Attempt and fail to delete a VLAN with a Prefix assigned to it.
@@ -1338,6 +1366,8 @@ class VLANTranslationPolicyTest(APIViewTestCases.APIViewTestCase):
                 'description': 'foobar6',
             },
         ]
+
+        super().setUpTestData()
 
 
 class VLANTranslationRuleTest(APIViewTestCases.APIViewTestCase):
@@ -1408,6 +1438,8 @@ class VLANTranslationRuleTest(APIViewTestCases.APIViewTestCase):
             'description': 'New description',
         }
 
+        super().setUpTestData()
+
 
 class ServiceTemplateTest(APIViewTestCases.APIViewTestCase):
     model = ServiceTemplate
@@ -1443,6 +1475,8 @@ class ServiceTemplateTest(APIViewTestCases.APIViewTestCase):
                 'ports': [11, 12],
             },
         ]
+
+        super().setUpTestData()
 
 
 class ServiceTest(APIViewTestCases.APIViewTestCase):
@@ -1496,3 +1530,5 @@ class ServiceTest(APIViewTestCases.APIViewTestCase):
                 'ports': [6],
             },
         ]
+
+        super().setUpTestData()

--- a/netbox/netbox/tests/test_graphql.py
+++ b/netbox/netbox/tests/test_graphql.py
@@ -56,6 +56,8 @@ class GraphQLAPITestCase(APITestCase):
         )
         Site.objects.bulk_create(sites)
 
+        super().setUpTestData()
+
     @override_settings(LOGIN_REQUIRED=True)
     def test_graphql_filter_objects(self):
         """

--- a/netbox/tenancy/tests/test_api.py
+++ b/netbox/tenancy/tests/test_api.py
@@ -60,6 +60,8 @@ class TenantGroupTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class TenantTest(APIViewTestCases.APIViewTestCase):
     model = Tenant
@@ -101,6 +103,8 @@ class TenantTest(APIViewTestCases.APIViewTestCase):
                 'group': tenant_groups[1].pk,
             },
         ]
+
+        super().setUpTestData()
 
 
 class ContactGroupTest(APIViewTestCases.APIViewTestCase):
@@ -147,6 +151,8 @@ class ContactGroupTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class ContactRoleTest(APIViewTestCases.APIViewTestCase):
     model = ContactRole
@@ -178,6 +184,8 @@ class ContactRoleTest(APIViewTestCases.APIViewTestCase):
             ContactRole(name='Contact Role 3', slug='contact-role-3'),
         )
         ContactRole.objects.bulk_create(contact_roles)
+
+        super().setUpTestData()
 
 
 class ContactTest(APIViewTestCases.APIViewTestCase):
@@ -218,6 +226,8 @@ class ContactTest(APIViewTestCases.APIViewTestCase):
                 'name': 'Contact 6',
             },
         ]
+
+        super().setUpTestData()
 
 
 class ContactAssignmentTest(APIViewTestCases.APIViewTestCase):
@@ -299,3 +309,5 @@ class ContactAssignmentTest(APIViewTestCases.APIViewTestCase):
                 'priority': ContactPriorityChoices.PRIORITY_TERTIARY,
             },
         ]
+
+        super().setUpTestData()

--- a/netbox/users/tests/test_api.py
+++ b/netbox/users/tests/test_api.py
@@ -63,6 +63,8 @@ class UserTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
     def test_that_password_is_changed(self):
         """
         Test that password is changed
@@ -176,6 +178,8 @@ class GroupTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
     def model_to_dict(self, instance, *args, **kwargs):
         # Overwrite permissions attr to work around the serializer field having a different name
         data = super().model_to_dict(instance, *args, **kwargs)
@@ -245,6 +249,8 @@ class TokenTest(
         cls.update_data = {
             'description': 'Token 1',
         }
+
+        super().setUpTestData()
 
     def test_provision_token_valid(self):
         """
@@ -402,6 +408,8 @@ class ObjectPermissionTest(
             'description': 'New description',
         }
 
+        super().setUpTestData()
+
 
 class UserConfigTest(APITestCase):
 
@@ -487,6 +495,8 @@ class OwnerGroupTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class OwnerTest(APIViewTestCases.APIViewTestCase):
     model = Owner
@@ -563,3 +573,5 @@ class OwnerTest(APIViewTestCases.APIViewTestCase):
             'users': [users[3].pk],
             'description': 'New description',
         }
+
+        super().setUpTestData()

--- a/netbox/utilities/testing/api.py
+++ b/netbox/utilities/testing/api.py
@@ -44,15 +44,23 @@ class APITestCase(ModelTestCase):
     client_class = APIClient
     view_namespace = None
 
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        # Create the test user
+        cls.user = User.objects.create_user(username='testuser')
+        cls.token = Token.objects.create(user=cls.user)
+        cls.header = {'HTTP_AUTHORIZATION': f'Bearer {TOKEN_PREFIX}{cls.token.key}.{cls.token.token}'}
+
     def setUp(self):
         """
         Create a user and token for API calls.
+
+        Note: intentionally does not call super().setUp()
         """
-        # Create the test user and assign permissions
-        self.user = User.objects.create_user(username='testuser')
+        # Add permissions for the test user
         self.add_permissions(*self.user_permissions)
-        self.token = Token.objects.create(user=self.user)
-        self.header = {'HTTP_AUTHORIZATION': f'Bearer {TOKEN_PREFIX}{self.token.key}.{self.token.token}'}
 
     def _get_view_namespace(self):
         return f'{self.view_namespace or self.model._meta.app_label}-api'

--- a/netbox/utilities/tests/test_api.py
+++ b/netbox/utilities/tests/test_api.py
@@ -136,6 +136,8 @@ class APIPaginationTestCase(APITestCase):
             Site(name=f'Site {i}', slug=f'site-{i}') for i in range(1, 101)
         ])
 
+        super().setUpTestData()
+
     def test_default_page_size(self):
         response = self.client.get(self.url, format='json', **self.header)
         page_size = get_config().PAGINATE_COUNT
@@ -316,6 +318,8 @@ class APIOrderingTestCase(APITestCase):
         )
         Site.objects.bulk_create(sites)
 
+        super().setUpTestData()
+
     def test_default_order(self):
         response = self.client.get(self.url, format='json', **self.header)
 
@@ -490,6 +494,8 @@ class APITrailingSlashTestCase(APITestCase):
     @classmethod
     def setUpTestData(cls):
         cls.site = Site.objects.create(name='Site 1', slug='site-1')
+
+        super().setUpTestData()
 
     def _strip_slash(self, url):
         return url.rstrip('/')

--- a/netbox/virtualization/tests/test_api.py
+++ b/netbox/virtualization/tests/test_api.py
@@ -67,6 +67,8 @@ class ClusterTypeTest(APIViewTestCases.APIViewTestCase):
         )
         ClusterType.objects.bulk_create(cluster_types)
 
+        super().setUpTestData()
+
 
 class ClusterGroupTest(APIViewTestCases.APIViewTestCase):
     model = ClusterGroup
@@ -98,6 +100,8 @@ class ClusterGroupTest(APIViewTestCases.APIViewTestCase):
             ClusterGroup(name='Cluster Group 3', slug='cluster-type-3'),
         )
         ClusterGroup.objects.bulk_create(cluster_Groups)
+
+        super().setUpTestData()
 
 
 class ClusterTest(APIViewTestCases.APIViewTestCase):
@@ -167,6 +171,8 @@ class ClusterTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class VirtualMachineTypeTest(APIViewTestCases.APIViewTestCase):
     model = VirtualMachineType
@@ -235,6 +241,8 @@ class VirtualMachineTypeTest(APIViewTestCases.APIViewTestCase):
             'default_memory': 8192,
             'description': 'New description',
         }
+
+        super().setUpTestData()
 
 
 class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
@@ -346,6 +354,8 @@ class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
                 'start_on_boot': VirtualMachineStartOnBootChoices.STATUS_ON,
             },
         ]
+
+        super().setUpTestData()
 
     def test_virtual_machine_type_defaults_applied_on_create(self):
         data = {
@@ -666,6 +676,8 @@ class VMInterfaceTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
     @tag('regression')
     def test_set_vminterface_as_object_in_custom_field(self):
         cf = CustomField.objects.create(
@@ -764,3 +776,5 @@ class VirtualDiskTest(APIViewTestCases.APIViewTestCase):
                 'size': 30,
             },
         ]
+
+        super().setUpTestData()

--- a/netbox/vpn/tests/test_api.py
+++ b/netbox/vpn/tests/test_api.py
@@ -49,6 +49,8 @@ class TunnelGroupTest(APIViewTestCases.APIViewTestCase):
         )
         TunnelGroup.objects.bulk_create(tunnel_groups)
 
+        super().setUpTestData()
+
 
 class TunnelTest(APIViewTestCases.APIViewTestCase):
     model = Tunnel
@@ -109,6 +111,8 @@ class TunnelTest(APIViewTestCases.APIViewTestCase):
                 'encapsulation': TunnelEncapsulationChoices.ENCAP_GRE,
             },
         ]
+
+        super().setUpTestData()
 
 
 class TunnelTerminationTest(APIViewTestCases.APIViewTestCase):
@@ -178,6 +182,8 @@ class TunnelTerminationTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class IKEProposalTest(APIViewTestCases.APIViewTestCase):
     model = IKEProposal
@@ -241,6 +247,8 @@ class IKEProposalTest(APIViewTestCases.APIViewTestCase):
                 'group': DHGroupChoices.GROUP_19,
             },
         ]
+
+        super().setUpTestData()
 
 
 class IKEPolicyTest(APIViewTestCases.APIViewTestCase):
@@ -316,6 +324,8 @@ class IKEPolicyTest(APIViewTestCases.APIViewTestCase):
             },
         ]
 
+        super().setUpTestData()
+
 
 class IPSecProposalTest(APIViewTestCases.APIViewTestCase):
     model = IPSecProposal
@@ -365,6 +375,8 @@ class IPSecProposalTest(APIViewTestCases.APIViewTestCase):
                 'authentication_algorithm': AuthenticationAlgorithmChoices.AUTH_HMAC_SHA256,
             },
         ]
+
+        super().setUpTestData()
 
 
 class IPSecPolicyTest(APIViewTestCases.APIViewTestCase):
@@ -427,6 +439,8 @@ class IPSecPolicyTest(APIViewTestCases.APIViewTestCase):
                 'proposals': [ipsec_proposals[0].pk, ipsec_proposals[1].pk],
             },
         ]
+
+        super().setUpTestData()
 
 
 class IPSecProfileTest(APIViewTestCases.APIViewTestCase):
@@ -519,6 +533,8 @@ class IPSecProfileTest(APIViewTestCases.APIViewTestCase):
             'description': 'New description',
         }
 
+        super().setUpTestData()
+
 
 class L2VPNTest(APIViewTestCases.APIViewTestCase):
     model = L2VPN
@@ -568,6 +584,8 @@ class L2VPNTest(APIViewTestCases.APIViewTestCase):
             ),  # No RD
         )
         L2VPN.objects.bulk_create(l2vpns)
+
+        super().setUpTestData()
 
     def test_status_filter(self):
         url = reverse('vpn-api:l2vpn-list')
@@ -656,3 +674,5 @@ class L2VPNTerminationTest(APIViewTestCases.APIViewTestCase):
         cls.bulk_update_data = {
             'l2vpn': l2vpns[2].pk
         }
+
+        super().setUpTestData()

--- a/netbox/wireless/tests/test_api.py
+++ b/netbox/wireless/tests/test_api.py
@@ -48,6 +48,8 @@ class WirelessLANGroupTest(APIViewTestCases.APIViewTestCase):
         WirelessLANGroup.objects.create(name='Wireless LAN Group 2', slug='wireless-lan-group-2')
         WirelessLANGroup.objects.create(name='Wireless LAN Group 3', slug='wireless-lan-group-3')
 
+        super().setUpTestData()
+
 
 class WirelessLANTest(APIViewTestCases.APIViewTestCase):
     model = WirelessLAN
@@ -118,6 +120,8 @@ class WirelessLANTest(APIViewTestCases.APIViewTestCase):
             'auth_psk': 'abc123def456',
         }
 
+        super().setUpTestData()
+
 
 class WirelessLinkTest(APIViewTestCases.APIViewTestCase):
     model = WirelessLink
@@ -177,3 +181,5 @@ class WirelessLinkTest(APIViewTestCases.APIViewTestCase):
                 'tenant': tenants[1].pk,
             },
         ]
+
+        super().setUpTestData()


### PR DESCRIPTION
### Fixes: #22077

This PR updates the API test setup flow so the shared test user, token, and authorization header are created once in the base `APITestCase.setUpTestData()` instead of being recreated before every test.

To preserve the base setup behavior, this also adds `super().setUpTestData()` to API test classes that override `setUpTestData()`. The calls are added after each class’s existing fixture setup to keep the current object creation order intact.

The per-test permission setup remains in `setUp()`, so permissions continue to be isolated and rolled back between individual tests.