### PR TITLE
Closes #22457: Use `hmac.compare_digest()` to authenticate API tokens

### DIFF
--- a/netbox/users/models/tokens.py
+++ b/netbox/users/models/tokens.py
@@ -282,7 +282,7 @@ class Token(models.Model):
         digest.
         """
         if self.v1:
-            return token == self.token
+            return hmac.compare_digest(token, self.plaintext)
         if self.v2:
             token = token.removeprefix(TOKEN_PREFIX)
             try:
@@ -291,7 +291,7 @@ class Token(models.Model):
                 # Invalid pepper ID
                 return False
             digest = hmac.new(pepper.encode('utf-8'), token.encode('utf-8'), hashlib.sha256).hexdigest()
-            return digest == self.hmac_digest
+            return hmac.compare_digest(digest, self.hmac_digest)
         return False
 
     def validate_client_ip(self, client_ip):


### PR DESCRIPTION
### Closes: #22457
