### PR TITLE
Fixes #22440: Remove errant changelog filter from OpenAPI spec

### DIFF
--- a/netbox/core/graphql/filter_mixins.py
+++ b/netbox/core/graphql/filter_mixins.py
@@ -1,12 +1,7 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Annotated
 
-import strawberry
 import strawberry_django
 from strawberry_django import DatetimeFilterLookup
-
-if TYPE_CHECKING:
-    from .filters import *
 
 __all__ = (
     'ChangeLoggingMixin',
@@ -15,9 +10,5 @@ __all__ = (
 
 @dataclass
 class ChangeLoggingMixin:
-    # TODO: "changelog" is not a valid field name; needs to be updated for ObjectChange
-    changelog: Annotated['ObjectChangeFilter', strawberry.lazy('core.graphql.filters')] | None = (
-        strawberry_django.filter_field()
-    )
     created: DatetimeFilterLookup | None = strawberry_django.filter_field()
     last_updated: DatetimeFilterLookup | None = strawberry_django.filter_field()


### PR DESCRIPTION
### Fixes: #22440

- Remove the errant `changelog` filter from ChangeLoggingMixin