### PR TITLE
Feat: Added rack reservations to rack units description

### DIFF
--- a/netbox/dcim/api/serializers_/rackunits.py
+++ b/netbox/dcim/api/serializers_/rackunits.py
@@ -6,6 +6,7 @@ from dcim.choices import *
 from netbox.api.fields import ChoiceField
 
 from .devices import DeviceSerializer
+from .racks import RackReservationSerializer
 
 __all__ = (
     'RackUnitSerializer',
@@ -24,6 +25,7 @@ class RackUnitSerializer(serializers.Serializer):
     name = serializers.CharField(read_only=True)
     face = ChoiceField(choices=DeviceFaceChoices, read_only=True)
     device = DeviceSerializer(nested=True, read_only=True)
+    reservation = RackReservationSerializer(nested=True, read_only=True)
     occupied = serializers.BooleanField(read_only=True)
     display = serializers.SerializerMethodField(read_only=True)
     description = serializers.SerializerMethodField(read_only=True)
@@ -34,4 +36,8 @@ class RackUnitSerializer(serializers.Serializer):
 
     @extend_schema_field(OpenApiTypes.STR)
     def get_description(self, obj):
-        return f'{obj["device"]}' if obj['device'] else None
+        if obj['device']:
+            return f'{obj["device"]}'
+        if obj['reservation']:
+            return f'Reservation #{obj["reservation"].pk}: {obj["reservation"].description}'
+        return None

--- a/netbox/dcim/models/racks.py
+++ b/netbox/dcim/models/racks.py
@@ -505,6 +505,7 @@ class Rack(ContactsMixin, ImageAttachmentsMixin, TrackingModelMixin, RackBase):
                 'name': u_name,
                 'face': face,
                 'device': None,
+                'reservation': None,
                 'occupied': False
             }
 
@@ -544,6 +545,10 @@ class Rack(ContactsMixin, ImageAttachmentsMixin, TrackingModelMixin, RackBase):
                         elevation[device.position]['device'] = device
                     elevation[device.position]['occupied'] = True
                     elevation[device.position]['height'] = device.device_type.u_height
+
+            for reservation in self.reservations.all():
+                for u in reservation.units:
+                    elevation[u]['reservation'] = reservation
 
         return [u for u in elevation.values()]
 

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -744,6 +744,34 @@ class RackTestCase(APIViewTestCases.APIViewTestCase):
         self.assertEqual(unoccupied_unit['device'], None)
         self.assertEqual(unoccupied_unit['description'], None)
 
+    def test_get_rack_elevation_description_is_reservation(self):
+        """
+        Verify occupied rack units include the reservation in their description.
+        """
+        rack = Rack.objects.first()
+        self.add_permissions('dcim.view_rack', 'dcim.view_device')
+        url = reverse('dcim-api:rack-elevation', kwargs={'pk': rack.pk})
+
+        user = User.objects.create(username='user1', is_active=True)
+        reservation = RackReservation.objects.create(
+            rack=rack,
+            units=[40, 41],
+            user=user,
+            description='Rack Elevation test reservation'
+        )
+
+        # Retrieve all units
+        response = self.client.get(url, **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
+        occupied_unit = next(unit for unit in response.data['results'] if unit['name'] == 'U40')
+        self.assertEqual(occupied_unit['reservation']['id'], reservation.pk)
+        self.assertEqual(occupied_unit['description'], f'Reservation #{reservation.pk}: {reservation.description}')
+
+        unoccupied_unit = next(unit for unit in response.data['results'] if unit['name'] == 'U39')
+        self.assertEqual(unoccupied_unit['reservation'], None)
+        self.assertEqual(unoccupied_unit['description'], None)
+
     def test_get_rack_elevation_svg(self):
         """
         GET a single rack elevation in SVG format.


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22216 and #20805.

<!--
    Please include a summary of the proposed changes below.
-->

This PR simply adds a "Reservation \#_X_: _Description_" description to the rack units serializer when there is a reservation tied to that unit. The current device name description from #20808 takes priority over this.
I did not add purple text, as this would require weird frontend logic, but it can still be done before merge if wanted.