### PR TITLE
Closes #22431: Replace random.choice with secrets.choice in Token.generate()

### DIFF
--- a/netbox/users/models/tokens.py
+++ b/netbox/users/models/tokens.py
@@ -1,6 +1,6 @@
 import hashlib
 import hmac
-import random
+import secrets
 import zoneinfo
 
 from django.conf import settings
@@ -260,7 +260,7 @@ class Token(models.Model):
         """
         Generate and return a random token value of the given length.
         """
-        return ''.join(random.choice(TOKEN_CHARSET) for _ in range(length))
+        return ''.join(secrets.choice(TOKEN_CHARSET) for _ in range(length))
 
     def update_digest(self):
         """

--- a/netbox/users/tests/test_models.py
+++ b/netbox/users/tests/test_models.py
@@ -1,10 +1,13 @@
+import secrets
 from datetime import timedelta
+from unittest.mock import patch
 
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 from django.utils import timezone
 
 from users.choices import TokenVersionChoices
+from users.constants import TOKEN_CHARSET, TOKEN_DEFAULT_LENGTH
 from users.models import Token, User
 from utilities.testing import create_test_user
 
@@ -103,6 +106,29 @@ class TokenTestCase(TestCase):
         token = Token(version=TokenVersionChoices.V2)
         with self.assertRaises(ValidationError):
             token.clean()
+
+    def test_generate_uses_csprng(self):
+        """
+        Regression: Token.generate() must use secrets.choice (CSPRNG), not random.choice
+        (Mersenne Twister). Verify that the call is routed through the secrets module.
+        """
+        with patch('users.models.tokens.secrets.choice', wraps=secrets.choice) as mock_choice:
+            value = Token.generate()
+
+        self.assertEqual(mock_choice.call_count, TOKEN_DEFAULT_LENGTH,
+                         "secrets.choice must be called once per token character")
+        self.assertEqual(len(value), TOKEN_DEFAULT_LENGTH)
+        self.assertTrue(all(c in TOKEN_CHARSET for c in value),
+                        "Generated token must only contain characters from TOKEN_CHARSET")
+
+    def test_generate_length_parameter(self):
+        """
+        Token.generate(length=N) returns a string of exactly N characters from TOKEN_CHARSET.
+        """
+        for length in (8, 20, TOKEN_DEFAULT_LENGTH, 64):
+            value = Token.generate(length=length)
+            self.assertEqual(len(value), length, f"Expected length {length}, got {len(value)}")
+            self.assertTrue(all(c in TOKEN_CHARSET for c in value))
 
 
 class UserConfigTestCase(TestCase):


### PR DESCRIPTION
### Closes: #22431

## Summary

Replaces the non-CSPRNG `random.choice()` call in `Token.generate()` with `secrets.choice()` (SR-001 / VM-317, CWE-338).

### Root cause

`Token.generate()` used `random.choice(TOKEN_CHARSET)` to build token strings. Python's `random` module uses the Mersenne Twister PRNG, which is not cryptographically secure. Observing approximately 624 32-bit outputs from the same worker process is sufficient to recover the full PRNG state and predict all subsequent outputs — including tokens minted for other users (potentially administrators) by the same worker.

### Fix

Replace `import random` with `import secrets` and change `random.choice` to `secrets.choice`. `secrets` is backed by `os.urandom()` / `getrandom()` (OS-level CSPRNG) and is immune to state-recovery attacks. This is a one-line logic change with no behavioural impact beyond improved entropy.

The fix plan also requested an audit of other `random.*` usages in auth-adjacent code; none were found.

### Tests

- `test_generate_uses_csprng` — patches `secrets.choice` with `wraps=` to verify it is called exactly `TOKEN_DEFAULT_LENGTH` times and that the output only contains `TOKEN_CHARSET` characters.
- `test_generate_length_parameter` — verifies the `length=` parameter is respected across several values.

Ref: SR-001 / VM-317 (internal security review, not an externally-reported disclosure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
