### PR TITLE
Closes #22195: Align continuation-line indentation in attrs.py docstrings

### DIFF
--- a/netbox/netbox/ui/attrs.py
+++ b/netbox/netbox/ui/attrs.py
@@ -274,7 +274,7 @@ class RelatedObjectAttr(ObjectAttribute):
     Parameters:
          linkify (bool): If True, the rendered value will be hyperlinked to the related object's detail view
          grouped_by (str): A second-order object to annotate alongside the related object; for example, an attribute
-            representing the dcim.Site model might specify grouped_by="region"
+              representing the dcim.Site model might specify grouped_by="region"
          colored (bool): If True, render the object as a colored badge when it exposes a `color` attribute
     """
     template_name = 'ui/attrs/object.html'
@@ -412,13 +412,13 @@ class GenericForeignKeyAttr(ObjectAttribute):
 
     Parameters:
          linkify (bool): If True, the rendered value will be hyperlinked
-             to the related object's detail view.
+              to the related object's detail view.
          nested (bool): If True and the related object exposes a callable
-             `get_ancestors(include_self=True)`, render the object together
-             with its ancestors as a breadcrumb, similar to `NestedObjectAttr`.
-             Non-hierarchical objects continue to render normally.
+              `get_ancestors(include_self=True)`, render the object together
+              with its ancestors as a breadcrumb, similar to `NestedObjectAttr`.
+              Non-hierarchical objects continue to render normally.
          max_depth (int): Maximum number of ancestors to display when
-             `nested` is enabled. Ignored otherwise.
+              `nested` is enabled. Ignored otherwise.
     """
     template_name = 'ui/attrs/generic_object.html'
 
@@ -463,7 +463,7 @@ class AddressAttr(MapURLMixin, ObjectAttribute):
 
     Parameters:
          map_url (bool/str): The URL to use when rendering the address. If True, the address will render as a
-            hyperlink using settings.MAPS_URL.
+              hyperlink using settings.MAPS_URL.
     """
     template_name = 'ui/attrs/address.html'
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Please note that
    our contribution policy requires that a feature request or bug report be
    approved and assigned prior to opening a pull request. This helps avoid
    waste time and effort on a proposed change that we might not be able to
    accept.

    IF YOUR PULL REQUEST DOES NOT REFERENCE AN ISSUE WHICH HAS BEEN ASSIGNED
    TO YOU, IT WILL BE CLOSED AUTOMATICALLY.

    Please specify your assigned issue number on the line below.
-->
### Fixes: #22195

<!--
    Please include a summary of the proposed changes below.
-->
Bump under-indented continuation lines in the Parameters sections of RelatedObjectAttr, GenericForeignKeyAttr, and AddressAttr so griffe's Google parser (used by zensical) no longer warns about confusing indentation. Whitespace-only change; no rendered output differs.