### PR TITLE
Closes #22561: Fix AttributeError when importing IPs with is_primary/is_oob set but no device

### DIFF
--- a/netbox/ipam/forms/bulk_import.py
+++ b/netbox/ipam/forms/bulk_import.py
@@ -377,13 +377,13 @@ class IPAddressImportForm(PrimaryModelImportForm):
 
     def clean_is_primary(self):
         # Make sure is_primary is None when it's not included in the uploaded data
-        if 'is_primary' not in self.data or not self.data['is_primary']:
+        if 'is_primary' not in self.data:
             return None
         return self.cleaned_data['is_primary']
 
     def clean_is_oob(self):
         # Make sure is_oob is None when it's not included in the uploaded data
-        if 'is_oob' not in self.data or not self.data['is_oob']:
+        if 'is_oob' not in self.data:
             return None
         return self.cleaned_data['is_oob']
 
@@ -429,8 +429,8 @@ class IPAddressImportForm(PrimaryModelImportForm):
         ipaddress = super().save(*args, **kwargs)
 
         # Set as primary for device/VM
-        if self.cleaned_data.get('is_primary') is not None:
-            parent = self.cleaned_data.get('device') or self.cleaned_data.get('virtual_machine')
+        parent = self.cleaned_data.get('device') or self.cleaned_data.get('virtual_machine')
+        if parent and self.cleaned_data.get('is_primary') is not None:
             if self.cleaned_data.get('is_primary'):
                 parent.snapshot()
                 if self.instance.address.version == 4:
@@ -450,8 +450,8 @@ class IPAddressImportForm(PrimaryModelImportForm):
                     parent.save()
 
         # Set as OOB for device
-        if self.cleaned_data.get('is_oob') is not None:
-            parent = self.cleaned_data.get('device')
+        parent = self.cleaned_data.get('device')
+        if parent and self.cleaned_data.get('is_oob') is not None:
             if self.cleaned_data.get('is_oob'):
                 parent.snapshot()
                 parent.oob_ip = ipaddress

--- a/netbox/ipam/forms/bulk_import.py
+++ b/netbox/ipam/forms/bulk_import.py
@@ -377,13 +377,13 @@ class IPAddressImportForm(PrimaryModelImportForm):
 
     def clean_is_primary(self):
         # Make sure is_primary is None when it's not included in the uploaded data
-        if 'is_primary' not in self.data:
+        if 'is_primary' not in self.data or not self.data['is_primary']:
             return None
         return self.cleaned_data['is_primary']
 
     def clean_is_oob(self):
         # Make sure is_oob is None when it's not included in the uploaded data
-        if 'is_oob' not in self.data:
+        if 'is_oob' not in self.data or not self.data['is_oob']:
             return None
         return self.cleaned_data['is_oob']
 

--- a/netbox/ipam/tests/test_forms.py
+++ b/netbox/ipam/tests/test_forms.py
@@ -68,27 +68,74 @@ class IPAddressImportFormTestCase(TestCase):
 
     def test_import_with_empty_is_primary_column_no_device(self):
         """
-        Regression test for #22561: importing an IP where the is_primary column is present
-        but empty (and no device/VM specified) should succeed, not raise AttributeError.
+        Regression test for #22561: importing an IP where the is_primary/is_oob columns are
+        present but empty (and no device/VM specified) should succeed, not raise AttributeError.
         """
         form = IPAddressImportForm(data={
             'address': '172.16.0.1/20',
             'status': 'active',
-            'vrf': '',
-            'tenant': '',
-            'role': '',
             'device': '',
             'virtual_machine': '',
             'interface': '',
-            'fhrp_group': '',
             'is_primary': '',
             'is_oob': '',
-            'dns_name': '',
             'description': 'gateway for group A - Site 01',
         })
         self.assertTrue(form.is_valid(), form.errors)
         ip = form.save()
         self.assertEqual(str(ip.address), '172.16.0.1/20')
+
+    def test_import_with_false_is_primary_no_device(self):
+        """
+        Regression test for #22561: importing an IP with an explicit is_primary=false (and no
+        device/VM specified) should succeed as a no-op, not raise AttributeError. An explicit
+        falsy boolean is not caught by clean_is_primary()'s "column absent" check.
+        """
+        form = IPAddressImportForm(data={
+            'address': '172.16.0.1/20',
+            'status': 'active',
+            'is_primary': 'false',
+            'is_oob': 'false',
+            'description': 'no parent specified',
+        })
+        self.assertTrue(form.is_valid(), form.errors)
+        ip = form.save()
+        self.assertEqual(str(ip.address), '172.16.0.1/20')
+
+    def test_primary_not_cleared_by_subsequent_non_primary_row_with_device(self):
+        """
+        Guard against re-breaking #21440 while fixing #22561: importing a second IP with
+        is_primary=false (device specified) must not clear the primary IP set by a previous
+        row. The save-side parent guard must leave the conservative "only clear if currently
+        primary" behavior intact.
+        """
+        form1 = IPAddressImportForm(data={
+            'address': '10.10.10.1/24',
+            'status': 'active',
+            'device': 'Device 1',
+            'interface': 'eth0',
+            'is_primary': True,
+        })
+        self.assertTrue(form1.is_valid(), form1.errors)
+        ip1 = form1.save()
+
+        self.device.refresh_from_db()
+        self.assertEqual(self.device.primary_ip4, ip1)
+
+        form2 = IPAddressImportForm(data={
+            'address': '10.10.10.2/24',
+            'status': 'active',
+            'device': 'Device 1',
+            'interface': 'eth0',
+            'is_primary': False,
+        })
+        self.assertTrue(form2.is_valid(), form2.errors)
+        form2.save()
+
+        self.device.refresh_from_db()
+        self.assertEqual(
+            self.device.primary_ip4, ip1, "primary IP was incorrectly cleared by a row with is_primary=False"
+        )
 
     def test_oob_import_not_cleared_by_subsequent_non_oob_row(self):
         """

--- a/netbox/ipam/tests/test_forms.py
+++ b/netbox/ipam/tests/test_forms.py
@@ -66,6 +66,30 @@ class IPAddressImportFormTestCase(TestCase):
             type=InterfaceTypeChoices.TYPE_1GE_FIXED,
         )
 
+    def test_import_with_empty_is_primary_column_no_device(self):
+        """
+        Regression test for #22561: importing an IP where the is_primary column is present
+        but empty (and no device/VM specified) should succeed, not raise AttributeError.
+        """
+        form = IPAddressImportForm(data={
+            'address': '172.16.0.1/20',
+            'status': 'active',
+            'vrf': '',
+            'tenant': '',
+            'role': '',
+            'device': '',
+            'virtual_machine': '',
+            'interface': '',
+            'fhrp_group': '',
+            'is_primary': '',
+            'is_oob': '',
+            'dns_name': '',
+            'description': 'gateway for group A - Site 01',
+        })
+        self.assertTrue(form.is_valid(), form.errors)
+        ip = form.save()
+        self.assertEqual(str(ip.address), '172.16.0.1/20')
+
     def test_oob_import_not_cleared_by_subsequent_non_oob_row(self):
         """
         Regression test for #21440: importing a second IP with is_oob=False should


### PR DESCRIPTION
### Closes: #22561

Importing an IP address with the `is_primary` or `is_oob` column present but no device or virtual machine raised `AttributeError: 'NoneType' object has no attribute 'primary_ip4'`. In `save()`, the device/VM lookup resolved to `None`, and the primary/OOB block dereferenced it anyway.

The fix moves the parent lookup ahead of each block and guards on the parent existing before touching `primary_ip4`/`primary_ip6`/`oob_ip`. A row that names no device/VM is now a no-op, matching how `MACAddressImportForm` and the interactive `IPAddressForm` handle the same flags.

This covers both an empty column value (the original report) and an explicit falsy value such as `false`, neither of which the `clean_is_primary()` column-absent check catches. The conservative "only clear if this IP is currently primary" behavior from #21440 is preserved for rows that do name a device.