### PR TITLE
Closes #21666: Add MU fiber connector type

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1637,6 +1637,10 @@ class PortTypeChoices(ChoiceSet):
     TYPE_LC_PC = 'lc-pc'
     TYPE_LC_UPC = 'lc-upc'
     TYPE_LC_APC = 'lc-apc'
+    TYPE_MU = 'mu'
+    TYPE_MU_PC = 'mu-pc'
+    TYPE_MU_UPC = 'mu-upc'
+    TYPE_MU_APC = 'mu-apc'
     TYPE_MTRJ = 'mtrj'
     TYPE_MPO = 'mpo'
     TYPE_LSH = 'lsh'
@@ -1700,6 +1704,10 @@ class PortTypeChoices(ChoiceSet):
                 (TYPE_LC_PC, 'LC/PC'),
                 (TYPE_LC_UPC, 'LC/UPC'),
                 (TYPE_LC_APC, 'LC/APC'),
+                (TYPE_MU, 'MU'),
+                (TYPE_MU_PC, 'MU/PC'),
+                (TYPE_MU_UPC, 'MU/UPC'),
+                (TYPE_MU_APC, 'MU/APC'),
                 (TYPE_LSH, 'LSH'),
                 (TYPE_LSH_PC, 'LSH/PC'),
                 (TYPE_LSH_UPC, 'LSH/UPC'),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #21666

<!--
    Please include a summary of the proposed changes below.
-->
According to this document 
https://osi.rosenberger.com/fileadmin/content/osi/EN/Products_Services/FO-Components/FO_Connectivity_Systems/DS_MU_Stecker_oe.pdf
the following MU connector types exist:
- PC
- UPC
- APC

Added by analogy with LC:
- MU
- MU/PC
- MU/UPC
- MU/APC

Picture from GUI
<img width="762" height="255" alt="MU" src="https://github.com/user-attachments/assets/6dcd33a8-dd69-49c7-88e5-42a04fb32258" />
