### PR TITLE
Fixes #22357: Remove unused `local_context_data` field from dcim.Module

### DIFF
--- a/netbox/dcim/migrations/0237_module_remove_local_context_data.py
+++ b/netbox/dcim/migrations/0237_module_remove_local_context_data.py
@@ -1,0 +1,15 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dcim', '0236_moduletype_component_counts'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='module',
+            name='local_context_data',
+        ),
+    ]

--- a/netbox/dcim/models/modules.py
+++ b/netbox/dcim/models/modules.py
@@ -9,7 +9,7 @@ from mptt.models import MPTTModel
 
 from dcim.choices import *
 from dcim.utils import create_port_mappings, update_interface_bridges
-from extras.models import ConfigContextModel, CustomField
+from extras.models import CustomField
 from netbox.models import PrimaryModel
 from netbox.models.features import ImageAttachmentsMixin
 from netbox.models.mixins import WeightMixin
@@ -240,7 +240,7 @@ class ModuleType(ImageAttachmentsMixin, PrimaryModel, WeightMixin):
         return yaml.dump(dict(data), sort_keys=False)
 
 
-class Module(TrackingModelMixin, PrimaryModel, ConfigContextModel):
+class Module(TrackingModelMixin, PrimaryModel):
     """
     A Module represents a field-installable component within a Device which may itself hold multiple device components
     (for example, a line card within a chassis switch). Modules are instantiated from ModuleTypes.


### PR DESCRIPTION
### Fixes: #22357

- Remove ConfigContextModel from the list of parent classes for Module
- Add a migration to remove the database table field