### PR TITLE
Closes #22198: Restrict ExportTemplate querysets for UI & REST API

### DIFF
--- a/netbox/extras/tests/test_views.py
+++ b/netbox/extras/tests/test_views.py
@@ -399,7 +399,7 @@ class ExportTemplateExportFlowTest(TestCase):
         broken_template.object_types.set([site_type])
 
     def test_export_template_invocation(self):
-        self.add_permissions('dcim.view_site')
+        self.add_permissions('dcim.view_site', 'extras.view_exporttemplate')
         url = reverse('dcim:site_list')
 
         response = self.client.get(f'{url}?export=Sites Export')
@@ -412,7 +412,7 @@ class ExportTemplateExportFlowTest(TestCase):
         self.assertEqual(rendered_names, {'Site A', 'Site B'})
 
     def test_export_template_render_error_redirects(self):
-        self.add_permissions('dcim.view_site')
+        self.add_permissions('dcim.view_site', 'extras.view_exporttemplate')
         url = reverse('dcim:site_list')
 
         # A broken template surfaces an exception during render; the view catches it and redirects

--- a/netbox/netbox/api/viewsets/mixins.py
+++ b/netbox/netbox/api/viewsets/mixins.py
@@ -41,7 +41,10 @@ class ExportTemplatesMixin:
     def list(self, request, *args, **kwargs):
         if 'export' in request.GET:
             object_type = ObjectType.objects.get_for_model(self.get_serializer_class().Meta.model)
-            et = ExportTemplate.objects.filter(object_types=object_type, name=request.GET['export']).first()
+            et = ExportTemplate.objects.restrict(request.user, 'view').filter(
+                object_types=object_type,
+                name=request.GET['export'],
+            ).first()
             if et is None:
                 raise Http404
             queryset = self.filter_queryset(self.get_queryset())

--- a/netbox/netbox/views/generic/bulk_views.py
+++ b/netbox/netbox/views/generic/bulk_views.py
@@ -185,7 +185,11 @@ class ObjectListView(BaseMultiObjectView, ActionsMixin, TableMixin):
 
             # Render an ExportTemplate
             if request.GET['export']:
-                template = get_object_or_404(ExportTemplate, object_types=object_type, name=request.GET['export'])
+                template = get_object_or_404(
+                    ExportTemplate.objects.restrict(request.user, 'view'),
+                    object_types=object_type,
+                    name=request.GET['export'],
+                )
                 return self.export_template(template, request)
 
             # Check for YAML export support on the model


### PR DESCRIPTION
### Fixes: netbox-community/netbox#22198

Apply `.restrict()` for the current user on the queryset when retrieving an ExportTemplate for rendering