### PR TITLE
Fixes #22206: Fix TypeError when validating Table Configurations with unset ordering

### DIFF
--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -658,7 +658,7 @@ class TableConfig(CloningMixin, ChangeLoggedModel):
         table = self.table_class([])
 
         # Validate ordering columns
-        for name in self.ordering:
+        for name in self.ordering or []:
             if name.startswith('-'):
                 name = name[1:]  # Strip leading hyphen
             if name not in table.columns:

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -24,6 +24,7 @@ from extras.models import (
     EventRule,
     ExportTemplate,
     ImageAttachment,
+    TableConfig,
     Tag,
     TaggedItem,
 )
@@ -31,6 +32,7 @@ from extras.models.mixins import RenderTemplateMixin
 from tenancy.models import Tenant, TenantGroup
 from utilities.exceptions import AbortRequest
 from utilities.jinja2 import render_jinja2
+from utilities.tables import get_table_for_model
 from virtualization.models import Cluster, ClusterGroup, ClusterType, VirtualMachine
 
 
@@ -188,6 +190,25 @@ class ImageAttachmentTestCase(TestCase):
         self.assertEqual(second.filename, 'action-buttons_sdmmer4.png')
 
         self.assertCountEqual(storage.files.keys(), {base_name, suffixed_name})
+
+
+class TableConfigTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.site_ct = ContentType.objects.get_for_model(Site)
+        cls.table_name = get_table_for_model(Site).__name__
+
+    def test_clean_accepts_ordering_none(self):
+        """clean() must accept ordering=None (field is null=True)."""
+        tc = TableConfig(
+            object_type=self.site_ct,
+            table=self.table_name,
+            name='No ordering',
+            columns=['name'],
+            # ordering left unset (defaults to None)
+        )
+        # Must not raise TypeError: 'NoneType' object is not iterable
+        tc.full_clean()
 
 
 class TagTestCase(TestCase):


### PR DESCRIPTION
### Fixes: #22206

This PR prevents `TableConfig.clean()` from raising a `TypeError` when `ordering` is unset.

It adds an explicit null-safe check so missing ordering is treated as “no ordering configured,” while preserving the existing validation behavior when ordering values are provided. It also includes a regression test to ensure `full_clean()` succeeds when the ordering field is left unset.