### PR TITLE
Fixes #22158: Cache empty config revision state to avoid per-request queries

### DIFF
--- a/netbox/netbox/config/__init__.py
+++ b/netbox/netbox/config/__init__.py
@@ -77,7 +77,9 @@ class Config:
         """Populate config data from Redis cache"""
         cached = cache.get('config', _MISSING)
         self._cache_miss = cached is _MISSING
-        self.config = {} if self._cache_miss else cached
+        # A cached value of None (ConfigRevision.data is nullable) or {} is a legitimate empty
+        # config and must not be treated as a miss; normalize it to an empty dict.
+        self.config = {} if self._cache_miss else (cached or {})
         self.version = cache.get('config_version')
         if self.config:
             logger.debug("Loaded configuration data from cache")

--- a/netbox/netbox/config/__init__.py
+++ b/netbox/netbox/config/__init__.py
@@ -20,6 +20,10 @@ _thread_locals = threading.local()
 
 logger = logging.getLogger('netbox.config')
 
+# Sentinel used to distinguish a cache miss from a cached "empty" config (an empty dict is a
+# legitimate cached value when no ConfigRevision exists).
+_MISSING = object()
+
 
 def get_config():
     """
@@ -47,7 +51,9 @@ class Config:
     """
     def __init__(self):
         self._populate_from_cache()
-        if not self.config or not self.version:
+        # Only consult the database when the cache has genuinely never been populated. A cached
+        # empty config (no ConfigRevision) is authoritative and must not trigger a re-query.
+        if self._cache_miss:
             self._populate_from_db()
         self.defaults = {param.name: param.default for param in PARAMS}
 
@@ -69,7 +75,9 @@ class Config:
 
     def _populate_from_cache(self):
         """Populate config data from Redis cache"""
-        self.config = cache.get('config') or {}
+        cached = cache.get('config', _MISSING)
+        self._cache_miss = cached is _MISSING
+        self.config = {} if self._cache_miss else cached
         self.version = cache.get('config_version')
         if self.config:
             logger.debug("Loaded configuration data from cache")
@@ -86,10 +94,17 @@ class Config:
             revision = ConfigRevision.objects.order_by('-created').first()
             if revision is None:
                 logger.debug("No configuration found in database; proceeding with default values")
+                # Cache the empty state so subsequent requests are served from the cache rather than
+                # re-querying the database on every request (#22158). Creating the first
+                # ConfigRevision overwrites this via the post_save handler.
+                cache.set('config', {}, None)
+                cache.set('config_version', None, None)
+                self._populate_from_cache()
                 return
             logger.debug(f"No active configuration revision found; falling back to most recent (#{revision.pk})")
         except DatabaseError:
-            # The database may not be available yet (e.g. when running a management command)
+            # The database may not be available yet (e.g. when running a management command). Do NOT
+            # cache anything here, so the next instantiation re-queries once the database is reachable.
             logger.warning("Skipping config initialization (database unavailable)")
             return
 

--- a/netbox/netbox/config/__init__.py
+++ b/netbox/netbox/config/__init__.py
@@ -75,12 +75,19 @@ class Config:
 
     def _populate_from_cache(self):
         """Populate config data from Redis cache"""
-        cached = cache.get('config', _MISSING)
-        self._cache_miss = cached is _MISSING
+        cached_config = cache.get('config', _MISSING)
+        cached_version = cache.get('config_version', _MISSING)
+
+        # Treat the cache as warm only when both keys are present. A missing 'config_version'
+        # (e.g. evicted or never written) must re-query the database, even if 'config' is cached.
+        # The no-revision branch writes both keys (config={}, config_version=None), so the
+        # intentional empty state is still a cache hit.
+        self._cache_miss = cached_config is _MISSING or cached_version is _MISSING
+
         # A cached value of None (ConfigRevision.data is nullable) or {} is a legitimate empty
-        # config and must not be treated as a miss; normalize it to an empty dict.
-        self.config = {} if self._cache_miss else (cached or {})
-        self.version = cache.get('config_version')
+        # config and must not crash attribute access; normalize it to an empty dict.
+        self.config = {} if cached_config is _MISSING else (cached_config or {})
+        self.version = None if cached_version is _MISSING else cached_version
         if self.config:
             logger.debug("Loaded configuration data from cache")
 

--- a/netbox/netbox/tests/test_config.py
+++ b/netbox/netbox/tests/test_config.py
@@ -71,6 +71,19 @@ class ConfigTestCase(TestCase):
         self.assertEqual(config.config, CONFIG_DATA)
         self.assertEqual(config.version, configrevision.pk)
 
+    def test_config_init_from_cache_null_data(self):
+        # ConfigRevision.data is nullable; a revision with data=None caches None. Config access
+        # must normalize that to an empty dict rather than crash on attribute lookup.
+        configrevision = ConfigRevision.objects.create(data=None)
+        configrevision.activate()
+
+        clear_config()
+        config = get_config()
+        self.assertEqual(config.config, {})
+        self.assertEqual(config.version, configrevision.pk)
+        # Attribute access must fall back to defaults without raising.
+        self.assertEqual(config.BANNER_TOP, '')
+
     def test_config_init_from_db(self):
         CONFIG_DATA = {'BANNER_TOP': 'A'}
 

--- a/netbox/netbox/tests/test_config.py
+++ b/netbox/netbox/tests/test_config.py
@@ -84,6 +84,22 @@ class ConfigTestCase(TestCase):
         # Attribute access must fall back to defaults without raising.
         self.assertEqual(config.BANNER_TOP, '')
 
+    def test_missing_version_key_requeries(self):
+        # If 'config_version' is missing (evicted/never written) while 'config' is cached, the
+        # cache must be treated as cold and re-populated from the database rather than leaving
+        # version=None when a ConfigRevision exists.
+        CONFIG_DATA = {'BANNER_TOP': 'A'}
+        configrevision = ConfigRevision.objects.create(data=CONFIG_DATA)
+        configrevision.activate()
+
+        # Drop only the version key, leaving 'config' populated.
+        cache.delete('config_version')
+        clear_config()
+
+        config = get_config()
+        self.assertEqual(config.config, CONFIG_DATA)
+        self.assertEqual(config.version, configrevision.pk)
+
     def test_config_init_from_db(self):
         CONFIG_DATA = {'BANNER_TOP': 'A'}
 

--- a/netbox/netbox/tests/test_config.py
+++ b/netbox/netbox/tests/test_config.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.core.cache import cache
 from django.db import connection
 from django.test import TestCase, override_settings
@@ -13,18 +12,20 @@ def _configrevision_query_count(queries):
     return len([q for q in queries if 'core_configrevision' in q['sql']])
 
 
-# Prefix cache keys to avoid interfering with the local environment
-CACHES = settings.CACHES
-CACHES['default'].update({'KEY_PREFIX': 'TEST-'})
-
-
-@override_settings(CACHES=CACHES)
+# Use a per-process in-memory cache so the shared 'config'/'config_version' keys can't be
+# contaminated by other tests running in parallel against the same Redis instance.
+@override_settings(CACHES={
+    'default': {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+        'LOCATION': 'netbox-config-tests',
+    },
+})
 class ConfigTestCase(TestCase):
 
     def setUp(self):
         super().setUp()
         # Register cleanup so it runs after each test, even on assertion failure.
-        # clear_config drops the thread-local Config; cache.clear wipes the Redis
+        # clear_config drops the thread-local Config; cache.clear wipes the cache
         # entries that configrevision.activate writes.
         self.addCleanup(cache.clear)
         self.addCleanup(clear_config)

--- a/netbox/netbox/tests/test_config.py
+++ b/netbox/netbox/tests/test_config.py
@@ -1,9 +1,17 @@
 from django.conf import settings
 from django.core.cache import cache
+from django.db import connection
 from django.test import TestCase, override_settings
+from django.test.utils import CaptureQueriesContext
 
 from core.models import ConfigRevision
 from netbox.config import clear_config, get_config
+
+
+def _configrevision_query_count(queries):
+    """Count captured queries that touch the core_configrevision table."""
+    return len([q for q in queries if 'core_configrevision' in q['sql']])
+
 
 # Prefix cache keys to avoid interfering with the local environment
 CACHES = settings.CACHES
@@ -29,6 +37,39 @@ class ConfigTestCase(TestCase):
         config = get_config()
         self.assertEqual(config.config, {})
         self.assertEqual(config.version, None)
+
+    def test_empty_config_not_requeried(self):
+        # With no ConfigRevision present, the empty state should be cached after the first load so
+        # that subsequent requests are served from the cache rather than re-querying the database
+        # on every request (#22158).
+        with CaptureQueriesContext(connection) as ctx:
+            first = get_config()
+        self.assertGreaterEqual(_configrevision_query_count(ctx.captured_queries), 1)
+        self.assertEqual(first.config, {})
+        self.assertEqual(first.version, None)
+
+        # Simulate the request boundary, where the middleware drops the thread-local config.
+        clear_config()
+
+        with CaptureQueriesContext(connection) as ctx:
+            second = get_config()
+        self.assertEqual(_configrevision_query_count(ctx.captured_queries), 0)
+        self.assertEqual(second.config, {})
+        self.assertEqual(second.version, None)
+
+    def test_empty_then_create_first_revision(self):
+        # Prime the cache with the empty state.
+        get_config()
+
+        # Creating the first ConfigRevision fires the post_save handler, which activates it and
+        # overwrites the cached empty state.
+        CONFIG_DATA = {'BANNER_TOP': 'A'}
+        configrevision = ConfigRevision.objects.create(data=CONFIG_DATA)
+
+        clear_config()
+        config = get_config()
+        self.assertEqual(config.config, CONFIG_DATA)
+        self.assertEqual(config.version, configrevision.pk)
 
     def test_config_init_from_db(self):
         CONFIG_DATA = {'BANNER_TOP': 'A'}


### PR DESCRIPTION
### Closes: #22158

When no `ConfigRevision` exists in the database, NetBox re-queried `core_configrevision` on every request. `Config._populate_from_db()` hit the "no revision" branch and returned without caching anything, so the cache was never seeded and each request (e.g. a health check polling `/api/`) repeated the lookup. With `CONN_MAX_AGE > 0`, the idle connections left behind made the query appear to accumulate in `pg_stat_activity`.

This caches the empty config state on first load. A sentinel distinguishes a genuine cache miss from a cached-empty state, so the database is consulted only when the cache has never been populated. Creating the first `ConfigRevision` overwrites the empty state via the existing `post_save` handler. The `DatabaseError` branch intentionally still does not cache, so management commands run before the database is reachable will retry.

Verified with new regression tests (the configrevision query fires once on a cold cache and not on subsequent requests) and confirmed against a running server with no `ConfigRevision` and `CONN_MAX_AGE` set: the query runs once, then requests are served from cache.

Notes for reviewers:

- The branching plugin's separate per-schema connection accumulation (dynamic `schema_*` aliases bypassing Django's `close_old_connections`) is a distinct issue, already fixed in netbox-branching v1.0.2 ([netboxlabs/netbox-branching#358](https://github.com/netboxlabs/netbox-branching/issues/358)). It is not addressed here.
- Not re-reading the database while the cache is warm is the intended design (the cache is the source of truth, synced on `ConfigRevision` save). This PR extends that contract to the empty state and does not change behavior on revision deletion.
