### PR TITLE
Fixes #22227: Limit NAT (outside) list to 10 with link to filtered view

### DIFF
--- a/netbox/ipam/forms/filtersets.py
+++ b/netbox/ipam/forms/filtersets.py
@@ -352,6 +352,7 @@ class IPAddressFilterForm(ContactModelFilterForm, TenancyFilterForm, PrimaryMode
         ),
         FieldSet('vrf_id', 'present_in_vrf_id', name=_('VRF')),
         FieldSet('device_id', 'virtual_machine_id', name=_('Device/VM')),
+        FieldSet('nat_inside_id', name=_('NAT')),
         FieldSet('tenant_group_id', 'tenant_id', name=_('Tenant')),
         FieldSet('owner_group_id', 'owner_id', name=_('Ownership')),
         FieldSet('contact', 'contact_role', 'contact_group', name=_('Contacts')),
@@ -396,6 +397,11 @@ class IPAddressFilterForm(ContactModelFilterForm, TenancyFilterForm, PrimaryMode
         queryset=VirtualMachine.objects.all(),
         required=False,
         label=_('Assigned VM'),
+    )
+    nat_inside_id = DynamicModelMultipleChoiceField(
+        queryset=IPAddress.objects.all(),
+        required=False,
+        label=_('NAT inside'),
     )
     status = forms.MultipleChoiceField(
         label=_('Status'),

--- a/netbox/ipam/tests/test_filtersets.py
+++ b/netbox/ipam/tests/test_filtersets.py
@@ -1307,6 +1307,10 @@ class IPAddressTestCase(TestCase, ChangeLoggedFilterSetTests):
         )
         IPAddress.objects.bulk_create(ipaddresses)
 
+        IPAddress.objects.filter(pk__in=[ipaddresses[1].pk, ipaddresses[2].pk]).update(
+            nat_inside=ipaddresses[0]
+        )
+
         services = (
             Service(
                 parent=devices[0],
@@ -1474,6 +1478,11 @@ class IPAddressTestCase(TestCase, ChangeLoggedFilterSetTests):
     def test_service(self):
         services = Service.objects.all()[:2]
         params = {'service_id': [services[0].pk, services[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_nat_inside(self):
+        inside = IPAddress.objects.filter(nat_outside__isnull=False).distinct().first()
+        params = {'nat_inside_id': [inside.pk]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 

--- a/netbox/templates/ipam/ipaddress/attrs/nat_outside.html
+++ b/netbox/templates/ipam/ipaddress/attrs/nat_outside.html
@@ -1,2 +1,17 @@
 {% load helpers %}
-{% for ip in value.all %}{{ ip|linkify }}{% if ip.assigned_object %} ({{ ip.assigned_object.parent_object|linkify }}){% endif %}<br/>{% empty %}<span class="text-muted">&mdash;</span>{% endfor %}
+{% with ips=value.all|slice:":11" %}
+  {% if ips %}
+    <ul class="list-unstyled mb-0">
+      {% for ip in ips|slice:":10" %}
+        <li>{{ ip|linkify }}{% if ip.assigned_object %} ({{ ip.assigned_object.parent_object|linkify }}){% endif %}</li>
+      {% endfor %}
+      {% if ips|length > 10 %}
+        <li>
+          <a href="{% url 'ipam:ipaddress_list' %}?nat_inside_id={{ object.pk }}" class="text-muted">…</a>
+        </li>
+      {% endif %}
+    </ul>
+  {% else %}
+    <span class="text-muted">&mdash;</span>
+  {% endif %}
+{% endwith %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22227

<!--
    Please include a summary of the proposed changes below.
-->
Render NAT (outside) entries as a vertical list capped at 10 items on the IP detail view; append a muted "…" link routing to the IP address list filtered by nat_inside_id when more exist. Expose nat_inside_id in IPAddressFilterForm so the applied filter is visible in the sidebar of the resulting list view, and add a filterset test for the existing nat_inside_id declaration.