### PR TITLE
Fixes #22247: use ContentType.name for related_object_type display on custom field detail

### DIFF
--- a/netbox/templates/extras/customfield/attrs/type.html
+++ b/netbox/templates/extras/customfield/attrs/type.html
@@ -1,1 +1,1 @@
-{% load helpers %}{{ object.get_type_display }}{% if object.related_object_type %} ({{ object.related_object_type.model|bettertitle }}){% endif %}
+{% load helpers %}{{ object.get_type_display }}{% if object.related_object_type %} ({{ object.related_object_type.name|bettertitle }}){% endif %}


### PR DESCRIPTION
## Summary

- Fixes the custom field detail page showing raw internal model names (e.g. `Ipaddress`, `Table24model`) in the **Type** field when a Related Object Type is set
- One-line template change: `related_object_type.model` → `related_object_type.name`

## Details

`ContentType.model` is the raw lowercase model name stored in the database (e.g. `ipaddress`, `table24model`). `bettertitle` only capitalises the first letter of each space-separated word, so single-word or programmatic names are not made human-readable.

`ContentType.name` is a property that returns `capfirst(model._meta.verbose_name)`, falling back to the raw model name when the model class is not registered. This gives correct, human-readable output for all cases:

| Related Object Type | Before | After |
|---|---|---|
| IP Address | `Object (Ipaddress)` | `Object (IP Address)` |
| Device | `Object (Device)` | `Object (Device)` |
| Custom object (plugin) | `Object (Table24model)` | `Object (Cat)` |

## Test Plan

- [ ] Create a Custom Field of type **Object**, set Related Object Type to **IP Address**, view the detail page — should now show `Object (IP Address)`
- [ ] Set Related Object Type to **Device** — should still show `Object (Device)`

Closes: #22247

🤖 Generated with [Claude Code](https://claude.com/claude-code)