### PR TITLE
Fixes #22273 replace broken ArrayField index for service model

### DIFF
--- a/netbox/ipam/graphql/types.py
+++ b/netbox/ipam/graphql/types.py
@@ -264,7 +264,7 @@ class ServiceType(ContactsMixin, PrimaryObjectType):
 
 @strawberry_django.type(
     models.ServiceTemplate,
-    exclude=('_ports_lowest'),
+    exclude=('_ports_lowest',),
     filters=ServiceTemplateFilter,
     pagination=True
 )

--- a/netbox/ipam/graphql/types.py
+++ b/netbox/ipam/graphql/types.py
@@ -244,7 +244,7 @@ class RouteTargetType(PrimaryObjectType):
 
 @strawberry_django.type(
     models.Service,
-    exclude=('parent_object_type', 'parent_object_id'),
+    exclude=('_min_port', 'parent_object_type', 'parent_object_id'),
     filters=ServiceFilter,
     pagination=True
 )

--- a/netbox/ipam/graphql/types.py
+++ b/netbox/ipam/graphql/types.py
@@ -244,7 +244,7 @@ class RouteTargetType(PrimaryObjectType):
 
 @strawberry_django.type(
     models.Service,
-    exclude=('_min_port', 'parent_object_type', 'parent_object_id'),
+    exclude=('_ports_lowest', 'parent_object_type', 'parent_object_id'),
     filters=ServiceFilter,
     pagination=True
 )
@@ -264,7 +264,7 @@ class ServiceType(ContactsMixin, PrimaryObjectType):
 
 @strawberry_django.type(
     models.ServiceTemplate,
-    fields='__all__',
+    exclude=('_ports_lowest'),
     filters=ServiceTemplateFilter,
     pagination=True
 )

--- a/netbox/ipam/migrations/0089_default_ordering_indexes.py
+++ b/netbox/ipam/migrations/0089_default_ordering_indexes.py
@@ -32,9 +32,12 @@ class Migration(migrations.Migration):
             model_name='role',
             index=models.Index(fields=['weight', 'name'], name='ipam_role_weight_01396b_idx'),
         ),
+        # Adding a dummy index, to allow a safe migration in case updating users already have services
+        # with a large number of ports configured (see issue #22273)
+        # Will get removed in 0091_alter_service_index_and_ordering
         migrations.AddIndex(
             model_name='service',
-            index=models.Index(fields=['protocol', 'ports', 'id'], name='ipam_servic_protoco_687d13_idx'),
+            index=models.Index(fields=['id'], name='ipam_servic_protoco_687d13_idx'),
         ),
         migrations.AddIndex(
             model_name='vlangroup',

--- a/netbox/ipam/migrations/0091_alter_service_index_and_ordering.py
+++ b/netbox/ipam/migrations/0091_alter_service_index_and_ordering.py
@@ -1,0 +1,51 @@
+from django.db import migrations, models
+
+
+def populate__min_ports(apps, schema_editor):
+    Service = apps.get_model('ipam', 'Service')
+    CHUNK_SIZE = 500
+    chunk = []
+    service_objects = Service.objects.filter(_min_port__isnull=True).only('id', 'ports', '_min_port')
+    for service in service_objects.iterator(chunk_size=CHUNK_SIZE):
+        if service.ports:
+            service._min_port = min(service.ports)
+            chunk.append(service)
+
+        if len(chunk) >= CHUNK_SIZE:
+            Service.objects.bulk_update(chunk, ['_min_port'])
+            chunk = []
+    if chunk:
+        Service.objects.bulk_update(chunk, ['_min_port'])
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('ipam', '0090_vlangroup_recompute_total_vlan_ids'),
+    ]
+
+    operations = [
+        migrations.RemoveIndex(
+            model_name='service',
+            name='ipam_servic_protoco_687d13_idx',
+        ),
+        migrations.AddField(
+            model_name='service',
+            name='_min_port',
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+        migrations.RunPython(populate__min_ports, migrations.RunPython.noop),
+        migrations.AddIndex(
+            model_name='service',
+            index=models.Index(
+                fields=['name', 'protocol', '_min_port', 'id'],
+                name='ipam_servic_name_ef1f28_idx'
+            ),
+        ),
+        migrations.AlterModelOptions(
+            name='service',
+            options={
+                'ordering': ('name', 'protocol', '_min_port', 'id')
+            },
+        ),
+    ]

--- a/netbox/ipam/migrations/0091_alter_service_index_and_ordering.py
+++ b/netbox/ipam/migrations/0091_alter_service_index_and_ordering.py
@@ -1,21 +1,37 @@
 from django.db import migrations, models
 
 
-def populate__min_ports(apps, schema_editor):
+def populate__ports_lowest(apps, schema_editor):
+    # Populate Service
     Service = apps.get_model('ipam', 'Service')
     CHUNK_SIZE = 500
     chunk = []
-    service_objects = Service.objects.filter(_min_port__isnull=True).only('id', 'ports', '_min_port')
+    service_objects = Service.objects.filter(_ports_lowest__isnull=True).only('id', 'ports', '_ports_lowest')
     for service in service_objects.iterator(chunk_size=CHUNK_SIZE):
         if service.ports:
-            service._min_port = min(service.ports)
+            service._ports_lowest = min(service.ports)
             chunk.append(service)
 
         if len(chunk) >= CHUNK_SIZE:
-            Service.objects.bulk_update(chunk, ['_min_port'])
+            Service.objects.bulk_update(chunk, ['_ports_lowest'])
             chunk = []
     if chunk:
-        Service.objects.bulk_update(chunk, ['_min_port'])
+        Service.objects.bulk_update(chunk, ['_ports_lowest'])
+
+    # Populate ServiceTemplate
+    ServiceTemplate = apps.get_model('ipam', 'ServiceTemplate')
+    chunk = []
+    template_objects = ServiceTemplate.objects.filter(_ports_lowest__isnull=True).only('id', 'ports', '_ports_lowest')
+    for template in template_objects.iterator(chunk_size=CHUNK_SIZE):
+        if template.ports:
+            template._ports_lowest = min(template.ports)
+            chunk.append(template)
+
+        if len(chunk) >= CHUNK_SIZE:
+            ServiceTemplate.objects.bulk_update(chunk, ['_ports_lowest'])
+            chunk = []
+    if chunk:
+        ServiceTemplate.objects.bulk_update(chunk, ['_ports_lowest'])
 
 
 class Migration(migrations.Migration):
@@ -31,21 +47,26 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='service',
-            name='_min_port',
+            name='_ports_lowest',
             field=models.PositiveIntegerField(blank=True, null=True),
         ),
-        migrations.RunPython(populate__min_ports, migrations.RunPython.noop),
+        migrations.AddField(
+            model_name='servicetemplate',
+            name='_ports_lowest',
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+        migrations.RunPython(populate__ports_lowest, migrations.RunPython.noop),
         migrations.AddIndex(
             model_name='service',
             index=models.Index(
-                fields=['name', 'protocol', '_min_port', 'id'],
-                name='ipam_servic_name_ef1f28_idx'
+                fields=['protocol', '_ports_lowest', 'id'],
+                name='ipam_servic_protoco_e2901d_idx'
             ),
         ),
         migrations.AlterModelOptions(
             name='service',
             options={
-                'ordering': ('name', 'protocol', '_min_port', 'id')
+                'ordering': ('protocol', '_ports_lowest', 'id')
             },
         ),
     ]

--- a/netbox/ipam/migrations/0091_alter_service_index_and_ordering.py
+++ b/netbox/ipam/migrations/0091_alter_service_index_and_ordering.py
@@ -11,7 +11,7 @@ def populate__ports_lowest(apps, schema_editor):
         qs = model.objects.filter(_ports_lowest__isnull=True).only('id', 'ports', '_ports_lowest')
         for obj in qs.iterator(chunk_size=CHUNK_SIZE):
             if obj.ports:
-                obj._ports_lowest = min(service.ports)
+                obj._ports_lowest = min(obj.ports)
                 chunk.append(obj)
             if len(chunk) >= CHUNK_SIZE:
                 model.objects.bulk_update(chunk, ['_ports_lowest'])

--- a/netbox/ipam/migrations/0091_alter_service_index_and_ordering.py
+++ b/netbox/ipam/migrations/0091_alter_service_index_and_ordering.py
@@ -2,36 +2,22 @@ from django.db import migrations, models
 
 
 def populate__ports_lowest(apps, schema_editor):
-    # Populate Service
     Service = apps.get_model('ipam', 'Service')
-    CHUNK_SIZE = 500
-    chunk = []
-    service_objects = Service.objects.filter(_ports_lowest__isnull=True).only('id', 'ports', '_ports_lowest')
-    for service in service_objects.iterator(chunk_size=CHUNK_SIZE):
-        if service.ports:
-            service._ports_lowest = min(service.ports)
-            chunk.append(service)
-
-        if len(chunk) >= CHUNK_SIZE:
-            Service.objects.bulk_update(chunk, ['_ports_lowest'])
-            chunk = []
-    if chunk:
-        Service.objects.bulk_update(chunk, ['_ports_lowest'])
-
-    # Populate ServiceTemplate
     ServiceTemplate = apps.get_model('ipam', 'ServiceTemplate')
-    chunk = []
-    template_objects = ServiceTemplate.objects.filter(_ports_lowest__isnull=True).only('id', 'ports', '_ports_lowest')
-    for template in template_objects.iterator(chunk_size=CHUNK_SIZE):
-        if template.ports:
-            template._ports_lowest = min(template.ports)
-            chunk.append(template)
+    CHUNK_SIZE = 500
 
-        if len(chunk) >= CHUNK_SIZE:
-            ServiceTemplate.objects.bulk_update(chunk, ['_ports_lowest'])
-            chunk = []
-    if chunk:
-        ServiceTemplate.objects.bulk_update(chunk, ['_ports_lowest'])
+    for model in (Service, ServiceTemplate):
+        chunk = []
+        qs = model.objects.filter(_ports_lowest__isnull=True).only('id', 'ports', '_ports_lowest')
+        for obj in qs.iterator(chunk_size=CHUNK_SIZE):
+            if obj.ports:
+                obj._ports_lowest = min(service.ports)
+                chunk.append(obj)
+            if len(chunk) >= CHUNK_SIZE:
+                model.objects.bulk_update(chunk, ['_ports_lowest'])
+                chunk = []
+        if chunk:
+            model.objects.bulk_update(chunk, ['_ports_lowest'])
 
 
 class Migration(migrations.Migration):

--- a/netbox/ipam/models/services.py
+++ b/netbox/ipam/models/services.py
@@ -96,10 +96,7 @@ class Service(ContactsMixin, ServiceBase, PrimaryModel):
 
     def save(self, *args, **kwargs):
         # On saving find the smallest port and save for default ordering
-        if self.ports:
-            self._min_port = min(self.ports)
-        else:
-            self._min_port = None
+        self._min_port = min(self.ports) if self.ports else None
 
         super().save(*args, **kwargs)
 

--- a/netbox/ipam/models/services.py
+++ b/netbox/ipam/models/services.py
@@ -97,6 +97,9 @@ class Service(ContactsMixin, ServiceBase, PrimaryModel):
     def save(self, *args, **kwargs):
         # On saving find the smallest port and save for default ordering
         self._min_port = min(self.ports) if self.ports else None
+        update_fields = kwargs.get('update_fields')
+        if update_fields is not None and '_min_port' not in update_fields:
+            kwargs['update_fields'] = list(update_fields) + ['_min_port']
 
         super().save(*args, **kwargs)
 

--- a/netbox/ipam/models/services.py
+++ b/netbox/ipam/models/services.py
@@ -74,7 +74,6 @@ class Service(ContactsMixin, ServiceBase, PrimaryModel):
         ct_field='parent_object_type',
         fk_field='parent_object_id'
     )
-
     name = models.CharField(
         max_length=100,
         verbose_name=_('name')
@@ -86,16 +85,29 @@ class Service(ContactsMixin, ServiceBase, PrimaryModel):
         verbose_name=_('IP addresses'),
         help_text=_("The specific IP addresses (if any) to which this application service is bound")
     )
+    _min_port = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+    )
 
     clone_fields = (
         'protocol', 'ports', 'description', 'parent_object_type', 'parent_object_id', 'ipaddresses',
     )
 
+    def save(self, *args, **kwargs):
+        # On saving find the smallest port and save for default ordering
+        if self.ports:
+            self._min_port = min(self.ports)
+        else:
+            self._min_port = None
+
+        super().save(*args, **kwargs)
+
     class Meta:
         indexes = (
-            models.Index(fields=('protocol', 'ports', 'id')),  # Default ordering
+            models.Index(fields=('name', 'protocol', '_min_port', 'id')),  # Default ordering
             models.Index(fields=('parent_object_type', 'parent_object_id')),
         )
-        ordering = ('protocol', 'ports', 'pk')  # (protocol, port) may be non-unique
+        ordering = ('name', 'protocol', '_min_port', 'id')
         verbose_name = _('application service')
         verbose_name_plural = _('application services')

--- a/netbox/ipam/models/services.py
+++ b/netbox/ipam/models/services.py
@@ -31,9 +31,21 @@ class ServiceBase(models.Model):
         ),
         verbose_name=_('port numbers')
     )
+    _ports_lowest = models.PositiveIntegerField(
+        null=True,
+        blank=True,
+    )
 
     class Meta:
         abstract = True
+
+    def save(self, *args, **kwargs):
+        # On saving find the smallest port and save for default ordering
+        self._ports_lowest = min(self.ports) if self.ports else None
+        update_fields = kwargs.get('update_fields')
+        if update_fields is not None and '_ports_lowest' not in update_fields:
+            kwargs['update_fields'] = list(update_fields) + ['_ports_lowest']
+        super().save(*args, **kwargs)
 
     def __str__(self):
         return f'{self.name} ({self.get_protocol_display()}/{self.port_list})'
@@ -85,29 +97,16 @@ class Service(ContactsMixin, ServiceBase, PrimaryModel):
         verbose_name=_('IP addresses'),
         help_text=_("The specific IP addresses (if any) to which this application service is bound")
     )
-    _min_port = models.PositiveIntegerField(
-        null=True,
-        blank=True,
-    )
 
     clone_fields = (
         'protocol', 'ports', 'description', 'parent_object_type', 'parent_object_id', 'ipaddresses',
     )
 
-    def save(self, *args, **kwargs):
-        # On saving find the smallest port and save for default ordering
-        self._min_port = min(self.ports) if self.ports else None
-        update_fields = kwargs.get('update_fields')
-        if update_fields is not None and '_min_port' not in update_fields:
-            kwargs['update_fields'] = list(update_fields) + ['_min_port']
-
-        super().save(*args, **kwargs)
-
     class Meta:
         indexes = (
-            models.Index(fields=('name', 'protocol', '_min_port', 'id')),  # Default ordering
+            models.Index(fields=('protocol', '_ports_lowest', 'id')),  # Default ordering
             models.Index(fields=('parent_object_type', 'parent_object_id')),
         )
-        ordering = ('name', 'protocol', '_min_port', 'id')
+        ordering = ('protocol', '_ports_lowest', 'id')
         verbose_name = _('application service')
         verbose_name_plural = _('application services')

--- a/netbox/ipam/tests/test_models.py
+++ b/netbox/ipam/tests/test_models.py
@@ -6,8 +6,10 @@ from netaddr import IPNetwork, IPSet
 
 from dcim.models import Site, SiteGroup
 from ipam.choices import *
+from ipam.constants import SERVICE_PORT_MAX, SERVICE_PORT_MIN
 from ipam.models import *
 from utilities.data import string_to_ranges
+from virtualization.models import VirtualMachine
 
 
 class AggregateTestCase(TestCase):
@@ -926,3 +928,31 @@ class VLANTestCase(TestCase):
         vlan.group = vlangroups[2]
         with self.assertRaises(ValidationError):
             vlan.full_clean()
+
+
+class ServiceTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.create(
+            name='Site 1',
+            slug='site-1',
+        )
+        VirtualMachine.objects.create(
+            name='virtual machine 1',
+            site=site,
+        )
+
+    def test_large_service(self):
+        """
+        Test creation of service with large number of ports.
+        Related to issue #22273
+        """
+        service = Service(
+            name='Service 1',
+            protocol=ServiceProtocolChoices.PROTOCOL_TCP,
+            ports=list(range(SERVICE_PORT_MIN, SERVICE_PORT_MAX)),
+            parent=VirtualMachine.objects.first(),
+        )
+        service.full_clean()
+        service.save()

--- a/netbox/ipam/tests/test_models.py
+++ b/netbox/ipam/tests/test_models.py
@@ -930,6 +930,46 @@ class VLANTestCase(TestCase):
             vlan.full_clean()
 
 
+class ServiceTemplateTestCase(TestCase):
+
+    def test_servicetemplate_lowest_port(self):
+        """
+        Test lowest port setting for servicetemplate
+        """
+        template = ServiceTemplate(
+            name='Template 1',
+            protocol=ServiceProtocolChoices.PROTOCOL_TCP,
+            ports=[80, 443, 22, 8080],  # small test list
+        )
+        template.full_clean()
+        template.save()
+        self.assertEqual(template._ports_lowest, 22)
+
+    def test_servicetemplate_single_port(self):
+        """
+        Test with a single port
+        """
+        template = ServiceTemplate(
+            name='Template 2',
+            protocol=ServiceProtocolChoices.PROTOCOL_UDP,
+            ports=[53],
+        )
+        template.full_clean()
+        template.save()
+        self.assertEqual(template._ports_lowest, 53)
+
+    def test_servicetemplate_empty_ports(self):
+        """
+        Test with empty ports list
+        """
+        template = ServiceTemplate(
+            name='Template 3',
+            protocol=ServiceProtocolChoices.PROTOCOL_TCP,
+            ports=[],
+        )
+        self.assertRaises(ValidationError, template.full_clean)
+
+
 class ServiceTestCase(TestCase):
 
     @classmethod
@@ -955,4 +995,6 @@ class ServiceTestCase(TestCase):
             parent=VirtualMachine.objects.first(),
         )
         service.full_clean()
+        # Testing .save() is the important part, to check for database problems
         service.save()
+        self.assertEqual(service._ports_lowest, SERVICE_PORT_MIN)


### PR DESCRIPTION
### Closes: #22273

- Replace the broken index in `0089_default_ordering_indexes.py` with a dummy to allow a smooth migration for users who are upgrading with a large set of ports
- Add internal _min_port field to hold the smallest port. It gets automatically set in the `save()` method
- Change the default ordering to Name, Protocol, Min Port and add a matching index
- Create a migration for the new database scheme
- Add Testcase for maximum number of ports to check if it everything gets saved without any problems