### PR TITLE
Fixes #22448: Ensure all objects are escaped under `handle_protectederror()`

### DIFF
--- a/netbox/utilities/error_handlers.py
+++ b/netbox/utilities/error_handlers.py
@@ -29,7 +29,7 @@ def handle_protectederror(obj_list, request, e):
 
     # Formulate the error message
     err_message = _("Unable to delete <strong>{objects}</strong>. {count} dependent objects were found: ").format(
-        objects=', '.join(str(obj) for obj in obj_list),
+        objects=', '.join(escape(obj) for obj in obj_list),
         count=len(protected_objects) if len(protected_objects) <= 50 else _('More than 50')
     )
 


### PR DESCRIPTION
### Fixes: #22448

Use `escape()` rather than `str()` when representing the primary objects. (Dependent objects are already escaped.)