### PR TITLE
Closes #22464: Update Documentation to use v2 Tokens in examples

### DIFF
--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -437,7 +437,7 @@ Script modules can be uploaded to NetBox via the REST API by sending a `multipar
 
 ```no-highlight
 curl -X POST \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 -H "Accept: application/json; indent=4" \
 -F "file=@/path/to/myscript.py" \
 http://netbox/api/extras/scripts/upload/
@@ -515,7 +515,7 @@ To run a script via the REST API, issue a POST request to the script's endpoint 
 
 ```no-highlight
 curl -X POST \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 -H "Content-Type: application/json" \
 -H "Accept: application/json; indent=4" \
 http://netbox/api/extras/scripts/example.MyReport/ \

--- a/docs/features/configuration-rendering.md
+++ b/docs/features/configuration-rendering.md
@@ -53,7 +53,7 @@ NetBox provides a REST API endpoint specifically for rendering the default confi
 
 ```no-highlight
 curl -X POST \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 -H "Content-Type: application/json" \
 -H "Accept: application/json; indent=4" \
 http://netbox:8000/api/dcim/devices/123/render-config/ \
@@ -81,7 +81,7 @@ To render a specific config template against a device's context data - rather th
 
 ```no-highlight
 curl -X POST \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 -H "Content-Type: application/json" \
 -H "Accept: application/json; indent=4" \
 http://netbox:8000/api/dcim/devices/123/render-config/ \
@@ -114,7 +114,7 @@ NetBox config templates can also be rendered without being tied to any specific 
 
 ```no-highlight
 curl -X POST \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 -H "Content-Type: application/json" \
 -H "Accept: application/json; indent=4" \
 http://netbox:8000/api/extras/config-templates/123/render/ \

--- a/docs/integrations/graphql-api.md
+++ b/docs/integrations/graphql-api.md
@@ -7,7 +7,7 @@ NetBox provides a read-only [GraphQL](https://graphql.org/) API to complement it
 GraphQL enables the client to specify an arbitrary nested list of fields to include in the response. All queries are made to the root `/graphql` API endpoint. For example, to return the circuit ID and provider name of each circuit with an active status, you can issue a request such as the following:
 
 ```
-curl -H "Authorization: Token $TOKEN" \
+curl -H "Authorization: Bearer $TOKEN" \
 -H "Content-Type: application/json" \
 -H "Accept: application/json" \
 http://netbox/graphql/ \

--- a/docs/integrations/rest-api.md
+++ b/docs/integrations/rest-api.md
@@ -179,7 +179,7 @@ Together, these values identify a unique object in NetBox. The assigned object (
 
 ```no-highlight
 curl -X POST \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 -H "Content-Type: application/json" \
 -H "Accept: application/json; indent=4" \
 http://netbox/api/ipam/ip-addresses/ \
@@ -502,7 +502,7 @@ To create a new object, make a `POST` request to the model's _list_ endpoint wit
 
 ```no-highlight
 curl -s -X POST \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 -H "Content-Type: application/json" \
 http://netbox/api/ipam/prefixes/ \
 --data '{"prefix": "192.0.2.0/24", "scope_type": "dcim.site", "scope_id": 6}' | jq '.'
@@ -555,7 +555,7 @@ http://netbox/api/ipam/prefixes/ \
 To create multiple instances of a model using a single request, make a `POST` request to the model's _list_ endpoint with a list of JSON objects representing each instance to be created. If successful, the response will contain a list of the newly created instances. The example below illustrates the creation of three new sites.
 
 ```no-highlight
-curl -X POST -H "Authorization: Token $TOKEN" \
+curl -X POST -H "Authorization: Bearer $TOKEN" \
 -H "Content-Type: application/json" \
 -H "Accept: application/json; indent=4" \
 http://netbox/api/dcim/sites/ \
@@ -595,7 +595,7 @@ To modify an object which has already been created, make a `PATCH` request to th
 
 ```no-highlight
 curl -s -X PATCH \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 -H "Content-Type: application/json" \
 http://netbox/api/ipam/prefixes/18691/ \
 --data '{"status": "reserved"}' | jq '.'
@@ -652,7 +652,7 @@ Multiple objects can be updated simultaneously by issuing a `PUT` or `PATCH` req
 
 ```no-highlight
 curl -s -X PATCH \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 -H "Content-Type: application/json" \
 http://netbox/api/dcim/sites/ \
 --data '[{"id": 10, "status": "active"}, {"id": 11, "status": "active"}]'
@@ -714,7 +714,7 @@ To delete an object from NetBox, make a `DELETE` request to the model's _detail_
 
 ```no-highlight
 curl -s -X DELETE \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 http://netbox/api/ipam/prefixes/18691/
 ```
 
@@ -729,7 +729,7 @@ NetBox supports the simultaneous deletion of multiple objects of the same type b
 
 ```no-highlight
 curl -s -X DELETE \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 -H "Content-Type: application/json" \
 http://netbox/api/dcim/sites/ \
 --data '[{"id": 10}, {"id": 11}, {"id": 12}]'
@@ -746,7 +746,7 @@ For example, the following API request will create a new site and record a messa
 
 ```no-highlight
 curl -s -X POST \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 -H "Content-Type: application/json" \
 http://netbox/api/dcim/sites/ \
 --data '{
@@ -766,7 +766,7 @@ For example, we can upload an image attachment using the `curl` command shown be
 
 ```no-highlight
 curl -X POST \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 -H "Accept: application/json; indent=4" \
 -F "object_type=dcim.site" \
 -F "object_id=2" \

--- a/docs/reference/filtering.md
+++ b/docs/reference/filtering.md
@@ -14,7 +14,7 @@ Some models have fields which are limited to specific choices, such as the `stat
 
 ```no-highlight
 $ curl -s -X OPTIONS \
--H "Authorization: Token $TOKEN" \
+-H "Authorization: Bearer $TOKEN" \
 -H "Content-Type: application/json" \
 http://netbox/api/ipam/prefixes/ | jq ".actions.POST.status.choices"
 [


### PR DESCRIPTION
### Closes: #22464

Change examples in documentation to use v2 Tokens instead of v1 tokens
