### PR TITLE
Closes #22338: Rename shared test base classes to avoid TestCase redeclarations

### DIFF
--- a/netbox/dcim/tests/test_cable_profiles.py
+++ b/netbox/dcim/tests/test_cable_profiles.py
@@ -9,10 +9,10 @@ from dcim.cable_profiles import (
 )
 from dcim.choices import CableProfileChoices
 from dcim.models import Cable, Interface, RearPort
-from dcim.tests.utils import CablePathTestCase
+from dcim.tests.utils import BaseCablePathTestCase
 
 
-class CableProfileLinkPeerTestCase(CablePathTestCase):
+class CableProfileLinkPeerTestCase(BaseCablePathTestCase):
     """
     Tests for link peer resolution with cable profiles.
     """
@@ -75,7 +75,7 @@ class CableProfileLinkPeerTestCase(CablePathTestCase):
             self.assertEqual(interface.link_peers, [rear_ports[1]])
 
 
-class CableProfilePeerTerminationTestCase(CablePathTestCase):
+class CableProfilePeerTerminationTestCase(BaseCablePathTestCase):
     """
     Tests for BaseCableProfile.get_peer_termination() and get_peer_terminations().
     Verifies that the batch method produces identical results to calling

--- a/netbox/dcim/tests/test_cablepaths.py
+++ b/netbox/dcim/tests/test_cablepaths.py
@@ -2,11 +2,11 @@ from circuits.models import *
 from dcim.choices import LinkStatusChoices
 from dcim.models import *
 from dcim.svg import CableTraceSVG
-from dcim.tests.utils import CablePathTestCase
+from dcim.tests.utils import BaseCablePathTestCase
 from utilities.exceptions import AbortRequest
 
 
-class LegacyCablePathTestCase(CablePathTestCase):
+class LegacyCablePathTestCase(BaseCablePathTestCase):
     """
     Test NetBox's ability to trace and retrace CablePaths in response to data model changes, without cable profiles.
 

--- a/netbox/dcim/tests/test_cablepaths2.py
+++ b/netbox/dcim/tests/test_cablepaths2.py
@@ -4,10 +4,10 @@ from circuits.models import CircuitTermination
 from dcim.choices import CableProfileChoices
 from dcim.models import *
 from dcim.svg import CableTraceSVG
-from dcim.tests.utils import CablePathTestCase
+from dcim.tests.utils import BaseCablePathTestCase
 
 
-class CablePathTestCase(CablePathTestCase):
+class CablePathTestCase(BaseCablePathTestCase):
     """
     Test the creation of CablePaths for Cables with different profiles applied.
 

--- a/netbox/dcim/tests/utils.py
+++ b/netbox/dcim/tests/utils.py
@@ -5,11 +5,11 @@ from dcim.models import *
 from dcim.utils import object_to_path_node
 
 __all__ = (
-    'CablePathTestCase',
+    'BaseCablePathTestCase',
 )
 
 
-class CablePathTestCase(TestCase):
+class BaseCablePathTestCase(TestCase):
     """
     Base class for test cases for cable paths.
     """

--- a/netbox/netbox/tests/test_jobs.py
+++ b/netbox/netbox/tests/test_jobs.py
@@ -33,7 +33,7 @@ class TestSystemJobRunner(JobRunner):
         pass
 
 
-class JobRunnerTestCase(TestCase):
+class BaseJobRunnerTestCase(TestCase):
     def tearDown(self):
         super().tearDown()
 
@@ -48,9 +48,9 @@ class JobRunnerTestCase(TestCase):
         return timezone.now() + timedelta(weeks=offset)
 
 
-class JobRunnerTestCase(JobRunnerTestCase):
+class JobRunnerTestCase(BaseJobRunnerTestCase):
     """
-    Test internal logic of `JobRunner`.
+    Test the internal logic of `JobRunner`.
     """
 
     def test_name_default(self):
@@ -101,7 +101,7 @@ class JobRunnerTestCase(JobRunnerTestCase):
         self.assertNotIn(_INSTALL_ROOT, tb_message)
 
 
-class EnqueueTestCase(JobRunnerTestCase):
+class EnqueueTestCase(BaseJobRunnerTestCase):
     """
     Test enqueuing of `JobRunner`.
     """
@@ -177,11 +177,11 @@ class EnqueueTestCase(JobRunnerTestCase):
         self.assertEqual(TestJobRunner.get_jobs(instance).count(), 1)
 
 
-class SystemJobTestCase(JobRunnerTestCase):
+class SystemJobTestCase(BaseJobRunnerTestCase):
     """
     Test that system jobs can be scheduled.
 
-    General functionality already tested by `JobRunnerTest` and `EnqueueTest`.
+    General functionality already tested by `JobRunnerTestCase` and `EnqueueTestCase`.
     """
 
     def test_scheduling(self):


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22338

This renames shared test base classes which had the same names as concrete test cases.

Updated base classes:

* `JobRunnerTestCase` -> `BaseJobRunnerTestCase`
* `CablePathTestCase` -> `BaseCablePathTestCase`

This avoids confusing redeclarations like `class JobRunnerTestCase(JobRunnerTestCase)` and `class CablePathTestCase(CablePathTestCase)`, and makes the inheritance chain clearer for the concrete test suites.

This is a tests-only cleanup.