### PR TITLE
Fixes #22521: Respect RAM_BASE_UNIT for VirtualMachineType

### DIFF
--- a/netbox/netbox/ui/attrs.py
+++ b/netbox/netbox/ui/attrs.py
@@ -119,26 +119,20 @@ class TextAttr(ObjectAttribute):
          style (str): CSS class to apply to the rendered attribute
          format_string (str): If specified, the value will be formatted using this string when rendering
          copy_button (bool): Set to True to include a copy-to-clipboard button
-         format_callable(callable): If specified, the callable will be called with the value to format the string.
     """
     template_name = 'ui/attrs/text.html'
 
-    def __init__(self, *args, style=None, format_string=None, copy_button=False, format_callable=None, **kwargs):
+    def __init__(self, *args, style=None, format_string=None, copy_button=False, **kwargs):
         super().__init__(*args, **kwargs)
         self.style = style
         self.format_string = format_string
-        self.format_callable = format_callable if callable(format_callable) else None
         self.copy_button = copy_button
 
     def get_value(self, obj):
         value = resolve_attr_path(obj, self.accessor)
-        # Apply format callable or string (if any)
-        # format callable takes precedence over format string
-        if value is not None and value != '':
-            if self.format_callable:
-                return self.format_callable(value)
-            if self.format_string:
-                return self.format_string.format(value)
+        # Apply format string (if any)
+        if value is not None and value != '' and self.format_string:
+            return self.format_string.format(value)
         return value
 
     def get_context(self, obj, attr, value, context):

--- a/netbox/netbox/ui/attrs.py
+++ b/netbox/netbox/ui/attrs.py
@@ -119,20 +119,26 @@ class TextAttr(ObjectAttribute):
          style (str): CSS class to apply to the rendered attribute
          format_string (str): If specified, the value will be formatted using this string when rendering
          copy_button (bool): Set to True to include a copy-to-clipboard button
+         format_callable(callable): If specified, the callable will be called with the value to format the string.
     """
     template_name = 'ui/attrs/text.html'
 
-    def __init__(self, *args, style=None, format_string=None, copy_button=False, **kwargs):
+    def __init__(self, *args, style=None, format_string=None, copy_button=False, format_callable=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.style = style
         self.format_string = format_string
+        self.format_callable = format_callable if callable(format_callable) else None
         self.copy_button = copy_button
 
     def get_value(self, obj):
         value = resolve_attr_path(obj, self.accessor)
-        # Apply format string (if any)
-        if value is not None and value != '' and self.format_string:
-            return self.format_string.format(value)
+        # Apply format callable or string (if any)
+        # format callable takes precedence over format string
+        if value is not None and value != '':
+            if self.format_callable:
+                return self.format_callable(value)
+            if self.format_string:
+                return self.format_string.format(value)
         return value
 
     def get_context(self, obj, attr, value, context):

--- a/netbox/templates/virtualization/virtualmachinetype/attrs/default_memory.html
+++ b/netbox/templates/virtualization/virtualmachinetype/attrs/default_memory.html
@@ -1,0 +1,2 @@
+{% load helpers %}
+{{ value|humanize_ram_capacity }}

--- a/netbox/virtualization/forms/bulk_edit.py
+++ b/netbox/virtualization/forms/bulk_edit.py
@@ -93,6 +93,9 @@ class VirtualMachineTypeBulkEditForm(PrimaryModelBulkEditForm):
     default_memory = forms.IntegerField(
         label=_('Default Memory (MB)'),
         required=False,
+    default_memory = forms.IntegerField(
+        label=_('Default memory)'),
+        required=False,
     )
 
     model = VirtualMachineType
@@ -108,7 +111,7 @@ class VirtualMachineTypeBulkEditForm(PrimaryModelBulkEditForm):
         super().__init__(*args, **kwargs)
 
         # Set unit label based on configured RAM_BASE_UNIT (MB vs MiB)
-        self.fields['default_memory'].label = _('Default Memory ({unit})').format(
+        self.fields['default_memory'].label = _('Default memory ({unit})').format(
             unit=get_capacity_unit_label(settings.RAM_BASE_UNIT)
         )
 

--- a/netbox/virtualization/forms/bulk_edit.py
+++ b/netbox/virtualization/forms/bulk_edit.py
@@ -104,6 +104,14 @@ class VirtualMachineTypeBulkEditForm(PrimaryModelBulkEditForm):
         'default_platform', 'default_vcpus', 'default_memory', 'description', 'comments',
     )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Set unit label based on configured RAM_BASE_UNIT (MB vs MiB)
+        self.fields['default_memory'].label = _('Default Memory ({unit})').format(
+            unit=get_capacity_unit_label(settings.RAM_BASE_UNIT)
+        )
+
 
 class VirtualMachineBulkEditForm(PrimaryModelBulkEditForm):
     virtual_machine_type = DynamicModelChoiceField(

--- a/netbox/virtualization/forms/bulk_edit.py
+++ b/netbox/virtualization/forms/bulk_edit.py
@@ -91,7 +91,7 @@ class VirtualMachineTypeBulkEditForm(PrimaryModelBulkEditForm):
         required=False,
     )
     default_memory = forms.IntegerField(
-        label=_('Default memory)'),
+        label=_('Default memory'),
         required=False,
     )
 

--- a/netbox/virtualization/forms/bulk_edit.py
+++ b/netbox/virtualization/forms/bulk_edit.py
@@ -91,9 +91,6 @@ class VirtualMachineTypeBulkEditForm(PrimaryModelBulkEditForm):
         required=False,
     )
     default_memory = forms.IntegerField(
-        label=_('Default Memory (MB)'),
-        required=False,
-    default_memory = forms.IntegerField(
         label=_('Default memory)'),
         required=False,
     )

--- a/netbox/virtualization/forms/filtersets.py
+++ b/netbox/virtualization/forms/filtersets.py
@@ -128,7 +128,9 @@ class VirtualMachineTypeFilterForm(PrimaryModelFilterSetForm):
         required=False,
     )
     default_memory = forms.IntegerField(
-        label=_(f'Default memory ({get_capacity_unit_label(settings.RAM_BASE_UNIT)})'),
+        label=_('Default memory ({unit})').format(
+            unit=get_capacity_unit_label(settings.RAM_BASE_UNIT)
+        ),
         required=False,
         min_value=0,
     )

--- a/netbox/virtualization/forms/filtersets.py
+++ b/netbox/virtualization/forms/filtersets.py
@@ -128,9 +128,7 @@ class VirtualMachineTypeFilterForm(PrimaryModelFilterSetForm):
         required=False,
     )
     default_memory = forms.IntegerField(
-        label=_('Default memory ({unit})').format(
-            unit=get_capacity_unit_label(settings.RAM_BASE_UNIT)
-        ),
+        label=_('Default memory'),
         required=False,
         min_value=0,
     )
@@ -141,6 +139,14 @@ class VirtualMachineTypeFilterForm(PrimaryModelFilterSetForm):
     )
 
     tag = TagFilterField(model)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Set unit label based on configured RAM_BASE_UNIT (MB vs MiB)
+        self.fields['default_memory'].label = _('Default Memory ({unit})').format(
+            unit=get_capacity_unit_label(settings.RAM_BASE_UNIT)
+        )
 
 
 class VirtualMachineFilterForm(

--- a/netbox/virtualization/forms/filtersets.py
+++ b/netbox/virtualization/forms/filtersets.py
@@ -144,7 +144,7 @@ class VirtualMachineTypeFilterForm(PrimaryModelFilterSetForm):
         super().__init__(*args, **kwargs)
 
         # Set unit label based on configured RAM_BASE_UNIT (MB vs MiB)
-        self.fields['default_memory'].label = _('Default Memory ({unit})').format(
+        self.fields['default_memory'].label = _('Default memory ({unit})').format(
             unit=get_capacity_unit_label(settings.RAM_BASE_UNIT)
         )
 

--- a/netbox/virtualization/forms/filtersets.py
+++ b/netbox/virtualization/forms/filtersets.py
@@ -128,7 +128,7 @@ class VirtualMachineTypeFilterForm(PrimaryModelFilterSetForm):
         required=False,
     )
     default_memory = forms.IntegerField(
-        label=_('Default memory (MB)'),
+        label=_(f'Default memory ({get_capacity_unit_label(settings.RAM_BASE_UNIT)})'),
         required=False,
         min_value=0,
     )

--- a/netbox/virtualization/forms/model_forms.py
+++ b/netbox/virtualization/forms/model_forms.py
@@ -196,7 +196,7 @@ class VirtualMachineTypeForm(PrimaryModelForm):
         super().__init__(*args, **kwargs)
 
         # Set unit label based on configured RAM_BASE_UNIT (MB vs MiB)
-        self.fields['default_memory'].label = _('Default Memory ({unit})').format(
+        self.fields['default_memory'].label = _('Default memory ({unit})').format(
             unit=get_capacity_unit_label(settings.RAM_BASE_UNIT)
         )
 

--- a/netbox/virtualization/forms/model_forms.py
+++ b/netbox/virtualization/forms/model_forms.py
@@ -192,6 +192,14 @@ class VirtualMachineTypeForm(PrimaryModelForm):
             'owner', 'comments', 'tags',
         )
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Set unit label based on configured RAM_BASE_UNIT (MB vs MiB)
+        self.fields['default_memory'].label = _('Default Memory ({unit})').format(
+            unit=get_capacity_unit_label(settings.RAM_BASE_UNIT)
+        )
+
 
 class VirtualMachineForm(TenancyForm, PrimaryModelForm):
     virtual_machine_type = forms.ModelChoiceField(

--- a/netbox/virtualization/models/virtualmachines.py
+++ b/netbox/virtualization/models/virtualmachines.py
@@ -62,7 +62,7 @@ class VirtualMachineType(ImageAttachmentsMixin, PrimaryModel):
         validators=(MinValueValidator(decimal.Decimal('0.01')),),
     )
     default_memory = models.PositiveIntegerField(
-        verbose_name=_('Default memory'),
+        verbose_name=_('default memory'),
         blank=True,
         null=True,
     )

--- a/netbox/virtualization/models/virtualmachines.py
+++ b/netbox/virtualization/models/virtualmachines.py
@@ -62,7 +62,7 @@ class VirtualMachineType(ImageAttachmentsMixin, PrimaryModel):
         validators=(MinValueValidator(decimal.Decimal('0.01')),),
     )
     default_memory = models.PositiveIntegerField(
-        verbose_name=_('default memory (MB)'),
+        verbose_name=_('Default memory'),
         blank=True,
         null=True,
     )

--- a/netbox/virtualization/tables/virtualmachines.py
+++ b/netbox/virtualization/tables/virtualmachines.py
@@ -1,9 +1,11 @@
 import django_tables2 as tables
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from dcim.tables.devices import BaseInterfaceTable
 from netbox.tables import NetBoxTable, PrimaryModelTable, columns
 from tenancy.tables import ContactsColumnMixin, TenancyColumnsMixin
+from utilities.forms.utils import get_capacity_unit_label
 from utilities.templatetags.helpers import humanize_disk_capacity, humanize_ram_capacity
 
 from ..models import VirtualDisk, VirtualMachine, VirtualMachineType, VMInterface
@@ -38,6 +40,11 @@ class VirtualMachineTypeTable(PrimaryModelTable):
     tags = columns.TagColumn(
         url_name='virtualization:virtualmachinetype_list'
     )
+    default_memory = tables.Column(
+        verbose_name=_('Default Memory ({unit})').format(
+            unit=get_capacity_unit_label(settings.RAM_BASE_UNIT)
+        )
+    )
 
     class Meta(PrimaryModelTable.Meta):
         model = VirtualMachineType
@@ -48,6 +55,7 @@ class VirtualMachineTypeTable(PrimaryModelTable):
         default_columns = (
             'pk', 'name', 'default_platform', 'default_vcpus', 'default_memory', 'virtual_machine_count', 'description',
         )
+
 
 #
 # Virtual machines

--- a/netbox/virtualization/tables/virtualmachines.py
+++ b/netbox/virtualization/tables/virtualmachines.py
@@ -1,11 +1,9 @@
 import django_tables2 as tables
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from dcim.tables.devices import BaseInterfaceTable
 from netbox.tables import NetBoxTable, PrimaryModelTable, columns
 from tenancy.tables import ContactsColumnMixin, TenancyColumnsMixin
-from utilities.forms.utils import get_capacity_unit_label
 from utilities.templatetags.helpers import humanize_disk_capacity, humanize_ram_capacity
 
 from ..models import VirtualDisk, VirtualMachine, VirtualMachineType, VMInterface
@@ -40,11 +38,6 @@ class VirtualMachineTypeTable(PrimaryModelTable):
     tags = columns.TagColumn(
         url_name='virtualization:virtualmachinetype_list'
     )
-    default_memory = tables.Column(
-        verbose_name=_('Default Memory ({unit})').format(
-            unit=get_capacity_unit_label(settings.RAM_BASE_UNIT)
-        )
-    )
 
     class Meta(PrimaryModelTable.Meta):
         model = VirtualMachineType
@@ -55,6 +48,9 @@ class VirtualMachineTypeTable(PrimaryModelTable):
         default_columns = (
             'pk', 'name', 'default_platform', 'default_vcpus', 'default_memory', 'virtual_machine_count', 'description',
         )
+
+    def render_default_memory(self, value):
+        return humanize_ram_capacity(value)
 
 
 #

--- a/netbox/virtualization/ui/panels.py
+++ b/netbox/virtualization/ui/panels.py
@@ -1,6 +1,8 @@
+from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from netbox.ui import attrs, panels
+from utilities.forms.utils import get_capacity_unit_label
 
 #
 # Cluster
@@ -26,7 +28,11 @@ class VirtualMachineTypePanel(panels.ObjectAttributesPanel):
     name = attrs.TextAttr('name')
     default_platform = attrs.RelatedObjectAttr('default_platform', linkify=True)
     default_vcpus = attrs.TextAttr('default_vcpus', label=_('Default vCPUs'))
-    default_memory = attrs.TextAttr('default_memory', format_string=_('{0} MB'), label=_('Default memory'))
+    default_memory = attrs.TextAttr(
+        'default_memory',
+        format_string=_(f'{{0}} {get_capacity_unit_label(settings.RAM_BASE_UNIT)}'),
+        label=_('Default memory')
+    )
     description = attrs.TextAttr('description')
 
 

--- a/netbox/virtualization/ui/panels.py
+++ b/netbox/virtualization/ui/panels.py
@@ -30,7 +30,7 @@ class VirtualMachineTypePanel(panels.ObjectAttributesPanel):
     default_vcpus = attrs.TextAttr('default_vcpus', label=_('Default vCPUs'))
     default_memory = attrs.TextAttr(
         'default_memory',
-        format_string=_(f'{{0}} {get_capacity_unit_label(settings.RAM_BASE_UNIT)}'),
+        format_string=f'{{0}} {get_capacity_unit_label(settings.RAM_BASE_UNIT)}',
         label=_('Default memory')
     )
     description = attrs.TextAttr('description')

--- a/netbox/virtualization/ui/panels.py
+++ b/netbox/virtualization/ui/panels.py
@@ -1,7 +1,6 @@
 from django.utils.translation import gettext_lazy as _
 
 from netbox.ui import attrs, panels
-from utilities.templatetags.helpers import humanize_ram_capacity
 
 #
 # Cluster
@@ -27,9 +26,9 @@ class VirtualMachineTypePanel(panels.ObjectAttributesPanel):
     name = attrs.TextAttr('name')
     default_platform = attrs.RelatedObjectAttr('default_platform', linkify=True)
     default_vcpus = attrs.TextAttr('default_vcpus', label=_('Default vCPUs'))
-    default_memory = attrs.TextAttr(
+    default_memory = attrs.TemplatedAttr(
         'default_memory',
-        format_callable=humanize_ram_capacity,
+        template_name='virtualization/virtualmachinetype/attrs/default_memory.html',
         label=_('Default memory')
     )
     description = attrs.TextAttr('description')

--- a/netbox/virtualization/ui/panels.py
+++ b/netbox/virtualization/ui/panels.py
@@ -1,8 +1,7 @@
-from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
 from netbox.ui import attrs, panels
-from utilities.forms.utils import get_capacity_unit_label
+from utilities.templatetags.helpers import humanize_ram_capacity
 
 #
 # Cluster
@@ -30,7 +29,7 @@ class VirtualMachineTypePanel(panels.ObjectAttributesPanel):
     default_vcpus = attrs.TextAttr('default_vcpus', label=_('Default vCPUs'))
     default_memory = attrs.TextAttr(
         'default_memory',
-        format_string=f'{{0}} {get_capacity_unit_label(settings.RAM_BASE_UNIT)}',
+        format_callable=humanize_ram_capacity,
         label=_('Default memory')
     )
     description = attrs.TextAttr('description')


### PR DESCRIPTION
Closes #22521: Make VirtualMachineType respect the RAM_BASE_UNIT setting.

Note: The translation files seem to contain a translation for the string 'Default Memory (MB)', but not for 'Default Memory (MiB)'. So translations need to be updated as well.