### PR TITLE
Closes #22317: Clear background queues in tearDown for isolation

### DIFF
--- a/netbox/core/tests/test_views.py
+++ b/netbox/core/tests/test_views.py
@@ -215,6 +215,14 @@ class BackgroundTaskTestCase(TestCase):
         get_queue('high').connection.flushall()
         get_queue('low').connection.flushall()
 
+    def tearDown(self):
+        super().tearDown()
+
+        # Clear all queues after each test so no leftover jobs leak into the next test suite
+        get_queue('default').connection.flushall()
+        get_queue('high').connection.flushall()
+        get_queue('low').connection.flushall()
+
     def test_background_queue_list(self):
         url = reverse('core:background_queue_list')
 

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -1155,6 +1155,12 @@ class ScriptTestCase(APITestCase):
         # Monkey-patch the Script model to return our TestScriptClass above
         Script.python_class = self.python_class
 
+        # The script-run endpoint gates on a live RQ worker. Tests run without
+        # one, so bypass the check to exercise validation and the enqueue path.
+        worker_patch = patch('extras.api.views.any_workers_for_queue', return_value=True)
+        worker_patch.start()
+        self.addCleanup(worker_patch.stop)
+
     def test_get_script(self):
         response = self.client.get(self.url, **self.header)
 


### PR DESCRIPTION
### Closes: netbox-community/netbox#22317

Adds tearDown method to BackgroundQueueTestCase that flushes all queues after each test. Prevents leftover jobs from leaking into later test suites and causing false positives or failures.