### PR TITLE
Fixes #22480: Revert forced handling of image attachments as downloads

### DIFF
--- a/netbox/netbox/tests/test_views.py
+++ b/netbox/netbox/tests/test_views.py
@@ -124,8 +124,8 @@ class MediaViewTestCase(TestCase):
         with patch('netbox.views.misc.serve', return_value=HttpResponse(status=200)):
             response = self.client.get(url)
         self.assertHttpStatus(response, 200)
-        self.assertEqual(response['Content-Disposition'], 'attachment')
-        self.assertEqual(response['X-Content-Type-Options'], 'nosniff')
+        self.assertEqual(response['Content-Security-Policy'], "sandbox; default-src 'none'")
+        self.assertEqual(response['X-Content-Type-Options'], "nosniff")
 
     def test_image_attachment_without_permission(self):
         url = reverse('media', kwargs={'path': self.image_attachment.image.name})
@@ -145,8 +145,8 @@ class MediaViewTestCase(TestCase):
         with patch('netbox.views.misc.serve', return_value=HttpResponse(status=200)):
             response = self.client.get(url)
         self.assertHttpStatus(response, 200)
-        self.assertEqual(response['Content-Disposition'], 'attachment')
-        self.assertEqual(response['X-Content-Type-Options'], 'nosniff')
+        self.assertEqual(response['Content-Security-Policy'], "sandbox; default-src 'none'")
+        self.assertEqual(response['X-Content-Type-Options'], "nosniff")
 
     def test_device_type_without_permission(self):
         url = reverse('media', kwargs={'path': self.device_type.front_image.name})

--- a/netbox/netbox/views/misc.py
+++ b/netbox/netbox/views/misc.py
@@ -159,6 +159,6 @@ class MediaView(TokenConditionalLoginRequiredMixin, View):
                 raise Http404
 
         response = serve(request, path, document_root=settings.MEDIA_ROOT)
-        response['Content-Disposition'] = 'attachment'
-        response['X-Content-Type-Options'] = 'nosniff'
+        response['Content-Security-Policy'] = "sandbox; default-src 'none'"
+        response['X-Content-Type-Options'] = "nosniff"
         return response


### PR DESCRIPTION
### Fixes: #22480

- Remove the `Content-Disposition: attachment` response header from MediaView
- Add the `Content-Security-Policy: sandbox; default-src 'none'` response header as a secondary layer of protection