### PR TITLE
Closes #22290: Use cleanup handlers for config test teardown

### DIFF
--- a/netbox/netbox/tests/test_config.py
+++ b/netbox/netbox/tests/test_config.py
@@ -10,22 +10,28 @@ CACHES = settings.CACHES
 CACHES['default'].update({'KEY_PREFIX': 'TEST-'})
 
 
+@override_settings(CACHES=CACHES)
 class ConfigTestCase(TestCase):
 
-    @override_settings(CACHES=CACHES)
-    def test_config_init_empty(self):
+    def setUp(self):
+        super().setUp()
+        # Register cleanup so it runs after each test, even on assertion failure.
+        # clear_config drops the thread-local Config; cache.clear wipes the Redis
+        # entries that configrevision.activate writes.
+        self.addCleanup(cache.clear)
+        self.addCleanup(clear_config)
+
+        # Defensive reset against pre-existing state from outside this class.
+        clear_config()
         cache.clear()
 
+    def test_config_init_empty(self):
         config = get_config()
         self.assertEqual(config.config, {})
         self.assertEqual(config.version, None)
 
-        clear_config()
-
-    @override_settings(CACHES=CACHES)
     def test_config_init_from_db(self):
         CONFIG_DATA = {'BANNER_TOP': 'A'}
-        cache.clear()
 
         # Create a config but don't load it into the cache
         configrevision = ConfigRevision.objects.create(data=CONFIG_DATA)
@@ -34,12 +40,8 @@ class ConfigTestCase(TestCase):
         self.assertEqual(config.config, CONFIG_DATA)
         self.assertEqual(config.version, configrevision.pk)
 
-        clear_config()
-
-    @override_settings(CACHES=CACHES)
     def test_config_init_from_cache(self):
         CONFIG_DATA = {'BANNER_TOP': 'B'}
-        cache.clear()
 
         # Create a config and load it into the cache
         configrevision = ConfigRevision.objects.create(data=CONFIG_DATA)
@@ -49,12 +51,9 @@ class ConfigTestCase(TestCase):
         self.assertEqual(config.config, CONFIG_DATA)
         self.assertEqual(config.version, configrevision.pk)
 
-        clear_config()
-
-    @override_settings(CACHES=CACHES, BANNER_TOP='Z')
+    @override_settings(BANNER_TOP='Z')
     def test_settings_override(self):
         CONFIG_DATA = {'BANNER_TOP': 'A'}
-        cache.clear()
 
         # Create a config and load it into the cache
         configrevision = ConfigRevision.objects.create(data=CONFIG_DATA)
@@ -63,5 +62,3 @@ class ConfigTestCase(TestCase):
         config = get_config()
         self.assertEqual(config.BANNER_TOP, 'Z')
         self.assertEqual(config.version, configrevision.pk)
-
-        clear_config()


### PR DESCRIPTION
### Closes: #22290

This updates `ConfigTestCase` to register `clear_config()` and `cache.clear()` with `addCleanup()` from `setUp()`, so the cleanup behavior is applied consistently across the whole test case class.

This avoids relying on manual cleanup calls at the end of individual tests and ensures cleanup still runs if a test fails early, helping prevent stale Redis-backed config state from leaking into later tests.