### PR TITLE
Closes #22097: Standardize remaining test class names to TestCase suffix

### DIFF
--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -1008,13 +1008,13 @@ class ExportTemplateContextTestCase(TestCase):
 
 def finalize_none_to_dash(value):
     """
-    Module-level helper used by RenderTemplateMixinRenderTest.test_environment_params_finalize_path_import.
+    Module-level helper used by RenderTemplateMixinRenderTestCase.test_environment_params_finalize_path_import.
     Exported so it can be referenced by dotted path from a Jinja environment_params value.
     """
     return '-' if value is None else value
 
 
-class RenderTemplateMixinRenderTest(TestCase):
+class RenderTemplateMixinRenderTestCase(TestCase):
     """
     Tests for RenderTemplateMixin.render() and get_environment_params(), exercised via ConfigTemplate.
     """
@@ -1094,7 +1094,7 @@ class RenderTemplateMixinRenderTest(TestCase):
         self.assertEqual(t.environment_params, {'undefined': 'jinja2.StrictUndefined'})
 
 
-class RenderTemplateMixinResponseTest(TestCase):
+class RenderTemplateMixinResponseTestCase(TestCase):
     """
     Tests for RenderTemplateMixin.render_to_response() HTTP behavior.
     """
@@ -1152,7 +1152,7 @@ class RenderTemplateMixinResponseTest(TestCase):
         self.assertEqual(response.content.decode(), rendered)
 
 
-class ExportTemplateRenderTest(TestCase):
+class ExportTemplateRenderTestCase(TestCase):
     """
     Tests for ExportTemplate.render() with a queryset bound into the template context.
     """
@@ -1208,7 +1208,7 @@ class EventRuleTestCase(TestCase):
             self.assertIn('action_data', cm.exception.message_dict)
 
 
-class JinjaEnvironmentParamsCleanTest(TestCase):
+class JinjaEnvironmentParamsCleanTestCase(TestCase):
     """Tests for RenderTemplateMixin.clean() validation of environment_params."""
 
     def _make_template(self, environment_params):
@@ -1285,7 +1285,7 @@ class JinjaEnvironmentParamsCleanTest(TestCase):
         self.assertIn('environment_params', cm.exception.message_dict)
 
 
-class JinjaEnvironmentParamsFilterTest(TestCase):
+class JinjaEnvironmentParamsFilterTestCase(TestCase):
     """Tests for RenderTemplateMixin._filter_environment_params()."""
 
     def test_allowed_keys_pass_through(self):
@@ -1307,7 +1307,7 @@ class JinjaEnvironmentParamsFilterTest(TestCase):
         self.assertEqual(RenderTemplateMixin._filter_environment_params({}), {})
 
 
-class JinjaEnvironmentParamsResolveTest(TestCase):
+class JinjaEnvironmentParamsResolveTestCase(TestCase):
     """Tests for RenderTemplateMixin._resolve_mapped_params()."""
 
     def test_undefined_resolved_to_class(self):
@@ -1329,7 +1329,7 @@ class JinjaEnvironmentParamsResolveTest(TestCase):
         self.assertEqual(RenderTemplateMixin._resolve_mapped_params({}), {})
 
 
-class JinjaEnvironmentParamsFinalizeTest(TestCase):
+class JinjaEnvironmentParamsFinalizeTestCase(TestCase):
     """Tests for RenderTemplateMixin._resolve_finalize() legacy carve-out."""
 
     def test_finalize_string_resolved_via_import_string(self):
@@ -1356,7 +1356,7 @@ class JinjaEnvironmentParamsFinalizeTest(TestCase):
         self.assertEqual(RenderTemplateMixin._resolve_finalize({}), {})
 
 
-class JinjaEnvironmentParamsIntegrationTest(TestCase):
+class JinjaEnvironmentParamsIntegrationTestCase(TestCase):
     """Integration tests for get_environment_params() end-to-end."""
 
     def _make_template(self, environment_params):

--- a/netbox/extras/tests/test_views.py
+++ b/netbox/extras/tests/test_views.py
@@ -370,7 +370,7 @@ class ExportTemplateTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         }
 
 
-class ExportTemplateExportFlowTest(TestCase):
+class ExportTemplateExportFlowTestCase(TestCase):
     """
     End-to-end test for ExportTemplate invocation via a list view's ?export=<name> query param.
     """

--- a/netbox/ipam/tests/test_models.py
+++ b/netbox/ipam/tests/test_models.py
@@ -9,7 +9,7 @@ from ipam.models import *
 from utilities.data import string_to_ranges
 
 
-class TestAggregate(TestCase):
+class AggregateTestCase(TestCase):
 
     def test_family_string(self):
         # Test property when prefix is a string
@@ -45,7 +45,7 @@ class TestAggregate(TestCase):
         self.assertEqual(aggregate.get_utilization(), 100)
 
 
-class TestIPRange(TestCase):
+class IPRangeTestCase(TestCase):
 
     def test_family_string(self):
         # Test property when start_address is a string
@@ -165,7 +165,7 @@ class TestIPRange(TestCase):
             iprange.clean()
 
 
-class TestPrefix(TestCase):
+class PrefixTestCase(TestCase):
 
     def test_family_string(self):
         # Test property when prefix is a string
@@ -424,7 +424,7 @@ class TestPrefix(TestCase):
         self.assertRaises(ValidationError, duplicate_prefix.clean)
 
 
-class TestPrefixHierarchy(TestCase):
+class PrefixHierarchyTestCase(TestCase):
     """
     Test the automatic updating of depth and child count in response to changes made within
     the prefix hierarchy.
@@ -622,7 +622,7 @@ class TestPrefixHierarchy(TestCase):
         self.assertEqual(prefixes[3]._children, 0)
 
 
-class TestIPAddress(TestCase):
+class IPAddressTestCase(TestCase):
 
     def test_family_string(self):
         # Test property when address is a string
@@ -717,7 +717,7 @@ class TestIPAddress(TestCase):
             ipaddress.clean()
 
 
-class TestVLANGroup(TestCase):
+class VLANGroupTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):
@@ -777,7 +777,7 @@ class TestVLANGroup(TestCase):
         self.assertEqual(vlangroup.total_vlan_ids, 100)
 
 
-class TestVLAN(TestCase):
+class VLANTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -15,7 +15,7 @@ from utilities.forms.utils import (
 from utilities.forms.widgets.select import AvailableOptions, SelectedOptions
 
 
-class ExpandIPNetwork(TestCase):
+class ExpandIPNetworkTestCase(TestCase):
     """
     Validate the operation of expand_ipnetwork_pattern().
     """
@@ -175,7 +175,7 @@ class ExpandIPNetwork(TestCase):
             sorted(expand_ipnetwork_pattern('1.2.3.[4,,5]/32', 4))
 
 
-class ExpandAlphanumeric(TestCase):
+class ExpandAlphanumericTestCase(TestCase):
     """
     Validate the operation of expand_alphanumeric_pattern().
     """

--- a/netbox/vpn/tests/test_models.py
+++ b/netbox/vpn/tests/test_models.py
@@ -6,7 +6,7 @@ from ipam.models import VLAN
 from vpn.models import *
 
 
-class TestL2VPNTermination(TestCase):
+class L2VPNTerminationTestCase(TestCase):
 
     @classmethod
     def setUpTestData(cls):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22097

<!--
    Please include a summary of the proposed changes below.
-->
Follow-up to #22159.
Rename the test classes missed by the original sweep.
