### PR TITLE
Closes #22393: Drop support for Redis 5.x

### DIFF
--- a/docs/installation/2-redis.md
+++ b/docs/installation/2-redis.md
@@ -10,9 +10,6 @@ sudo apt install -y redis-server
 
 Before continuing, verify that your installed version of Redis is at least v6.0:
 
-!!! warning "Redis v5.x is deprecated"
-    Support for Redis versions older than 6.0 is deprecated and will be removed in NetBox v4.7.
-
 ```no-highlight
 redis-server -v
 ```

--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -29,7 +29,7 @@ The following sections detail how to set up a new instance of NetBox:
 |------------|--------------------|
 | Python     | 3.12, 3.13, 3.14   |
 | PostgreSQL | 15+                |
-| Redis      | 4.0+               |
+| Redis      | 6.0+               |
 
 Below is a simplified overview of the NetBox application stack for reference:
 

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -34,7 +34,7 @@ NetBox requires the following dependencies:
 |------------|--------------------|
 | Python     | 3.12, 3.13, 3.14   |
 | PostgreSQL | 15+                |
-| Redis      | 4.0+               |
+| Redis      | 6.0+               |
 
 ### Version History
 

--- a/netbox/core/checks.py
+++ b/netbox/core/checks.py
@@ -74,22 +74,21 @@ def check_postgresql_version(app_configs, **kwargs):
 @register(Tags.caches)
 def check_redis_version(app_configs, **kwargs):
     """
-    Warn if the Redis version is less than 6.0, as support for Redis older than 6.0
-    will be removed in NetBox v4.7.
+    Report an error if the Redis version is less than 6.0.
     """
-    warnings = []
+    errors = []
     try:
         client = cache.client.get_client()
         redis_version = tuple(int(x) for x in client.info()['redis_version'].split('.'))
         if redis_version < (6, 0):
-            warnings.append(
-                Warning(
-                    f'Support for Redis {".".join(str(x) for x in redis_version)} is deprecated and will be '
-                    f'removed in NetBox v4.7.',
+            errors.append(
+                Error(
+                    f'Redis {".".join(str(x) for x in redis_version)} is not supported. NetBox requires Redis 6.0 '
+                    f'or later.',
                     hint='Please upgrade to Redis 6.0 or later.',
-                    id='netbox.W002',
+                    id='netbox.E002',
                 )
             )
     except Exception:
         pass
-    return warnings
+    return errors


### PR DESCRIPTION
### Closes: #22393

- Bump the documented minimum version of Redis from 5.0 to 6.0
- Update the `check_redis_version()` system check to raise an error (not a warning) if Redis is not 6.0+