### PR TITLE
Fixes #22236: Preserve Changelog Messages for Table Configuration changes

### DIFF
--- a/netbox/extras/api/serializers_/tableconfigs.py
+++ b/netbox/extras/api/serializers_/tableconfigs.py
@@ -1,14 +1,14 @@
 from core.models import ObjectType
 from extras.models import TableConfig
 from netbox.api.fields import ContentTypeField
-from netbox.api.serializers import ValidatedModelSerializer
+from netbox.api.serializers import ChangeLogMessageSerializer, ValidatedModelSerializer
 
 __all__ = (
     'TableConfigSerializer',
 )
 
 
-class TableConfigSerializer(ValidatedModelSerializer):
+class TableConfigSerializer(ChangeLogMessageSerializer, ValidatedModelSerializer):
     object_type = ContentTypeField(
         queryset=ObjectType.objects.all()
     )


### PR DESCRIPTION
### Closes: #22236

This updates `TableConfigSerializer` to inherit from `ChangeLogMessageSerializer`, allowing `changelog_message` values submitted via the REST API to be recorded on the resulting `ObjectChange`.

This brings table configuration changes in line with other changelog-tracked extras models.