### PR TITLE
Closes #22280: Set 91% test coverage threshold and exclude non-testable paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,17 @@ sigterm = true
 
 [tool.coverage.report]
 skip_covered = true
+fail_under = 91
 omit = [
     "*/migrations/*",
     "*/tests/*",
+    # Non-application code (no testable logic / not part of the app)
+    "netbox/scripts/*",  # SCRIPTS_ROOT: user/generated scripts
+    "*/netbox/configuration*.py",  # settings/config files (template, testing, local)
+    "*/netbox/wsgi.py",  # WSGI entrypoint
+    "*/generate_secret_key.py",  # standalone CLI helper
+    "*/utilities/debug.py",  # debug-toolbar hook, active only when DEBUG=True
+    "*/extras/management/commands/housekeeping.py",  # deprecated; will not be tested
 ]
 
 [tool.pyright]


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22280

<!--
    Please include a summary of the proposed changes below.
-->
Exclude non-application code from coverage reports and set fail_under to 91%. Omits scripts, configuration files, WSGI entrypoint, secret key generator, debug utilities, and deprecated management commands that lack testable logic or are outside the application scope.