### PR TITLE
Closes #22319: Clear RQ queue after Event Rule tests

### DIFF
--- a/netbox/extras/tests/test_event_rules.py
+++ b/netbox/extras/tests/test_event_rules.py
@@ -33,6 +33,12 @@ class EventRuleTestCase(APITestCase):
         self.queue = django_rq.get_queue('default')
         self.queue.empty()
 
+    def tearDown(self):
+        super().tearDown()
+
+        # Clear the queue so leftover jobs do not leak to the next test suite
+        self.queue.empty()
+
     @classmethod
     def setUpTestData(cls):
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22319

<!--
    Please include a summary of the proposed changes below.
-->
Add `tearDown` method to empty the default queue after each test. Prevents leftover jobs from leaking into later test suites that may reuse the same queue instance.