### PR TITLE
Fixes #22454: Fix serialization of decimal custom field values

### DIFF
--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -461,6 +461,8 @@ class CustomField(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMo
         """
         if value is None:
             return value
+        if self.type == CustomFieldTypeChoices.TYPE_DECIMAL:
+            return float(value)
         if self.type == CustomFieldTypeChoices.TYPE_DATE and type(value) is date:
             return value.isoformat()
         if self.type == CustomFieldTypeChoices.TYPE_DATETIME and type(value) is datetime:


### PR DESCRIPTION
### Closes: #22454

Add `float(value)` conversion for `TYPE_DECIMAL` in `serialize()`, matching what `CustomFieldJSONEncoder` already does when saving to the database. The one-line addition ensures `custom_field_data` always holds a Python `float` for decimal fields, so both snapshots serialize consistently as JSON numbers.