### PR TITLE
Closes #22392: Deprecate support for Redis 5.x

### DIFF
--- a/docs/installation/2-redis.md
+++ b/docs/installation/2-redis.md
@@ -8,7 +8,10 @@
 sudo apt install -y redis-server
 ```
 
-Before continuing, verify that your installed version of Redis is at least v5.0:
+Before continuing, verify that your installed version of Redis is at least v6.0:
+
+!!! warning "Redis v5.x is deprecated"
+    Support for Redis versions older than 6.0 is deprecated and will be removed in NetBox v4.7.
 
 ```no-highlight
 redis-server -v

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -29,9 +29,10 @@ The following sections detail how to set up a new instance of NetBox:
 |------------|--------------------|
 | Python     | 3.12, 3.13, 3.14   |
 | PostgreSQL | 14+ [^1]           |
-| Redis      | 5.0+               |
+| Redis      | 5.0+ [^2]          |
 
 [^1]: Support for PostgreSQL 14 is deprecated and will be removed in NetBox v4.7. PostgreSQL 15 or later will be required.
+[^2]: Support for Redis versions older than 6.0 is deprecated and will be removed in NetBox v4.7. Redis 6.0 or later will be required.
 
 Below is a simplified overview of the NetBox application stack for reference:
 

--- a/netbox/core/apps.py
+++ b/netbox/core/apps.py
@@ -22,7 +22,7 @@ class CoreConfig(AppConfig):
 
     def ready(self):
         from core.api import schema  # noqa: F401
-        from core.checks import check_duplicate_indexes, check_postgresql_version  # noqa: F401
+        from core.checks import check_duplicate_indexes, check_postgresql_version, check_redis_version  # noqa: F401
         from netbox import context_managers  # noqa: F401
         from netbox.models.features import register_models
 

--- a/netbox/core/checks.py
+++ b/netbox/core/checks.py
@@ -1,4 +1,5 @@
 from django.apps import apps
+from django.core.cache import cache
 from django.core.checks import Error, Tags, Warning, register
 from django.db import connection
 from django.db.models import Index, UniqueConstraint
@@ -6,6 +7,7 @@ from django.db.models import Index, UniqueConstraint
 __all__ = (
     'check_duplicate_indexes',
     'check_postgresql_version',
+    'check_redis_version',
 )
 
 
@@ -62,6 +64,30 @@ def check_postgresql_version(app_configs, **kwargs):
                     f'Support for PostgreSQL {major_version} is deprecated and will be removed in NetBox v4.7.',
                     hint='Please upgrade to PostgreSQL 15 or later.',
                     id='netbox.W001',
+                )
+            )
+    except Exception:
+        pass
+    return warnings
+
+
+@register(Tags.caches)
+def check_redis_version(app_configs, **kwargs):
+    """
+    Warn if the Redis version is less than 6.0, as support for Redis older than 6.0
+    will be removed in NetBox v4.7.
+    """
+    warnings = []
+    try:
+        client = cache.client.get_client()
+        redis_version = tuple(int(x) for x in client.info()['redis_version'].split('.'))
+        if redis_version < (6, 0):
+            warnings.append(
+                Warning(
+                    f'Support for Redis {".".join(str(x) for x in redis_version)} is deprecated and will be '
+                    f'removed in NetBox v4.7.',
+                    hint='Please upgrade to Redis 6.0 or later.',
+                    id='netbox.W002',
                 )
             )
     except Exception:


### PR DESCRIPTION
### Closes: #22392

- Register the new `check_redis_version()` function as a Django check to warn when the Redis version is <6.0
- Update the documentation