### PR TITLE
Closes #22097: Standardize test class naming to TestCase suffix

### DIFF
--- a/netbox/circuits/tests/test_api.py
+++ b/netbox/circuits/tests/test_api.py
@@ -8,7 +8,7 @@ from ipam.models import ASN, RIR
 from utilities.testing import APITestCase, APIViewTestCases
 
 
-class AppTest(APITestCase):
+class AppTestCase(APITestCase):
 
     def test_root(self):
         url = reverse('circuits-api:api-root')
@@ -17,7 +17,7 @@ class AppTest(APITestCase):
         self.assertEqual(response.status_code, 200)
 
 
-class ProviderTest(APIViewTestCases.APIViewTestCase):
+class ProviderTestCase(APIViewTestCases.APIViewTestCase):
     model = Provider
     brief_fields = ['circuit_count', 'description', 'display', 'id', 'name', 'slug', 'url']
     bulk_update_data = {
@@ -59,7 +59,7 @@ class ProviderTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class CircuitTypeTest(APIViewTestCases.APIViewTestCase):
+class CircuitTypeTestCase(APIViewTestCases.APIViewTestCase):
     model = CircuitType
     brief_fields = ['circuit_count', 'description', 'display', 'id', 'name', 'slug', 'url']
     create_data = (
@@ -91,7 +91,7 @@ class CircuitTypeTest(APIViewTestCases.APIViewTestCase):
         CircuitType.objects.bulk_create(circuit_types)
 
 
-class CircuitTest(APIViewTestCases.APIViewTestCase):
+class CircuitTestCase(APIViewTestCases.APIViewTestCase):
     model = Circuit
     brief_fields = ['cid', 'description', 'display', 'id', 'provider', 'url']
     bulk_update_data = {
@@ -155,7 +155,7 @@ class CircuitTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class CircuitTerminationTest(APIViewTestCases.APIViewTestCase):
+class CircuitTerminationTestCase(APIViewTestCases.APIViewTestCase):
     model = CircuitTermination
     brief_fields = ['_occupied', 'cable', 'circuit', 'description', 'display', 'id', 'term_side', 'url']
     user_permissions = ('circuits.view_circuit', )
@@ -217,7 +217,7 @@ class CircuitTerminationTest(APIViewTestCases.APIViewTestCase):
         }
 
 
-class CircuitGroupTest(APIViewTestCases.APIViewTestCase):
+class CircuitGroupTestCase(APIViewTestCases.APIViewTestCase):
     model = CircuitGroup
     brief_fields = ['display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -249,7 +249,7 @@ class CircuitGroupTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class ProviderAccountTest(APIViewTestCases.APIViewTestCase):
+class ProviderAccountTestCase(APIViewTestCases.APIViewTestCase):
     model = ProviderAccount
     brief_fields = ['account', 'description', 'display', 'id', 'name', 'url']
     user_permissions = ('circuits.view_provider',)
@@ -293,7 +293,7 @@ class ProviderAccountTest(APIViewTestCases.APIViewTestCase):
         }
 
 
-class CircuitGroupAssignmentTest(APIViewTestCases.APIViewTestCase):
+class CircuitGroupAssignmentTestCase(APIViewTestCases.APIViewTestCase):
     model = CircuitGroupAssignment
     brief_fields = ['display', 'group', 'id', 'member', 'member_id', 'member_type', 'priority', 'url']
     bulk_update_data = {
@@ -368,7 +368,7 @@ class CircuitGroupAssignmentTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class ProviderNetworkTest(APIViewTestCases.APIViewTestCase):
+class ProviderNetworkTestCase(APIViewTestCases.APIViewTestCase):
     model = ProviderNetwork
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     user_permissions = ('circuits.view_provider', )
@@ -409,7 +409,7 @@ class ProviderNetworkTest(APIViewTestCases.APIViewTestCase):
         }
 
 
-class VirtualCircuitTypeTest(APIViewTestCases.APIViewTestCase):
+class VirtualCircuitTypeTestCase(APIViewTestCases.APIViewTestCase):
     model = VirtualCircuitType
     brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url', 'virtual_circuit_count']
     create_data = (
@@ -441,7 +441,7 @@ class VirtualCircuitTypeTest(APIViewTestCases.APIViewTestCase):
         VirtualCircuitType.objects.bulk_create(virtual_circuit_types)
 
 
-class VirtualCircuitTest(APIViewTestCases.APIViewTestCase):
+class VirtualCircuitTestCase(APIViewTestCases.APIViewTestCase):
     model = VirtualCircuit
     brief_fields = ['cid', 'description', 'display', 'id', 'provider_network', 'url']
     bulk_update_data = {
@@ -505,7 +505,7 @@ class VirtualCircuitTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class VirtualCircuitTerminationTest(APIViewTestCases.APIViewTestCase):
+class VirtualCircuitTerminationTestCase(APIViewTestCases.APIViewTestCase):
     model = VirtualCircuitTermination
     brief_fields = ['description', 'display', 'id', 'interface', 'role', 'url', 'virtual_circuit']
     bulk_update_data = {

--- a/netbox/circuits/tests/test_tables.py
+++ b/netbox/circuits/tests/test_tables.py
@@ -2,45 +2,45 @@ from circuits.tables import *
 from utilities.testing import TableTestCases
 
 
-class CircuitTypeTableTest(TableTestCases.StandardTableTestCase):
+class CircuitTypeTableTestCase(TableTestCases.StandardTableTestCase):
     table = CircuitTypeTable
 
 
-class CircuitTableTest(TableTestCases.StandardTableTestCase):
+class CircuitTableTestCase(TableTestCases.StandardTableTestCase):
     table = CircuitTable
 
 
-class CircuitTerminationTableTest(TableTestCases.StandardTableTestCase):
+class CircuitTerminationTableTestCase(TableTestCases.StandardTableTestCase):
     table = CircuitTerminationTable
 
 
-class CircuitGroupTableTest(TableTestCases.StandardTableTestCase):
+class CircuitGroupTableTestCase(TableTestCases.StandardTableTestCase):
     table = CircuitGroupTable
 
 
-class CircuitGroupAssignmentTableTest(TableTestCases.StandardTableTestCase):
+class CircuitGroupAssignmentTableTestCase(TableTestCases.StandardTableTestCase):
     table = CircuitGroupAssignmentTable
 
 
-class ProviderTableTest(TableTestCases.StandardTableTestCase):
+class ProviderTableTestCase(TableTestCases.StandardTableTestCase):
     table = ProviderTable
 
 
-class ProviderAccountTableTest(TableTestCases.StandardTableTestCase):
+class ProviderAccountTableTestCase(TableTestCases.StandardTableTestCase):
     table = ProviderAccountTable
 
 
-class ProviderNetworkTableTest(TableTestCases.StandardTableTestCase):
+class ProviderNetworkTableTestCase(TableTestCases.StandardTableTestCase):
     table = ProviderNetworkTable
 
 
-class VirtualCircuitTypeTableTest(TableTestCases.StandardTableTestCase):
+class VirtualCircuitTypeTableTestCase(TableTestCases.StandardTableTestCase):
     table = VirtualCircuitTypeTable
 
 
-class VirtualCircuitTableTest(TableTestCases.StandardTableTestCase):
+class VirtualCircuitTableTestCase(TableTestCases.StandardTableTestCase):
     table = VirtualCircuitTable
 
 
-class VirtualCircuitTerminationTableTest(TableTestCases.StandardTableTestCase):
+class VirtualCircuitTerminationTableTestCase(TableTestCases.StandardTableTestCase):
     table = VirtualCircuitTerminationTable

--- a/netbox/core/tests/test_api.py
+++ b/netbox/core/tests/test_api.py
@@ -17,7 +17,7 @@ from utilities.testing.utils import disable_logging
 from ..models import *
 
 
-class AppTest(APITestCase):
+class AppTestCase(APITestCase):
 
     def test_root(self):
         url = reverse('core-api:api-root')
@@ -26,7 +26,7 @@ class AppTest(APITestCase):
         self.assertEqual(response.status_code, 200)
 
 
-class DataSourceTest(APIViewTestCases.APIViewTestCase):
+class DataSourceTestCase(APIViewTestCases.APIViewTestCase):
     model = DataSource
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -62,7 +62,7 @@ class DataSourceTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class DataFileTest(
+class DataFileTestCase(
     APIViewTestCases.GetObjectViewTestCase,
     APIViewTestCases.ListObjectsViewTestCase,
     APIViewTestCases.GraphQLTestCase
@@ -105,7 +105,7 @@ class DataFileTest(
         DataFile.objects.bulk_create(data_files)
 
 
-class ObjectTypeTest(APITestCase):
+class ObjectTypeTestCase(APITestCase):
 
     def test_list_objects(self):
         object_type_count = ObjectType.objects.count()

--- a/netbox/core/tests/test_changelog.py
+++ b/netbox/core/tests/test_changelog.py
@@ -33,7 +33,7 @@ from utilities.testing.utils import create_tags, create_test_device, post_data
 from utilities.testing.views import ModelViewTestCase
 
 
-class ChangeLogViewTest(ModelViewTestCase):
+class ChangeLogViewTestCase(ModelViewTestCase):
     model = Site
 
     @classmethod
@@ -397,7 +397,7 @@ class ChangeLogViewTest(ModelViewTestCase):
         self.assertEqual(objectchanges.count(), 2)
 
 
-class ChangeLogAPITest(APITestCase):
+class ChangeLogAPITestCase(APITestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -703,7 +703,7 @@ class ChangeLogAPITest(APITestCase):
         self.assertEqual(changes[3].action, ObjectChangeActionChoices.ACTION_DELETE)
 
 
-class ChangelogPruneRetentionTest(TestCase):
+class ChangelogPruneRetentionTestCase(TestCase):
     """Test suite for Changelog pruning retention settings."""
 
     @staticmethod

--- a/netbox/core/tests/test_data_backends.py
+++ b/netbox/core/tests/test_data_backends.py
@@ -12,7 +12,7 @@ except ImportError:
     DULWICH_AVAILABLE = False
 
 
-class URLEmbeddedCredentialsTests(TestCase):
+class URLEmbeddedCredentialsTestCase(TestCase):
     def test_url_with_embedded_username(self):
         self.assertTrue(url_has_embedded_credentials('https://myuser@bitbucket.org/workspace/repo.git'))
 
@@ -54,7 +54,7 @@ class URLEmbeddedCredentialsTests(TestCase):
 
 
 @skipIf(not DULWICH_AVAILABLE, "dulwich is not installed")
-class GitBackendCredentialIntegrationTests(TestCase):
+class GitBackendCredentialIntegrationTestCase(TestCase):
     """
     Integration tests that verify GitBackend correctly applies credential logic.
 

--- a/netbox/core/tests/test_models.py
+++ b/netbox/core/tests/test_models.py
@@ -150,7 +150,7 @@ class DataSourceChangeLoggingTestCase(TestCase):
         self.assertEqual(objectchange.postchange_data['parameters']['password'], CENSOR_TOKEN)
 
 
-class ObjectTypeTest(TestCase):
+class ObjectTypeTestCase(TestCase):
 
     def test_create(self):
         """
@@ -227,7 +227,7 @@ class ObjectTypeTest(TestCase):
         self.assertNotIn(ObjectType.objects.get_by_natural_key('dcim', 'cabletermination'), bookmarks_ots)
 
 
-class JobTest(TestCase):
+class JobTestCase(TestCase):
 
     def _make_job(self, user, notifications):
         """

--- a/netbox/core/tests/test_tables.py
+++ b/netbox/core/tests/test_tables.py
@@ -3,24 +3,24 @@ from core.tables import *
 from utilities.testing import TableTestCases
 
 
-class DataSourceTableTest(TableTestCases.StandardTableTestCase):
+class DataSourceTableTestCase(TableTestCases.StandardTableTestCase):
     table = DataSourceTable
 
 
-class DataFileTableTest(TableTestCases.StandardTableTestCase):
+class DataFileTableTestCase(TableTestCases.StandardTableTestCase):
     table = DataFileTable
 
 
-class JobTableTest(TableTestCases.StandardTableTestCase):
+class JobTableTestCase(TableTestCases.StandardTableTestCase):
     table = JobTable
 
 
-class ObjectChangeTableTest(TableTestCases.StandardTableTestCase):
+class ObjectChangeTableTestCase(TableTestCases.StandardTableTestCase):
     table = ObjectChangeTable
     queryset_sources = [
         ('ObjectChangeListView', ObjectChange.objects.all()),
     ]
 
 
-class ConfigRevisionTableTest(TableTestCases.StandardTableTestCase):
+class ConfigRevisionTableTestCase(TableTestCases.StandardTableTestCase):
     table = ConfigRevisionTable

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -29,7 +29,7 @@ from wireless.choices import WirelessChannelChoices
 from wireless.models import WirelessLAN
 
 
-class AppTest(APITestCase):
+class AppTestCase(APITestCase):
 
     def test_root(self):
 
@@ -76,7 +76,7 @@ class Mixins:
             self.assertEqual(segment1[2][0]['name'], peer_obj.name)
 
 
-class RegionTest(APIViewTestCases.APIViewTestCase):
+class RegionTestCase(APIViewTestCases.APIViewTestCase):
     model = Region
     brief_fields = ['_depth', 'description', 'display', 'id', 'name', 'site_count', 'slug', 'url']
     create_data = [
@@ -107,7 +107,7 @@ class RegionTest(APIViewTestCases.APIViewTestCase):
         Region.objects.create(name='Region 3', slug='region-3')
 
 
-class SiteGroupTest(APIViewTestCases.APIViewTestCase):
+class SiteGroupTestCase(APIViewTestCases.APIViewTestCase):
     model = SiteGroup
     brief_fields = ['_depth', 'description', 'display', 'id', 'name', 'site_count', 'slug', 'url']
     create_data = [
@@ -140,7 +140,7 @@ class SiteGroupTest(APIViewTestCases.APIViewTestCase):
         SiteGroup.objects.create(name='Site Group 3', slug='site-group-3', comments='Hi!')
 
 
-class SiteTest(APIViewTestCases.APIViewTestCase):
+class SiteTestCase(APIViewTestCases.APIViewTestCase):
     model = Site
     brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url']
     bulk_update_data = {
@@ -420,7 +420,7 @@ class SiteTest(APIViewTestCases.APIViewTestCase):
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
 
 
-class LocationTest(APIViewTestCases.APIViewTestCase):
+class LocationTestCase(APIViewTestCases.APIViewTestCase):
     model = Location
     brief_fields = ['_depth', 'description', 'display', 'id', 'name', 'rack_count', 'slug', 'url']
     bulk_update_data = {
@@ -504,7 +504,7 @@ class LocationTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class RackGroupTest(APIViewTestCases.APIViewTestCase):
+class RackGroupTestCase(APIViewTestCases.APIViewTestCase):
     model = RackGroup
     brief_fields = ['description', 'display', 'id', 'name', 'rack_count', 'slug', 'url']
     create_data = [
@@ -536,7 +536,7 @@ class RackGroupTest(APIViewTestCases.APIViewTestCase):
         RackGroup.objects.bulk_create(rack_groups)
 
 
-class RackRoleTest(APIViewTestCases.APIViewTestCase):
+class RackRoleTestCase(APIViewTestCases.APIViewTestCase):
     model = RackRole
     brief_fields = ['description', 'display', 'id', 'name', 'rack_count', 'slug', 'url']
     create_data = [
@@ -571,7 +571,7 @@ class RackRoleTest(APIViewTestCases.APIViewTestCase):
         RackRole.objects.bulk_create(rack_roles)
 
 
-class RackTypeTest(APIViewTestCases.APIViewTestCase):
+class RackTypeTestCase(APIViewTestCases.APIViewTestCase):
     model = RackType
     brief_fields = ['description', 'display', 'id', 'manufacturer', 'model', 'rack_count', 'slug', 'url']
     bulk_update_data = {
@@ -631,7 +631,7 @@ class RackTypeTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class RackTest(APIViewTestCases.APIViewTestCase):
+class RackTestCase(APIViewTestCases.APIViewTestCase):
     model = Rack
     brief_fields = ['description', 'device_count', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -729,7 +729,7 @@ class RackTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(response.get('Content-Type'), 'image/svg+xml')
 
 
-class RackReservationTest(APIViewTestCases.APIViewTestCase):
+class RackReservationTestCase(APIViewTestCases.APIViewTestCase):
     model = RackReservation
     brief_fields = ['description', 'display', 'id', 'status', 'units', 'url', 'user']
     bulk_update_data = {
@@ -804,7 +804,7 @@ class RackReservationTest(APIViewTestCases.APIViewTestCase):
             self.assertEqual(result['unit_count'], len(result['units']))
 
 
-class ManufacturerTest(APIViewTestCases.APIViewTestCase):
+class ManufacturerTestCase(APIViewTestCases.APIViewTestCase):
     model = Manufacturer
     brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
@@ -836,7 +836,7 @@ class ManufacturerTest(APIViewTestCases.APIViewTestCase):
         Manufacturer.objects.bulk_create(manufacturers)
 
 
-class DeviceTypeTest(APIViewTestCases.APIViewTestCase):
+class DeviceTypeTestCase(APIViewTestCases.APIViewTestCase):
     model = DeviceType
     brief_fields = ['description', 'device_count', 'display', 'id', 'manufacturer', 'model', 'slug', 'url']
     bulk_update_data = {
@@ -882,7 +882,7 @@ class DeviceTypeTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class ModuleTypeTest(APIViewTestCases.APIViewTestCase):
+class ModuleTypeTestCase(APIViewTestCases.APIViewTestCase):
     model = ModuleType
     brief_fields = ['description', 'display', 'id', 'manufacturer', 'model', 'module_count', 'profile', 'url']
     bulk_update_data = {
@@ -922,7 +922,7 @@ class ModuleTypeTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class ModuleTypeProfileTest(APIViewTestCases.APIViewTestCase):
+class ModuleTypeProfileTestCase(APIViewTestCases.APIViewTestCase):
     model = ModuleTypeProfile
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     SCHEMAS = [
@@ -986,7 +986,7 @@ class ModuleTypeProfileTest(APIViewTestCases.APIViewTestCase):
         ModuleTypeProfile.objects.bulk_create(module_type_profiles)
 
 
-class ConsolePortTemplateTest(APIViewTestCases.APIViewTestCase):
+class ConsolePortTemplateTestCase(APIViewTestCases.APIViewTestCase):
     model = ConsolePortTemplate
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -1030,7 +1030,7 @@ class ConsolePortTemplateTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class ConsoleServerPortTemplateTest(APIViewTestCases.APIViewTestCase):
+class ConsoleServerPortTemplateTestCase(APIViewTestCases.APIViewTestCase):
     model = ConsoleServerPortTemplate
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -1074,7 +1074,7 @@ class ConsoleServerPortTemplateTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class PowerPortTemplateTest(APIViewTestCases.APIViewTestCase):
+class PowerPortTemplateTestCase(APIViewTestCases.APIViewTestCase):
     model = PowerPortTemplate
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -1118,7 +1118,7 @@ class PowerPortTemplateTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class PowerOutletTemplateTest(APIViewTestCases.APIViewTestCase):
+class PowerOutletTemplateTestCase(APIViewTestCases.APIViewTestCase):
     model = PowerOutletTemplate
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -1176,7 +1176,7 @@ class PowerOutletTemplateTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class InterfaceTemplateTest(APIViewTestCases.APIViewTestCase):
+class InterfaceTemplateTestCase(APIViewTestCases.APIViewTestCase):
     model = InterfaceTemplate
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -1224,7 +1224,7 @@ class InterfaceTemplateTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class FrontPortTemplateTest(APIViewTestCases.APIViewTestCase):
+class FrontPortTemplateTestCase(APIViewTestCases.APIViewTestCase):
     model = FrontPortTemplate
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -1341,7 +1341,7 @@ class FrontPortTemplateTest(APIViewTestCases.APIViewTestCase):
         )
 
 
-class RearPortTemplateTest(APIViewTestCases.APIViewTestCase):
+class RearPortTemplateTestCase(APIViewTestCases.APIViewTestCase):
     model = RearPortTemplate
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -1457,7 +1457,7 @@ class RearPortTemplateTest(APIViewTestCases.APIViewTestCase):
         )
 
 
-class ModuleBayTemplateTest(APIViewTestCases.APIViewTestCase):
+class ModuleBayTemplateTestCase(APIViewTestCases.APIViewTestCase):
     model = ModuleBayTemplate
     brief_fields = ['description', 'display', 'enabled', 'id', 'name', 'url']
     bulk_update_data = {
@@ -1499,7 +1499,7 @@ class ModuleBayTemplateTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class DeviceBayTemplateTest(APIViewTestCases.APIViewTestCase):
+class DeviceBayTemplateTestCase(APIViewTestCases.APIViewTestCase):
     model = DeviceBayTemplate
     brief_fields = ['description', 'display', 'enabled', 'id', 'name', 'url']
     bulk_update_data = {
@@ -1541,7 +1541,7 @@ class DeviceBayTemplateTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class InventoryItemTemplateTest(APIViewTestCases.APIViewTestCase):
+class InventoryItemTemplateTestCase(APIViewTestCases.APIViewTestCase):
     model = InventoryItemTemplate
     brief_fields = ['_depth', 'description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -1601,7 +1601,7 @@ class InventoryItemTemplateTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class DeviceRoleTest(APIViewTestCases.APIViewTestCase):
+class DeviceRoleTestCase(APIViewTestCases.APIViewTestCase):
     model = DeviceRole
     brief_fields = [
         '_depth', 'description', 'device_count', 'display', 'id', 'name', 'slug', 'url', 'virtualmachine_count'
@@ -1635,7 +1635,7 @@ class DeviceRoleTest(APIViewTestCases.APIViewTestCase):
         DeviceRole.objects.create(name='Device Role 3', slug='device-role-3', color='0000ff')
 
 
-class PlatformTest(APIViewTestCases.APIViewTestCase):
+class PlatformTestCase(APIViewTestCases.APIViewTestCase):
     model = Platform
     brief_fields = [
         '_depth', 'description', 'device_count', 'display', 'id', 'name', 'slug', 'url', 'virtualmachine_count',
@@ -1670,7 +1670,7 @@ class PlatformTest(APIViewTestCases.APIViewTestCase):
             platform.save()
 
 
-class DeviceTest(APIViewTestCases.APIViewTestCase):
+class DeviceTestCase(APIViewTestCases.APIViewTestCase):
     model = Device
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -2020,7 +2020,7 @@ class DeviceTest(APIViewTestCases.APIViewTestCase):
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
 
 
-class ModuleTest(APIViewTestCases.APIViewTestCase):
+class ModuleTestCase(APIViewTestCases.APIViewTestCase):
     model = Module
     brief_fields = ['description', 'device', 'display', 'id', 'module_bay', 'module_type', 'url']
     bulk_update_data = {
@@ -2355,7 +2355,7 @@ class ModuleTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(len(response.data['results']), 1)
 
 
-class ConsolePortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
+class ConsolePortTestCase(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = ConsolePort
     brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -2398,7 +2398,7 @@ class ConsolePortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCa
         ]
 
 
-class ConsoleServerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
+class ConsoleServerPortTestCase(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = ConsoleServerPort
     brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -2441,7 +2441,7 @@ class ConsoleServerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIView
         ]
 
 
-class PowerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
+class PowerPortTestCase(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = PowerPort
     brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -2481,7 +2481,7 @@ class PowerPortTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase
         ]
 
 
-class PowerOutletTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
+class PowerOutletTestCase(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = PowerOutlet
     brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -2530,7 +2530,7 @@ class PowerOutletTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCa
         ]
 
 
-class InterfaceTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
+class InterfaceTestCase(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase):
     model = Interface
     brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -2739,7 +2739,7 @@ class InterfaceTest(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTestCase
         self._perform_interface_test_with_invalid_data(InterfaceModeChoices.MODE_TAGGED_ALL, invalid_data)
 
 
-class FrontPortTest(APIViewTestCases.APIViewTestCase):
+class FrontPortTestCase(APIViewTestCases.APIViewTestCase):
     model = FrontPort
     brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -2858,7 +2858,7 @@ class FrontPortTest(APIViewTestCases.APIViewTestCase):
         self.assertHttpStatus(response, status.HTTP_200_OK)
 
 
-class RearPortTest(APIViewTestCases.APIViewTestCase):
+class RearPortTestCase(APIViewTestCases.APIViewTestCase):
     model = RearPort
     brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -2974,7 +2974,7 @@ class RearPortTest(APIViewTestCases.APIViewTestCase):
         self.assertHttpStatus(response, status.HTTP_200_OK)
 
 
-class ModuleBayTest(APIViewTestCases.APIViewTestCase):
+class ModuleBayTestCase(APIViewTestCases.APIViewTestCase):
     model = ModuleBay
     brief_fields = ['_occupied', 'description', 'display', 'enabled', 'id', 'installed_module', 'name', 'url']
     bulk_update_data = {
@@ -3016,7 +3016,7 @@ class ModuleBayTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class DeviceBayTest(APIViewTestCases.APIViewTestCase):
+class DeviceBayTestCase(APIViewTestCases.APIViewTestCase):
     model = DeviceBay
     brief_fields = ['_occupied', 'description', 'device', 'display', 'enabled', 'id', 'name', 'url']
     bulk_update_data = {
@@ -3080,7 +3080,7 @@ class DeviceBayTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class InventoryItemTest(APIViewTestCases.APIViewTestCase):
+class InventoryItemTestCase(APIViewTestCases.APIViewTestCase):
     model = InventoryItem
     brief_fields = ['_depth', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -3147,7 +3147,7 @@ class InventoryItemTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class InventoryItemRoleTest(APIViewTestCases.APIViewTestCase):
+class InventoryItemRoleTestCase(APIViewTestCases.APIViewTestCase):
     model = InventoryItemRole
     brief_fields = ['description', 'display', 'id', 'inventoryitem_count', 'name', 'slug', 'url']
     create_data = [
@@ -3182,7 +3182,7 @@ class InventoryItemRoleTest(APIViewTestCases.APIViewTestCase):
         InventoryItemRole.objects.bulk_create(roles)
 
 
-class CableBundleTest(APIViewTestCases.APIViewTestCase):
+class CableBundleTestCase(APIViewTestCases.APIViewTestCase):
     model = CableBundle
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
@@ -3236,7 +3236,7 @@ class CableBundleTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(response.data['cable_count'], 2)
 
 
-class CableTest(APIViewTestCases.APIViewTestCase):
+class CableTestCase(APIViewTestCases.APIViewTestCase):
     model = Cable
     brief_fields = ['description', 'display', 'id', 'label', 'url']
     bulk_update_data = {
@@ -3445,7 +3445,7 @@ class CableTest(APIViewTestCases.APIViewTestCase):
                 self.assertSetEqual(set(ids), expected)
 
 
-class CableTerminationTest(
+class CableTerminationTestCase(
     APIViewTestCases.GetObjectViewTestCase,
     APIViewTestCases.ListObjectsViewTestCase,
 ):
@@ -3474,7 +3474,7 @@ class CableTerminationTest(
             cable.save()
 
 
-class ConnectedDeviceTest(APITestCase):
+class ConnectedDeviceTestCase(APITestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -3511,7 +3511,7 @@ class ConnectedDeviceTest(APITestCase):
         self.assertHttpStatus(response, status.HTTP_404_NOT_FOUND)
 
 
-class VirtualChassisTest(APIViewTestCases.APIViewTestCase):
+class VirtualChassisTestCase(APIViewTestCases.APIViewTestCase):
     model = VirtualChassis
     brief_fields = ['description', 'display', 'id', 'master', 'member_count', 'name', 'url']
 
@@ -3592,7 +3592,7 @@ class VirtualChassisTest(APIViewTestCases.APIViewTestCase):
         }
 
 
-class PowerPanelTest(APIViewTestCases.APIViewTestCase):
+class PowerPanelTestCase(APIViewTestCases.APIViewTestCase):
     model = PowerPanel
     brief_fields = ['description', 'display', 'id', 'name', 'powerfeed_count', 'url']
     user_permissions = ('dcim.view_site', )
@@ -3642,7 +3642,7 @@ class PowerPanelTest(APIViewTestCases.APIViewTestCase):
         }
 
 
-class PowerFeedTest(APIViewTestCases.APIViewTestCase):
+class PowerFeedTestCase(APIViewTestCases.APIViewTestCase):
     model = PowerFeed
     brief_fields = ['_occupied', 'cable', 'description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -3698,7 +3698,7 @@ class PowerFeedTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class VirtualDeviceContextTest(APIViewTestCases.APIViewTestCase):
+class VirtualDeviceContextTestCase(APIViewTestCases.APIViewTestCase):
     model = VirtualDeviceContext
     brief_fields = ['description', 'device', 'display', 'id', 'identifier', 'name', 'url']
     bulk_update_data = {
@@ -3752,7 +3752,7 @@ class VirtualDeviceContextTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class MACAddressTest(APIViewTestCases.APIViewTestCase):
+class MACAddressTestCase(APIViewTestCases.APIViewTestCase):
     model = MACAddress
     brief_fields = ['description', 'display', 'id', 'mac_address', 'url']
     bulk_update_data = {

--- a/netbox/dcim/tests/test_cable_profiles.py
+++ b/netbox/dcim/tests/test_cable_profiles.py
@@ -12,7 +12,7 @@ from dcim.models import Cable, Interface, RearPort
 from dcim.tests.utils import CablePathTestCase
 
 
-class CableProfileLinkPeerTests(CablePathTestCase):
+class CableProfileLinkPeerTestCase(CablePathTestCase):
     """
     Tests for link peer resolution with cable profiles.
     """
@@ -75,7 +75,7 @@ class CableProfileLinkPeerTests(CablePathTestCase):
             self.assertEqual(interface.link_peers, [rear_ports[1]])
 
 
-class CableProfilePeerTerminationTests(CablePathTestCase):
+class CableProfilePeerTerminationTestCase(CablePathTestCase):
     """
     Tests for BaseCableProfile.get_peer_termination() and get_peer_terminations().
     Verifies that the batch method produces identical results to calling

--- a/netbox/dcim/tests/test_cablepaths.py
+++ b/netbox/dcim/tests/test_cablepaths.py
@@ -6,7 +6,7 @@ from dcim.tests.utils import CablePathTestCase
 from utilities.exceptions import AbortRequest
 
 
-class LegacyCablePathTests(CablePathTestCase):
+class LegacyCablePathTestCase(CablePathTestCase):
     """
     Test NetBox's ability to trace and retrace CablePaths in response to data model changes, without cable profiles.
 

--- a/netbox/dcim/tests/test_cablepaths2.py
+++ b/netbox/dcim/tests/test_cablepaths2.py
@@ -7,7 +7,7 @@ from dcim.svg import CableTraceSVG
 from dcim.tests.utils import CablePathTestCase
 
 
-class CablePathTests(CablePathTestCase):
+class CablePathTestCase(CablePathTestCase):
     """
     Test the creation of CablePaths for Cables with different profiles applied.
 

--- a/netbox/dcim/tests/test_tables.py
+++ b/netbox/dcim/tests/test_tables.py
@@ -7,19 +7,19 @@ from utilities.testing import TableTestCases
 #
 
 
-class RegionTableTest(TableTestCases.StandardTableTestCase):
+class RegionTableTestCase(TableTestCases.StandardTableTestCase):
     table = RegionTable
 
 
-class SiteGroupTableTest(TableTestCases.StandardTableTestCase):
+class SiteGroupTableTestCase(TableTestCases.StandardTableTestCase):
     table = SiteGroupTable
 
 
-class SiteTableTest(TableTestCases.StandardTableTestCase):
+class SiteTableTestCase(TableTestCases.StandardTableTestCase):
     table = SiteTable
 
 
-class LocationTableTest(TableTestCases.StandardTableTestCase):
+class LocationTableTestCase(TableTestCases.StandardTableTestCase):
     table = LocationTable
 
 
@@ -27,19 +27,19 @@ class LocationTableTest(TableTestCases.StandardTableTestCase):
 # Racks
 #
 
-class RackRoleTableTest(TableTestCases.StandardTableTestCase):
+class RackRoleTableTestCase(TableTestCases.StandardTableTestCase):
     table = RackRoleTable
 
 
-class RackTypeTableTest(TableTestCases.StandardTableTestCase):
+class RackTypeTableTestCase(TableTestCases.StandardTableTestCase):
     table = RackTypeTable
 
 
-class RackTableTest(TableTestCases.StandardTableTestCase):
+class RackTableTestCase(TableTestCases.StandardTableTestCase):
     table = RackTable
 
 
-class RackReservationTableTest(TableTestCases.StandardTableTestCase):
+class RackReservationTableTestCase(TableTestCases.StandardTableTestCase):
     table = RackReservationTable
 
 
@@ -47,11 +47,11 @@ class RackReservationTableTest(TableTestCases.StandardTableTestCase):
 # Device types
 #
 
-class ManufacturerTableTest(TableTestCases.StandardTableTestCase):
+class ManufacturerTableTestCase(TableTestCases.StandardTableTestCase):
     table = ManufacturerTable
 
 
-class DeviceTypeTableTest(TableTestCases.StandardTableTestCase):
+class DeviceTypeTableTestCase(TableTestCases.StandardTableTestCase):
     table = DeviceTypeTable
 
 
@@ -59,15 +59,15 @@ class DeviceTypeTableTest(TableTestCases.StandardTableTestCase):
 # Module types
 #
 
-class ModuleTypeProfileTableTest(TableTestCases.StandardTableTestCase):
+class ModuleTypeProfileTableTestCase(TableTestCases.StandardTableTestCase):
     table = ModuleTypeProfileTable
 
 
-class ModuleTypeTableTest(TableTestCases.StandardTableTestCase):
+class ModuleTypeTableTestCase(TableTestCases.StandardTableTestCase):
     table = ModuleTypeTable
 
 
-class ModuleTableTest(TableTestCases.StandardTableTestCase):
+class ModuleTableTestCase(TableTestCases.StandardTableTestCase):
     table = ModuleTable
 
     def test_profile_column_available(self):
@@ -78,15 +78,15 @@ class ModuleTableTest(TableTestCases.StandardTableTestCase):
 # Devices
 #
 
-class DeviceRoleTableTest(TableTestCases.StandardTableTestCase):
+class DeviceRoleTableTestCase(TableTestCases.StandardTableTestCase):
     table = DeviceRoleTable
 
 
-class PlatformTableTest(TableTestCases.StandardTableTestCase):
+class PlatformTableTestCase(TableTestCases.StandardTableTestCase):
     table = PlatformTable
 
 
-class DeviceTableTest(TableTestCases.StandardTableTestCase):
+class DeviceTableTestCase(TableTestCases.StandardTableTestCase):
     table = DeviceTable
 
 
@@ -94,47 +94,47 @@ class DeviceTableTest(TableTestCases.StandardTableTestCase):
 # Device components
 #
 
-class ConsolePortTableTest(TableTestCases.StandardTableTestCase):
+class ConsolePortTableTestCase(TableTestCases.StandardTableTestCase):
     table = ConsolePortTable
 
 
-class ConsoleServerPortTableTest(TableTestCases.StandardTableTestCase):
+class ConsoleServerPortTableTestCase(TableTestCases.StandardTableTestCase):
     table = ConsoleServerPortTable
 
 
-class PowerPortTableTest(TableTestCases.StandardTableTestCase):
+class PowerPortTableTestCase(TableTestCases.StandardTableTestCase):
     table = PowerPortTable
 
 
-class PowerOutletTableTest(TableTestCases.StandardTableTestCase):
+class PowerOutletTableTestCase(TableTestCases.StandardTableTestCase):
     table = PowerOutletTable
 
 
-class InterfaceTableTest(TableTestCases.StandardTableTestCase):
+class InterfaceTableTestCase(TableTestCases.StandardTableTestCase):
     table = InterfaceTable
 
 
-class FrontPortTableTest(TableTestCases.StandardTableTestCase):
+class FrontPortTableTestCase(TableTestCases.StandardTableTestCase):
     table = FrontPortTable
 
 
-class RearPortTableTest(TableTestCases.StandardTableTestCase):
+class RearPortTableTestCase(TableTestCases.StandardTableTestCase):
     table = RearPortTable
 
 
-class ModuleBayTableTest(TableTestCases.StandardTableTestCase):
+class ModuleBayTableTestCase(TableTestCases.StandardTableTestCase):
     table = ModuleBayTable
 
 
-class DeviceBayTableTest(TableTestCases.StandardTableTestCase):
+class DeviceBayTableTestCase(TableTestCases.StandardTableTestCase):
     table = DeviceBayTable
 
 
-class InventoryItemTableTest(TableTestCases.StandardTableTestCase):
+class InventoryItemTableTestCase(TableTestCases.StandardTableTestCase):
     table = InventoryItemTable
 
 
-class InventoryItemRoleTableTest(TableTestCases.StandardTableTestCase):
+class InventoryItemRoleTableTestCase(TableTestCases.StandardTableTestCase):
     table = InventoryItemRoleTable
 
 
@@ -142,21 +142,21 @@ class InventoryItemRoleTableTest(TableTestCases.StandardTableTestCase):
 # Connections
 #
 
-class ConsoleConnectionTableTest(TableTestCases.StandardTableTestCase):
+class ConsoleConnectionTableTestCase(TableTestCases.StandardTableTestCase):
     table = ConsoleConnectionTable
     queryset_sources = [
         ('ConsoleConnectionsListView', ConsolePort.objects.filter(_path__is_complete=True)),
     ]
 
 
-class PowerConnectionTableTest(TableTestCases.StandardTableTestCase):
+class PowerConnectionTableTestCase(TableTestCases.StandardTableTestCase):
     table = PowerConnectionTable
     queryset_sources = [
         ('PowerConnectionsListView', PowerPort.objects.filter(_path__is_complete=True)),
     ]
 
 
-class InterfaceConnectionTableTest(TableTestCases.StandardTableTestCase):
+class InterfaceConnectionTableTestCase(TableTestCases.StandardTableTestCase):
     table = InterfaceConnectionTable
     queryset_sources = [
         ('InterfaceConnectionsListView', Interface.objects.filter(_path__is_complete=True)),
@@ -167,7 +167,7 @@ class InterfaceConnectionTableTest(TableTestCases.StandardTableTestCase):
 # Cables
 #
 
-class CableTableTest(TableTestCases.StandardTableTestCase):
+class CableTableTestCase(TableTestCases.StandardTableTestCase):
     table = CableTable
 
 
@@ -175,11 +175,11 @@ class CableTableTest(TableTestCases.StandardTableTestCase):
 # Power
 #
 
-class PowerPanelTableTest(TableTestCases.StandardTableTestCase):
+class PowerPanelTableTestCase(TableTestCases.StandardTableTestCase):
     table = PowerPanelTable
 
 
-class PowerFeedTableTest(TableTestCases.StandardTableTestCase):
+class PowerFeedTableTestCase(TableTestCases.StandardTableTestCase):
     table = PowerFeedTable
 
 
@@ -187,7 +187,7 @@ class PowerFeedTableTest(TableTestCases.StandardTableTestCase):
 # Virtual chassis
 #
 
-class VirtualChassisTableTest(TableTestCases.StandardTableTestCase):
+class VirtualChassisTableTestCase(TableTestCases.StandardTableTestCase):
     table = VirtualChassisTable
 
 
@@ -195,7 +195,7 @@ class VirtualChassisTableTest(TableTestCases.StandardTableTestCase):
 # Virtual device contexts
 #
 
-class VirtualDeviceContextTableTest(TableTestCases.StandardTableTestCase):
+class VirtualDeviceContextTableTestCase(TableTestCases.StandardTableTestCase):
     table = VirtualDeviceContextTable
 
 
@@ -203,5 +203,5 @@ class VirtualDeviceContextTableTest(TableTestCases.StandardTableTestCase):
 # MAC addresses
 #
 
-class MACAddressTableTest(TableTestCases.StandardTableTestCase):
+class MACAddressTableTestCase(TableTestCases.StandardTableTestCase):
     table = MACAddressTable

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -22,7 +22,7 @@ from users.models import Group, Token, User
 from utilities.testing import APITestCase, APIViewTestCases
 
 
-class AppTest(APITestCase):
+class AppTestCase(APITestCase):
 
     def test_root(self):
 
@@ -32,7 +32,7 @@ class AppTest(APITestCase):
         self.assertEqual(response.status_code, 200)
 
 
-class WebhookTest(APIViewTestCases.APIViewTestCase):
+class WebhookTestCase(APIViewTestCases.APIViewTestCase):
     model = Webhook
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
@@ -74,7 +74,7 @@ class WebhookTest(APIViewTestCases.APIViewTestCase):
         Webhook.objects.bulk_create(webhooks)
 
 
-class EventRuleTest(APIViewTestCases.APIViewTestCase):
+class EventRuleTestCase(APIViewTestCases.APIViewTestCase):
     model = EventRule
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -152,7 +152,7 @@ class EventRuleTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class CustomFieldTest(APIViewTestCases.APIViewTestCase):
+class CustomFieldTestCase(APIViewTestCases.APIViewTestCase):
     model = CustomField
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
@@ -204,7 +204,7 @@ class CustomFieldTest(APIViewTestCases.APIViewTestCase):
             cf.object_types.add(site_ct)
 
 
-class CustomFieldChoiceSetTest(APIViewTestCases.APIViewTestCase):
+class CustomFieldChoiceSetTestCase(APIViewTestCases.APIViewTestCase):
     model = CustomFieldChoiceSet
     brief_fields = ['choices_count', 'description', 'display', 'id', 'name', 'url']
     create_data = [
@@ -325,7 +325,7 @@ class CustomFieldChoiceSetTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(response.status_code, 400)
 
 
-class CustomLinkTest(APIViewTestCases.APIViewTestCase):
+class CustomLinkTestCase(APIViewTestCases.APIViewTestCase):
     model = CustomLink
     brief_fields = ['display', 'id', 'name', 'url']
     create_data = [
@@ -385,7 +385,7 @@ class CustomLinkTest(APIViewTestCases.APIViewTestCase):
             custom_link.object_types.set([site_type])
 
 
-class SavedFilterTest(APIViewTestCases.APIViewTestCase):
+class SavedFilterTestCase(APIViewTestCases.APIViewTestCase):
     model = SavedFilter
     brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
@@ -458,7 +458,7 @@ class SavedFilterTest(APIViewTestCases.APIViewTestCase):
             savedfilter.object_types.set([site_type])
 
 
-class BookmarkTest(
+class BookmarkTestCase(
     APIViewTestCases.GetObjectViewTestCase,
     APIViewTestCases.ListObjectsViewTestCase,
     APIViewTestCases.CreateObjectViewTestCase,
@@ -510,7 +510,7 @@ class BookmarkTest(
         ]
 
 
-class ExportTemplateTest(APIViewTestCases.APIViewTestCase):
+class ExportTemplateTestCase(APIViewTestCases.APIViewTestCase):
     model = ExportTemplate
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
@@ -560,7 +560,7 @@ class ExportTemplateTest(APIViewTestCases.APIViewTestCase):
             et.object_types.set([device_object_type])
 
 
-class TagTest(APIViewTestCases.APIViewTestCase):
+class TagTestCase(APIViewTestCases.APIViewTestCase):
     model = Tag
     brief_fields = ['color', 'description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
@@ -593,7 +593,7 @@ class TagTest(APIViewTestCases.APIViewTestCase):
         Tag.objects.bulk_create(tags)
 
 
-class TaggedItemTest(
+class TaggedItemTestCase(
     APIViewTestCases.GetObjectViewTestCase,
     APIViewTestCases.ListObjectsViewTestCase
 ):
@@ -622,7 +622,7 @@ class TaggedItemTest(
 
 
 # TODO: Standardize to APIViewTestCase (needs create & update tests)
-class ImageAttachmentTest(
+class ImageAttachmentTestCase(
     APIViewTestCases.GetObjectViewTestCase,
     APIViewTestCases.ListObjectsViewTestCase,
     APIViewTestCases.DeleteObjectViewTestCase,
@@ -666,7 +666,7 @@ class ImageAttachmentTest(
         ImageAttachment.objects.bulk_create(image_attachments)
 
 
-class JournalEntryTest(APIViewTestCases.APIViewTestCase):
+class JournalEntryTestCase(APIViewTestCases.APIViewTestCase):
     model = JournalEntry
     brief_fields = ['created', 'display', 'id', 'url']
     bulk_update_data = {
@@ -716,7 +716,7 @@ class JournalEntryTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class ConfigContextProfileTest(APIViewTestCases.APIViewTestCase):
+class ConfigContextProfileTestCase(APIViewTestCases.APIViewTestCase):
     model = ConfigContextProfile
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
@@ -825,7 +825,7 @@ class ConfigContextProfileTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(response.data['data_file']['id'], datafile.pk)
 
 
-class ConfigContextTest(APIViewTestCases.APIViewTestCase):
+class ConfigContextTestCase(APIViewTestCases.APIViewTestCase):
     model = ConfigContext
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
@@ -951,7 +951,7 @@ class ConfigContextTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(response.data['data_file']['id'], datafile.pk)
 
 
-class ConfigTemplateTest(APIViewTestCases.APIViewTestCase):
+class ConfigTemplateTestCase(APIViewTestCases.APIViewTestCase):
     model = ConfigTemplate
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
@@ -1036,7 +1036,7 @@ class ConfigTemplateTest(APIViewTestCases.APIViewTestCase):
         self.assertHttpStatus(response, status.HTTP_200_OK)
 
 
-class ScriptTest(APITestCase):
+class ScriptTestCase(APITestCase):
 
     class TestScriptClass(PythonClass):
         class Meta:
@@ -1162,7 +1162,7 @@ class ScriptTest(APITestCase):
             self.TestScriptClass.Meta.scheduling_enabled = original
 
 
-class CreatedUpdatedFilterTest(APITestCase):
+class CreatedUpdatedFilterTestCase(APITestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -1236,7 +1236,7 @@ class CreatedUpdatedFilterTest(APITestCase):
         self.assertEqual(response.data['results'][0]['id'], rack2.pk)
 
 
-class SubscriptionTest(APIViewTestCases.APIViewTestCase):
+class SubscriptionTestCase(APIViewTestCases.APIViewTestCase):
     model = Subscription
     brief_fields = ['display', 'id', 'object_id', 'object_type', 'url', 'user']
 
@@ -1295,7 +1295,7 @@ class SubscriptionTest(APIViewTestCases.APIViewTestCase):
         }
 
 
-class NotificationGroupTest(APIViewTestCases.APIViewTestCase):
+class NotificationGroupTestCase(APIViewTestCases.APIViewTestCase):
     model = NotificationGroup
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
@@ -1372,7 +1372,7 @@ class NotificationGroupTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class NotificationTest(APIViewTestCases.APIViewTestCase):
+class NotificationTestCase(APIViewTestCases.APIViewTestCase):
     model = Notification
     brief_fields = ['display', 'event_type', 'id', 'object_id', 'object_type', 'read', 'url', 'user']
     bulk_update_data = {
@@ -1436,7 +1436,7 @@ class NotificationTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class ScriptModuleTest(APITestCase):
+class ScriptModuleTestCase(APITestCase):
     """
     Tests for the POST /api/extras/scripts/upload/ endpoint.
 

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -134,7 +134,7 @@ class ConditionTestCase(TestCase):
         self.assertTrue(c.eval({'x': '123'}))
 
 
-class ConditionSetTest(TestCase):
+class ConditionSetTestCase(TestCase):
 
     def test_empty(self):
         with self.assertRaises(ValueError):

--- a/netbox/extras/tests/test_custom_validation.py
+++ b/netbox/extras/tests/test_custom_validation.py
@@ -8,7 +8,7 @@ from netbox.choices import CSVDelimiterChoices, ImportFormatChoices
 from utilities.testing import APITestCase, ModelViewTestCase, create_tags, post_data
 
 
-class ModelFormCustomValidationTest(TestCase):
+class ModelFormCustomValidationTestCase(TestCase):
 
     @override_settings(CUSTOM_VALIDATORS={
         'circuits.provider': [
@@ -58,7 +58,7 @@ class ModelFormCustomValidationTest(TestCase):
         self.assertTrue(form.is_valid())
 
 
-class BulkEditCustomValidationTest(ModelViewTestCase):
+class BulkEditCustomValidationTestCase(ModelViewTestCase):
     model = Provider
 
     @classmethod
@@ -155,7 +155,7 @@ class BulkEditCustomValidationTest(ModelViewTestCase):
             self.assertTrue(provider.asns.exists())
 
 
-class BulkImportCustomValidationTest(ModelViewTestCase):
+class BulkImportCustomValidationTestCase(ModelViewTestCase):
     model = Provider
 
     @classmethod
@@ -214,7 +214,7 @@ class BulkImportCustomValidationTest(ModelViewTestCase):
         self.assertTrue(Provider.objects.exists())
 
 
-class APISerializerCustomValidationTest(APITestCase):
+class APISerializerCustomValidationTestCase(APITestCase):
 
     @override_settings(CUSTOM_VALIDATORS={
         'circuits.provider': [

--- a/netbox/extras/tests/test_customfields.py
+++ b/netbox/extras/tests/test_customfields.py
@@ -19,7 +19,7 @@ from utilities.testing import APITestCase, TestCase
 from virtualization.models import VirtualMachine
 
 
-class CustomFieldTest(TestCase):
+class CustomFieldTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -762,7 +762,7 @@ class CustomFieldTest(TestCase):
             ).full_clean()
 
 
-class CustomFieldManagerTest(TestCase):
+class CustomFieldManagerTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -776,7 +776,7 @@ class CustomFieldManagerTest(TestCase):
         self.assertEqual(CustomField.objects.get_for_model(VirtualMachine).count(), 0)
 
 
-class CustomFieldAPITest(APITestCase):
+class CustomFieldAPITestCase(APITestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -1564,7 +1564,7 @@ class CustomFieldAPITest(APITestCase):
         self.assertHttpStatus(response, status.HTTP_200_OK)
 
 
-class CustomFieldImportTest(TestCase):
+class CustomFieldImportTestCase(TestCase):
     user_permissions = (
         'dcim.view_site',
         'dcim.add_site',
@@ -1694,7 +1694,7 @@ class CustomFieldImportTest(TestCase):
         self.assertIn('cf_select', form.errors)
 
 
-class CustomFieldModelTest(TestCase):
+class CustomFieldModelTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -1755,7 +1755,7 @@ class CustomFieldModelTest(TestCase):
         site.clean()
 
 
-class CustomFieldModelFilterTest(TestCase):
+class CustomFieldModelFilterTestCase(TestCase):
     queryset = Site.objects.all()
     filterset = SiteFilterSet
 

--- a/netbox/extras/tests/test_customvalidators.py
+++ b/netbox/extras/tests/test_customvalidators.py
@@ -98,7 +98,7 @@ request_validator = CustomValidator({
 custom_validator = MyValidator()
 
 
-class CustomValidatorTest(TestCase):
+class CustomValidatorTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -207,7 +207,7 @@ class CustomValidatorTest(TestCase):
         request_validator(site, request)
 
 
-class CustomValidatorConfigTest(TestCase):
+class CustomValidatorConfigTestCase(TestCase):
 
     @override_settings(
         CUSTOM_VALIDATORS={
@@ -242,7 +242,7 @@ class CustomValidatorConfigTest(TestCase):
             Site(name='bar', slug='bar').clean()
 
 
-class ProtectionRulesConfigTest(TestCase):
+class ProtectionRulesConfigTestCase(TestCase):
 
     @override_settings(
         PROTECTION_RULES={

--- a/netbox/extras/tests/test_dashboard.py
+++ b/netbox/extras/tests/test_dashboard.py
@@ -3,7 +3,7 @@ from django.test import TestCase, tag
 from extras.dashboard.widgets import ObjectListWidget
 
 
-class ObjectListWidgetTests(TestCase):
+class ObjectListWidgetTestCase(TestCase):
     def test_widget_config_form_validates_model(self):
         model_info = 'extras.notification'
         form = ObjectListWidget.ConfigForm({'model': model_info})

--- a/netbox/extras/tests/test_event_rules.py
+++ b/netbox/extras/tests/test_event_rules.py
@@ -24,7 +24,7 @@ from netbox.context_managers import event_tracking
 from utilities.testing import APITestCase
 
 
-class EventRuleTest(APITestCase):
+class EventRuleTestCase(APITestCase):
 
     def setUp(self):
         super().setUp()

--- a/netbox/extras/tests/test_forms.py
+++ b/netbox/extras/tests/test_forms.py
@@ -9,7 +9,7 @@ from extras.forms.model_forms import CustomFieldChoiceSetForm
 from extras.models import CustomField, CustomFieldChoiceSet
 
 
-class CustomFieldModelFormTest(TestCase):
+class CustomFieldModelFormTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -91,7 +91,7 @@ class CustomFieldModelFormTest(TestCase):
             self.assertIsNone(instance.custom_field_data[field_type])
 
 
-class CustomFieldChoiceSetFormTest(TestCase):
+class CustomFieldChoiceSetFormTestCase(TestCase):
 
     def test_escaped_colons_preserved_on_edit(self):
         choice_set = CustomFieldChoiceSet.objects.create(
@@ -142,7 +142,7 @@ class CustomFieldChoiceSetFormTest(TestCase):
         self.assertEqual(updated.choice_colors, {'choice2': 'green', 'foo:bar': 'red'})
 
 
-class SavedFilterFormTest(TestCase):
+class SavedFilterFormTestCase(TestCase):
 
     def test_basic_submit(self):
         """

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -67,7 +67,7 @@ class OverwriteStyleMemoryStorage(Storage):
         return f'https://example.invalid/{name}'
 
 
-class ImageAttachmentTests(TestCase):
+class ImageAttachmentTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.ct_rack = ContentType.objects.get_by_natural_key('dcim', 'rack')
@@ -185,7 +185,7 @@ class ImageAttachmentTests(TestCase):
         self.assertCountEqual(storage.files.keys(), {base_name, suffixed_name})
 
 
-class TagTest(TestCase):
+class TagTestCase(TestCase):
 
     def test_default_ordering_weight_then_name_is_set(self):
         Tag.objects.create(name='Tag 1', slug='tag-1', weight=3000)
@@ -244,7 +244,7 @@ class TagTest(TestCase):
             sitegroup.tags.add(tag)
 
 
-class ConfigContextTest(TestCase):
+class ConfigContextTestCase(TestCase):
     """
     These test cases deal with the weighting, ordering, and deep merge logic of config context data.
 
@@ -792,7 +792,7 @@ class ConfigContextTest(TestCase):
         self.assertTrue(distinct_subqueries[0].distinct)
 
 
-class ConfigTemplateTest(TestCase):
+class ConfigTemplateTestCase(TestCase):
     """
     TODO: These test cases deal with the weighting, ordering, and deep merge logic of config context data.
     """
@@ -905,7 +905,7 @@ class ConfigTemplateTest(TestCase):
             self.assertEqual(autosync_records.count(), 0, "AutoSyncRecord should be deleted after detaching")
 
 
-class ConfigTemplateDebugTest(TestCase):
+class ConfigTemplateDebugTestCase(TestCase):
     """
     Tests for the ConfigTemplate debug field and its effect on template rendering error output.
     """
@@ -953,7 +953,7 @@ class ConfigTemplateDebugTest(TestCase):
             render_jinja2("{% debug %}", {}, debug=False)
 
 
-class ExportTemplateContextTest(TestCase):
+class ExportTemplateContextTestCase(TestCase):
     """
     Tests for ExportTemplate.get_context() including public model population.
     """
@@ -986,7 +986,7 @@ class ExportTemplateContextTest(TestCase):
         self.assertIs(ctx['dcim']['Site'], Site)
 
 
-class EventRuleTest(TestCase):
+class EventRuleTestCase(TestCase):
 
     def test_action_data_clean_accepts_dict(self):
         """

--- a/netbox/extras/tests/test_scripts.py
+++ b/netbox/extras/tests/test_scripts.py
@@ -32,7 +32,7 @@ JSON_DATA = """
 """
 
 
-class ScriptVariablesTest(TestCase):
+class ScriptVariablesTestCase(TestCase):
 
     def test_stringvar(self):
 

--- a/netbox/extras/tests/test_tables.py
+++ b/netbox/extras/tests/test_tables.py
@@ -3,31 +3,31 @@ from extras.tables import *
 from utilities.testing import TableTestCases
 
 
-class CustomFieldTableTest(TableTestCases.StandardTableTestCase):
+class CustomFieldTableTestCase(TableTestCases.StandardTableTestCase):
     table = CustomFieldTable
 
 
-class CustomFieldChoiceSetTableTest(TableTestCases.StandardTableTestCase):
+class CustomFieldChoiceSetTableTestCase(TableTestCases.StandardTableTestCase):
     table = CustomFieldChoiceSetTable
 
 
-class CustomLinkTableTest(TableTestCases.StandardTableTestCase):
+class CustomLinkTableTestCase(TableTestCases.StandardTableTestCase):
     table = CustomLinkTable
 
 
-class ExportTemplateTableTest(TableTestCases.StandardTableTestCase):
+class ExportTemplateTableTestCase(TableTestCases.StandardTableTestCase):
     table = ExportTemplateTable
 
 
-class SavedFilterTableTest(TableTestCases.StandardTableTestCase):
+class SavedFilterTableTestCase(TableTestCases.StandardTableTestCase):
     table = SavedFilterTable
 
 
-class TableConfigTableTest(TableTestCases.StandardTableTestCase):
+class TableConfigTableTestCase(TableTestCases.StandardTableTestCase):
     table = TableConfigTable
 
 
-class BookmarkTableTest(TableTestCases.StandardTableTestCase):
+class BookmarkTableTestCase(TableTestCases.StandardTableTestCase):
     table = BookmarkTable
 
     # The list view for this table lives in account.views (not extras.views),
@@ -37,11 +37,11 @@ class BookmarkTableTest(TableTestCases.StandardTableTestCase):
     ]
 
 
-class NotificationGroupTableTest(TableTestCases.StandardTableTestCase):
+class NotificationGroupTableTestCase(TableTestCases.StandardTableTestCase):
     table = NotificationGroupTable
 
 
-class NotificationTableTest(TableTestCases.StandardTableTestCase):
+class NotificationTableTestCase(TableTestCases.StandardTableTestCase):
     table = NotificationTable
 
     # The list view for this table lives in account.views (not extras.views),
@@ -51,7 +51,7 @@ class NotificationTableTest(TableTestCases.StandardTableTestCase):
     ]
 
 
-class SubscriptionTableTest(TableTestCases.StandardTableTestCase):
+class SubscriptionTableTestCase(TableTestCases.StandardTableTestCase):
     table = SubscriptionTable
 
     # The list view for this table lives in account.views (not extras.views),
@@ -61,33 +61,33 @@ class SubscriptionTableTest(TableTestCases.StandardTableTestCase):
     ]
 
 
-class WebhookTableTest(TableTestCases.StandardTableTestCase):
+class WebhookTableTestCase(TableTestCases.StandardTableTestCase):
     table = WebhookTable
 
 
-class EventRuleTableTest(TableTestCases.StandardTableTestCase):
+class EventRuleTableTestCase(TableTestCases.StandardTableTestCase):
     table = EventRuleTable
 
 
-class TagTableTest(TableTestCases.StandardTableTestCase):
+class TagTableTestCase(TableTestCases.StandardTableTestCase):
     table = TagTable
 
 
-class ConfigContextProfileTableTest(TableTestCases.StandardTableTestCase):
+class ConfigContextProfileTableTestCase(TableTestCases.StandardTableTestCase):
     table = ConfigContextProfileTable
 
 
-class ConfigContextTableTest(TableTestCases.StandardTableTestCase):
+class ConfigContextTableTestCase(TableTestCases.StandardTableTestCase):
     table = ConfigContextTable
 
 
-class ConfigTemplateTableTest(TableTestCases.StandardTableTestCase):
+class ConfigTemplateTableTestCase(TableTestCases.StandardTableTestCase):
     table = ConfigTemplateTable
 
 
-class ImageAttachmentTableTest(TableTestCases.StandardTableTestCase):
+class ImageAttachmentTableTestCase(TableTestCases.StandardTableTestCase):
     table = ImageAttachmentTable
 
 
-class JournalEntryTableTest(TableTestCases.StandardTableTestCase):
+class JournalEntryTableTestCase(TableTestCases.StandardTableTestCase):
     table = JournalEntryTable

--- a/netbox/extras/tests/test_tags.py
+++ b/netbox/extras/tests/test_tags.py
@@ -5,7 +5,7 @@ from dcim.models import Site
 from utilities.testing import APITestCase, create_tags
 
 
-class TaggedItemTest(APITestCase):
+class TaggedItemTestCase(APITestCase):
     """
     Test the application of Tags to and item (a Site, for example) upon creation (POST) and modification (PATCH).
     """

--- a/netbox/extras/tests/test_utils.py
+++ b/netbox/extras/tests/test_utils.py
@@ -11,7 +11,7 @@ from tenancy.models import ContactGroup, TenantGroup
 from wireless.models import WirelessLANGroup
 
 
-class FilenameFromModelTests(TestCase):
+class FilenameFromModelTestCase(TestCase):
     def test_expected_output(self):
         cases = (
             (ExportTemplate, 'netbox_export_templates'),
@@ -43,7 +43,7 @@ class OverwriteStyleStorage(Storage):
         return f'{file_root}_sdmmer4{file_ext}'
 
 
-class ImageUploadTests(TestCase):
+class ImageUploadTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
         # We only need a ContentType with model="rack" for the prefix;

--- a/netbox/extras/tests/test_views.py
+++ b/netbox/extras/tests/test_views.py
@@ -181,6 +181,27 @@ class CustomLinkTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         }
 
 
+class CustomLinkRenderingTestCase(TestCase):
+    user_permissions = ['dcim.view_site']
+
+    def test_view_object_with_custom_link(self):
+        customlink = CustomLink(
+            name='Test',
+            link_text='FOO {{ object.name }} BAR',
+            link_url='http://example.com/?site={{ object.slug }}',
+            new_window=False
+        )
+        customlink.save()
+        customlink.object_types.set([ObjectType.objects.get_for_model(Site)])
+
+        site = Site(name='Test Site', slug='test-site')
+        site.save()
+
+        response = self.client.get(site.get_absolute_url(), follow=True)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(f'FOO {site.name} BAR', str(response.content))
+
+
 class SavedFilterTestCase(ViewTestCases.PrimaryObjectViewTestCase):
     model = SavedFilter
 
@@ -703,27 +724,6 @@ class JournalEntryTestCase(
         }
 
 
-class CustomLinkTest(TestCase):
-    user_permissions = ['dcim.view_site']
-
-    def test_view_object_with_custom_link(self):
-        customlink = CustomLink(
-            name='Test',
-            link_text='FOO {{ object.name }} BAR',
-            link_url='http://example.com/?site={{ object.slug }}',
-            new_window=False
-        )
-        customlink.save()
-        customlink.object_types.set([ObjectType.objects.get_for_model(Site)])
-
-        site = Site(name='Test Site', slug='test-site')
-        site.save()
-
-        response = self.client.get(site.get_absolute_url(), follow=True)
-        self.assertEqual(response.status_code, 200)
-        self.assertIn(f'FOO {site.name} BAR', str(response.content))
-
-
 class SubscriptionTestCase(
     ViewTestCases.CreateObjectViewTestCase,
     ViewTestCases.DeleteObjectViewTestCase,
@@ -887,7 +887,7 @@ class NotificationTestCase(
         return
 
 
-class ScriptListViewTest(TestCase):
+class ScriptListViewTestCase(TestCase):
     user_permissions = ['extras.view_script']
 
     def test_script_list_embedded_parameter(self):
@@ -905,7 +905,7 @@ class ScriptListViewTest(TestCase):
         self.assertTemplateUsed(response, 'extras/inc/script_list_content.html')
 
 
-class ScriptValidationErrorTest(TestCase):
+class ScriptValidationErrorTestCase(TestCase):
     user_permissions = ['extras.view_script', 'extras.run_script']
 
     class TestScriptMixin:
@@ -936,7 +936,7 @@ class ScriptValidationErrorTest(TestCase):
 
     def setUp(self):
         super().setUp()
-        Script.python_class = property(lambda self: ScriptValidationErrorTest.TestScriptClass)
+        Script.python_class = property(lambda self: ScriptValidationErrorTestCase.TestScriptClass)
 
     @tag('regression')
     def test_script_validation_error_displays_message(self):
@@ -975,7 +975,7 @@ class ScriptValidationErrorTest(TestCase):
         self.assertEqual(len(messages), 0)
 
 
-class ScriptDefaultValuesTest(TestCase):
+class ScriptDefaultValuesTestCase(TestCase):
     user_permissions = ['extras.view_script', 'extras.run_script']
 
     class TestScriptClass(PythonClass):
@@ -1005,7 +1005,7 @@ class ScriptDefaultValuesTest(TestCase):
 
     def setUp(self):
         super().setUp()
-        Script.python_class = property(lambda self: ScriptDefaultValuesTest.TestScriptClass)
+        Script.python_class = property(lambda self: ScriptDefaultValuesTestCase.TestScriptClass)
 
     def test_default_values_are_used(self):
         url = reverse('extras:script', kwargs={'pk': self.script.pk})

--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -14,7 +14,7 @@ from utilities.data import string_to_ranges
 from utilities.testing import APITestCase, APIViewTestCases, create_test_device, disable_logging
 
 
-class AppTest(APITestCase):
+class AppTestCase(APITestCase):
 
     def test_root(self):
 
@@ -24,7 +24,7 @@ class AppTest(APITestCase):
         self.assertEqual(response.status_code, 200)
 
 
-class ASNRangeTest(APIViewTestCases.APIViewTestCase):
+class ASNRangeTestCase(APIViewTestCases.APIViewTestCase):
     model = ASNRange
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -136,7 +136,7 @@ class ASNRangeTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(len(response.data), 10)
 
 
-class ASNTest(APIViewTestCases.APIViewTestCase):
+class ASNTestCase(APIViewTestCases.APIViewTestCase):
     model = ASN
     brief_fields = ['asn', 'description', 'display', 'id', 'url']
     bulk_update_data = {
@@ -200,7 +200,7 @@ class ASNTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class VRFTest(APIViewTestCases.APIViewTestCase):
+class VRFTestCase(APIViewTestCases.APIViewTestCase):
     model = VRF
     brief_fields = ['description', 'display', 'id', 'name', 'prefix_count', 'rd', 'url']
     create_data = [
@@ -232,7 +232,7 @@ class VRFTest(APIViewTestCases.APIViewTestCase):
         VRF.objects.bulk_create(vrfs)
 
 
-class RouteTargetTest(APIViewTestCases.APIViewTestCase):
+class RouteTargetTestCase(APIViewTestCases.APIViewTestCase):
     model = RouteTarget
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     create_data = [
@@ -261,7 +261,7 @@ class RouteTargetTest(APIViewTestCases.APIViewTestCase):
         RouteTarget.objects.bulk_create(route_targets)
 
 
-class RIRTest(APIViewTestCases.APIViewTestCase):
+class RIRTestCase(APIViewTestCases.APIViewTestCase):
     model = RIR
     brief_fields = ['aggregate_count', 'description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
@@ -293,7 +293,7 @@ class RIRTest(APIViewTestCases.APIViewTestCase):
         RIR.objects.bulk_create(rirs)
 
 
-class AggregateTest(APIViewTestCases.APIViewTestCase):
+class AggregateTestCase(APIViewTestCases.APIViewTestCase):
     model = Aggregate
     brief_fields = ['description', 'display', 'family', 'id', 'prefix', 'url']
     bulk_update_data = {
@@ -381,7 +381,7 @@ class AggregateTest(APIViewTestCases.APIViewTestCase):
         # No exception occurred; invalid entries were ignored
 
 
-class RoleTest(APIViewTestCases.APIViewTestCase):
+class RoleTestCase(APIViewTestCases.APIViewTestCase):
     model = Role
     brief_fields = ['asn_count', 'description', 'display', 'id', 'name', 'prefix_count', 'slug', 'url', 'vlan_count']
     create_data = [
@@ -424,7 +424,7 @@ class RoleTest(APIViewTestCases.APIViewTestCase):
         ASN.objects.bulk_create(asns)
 
 
-class PrefixTest(APIViewTestCases.APIViewTestCase):
+class PrefixTestCase(APIViewTestCases.APIViewTestCase):
     model = Prefix
     brief_fields = ['_depth', 'description', 'display', 'family', 'id', 'prefix', 'url']
     create_data = [
@@ -664,7 +664,7 @@ class PrefixTest(APIViewTestCases.APIViewTestCase):
         self.assertTrue(data['data']['tenant_list'])  # tenant returned
 
 
-class IPRangeTest(APIViewTestCases.APIViewTestCase):
+class IPRangeTestCase(APIViewTestCases.APIViewTestCase):
     model = IPRange
     brief_fields = ['description', 'display', 'end_address', 'family', 'id', 'start_address', 'url']
     create_data = [
@@ -822,7 +822,7 @@ class IPRangeTest(APIViewTestCases.APIViewTestCase):
         # No exception occurred; invalid entries were ignored
 
 
-class IPAddressTest(APIViewTestCases.APIViewTestCase):
+class IPAddressTestCase(APIViewTestCases.APIViewTestCase):
     model = IPAddress
     brief_fields = ['address', 'description', 'display', 'family', 'id', 'url']
     create_data = [
@@ -977,7 +977,7 @@ class IPAddressTest(APIViewTestCases.APIViewTestCase):
         self.assertIn(str(device1.pk), ids)
 
 
-class FHRPGroupTest(APIViewTestCases.APIViewTestCase):
+class FHRPGroupTestCase(APIViewTestCases.APIViewTestCase):
     model = FHRPGroup
     brief_fields = ['description', 'display', 'group_id', 'id', 'protocol', 'url']
     bulk_update_data = {
@@ -1028,7 +1028,7 @@ class FHRPGroupTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class FHRPGroupAssignmentTest(APIViewTestCases.APIViewTestCase):
+class FHRPGroupAssignmentTestCase(APIViewTestCases.APIViewTestCase):
     model = FHRPGroupAssignment
     brief_fields = ['display', 'group', 'id', 'interface_id', 'interface_type', 'priority', 'url']
     bulk_update_data = {
@@ -1108,7 +1108,7 @@ class FHRPGroupAssignmentTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class VLANGroupTest(APIViewTestCases.APIViewTestCase):
+class VLANGroupTestCase(APIViewTestCases.APIViewTestCase):
     model = VLANGroup
     brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url', 'vlan_count']
     create_data = [
@@ -1231,7 +1231,7 @@ class VLANGroupTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(response.data[2]['vid'], 6)
 
 
-class VLANTest(APIViewTestCases.APIViewTestCase):
+class VLANTestCase(APIViewTestCases.APIViewTestCase):
     model = VLAN
     brief_fields = ['description', 'display', 'id', 'name', 'url', 'vid']
     bulk_update_data = {
@@ -1298,7 +1298,7 @@ class VLANTest(APIViewTestCases.APIViewTestCase):
         self.assertTrue(content['detail'].startswith('Unable to delete object.'))
 
 
-class VLANTranslationPolicyTest(APIViewTestCases.APIViewTestCase):
+class VLANTranslationPolicyTestCase(APIViewTestCases.APIViewTestCase):
     model = VLANTranslationPolicy
     brief_fields = ['description', 'display', 'id', 'name', 'url',]
     bulk_update_data = {
@@ -1340,7 +1340,7 @@ class VLANTranslationPolicyTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class VLANTranslationRuleTest(APIViewTestCases.APIViewTestCase):
+class VLANTranslationRuleTestCase(APIViewTestCases.APIViewTestCase):
     model = VLANTranslationRule
     brief_fields = ['description', 'display', 'id', 'local_vid', 'policy', 'remote_vid', 'url']
 
@@ -1409,7 +1409,7 @@ class VLANTranslationRuleTest(APIViewTestCases.APIViewTestCase):
         }
 
 
-class ServiceTemplateTest(APIViewTestCases.APIViewTestCase):
+class ServiceTemplateTestCase(APIViewTestCases.APIViewTestCase):
     model = ServiceTemplate
     brief_fields = ['description', 'display', 'id', 'name', 'ports', 'protocol', 'url']
     bulk_update_data = {
@@ -1445,7 +1445,7 @@ class ServiceTemplateTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class ServiceTest(APIViewTestCases.APIViewTestCase):
+class ServiceTestCase(APIViewTestCases.APIViewTestCase):
     model = Service
     brief_fields = ['description', 'display', 'id', 'name', 'ports', 'protocol', 'url']
     bulk_update_data = {

--- a/netbox/ipam/tests/test_lookups.py
+++ b/netbox/ipam/tests/test_lookups.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from ipam.models import VLANGroup
 
 
-class VLANGroupRangeContainsLookupTests(TestCase):
+class VLANGroupRangeContainsLookupTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
         # Two ranges: [1,11) and [20,31)

--- a/netbox/ipam/tests/test_tables.py
+++ b/netbox/ipam/tests/test_tables.py
@@ -7,7 +7,7 @@ from ipam.utils import annotate_ip_space
 from utilities.testing import TableTestCases
 
 
-class AnnotatedIPAddressTableTest(TestCase):
+class AnnotatedIPAddressTableTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -180,43 +180,43 @@ class AnnotatedIPAddressTableTest(TestCase):
 # Table ordering tests
 #
 
-class VRFTableTest(TableTestCases.StandardTableTestCase):
+class VRFTableTestCase(TableTestCases.StandardTableTestCase):
     table = VRFTable
 
 
-class RouteTargetTableTest(TableTestCases.StandardTableTestCase):
+class RouteTargetTableTestCase(TableTestCases.StandardTableTestCase):
     table = RouteTargetTable
 
 
-class RIRTableTest(TableTestCases.StandardTableTestCase):
+class RIRTableTestCase(TableTestCases.StandardTableTestCase):
     table = RIRTable
 
 
-class AggregateTableTest(TableTestCases.StandardTableTestCase):
+class AggregateTableTestCase(TableTestCases.StandardTableTestCase):
     table = AggregateTable
 
 
-class RoleTableTest(TableTestCases.StandardTableTestCase):
+class RoleTableTestCase(TableTestCases.StandardTableTestCase):
     table = RoleTable
 
 
-class PrefixTableTest(TableTestCases.StandardTableTestCase):
+class PrefixTableTestCase(TableTestCases.StandardTableTestCase):
     table = PrefixTable
 
 
-class IPRangeTableTest(TableTestCases.StandardTableTestCase):
+class IPRangeTableTestCase(TableTestCases.StandardTableTestCase):
     table = IPRangeTable
 
 
-class IPAddressTableTest(TableTestCases.StandardTableTestCase):
+class IPAddressTableTestCase(TableTestCases.StandardTableTestCase):
     table = IPAddressTable
 
 
-class FHRPGroupTableTest(TableTestCases.StandardTableTestCase):
+class FHRPGroupTableTestCase(TableTestCases.StandardTableTestCase):
     table = FHRPGroupTable
 
 
-class FHRPGroupAssignmentTableTest(TableTestCases.StandardTableTestCase):
+class FHRPGroupAssignmentTableTestCase(TableTestCases.StandardTableTestCase):
     table = FHRPGroupAssignmentTable
 
     # No ObjectListView exists for this table; it is only rendered inline on
@@ -226,33 +226,33 @@ class FHRPGroupAssignmentTableTest(TableTestCases.StandardTableTestCase):
     ]
 
 
-class VLANGroupTableTest(TableTestCases.StandardTableTestCase):
+class VLANGroupTableTestCase(TableTestCases.StandardTableTestCase):
     table = VLANGroupTable
 
 
-class VLANTableTest(TableTestCases.StandardTableTestCase):
+class VLANTableTestCase(TableTestCases.StandardTableTestCase):
     table = VLANTable
 
 
-class VLANTranslationPolicyTableTest(TableTestCases.StandardTableTestCase):
+class VLANTranslationPolicyTableTestCase(TableTestCases.StandardTableTestCase):
     table = VLANTranslationPolicyTable
 
 
-class VLANTranslationRuleTableTest(TableTestCases.StandardTableTestCase):
+class VLANTranslationRuleTableTestCase(TableTestCases.StandardTableTestCase):
     table = VLANTranslationRuleTable
 
 
-class ASNRangeTableTest(TableTestCases.StandardTableTestCase):
+class ASNRangeTableTestCase(TableTestCases.StandardTableTestCase):
     table = ASNRangeTable
 
 
-class ASNTableTest(TableTestCases.StandardTableTestCase):
+class ASNTableTestCase(TableTestCases.StandardTableTestCase):
     table = ASNTable
 
 
-class ServiceTemplateTableTest(TableTestCases.StandardTableTestCase):
+class ServiceTemplateTableTestCase(TableTestCases.StandardTableTestCase):
     table = ServiceTemplateTable
 
 
-class ServiceTableTest(TableTestCases.StandardTableTestCase):
+class ServiceTableTestCase(TableTestCases.StandardTableTestCase):
     table = ServiceTable

--- a/netbox/netbox/tests/test_api.py
+++ b/netbox/netbox/tests/test_api.py
@@ -11,7 +11,7 @@ from users.models import Token
 from utilities.testing import APITestCase
 
 
-class AppTest(APITestCase):
+class AppTestCase(APITestCase):
 
     def test_http_headers(self):
         response = self.client.get(reverse('api-root'), **self.header)
@@ -46,7 +46,7 @@ class AppTest(APITestCase):
         self.assertEqual(response.data['id'], self.user.pk)
 
 
-class OptionalLimitOffsetPaginationTest(TestCase):
+class OptionalLimitOffsetPaginationTestCase(TestCase):
 
     def setUp(self):
         self.paginator = NetBoxPagination()

--- a/netbox/netbox/tests/test_forms.py
+++ b/netbox/netbox/tests/test_forms.py
@@ -5,7 +5,7 @@ from dcim.forms import InterfaceImportForm
 from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
 
 
-class NetBoxModelImportFormCleanTest(TestCase):
+class NetBoxModelImportFormCleanTestCase(TestCase):
     """
     Test the clean() method of NetBoxModelImportForm to ensure it properly converts
     empty strings to None for nullable fields during CSV import.

--- a/netbox/netbox/tests/test_jobs.py
+++ b/netbox/netbox/tests/test_jobs.py
@@ -39,7 +39,7 @@ class JobRunnerTestCase(TestCase):
         return timezone.now() + timedelta(weeks=offset)
 
 
-class JobRunnerTest(JobRunnerTestCase):
+class JobRunnerTestCase(JobRunnerTestCase):
     """
     Test internal logic of `JobRunner`.
     """
@@ -92,7 +92,7 @@ class JobRunnerTest(JobRunnerTestCase):
         self.assertNotIn(_INSTALL_ROOT, tb_message)
 
 
-class EnqueueTest(JobRunnerTestCase):
+class EnqueueTestCase(JobRunnerTestCase):
     """
     Test enqueuing of `JobRunner`.
     """
@@ -168,7 +168,7 @@ class EnqueueTest(JobRunnerTestCase):
         self.assertEqual(TestJobRunner.get_jobs(instance).count(), 1)
 
 
-class SystemJobTest(JobRunnerTestCase):
+class SystemJobTestCase(JobRunnerTestCase):
     """
     Test that system jobs can be scheduled.
 

--- a/netbox/netbox/tests/test_models.py
+++ b/netbox/netbox/tests/test_models.py
@@ -7,7 +7,7 @@ from core.models import ObjectChange
 from netbox.tests.dummy_plugin.models import DummyNetBoxModel
 
 
-class ModelTest(TestCase):
+class ModelTestCase(TestCase):
 
     def test_get_absolute_url(self):
         m = ObjectChange()

--- a/netbox/netbox/tests/test_object_actions.py
+++ b/netbox/netbox/tests/test_object_actions.py
@@ -7,7 +7,7 @@ from dcim.models import Device, DeviceType, Manufacturer
 from netbox.object_actions import AddObject, BulkEdit, BulkImport
 
 
-class ObjectActionTest(TestCase):
+class ObjectActionTestCase(TestCase):
 
     def test_get_url_core_model(self):
         """Test URL generation for core NetBox models"""

--- a/netbox/netbox/tests/test_plugins.py
+++ b/netbox/netbox/tests/test_plugins.py
@@ -18,7 +18,7 @@ from netbox.tests.dummy_plugin.webhook_callbacks import set_context
 
 
 @skipIf('netbox.tests.dummy_plugin' not in settings.PLUGINS, "dummy_plugin not in settings.PLUGINS")
-class PluginTest(TestCase):
+class PluginTestCase(TestCase):
 
     def test_config(self):
 
@@ -229,7 +229,7 @@ class PluginTest(TestCase):
         self.assertIn(set_context, registry['webhook_callbacks'])
 
 
-class PluginNavigationTest(TestCase):
+class PluginNavigationTestCase(TestCase):
 
     def test_plugin_menu_item_independent_permissions(self):
         item1 = PluginMenuItem(link='test1', link_text='Test 1')

--- a/netbox/netbox/tests/test_registry.py
+++ b/netbox/netbox/tests/test_registry.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from netbox.registry import Registry
 
 
-class RegistryTest(TestCase):
+class RegistryTestCase(TestCase):
 
     def test_set_store(self):
         reg = Registry({

--- a/netbox/netbox/tests/test_tables.py
+++ b/netbox/netbox/tests/test_tables.py
@@ -8,7 +8,7 @@ from netbox.tables import NetBoxTable, columns
 from utilities.testing import create_tags, create_test_device, create_test_user
 
 
-class BaseTableTest(TestCase):
+class BaseTableTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -99,7 +99,7 @@ class TagColumnTable(NetBoxTable):
         default_columns = fields
 
 
-class TagColumnTest(TestCase):
+class TagColumnTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):

--- a/netbox/netbox/tests/test_ui.py
+++ b/netbox/netbox/tests/test_ui.py
@@ -29,7 +29,7 @@ from vpn.choices import (
 from vpn.models import IKEPolicy, IKEProposal, IPSecPolicy, IPSecProfile
 
 
-class ChoiceAttrTest(TestCase):
+class ChoiceAttrTestCase(TestCase):
     """
     Test class for validating the behavior of ChoiceAttr attribute accessor.
 
@@ -112,7 +112,7 @@ class ChoiceAttrTest(TestCase):
         )
 
 
-class RelatedObjectListAttrTest(TestCase):
+class RelatedObjectListAttrTestCase(TestCase):
     """
     Test suite for RelatedObjectListAttr functionality.
 
@@ -222,7 +222,7 @@ class RelatedObjectListAttrTest(TestCase):
         self.assertIn('…', rendered)
 
 
-class TextAttrTest(TestCase):
+class TextAttrTestCase(TestCase):
 
     def test_get_value_with_format_string(self):
         attr = attrs.TextAttr('asn', format_string='AS{}')
@@ -247,7 +247,7 @@ class TextAttrTest(TestCase):
         self.assertTrue(context['copy_button'])
 
 
-class NumericAttrTest(TestCase):
+class NumericAttrTestCase(TestCase):
 
     def test_get_context_with_unit_accessor(self):
         attr = attrs.NumericAttr('speed', unit_accessor='speed_unit')
@@ -268,7 +268,7 @@ class NumericAttrTest(TestCase):
         self.assertTrue(context['copy_button'])
 
 
-class BooleanAttrTest(TestCase):
+class BooleanAttrTestCase(TestCase):
 
     def test_false_value_shown_by_default(self):
         attr = attrs.BooleanAttr('enabled')
@@ -286,7 +286,7 @@ class BooleanAttrTest(TestCase):
         self.assertIs(attr.get_value(obj), True)
 
 
-class ImageAttrTest(TestCase):
+class ImageAttrTestCase(TestCase):
 
     def test_invalid_decoding_raises_value_error(self):
         with self.assertRaises(ValueError):
@@ -314,7 +314,7 @@ class ImageAttrTest(TestCase):
         self.assertFalse(context['load_lazy'])
 
 
-class RelatedObjectAttrTest(TestCase):
+class RelatedObjectAttrTestCase(TestCase):
 
     def test_get_context_with_grouped_by(self):
         region = SimpleNamespace(name='Region 1')
@@ -339,7 +339,7 @@ class RelatedObjectAttrTest(TestCase):
         self.assertTrue(context['linkify'])
 
 
-class GenericForeignKeyAttrTest(TestCase):
+class GenericForeignKeyAttrTestCase(TestCase):
 
     class TreeNode:
         def __init__(self, name, ancestors=()):
@@ -422,7 +422,7 @@ class GenericForeignKeyAttrTest(TestCase):
         self.assertIsNone(context['nodes'])
 
 
-class GPSCoordinatesAttrTest(TestCase):
+class GPSCoordinatesAttrTestCase(TestCase):
 
     def test_missing_latitude_returns_placeholder(self):
         attr = attrs.GPSCoordinatesAttr()
@@ -440,7 +440,7 @@ class GPSCoordinatesAttrTest(TestCase):
         self.assertEqual(attr.render(obj, {'name': 'coordinates'}), attr.placeholder)
 
 
-class DateTimeAttrTest(TestCase):
+class DateTimeAttrTestCase(TestCase):
 
     def test_default_spec(self):
         attr = attrs.DateTimeAttr('created')
@@ -461,7 +461,7 @@ class DateTimeAttrTest(TestCase):
         self.assertEqual(context['spec'], 'minutes')
 
 
-class ObjectsTablePanelTest(TestCase):
+class ObjectsTablePanelTestCase(TestCase):
     """
     Verify that ObjectsTablePanel.should_render() hides the panel when
     the requesting user lacks view permission for the panel's model.

--- a/netbox/tenancy/tests/test_api.py
+++ b/netbox/tenancy/tests/test_api.py
@@ -6,7 +6,7 @@ from tenancy.models import *
 from utilities.testing import APITestCase, APIViewTestCases
 
 
-class AppTest(APITestCase):
+class AppTestCase(APITestCase):
 
     def test_root(self):
 
@@ -16,7 +16,7 @@ class AppTest(APITestCase):
         self.assertEqual(response.status_code, 200)
 
 
-class TenantGroupTest(APIViewTestCases.APIViewTestCase):
+class TenantGroupTestCase(APIViewTestCases.APIViewTestCase):
     model = TenantGroup
     brief_fields = ['_depth', 'description', 'display', 'id', 'name', 'slug', 'tenant_count', 'url']
     bulk_update_data = {
@@ -61,7 +61,7 @@ class TenantGroupTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class TenantTest(APIViewTestCases.APIViewTestCase):
+class TenantTestCase(APIViewTestCases.APIViewTestCase):
     model = Tenant
     brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url']
     bulk_update_data = {
@@ -103,7 +103,7 @@ class TenantTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class ContactGroupTest(APIViewTestCases.APIViewTestCase):
+class ContactGroupTestCase(APIViewTestCases.APIViewTestCase):
     model = ContactGroup
     brief_fields = ['_depth', 'contact_count', 'description', 'display', 'id', 'name', 'slug', 'url']
     bulk_update_data = {
@@ -148,7 +148,7 @@ class ContactGroupTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class ContactRoleTest(APIViewTestCases.APIViewTestCase):
+class ContactRoleTestCase(APIViewTestCases.APIViewTestCase):
     model = ContactRole
     brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
@@ -180,7 +180,7 @@ class ContactRoleTest(APIViewTestCases.APIViewTestCase):
         ContactRole.objects.bulk_create(contact_roles)
 
 
-class ContactTest(APIViewTestCases.APIViewTestCase):
+class ContactTestCase(APIViewTestCases.APIViewTestCase):
     model = Contact
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -220,7 +220,7 @@ class ContactTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class ContactAssignmentTest(APIViewTestCases.APIViewTestCase):
+class ContactAssignmentTestCase(APIViewTestCases.APIViewTestCase):
     model = ContactAssignment
     brief_fields = ['contact', 'display', 'id', 'priority', 'role', 'url']
     bulk_update_data = {

--- a/netbox/tenancy/tests/test_tables.py
+++ b/netbox/tenancy/tests/test_tables.py
@@ -2,25 +2,25 @@ from tenancy.tables import *
 from utilities.testing import TableTestCases
 
 
-class TenantGroupTableTest(TableTestCases.StandardTableTestCase):
+class TenantGroupTableTestCase(TableTestCases.StandardTableTestCase):
     table = TenantGroupTable
 
 
-class TenantTableTest(TableTestCases.StandardTableTestCase):
+class TenantTableTestCase(TableTestCases.StandardTableTestCase):
     table = TenantTable
 
 
-class ContactGroupTableTest(TableTestCases.StandardTableTestCase):
+class ContactGroupTableTestCase(TableTestCases.StandardTableTestCase):
     table = ContactGroupTable
 
 
-class ContactRoleTableTest(TableTestCases.StandardTableTestCase):
+class ContactRoleTableTestCase(TableTestCases.StandardTableTestCase):
     table = ContactRoleTable
 
 
-class ContactTableTest(TableTestCases.StandardTableTestCase):
+class ContactTableTestCase(TableTestCases.StandardTableTestCase):
     table = ContactTable
 
 
-class ContactAssignmentTableTest(TableTestCases.StandardTableTestCase):
+class ContactAssignmentTableTestCase(TableTestCases.StandardTableTestCase):
     table = ContactAssignmentTable

--- a/netbox/users/tests/test_api.py
+++ b/netbox/users/tests/test_api.py
@@ -8,7 +8,7 @@ from utilities.data import deepmerge
 from utilities.testing import APITestCase, APIViewTestCases, create_test_user
 
 
-class AppTest(APITestCase):
+class AppTestCase(APITestCase):
 
     def test_root(self):
 
@@ -17,7 +17,7 @@ class AppTest(APITestCase):
         self.assertEqual(response.status_code, 200)
 
 
-class UserTest(APIViewTestCases.APIViewTestCase):
+class UserTestCase(APIViewTestCases.APIViewTestCase):
     model = User
     brief_fields = ['display', 'id', 'url', 'username']
     validation_excluded_fields = ['password']
@@ -137,7 +137,7 @@ class UserTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(response.status_code, 400)
 
 
-class GroupTest(APIViewTestCases.APIViewTestCase):
+class GroupTestCase(APIViewTestCases.APIViewTestCase):
     model = Group
     brief_fields = ['description', 'display', 'id', 'name', 'url']
 
@@ -189,7 +189,7 @@ class GroupTest(APIViewTestCases.APIViewTestCase):
         return
 
 
-class TokenTest(
+class TokenTestCase(
     # No GraphQL support for Token
     APIViewTestCases.GetObjectViewTestCase,
     APIViewTestCases.ListObjectsViewTestCase,
@@ -330,7 +330,7 @@ class TokenTest(
         self.assertEqual(token1.user, user1, "Token's user should not have changed")
 
 
-class ObjectPermissionTest(
+class ObjectPermissionTestCase(
     # No GraphQL support for ObjectPermission
     APIViewTestCases.GetObjectViewTestCase,
     APIViewTestCases.ListObjectsViewTestCase,
@@ -403,7 +403,7 @@ class ObjectPermissionTest(
         }
 
 
-class UserConfigTest(APITestCase):
+class UserConfigTestCase(APITestCase):
 
     def test_get(self):
         """
@@ -456,7 +456,7 @@ class UserConfigTest(APITestCase):
         self.assertDictEqual(userconfig.data, new_data)
 
 
-class OwnerGroupTest(APIViewTestCases.APIViewTestCase):
+class OwnerGroupTestCase(APIViewTestCases.APIViewTestCase):
     model = OwnerGroup
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -488,7 +488,7 @@ class OwnerGroupTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class OwnerTest(APIViewTestCases.APIViewTestCase):
+class OwnerTestCase(APIViewTestCases.APIViewTestCase):
     model = Owner
     brief_fields = ['description', 'display', 'id', 'name', 'url']
 

--- a/netbox/users/tests/test_models.py
+++ b/netbox/users/tests/test_models.py
@@ -9,7 +9,7 @@ from users.models import Token, User
 from utilities.testing import create_test_user
 
 
-class TokenTest(TestCase):
+class TokenTestCase(TestCase):
     """
     Test class for testing the functionality of the Token model.
     """
@@ -105,7 +105,7 @@ class TokenTest(TestCase):
             token.clean()
 
 
-class UserConfigTest(TestCase):
+class UserConfigTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):

--- a/netbox/users/tests/test_preferences.py
+++ b/netbox/users/tests/test_preferences.py
@@ -15,7 +15,7 @@ DEFAULT_USER_PREFERENCES = {
 }
 
 
-class UserPreferencesTest(TestCase):
+class UserPreferencesTestCase(TestCase):
     user_permissions = ['dcim.view_site']
 
     def test_userpreference(self):

--- a/netbox/users/tests/test_tables.py
+++ b/netbox/users/tests/test_tables.py
@@ -2,25 +2,25 @@ from users.tables import *
 from utilities.testing import TableTestCases
 
 
-class TokenTableTest(TableTestCases.StandardTableTestCase):
+class TokenTableTestCase(TableTestCases.StandardTableTestCase):
     table = TokenTable
 
 
-class UserTableTest(TableTestCases.StandardTableTestCase):
+class UserTableTestCase(TableTestCases.StandardTableTestCase):
     table = UserTable
 
 
-class GroupTableTest(TableTestCases.StandardTableTestCase):
+class GroupTableTestCase(TableTestCases.StandardTableTestCase):
     table = GroupTable
 
 
-class ObjectPermissionTableTest(TableTestCases.StandardTableTestCase):
+class ObjectPermissionTableTestCase(TableTestCases.StandardTableTestCase):
     table = ObjectPermissionTable
 
 
-class OwnerGroupTableTest(TableTestCases.StandardTableTestCase):
+class OwnerGroupTableTestCase(TableTestCases.StandardTableTestCase):
     table = OwnerGroupTable
 
 
-class OwnerTableTest(TableTestCases.StandardTableTestCase):
+class OwnerTableTestCase(TableTestCases.StandardTableTestCase):
     table = OwnerTable

--- a/netbox/utilities/tests/test_api.py
+++ b/netbox/utilities/tests/test_api.py
@@ -14,7 +14,7 @@ from utilities.api import get_prefetches_for_serializer, get_view_name
 from utilities.testing import APITestCase, disable_warnings
 
 
-class WritableNestedSerializerTest(APITestCase):
+class WritableNestedSerializerTestCase(APITestCase):
     """
     Test the operation of WritableNestedSerializer using VLANSerializer as our test subject.
     """

--- a/netbox/utilities/tests/test_conversions.py
+++ b/netbox/utilities/tests/test_conversions.py
@@ -6,7 +6,7 @@ from utilities.conversion import to_grams, to_meters
 from utilities.testing.base import TestCase
 
 
-class ConversionsTest(TestCase):
+class ConversionsTestCase(TestCase):
 
     def test_to_grams(self):
         self.assertEqual(

--- a/netbox/utilities/tests/test_counters.py
+++ b/netbox/utilities/tests/test_counters.py
@@ -7,7 +7,7 @@ from utilities.testing.base import TestCase
 from utilities.testing.utils import create_test_device
 
 
-class CountersTest(TestCase):
+class CountersTestCase(TestCase):
     """
     Validate the operation of the CounterCacheField (tracking counters).
     """

--- a/netbox/utilities/tests/test_filter_modifiers.py
+++ b/netbox/utilities/tests/test_filter_modifiers.py
@@ -43,7 +43,7 @@ class TestFilterSet(BaseFilterSet):
         fields = ['char_field', 'integer_field', 'decimal_field', 'date_field', 'boolean_field']
 
 
-class FilterModifierWidgetTest(TestCase):
+class FilterModifierWidgetTestCase(TestCase):
     """Tests for FilterModifierWidget value extraction and rendering."""
 
     def test_value_from_datadict_finds_value_in_lookup_variant(self):
@@ -170,7 +170,7 @@ class FilterModifierWidgetTest(TestCase):
         self.assertIn('value="test"', html)
 
 
-class FilterModifierMixinTest(TestCase):
+class FilterModifierMixinTestCase(TestCase):
     """Tests for FilterModifierMixin form field enhancement."""
 
     def test_mixin_enhances_char_field_with_modifiers(self):
@@ -250,7 +250,7 @@ class FilterModifierMixinTest(TestCase):
         self.assertEqual(lookup_codes, expected_lookups)
 
 
-class ExtendedLookupFilterPillsTest(TestCase):
+class ExtendedLookupFilterPillsTestCase(TestCase):
     """Tests for filter pill rendering of extended lookups."""
 
     @classmethod
@@ -307,7 +307,7 @@ class ExtendedLookupFilterPillsTest(TestCase):
         self.assertIn('ABC123', filter_pill['link_text'])
 
 
-class EmptyLookupTest(TestCase):
+class EmptyLookupTestCase(TestCase):
     """Tests for empty (is empty/not empty) lookup support."""
 
     @classmethod
@@ -343,7 +343,7 @@ class EmptyLookupTest(TestCase):
         self.assertIn('not empty', filter_pill['link_text'].lower())
 
 
-class ObjectCustomFieldEmptyLookupTest(TestCase):
+class ObjectCustomFieldEmptyLookupTestCase(TestCase):
     """
     Regression test for https://github.com/netbox-community/netbox/issues/21535.
 

--- a/netbox/utilities/tests/test_filters.py
+++ b/netbox/utilities/tests/test_filters.py
@@ -37,7 +37,7 @@ from utilities.filters import (
 from wireless.choices import WirelessRoleChoices
 
 
-class TreeNodeMultipleChoiceFilterTest(TestCase):
+class TreeNodeMultipleChoiceFilterTestCase(TestCase):
 
     class SiteFilterSet(django_filters.FilterSet):
         region = TreeNodeMultipleChoiceFilter(
@@ -121,7 +121,7 @@ class DummyModel(models.Model):
     tags = TaggableManager(through=TaggedItem)
 
 
-class BaseFilterSetTest(TestCase):
+class BaseFilterSetTestCase(TestCase):
     """
     Ensure that a BaseFilterSet automatically creates the expected set of filters for each filter type.
     """
@@ -387,7 +387,7 @@ class BaseFilterSetTest(TestCase):
         self.assertEqual(self.filters['treeforeignkeyfield__n'].exclude, True)
 
 
-class DynamicFilterLookupExpressionTest(TestCase):
+class DynamicFilterLookupExpressionTestCase(TestCase):
     """
     Validate function of automatically generated filters using the Device model as an example.
     """

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -304,7 +304,7 @@ class ExpandAlphanumeric(TestCase):
             sorted(expand_alphanumeric_pattern('r[a,,b]a'))
 
 
-class ImportFormTest(TestCase):
+class ImportFormTestCase(TestCase):
 
     def test_format_detection(self):
         form = BulkImportForm()
@@ -384,7 +384,7 @@ class ImportFormTest(TestCase):
         ])
 
 
-class BulkRenameFormTest(TestCase):
+class BulkRenameFormTestCase(TestCase):
     def test_no_strip_whitespace(self):
         # Tests to make sure Bulk Rename Form isn't stripping whitespaces
         # See: https://github.com/netbox-community/netbox/issues/13791
@@ -397,7 +397,7 @@ class BulkRenameFormTest(TestCase):
         self.assertEqual(form.cleaned_data["replace"], " world ")
 
 
-class GetFieldValueTest(TestCase):
+class GetFieldValueTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -457,7 +457,7 @@ class GetFieldValueTest(TestCase):
         )
 
 
-class CSVSelectWidgetTest(TestCase):
+class CSVSelectWidgetTestCase(TestCase):
     """
     Validate that CSVSelectWidget treats blank values as omitted.
     This allows model defaults to be applied when CSV fields are present but empty.
@@ -489,7 +489,7 @@ class CSVSelectWidgetTest(TestCase):
         self.assertFalse(widget.value_omitted_from_data(data, {}, 'test_field'))
 
 
-class SelectMultipleWidgetTest(TestCase):
+class SelectMultipleWidgetTestCase(TestCase):
     """
     Validate filtering behavior of AvailableOptions and SelectedOptions widgets.
     """
@@ -557,7 +557,7 @@ class SelectMultipleWidgetTest(TestCase):
         self.assertEqual(widget.choices[1][1], [(3, 'Option 3')])
 
 
-class GetCapacityUnitLabelTest(TestCase):
+class GetCapacityUnitLabelTestCase(TestCase):
     """
     Test the get_capacity_unit_label function for correct base unit label.
     """

--- a/netbox/utilities/tests/test_managers.py
+++ b/netbox/utilities/tests/test_managers.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from dcim.models import Site
 
 
-class NaturalOrderByManagerTest(TestCase):
+class NaturalOrderByManagerTestCase(TestCase):
     """
     Ensure consistent natural ordering given myriad sample data. We use dcim.Site as our guinea pig because it's simple.
     """

--- a/netbox/utilities/tests/test_permissions.py
+++ b/netbox/utilities/tests/test_permissions.py
@@ -9,7 +9,7 @@ from utilities.permissions import ModelAction, register_model_actions
 from virtualization.models import VirtualMachine
 
 
-class ModelActionTest(TestCase):
+class ModelActionTestCase(TestCase):
 
     def test_hash(self):
         action1 = ModelAction(name='sync')
@@ -36,7 +36,7 @@ class ModelActionTest(TestCase):
         self.assertEqual(len(actions), 2)
 
 
-class RegisterModelActionsTest(TestCase):
+class RegisterModelActionsTestCase(TestCase):
 
     def setUp(self):
         self._original_actions = dict(registry['model_actions'])
@@ -107,7 +107,7 @@ class RegisterModelActionsTest(TestCase):
         self.assertEqual(action_fields.count('action_render_config'), 1)
 
 
-class ObjectPermissionFormTest(TestCase):
+class ObjectPermissionFormTestCase(TestCase):
 
     def setUp(self):
         self._original_actions = dict(registry['model_actions'])

--- a/netbox/utilities/tests/test_prefetch.py
+++ b/netbox/utilities/tests/test_prefetch.py
@@ -3,7 +3,7 @@ from utilities.prefetch import get_prefetchable_fields
 from utilities.testing.base import TestCase
 
 
-class GetPrefetchableFieldsTest(TestCase):
+class GetPrefetchableFieldsTestCase(TestCase):
     """
     Verify the operation of get_prefetchable_fields()
     """

--- a/netbox/utilities/tests/test_request.py
+++ b/netbox/utilities/tests/test_request.py
@@ -5,7 +5,7 @@ from netaddr import IPAddress
 from utilities.request import copy_safe_request, get_client_ip
 
 
-class CopySafeRequestTests(TestCase):
+class CopySafeRequestTestCase(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
 
@@ -39,7 +39,7 @@ class CopySafeRequestTests(TestCase):
         self.assertNotIn('HTTP_X_CUSTOM_INT', fake.META)
 
 
-class GetClientIPTests(TestCase):
+class GetClientIPTestCase(TestCase):
     def setUp(self):
         self.factory = RequestFactory()
 

--- a/netbox/utilities/tests/test_templatetags.py
+++ b/netbox/utilities/tests/test_templatetags.py
@@ -11,7 +11,7 @@ from utilities.templatetags.builtins.tags import badge, customfield_value, stati
 from utilities.templatetags.helpers import _humanize_capacity, humanize_speed
 
 
-class CustomFieldValueTagTest(TestCase):
+class CustomFieldValueTagTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
         object_type = ObjectType.objects.get_for_model(Site)
@@ -60,7 +60,7 @@ class CustomFieldValueTagTest(TestCase):
         self.assertEqual(context['value'], ['Option B'])
 
 
-class StaticWithParamsTest(TestCase):
+class StaticWithParamsTestCase(TestCase):
     """
     Test the static_with_params template tag functionality.
     """
@@ -103,7 +103,7 @@ class StaticWithParamsTest(TestCase):
                 self.assertNotIn('v=old_version', result)
 
 
-class BadgeTest(TestCase):
+class BadgeTestCase(TestCase):
     """
     Test the badge template tag functionality.
     """
@@ -117,7 +117,7 @@ class BadgeTest(TestCase):
         self.assertIn('>Role<', html)
 
 
-class HumanizeCapacityTest(TestCase):
+class HumanizeCapacityTestCase(TestCase):
     """
     Test the _humanize_capacity function for correct SI/IEC unit label selection.
     """
@@ -160,7 +160,7 @@ class HumanizeCapacityTest(TestCase):
         self.assertEqual(_humanize_capacity(2000), '2.00 GB')
 
 
-class HumanizeSpeedTest(TestCase):
+class HumanizeSpeedTestCase(TestCase):
     """
     Test the humanize_speed filter for correct unit selection and decimal formatting.
     """

--- a/netbox/utilities/tests/test_utils.py
+++ b/netbox/utilities/tests/test_utils.py
@@ -6,7 +6,7 @@ from utilities.query import dict_to_filter_params
 from utilities.querydict import normalize_querydict
 
 
-class DictToFilterParamsTest(TestCase):
+class DictToFilterParamsTestCase(TestCase):
     """
     Validate the operation of dict_to_filter_params().
     """
@@ -39,7 +39,7 @@ class DictToFilterParamsTest(TestCase):
         self.assertNotEqual(dict_to_filter_params(input), output)
 
 
-class NormalizeQueryDictTest(TestCase):
+class NormalizeQueryDictTestCase(TestCase):
     """
     Validate normalize_querydict() utility function.
     """
@@ -50,7 +50,7 @@ class NormalizeQueryDictTest(TestCase):
         )
 
 
-class DeepMergeTest(TestCase):
+class DeepMergeTestCase(TestCase):
     """
     Validate the behavior of the deepmerge() utility.
     """

--- a/netbox/virtualization/tests/test_api.py
+++ b/netbox/virtualization/tests/test_api.py
@@ -26,7 +26,7 @@ from virtualization.choices import *
 from virtualization.models import *
 
 
-class AppTest(APITestCase):
+class AppTestCase(APITestCase):
 
     def test_root(self):
 
@@ -36,7 +36,7 @@ class AppTest(APITestCase):
         self.assertEqual(response.status_code, 200)
 
 
-class ClusterTypeTest(APIViewTestCases.APIViewTestCase):
+class ClusterTypeTestCase(APIViewTestCases.APIViewTestCase):
     model = ClusterType
     brief_fields = ['cluster_count', 'description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
@@ -68,7 +68,7 @@ class ClusterTypeTest(APIViewTestCases.APIViewTestCase):
         ClusterType.objects.bulk_create(cluster_types)
 
 
-class ClusterGroupTest(APIViewTestCases.APIViewTestCase):
+class ClusterGroupTestCase(APIViewTestCases.APIViewTestCase):
     model = ClusterGroup
     brief_fields = ['cluster_count', 'description', 'display', 'id', 'name', 'slug', 'url']
     create_data = [
@@ -100,7 +100,7 @@ class ClusterGroupTest(APIViewTestCases.APIViewTestCase):
         ClusterGroup.objects.bulk_create(cluster_Groups)
 
 
-class ClusterTest(APIViewTestCases.APIViewTestCase):
+class ClusterTestCase(APIViewTestCases.APIViewTestCase):
     model = Cluster
     brief_fields = ['description', 'display', 'id', 'name', 'url', 'virtualmachine_count']
     bulk_update_data = {
@@ -168,7 +168,7 @@ class ClusterTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class VirtualMachineTypeTest(APIViewTestCases.APIViewTestCase):
+class VirtualMachineTypeTestCase(APIViewTestCases.APIViewTestCase):
     model = VirtualMachineType
     brief_fields = ['description', 'display', 'id', 'name', 'slug', 'url']
     user_permissions = ('dcim.view_platform', 'virtualization.view_virtualmachine')
@@ -237,7 +237,7 @@ class VirtualMachineTypeTest(APIViewTestCases.APIViewTestCase):
         }
 
 
-class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
+class VirtualMachineTestCase(APIViewTestCases.APIViewTestCase):
     model = VirtualMachine
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -596,7 +596,7 @@ class VirtualMachineTest(APIViewTestCases.APIViewTestCase):
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
 
 
-class VMInterfaceTest(APIViewTestCases.APIViewTestCase):
+class VMInterfaceTestCase(APIViewTestCases.APIViewTestCase):
     model = VMInterface
     brief_fields = ['description', 'display', 'id', 'name', 'url', 'virtual_machine']
     bulk_update_data = {
@@ -727,7 +727,7 @@ class VMInterfaceTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(virtual_machine.interfaces.count(), 2)  # Child & parent were both deleted
 
 
-class VirtualDiskTest(APIViewTestCases.APIViewTestCase):
+class VirtualDiskTestCase(APIViewTestCases.APIViewTestCase):
     model = VirtualDisk
     brief_fields = ['description', 'display', 'id', 'name', 'size', 'url', 'virtual_machine']
     bulk_update_data = {

--- a/netbox/virtualization/tests/test_tables.py
+++ b/netbox/virtualization/tests/test_tables.py
@@ -2,25 +2,25 @@ from utilities.testing import TableTestCases
 from virtualization.tables import *
 
 
-class ClusterTypeTableTest(TableTestCases.StandardTableTestCase):
+class ClusterTypeTableTestCase(TableTestCases.StandardTableTestCase):
     table = ClusterTypeTable
 
 
-class ClusterGroupTableTest(TableTestCases.StandardTableTestCase):
+class ClusterGroupTableTestCase(TableTestCases.StandardTableTestCase):
     table = ClusterGroupTable
 
 
-class ClusterTableTest(TableTestCases.StandardTableTestCase):
+class ClusterTableTestCase(TableTestCases.StandardTableTestCase):
     table = ClusterTable
 
 
-class VirtualMachineTableTest(TableTestCases.StandardTableTestCase):
+class VirtualMachineTableTestCase(TableTestCases.StandardTableTestCase):
     table = VirtualMachineTable
 
 
-class VMInterfaceTableTest(TableTestCases.StandardTableTestCase):
+class VMInterfaceTableTestCase(TableTestCases.StandardTableTestCase):
     table = VMInterfaceTable
 
 
-class VirtualDiskTableTest(TableTestCases.StandardTableTestCase):
+class VirtualDiskTableTestCase(TableTestCases.StandardTableTestCase):
     table = VirtualDiskTable

--- a/netbox/vpn/tests/test_api.py
+++ b/netbox/vpn/tests/test_api.py
@@ -9,7 +9,7 @@ from vpn.choices import *
 from vpn.models import *
 
 
-class AppTest(APITestCase):
+class AppTestCase(APITestCase):
 
     def test_root(self):
         url = reverse('vpn-api:api-root')
@@ -18,7 +18,7 @@ class AppTest(APITestCase):
         self.assertEqual(response.status_code, 200)
 
 
-class TunnelGroupTest(APIViewTestCases.APIViewTestCase):
+class TunnelGroupTestCase(APIViewTestCases.APIViewTestCase):
     model = TunnelGroup
     brief_fields = ['description', 'display', 'id', 'name', 'slug', 'tunnel_count', 'url']
     create_data = (
@@ -50,7 +50,7 @@ class TunnelGroupTest(APIViewTestCases.APIViewTestCase):
         TunnelGroup.objects.bulk_create(tunnel_groups)
 
 
-class TunnelTest(APIViewTestCases.APIViewTestCase):
+class TunnelTestCase(APIViewTestCases.APIViewTestCase):
     model = Tunnel
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -111,7 +111,7 @@ class TunnelTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class TunnelTerminationTest(APIViewTestCases.APIViewTestCase):
+class TunnelTerminationTestCase(APIViewTestCases.APIViewTestCase):
     model = TunnelTermination
     brief_fields = ['display', 'id', 'url']
     bulk_update_data = {
@@ -179,7 +179,7 @@ class TunnelTerminationTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class IKEProposalTest(APIViewTestCases.APIViewTestCase):
+class IKEProposalTestCase(APIViewTestCases.APIViewTestCase):
     model = IKEProposal
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -243,7 +243,7 @@ class IKEProposalTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class IKEPolicyTest(APIViewTestCases.APIViewTestCase):
+class IKEPolicyTestCase(APIViewTestCases.APIViewTestCase):
     model = IKEPolicy
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -317,7 +317,7 @@ class IKEPolicyTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class IPSecProposalTest(APIViewTestCases.APIViewTestCase):
+class IPSecProposalTestCase(APIViewTestCases.APIViewTestCase):
     model = IPSecProposal
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -367,7 +367,7 @@ class IPSecProposalTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class IPSecPolicyTest(APIViewTestCases.APIViewTestCase):
+class IPSecPolicyTestCase(APIViewTestCases.APIViewTestCase):
     model = IPSecPolicy
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
@@ -429,7 +429,7 @@ class IPSecPolicyTest(APIViewTestCases.APIViewTestCase):
         ]
 
 
-class IPSecProfileTest(APIViewTestCases.APIViewTestCase):
+class IPSecProfileTestCase(APIViewTestCases.APIViewTestCase):
     model = IPSecProfile
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     user_permissions = ('vpn.view_ikepolicy', 'vpn.view_ipsecpolicy')
@@ -520,7 +520,7 @@ class IPSecProfileTest(APIViewTestCases.APIViewTestCase):
         }
 
 
-class L2VPNTest(APIViewTestCases.APIViewTestCase):
+class L2VPNTestCase(APIViewTestCases.APIViewTestCase):
     model = L2VPN
     brief_fields = ['description', 'display', 'id', 'identifier', 'name', 'slug', 'type', 'url']
     create_data = [
@@ -602,7 +602,7 @@ class L2VPNTest(APIViewTestCases.APIViewTestCase):
         self.assertEqual(response_data['count'], 1)
 
 
-class L2VPNTerminationTest(APIViewTestCases.APIViewTestCase):
+class L2VPNTerminationTestCase(APIViewTestCases.APIViewTestCase):
     model = L2VPNTermination
     brief_fields = ['display', 'id', 'l2vpn', 'url']
     user_permissions = ('dcim.view_location', 'vpn.view_l2vpn')

--- a/netbox/vpn/tests/test_tables.py
+++ b/netbox/vpn/tests/test_tables.py
@@ -2,41 +2,41 @@ from utilities.testing import TableTestCases
 from vpn.tables import *
 
 
-class TunnelGroupTableTest(TableTestCases.StandardTableTestCase):
+class TunnelGroupTableTestCase(TableTestCases.StandardTableTestCase):
     table = TunnelGroupTable
 
 
-class TunnelTableTest(TableTestCases.StandardTableTestCase):
+class TunnelTableTestCase(TableTestCases.StandardTableTestCase):
     table = TunnelTable
 
 
-class TunnelTerminationTableTest(TableTestCases.StandardTableTestCase):
+class TunnelTerminationTableTestCase(TableTestCases.StandardTableTestCase):
     table = TunnelTerminationTable
 
 
-class IKEProposalTableTest(TableTestCases.StandardTableTestCase):
+class IKEProposalTableTestCase(TableTestCases.StandardTableTestCase):
     table = IKEProposalTable
 
 
-class IKEPolicyTableTest(TableTestCases.StandardTableTestCase):
+class IKEPolicyTableTestCase(TableTestCases.StandardTableTestCase):
     table = IKEPolicyTable
 
 
-class IPSecProposalTableTest(TableTestCases.StandardTableTestCase):
+class IPSecProposalTableTestCase(TableTestCases.StandardTableTestCase):
     table = IPSecProposalTable
 
 
-class IPSecPolicyTableTest(TableTestCases.StandardTableTestCase):
+class IPSecPolicyTableTestCase(TableTestCases.StandardTableTestCase):
     table = IPSecPolicyTable
 
 
-class IPSecProfileTableTest(TableTestCases.StandardTableTestCase):
+class IPSecProfileTableTestCase(TableTestCases.StandardTableTestCase):
     table = IPSecProfileTable
 
 
-class L2VPNTableTest(TableTestCases.StandardTableTestCase):
+class L2VPNTableTestCase(TableTestCases.StandardTableTestCase):
     table = L2VPNTable
 
 
-class L2VPNTerminationTableTest(TableTestCases.StandardTableTestCase):
+class L2VPNTerminationTableTestCase(TableTestCases.StandardTableTestCase):
     table = L2VPNTerminationTable

--- a/netbox/wireless/tests/test_api.py
+++ b/netbox/wireless/tests/test_api.py
@@ -8,7 +8,7 @@ from wireless.choices import *
 from wireless.models import *
 
 
-class AppTest(APITestCase):
+class AppTestCase(APITestCase):
 
     def test_root(self):
         url = reverse('wireless-api:api-root')
@@ -17,7 +17,7 @@ class AppTest(APITestCase):
         self.assertEqual(response.status_code, 200)
 
 
-class WirelessLANGroupTest(APIViewTestCases.APIViewTestCase):
+class WirelessLANGroupTestCase(APIViewTestCases.APIViewTestCase):
     model = WirelessLANGroup
     brief_fields = ['_depth', 'description', 'display', 'id', 'name', 'slug', 'url', 'wirelesslan_count']
     create_data = [
@@ -49,7 +49,7 @@ class WirelessLANGroupTest(APIViewTestCases.APIViewTestCase):
         WirelessLANGroup.objects.create(name='Wireless LAN Group 3', slug='wireless-lan-group-3')
 
 
-class WirelessLANTest(APIViewTestCases.APIViewTestCase):
+class WirelessLANTestCase(APIViewTestCases.APIViewTestCase):
     model = WirelessLAN
     brief_fields = ['description', 'display', 'id', 'ssid', 'url']
 
@@ -119,7 +119,7 @@ class WirelessLANTest(APIViewTestCases.APIViewTestCase):
         }
 
 
-class WirelessLinkTest(APIViewTestCases.APIViewTestCase):
+class WirelessLinkTestCase(APIViewTestCases.APIViewTestCase):
     model = WirelessLink
     brief_fields = ['description', 'display', 'id', 'ssid', 'url']
     bulk_update_data = {

--- a/netbox/wireless/tests/test_tables.py
+++ b/netbox/wireless/tests/test_tables.py
@@ -2,13 +2,13 @@ from utilities.testing import TableTestCases
 from wireless.tables import *
 
 
-class WirelessLANGroupTableTest(TableTestCases.StandardTableTestCase):
+class WirelessLANGroupTableTestCase(TableTestCases.StandardTableTestCase):
     table = WirelessLANGroupTable
 
 
-class WirelessLANTableTest(TableTestCases.StandardTableTestCase):
+class WirelessLANTableTestCase(TableTestCases.StandardTableTestCase):
     table = WirelessLANTable
 
 
-class WirelessLinkTableTest(TableTestCases.StandardTableTestCase):
+class WirelessLinkTableTestCase(TableTestCases.StandardTableTestCase):
     table = WirelessLinkTable


### PR DESCRIPTION
### Fixes: #22097

This PR standardizes test class naming across the entire NetBox codebase by renaming all *Test and *Tests classes to *TestCase, bringing them in line with Django's own conventions and making the test suite more consistent and predictable for contributors.

Changes:  
  - Renamed 361 test classes across 57 files in all apps (dcim, ipam, extras, circuits, vpn, virtualization, tenancy, wireless, users, core, utilities, and the core netbox package)
  - Fixed two setUp() lambdas in extras/tests/test_views.py that referenced classes by name and needed updating accordingly
  - Resolved a naming collision in extras/tests/test_views.py where a rendering-focused test class was renamed to CustomLinkRenderingTestCase to distinguish it from the existing CRUD-focused CustomLinkTestCase, and moved it adjacent to that class for clarity
  - Pure mixin base classes (BaseFilterSetTests, ChangeLoggedFilterSetTests, DeviceComponentFilterSetTests, DeviceComponentTemplateFilterSetTests) were intentionally left unchanged as renaming them would be a breaking change for plugins (a follow-up housekeeping issue has been opened to address these in a future breaking-change release #22161)
