### PR TITLE
Closes #22239: Rename apply button for table configs

### DIFF
--- a/netbox/templates/htmx/table.html
+++ b/netbox/templates/htmx/table.html
@@ -1,5 +1,6 @@
 {# Render an HTMX-enabled table with paginator #}
 {% load helpers %}
+{% load i18n %}
 {% load buttons %}
 {% load render_table from django_tables2 %}
 
@@ -23,7 +24,7 @@
 
   {# Include the updated "save" link for the table configuration #}
   {% if table.config_params and not table.embedded %}
-    <a class="dropdown-item" hx-swap-oob="outerHTML:#table_save_link" href="{% url 'extras:tableconfig_add' %}?{{ table.config_params }}&return_url={{ request.path }}" id="table_save_link">Save</a>
+    <a class="dropdown-item" hx-swap-oob="outerHTML:#table_save_link" href="{% url 'extras:tableconfig_add' %}?{{ table.config_params }}&return_url={{ request.path }}" id="table_save_link">{% trans "Save" %}</a>
   {% endif %}
 
   {# Update the bulk action buttons with new query parameters #}

--- a/netbox/templates/inc/table_controls_htmx.html
+++ b/netbox/templates/inc/table_controls_htmx.html
@@ -38,7 +38,7 @@
           </button>
           <div class="dropdown-menu">
             {% if table.config_params %}
-              <a class="dropdown-item" href="{% url 'extras:tableconfig_add' %}?{{ table.config_params }}&return_url={{ request.path }}" id="table_save_link">Save</a>
+              <a class="dropdown-item" href="{% url 'extras:tableconfig_add' %}?{{ table.config_params }}&return_url={{ request.path }}" id="table_save_link">{% trans "Save" %}</a>
             {% endif %}
             {% if table.config_params and table_configs %}
               <hr class="dropdown-divider">

--- a/netbox/utilities/templates/helpers/table_config_form.html
+++ b/netbox/utilities/templates/helpers/table_config_form.html
@@ -36,8 +36,8 @@
           </div>
         </div>
         <div class="modal-footer">
-            <button type="submit" class="btn btn-outline-danger" id="reset_tableconfig" value="Reset">{% trans "Reset" %}</button>
-            <button type="submit" class="btn btn-primary" id="save_tableconfig" value="Save">{% trans "Save" %}</button>
+          <button type="submit" class="btn btn-outline-danger" id="reset_tableconfig" value="Reset">{% trans "Reset" %}</button>
+          <button type="submit" class="btn btn-primary" id="apply_tableconfig" value="Apply">{% trans "Apply" %}</button>
         </div>
       </form>
     </div>


### PR DESCRIPTION
### Closes: #22239

- Rename the table configuration button from "Save" to "Apply"
- Address some missing string translations