### PR TITLE
Fixes #22158: Cache empty ConfigRevision lookup result

### DIFF
--- a/netbox/core/signals.py
+++ b/netbox/core/signals.py
@@ -77,6 +77,23 @@ def update_object_types(sender, **kwargs):
 
 
 #
+# Configuration
+#
+
+@receiver(post_migrate)
+def create_default_config_revision(sender, **kwargs):
+    """
+    Ensure at least one ConfigRevision exists after migrations so that runtime config
+    lookups always find a row to cache. Without this, an empty installation re-runs
+    the ConfigRevision lookup on every request.
+    """
+    if sender.name != 'core':
+        return
+    if not ConfigRevision.objects.exists():
+        ConfigRevision.objects.create(data={}, active=True)
+
+
+#
 # Change logging & event handling
 #
 

--- a/netbox/netbox/tests/test_config.py
+++ b/netbox/netbox/tests/test_config.py
@@ -13,14 +13,10 @@ CACHES['default'].update({'KEY_PREFIX': 'TEST-'})
 class ConfigTestCase(TestCase):
 
     @override_settings(CACHES=CACHES)
-    def test_config_init_empty(self):
-        cache.clear()
-
-        config = get_config()
-        self.assertEqual(config.config, {})
-        self.assertEqual(config.version, None)
-
-        clear_config()
+    def test_default_revision_bootstrapped(self):
+        # The post_migrate handler should have created a default ConfigRevision
+        # so runtime config lookups always find a row to cache.
+        self.assertTrue(ConfigRevision.objects.exists())
 
     @override_settings(CACHES=CACHES)
     def test_config_init_from_db(self):


### PR DESCRIPTION
## Summary

- Fixes [#22158](https://github.com/netbox-community/netbox/issues/22158): on installs with an empty `core_configrevision` table, every HTTP request re-runs both the `active=True` and `ORDER BY created DESC LIMIT 1` lookups. With `CONN_MAX_AGE > 0` plus enough gunicorn worker threads, idle DB connections each showing the config query as their last statement accumulate toward `max_connections`.
- Bootstrap a default `ConfigRevision` (empty `data`, `active=True`) from a `post_migrate` handler in `core/signals.py`. The table is therefore never empty after install, so `_populate_from_db()` always finds a row to cache and subsequent `get_config()` calls serve from Redis. The existing `post_save` signal on `ConfigRevision` continues to refresh the cache whenever a new revision is saved.

Closes: #22158

### Note on the earlier approach

An earlier revision of this PR negative-cached the empty result by writing `{}` to Redis. That approach broke `ConfigTestCase` under `--parallel` (the new shared-cache write raced against tests that create their own `ConfigRevision`), which is why CI failed on Python 3.12. Bootstrapping eliminates the empty path entirely and avoids the new shared-cache write.

## Test plan

- [x] `python netbox/manage.py test netbox.tests.test_config` — passes with the renamed `test_default_revision_bootstrapped` asserting the post_migrate handler ran.
- [x] `python netbox/manage.py test core` — 198 core tests pass.
- [ ] Manual: spin up NetBox against an empty DB with `CONN_MAX_AGE > 0`, hit `GET /api/` repeatedly, and confirm `SELECT COUNT(*) FROM pg_stat_activity WHERE query LIKE '%core_configrevision%'` stays at the worker/thread count rather than climbing toward `max_connections`.
- [ ] Manual: confirm the admin "Configuration" view still works — the bootstrap revision is created with `active=True`, so the existing UI treats it as the current configuration and offers it for editing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)