### PR TITLE
Closes #22012: Allow rack starting unit to be zero

### DIFF
--- a/docs/models/dcim/racktype.md
+++ b/docs/models/dcim/racktype.md
@@ -36,7 +36,7 @@ The height of the rack, measured in units.
 
 ### Starting Unit
 
-The number of the numerically lowest unit in the rack. This value defaults to one, but may be higher in certain situations. For example, you may want to model only a select range of units within a shared physical rack (e.g. U13 through U24).
+The number of the numerically lowest unit in the rack. This value defaults to one, but may differ in certain situations (minimal valid value is zero). For example, you may want to model only a select range of units within a shared physical rack (e.g. U13 through U24).
 
 ### Outer Dimensions
 

--- a/docs/models/dcim/racktype.md
+++ b/docs/models/dcim/racktype.md
@@ -36,7 +36,7 @@ The height of the rack, measured in units.
 
 ### Starting Unit
 
-The number of the numerically lowest unit in the rack. This value defaults to one, but may differ in certain situations (minimal valid value is zero). For example, you may want to model only a select range of units within a shared physical rack (e.g. U13 through U24).
+The number of the numerically lowest unit in the rack. This value defaults to one, but may differ depending on the numbering scheme used in the rack. The minimum valid value is zero. For example, you may want to model only a select range of units within a shared physical rack (e.g. U13 through U24).
 
 ### Outer Dimensions
 

--- a/netbox/dcim/api/serializers_/devices.py
+++ b/netbox/dcim/api/serializers_/devices.py
@@ -53,7 +53,7 @@ class DeviceSerializer(PrimaryModelSerializer):
         decimal_places=1,
         allow_null=True,
         label=_('Position (U)'),
-        min_value=decimal.Decimal(0.5),
+        min_value=decimal.Decimal(0),
         default=None
     )
     status = ChoiceField(choices=DeviceStatusChoices, required=False)

--- a/netbox/dcim/forms/bulk_edit.py
+++ b/netbox/dcim/forms/bulk_edit.py
@@ -252,7 +252,7 @@ class RackTypeBulkEditForm(PrimaryModelBulkEditForm):
     )
     starting_unit = forms.IntegerField(
         required=False,
-        min_value=1
+        min_value=0
     )
     desc_units = forms.NullBooleanField(
         required=False,

--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -218,7 +218,7 @@ class RackTypeImportForm(PrimaryModelImportForm):
     )
     starting_unit = forms.IntegerField(
         required=False,
-        min_value=1,
+        min_value=0,
         help_text=_('The lowest-numbered position in the rack')
     )
     width = forms.ChoiceField(

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -313,7 +313,7 @@ class RackBaseFilterForm(PrimaryModelFilterSetForm):
     )
     starting_unit = forms.IntegerField(
         required=False,
-        min_value=1
+        min_value=0
     )
     desc_units = forms.NullBooleanField(
         required=False,

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -1,3 +1,5 @@
+import decimal
+
 from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.core.validators import EMPTY_VALUES
@@ -785,7 +787,7 @@ class DeviceForm(TenancyForm, PrimaryModelForm):
 
         # Rack position
         position = self.data.get('position') if self.data.get('position') is not None else self.initial.get('position')
-        if position is not None:
+        if isinstance(position, (int, decimal.Decimal)):
             self.fields['position'].widget.choices = [(position, f'U{position}')]
 
 

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -1,5 +1,3 @@
-import decimal
-
 from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.core.validators import EMPTY_VALUES
@@ -786,8 +784,8 @@ class DeviceForm(TenancyForm, PrimaryModelForm):
             self.fields['oob_ip'].widget.attrs['readonly'] = True
 
         # Rack position
-        position = self.data.get('position') if self.data.get('position') is not None else self.initial.get('position')
-        if isinstance(position, (int, decimal.Decimal)):
+        position = self.data.get('position')
+        if position not in EMPTY_VALUES or (position := self.initial.get('position')) not in EMPTY_VALUES:
             self.fields['position'].widget.choices = [(position, f'U{position}')]
 
 

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -784,8 +784,8 @@ class DeviceForm(TenancyForm, PrimaryModelForm):
             self.fields['oob_ip'].widget.attrs['readonly'] = True
 
         # Rack position
-        position = self.data.get('position') or self.initial.get('position')
-        if position:
+        position = self.data.get('position') if self.data.get('position') is not None else self.initial.get('position')
+        if position is not None:
             self.fields['position'].widget.choices = [(position, f'U{position}')]
 
 

--- a/netbox/dcim/migrations/0236_allow_rack_starting_unit_zero.py
+++ b/netbox/dcim/migrations/0236_allow_rack_starting_unit_zero.py
@@ -1,0 +1,35 @@
+import django.core.validators
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dcim', '0235_cabletermination_circuit_site_cache'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='device',
+            name='position',
+            field=models.DecimalField(
+                blank=True,
+                decimal_places=1,
+                max_digits=4,
+                null=True,
+                validators=[
+                    django.core.validators.MinValueValidator(0),
+                    django.core.validators.MaxValueValidator(100.5)
+                ]),
+        ),
+        migrations.AlterField(
+            model_name='rack',
+            name='starting_unit',
+            field=models.PositiveSmallIntegerField(default=1, validators=[django.core.validators.MinValueValidator(0)]),
+        ),
+        migrations.AlterField(
+            model_name='racktype',
+            name='starting_unit',
+            field=models.PositiveSmallIntegerField(default=1, validators=[django.core.validators.MinValueValidator(0)]),
+        ),
+    ]

--- a/netbox/dcim/migrations/0237_allow_rack_starting_unit_zero.py
+++ b/netbox/dcim/migrations/0237_allow_rack_starting_unit_zero.py
@@ -8,6 +8,13 @@ class Migration(migrations.Migration):
         ('dcim', '0236_moduletype_component_counts'),
     ]
 
+    def clear_legacy_0u_positions(apps, schema_editor):
+        Device = apps.get_model('dcim', 'Device')
+        Device.objects.filter(
+            device_type__u_height=0,
+            position=0,
+        ).update(position=None)
+
     operations = [
         migrations.AlterField(
             model_name='device',
@@ -32,4 +39,5 @@ class Migration(migrations.Migration):
             name='starting_unit',
             field=models.PositiveSmallIntegerField(default=1, validators=[django.core.validators.MinValueValidator(0)]),
         ),
+        migrations.RunPython(clear_legacy_0u_positions, migrations.RunPython.noop),
     ]

--- a/netbox/dcim/migrations/0237_allow_rack_starting_unit_zero.py
+++ b/netbox/dcim/migrations/0237_allow_rack_starting_unit_zero.py
@@ -5,7 +5,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('dcim', '0235_cabletermination_circuit_site_cache'),
+        ('dcim', '0236_moduletype_component_counts'),
     ]
 
     operations = [

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -847,7 +847,7 @@ class Device(
                             "device."
                         )
                     })
-                if self.device_type.is_child_device and self.position:
+                if self.device_type.is_child_device and self.position is not None:
                     raise ValidationError({
                         'position': _(
                             "Child device types cannot be assigned to a rack position. This is an attribute of the "

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -584,7 +584,7 @@ class Device(
         decimal_places=1,
         blank=True,
         null=True,
-        validators=[MinValueValidator(1), MaxValueValidator(RACK_U_HEIGHT_MAX + 0.5)],
+        validators=[MinValueValidator(0), MaxValueValidator(RACK_U_HEIGHT_MAX + 0.5)],
         verbose_name=_('position (U)'),
         help_text=_('The lowest-numbered unit occupied by the device')
     )
@@ -812,24 +812,24 @@ class Device(
                 raise ValidationError({
                     'face': _("Cannot select a rack face without assigning a rack."),
                 })
-            if self.position:
+            if self.position is not None:
                 raise ValidationError({
                     'position': _("Cannot select a rack position without assigning a rack."),
                 })
 
         # Validate rack position and face
-        if self.position and self.position % decimal.Decimal(0.5):
+        if self.position is not None and self.position % decimal.Decimal(0.5):
             raise ValidationError({
                 'position': _("Position must be in increments of 0.5 rack units.")
             })
-        if self.position and not self.face:
+        if self.position is not None and not self.face:
             raise ValidationError({
                 'face': _("Must specify rack face when defining rack position."),
             })
 
         # Prevent 0U devices from being assigned to a specific position
         if hasattr(self, 'device_type'):
-            if self.position and self.device_type.u_height == 0:
+            if self.position is not None and self.device_type.u_height == 0:
                 raise ValidationError({
                     'position': _(
                         "A 0U device type ({device_type}) cannot be assigned to a rack position."
@@ -861,7 +861,7 @@ class Device(
                 available_units = self.rack.get_available_units(
                     u_height=self.device_type.u_height, rack_face=rack_face, exclude=exclude_list
                 )
-                if self.position and self.position not in available_units:
+                if self.position is not None and self.position not in available_units:
                     raise ValidationError({
                         'position': _(
                             "U{position} is already occupied or does not have sufficient space to accommodate this "

--- a/netbox/dcim/models/racks.py
+++ b/netbox/dcim/models/racks.py
@@ -639,7 +639,7 @@ class Rack(ContactsMixin, ImageAttachmentsMixin, TrackingModelMixin, RackBase):
         return elevation.render(face)
 
     def get_0u_devices(self):
-        return self.devices.filter(position=0)
+        return self.devices.filter(device_type__u_height=0)
 
     def get_utilization(self):
         """

--- a/netbox/dcim/models/racks.py
+++ b/netbox/dcim/models/racks.py
@@ -76,7 +76,7 @@ class RackBase(WeightMixin, PrimaryModel):
     starting_unit = models.PositiveSmallIntegerField(
         default=RACK_STARTING_UNIT_DEFAULT,
         verbose_name=_('starting unit'),
-        validators=[MinValueValidator(1)],
+        validators=[MinValueValidator(0)],
         help_text=_('Starting unit for rack')
     )
     desc_units = models.BooleanField(
@@ -522,7 +522,7 @@ class Rack(ContactsMixin, ImageAttachmentsMixin, TrackingModelMixin, RackBase):
                 pk=exclude
             ).filter(
                 rack=self,
-                position__gt=0,
+                position__isnull=False,
                 device_type__u_height__gt=0
             ).filter(
                 Q(face=face) | Q(device_type__is_full_depth=True)
@@ -559,7 +559,7 @@ class Rack(ContactsMixin, ImageAttachmentsMixin, TrackingModelMixin, RackBase):
         :param ignore_excluded_devices: Ignore devices that are marked to exclude from utilization calculations
         """
         # Gather all devices which consume U space within the rack
-        devices = self.devices.prefetch_related('device_type').filter(position__gte=1)
+        devices = self.devices.prefetch_related('device_type').filter(position__isnull=False)
         if ignore_excluded_devices:
             devices = devices.exclude(device_type__exclude_from_utilization=True)
 

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -370,6 +370,50 @@ class RackTestCase(TestCase):
         rack.refresh_from_db()
         self.assertEqual(rack.get_utilization(), 1 / 42 * 100)
 
+    def test_starting_unit_zero_rack(self):
+        """
+        Check that a Rack with starting unit zero can be used.
+        """
+        site = Site.objects.first()
+        location = Location.objects.first()
+
+        rack0 = Rack(
+            name='Rack start zero',
+            site=site,
+            location=location,
+            starting_unit=0,
+            u_height=42
+        )
+        rack0.save()
+
+        self.assertEqual(rack0.starting_unit, 0)
+
+        # Test device in slot U0
+        Device(
+            name='Device 1',
+            device_type=DeviceType.objects.first(),
+            role=DeviceRole.objects.first(),
+            site=site,
+            rack=rack0,
+            position=0
+        ).save()
+        rack0.refresh_from_db()
+        self.assertEqual(rack0.get_utilization(), 1 / 42 * 100)
+
+        # Last usable unit should be U41
+        Device(
+            name='Device 2',
+            device_type=DeviceType.objects.first(),
+            role=DeviceRole.objects.first(),
+            site=site,
+            rack=rack0,
+            position=42,
+            face=DeviceFaceChoices.FACE_FRONT,
+        ).save()
+
+        with self.assertRaises(ValidationError):
+            rack0.clean()
+
 
 class DeviceTestCase(TestCase):
 

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -350,13 +350,17 @@ class RackTestCase(TestCase):
         site = Site.objects.first()
         rack = Rack.objects.first()
 
-        Device(
+        device = Device(
             name='Device 1',
             role=DeviceRole.objects.first(),
-            device_type=DeviceType.objects.first(),
+            device_type=DeviceType.objects.get(u_height=0),
             site=site,
             rack=rack
-        ).save()
+        )
+        device.full_clean()
+        device.save()
+
+        self.assertEqual(device.rack, rack)
 
     def test_mount_half_u_devices(self):
         """
@@ -435,17 +439,44 @@ class RackTestCase(TestCase):
         rack.refresh_from_db()
         self.assertEqual(rack.get_utilization(), 1 / 42 * 100)
 
+    def test_0u_devices(self):
+        """
+        Check that get_0u_devices() successfully return 0U devices.
+        """
+        site = Site.objects.first()
+        rack = Rack.objects.first()
+
+        device1 = Device.objects.create(
+            name='Device 1',
+            role=DeviceRole.objects.first(),
+            device_type=DeviceType.objects.get(u_height=0),
+            site=site,
+            rack=rack
+        )
+        device1.full_clean()
+        device1.save()
+        device2 = Device.objects.create(
+            name='Device 2',
+            role=DeviceRole.objects.first(),
+            device_type=DeviceType.objects.get(u_height=0),
+            site=site,
+            rack=rack
+        )
+        device2.full_clean()
+        device2.save()
+
+        self.assertQuerySetEqual(rack.get_0u_devices(), [device1, device2])
+
     def test_starting_unit_zero_rack(self):
         """
         Check that a Rack with starting unit zero can be used.
         """
         site = Site.objects.first()
-        location = Location.objects.first()
 
         rack0 = Rack(
             name='Rack start zero',
             site=site,
-            location=location,
+            location=Location.objects.first(),
             starting_unit=0,
             u_height=42
         )
@@ -454,30 +485,70 @@ class RackTestCase(TestCase):
         self.assertEqual(rack0.starting_unit, 0)
 
         # Test device in slot U0
-        Device(
+        device1 = Device(
             name='Device 1',
             device_type=DeviceType.objects.first(),
             role=DeviceRole.objects.first(),
             site=site,
             rack=rack0,
-            position=0
-        ).save()
+            position=0,
+            face=DeviceFaceChoices.FACE_FRONT,
+        )
+        device1.full_clean()
+        device1.save()
         rack0.refresh_from_db()
         self.assertEqual(rack0.get_utilization(), 1 / 42 * 100)
+        self.assertQuerySetEqual(rack0.devices.all(), [device1])
+
+        # Check that get_0u_devices() doesn't return our device
+        self.assertQuerySetEqual(rack0.get_0u_devices(), [])
 
         # Last usable unit should be U41
-        Device(
+        device2 = Device(
             name='Device 2',
+            device_type=DeviceType.objects.first(),
+            role=DeviceRole.objects.first(),
+            site=site,
+            rack=rack0,
+            position=41,
+            face=DeviceFaceChoices.FACE_FRONT,
+        )
+        device2.full_clean()
+        device2.save()
+        rack0.refresh_from_db()
+        self.assertEqual(rack0.get_utilization(), 2 / 42 * 100)
+        self.assertQuerySetEqual(rack0.devices.all(), [device1, device2])
+
+        device3 = Device(
+            name='Device 3',
             device_type=DeviceType.objects.first(),
             role=DeviceRole.objects.first(),
             site=site,
             rack=rack0,
             position=42,
             face=DeviceFaceChoices.FACE_FRONT,
-        ).save()
-
+        )
         with self.assertRaises(ValidationError):
-            rack0.clean()
+            device3.full_clean()
+
+    def test_rack_device_fails_zero_slot(self):
+        """
+        Check that standard rack (starting unit 1) still refuses a device for slot 0.
+        """
+        site = Site.objects.first()
+        rack = Rack.objects.first()
+
+        device1 = Device(
+            name='Device 1',
+            device_type=DeviceType.objects.first(),
+            role=DeviceRole.objects.first(),
+            site=site,
+            rack=rack,
+            position=0,
+            face=DeviceFaceChoices.FACE_FRONT,
+        )
+        with self.assertRaises(ValidationError):
+            device1.full_clean()
 
 
 class DeviceTestCase(TestCase):

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -472,6 +472,7 @@ class RackTestCase(TestCase):
         Check that a Rack with starting unit zero can be used.
         """
         site = Site.objects.first()
+        device_type = DeviceType.objects.filter(u_height=1).first()
 
         rack0 = Rack(
             name='Rack start zero',
@@ -487,7 +488,7 @@ class RackTestCase(TestCase):
         # Test device in slot U0
         device1 = Device(
             name='Device 1',
-            device_type=DeviceType.objects.first(),
+            device_type=device_type,
             role=DeviceRole.objects.first(),
             site=site,
             rack=rack0,
@@ -506,7 +507,7 @@ class RackTestCase(TestCase):
         # Last usable unit should be U41
         device2 = Device(
             name='Device 2',
-            device_type=DeviceType.objects.first(),
+            device_type=device_type,
             role=DeviceRole.objects.first(),
             site=site,
             rack=rack0,
@@ -521,7 +522,7 @@ class RackTestCase(TestCase):
 
         device3 = Device(
             name='Device 3',
-            device_type=DeviceType.objects.first(),
+            device_type=device_type,
             role=DeviceRole.objects.first(),
             site=site,
             rack=rack0,

--- a/netbox/templates/dcim/device/attrs/parent_device.html
+++ b/netbox/templates/dcim/device/attrs/parent_device.html
@@ -3,7 +3,7 @@
   <li class="breadcrumb-item">{{ value.device|linkify }}</li>
   <li class="breadcrumb-item">{{ value }}</li>
 </ol>
-{% if value.device.position %}
+{% if value.device.position is not None %}
   <a href="{{ value.device.rack.get_absolute_url }}?device={{ value.device.pk }}" class="btn btn-primary btn-sm d-print-none" title="{% trans "Highlight device in rack" %}">
     <i class="mdi mdi-view-day-outline"></i>
   </a>

--- a/netbox/templates/dcim/device/attrs/rack.html
+++ b/netbox/templates/dcim/device/attrs/rack.html
@@ -1,13 +1,13 @@
 {% load i18n %}
 <span>
   {{ value|linkify }}
-  {% if value and object.position %}
+  {% if value and object.position is not None %}
     (U{{ object.position|floatformat }} / {{ object.get_face_display }})
   {% elif value and object.device_type.u_height %}
     <span class="badge text-bg-warning">{% trans "Not racked" %}</span>
   {% endif %}
 </span>
-{% if object.position %}
+{% if object.position is not None %}
   <a href="{{ value.get_absolute_url }}?device={{ object.pk }}" class="btn btn-primary btn-sm d-print-none" title="{% trans "Highlight device in rack" %}">
     <i class="mdi mdi-view-day-outline"></i>
   </a>


### PR DESCRIPTION
### Closes: #22012

Files were changed to allow a rack to have a starting unit of zero.

The constant `RACK_STARTING_UNIT_DEFAULT` was kept as 1, because I guess that even though 0 should be possible as starting unit, the default should stay at one. 
If this assumption is not correct, the default value can be changed as well.