### PR TITLE
Fixes #22528: Fix keyboard navigation for object list tabs

### DIFF
--- a/netbox/templates/generic/object_list.html
+++ b/netbox/templates/generic/object_list.html
@@ -38,10 +38,10 @@ Context:
 {% block tabs %}
   <ul class="nav nav-tabs" role="tablist">
     <li class="nav-item" role="presentation">
-      <a class="nav-link active" id="object-list-tab" data-bs-toggle="tab" data-bs-target="#object-list" type="button" role="tab" aria-controls="object-list" aria-selected="true">
+      <button class="nav-link active" id="object-list-tab" data-bs-toggle="tab" data-bs-target="#object-list" type="button" role="tab" aria-controls="object-list" aria-selected="true">
         {% trans "Results" %}
         <span class="badge text-bg-secondary total-object-count">{% if table.page.paginator.count %}{{ table.page.paginator.count }}{% else %}{{ total_count|default:"0" }}{% endif %}</span>
-      </a>
+      </button>
     </li>
     {% if filter_form %}
       <li class="nav-item" role="presentation">


### PR DESCRIPTION
### Fixes: #22528

The Results/Filters tabs on object list pages were not keyboard operable — arrow keys did nothing and the Results tab could not receive focus.

The "Results" tab in `generic/object_list.html` was rendered as an `<a>` element with no `href`. Anchors without an `href` are not in the keyboard tab order, so the tab could never be focused. Bootstrap 5.3 binds its arrow-key `keydown` handler to the active tab (auto-initialized on page load), so with an unfocusable active tab that handler never fired and arrow-key navigation was dead. The element even carried an invalid `type="button"` attribute, indicating it was always meant to be a button. The adjacent "Filters" tab was already a `<button>`.

This change converts the "Results" tab from `<a>` to `<button>`, matching the "Filters" tab. A `<button>` is natively focusable, so keyboard users can Tab into the tablist and Bootstrap's roving-tabindex / arrow-key / Home / End navigation works as expected. The existing ARIA roles and attributes (`tablist`/`tab`/`tabpanel`, `aria-selected`, `aria-controls`) are unchanged.

This is a template-only change; no JavaScript rebuild is required.
