### PR TITLE
Closes #22349: Correct documentation to reflect minimum Redis version of 5.0

### DIFF
--- a/docs/installation/2-redis.md
+++ b/docs/installation/2-redis.md
@@ -8,7 +8,7 @@
 sudo apt install -y redis-server
 ```
 
-Before continuing, verify that your installed version of Redis is at least v4.0:
+Before continuing, verify that your installed version of Redis is at least v5.0:
 
 ```no-highlight
 redis-server -v

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -29,7 +29,7 @@ The following sections detail how to set up a new instance of NetBox:
 |------------|--------------------|
 | Python     | 3.12, 3.13, 3.14   |
 | PostgreSQL | 14+ [^1]           |
-| Redis      | 4.0+               |
+| Redis      | 5.0+               |
 
 [^1]: Support for PostgreSQL 14 is deprecated and will be removed in NetBox v4.7. PostgreSQL 15 or later will be required.
 

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -34,7 +34,7 @@ NetBox requires the following dependencies:
 |------------|--------------------|
 | Python     | 3.12, 3.13, 3.14   |
 | PostgreSQL | 14+ [^1]           |
-| Redis      | 4.0+               |
+| Redis      | 5.0+               |
 
 [^1]: Support for PostgreSQL 14 is deprecated and will be removed in NetBox v4.7. PostgreSQL 15 or later will be required.
 
@@ -42,10 +42,10 @@ NetBox requires the following dependencies:
 
 | NetBox Version | Python min | Python max | PostgreSQL min | Redis min |                                       Documentation                                       |
 |:--------------:|:----------:|:----------:|:--------------:|:---------:|:-----------------------------------------------------------------------------------------:|
-|      4.6       |    3.12    |    3.14    |       14       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.6.0/docs/installation/index.md) |
-|      4.5       |    3.12    |    3.14    |       14       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.5.0/docs/installation/index.md) |
-|      4.4       |    3.10    |    3.12    |       14       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.4.0/docs/installation/index.md) |
-|      4.3       |    3.10    |    3.12    |       14       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.3.0/docs/installation/index.md) |
+|      4.6       |    3.12    |    3.14    |       14       |    5.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.6.0/docs/installation/index.md) |
+|      4.5       |    3.12    |    3.14    |       14       |    5.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.5.0/docs/installation/index.md) |
+|      4.4       |    3.10    |    3.12    |       14       |    5.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.4.0/docs/installation/index.md) |
+|      4.3       |    3.10    |    3.12    |       14       |    5.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.3.0/docs/installation/index.md) |
 |      4.2       |    3.10    |    3.12    |       13       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.2.0/docs/installation/index.md) |
 |      4.1       |    3.10    |    3.12    |       12       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.1.0/docs/installation/index.md) |
 |      4.0       |    3.10    |    3.12    |       12       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.0.0/docs/installation/index.md) |


### PR DESCRIPTION
### Fixes: #22349

Bump the minimum Redis version from 4.0 to 5.0 for NetBox v4.3+.