### PR TITLE
Closes #22419: Replace DeprecationWarning with FutureWarning for user-facing deprecations

### DIFF
--- a/netbox/netbox/api/pagination.py
+++ b/netbox/netbox/api/pagination.py
@@ -230,7 +230,7 @@ def __getattr__(name):
         warnings.warn(
             "OptionalLimitOffsetPagination has been renamed to NetBoxPagination. "
             "OptionalLimitOffsetPagination will be removed in NetBox v4.7.0.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return NetBoxPagination
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/netbox/netbox/constants.py
+++ b/netbox/netbox/constants.py
@@ -61,7 +61,7 @@ def __getattr__(name):
         warnings.warn(
             f"{name} is deprecated and will be removed in NetBox v4.7. "
             "Define action permissions via ObjectAction subclasses instead.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
         return _DEFAULT_ACTION_PERMISSIONS

--- a/netbox/netbox/registry.py
+++ b/netbox/netbox/registry.py
@@ -15,7 +15,7 @@ class Registry(dict):
             warnings.warn(
                 'The "models" registry key is deprecated and will be removed in NetBox v4.7. Registered models can be '
                 'obtained by calling ObjectType.objects.public().',
-                DeprecationWarning,
+                FutureWarning,
                 stacklevel=2,
             )
         try:

--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -263,13 +263,13 @@ if not LOGIN_REQUIRED:
     warnings.warn(
         "LOGIN_REQUIRED is deprecated and will be removed in NetBox v5.0. Unauthenticated access to the application "
         "will no longer be supported. Please plan to require authentication for all users before upgrading.",
-        DeprecationWarning,
+        FutureWarning,
     )
 elif hasattr(configuration, 'LOGIN_REQUIRED'):
     warnings.warn(
         "LOGIN_REQUIRED is deprecated and will be removed in NetBox v5.0. This parameter can be removed from your "
         "configuration file.",
-        DeprecationWarning,
+        FutureWarning,
     )
 
 
@@ -300,13 +300,13 @@ if STORAGE_BACKEND is not None:
     else:
         warnings.warn(
             "STORAGE_BACKEND is deprecated, use the new STORAGES setting instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
 
 if STORAGE_CONFIG is not None:
     warnings.warn(
         "STORAGE_CONFIG is deprecated, use the new STORAGES setting instead.",
-        DeprecationWarning,
+        FutureWarning,
     )
 
 # Default STORAGES for Django
@@ -657,7 +657,7 @@ for config_param in ('SENTRY_DSN', 'SENTRY_SAMPLE_RATE', 'SENTRY_SEND_DEFAULT_PI
     if hasattr(configuration, config_param):
         warnings.warn(
             f"{config_param} is deprecated and will be removed in NetBox v4.7. Use SENTRY_CONFIG instead.",
-            DeprecationWarning,
+            FutureWarning,
         )
 
 if SENTRY_ENABLED:

--- a/netbox/netbox/views/generic/mixins.py
+++ b/netbox/netbox/views/generic/mixins.py
@@ -45,7 +45,7 @@ class ActionsMixin:
         warnings.warn(
             f"{self.__class__.__name__}.actions is defined as a dictionary, which is deprecated and will be removed "
             "in NetBox v4.7. Define actions as a list of ObjectAction subclasses instead.",
-            DeprecationWarning,
+            FutureWarning,
             stacklevel=2,
         )
 

--- a/netbox/utilities/forms/fields/expandable.py
+++ b/netbox/utilities/forms/fields/expandable.py
@@ -79,7 +79,7 @@ def __getattr__(name):
         warnings.warn(
             "ExpandableIPAddressField has been renamed to ExpandableIPNetworkField. "
             "ExpandableIPAddressField will be removed in NetBox v4.7.0.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return ExpandableIPNetworkField
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/netbox/utilities/forms/utils.py
+++ b/netbox/utilities/forms/utils.py
@@ -303,7 +303,7 @@ def __getattr__(name):
         warnings.warn(
             "expand_ipaddress_pattern() has been renamed to expand_ipnetwork_pattern(). "
             "expand_ipaddress_pattern() will be removed in NetBox v4.7.0.",
-            DeprecationWarning,
+            FutureWarning,
         )
         return expand_ipnetwork_pattern
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
### Closes: #22419

## Summary

Replaces all `DeprecationWarning` with `FutureWarning` in user-facing deprecation notices across 7 files. `DeprecationWarning` is silenced by default in production environments, so operators relying on configuration files or plugin APIs were never seeing these warnings. `FutureWarning` is shown by default and is the correct choice for anything end-user- or operator-visible.

Affected sites:
- `netbox/registry.py` — `"models"` registry key deprecation
- `netbox/constants.py` — legacy action permissions deprecation
- `netbox/settings.py` — `LOGIN_REQUIRED`, `STORAGE_BACKEND`, `STORAGE_CONFIG`, and legacy Sentry config params
- `netbox/api/pagination.py` — `OptionalLimitOffsetPagination` rename
- `netbox/views/generic/mixins.py` — `actions` dict deprecation
- `utilities/forms/fields/expandable.py` — `ExpandableIPAddressField` rename
- `utilities/forms/utils.py` — `expand_ipaddress_pattern()` rename

## Test plan

- [ ] Verify a deprecated config param (e.g. `LOGIN_REQUIRED`) produces a visible `FutureWarning` on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)
