### PR TITLE
Fixes #22287: Use ContentTypeFilter for EventRule `action_object_type`

### DIFF
--- a/netbox/extras/graphql/filters.py
+++ b/netbox/extras/graphql/filters.py
@@ -404,7 +404,9 @@ class EventRuleFilter(CustomFieldsFilterMixin, TagsFilterMixin, ChangeLoggedMode
     action_type: BaseFilterLookup[Annotated['EventRuleActionEnum', strawberry.lazy('extras.graphql.enums')]] | None = (
         strawberry_django.filter_field()
     )
-    action_object_type: StrFilterLookup[str] | None = strawberry_django.filter_field()
+    action_object_type: Annotated['ContentTypeFilter', strawberry.lazy('core.graphql.filters')] | None = (
+        strawberry_django.filter_field()
+    )
     action_object_type_id: ID | None = strawberry_django.filter_field()
     action_object_id: ID | None = strawberry_django.filter_field()
     action_data: Annotated['JSONFilter', strawberry.lazy('netbox.graphql.filter_lookups')] | None = (


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Fixes: #22287

<!--
    Please include a summary of the proposed changes below.
-->
Change `action_object_type` field in `EventRuleFilter` from `StrFilterLookup` to `ContentTypeFilter` for proper content type filtering in GraphQL API.