### PR TITLE
Fixes #22388: Pin redis-py to <8.0

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -138,6 +138,11 @@ psycopg[c,pool]
 # https://github.com/yaml/pyyaml/blob/master/CHANGES
 PyYAML
 
+# redis-py
+# https://github.com/redis/redis-py
+# Default protocol changes to RESP3 in v8.0; see #22388
+redis<8.0
+
 # Requests
 # https://github.com/psf/requests/blob/main/HISTORY.md
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,6 +32,7 @@ nh3==0.3.5
 Pillow==12.2.0
 psycopg[c,pool]==3.3.4
 PyYAML==6.0.3
+redis==7.4.0
 requests==2.34.2
 rq==2.9.0
 social-auth-app-django==5.9.0


### PR DESCRIPTION
### Fixes: #22388

- Pin `redis-py` to v7.4.0 to avoid the change in default protocol in v8.0.