### PR TITLE
Closes #18987: Preserve restricted related values on edit forms

### DIFF
--- a/docs/administration/permissions.md
+++ b/docs/administration/permissions.md
@@ -113,3 +113,7 @@ Device.objects.filter(
 ### Creating and Modifying Objects
 
 The same sort of logic is in play when a user attempts to create or modify an object in NetBox, with a twist. Once validation has completed, NetBox starts an atomic database transaction to facilitate the change, and the object is created or saved normally. Next, still within the transaction, NetBox issues a second query to retrieve the newly created/updated object, filtering the restricted queryset with the object's primary key. If this query fails to return the object, NetBox knows that the new revision does not match the constraints imposed by the permission. The transaction is then rolled back, leaving the database in its original state prior to the change, and the user is informed of the violation.
+
+#### Preserving Restricted Related Values
+
+When editing an object that references related objects the user is not permitted to view (for example a tag, tenant, or custom field value constrained away by a permission), those current values are shown read-only on the edit form and preserved when the form is saved. Single-value fields are disabled entirely; multi-value fields (such as tags) remain editable for the values the user can see, while the restricted current values are rendered as disabled options. This prevents a user from unintentionally clearing related objects they cannot see, without exposing any other restricted objects or allowing the restricted values to be replaced.

--- a/netbox/circuits/forms/model_forms.py
+++ b/netbox/circuits/forms/model_forms.py
@@ -213,6 +213,10 @@ class CircuitTerminationForm(NetBoxModelForm):
         FieldSet('port_speed', 'upstream_speed', 'xconnect_id', 'pp_info', name=_('Termination Details')),
     )
 
+    restricted_related_selectors = {
+        'termination': {'path': 'termination', 'lock_fields': ('termination_type',)},
+    }
+
     class Meta:
         model = CircuitTermination
         fields = [
@@ -306,6 +310,10 @@ class CircuitGroupAssignmentForm(NetBoxModelForm):
     fieldsets = (
         FieldSet('group', 'member_type', 'member', 'priority', 'tags', name=_('Group Assignment')),
     )
+
+    restricted_related_selectors = {
+        'member': {'path': 'member', 'lock_fields': ('member_type',)},
+    }
 
     class Meta:
         model = CircuitGroupAssignment

--- a/netbox/dcim/forms/mixins.py
+++ b/netbox/dcim/forms/mixins.py
@@ -38,6 +38,11 @@ class ScopedForm(forms.Form):
         selector=True
     )
 
+    # Duplicated by ipam.VLANGroupForm, which needs broader scope_type choices and cannot inherit ScopedForm.
+    restricted_related_selectors = {
+        'scope': {'path': 'scope', 'lock_fields': ('scope_type',)},
+    }
+
     def __init__(self, *args, **kwargs):
         instance = kwargs.get('instance')
         initial = kwargs.get('initial', {})

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -12,7 +12,7 @@ from extras.models import ConfigTemplate
 from ipam.choices import VLANQinQRoleChoices
 from ipam.models import ASN, VLAN, VRF, IPAddress, VLANGroup, VLANTranslationPolicy
 from netbox.forms import NestedGroupModelForm, NetBoxModelForm, OrganizationalModelForm, PrimaryModelForm
-from netbox.forms.mixins import ChangelogMessageMixin, OwnerMixin
+from netbox.forms.mixins import ChangelogMessageMixin, OwnerMixin, RestrictedRelatedFieldsMixin
 from tenancy.forms import TenancyForm
 from users.models import User
 from utilities.forms import add_blank_choice, get_field_value
@@ -1043,7 +1043,7 @@ class VCMemberSelectForm(forms.Form):
 # Device component templates
 #
 
-class ComponentTemplateForm(ChangelogMessageMixin, forms.ModelForm):
+class ComponentTemplateForm(RestrictedRelatedFieldsMixin, ChangelogMessageMixin, forms.ModelForm):
     device_type = DynamicModelChoiceField(
         label=_('Device type'),
         queryset=DeviceType.objects.all(),
@@ -1058,6 +1058,11 @@ class ComponentTemplateForm(ChangelogMessageMixin, forms.ModelForm):
         # Disable reassignment of DeviceType when editing an existing instance
         if self.instance.pk:
             self.fields['device_type'].disabled = True
+
+    def clean(self):
+        # Merge restricted current members hidden from the user back into multi-value fields so they survive on save.
+        self._merge_restricted_preserved_members()
+        return super().clean()
 
 
 class ModularComponentTemplateForm(ComponentTemplateForm):
@@ -1362,6 +1367,17 @@ class InventoryItemTemplateForm(ComponentTemplateForm):
         },
         label=_('Rear port template')
     )
+
+    # Sibling selectors stored as the component GenericForeignKey; the model picks the matching field.
+    restricted_related_selectors = {
+        'consoleporttemplate': {'path': 'component', 'model': ConsolePortTemplate},
+        'consoleserverporttemplate': {'path': 'component', 'model': ConsoleServerPortTemplate},
+        'frontporttemplate': {'path': 'component', 'model': FrontPortTemplate},
+        'interfacetemplate': {'path': 'component', 'model': InterfaceTemplate},
+        'poweroutlettemplate': {'path': 'component', 'model': PowerOutletTemplate},
+        'powerporttemplate': {'path': 'component', 'model': PowerPortTemplate},
+        'rearporttemplate': {'path': 'component', 'model': RearPortTemplate},
+    }
 
     fieldsets = (
         FieldSet(
@@ -1846,6 +1862,17 @@ class InventoryItemForm(DeviceComponentForm):
         label=_('Rear port')
     )
 
+    # Sibling selectors stored as the component GenericForeignKey; the model picks the matching field.
+    restricted_related_selectors = {
+        'consoleport': {'path': 'component', 'model': ConsolePort},
+        'consoleserverport': {'path': 'component', 'model': ConsoleServerPort},
+        'frontport': {'path': 'component', 'model': FrontPort},
+        'interface': {'path': 'component', 'model': Interface},
+        'poweroutlet': {'path': 'component', 'model': PowerOutlet},
+        'powerport': {'path': 'component', 'model': PowerPort},
+        'rearport': {'path': 'component', 'model': RearPort},
+    }
+
     fieldsets = (
         FieldSet(
             'device', 'parent', 'name', 'label', 'status', 'role', 'description', 'tags',
@@ -2008,6 +2035,12 @@ class MACAddressForm(PrimaryModelForm):
             ),
         ),
     )
+
+    restricted_related_selectors = {
+        # The selectors are stored as the assigned_object GenericForeignKey; the model picks the matching one.
+        'interface': {'path': 'assigned_object', 'model': Interface},
+        'vminterface': {'path': 'assigned_object', 'model': VMInterface},
+    }
 
     class Meta:
         model = MACAddress

--- a/netbox/dcim/tests/test_forms.py
+++ b/netbox/dcim/tests/test_forms.py
@@ -16,7 +16,7 @@ from dcim.models import *
 from ipam.models import ASN, RIR, VLAN
 from utilities.exceptions import AbortRequest
 from utilities.forms.rendering import M2MAddRemoveFields
-from utilities.testing import create_test_device
+from utilities.testing import create_test_device, simulate_restrict
 from virtualization.models import Cluster, ClusterGroup, ClusterType
 
 
@@ -666,3 +666,46 @@ class SiteFormTestCase(TestCase):
         self.assertEqual(site.asns.count(), M2MAddRemoveFields.THRESHOLD)
         self.assertTrue(site.asns.filter(pk__in=add_pks).count() == 3)
         self.assertFalse(site.asns.filter(pk__in=remove_pks).exists())
+
+
+class RestrictedComponentTemplateFormTest(TestCase):
+    """Component-template forms (not NetBoxModelForms) preserve hidden FK selectors via the mixin on the base."""
+
+    @classmethod
+    def setUpTestData(cls):
+        manufacturer = Manufacturer.objects.create(name='Manufacturer 1', slug='manufacturer-1')
+        cls.device_type = DeviceType.objects.create(manufacturer=manufacturer, model='Model 1', slug='model-1')
+
+    def test_poweroutlettemplate_hidden_power_port_is_preserved(self):
+        """Editing a power outlet template whose power_port is hidden preserves it on save."""
+        pp = PowerPortTemplate.objects.create(device_type=self.device_type, name='psu0')
+        outlet = PowerOutletTemplate.objects.create(device_type=self.device_type, name='out0', power_port=pp)
+
+        form = PowerOutletTemplateForm(
+            data={'device_type': self.device_type.pk, 'name': 'out0'},
+            instance=outlet,
+        )
+        simulate_restrict(form, 'power_port', PowerPortTemplate.objects.none())
+
+        self.assertTrue(form.fields['power_port'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        outlet = form.save()
+        self.assertEqual(outlet.power_port, pp)
+
+    def test_interfacetemplate_hidden_bridge_is_preserved(self):
+        """Editing an interface template whose bridge is hidden preserves it on save."""
+        other = InterfaceTemplate.objects.create(device_type=self.device_type, name='br0', type='1000base-t')
+        iface = InterfaceTemplate.objects.create(
+            device_type=self.device_type, name='eth1', type='1000base-t', bridge=other
+        )
+
+        form = InterfaceTemplateForm(
+            data={'device_type': self.device_type.pk, 'name': 'eth1', 'type': '1000base-t'},
+            instance=iface,
+        )
+        simulate_restrict(form, 'bridge', InterfaceTemplate.objects.none())
+
+        self.assertTrue(form.fields['bridge'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        iface = form.save()
+        self.assertEqual(iface.bridge, other)

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -14,7 +14,7 @@ from extras.constants import IMAGE_ATTACHMENT_IMAGE_FORMATS
 from extras.models import *
 from netbox.events import get_event_type_choices
 from netbox.forms import NetBoxModelForm, PrimaryModelForm
-from netbox.forms.mixins import ChangelogMessageMixin, OwnerMixin
+from netbox.forms.mixins import ChangelogMessageMixin, OwnerMixin, RestrictedRelatedFieldsMixin
 from tenancy.models import Tenant, TenantGroup
 from users.models import Group, User
 from utilities.forms import get_field_value
@@ -53,7 +53,7 @@ __all__ = (
 )
 
 
-class CustomFieldForm(ChangelogMessageMixin, OwnerMixin, forms.ModelForm):
+class CustomFieldForm(RestrictedRelatedFieldsMixin, ChangelogMessageMixin, OwnerMixin, forms.ModelForm):
     object_types = ContentTypeMultipleChoiceField(
         label=_('Object types'),
         queryset=ObjectType.objects.with_feature('custom_fields'),
@@ -492,7 +492,7 @@ class BookmarkForm(forms.ModelForm):
         fields = ('object_type', 'object_id')
 
 
-class NotificationGroupForm(ChangelogMessageMixin, forms.ModelForm):
+class NotificationGroupForm(RestrictedRelatedFieldsMixin, ChangelogMessageMixin, forms.ModelForm):
     groups = DynamicModelMultipleChoiceField(
         label=_('Groups'),
         required=False,
@@ -510,6 +510,7 @@ class NotificationGroupForm(ChangelogMessageMixin, forms.ModelForm):
 
     def clean(self):
         super().clean()
+        self._merge_restricted_preserved_members()
 
         # At least one User or Group must be assigned
         if not self.cleaned_data['groups'] and not self.cleaned_data['users']:
@@ -577,6 +578,11 @@ class EventRuleForm(OwnerMixin, NetBoxModelForm):
         FieldSet('event_types', 'conditions', name=_('Triggers')),
         FieldSet('action_type', 'action_choice', 'action_data', name=_('Action')),
     )
+
+    # action_object_type/action_object_id are recomputed in clean() from these two fields.
+    restricted_related_selectors = {
+        'action_choice': {'path': 'action_object', 'lock_fields': ('action_type',)},
+    }
 
     class Meta:
         model = EventRule
@@ -709,7 +715,9 @@ class ConfigContextProfileForm(SyncedDataMixin, PrimaryModelForm):
         )
 
 
-class ConfigContextForm(ChangelogMessageMixin, SyncedDataMixin, OwnerMixin, forms.ModelForm):
+class ConfigContextForm(
+    RestrictedRelatedFieldsMixin, ChangelogMessageMixin, SyncedDataMixin, OwnerMixin, forms.ModelForm
+):
     profile = DynamicModelChoiceField(
         label=_('Profile'),
         queryset=ConfigContextProfile.objects.all(),
@@ -819,6 +827,7 @@ class ConfigContextForm(ChangelogMessageMixin, SyncedDataMixin, OwnerMixin, form
 
     def clean(self):
         super().clean()
+        self._merge_restricted_preserved_members()
 
         if not self.cleaned_data.get('data') and not self.cleaned_data.get('data_file'):
             raise forms.ValidationError(_("Must specify either local data or a data file"))
@@ -826,7 +835,9 @@ class ConfigContextForm(ChangelogMessageMixin, SyncedDataMixin, OwnerMixin, form
         return self.cleaned_data
 
 
-class ConfigTemplateForm(ChangelogMessageMixin, SyncedDataMixin, OwnerMixin, forms.ModelForm):
+class ConfigTemplateForm(
+    RestrictedRelatedFieldsMixin, ChangelogMessageMixin, SyncedDataMixin, OwnerMixin, forms.ModelForm
+):
     tags = DynamicModelMultipleChoiceField(
         label=_('Tags'),
         queryset=Tag.objects.all(),
@@ -866,6 +877,7 @@ class ConfigTemplateForm(ChangelogMessageMixin, SyncedDataMixin, OwnerMixin, for
 
     def clean(self):
         super().clean()
+        self._merge_restricted_preserved_members()
 
         if not self.cleaned_data.get('template_code') and not self.cleaned_data.get('data_file'):
             raise forms.ValidationError(_("Must specify either local content or a data file"))

--- a/netbox/extras/tests/test_forms.py
+++ b/netbox/extras/tests/test_forms.py
@@ -10,10 +10,28 @@ from core.models import DataSource, ObjectType
 from dcim.forms import SiteForm
 from dcim.models import Site
 from extras.choices import CustomFieldTypeChoices
-from extras.forms import SavedFilterForm, TableConfigBulkEditForm, TableConfigForm
+from extras.forms import (
+    ConfigContextForm,
+    ConfigTemplateForm,
+    CustomFieldForm,
+    NotificationGroupForm,
+    SavedFilterForm,
+    TableConfigBulkEditForm,
+    TableConfigForm,
+)
 from extras.forms.model_forms import CustomFieldChoiceSetForm
 from extras.forms.scripts import ScriptFileForm
-from extras.models import CustomField, CustomFieldChoiceSet, ScriptModule
+from extras.models import (
+    ConfigContext,
+    ConfigTemplate,
+    CustomField,
+    CustomFieldChoiceSet,
+    NotificationGroup,
+    ScriptModule,
+    Tag,
+)
+from users.models import Group
+from utilities.testing import simulate_restrict
 
 
 class CustomFieldModelFormTestCase(TestCase):
@@ -337,3 +355,83 @@ class TableConfigFormTestCase(TestCase):
         form = TableConfigBulkEditForm()
         self.assertIn('changelog_message', form.fields)
         self.assertIn('changelog_message', form.meta_fields)
+
+
+class RestrictedCustomFieldFormTest(TestCase):
+    """CustomFieldForm (not a NetBoxModelForm) preserves a hidden choice_set FK via the mixin."""
+
+    def test_hidden_choice_set_is_preserved(self):
+        """Editing a custom field whose choice_set is hidden preserves it on save."""
+        site_type = ObjectType.objects.get_for_model(Site)
+        choice_set = CustomFieldChoiceSet.objects.create(name='Choice Set 1', extra_choices=(('A', 'A'), ('B', 'B')))
+        cf = CustomField.objects.create(name='field_x', label='Field X', type='select', choice_set=choice_set)
+        cf.object_types.set([site_type])
+
+        form = CustomFieldForm(
+            data={
+                'name': 'field_x',
+                'label': 'Field X',
+                'type': 'select',
+                'object_types': [site_type.pk],
+                'search_weight': 1000,
+                'filter_logic': 'exact',
+                'weight': 100,
+                'ui_visible': 'always',
+                'ui_editable': 'yes',
+            },
+            instance=cf,
+        )
+        simulate_restrict(form, 'choice_set', CustomFieldChoiceSet.objects.none())
+
+        self.assertTrue(form.fields['choice_set'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        cf = form.save()
+        self.assertEqual(cf.choice_set, choice_set)
+
+
+class RestrictedExtrasM2MFormTest(TestCase):
+    """Extras M2M forms (not NetBoxModelForms) preserve hidden members via the mixin + clean() merge."""
+
+    def test_configcontext_hidden_site_is_preserved(self):
+        """Editing a config context with a hidden assigned site keeps it on save."""
+        visible = Site.objects.create(name='Visible', slug='visible')
+        hidden = Site.objects.create(name='Hidden', slug='hidden')
+        cc = ConfigContext.objects.create(name='CC 1', weight=100, data={'foo': 123})
+        cc.sites.set([visible, hidden])
+
+        form = ConfigContextForm(
+            data={'name': 'CC 1', 'weight': 100, 'is_active': True, 'data': '{"foo": 123}', 'sites': [visible.pk]},
+            instance=cc,
+        )
+        simulate_restrict(form, 'sites', Site.objects.filter(pk=visible.pk))
+        self.assertTrue(form.is_valid(), form.errors)
+        cc = form.save()
+        self.assertEqual(set(cc.sites.all()), {visible, hidden})
+
+    def test_configtemplate_hidden_tag_is_preserved(self):
+        """Editing a config template with a hidden tag keeps it while visible tags stay editable."""
+        visible = Tag.objects.create(name='Visible', slug='visible')
+        hidden = Tag.objects.create(name='Hidden', slug='hidden')
+        ct = ConfigTemplate.objects.create(name='CT 1', template_code='x')
+        ct.tags.set([visible, hidden])
+
+        form = ConfigTemplateForm(
+            data={'name': 'CT 1', 'template_code': 'x', 'tags': [visible.pk]},
+            instance=ct,
+        )
+        simulate_restrict(form, 'tags', Tag.objects.filter(pk=visible.pk))
+        self.assertTrue(form.is_valid(), form.errors)
+        ct = form.save()
+        self.assertEqual(set(ct.tags.all()), {visible, hidden})
+
+    def test_notificationgroup_only_hidden_group_stays_valid_and_preserved(self):
+        """A notification group whose only group is hidden stays valid and keeps it (merge precedes validation)."""
+        hidden = Group.objects.create(name='Hidden group')
+        ng = NotificationGroup.objects.create(name='NG 1')
+        ng.groups.set([hidden])
+
+        form = NotificationGroupForm(data={'name': 'NG 1'}, instance=ng)
+        simulate_restrict(form, 'groups', Group.objects.none())
+        self.assertTrue(form.is_valid(), form.errors)
+        ng = form.save()
+        self.assertEqual(set(ng.groups.all()), {hidden})

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -11,6 +11,7 @@ from ipam.constants import *
 from ipam.formfields import IPNetworkFormField
 from ipam.models import *
 from netbox.forms import NetBoxModelForm, OrganizationalModelForm, PrimaryModelForm
+from netbox.forms.mixins import RestrictedRelatedFieldsMixin
 from tenancy.forms import TenancyForm
 from utilities.exceptions import PermissionsViolation
 from utilities.forms import add_blank_choice
@@ -356,6 +357,13 @@ class IPAddressForm(TenancyForm, PrimaryModelForm):
         FieldSet('nat_inside', name=_('NAT IP (Inside)')),
     )
 
+    restricted_related_selectors = {
+        # The selectors are stored as the assigned_object GenericForeignKey; the model picks the matching one.
+        'interface': {'path': 'assigned_object', 'model': Interface},
+        'vminterface': {'path': 'assigned_object', 'model': VMInterface},
+        'fhrpgroup': {'path': 'assigned_object', 'model': FHRPGroup},
+    }
+
     class Meta:
         model = IPAddress
         fields = [
@@ -587,7 +595,7 @@ class FHRPGroupForm(PrimaryModelForm):
                 })
 
 
-class FHRPGroupAssignmentForm(forms.ModelForm):
+class FHRPGroupAssignmentForm(RestrictedRelatedFieldsMixin, forms.ModelForm):
     group = DynamicModelChoiceField(
         label=_('Group'),
         queryset=FHRPGroup.objects.all()
@@ -644,6 +652,11 @@ class VLANGroupForm(TenancyForm, OrganizationalModelForm):
         FieldSet('scope_type', 'scope', name=_('Scope')),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
     )
+
+    # Mirror of dcim ScopedForm.restricted_related_selectors; keep in sync (VLANGroup uses VLANGROUP_SCOPE_TYPES).
+    restricted_related_selectors = {
+        'scope': {'path': 'scope', 'lock_fields': ('scope_type',)},
+    }
 
     class Meta:
         model = VLANGroup
@@ -833,6 +846,10 @@ class ServiceForm(PrimaryModelForm):
             'ipaddresses', 'description', 'tags', name=_('Application Service')
         ),
     )
+
+    restricted_related_selectors = {
+        'parent': {'path': 'parent', 'lock_fields': ('parent_object_type',)},
+    }
 
     class Meta:
         model = Service

--- a/netbox/ipam/tests/test_forms.py
+++ b/netbox/ipam/tests/test_forms.py
@@ -3,8 +3,10 @@ from django.test import TestCase
 
 from dcim.constants import InterfaceTypeChoices
 from dcim.models import Device, DeviceRole, DeviceType, Interface, Location, Manufacturer, Region, Site, SiteGroup
-from ipam.forms import PrefixForm, VLANIDBulkCreateForm
+from ipam.forms import FHRPGroupAssignmentForm, PrefixForm, VLANIDBulkCreateForm
 from ipam.forms.bulk_import import IPAddressImportForm
+from ipam.models import FHRPGroup, FHRPGroupAssignment
+from utilities.testing import create_test_device, simulate_restrict
 
 
 class PrefixFormTestCase(TestCase):
@@ -195,3 +197,28 @@ class VLANFormTestCase(TestCase):
                 form = VLANIDBulkCreateForm({'pattern': pattern})
                 self.assertFalse(form.is_valid())
                 self.assertIn('pattern', form.errors)
+
+
+class RestrictedFHRPGroupAssignmentFormTest(TestCase):
+    """FHRPGroupAssignmentForm (not a NetBoxModelForm) preserves a hidden group FK via the mixin."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.device = create_test_device('Device 1')
+        cls.interface = Interface.objects.create(device=cls.device, name='eth0', type='1000base-t')
+
+    def test_hidden_group_is_preserved(self):
+        """Editing an FHRP group assignment whose group is hidden preserves it on save."""
+        group = FHRPGroup.objects.create(protocol='vrrp2', group_id=1)
+        assignment = FHRPGroupAssignment.objects.create(interface=self.interface, group=group, priority=10)
+
+        form = FHRPGroupAssignmentForm(
+            data={'group': group.pk, 'priority': 10},
+            instance=assignment,
+        )
+        simulate_restrict(form, 'group', FHRPGroup.objects.none())
+
+        self.assertTrue(form.fields['group'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        assignment = form.save()
+        self.assertEqual(assignment.group, group)

--- a/netbox/netbox/forms/mixins.py
+++ b/netbox/netbox/forms/mixins.py
@@ -1,17 +1,24 @@
 from django import forms
+from django.contrib.contenttypes.models import ContentType
+from django.core.exceptions import FieldDoesNotExist
+from django.db.models import Model
+from django.utils.html import format_html
 from django.utils.translation import gettext as _
+from django.utils.translation import gettext_lazy
 
 from core.models import ObjectType
 from extras.choices import *
 from extras.models import *
 from users.models import Owner, OwnerGroup
 from utilities.forms.fields import DynamicModelChoiceField, DynamicModelMultipleChoiceField
+from utilities.forms.widgets.misc import RestrictedChoiceLabel
 
 __all__ = (
     'ChangelogMessageMixin',
     'CustomFieldsMixin',
     'OwnerFilterMixin',
     'OwnerMixin',
+    'RestrictedRelatedFieldsMixin',
     'SavedFiltersMixin',
     'TagsMixin',
 )
@@ -190,3 +197,339 @@ class OwnerFilterMixin(forms.Form):
         },
         label=_('Owner'),
     )
+
+
+class RestrictedRelatedFieldsMixin:
+    """
+    Form mixin that preserves already-assigned related values hidden by object-permission filtering.
+
+    Driven by restrict_form_fields() (or prepare_restricted_queryset_fields() directly): when a field's queryset is
+    narrowed so the current value is no longer a choice, that value is shown read-only and preserved on save. Kept as
+    a standalone mixin so forms that are not NetBoxModelForms (e.g. component-template forms) can opt in.
+    """
+
+    restricted_value_help_text = gettext_lazy(
+        'This field includes one or more restricted values that cannot be changed. '
+        'They will be preserved when this form is saved.'
+    )
+
+    # Maps selector form fields whose current value is stored under a different instance attribute (e.g. a
+    # GenericForeignKey). Keys are form field names; entries may declare:
+    #   path: dotted attribute path on the instance holding the current value (read from the instance only)
+    #   model: expected model class; set when several selector fields share one path (picks the matching field)
+    #   lock_fields: controller field names locked alongside the selector when its current value is hidden
+    # Merged across the MRO by __init_subclass__: a subclass's entries combine with those declared by base
+    # classes (e.g. ScopedForm's 'scope'), the subclass winning on key conflicts, so inherited selectors are
+    # never silently dropped.
+    restricted_related_selectors = {}
+
+    def __init_subclass__(cls, **kwargs):
+        super().__init_subclass__(**kwargs)
+        merged = {}
+        for klass in reversed(cls.__mro__):
+            merged.update(klass.__dict__.get('restricted_related_selectors', {}))
+        cls.restricted_related_selectors = merged
+
+    def prepare_restricted_queryset_fields(self, restricted_fields, user=None, action='view'):
+        """
+        Render assigned values which were removed by object-permission filtering as read-only.
+
+        `restricted_fields` maps each restricted field name to its original (pre-restriction) queryset. `user` and
+        `action` allow re-checking visibility for GenericForeignKey values whose model differs from the field.
+
+        Security rules:
+
+        * Only values already assigned to the current instance are added back; the rest of the original queryset is
+          never exposed.
+        * A value is preserved only when the user cannot view it; values excluded by the form's own base queryset
+          are left untouched.
+        * Restricted current values are read-only and submitted or tampered values for them are ignored.
+
+        Scalar fields (and fields already disabled, e.g. read-only custom fields) are disabled entirely. Editable
+        multi-value fields stay editable so the user can manage permitted values, while restricted current members
+        are shown as disabled options and preserved server-side in clean().
+        """
+        # Guard against running twice on the same form (which would double-wrap labels and duplicate help text).
+        if getattr(self, '_restricted_queryset_fields_prepared', False) or not self.instance.pk:
+            return
+        self._restricted_queryset_fields_prepared = True
+        self._restricted_preserved_members = {}
+
+        for field_name, original_queryset in restricted_fields.items():
+            field = self.fields.get(field_name)
+            if field is None:
+                continue
+
+            restricted_queryset = getattr(field, 'queryset', None)
+            if restricted_queryset is None:
+                continue
+
+            current_objects = self._get_restricted_queryset_field_current_objects(field_name, original_queryset)
+            if not current_objects:
+                continue
+
+            hidden_objects = self._hidden_restricted_objects(
+                restricted_queryset, original_queryset, current_objects, user, action,
+                declared_selector=field_name in self.restricted_related_selectors,
+            )
+            if not hidden_objects:
+                continue
+
+            if isinstance(field, forms.ModelMultipleChoiceField) and not field.disabled:
+                self._prepare_restricted_multiple_field(
+                    field_name, field, original_queryset, restricted_queryset, current_objects, hidden_objects
+                )
+            else:
+                self._lock_restricted_queryset_field(field_name, field, current_objects, hidden_objects)
+
+    def _lock_restricted_queryset_field(self, field_name, field, current_objects, hidden_objects):
+        """
+        Show only the current value(s) and make the whole field read-only for this request.
+
+        Disabling the field makes Django ignore submitted data and clean the initial value instead. The queryset is
+        narrowed to the current objects using their own model, so a GenericForeignKey value is preserved even when
+        the submitted type field points at a different model. Controller fields declared for the selector
+        (lock_fields) are locked too so construct_instance() and clean() cannot corrupt the preserved value.
+        """
+        multiple = isinstance(field, forms.ModelMultipleChoiceField)
+        field.disabled = True
+        field.required = False
+        field.widget.is_required = False
+
+        field.queryset = self._queryset_for_objects(current_objects)
+
+        if multiple:
+            initial = [field.prepare_value(obj) for obj in current_objects]
+        else:
+            initial = field.prepare_value(current_objects[0])
+        field.initial = initial
+        self.initial[field_name] = initial
+
+        self._lock_controller_fields(field_name, hidden_objects)
+        self._append_restricted_value_help_text(field)
+
+    def _queryset_for_objects(self, objects):
+        """
+        Build a queryset over the objects' own model restricted to their PKs. A scalar selector holds one type at a
+        time, so all objects share a model.
+        """
+        model = type(objects[0])
+        return model.objects.filter(pk__in=[obj.pk for obj in objects])
+
+    def _lock_controller_fields(self, field_name, hidden_objects):
+        """
+        Lock the controller fields declared for a selector (lock_fields) so a submitted value cannot corrupt the
+        preserved assignment. A content type controller is pinned to the current object's own type; any other
+        controller is pinned to the value stored on the instance.
+        """
+        selector = self.restricted_related_selectors.get(field_name) or {}
+        for controller_name in selector.get('lock_fields', ()):
+            controller = self.fields.get(controller_name)
+            if controller is None:
+                continue
+            queryset = getattr(controller, 'queryset', None)
+            if queryset is not None and issubclass(queryset.model, ContentType):
+                content_type = ContentType.objects.get_for_model(type(hidden_objects[0]))
+                controller.queryset = queryset.model.objects.filter(pk=content_type.pk)
+                initial = content_type.pk
+            else:
+                initial = getattr(self.instance, controller_name, None)
+                if isinstance(initial, Model):
+                    initial = initial.pk
+            controller.disabled = True
+            controller.required = False
+            controller.widget.is_required = False
+            controller.initial = initial
+            self.initial[controller_name] = initial
+
+    def _prepare_restricted_multiple_field(
+        self, field_name, field, original_queryset, restricted_queryset, current_objects, hidden_objects
+    ):
+        """
+        Keep an editable multi-value field editable while rendering restricted current members as disabled options.
+
+        The user can still add or remove permitted values. Restricted current members are added back to the
+        queryset (so the current values validate and render selected) and shown as disabled options as a read-only
+        hint. Preservation is enforced in clean(): the hidden members are merged back into the field value
+        regardless of what the widget submits. Forged values are still rejected, because only the already-assigned
+        restricted members are added to the queryset.
+        """
+        hidden_pks = [obj.pk for obj in hidden_objects]
+
+        field.required = False
+        field.widget.is_required = False
+
+        # Allow the visible choices plus the already-assigned restricted members; expose nothing else. The two sides
+        # are disjoint by PK (hidden members are exactly those absent from the restricted queryset), so no DISTINCT.
+        hidden_queryset = original_queryset.filter(pk__in=hidden_pks)
+        field.queryset = restricted_queryset | hidden_queryset
+
+        # Show all current members selected on render.
+        initial = [field.prepare_value(obj) for obj in current_objects]
+        field.initial = initial
+        self.initial[field_name] = initial
+
+        # Render the restricted members as disabled options (a read-only hint; preservation is enforced server-side).
+        self._mark_restricted_choice_labels_disabled(field, hidden_objects)
+
+        # Preserve the hidden members on save without mutating submitted data.
+        self._restricted_preserved_members[field_name] = hidden_objects
+
+        self._append_restricted_value_help_text(field)
+
+    def _mark_restricted_choice_labels_disabled(self, field, hidden_objects):
+        """
+        Wrap label_from_instance so the restricted members render as disabled options.
+        """
+        hidden_values = {str(field.prepare_value(obj)) for obj in hidden_objects}
+        label_from_instance = field.label_from_instance
+
+        def label_with_restricted_marker(obj):
+            label = label_from_instance(obj)
+            if str(field.prepare_value(obj)) in hidden_values:
+                return RestrictedChoiceLabel(label)
+            return label
+
+        field.label_from_instance = label_with_restricted_marker
+
+    def _append_restricted_value_help_text(self, field):
+        if field.help_text:
+            field.help_text = format_html('{} {}', field.help_text, self.restricted_value_help_text)
+        else:
+            field.help_text = self.restricted_value_help_text
+
+    def _get_objects_from_queryset(self, queryset, pks):
+        """
+        Return objects for `pks` from `queryset`, preserving order. Used for selectors whose current PKs are known
+        to belong to the queryset's model.
+        """
+        if not pks:
+            return []
+        objects_by_pk = {str(obj.pk): obj for obj in queryset.filter(pk__in=pks)}
+        return [objects_by_pk[str(pk)] for pk in pks if str(pk) in objects_by_pk]
+
+    def _hidden_restricted_objects(self, restricted_queryset, original_queryset, current_objects, user, action,
+                                   declared_selector=False):
+        """
+        Return the subset of `current_objects` the user cannot view (and which were valid choices before
+        restriction).
+
+        Objects whose model matches the field are checked against the field's own restricted/original querysets in a
+        single pair of queries. Objects of a different model (a GenericForeignKey whose paired type field was changed,
+        of which a selector holds at most one) are checked individually against their own model, so a same-PK object
+        of another model is never mistaken for the current value.
+
+        For a declared selector (`restricted_related_selectors`), the field queryset is derived from submitted
+        controller data and may be empty (a blanked optional type field leaves the selector on its default `.none()`)
+        or of the wrong model. The current value is read from the instance, so visibility is always judged against the
+        object's own model, never the field queryset.
+        """
+        field_model = getattr(restricted_queryset, 'model', None)
+        if declared_selector:
+            same_model = []
+            other_model = list(current_objects)
+        else:
+            same_model = [obj for obj in current_objects if field_model is not None and type(obj) is field_model]
+            other_model = [obj for obj in current_objects if field_model is None or type(obj) is not field_model]
+
+        hidden = []
+        if same_model:
+            pks = [obj.pk for obj in same_model]
+            was_choice = set(original_queryset.filter(pk__in=pks).values_list('pk', flat=True))
+            visible = set(restricted_queryset.filter(pk__in=pks).values_list('pk', flat=True))
+            hidden += [obj for obj in same_model if obj.pk in was_choice and obj.pk not in visible]
+
+        for obj in other_model:
+            manager = type(obj).objects
+            if user is not None and hasattr(manager, 'restrict'):
+                if not manager.restrict(user, action).filter(pk=obj.pk).exists():
+                    hidden.append(obj)
+            else:
+                # Without a user we cannot re-check visibility for a different model, so preserve to avoid data loss.
+                hidden.append(obj)
+
+        return hidden
+
+    def _get_restricted_queryset_field_current_objects(self, field_name, original_queryset):
+        """
+        Return the current assigned objects for a restricted form field, read from the instance (never submitted
+        data). Objects carry their true model, so a GenericForeignKey value is never looked up against a model
+        chosen from submitted data.
+        """
+        if selector := self.restricted_related_selectors.get(field_name):
+            return self._get_restricted_selector_current_objects(selector)
+
+        if field_name in getattr(self, 'custom_fields', {}):
+            pks = self._get_restricted_custom_field_current_pks(field_name)
+            return self._get_objects_from_queryset(original_queryset, pks)
+
+        return self._get_current_objects_from_instance(field_name)
+
+    def _get_restricted_selector_current_objects(self, selector):
+        """
+        Resolve a declared selector's current value by walking its dotted path from the instance. When the
+        declaration names a model, a value of any other model belongs to a sibling selector and is skipped.
+        """
+        obj = self.instance
+        for attr in selector['path'].split('.'):
+            obj = getattr(obj, attr, None)
+            if obj is None:
+                return []
+        model = selector.get('model')
+        if model is not None and type(obj) is not model:
+            return []
+        return [obj]
+
+    def _get_current_objects_from_instance(self, field_name):
+        """
+        Resolve current assigned objects from the instance for forward/reverse M2M, FK/O2O, and same-named
+        GenericForeignKey fields. Returns model instances of their true type.
+        """
+        try:
+            model_field = self.instance._meta.get_field(field_name)
+        except FieldDoesNotExist:
+            model_field = None
+
+        # Forward many-to-many (includes django-taggit tags).
+        if model_field is not None and getattr(model_field, 'many_to_many', False):
+            return list(getattr(self.instance, field_name).all())
+
+        attr = getattr(self.instance, field_name, None)
+
+        # Reverse many-to-many exposed directly on a form.
+        if hasattr(attr, 'all') and hasattr(attr, 'values_list'):
+            return list(attr.all())
+
+        # Forward FK/O2O or a same-named GenericForeignKey: a single related object.
+        if isinstance(attr, Model):
+            return [attr]
+
+        return []
+
+    def _get_restricted_custom_field_current_pks(self, field_name):
+        """
+        Return current serialized PKs for object and multi-object custom fields.
+        """
+        customfield = self.custom_fields[field_name]
+        value = self.instance.custom_field_data.get(customfield.name)
+
+        if customfield.type == CustomFieldTypeChoices.TYPE_OBJECT:
+            if value is None:
+                return []
+            return [value.pk if isinstance(value, Model) else value]
+
+        if customfield.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
+            return [
+                obj.pk if isinstance(obj, Model) else obj
+                for obj in value or []
+            ]
+
+        return []
+
+    def _merge_restricted_preserved_members(self):
+        for field_name, objects in getattr(self, '_restricted_preserved_members', {}).items():
+            if field_name not in self.cleaned_data:
+                continue
+            existing = list(self.cleaned_data[field_name])
+            existing_pks = {obj.pk for obj in existing}
+            self.cleaned_data[field_name] = existing + [obj for obj in objects if obj.pk not in existing_pks]

--- a/netbox/netbox/forms/model_forms.py
+++ b/netbox/netbox/forms/model_forms.py
@@ -8,7 +8,7 @@ from extras.choices import *
 from utilities.forms.fields import CommentField, SlugField
 from utilities.forms.mixins import CheckLastUpdatedMixin
 
-from .mixins import ChangelogMessageMixin, CustomFieldsMixin, OwnerMixin, TagsMixin
+from .mixins import ChangelogMessageMixin, CustomFieldsMixin, OwnerMixin, RestrictedRelatedFieldsMixin, TagsMixin
 
 __all__ = (
     'NestedGroupModelForm',
@@ -19,6 +19,7 @@ __all__ = (
 
 
 class NetBoxModelForm(
+    RestrictedRelatedFieldsMixin,
     ChangelogMessageMixin,
     CheckLastUpdatedMixin,
     CustomFieldsMixin,
@@ -50,6 +51,9 @@ class NetBoxModelForm(
         return customfield.to_form_field()
 
     def clean(self):
+        # Merge restricted current members the user could not see back into multi-value fields so they survive on
+        # save (their options are disabled in the widget and so are not submitted).
+        self._merge_restricted_preserved_members()
 
         # Save custom field data on instance
         for cf_name, customfield in self.custom_fields.items():

--- a/netbox/netbox/tests/test_restricted_form_fields.py
+++ b/netbox/netbox/tests/test_restricted_form_fields.py
@@ -1,0 +1,1078 @@
+from django.test import TestCase as DjangoTestCase
+from django.urls import reverse
+
+from circuits.forms import CircuitGroupAssignmentForm, CircuitTerminationForm
+from circuits.models import (
+    Circuit,
+    CircuitGroup,
+    CircuitGroupAssignment,
+    CircuitTermination,
+    CircuitType,
+    Provider,
+    ProviderNetwork,
+    VirtualCircuit,
+)
+from core.models import ObjectType
+from dcim.forms import (
+    InventoryItemForm,
+    InventoryItemTemplateForm,
+    MACAddressForm,
+)
+from dcim.models import (
+    Device,
+    DeviceRole,
+    DeviceType,
+    Interface,
+    InterfaceTemplate,
+    InventoryItem,
+    InventoryItemTemplate,
+    MACAddress,
+    Manufacturer,
+    PowerPort,
+    Site,
+)
+from extras.choices import CustomFieldTypeChoices, CustomFieldUIEditableChoices, EventRuleActionChoices
+from extras.forms import EventRuleForm
+from extras.models import (
+    CustomField,
+    EventRule,
+    NotificationGroup,
+    Tag,
+    Webhook,
+)
+from ipam.forms import IPAddressForm, PrefixForm, ServiceForm, VLANGroupForm
+from ipam.models import IPAddress, Prefix, Service, VLANGroup
+from netbox.forms import NetBoxModelForm
+from tenancy.models import Tenant
+from users.models import ObjectPermission, User
+from utilities.forms.utils import restrict_form_fields
+from utilities.forms.widgets.misc import RestrictedChoiceLabel
+from utilities.testing import TestCase, create_test_device, create_test_virtualmachine, simulate_restrict
+from virtualization.forms import ClusterForm
+from virtualization.models import Cluster, ClusterType, VirtualMachine, VMInterface
+from vpn.choices import TunnelTerminationTypeChoices
+from vpn.forms import L2VPNTerminationForm, TunnelTerminationForm
+from vpn.models import L2VPN, L2VPNTermination, Tunnel, TunnelTermination
+from wireless.forms import WirelessLANForm
+from wireless.models import WirelessLAN
+
+
+class SiteTagsForm(NetBoxModelForm):
+    class Meta:
+        model = Site
+        fields = ('name', 'slug', 'status', 'tags')
+
+
+class SiteTenantForm(NetBoxModelForm):
+    class Meta:
+        model = Site
+        fields = ('name', 'slug', 'status', 'tenant')
+
+
+class SiteBaseForm(NetBoxModelForm):
+    class Meta:
+        model = Site
+        fields = ('name', 'slug', 'status')
+
+
+class RestrictedScalarFieldTest(DjangoTestCase):
+
+    def setUp(self):
+        self.visible_tenant = Tenant.objects.create(name='Visible Tenant', slug='visible-tenant')
+        self.hidden_tenant = Tenant.objects.create(name='Hidden Tenant', slug='hidden-tenant')
+
+    def test_restricted_value_is_shown_disabled_and_preserved(self):
+        """A scalar value removed by permissions is shown read-only and preserved on save."""
+        site = Site.objects.create(name='Site 1', slug='site-1', tenant=self.hidden_tenant)
+
+        form = SiteTenantForm(
+            data={'name': site.name, 'slug': site.slug, 'status': 'active'},
+            instance=site
+        )
+        simulate_restrict(form, 'tenant', Tenant.objects.filter(pk=self.visible_tenant.pk))
+
+        self.assertTrue(form.fields['tenant'].disabled)
+        self.assertEqual(form['tenant'].value(), self.hidden_tenant.pk)
+        self.assertIn(self.hidden_tenant.pk, set(form.fields['tenant'].queryset.values_list('pk', flat=True)))
+
+        self.assertTrue(form.is_valid(), form.errors)
+        site = form.save()
+        self.assertEqual(site.tenant, self.hidden_tenant)
+
+    def test_replacement_is_ignored(self):
+        """A submitted replacement for a disabled scalar field is ignored."""
+        site = Site.objects.create(name='Site 1', slug='site-1', tenant=self.hidden_tenant)
+
+        form = SiteTenantForm(
+            data={'name': site.name, 'slug': site.slug, 'status': 'active', 'tenant': self.visible_tenant.pk},
+            instance=site
+        )
+        simulate_restrict(form, 'tenant', Tenant.objects.filter(pk=self.visible_tenant.pk))
+
+        self.assertTrue(form.fields['tenant'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        site = form.save()
+        self.assertEqual(site.tenant, self.hidden_tenant)
+
+    def test_visible_value_is_not_locked(self):
+        """A visible scalar value remains editable (the field is not disabled)."""
+        site = Site.objects.create(name='Site 1', slug='site-1', tenant=self.visible_tenant)
+
+        form = SiteTenantForm(
+            data={'name': site.name, 'slug': site.slug, 'status': 'active', 'tenant': self.visible_tenant.pk},
+            instance=site
+        )
+        simulate_restrict(form, 'tenant', Tenant.objects.filter(pk=self.visible_tenant.pk))
+
+        self.assertFalse(form.fields['tenant'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_business_excluded_value_is_not_locked(self):
+        """A value absent from the original queryset for non-permission reasons is not locked."""
+        site = Site.objects.create(name='Site 1', slug='site-1', tenant=self.hidden_tenant)
+
+        form = SiteTenantForm(
+            data={'name': site.name, 'slug': site.slug, 'status': 'active', 'tenant': self.visible_tenant.pk},
+            instance=site
+        )
+        # The original queryset already excludes the current tenant (business filter); nothing further is removed.
+        business_queryset = Tenant.objects.filter(pk=self.visible_tenant.pk)
+        simulate_restrict(form, 'tenant', business_queryset, original_queryset=business_queryset)
+
+        self.assertFalse(form.fields['tenant'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        site = form.save()
+        self.assertEqual(site.tenant, self.visible_tenant)
+
+    def test_locked_field_keeps_existing_help_text(self):
+        """Locking a field appends to, rather than replaces, any existing help text."""
+        site = Site.objects.create(name='Site 1', slug='site-1', tenant=self.hidden_tenant)
+
+        form = SiteTenantForm(
+            data={'name': site.name, 'slug': site.slug, 'status': 'active'},
+            instance=site
+        )
+        form.fields['tenant'].help_text = 'Existing help.'
+        simulate_restrict(form, 'tenant', Tenant.objects.filter(pk=self.visible_tenant.pk))
+
+        help_text = str(form.fields['tenant'].help_text)
+        self.assertIn('Existing help.', help_text)
+        self.assertIn('restricted value', help_text)
+
+    def test_unrestricted_user_does_not_lock_fields(self):
+        """When restrict() leaves every field unchanged (e.g. a superuser), preparation is skipped entirely."""
+        user = User.objects.create_user(username='superuser', is_superuser=True)
+        site = Site.objects.create(name='Site 1', slug='site-1', tenant=self.hidden_tenant)
+
+        form = SiteTenantForm(instance=site)
+        restrict_form_fields(form, user)
+
+        self.assertFalse(form.fields['tenant'].disabled)
+        self.assertFalse(getattr(form, '_restricted_queryset_fields_prepared', False))
+
+    def test_preparation_is_idempotent(self):
+        """Running the preparation twice does not duplicate help text or re-wrap labels."""
+        site = Site.objects.create(name='Site 1', slug='site-1', tenant=self.hidden_tenant)
+
+        form = SiteTenantForm(
+            data={'name': site.name, 'slug': site.slug, 'status': 'active'},
+            instance=site
+        )
+        simulate_restrict(form, 'tenant', Tenant.objects.filter(pk=self.visible_tenant.pk))
+        help_text = str(form.fields['tenant'].help_text)
+
+        form.prepare_restricted_queryset_fields({'tenant': Tenant.objects.all()})
+        self.assertEqual(str(form.fields['tenant'].help_text), help_text)
+
+
+class RestrictedMultiValueFieldTest(DjangoTestCase):
+
+    def setUp(self):
+        self.visible_tag = Tag.objects.create(name='Visible Tag', slug='visible-tag')
+        self.hidden_tag = Tag.objects.create(name='Hidden Tag', slug='hidden-tag')
+        self.other_hidden_tag = Tag.objects.create(name='Other Hidden Tag', slug='other-hidden-tag')
+
+    def test_restricted_member_is_read_only_but_field_stays_editable(self):
+        """A restricted current tag is preserved while the field stays editable; removing the visible tag works."""
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        site.tags.set([self.visible_tag, self.hidden_tag])
+
+        form = SiteTagsForm(
+            # The user removes the visible tag. The restricted tag's option is disabled and not submitted.
+            data={'name': site.name, 'slug': site.slug, 'status': 'active', 'tags': []},
+            instance=site
+        )
+        simulate_restrict(form, 'tags', Tag.objects.filter(pk=self.visible_tag.pk))
+
+        self.assertFalse(form.fields['tags'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        site = form.save()
+        self.assertEqual(set(site.tags.values_list('pk', flat=True)), {self.hidden_tag.pk})
+
+    def test_visible_tag_can_be_added_while_restricted_member_preserved(self):
+        """A visible tag can be added while the restricted current tag is preserved."""
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        site.tags.set([self.hidden_tag])
+
+        form = SiteTagsForm(
+            data={'name': site.name, 'slug': site.slug, 'status': 'active', 'tags': [self.visible_tag.pk]},
+            instance=site
+        )
+        simulate_restrict(form, 'tags', Tag.objects.filter(pk=self.visible_tag.pk))
+
+        self.assertFalse(form.fields['tags'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        site = form.save()
+        self.assertEqual(
+            set(site.tags.values_list('pk', flat=True)),
+            {self.hidden_tag.pk, self.visible_tag.pk}
+        )
+
+    def test_restricted_member_preserved_on_prefixed_form(self):
+        """Preservation works for a prefixed form: hidden members are merged in clean(), not into submitted data."""
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        site.tags.set([self.visible_tag, self.hidden_tag])
+
+        form = SiteTagsForm(
+            data={
+                'quickadd-name': site.name,
+                'quickadd-slug': site.slug,
+                'quickadd-status': 'active',
+                'quickadd-tags': [],
+            },
+            instance=site,
+            prefix='quickadd'
+        )
+        simulate_restrict(form, 'tags', Tag.objects.filter(pk=self.visible_tag.pk))
+
+        self.assertFalse(form.fields['tags'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        site = form.save()
+        self.assertEqual(set(site.tags.values_list('pk', flat=True)), {self.hidden_tag.pk})
+
+    def test_forged_non_current_restricted_value_is_rejected(self):
+        """A restricted tag not already assigned cannot be added."""
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        site.tags.set([self.hidden_tag])
+
+        form = SiteTagsForm(
+            data={'name': site.name, 'slug': site.slug, 'status': 'active', 'tags': [self.other_hidden_tag.pk]},
+            instance=site
+        )
+        simulate_restrict(form, 'tags', Tag.objects.filter(pk=self.visible_tag.pk))
+
+        self.assertFalse(form.fields['tags'].disabled)
+        self.assertFalse(form.is_valid())
+
+    def test_restricted_choice_label(self):
+        """RestrictedChoiceLabel is disabled and stringifies to its wrapped label."""
+        label = RestrictedChoiceLabel('Tag 1')
+        self.assertTrue(label.disabled)
+        self.assertEqual(str(label), 'Tag 1')
+
+    def test_restricted_member_renders_as_disabled_option(self):
+        """The restricted member renders as a disabled <option> while the field itself is not disabled."""
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        site.tags.set([self.visible_tag, self.hidden_tag])
+
+        form = SiteTagsForm(instance=site)
+        simulate_restrict(form, 'tags', Tag.objects.filter(pk=self.visible_tag.pk))
+
+        rendered = str(form['tags'])
+        # The <select> itself is not disabled; only the restricted option carries disabled="disabled".
+        self.assertFalse(form.fields['tags'].disabled)
+        self.assertIn(f'value="{self.hidden_tag.pk}"', rendered)
+        self.assertIn('disabled="disabled"', rendered)
+
+    def test_visible_field_remains_editable(self):
+        """A fully visible tags field stays editable and can be cleared."""
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        site.tags.set([self.visible_tag])
+
+        form = SiteTagsForm(
+            data={'name': site.name, 'slug': site.slug, 'status': 'active', 'tags': []},
+            instance=site
+        )
+        simulate_restrict(form, 'tags', Tag.objects.filter(pk=self.visible_tag.pk))
+
+        self.assertFalse(form.fields['tags'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        site = form.save()
+        self.assertEqual(site.tags.count(), 0)
+
+    def test_editable_field_rejects_forged_value(self):
+        """An editable field (no hidden current value) still validates submitted values against the restricted qs."""
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        site.tags.set([self.visible_tag])
+
+        form = SiteTagsForm(
+            data={
+                'name': site.name,
+                'slug': site.slug,
+                'status': 'active',
+                'tags': [self.visible_tag.pk, self.other_hidden_tag.pk],
+            },
+            instance=site
+        )
+        simulate_restrict(form, 'tags', Tag.objects.filter(pk=self.visible_tag.pk))
+
+        self.assertFalse(form.fields['tags'].disabled)
+        self.assertFalse(form.is_valid())
+
+
+class RestrictedCustomFieldTest(DjangoTestCase):
+
+    def setUp(self):
+        site_type = ObjectType.objects.get_for_model(Site)
+        tenant_type = ObjectType.objects.get_for_model(Tenant)
+
+        self.cf_object = CustomField.objects.create(
+            name='primary_vendor',
+            type=CustomFieldTypeChoices.TYPE_OBJECT,
+            related_object_type=tenant_type
+        )
+        self.cf_object.object_types.set([site_type])
+
+        self.cf_multiobject = CustomField.objects.create(
+            name='vendors',
+            type=CustomFieldTypeChoices.TYPE_MULTIOBJECT,
+            related_object_type=tenant_type
+        )
+        self.cf_multiobject.object_types.set([site_type])
+
+        self.visible_tenant = Tenant.objects.create(name='Visible Tenant', slug='visible-tenant')
+        self.hidden_tenant = Tenant.objects.create(name='Hidden Tenant', slug='hidden-tenant')
+
+    def test_editable_multiobject_restricted_member_is_preserved(self):
+        """An editable multi-object custom field stays editable; the restricted member is preserved."""
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        site.custom_field_data['vendors'] = [self.hidden_tenant.pk, self.visible_tenant.pk]
+        site.save()
+
+        form = SiteBaseForm(
+            # The user removes the visible tenant; the restricted tenant's option is disabled and not submitted.
+            data={'name': site.name, 'slug': site.slug, 'status': 'active', 'cf_vendors': []},
+            instance=site
+        )
+        simulate_restrict(form, 'cf_vendors', Tenant.objects.filter(pk=self.visible_tenant.pk))
+
+        self.assertFalse(form.fields['cf_vendors'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        site = form.save()
+        self.assertEqual(set(site.custom_field_data['vendors']), {self.hidden_tenant.pk})
+
+    def test_two_restricted_multi_value_fields_are_both_preserved(self):
+        """Two restricted multi-value fields on one bound form both preserve their restricted members."""
+        visible_tag = Tag.objects.create(name='Visible Tag', slug='visible-tag-multi')
+        hidden_tag = Tag.objects.create(name='Hidden Tag', slug='hidden-tag-multi')
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        site.tags.set([visible_tag, hidden_tag])
+        site.custom_field_data['vendors'] = [self.hidden_tenant.pk, self.visible_tenant.pk]
+        site.save()
+
+        form = SiteBaseForm(
+            data={'name': site.name, 'slug': site.slug, 'status': 'active', 'tags': [], 'cf_vendors': []},
+            instance=site
+        )
+        form.fields['tags'].queryset = Tag.objects.filter(pk=visible_tag.pk)
+        form.fields['cf_vendors'].queryset = Tenant.objects.filter(pk=self.visible_tenant.pk)
+        form.prepare_restricted_queryset_fields({
+            'tags': Tag.objects.all(),
+            'cf_vendors': Tenant.objects.all(),
+        })
+
+        self.assertFalse(form.fields['tags'].disabled)
+        self.assertFalse(form.fields['cf_vendors'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        site = form.save()
+        self.assertEqual(set(site.tags.values_list('pk', flat=True)), {hidden_tag.pk})
+        self.assertEqual(set(site.custom_field_data['vendors']), {self.hidden_tenant.pk})
+
+    def test_hidden_object_value_is_shown_disabled_and_preserved(self):
+        """An object custom field with a hidden value is disabled and preserved."""
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        site.custom_field_data['primary_vendor'] = self.hidden_tenant.pk
+        site.save()
+
+        form = SiteBaseForm(
+            data={'name': site.name, 'slug': site.slug, 'status': 'active'},
+            instance=site
+        )
+        simulate_restrict(form, 'cf_primary_vendor', Tenant.objects.filter(pk=self.visible_tenant.pk))
+
+        self.assertTrue(form.fields['cf_primary_vendor'].disabled)
+        self.assertEqual(form['cf_primary_vendor'].value(), self.hidden_tenant.pk)
+        self.assertTrue(form.is_valid(), form.errors)
+        site = form.save()
+        self.assertEqual(site.custom_field_data['primary_vendor'], self.hidden_tenant.pk)
+
+    def test_readonly_multiobject_hidden_value_is_preserved(self):
+        """A read-only (ui_editable='no') multi-object custom field with a hidden member is preserved."""
+        cf = CustomField.objects.create(
+            name='readonly_vendors',
+            type=CustomFieldTypeChoices.TYPE_MULTIOBJECT,
+            related_object_type=ObjectType.objects.get_for_model(Tenant),
+            ui_editable=CustomFieldUIEditableChoices.NO
+        )
+        cf.object_types.set([ObjectType.objects.get_for_model(Site)])
+
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        site.custom_field_data['readonly_vendors'] = [self.hidden_tenant.pk, self.visible_tenant.pk]
+        site.save()
+
+        form = SiteBaseForm(
+            data={'name': site.name, 'slug': site.slug, 'status': 'active'},
+            instance=site
+        )
+        self.assertTrue(form.fields['cf_readonly_vendors'].disabled)
+        simulate_restrict(form, 'cf_readonly_vendors', Tenant.objects.filter(pk=self.visible_tenant.pk))
+
+        self.assertTrue(form.is_valid(), form.errors)
+        site = form.save()
+        self.assertEqual(
+            set(site.custom_field_data['readonly_vendors']),
+            {self.hidden_tenant.pk, self.visible_tenant.pk}
+        )
+
+
+class RestrictedSyntheticSelectorTest(DjangoTestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        manufacturer = Manufacturer.objects.create(name='Manufacturer 1', slug='manufacturer-1')
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model='Model 1', slug='model-1')
+        role = DeviceRole.objects.create(name='Role 1', slug='role-1')
+        site = Site.objects.create(name='Site 1', slug='site-1')
+        cls.device = Device.objects.create(name='Device 1', device_type=device_type, role=role, site=site)
+        cls.interface = Interface.objects.create(device=cls.device, name='eth0', type='1000base-t')
+
+    def test_ipaddress_selector_resolves_current_assignment(self):
+        """The declared selectors resolve the assigned interface only for the matching field."""
+        ip = IPAddress(address='192.0.2.1/24')
+        ip.assigned_object = self.interface
+        ip.save()
+        ip = IPAddress.objects.get(pk=ip.pk)
+
+        form = IPAddressForm(instance=ip)
+        original = Interface.objects.all()
+        self.assertEqual(form._get_restricted_queryset_field_current_objects('interface', original), [self.interface])
+        self.assertEqual(form._get_restricted_queryset_field_current_objects('vminterface', original), [])
+        self.assertEqual(form._get_restricted_queryset_field_current_objects('fhrpgroup', original), [])
+
+    def test_macaddress_selector_resolves_current_assignment(self):
+        """The declared selectors resolve the assigned interface only for the matching field."""
+        mac = MACAddress(mac_address='00:11:22:33:44:55')
+        mac.assigned_object = self.interface
+        mac.save()
+
+        form = MACAddressForm(instance=mac)
+        original = Interface.objects.all()
+        self.assertEqual(form._get_restricted_queryset_field_current_objects('interface', original), [self.interface])
+        self.assertEqual(form._get_restricted_queryset_field_current_objects('vminterface', original), [])
+
+        # An unassigned object resolves no current value for any selector.
+        unassigned = MACAddress.objects.create(mac_address='00:11:22:33:44:66')
+        form = MACAddressForm(instance=unassigned)
+        self.assertEqual(form._get_restricted_queryset_field_current_objects('interface', original), [])
+
+    def test_l2vpntermination_selector_resolves_current_assignment(self):
+        """The declared selectors resolve the assigned interface only for the matching field."""
+        l2vpn = L2VPN.objects.create(name='L2VPN 1', slug='l2vpn-1', type='vxlan')
+        termination = L2VPNTermination(l2vpn=l2vpn)
+        termination.assigned_object = self.interface
+        termination.save()
+
+        form = L2VPNTerminationForm(instance=termination)
+        original = Interface.objects.all()
+        self.assertEqual(form._get_restricted_queryset_field_current_objects('interface', original), [self.interface])
+        self.assertEqual(form._get_restricted_queryset_field_current_objects('vminterface', original), [])
+        self.assertEqual(form._get_restricted_queryset_field_current_objects('vlan', original), [])
+
+    def test_ipaddress_cross_selector_submission_cannot_replace_hidden_assignment(self):
+        """A value submitted for a sibling selector cannot silently replace a hidden assignment."""
+        ip = IPAddress(address='192.0.2.1/24')
+        ip.assigned_object = self.interface
+        ip.save()
+        ip = IPAddress.objects.get(pk=ip.pk)
+        vm = create_test_virtualmachine('VM 1')
+        vminterface = VMInterface.objects.create(virtual_machine=vm, name='eth0')
+
+        form = IPAddressForm(
+            data={'address': '192.0.2.1/24', 'status': 'active', 'vminterface': vminterface.pk},
+            instance=ip,
+        )
+        simulate_restrict(form, 'interface', Interface.objects.none())
+
+        # The locked hidden interface plus the submitted sibling trip the single-assignment validation.
+        self.assertFalse(form.is_valid())
+        self.assertIn('vminterface', form.errors)
+        self.assertEqual(IPAddress.objects.get(pk=ip.pk).assigned_object, self.interface)
+
+    def test_tunneltermination_parent_resolves_through_termination(self):
+        """The auxiliary parent selector resolves the termination's owner via its dotted path."""
+        tunnel = Tunnel.objects.create(name='Tunnel 1', encapsulation='gre', status='active')
+        termination = TunnelTermination.objects.create(tunnel=tunnel, role='peer', termination=self.interface)
+
+        form = TunnelTerminationForm(instance=termination)
+        self.assertEqual(
+            form._get_restricted_queryset_field_current_objects('parent', Device.objects.all()),
+            [self.device],
+        )
+
+    def test_hidden_assigned_object_is_shown_disabled_and_preserved(self):
+        """Editing a MAC address whose assigned interface is hidden shows it disabled and preserves it."""
+        mac = MACAddress(mac_address='00:11:22:33:44:55')
+        mac.assigned_object = self.interface
+        mac.save()
+
+        form = MACAddressForm(data={'mac_address': '00:11:22:33:44:55'}, instance=mac)
+        simulate_restrict(form, 'interface', Interface.objects.none())
+
+        self.assertTrue(form.fields['interface'].disabled)
+        self.assertEqual(form['interface'].value(), self.interface.pk)
+        self.assertTrue(form.is_valid(), form.errors)
+        mac = form.save()
+        self.assertEqual(mac.assigned_object, self.interface)
+
+    def test_inventoryitem_selector_resolves_current_assignment(self):
+        """The declared selectors resolve the assigned component only for the matching field."""
+        item = InventoryItem(device=self.device, name='Item 1')
+        item.component = self.interface
+        item.save()
+
+        form = InventoryItemForm(instance=item)
+        self.assertEqual(
+            form._get_restricted_queryset_field_current_objects('interface', Interface.objects.all()),
+            [self.interface],
+        )
+        self.assertEqual(
+            form._get_restricted_queryset_field_current_objects('powerport', PowerPort.objects.all()),
+            [],
+        )
+
+    def test_inventoryitem_hidden_component_is_preserved(self):
+        """Editing an inventory item whose component is hidden shows it disabled and preserves it on save."""
+        item = InventoryItem(device=self.device, name='Item 1')
+        item.component = self.interface
+        item.save()
+
+        form = InventoryItemForm(
+            data={'device': self.device.pk, 'name': 'Item 1', 'status': 'active'},
+            instance=item,
+        )
+        simulate_restrict(form, 'interface', Interface.objects.none())
+
+        self.assertTrue(form.fields['interface'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        item = form.save()
+        self.assertEqual(item.component, self.interface)
+
+    def test_inventoryitem_cross_selector_submission_cannot_replace_hidden_component(self):
+        """A value submitted for a sibling selector cannot silently replace a hidden component."""
+        item = InventoryItem(device=self.device, name='Item 1')
+        item.component = self.interface
+        item.save()
+        powerport = PowerPort.objects.create(device=self.device, name='psu0')
+
+        form = InventoryItemForm(
+            data={'device': self.device.pk, 'name': 'Item 1', 'status': 'active', 'powerport': powerport.pk},
+            instance=item,
+        )
+        simulate_restrict(form, 'interface', Interface.objects.none())
+
+        # The locked hidden interface plus the submitted sibling trip the single-assignment guard.
+        self.assertFalse(form.is_valid())
+        self.assertIn('__all__', form.errors)
+        self.assertEqual(InventoryItem.objects.get(pk=item.pk).component, self.interface)
+
+    def test_inventoryitemtemplate_hidden_component_is_preserved(self):
+        """Editing an inventory item template whose component is hidden preserves it on save."""
+        device_type = self.device.device_type
+        template = InterfaceTemplate.objects.create(device_type=device_type, name='eth0', type='1000base-t')
+        item = InventoryItemTemplate(device_type=device_type, name='Item 1')
+        item.component = template
+        item.save()
+
+        form = InventoryItemTemplateForm(
+            data={'device_type': device_type.pk, 'name': 'Item 1'},
+            instance=item,
+        )
+        simulate_restrict(form, 'interfacetemplate', InterfaceTemplate.objects.none())
+
+        self.assertTrue(form.fields['interfacetemplate'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        item = form.save()
+        self.assertEqual(item.component, template)
+
+
+class RestrictedEditViewTest(TestCase):
+
+    def setUp(self):
+        super().setUp()
+        self.visible_tag = Tag.objects.create(name='VisibleTagAlpha', slug='visible-tag-alpha')
+        self.hidden_tag = Tag.objects.create(name='HiddenTagBravo', slug='hidden-tag-bravo')
+        self.site = Site.objects.create(name='Site 1', slug='site-1', status='active')
+        self.site.tags.set([self.visible_tag, self.hidden_tag])
+
+    def _grant(self):
+        # Allow editing the site, but only viewing the single visible tag (all tenants remain hidden).
+        self.add_permissions('dcim.view_site', 'dcim.change_site')
+        obj_perm = ObjectPermission(
+            name='View visible tag only',
+            constraints={'pk': self.visible_tag.pk},
+            actions=['view'],
+        )
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(ObjectType.objects.get_for_model(Tag))
+
+    def _edit_url(self):
+        return reverse('dcim:site_edit', kwargs={'pk': self.site.pk})
+
+    def test_edit_preserves_restricted_tag(self):
+        """Keeping the visible tag preserves the restricted tag too."""
+        self._grant()
+        data = {'name': self.site.name, 'slug': self.site.slug, 'status': 'active', 'tags': [self.visible_tag.pk]}
+        response = self.client.post(self._edit_url(), data)
+
+        self.assertEqual(response.status_code, 302)
+        self.site.refresh_from_db()
+        self.assertEqual(
+            set(self.site.tags.values_list('pk', flat=True)),
+            {self.visible_tag.pk, self.hidden_tag.pk}
+        )
+
+    def test_edit_can_remove_visible_tag_while_restricted_preserved(self):
+        """Removing the visible tag drops only it; the restricted tag is preserved."""
+        self._grant()
+        data = {'name': self.site.name, 'slug': self.site.slug, 'status': 'active', 'tags': []}
+        response = self.client.post(self._edit_url(), data)
+
+        self.assertEqual(response.status_code, 302)
+        self.site.refresh_from_db()
+        self.assertEqual(set(self.site.tags.values_list('pk', flat=True)), {self.hidden_tag.pk})
+
+    def test_edit_preserves_hidden_tenant(self):
+        """A scalar value the user cannot view is preserved across an edit."""
+        tenant = Tenant.objects.create(name='SecretTenantDelta', slug='secret-tenant-delta')
+        self.site.tenant = tenant
+        self.site.save()
+        self._grant()
+
+        data = {'name': self.site.name, 'slug': self.site.slug, 'status': 'active', 'tags': [self.visible_tag.pk]}
+        response = self.client.post(self._edit_url(), data)
+
+        self.assertEqual(response.status_code, 302)
+        self.site.refresh_from_db()
+        self.assertEqual(self.site.tenant, tenant)
+
+    def test_get_shows_restricted_values_disabled(self):
+        """The edit form renders the restricted current values read-only with explanatory help text."""
+        tenant = Tenant.objects.create(name='SecretTenantDelta', slug='secret-tenant-delta')
+        self.site.tenant = tenant
+        self.site.save()
+        self._grant()
+
+        response = self.client.get(self._edit_url())
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+
+        # The current restricted values are now shown read-only.
+        self.assertIn('HiddenTagBravo', content)
+        self.assertIn('SecretTenantDelta', content)
+        self.assertIn('disabled="disabled"', content)
+        self.assertIn('restricted values that cannot be changed', content)
+
+
+class RestrictedTypeDrivenSelectorTest(TestCase):
+    """Forms whose selector model is chosen by a paired content-type field preserve hidden current values."""
+
+    def setUp(self):
+        super().setUp()
+        # The user may edit, but has no view permission on the related models, so their values are hidden.
+        self.add_permissions(
+            'ipam.add_service', 'ipam.change_service',
+            'ipam.add_vlangroup', 'ipam.change_vlangroup',
+            'vpn.add_tunneltermination', 'vpn.change_tunneltermination',
+            'circuits.add_circuittermination', 'circuits.change_circuittermination',
+            'circuits.add_circuitgroupassignment', 'circuits.change_circuitgroupassignment',
+            'extras.add_eventrule', 'extras.change_eventrule',
+            'ipam.add_prefix', 'ipam.change_prefix',
+            'wireless.add_wirelesslan', 'wireless.change_wirelesslan',
+            'virtualization.add_cluster', 'virtualization.change_cluster',
+        )
+        self.device = create_test_device('Device 1')
+        self.interface = Interface.objects.create(device=self.device, name='eth0', type='1000base-t')
+
+    def test_service_parent_hidden_is_preserved(self):
+        """A Service whose parent device is hidden keeps that parent on save."""
+        service = Service.objects.create(name='svc', protocol='tcp', ports=[80], parent=self.device)
+        device_ct = ObjectType.objects.get_for_model(Device)
+
+        form = ServiceForm(
+            data={'name': 'svc', 'protocol': 'tcp', 'ports': '80', 'parent_object_type': device_ct.pk},
+            instance=service,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['parent'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        service = form.save()
+        self.assertEqual(service.parent, self.device)
+
+    def test_service_parent_type_tamper_is_blocked(self):
+        """Switching parent_object_type while the current parent is hidden cannot drop or remap the parent."""
+        service = Service.objects.create(name='svc', protocol='tcp', ports=[80], parent=self.device)
+        vm_ct = ObjectType.objects.get_for_model(VirtualMachine)
+
+        form = ServiceForm(
+            # Tampered: claim the parent is now a VirtualMachine, with no parent selected.
+            data={'name': 'svc', 'protocol': 'tcp', 'ports': '80', 'parent_object_type': vm_ct.pk, 'parent': ''},
+            instance=service,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['parent'].disabled)
+        self.assertTrue(form.fields['parent_object_type'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        service = form.save()
+        self.assertEqual(service.parent, self.device)
+        self.assertEqual(service.parent_object_type.model_class(), Device)
+
+    def test_vlangroup_scope_hidden_is_preserved(self):
+        """A VLANGroup whose scope site is hidden keeps that scope on save."""
+        site = Site.objects.create(name='Scope Site', slug='scope-site')
+        group = VLANGroup.objects.create(name='Group 1', slug='group-1', scope=site)
+        site_ct = ObjectType.objects.get_for_model(Site)
+
+        form = VLANGroupForm(
+            data={'name': 'Group 1', 'slug': 'group-1', 'vid_ranges': '1-100', 'scope_type': site_ct.pk},
+            instance=group,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['scope'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        group = form.save()
+        self.assertEqual(group.scope, site)
+
+    def test_tunneltermination_hidden_is_preserved(self):
+        """A TunnelTermination whose interface is hidden keeps that termination on save."""
+        tunnel = Tunnel.objects.create(name='Tunnel 1', encapsulation='gre', status='active')
+        termination = TunnelTermination.objects.create(tunnel=tunnel, role='peer', termination=self.interface)
+
+        form = TunnelTerminationForm(
+            data={'tunnel': tunnel.pk, 'role': 'peer', 'type': TunnelTerminationTypeChoices.TYPE_DEVICE},
+            instance=termination,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['termination'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        termination = form.save()
+        self.assertEqual(termination.termination, self.interface)
+
+    def test_tunneltermination_type_tamper_is_blocked(self):
+        """Switching the termination type while the interface is hidden cannot drop or remap it."""
+        tunnel = Tunnel.objects.create(name='Tunnel 1', encapsulation='gre', status='active')
+        termination = TunnelTermination.objects.create(tunnel=tunnel, role='peer', termination=self.interface)
+
+        form = TunnelTerminationForm(
+            # Tampered: claim a virtual-machine termination, with nothing selected.
+            data={
+                'tunnel': tunnel.pk, 'role': 'peer',
+                'type': TunnelTerminationTypeChoices.TYPE_VIRTUALMACHINE, 'parent': '', 'termination': '',
+            },
+            instance=termination,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['termination'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        termination = form.save()
+        self.assertEqual(termination.termination, self.interface)
+
+    def test_circuittermination_hidden_is_preserved(self):
+        """A CircuitTermination whose terminating site is hidden keeps that termination on save."""
+        self.add_permissions('circuits.view_circuit')
+        provider = Provider.objects.create(name='Provider 1', slug='provider-1')
+        circuit_type = CircuitType.objects.create(name='Type 1', slug='type-1')
+        circuit = Circuit.objects.create(provider=provider, type=circuit_type, cid='Circuit 1')
+        site = Site.objects.create(name='Term Site', slug='term-site')
+        termination = CircuitTermination.objects.create(circuit=circuit, term_side='A', termination=site)
+        site_ct = ObjectType.objects.get_for_model(Site)
+
+        form = CircuitTerminationForm(
+            data={'circuit': circuit.pk, 'term_side': 'A', 'termination_type': site_ct.pk},
+            instance=termination,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['termination'].disabled)
+        self.assertTrue(form.fields['termination_type'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        termination = form.save()
+        self.assertEqual(termination.termination, site)
+
+    def test_circuittermination_type_tamper_is_blocked(self):
+        """Switching termination_type while the current termination is hidden cannot drop or remap it."""
+        self.add_permissions('circuits.view_circuit')
+        provider = Provider.objects.create(name='Provider 1', slug='provider-1')
+        circuit_type = CircuitType.objects.create(name='Type 1', slug='type-1')
+        circuit = Circuit.objects.create(provider=provider, type=circuit_type, cid='Circuit 1')
+        site = Site.objects.create(name='Term Site', slug='term-site')
+        termination = CircuitTermination.objects.create(circuit=circuit, term_side='A', termination=site)
+        providernetwork_ct = ObjectType.objects.get_for_model(ProviderNetwork)
+
+        form = CircuitTerminationForm(
+            # Tampered: claim a provider-network termination, with nothing selected.
+            data={
+                'circuit': circuit.pk, 'term_side': 'A',
+                'termination_type': providernetwork_ct.pk, 'termination': '',
+            },
+            instance=termination,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['termination'].disabled)
+        self.assertTrue(form.fields['termination_type'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        termination = form.save()
+        self.assertEqual(termination.termination, site)
+        self.assertEqual(termination.termination_type.model_class(), Site)
+
+    def test_circuitgroupassignment_hidden_is_preserved(self):
+        """A group assignment whose member circuit is hidden keeps that member on save."""
+        self.add_permissions('circuits.view_circuitgroup')
+        provider = Provider.objects.create(name='Provider 1', slug='provider-1')
+        circuit_type = CircuitType.objects.create(name='Type 1', slug='type-1')
+        circuit = Circuit.objects.create(provider=provider, type=circuit_type, cid='Circuit 1')
+        group = CircuitGroup.objects.create(name='Group 1', slug='group-1')
+        assignment = CircuitGroupAssignment.objects.create(group=group, member=circuit)
+        circuit_ct = ObjectType.objects.get_for_model(Circuit)
+
+        form = CircuitGroupAssignmentForm(
+            data={'group': group.pk, 'member_type': circuit_ct.pk},
+            instance=assignment,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['member'].disabled)
+        self.assertTrue(form.fields['member_type'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        assignment = form.save()
+        self.assertEqual(assignment.member, circuit)
+
+    def test_circuitgroupassignment_type_tamper_is_blocked(self):
+        """Switching member_type while the current member is hidden cannot drop or remap it."""
+        self.add_permissions('circuits.view_circuitgroup')
+        provider = Provider.objects.create(name='Provider 1', slug='provider-1')
+        circuit_type = CircuitType.objects.create(name='Type 1', slug='type-1')
+        circuit = Circuit.objects.create(provider=provider, type=circuit_type, cid='Circuit 1')
+        group = CircuitGroup.objects.create(name='Group 1', slug='group-1')
+        assignment = CircuitGroupAssignment.objects.create(group=group, member=circuit)
+        virtualcircuit_ct = ObjectType.objects.get_for_model(VirtualCircuit)
+
+        form = CircuitGroupAssignmentForm(
+            # Tampered: claim a virtual-circuit member, with nothing selected.
+            data={'group': group.pk, 'member_type': virtualcircuit_ct.pk, 'member': ''},
+            instance=assignment,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['member'].disabled)
+        self.assertTrue(form.fields['member_type'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        assignment = form.save()
+        self.assertEqual(assignment.member, circuit)
+        self.assertEqual(assignment.member_type.model_class(), Circuit)
+
+    def test_eventrule_hidden_webhook_is_preserved(self):
+        """An EventRule whose webhook is hidden keeps its action object on save."""
+        webhook = Webhook.objects.create(name='Webhook 1', payload_url='http://example.com/')
+        rule = EventRule.objects.create(
+            name='Rule 1',
+            action_type=EventRuleActionChoices.WEBHOOK,
+            action_object=webhook,
+            event_types=['object_created'],
+        )
+        site_ot = ObjectType.objects.get_for_model(Site)
+        rule.object_types.set([site_ot])
+
+        form = EventRuleForm(
+            data={
+                'name': 'Rule 1',
+                'object_types': [site_ot.pk],
+                'event_types': ['object_created'],
+                'action_type': EventRuleActionChoices.WEBHOOK,
+            },
+            instance=rule,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['action_choice'].disabled)
+        self.assertTrue(form.fields['action_type'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        rule = EventRule.objects.get(pk=rule.pk)
+        self.assertEqual(rule.action_object, webhook)
+
+    def test_eventrule_action_type_tamper_is_blocked(self):
+        """Switching action_type while the action object is hidden cannot remap the action."""
+        webhook = Webhook.objects.create(name='Webhook 1', payload_url='http://example.com/')
+        rule = EventRule.objects.create(
+            name='Rule 1',
+            action_type=EventRuleActionChoices.WEBHOOK,
+            action_object=webhook,
+            event_types=['object_created'],
+        )
+        site_ot = ObjectType.objects.get_for_model(Site)
+        rule.object_types.set([site_ot])
+        group = NotificationGroup.objects.create(name='Group 1')
+
+        form = EventRuleForm(
+            # Tampered: claim a notification action targeting another object.
+            data={
+                'name': 'Rule 1',
+                'object_types': [site_ot.pk],
+                'event_types': ['object_created'],
+                'action_type': EventRuleActionChoices.NOTIFICATION,
+                'action_choice': group.pk,
+            },
+            instance=rule,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['action_choice'].disabled)
+        self.assertTrue(form.fields['action_type'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        form.save()
+        rule = EventRule.objects.get(pk=rule.pk)
+        self.assertEqual(rule.action_object, webhook)
+        self.assertEqual(rule.action_object_type.model_class(), Webhook)
+        self.assertEqual(rule.action_object_id, webhook.pk)
+
+    def test_vlangroup_scope_type_blank_tamper_is_blocked(self):
+        """Blanking the optional scope_type cannot drop a hidden scope."""
+        site = Site.objects.create(name='Scope Site', slug='scope-site')
+        group = VLANGroup.objects.create(name='Group 1', slug='group-1', scope=site)
+
+        form = VLANGroupForm(
+            data={'name': 'Group 1', 'slug': 'group-1', 'vid_ranges': '1-100', 'scope_type': '', 'scope': ''},
+            instance=group,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['scope'].disabled)
+        self.assertTrue(form.fields['scope_type'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        group = form.save()
+        self.assertEqual(group.scope, site)
+        self.assertEqual(group.scope_type.model_class(), Site)
+
+    def test_circuitgroupassignment_member_type_blank_tamper_is_blocked(self):
+        """Blanking the optional member_type cannot drop a hidden member circuit."""
+        self.add_permissions('circuits.view_circuitgroup')
+        provider = Provider.objects.create(name='Provider 1', slug='provider-1')
+        circuit_type = CircuitType.objects.create(name='Type 1', slug='type-1')
+        circuit = Circuit.objects.create(provider=provider, type=circuit_type, cid='Circuit 1')
+        group = CircuitGroup.objects.create(name='Group 1', slug='group-1')
+        assignment = CircuitGroupAssignment.objects.create(group=group, member=circuit)
+
+        form = CircuitGroupAssignmentForm(
+            data={'group': group.pk, 'member_type': '', 'member': ''},
+            instance=assignment,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['member'].disabled)
+        self.assertTrue(form.fields['member_type'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        assignment = form.save()
+        self.assertEqual(assignment.member, circuit)
+        self.assertEqual(assignment.member_type.model_class(), Circuit)
+
+    def test_prefix_scope_blank_tamper_is_blocked(self):
+        """PrefixForm inherits the scope selector from ScopedForm via the MRO; blanking scope_type cannot drop it."""
+        site = Site.objects.create(name='Scope Site', slug='scope-site')
+        prefix = Prefix.objects.create(prefix='10.0.0.0/24', scope=site)
+
+        form = PrefixForm(
+            data={'prefix': '10.0.0.0/24', 'status': 'active', 'scope_type': '', 'scope': ''},
+            instance=prefix,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['scope'].disabled)
+        self.assertTrue(form.fields['scope_type'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        prefix = form.save()
+        self.assertEqual(prefix.scope, site)
+        self.assertEqual(prefix.scope_type.model_class(), Site)
+
+    def test_wirelesslan_scope_blank_tamper_is_blocked(self):
+        """WirelessLANForm inherits the scope selector from ScopedForm; blanking scope_type cannot drop it."""
+        site = Site.objects.create(name='Scope Site', slug='scope-site')
+        wireless_lan = WirelessLAN.objects.create(ssid='WLAN 1', scope=site)
+
+        form = WirelessLANForm(
+            data={'ssid': 'WLAN 1', 'status': 'active', 'scope_type': '', 'scope': ''},
+            instance=wireless_lan,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['scope'].disabled)
+        self.assertTrue(form.fields['scope_type'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        wireless_lan = form.save()
+        self.assertEqual(wireless_lan.scope, site)
+        self.assertEqual(wireless_lan.scope_type.model_class(), Site)
+
+    def test_cluster_scope_blank_tamper_is_blocked(self):
+        """ClusterForm inherits the scope selector from ScopedForm; blanking scope_type cannot drop it."""
+        self.add_permissions('virtualization.view_clustertype')
+        site = Site.objects.create(name='Scope Site', slug='scope-site')
+        cluster_type = ClusterType.objects.create(name='Cluster Type 1', slug='cluster-type-1')
+        cluster = Cluster.objects.create(name='Cluster 1', type=cluster_type, scope=site)
+
+        form = ClusterForm(
+            data={
+                'name': 'Cluster 1', 'type': cluster_type.pk, 'status': 'active', 'scope_type': '', 'scope': '',
+            },
+            instance=cluster,
+        )
+        restrict_form_fields(form, self.user)
+
+        self.assertTrue(form.fields['scope'].disabled)
+        self.assertTrue(form.fields['scope_type'].disabled)
+        self.assertTrue(form.is_valid(), form.errors)
+        cluster = form.save()
+        self.assertEqual(cluster.scope, site)
+        self.assertEqual(cluster.scope_type.model_class(), Site)
+
+
+class RestrictedSelectorMergeBaseForm(NetBoxModelForm):
+    restricted_related_selectors = {'scope': {'path': 'scope'}}
+
+    class Meta:
+        model = Site
+        fields = ('name', 'slug', 'status')
+
+
+class RestrictedSelectorMergeChildForm(RestrictedSelectorMergeBaseForm):
+    restricted_related_selectors = {'extra': {'path': 'extra'}}
+
+    class Meta:
+        model = Site
+        fields = ('name', 'slug', 'status')
+
+
+class RestrictedSelectorMergeTest(DjangoTestCase):
+    """__init_subclass__ merges restricted_related_selectors across the MRO instead of overriding."""
+
+    def test_subclass_merges_inherited_selectors(self):
+        # The child keeps the base's 'scope' selector while adding its own 'extra'.
+        self.assertEqual(
+            set(RestrictedSelectorMergeChildForm.restricted_related_selectors),
+            {'scope', 'extra'},
+        )

--- a/netbox/users/forms/model_forms.py
+++ b/netbox/users/forms/model_forms.py
@@ -13,6 +13,7 @@ from core.models import ObjectType
 from ipam.formfields import IPNetworkFormField
 from ipam.validators import prefix_validator
 from netbox.config import get_config
+from netbox.forms.mixins import RestrictedRelatedFieldsMixin
 from netbox.preferences import PREFERENCES
 from netbox.registry import registry
 from users.choices import TokenVersionChoices
@@ -204,7 +205,7 @@ class TokenForm(UserTokenForm):
         return self.cleaned_data
 
 
-class UserForm(forms.ModelForm):
+class UserForm(RestrictedRelatedFieldsMixin, forms.ModelForm):
     password = forms.CharField(
         label=_('Password'),
         widget=forms.PasswordInput(),
@@ -260,6 +261,7 @@ class UserForm(forms.ModelForm):
         return instance
 
     def clean(self):
+        self._merge_restricted_preserved_members()
 
         # Check that password confirmation matches if password is set
         if self.cleaned_data['password'] and self.cleaned_data['password'] != self.cleaned_data['confirm_password']:
@@ -270,7 +272,7 @@ class UserForm(forms.ModelForm):
             password_validation.validate_password(self.cleaned_data['password'], self.instance)
 
 
-class GroupForm(forms.ModelForm):
+class GroupForm(RestrictedRelatedFieldsMixin, forms.ModelForm):
     users = DynamicModelMultipleChoiceField(
         label=_('Users'),
         required=False,
@@ -300,6 +302,11 @@ class GroupForm(forms.ModelForm):
         # Populate assigned users and permissions
         if self.instance.pk:
             self.fields['users'].initial = self.instance.users.values_list('id', flat=True)
+
+    def clean(self):
+        super().clean()
+        self._merge_restricted_preserved_members()
+        return self.cleaned_data
 
     def save(self, *args, **kwargs):
         instance = super().save(*args, **kwargs)
@@ -331,7 +338,7 @@ def get_object_types_choices():
     return list(choices_by_app.items())
 
 
-class ObjectPermissionForm(forms.ModelForm):
+class ObjectPermissionForm(RestrictedRelatedFieldsMixin, forms.ModelForm):
     object_types = ContentTypeMultipleChoiceField(
         label=_('Object types'),
         queryset=ObjectType.objects.all(),
@@ -482,6 +489,7 @@ class ObjectPermissionForm(forms.ModelForm):
 
     def clean(self):
         super().clean()
+        self._merge_restricted_preserved_members()
 
         object_types = self.cleaned_data.get('object_types', [])
         constraints = self.cleaned_data.get('constraints')
@@ -551,7 +559,7 @@ class OwnerGroupForm(forms.ModelForm):
         ]
 
 
-class OwnerForm(forms.ModelForm):
+class OwnerForm(RestrictedRelatedFieldsMixin, forms.ModelForm):
     fieldsets = (
         FieldSet('name', 'group', 'description', name=_('Owner')),
         FieldSet('user_groups', name=_('Groups')),
@@ -580,3 +588,8 @@ class OwnerForm(forms.ModelForm):
         fields = [
             'name', 'group', 'description', 'user_groups', 'users',
         ]
+
+    def clean(self):
+        super().clean()
+        self._merge_restricted_preserved_members()
+        return self.cleaned_data

--- a/netbox/users/tests/test_forms.py
+++ b/netbox/users/tests/test_forms.py
@@ -1,0 +1,71 @@
+from django.test import TestCase
+
+from core.models import ObjectType
+from dcim.models import Site
+from users.forms import GroupForm, ObjectPermissionForm, OwnerForm, UserForm
+from users.models import Group, ObjectPermission, Owner, User
+from utilities.testing import simulate_restrict
+
+
+class RestrictedUsersFormTest(TestCase):
+    """Users-app M2M forms (not NetBoxModelForms) preserve hidden members via the mixin + clean() merge."""
+
+    def test_userform_hidden_group_is_preserved(self):
+        """Editing a user with a hidden group keeps it on save (Meta.fields save_m2m path)."""
+        visible = Group.objects.create(name='Visible')
+        hidden = Group.objects.create(name='Hidden')
+        user = User.objects.create(username='user1')
+        user.groups.set([visible, hidden])
+
+        form = UserForm(data={'username': 'user1', 'groups': [visible.pk]}, instance=user)
+        simulate_restrict(form, 'groups', Group.objects.filter(pk=visible.pk))
+        self.assertTrue(form.is_valid(), form.errors)
+        user = form.save()
+        self.assertEqual(set(user.groups.all()), {visible, hidden})
+
+    def test_groupform_hidden_user_is_preserved(self):
+        """Editing a group with a hidden member keeps it on save (custom .set() path)."""
+        visible = User.objects.create(username='visible')
+        hidden = User.objects.create(username='hidden')
+        group = Group.objects.create(name='Group 1')
+        group.users.set([visible, hidden])
+
+        form = GroupForm(data={'name': 'Group 1', 'users': [visible.pk]}, instance=group)
+        simulate_restrict(form, 'users', User.objects.filter(pk=visible.pk))
+        self.assertTrue(form.is_valid(), form.errors)
+        group = form.save()
+        self.assertEqual(set(group.users.all()), {visible, hidden})
+
+    def test_objectpermissionform_hidden_user_is_preserved(self):
+        """Editing an object permission with a hidden user keeps it on save (custom .set() path)."""
+        visible = User.objects.create(username='visible')
+        hidden = User.objects.create(username='hidden')
+        perm = ObjectPermission.objects.create(name='Perm 1', actions=['view'])
+        perm.users.set([visible, hidden])
+
+        form = ObjectPermissionForm(
+            data={
+                'name': 'Perm 1',
+                'object_types_1': [ObjectType.objects.get_for_model(Site).pk],
+                'actions': 'view',
+                'users': [visible.pk],
+            },
+            instance=perm,
+        )
+        simulate_restrict(form, 'users', User.objects.filter(pk=visible.pk))
+        self.assertTrue(form.is_valid(), form.errors)
+        perm = form.save()
+        self.assertEqual(set(perm.users.all()), {visible, hidden})
+
+    def test_ownerform_hidden_user_group_is_preserved(self):
+        """Editing an owner with a hidden user group keeps it on save (Meta.fields save_m2m path)."""
+        visible = Group.objects.create(name='Visible')
+        hidden = Group.objects.create(name='Hidden')
+        owner = Owner.objects.create(name='Owner 1')
+        owner.user_groups.set([visible, hidden])
+
+        form = OwnerForm(data={'name': 'Owner 1', 'user_groups': [visible.pk]}, instance=owner)
+        simulate_restrict(form, 'user_groups', Group.objects.filter(pk=visible.pk))
+        self.assertTrue(form.is_valid(), form.errors)
+        owner = form.save()
+        self.assertEqual(set(owner.user_groups.all()), {visible, hidden})

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -219,10 +219,32 @@ def restrict_form_fields(form, user, action='view'):
     """
     Restrict all form fields which reference a RestrictedQuerySet. This ensures that users see only permitted objects
     as available choices.
+
+    Forms may optionally expose already-assigned values which were removed by permission filtering as read-only. This
+    is handled by the form: only values already assigned to the current instance are added back (never the rest of the
+    original queryset), they are rendered read-only, and submitted/tampered values for them are ignored.
     """
-    for field in form.fields.values():
+    restricted_fields = {}
+
+    for name, field in form.fields.items():
         if hasattr(field, 'queryset') and issubclass(field.queryset.__class__, RestrictedQuerySet):
-            field.queryset = field.queryset.restrict(user, action)
+            original_queryset = field.queryset
+            restricted_queryset = original_queryset.restrict(user, action)
+            field.queryset = restricted_queryset
+            # restrict() returns the same queryset object (identity unchanged) whenever no row-level restriction
+            # applies: superusers, permission-exempt models, and users who hold the permission with no attribute
+            # constraints all fall through to `return self`. Those fields are excluded here by the identity check
+            # below. A field is recorded only when restrict() narrows the queryset to a new object;
+            # prepare_restricted_queryset_fields() then locks a value only when it is genuinely hidden.
+            if restricted_queryset is not original_queryset:
+                restricted_fields[name] = original_queryset
+
+    if (
+        restricted_fields and
+        getattr(getattr(form, 'instance', None), 'pk', None) and
+        hasattr(form, 'prepare_restricted_queryset_fields')
+    ):
+        form.prepare_restricted_queryset_fields(restricted_fields, user=user, action=action)
 
 
 def parse_csv(reader):

--- a/netbox/utilities/forms/widgets/misc.py
+++ b/netbox/utilities/forms/widgets/misc.py
@@ -6,6 +6,7 @@ __all__ = (
     'ClearableFileInput',
     'MarkdownWidget',
     'NumberWithOptions',
+    'RestrictedChoiceLabel',
     'SlugWidget',
 )
 
@@ -85,3 +86,18 @@ class ChoicesWidget(forms.Textarea):
         if type(value) is list:
             return '\n'.join([f'{k}:{v}' for k, v in value])
         return value
+
+
+class RestrictedChoiceLabel:
+    """
+    Wraps a choice label so widgets/select_option.html renders that single <option> as disabled. Used to identify a
+    restricted current value as read-only in widgets which honor disabled options. Preservation itself is enforced
+    server-side, not by the widget.
+    """
+    disabled = True
+
+    def __init__(self, label):
+        self.label = label
+
+    def __str__(self):
+        return str(self.label)

--- a/netbox/utilities/templates/widgets/select_option.html
+++ b/netbox/utilities/templates/widgets/select_option.html
@@ -1,1 +1,6 @@
+{% comment %}
+A RestrictedChoiceLabel (netbox.forms.model_forms) sets label.disabled=True to render its single <option> as
+disabled, marking a restricted current value read-only. Preservation is enforced server-side, not by this attribute.
+Any label object exposing a truthy .disabled triggers this; plain string labels never do.
+{% endcomment %}
 <option value="{{ widget.value }}"{% include "django/forms/widgets/attrs.html" %}{% if widget.label.disabled %} disabled="disabled"{% endif %}>{{ widget.label.label|default:widget.label }}</option>

--- a/netbox/utilities/testing/utils.py
+++ b/netbox/utilities/testing/utils.py
@@ -41,6 +41,18 @@ def post_data(data):
     return ret
 
 
+def simulate_restrict(form, field_name, restricted_queryset, original_queryset=None):
+    """
+    Stand in for restrict_form_fields() in a form unit test: record the original (pre-restriction) queryset, swap in
+    the restricted one, then prepare the read-only display. `original_queryset` defaults to the field's current
+    queryset. The form must expose prepare_restricted_queryset_fields() (i.e. use RestrictedRelatedFieldsMixin).
+    """
+    if original_queryset is None:
+        original_queryset = form.fields[field_name].queryset
+    form.fields[field_name].queryset = restricted_queryset
+    form.prepare_restricted_queryset_fields({field_name: original_queryset})
+
+
 def create_test_device(name, site=None, **attrs):
     """
     Convenience method for creating a Device (e.g. for component testing).

--- a/netbox/vpn/forms/model_forms.py
+++ b/netbox/vpn/forms/model_forms.py
@@ -253,6 +253,13 @@ class TunnelTerminationForm(NetBoxModelForm):
         FieldSet('tunnel', 'role', 'type', 'parent', 'termination', 'outside_ip', 'tags'),
     )
 
+    # type is not locked: clean() writes instance.termination from the locked selector and never branches on it.
+    restricted_related_selectors = {
+        'termination': {'path': 'termination'},
+        # parent is an auxiliary selector for the device or VM owning the termination.
+        'parent': {'path': 'termination.parent_object'},
+    }
+
     class Meta:
         model = TunnelTermination
         fields = [
@@ -454,6 +461,13 @@ class L2VPNTerminationForm(NetBoxModelForm):
             'tags',
         ),
     )
+
+    restricted_related_selectors = {
+        # The selectors are stored as the assigned_object GenericForeignKey; the model picks the matching one.
+        'interface': {'path': 'assigned_object', 'model': Interface},
+        'vminterface': {'path': 'assigned_object', 'model': VMInterface},
+        'vlan': {'path': 'assigned_object', 'model': VLAN},
+    }
 
     class Meta:
         model = L2VPNTermination


### PR DESCRIPTION
### Closes: netbox-community/netbox#18987

Add read-only preservation of related object values hidden by object permissions. Single-value fields are disabled entirely; multi-value fields remain editable for visible values while restricted current values appear as disabled options and are merged back on save.

Fixes data loss when users edit objects with related values they cannot view, such as tags or tenants constrained by permissions.