### PR TITLE
Fixes #22532: Ensure all empty table headers have an ARIA label

### DIFF
--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -424,7 +424,7 @@ class NotificationTable(NetBoxTable):
         orderable=False,
         attrs={
             'td': {'class': 'w-1'},
-            'th': {'class': 'w-1'},
+            'th': {'class': 'w-1', 'aria-label': _('Type')},
         },
         verbose_name=''
     )

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -248,6 +248,9 @@ class ActionsColumn(tables.Column):
         direct button link and icon (default: True)
     """
     attrs = {
+        'th': {
+            'aria-label': _('Actions'),
+        },
         'td': {
             'class': 'text-end text-nowrap noprint p-1'
         }

--- a/netbox/templates/core/configrevision_restore.html
+++ b/netbox/templates/core/configrevision_restore.html
@@ -36,7 +36,7 @@
             <th scope="col">{% trans "Parameter" %}</th>
             <th scope="col">{% trans "Current Value" %}</th>
             <th scope="col">{% trans "New Value" %}</th>
-            <th scope="col"></th>
+            <th scope="col" aria-label="{% trans "Changed" %}"></th>
           </tr>
         </thead>
         <tbody>

--- a/netbox/templates/dcim/inc/panels/inventory_items.html
+++ b/netbox/templates/dcim/inc/panels/inventory_items.html
@@ -18,7 +18,7 @@
         <th>{% trans "Name" %}</th>
         <th>{% trans "Label" %}</th>
         <th>{% trans "Role" %}</th>
-        <th></th>
+        <th aria-label="{% trans "Actions" %}"></th>
       </tr>
     </thead>
     <tbody>

--- a/netbox/templates/dcim/panels/component_inventory_items.html
+++ b/netbox/templates/dcim/panels/component_inventory_items.html
@@ -8,7 +8,7 @@
         <th>{% trans "Name" %}</th>
         <th>{% trans "Label" %}</th>
         <th>{% trans "Role" %}</th>
-        <th></th>
+        <th aria-label="{% trans "Actions" %}"></th>
       </tr>
     </thead>
     <tbody>

--- a/netbox/templates/dcim/panels/interface_wireless.html
+++ b/netbox/templates/dcim/panels/interface_wireless.html
@@ -6,7 +6,7 @@
     <table class="table table-hover attr-table">
       <thead>
         <tr class="border-bottom">
-          <th></th>
+          <th aria-label="{% trans "Attribute" %}"></th>
           <th>{% trans "Local" %}</th>
           {% if peer %}
             <th>{% trans "Peer" %}</th>

--- a/netbox/templates/dcim/virtualchassis_edit.html
+++ b/netbox/templates/dcim/virtualchassis_edit.html
@@ -66,7 +66,7 @@
                     <th>{% trans "Serial" %}</th>
                     <th>{% trans "Position" %}</th>
                     <th>{% trans "Priority" %}</th>
-                    <th></th>
+                    <th aria-label="{% trans "Actions" %}"></th>
                 </tr>
             </thead>
             <tbody>

--- a/netbox/templates/extras/inc/script_list_content.html
+++ b/netbox/templates/extras/inc/script_list_content.html
@@ -33,7 +33,7 @@
               <th>{% trans "Description" %}</th>
               <th>{% trans "Last Run" %}</th>
               <th>{% trans "Status" %}</th>
-              <th></th>
+              <th aria-label="{% trans "Actions" %}"></th>
             </tr>
           </thead>
           <tbody>

--- a/netbox/templates/ipam/inc/panels/fhrp_groups.html
+++ b/netbox/templates/ipam/inc/panels/fhrp_groups.html
@@ -24,7 +24,7 @@
         <th>{% trans "Protocol" %}</th>
         <th>{% trans "Virtual IPs" %}</th>
         <th>{% trans "Priority" %}</th>
-        <th></th>
+        <th aria-label="{% trans "Actions" %}"></th>
       </tr>
     </thead>
     <tbody>

--- a/netbox/templates/ipam/panels/fhrp_groups.html
+++ b/netbox/templates/ipam/panels/fhrp_groups.html
@@ -10,7 +10,7 @@
         <th>{% trans "Protocol" %}</th>
         <th>{% trans "Virtual IPs" %}</th>
         <th>{% trans "Priority" %}</th>
-        <th></th>
+        <th aria-label="{% trans "Actions" %}"></th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
## Fixes: #22532

### Summary

Screen readers encountered empty `<th>` header cells in object tables, so data cells weren't properly associated with a column header. This adds accessible names to all such cells across the application.

### Changes

**Shared table columns** (propagates to every object-list table):
- `ActionsColumn` — the trailing edit/delete/changelog column had an empty header; now `aria-label="Actions"`. This was the empty `<th>` on the results table referenced in the issue.
- `NotificationTable.icon` — icon-only column; now `aria-label="Type"`.

**Hand-written panel/detail tables** — added an `aria-label` to each remaining empty `<th>`:
- `ipam/panels/fhrp_groups.html`, `ipam/inc/panels/fhrp_groups.html` → "Actions"
- `extras/inc/script_list_content.html` → "Actions"
- `dcim/virtualchassis_edit.html` → "Actions"
- `dcim/panels/component_inventory_items.html`, `dcim/inc/panels/inventory_items.html` → "Actions"
- `core/configrevision_restore.html` → "Changed" (change-indicator column)
- `dcim/panels/interface_wireless.html` → "Attribute" (corner cell of the Local/Peer comparison matrix)

The select/checkbox column named in the issue was already accessible (`aria-label="Select all"`, added in #17069); the genuinely empty header on the results table was the trailing actions column.

### Verification

- Programmatic scan of all 168 `BaseTable` subclasses: 0 columns with a blank header and no accessible name (down from 2).
- Template grep: no remaining empty `<th></th>` without an `aria-label`.
- All new labels are i18n-wrapped (`gettext_lazy` / `{% trans %}`).
- `ruff` clean; affected view tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)