### PR TITLE
Fixes #22527: Notify screen reader of quick search updates

### DIFF
--- a/netbox/templates/htmx/table.html
+++ b/netbox/templates/htmx/table.html
@@ -22,6 +22,17 @@
     <div hx-swap-oob="innerHTML:.total-object-count">{{ table.rows|length }}</div>
   {% endif %}
 
+  {# Announce the updated result count to assistive technology #}
+  {% if not table.embedded %}
+    <div hx-swap-oob="innerHTML:#object-list-status">
+      {% blocktrans trimmed count count=table.page.paginator.count %}
+        {{ count }} result found
+      {% plural %}
+        {{ count }} results found
+      {% endblocktrans %}
+    </div>
+  {% endif %}
+
   {# Include the updated "save" link for the table configuration #}
   {% if table.config_params and not table.embedded %}
     <a class="dropdown-item" hx-swap-oob="outerHTML:#table_save_link" href="{% url 'extras:tableconfig_add' %}?{{ table.config_params }}&return_url={{ request.path }}" id="table_save_link">{% trans "Save" %}</a>

--- a/netbox/templates/inc/table_controls_htmx.html
+++ b/netbox/templates/inc/table_controls_htmx.html
@@ -1,6 +1,9 @@
 {% load helpers %}
 {% load i18n %}
 
+{# Live region used to announce updated results (e.g. after a quick search) to assistive technology #}
+<div id="object-list-status" class="visually-hidden" role="status" aria-live="polite"></div>
+
 <div class="row mb-3" id="results">
   <div class="col-auto d-print-none">
     <div class="input-group input-group-flat me-2 quicksearch" hx-disinherit="hx-select hx-swap">


### PR DESCRIPTION
## Fixes: #22527

### Problem

When a user enters a term in the "Quick search" box on an object list, htmx swaps fresh results into the `#object_list` container, but the change is never conveyed to assistive technology. There's no ARIA live region, so screen-reader users get no notification that the content changed.

### Fix

Two template changes:

1. **`inc/table_controls_htmx.html`** — Added a persistent, visually-hidden live region next to the quick search input:

   ```html
   <div id="object-list-status" class="visually-hidden" role="status" aria-live="polite"></div>
   ```

   It's empty on initial load (so nothing is announced when the page first renders) and stays in the DOM so its later content changes get announced.

2. **`htmx/table.html`** — On every htmx table reload, an out-of-band swap (`hx-swap-oob="innerHTML:#object-list-status"`) updates that region with a concise, translatable count rather than re-reading the whole table:

   ```
   "{{ count }} result(s) found"
   ```

### Notes

- This satisfies both of the issue's requirements: updates are announced via a `role="status"` / `aria-live="polite"` region, and the announcement is concise (just the result count).
- Using an `innerHTML:` swap (not `outerHTML`) preserves the live-region node itself, which is required for assistive tech to detect the change.
- The same fix covers both `generic/object_list.html` and `generic/object_children.html`, since both include the shared `inc/table_controls_htmx.html`.
