### PR TITLE
Closes #22395: Remove unused save() override on ManagedFileForm

### DIFF
--- a/netbox/core/forms/model_forms.py
+++ b/netbox/core/forms/model_forms.py
@@ -114,15 +114,6 @@ class ManagedFileForm(SyncedDataMixin, NetBoxModelForm):
 
         return self.cleaned_data
 
-    def save(self, *args, **kwargs):
-        # If a file was uploaded, save it to disk
-        if self.cleaned_data['upload_file']:
-            self.instance.file_path = self.cleaned_data['upload_file'].name
-            with open(self.instance.full_path, 'wb+') as new_file:
-                new_file.write(self.cleaned_data['upload_file'].read())
-
-        return super().save(*args, **kwargs)
-
 
 class ConfigFormMetaclass(forms.models.ModelFormMetaclass):
 

--- a/netbox/extras/forms/scripts.py
+++ b/netbox/extras/forms/scripts.py
@@ -112,5 +112,4 @@ class ScriptFileForm(ManagedFileForm):
             data = self.cleaned_data['upload_file']
             storage.save(filename, data)
 
-        # need to skip ManagedFileForm save method
-        return super(ManagedFileForm, self).save(*args, **kwargs)
+        return super().save(*args, **kwargs)


### PR DESCRIPTION
### Closes: #22395

Removes the `save()` override on `core.forms.ManagedFileForm`, which wrote uploaded files to disk via a raw `open(self.instance.full_path, 'wb+')`. No code path reached it: its only subclass, `ScriptFileForm`, overrides `save()` to write through the django-storages backend and explicitly skipped the base implementation with `super(ManagedFileForm, self).save()`. With the override gone, that call simplifies back to a plain `super().save()`.

The override was a leftover from #18680, which moved both upload paths (the form and `ScriptModuleSerializer.create()`) onto django-storages but left the old form-level write in place. The change is behavior-preserving, since the method had no live caller.
