### PR TITLE
Closes #14914: Add test for automatic plugin dashboard widget registration

### DIFF
--- a/netbox/netbox/tests/dummy_plugin/__init__.py
+++ b/netbox/netbox/tests/dummy_plugin/__init__.py
@@ -24,7 +24,7 @@ class DummyPluginConfig(PluginConfig):
     def ready(self):
         super().ready()
 
-        from . import jobs, webhook_callbacks  # noqa: F401
+        from . import jobs, webhook_callbacks, widgets  # noqa: F401
 
 
 config = DummyPluginConfig

--- a/netbox/netbox/tests/dummy_plugin/widgets.py
+++ b/netbox/netbox/tests/dummy_plugin/widgets.py
@@ -1,0 +1,11 @@
+from extras.dashboard.utils import register_widget
+from extras.dashboard.widgets import DashboardWidget
+
+
+@register_widget
+class DummyDashboardWidget(DashboardWidget):
+    default_title = 'Dummy Dashboard Widget'
+    description = 'A dummy dashboard widget for testing plugin registration.'
+
+    def render(self, request):
+        return 'Dummy dashboard widget content'

--- a/netbox/netbox/tests/test_plugins.py
+++ b/netbox/netbox/tests/test_plugins.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 
 from core.choices import JobIntervalChoices
 from core.models import ObjectType
+from extras.dashboard.widgets import DashboardWidget
 from netbox.graphql.schema import Query
 from netbox.plugins.navigation import PluginMenu, PluginMenuButton, PluginMenuItem
 from netbox.plugins.utils import get_plugin_config
@@ -102,6 +103,15 @@ class PluginTestCase(TestCase):
 
         self.assertIn(GlobalContent, registry['plugins']['template_extensions'][None])
         self.assertIn(SiteContent, registry['plugins']['template_extensions']['dcim.site'])
+
+    def test_dashboard_widget(self):
+        """
+        Check that plugin dashboard widgets are registered.
+        """
+        self.assertIn('netbox.DummyDashboardWidget', registry['widgets'])
+
+        widget_class = registry['widgets']['netbox.DummyDashboardWidget']
+        self.assertTrue(issubclass(widget_class, DashboardWidget))
 
     def test_registered_columns(self):
         """


### PR DESCRIPTION
### Fixes: #14914

Adds a minimal dashboard widget to the dummy test plugin and imports it during plugin initialization so it is registered automatically.

This also adds a test to verify that plugin-provided dashboard widgets are present in the widget registry and inherit from the `DashboardWidget` base class.