### PR TITLE
#22411 - Enforce token write ability when running scripts via the REST API

### DIFF
--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -7,7 +7,6 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import RetrieveUpdateDestroyAPIView
 from rest_framework.mixins import CreateModelMixin, ListModelMixin, RetrieveModelMixin
-from rest_framework.permissions import SAFE_METHODS
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.routers import APIRootView
@@ -22,6 +21,7 @@ from netbox.api.metadata import ContentTypeMetadata
 from netbox.api.renderers import TextRenderer
 from netbox.api.viewsets import BaseViewSet, NetBoxModelViewSet
 from netbox.api.viewsets.mixins import ObjectValidationMixin
+from users.models import Token
 from utilities.exceptions import RQWorkerNotRunningException
 from utilities.request import copy_safe_request
 from utilities.rqworker import any_workers_for_queue
@@ -301,13 +301,6 @@ class ScriptViewSet(ModelViewSet):
     _ignore_model_permissions = True
     lookup_value_regex = '[^/]+'  # Allow dots
 
-    def get_permissions(self):
-        # Running a script is an unsafe action which does not map to a standard CRUD operation; enforce the
-        # calling token's write ability (in addition to the run_script check performed in post()).
-        if self.request.method not in SAFE_METHODS:
-            return [TokenWritePermission()]
-        return super().get_permissions()
-
     def initial(self, request, *args, **kwargs):
         super().initial(request, *args, **kwargs)
 
@@ -341,6 +334,11 @@ class ScriptViewSet(ModelViewSet):
         """
 
         script = self._get_script(pk)
+
+        # Running a script is a state-changing operation. If token authentication is in use, enforce the token's
+        # write ability. Session-authenticated requests are unaffected (request.auth is not a Token).
+        if isinstance(request.auth, Token) and not request.auth.write_enabled:
+            raise PermissionDenied("This token does not permit write operations.")
 
         if not request.user.has_perm('extras.run_script', obj=script):
             raise PermissionDenied("This user does not have permission to run this script.")

--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -7,6 +7,7 @@ from rest_framework.decorators import action
 from rest_framework.exceptions import PermissionDenied
 from rest_framework.generics import RetrieveUpdateDestroyAPIView
 from rest_framework.mixins import CreateModelMixin, ListModelMixin, RetrieveModelMixin
+from rest_framework.permissions import SAFE_METHODS
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
 from rest_framework.routers import APIRootView
@@ -299,6 +300,13 @@ class ScriptViewSet(ModelViewSet):
 
     _ignore_model_permissions = True
     lookup_value_regex = '[^/]+'  # Allow dots
+
+    def get_permissions(self):
+        # Running a script is an unsafe action which does not map to a standard CRUD operation; enforce the
+        # calling token's write ability (in addition to the run_script check performed in post()).
+        if self.request.method not in SAFE_METHODS:
+            return [TokenWritePermission()]
+        return super().get_permissions()
 
     def initial(self, request, *args, **kwargs):
         super().initial(request, *args, **kwargs)

--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -333,12 +333,13 @@ class ScriptViewSet(ModelViewSet):
         Run a Script identified by its numeric PK or module & name and return the pending Job as the result
         """
 
-        script = self._get_script(pk)
-
         # Running a script is a state-changing operation. If token authentication is in use, enforce the token's
-        # write ability. Session-authenticated requests are unaffected (request.auth is not a Token).
+        # write ability before performing any object lookup. Session-authenticated requests are unaffected
+        # (request.auth is not a Token).
         if isinstance(request.auth, Token) and not request.auth.write_enabled:
             raise PermissionDenied("This token does not permit write operations.")
+
+        script = self._get_script(pk)
 
         if not request.user.has_perm('extras.run_script', obj=script):
             raise PermissionDenied("This user does not have permission to run this script.")

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -1239,6 +1239,29 @@ class ScriptTestCase(APITestCase):
             # Restore the original setting for other tests
             self.TestScriptClass.Meta.scheduling_enabled = original
 
+    def test_run_token_write_enabled(self):
+        """
+        Running a script is an unsafe (state-changing) action and must be rejected when the calling token has
+        write_enabled=False, even if the user holds the run_script permission.
+        """
+        self.add_permissions('extras.run_script')
+        payload = {
+            'data': {'var1': 'hello', 'var2': 1, 'var3': False},
+            'commit': True,
+        }
+
+        # A token with write_enabled=False should be rejected
+        token = Token.objects.create(version=2, user=self.user, write_enabled=False)
+        token_header = f'Bearer {TOKEN_PREFIX}{token.key}.{token.token}'
+        response = self.client.post(self.url, payload, format='json', HTTP_AUTHORIZATION=token_header)
+        self.assertHttpStatus(response, status.HTTP_403_FORBIDDEN)
+
+        # Enabling write ability on the token should allow the script to run
+        token.write_enabled = True
+        token.save()
+        response = self.client.post(self.url, payload, format='json', HTTP_AUTHORIZATION=token_header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
 
 class CreatedUpdatedFilterTestCase(APITestCase):
 

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -1262,6 +1262,22 @@ class ScriptTestCase(APITestCase):
         response = self.client.post(self.url, payload, format='json', HTTP_AUTHORIZATION=token_header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
 
+    def test_run_session_auth(self):
+        """
+        The token write-ability check applies only to token authentication. Session-authenticated requests
+        (where request.auth is not a Token) must still be allowed to run scripts.
+        """
+        self.add_permissions('extras.run_script')
+        payload = {
+            'data': {'var1': 'hello', 'var2': 1, 'var3': False},
+            'commit': True,
+        }
+
+        # Authenticate via session rather than a token; request.auth is None
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(self.url, payload, format='json')
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
 
 class CreatedUpdatedFilterTestCase(APITestCase):
 


### PR DESCRIPTION
### Closes: #22411 

The script execution endpoint (`POST /api/extras/scripts/{id}/`) did not honor the calling token's `write_enabled` flag. `ScriptViewSet` overrides `permission_classes` with `[IsAuthenticatedOrLoginNotRequired]`, which removes `TokenPermissions` (the only permission class that consults `request.auth.write_enabled`) from the chain. As a result, a read-only token (`write_enabled=False`) whose user holds the `run_script` permission could still trigger script execution, bypassing the read-only restriction that operators expect such tokens to enforce.

### Changes

* Added an explicit token write-ability check in `ScriptViewSet.post()`: when the request is token-authenticated (`request.auth` is a `Token`) and the token has `write_enabled=False`, the request is rejected with `403 Forbidden`. The existing object-level `run_script` permission check is retained.
* The check is intentionally scoped to token authentication. This endpoint also supports session authentication via `IsAuthenticatedOrLoginNotRequired`, so session-authenticated requests (where `request.auth` is not a `Token`) are unaffected and continue to work as before.
* Added `ScriptTestCase.test_run_token_write_enabled`: a `write_enabled=False` token (with the `run_script` permission) receives `403 Forbidden`, and `200 OK` once the token's write ability is enabled.
* Added `ScriptTestCase.test_run_session_auth`: a session-authenticated request (no token) is still permitted to run scripts, guarding against a regression in the session-auth path.

### Notes

The other REST API viewsets that override `permission_classes` with `IsAuthenticatedOrLoginNotRequired` (`StatusView`, `ObjectTypeViewSet`, `ConnectedDeviceViewSet`) expose only read-only (`GET`) methods, so the missing write check has no effect there — `ScriptViewSet` was the sole affected endpoint.