### PR TITLE
22378 reshape customscript object column

### DIFF
--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -816,6 +816,28 @@ class ScriptResultsTable(BaseTable):
         )
 
     def render_object(self, value, record):
+        try:
+            if record['url']:
+                from django.urls import resolve
+                match = resolve(record['url'])
+                view_class = match.func.view_class
+                if not (hasattr(view_class, "queryset") and hasattr(view_class.queryset, "model")):
+                    return format_html("<a href='{}'>{}</a>", record['url'], value)
+                model = view_class.queryset.model
+                obj = model.objects.get(**match.kwargs)
+
+                if hasattr(obj, "parent_object") and obj.parent_object:
+                    return format_html(
+                        "<a href='{}'>{}</a> / <a href='{}'>{}</a>",
+                        obj.parent_object.get_absolute_url(),
+                        obj.parent_object,
+                        record['url'],
+                        value,
+                    )
+        except RuntimeException:
+            # in case anything goes wrong at all, we always can fall back to the previous style
+            pass
+
         return format_html("<a href='{}'>{}</a>", record['url'], value)
 
 

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -2,6 +2,7 @@ import json
 
 import django_tables2 as tables
 from django.template.defaultfilters import filesizeformat
+from django.urls import resolve
 from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 
@@ -817,24 +818,22 @@ class ScriptResultsTable(BaseTable):
 
     def render_object(self, value, record):
         try:
-            if record['url']:
-                from django.urls import resolve
-                match = resolve(record['url'])
-                view_class = match.func.view_class
-                if not (hasattr(view_class, "queryset") and hasattr(view_class.queryset, "model")):
-                    return format_html("<a href='{}'>{}</a>", record['url'], value)
-                model = view_class.queryset.model
-                obj = model.objects.get(**match.kwargs)
+            match = resolve(record['url'])
+            view_class = match.func.view_class
+            if not (hasattr(view_class, "queryset") and hasattr(view_class.queryset, "model")):
+                return format_html("<a href='{}'>{}</a>", record['url'], value)
+            model = view_class.queryset.model
+            obj = model.objects.get(**match.kwargs)
 
-                if hasattr(obj, "parent_object") and obj.parent_object:
-                    return format_html(
-                        "<a href='{}'>{}</a> / <a href='{}'>{}</a>",
-                        obj.parent_object.get_absolute_url(),
-                        obj.parent_object,
-                        record['url'],
-                        value,
-                    )
-        except RuntimeException:
+            if hasattr(obj, "parent_object") and obj.parent_object:
+                return format_html(
+                    "<a href='{}'>{}</a> / <a href='{}'>{}</a>",
+                    obj.parent_object.get_absolute_url(),
+                    obj.parent_object,
+                    record['url'],
+                    value,
+                )
+        except Exception:
             # in case anything goes wrong at all, we always can fall back to the previous style
             pass
 

--- a/netbox/extras/tables/tables.py
+++ b/netbox/extras/tables/tables.py
@@ -818,9 +818,6 @@ class ScriptResultsTable(BaseTable):
     def render_object(self, value, record):
         return format_html("<a href='{}'>{}</a>", record['url'], value)
 
-    def render_url(self, value):
-        return format_html("<a href='{}'>{}</a>", value, value)
-
 
 class ScriptJobTable(JobTable):
     id = tables.TemplateColumn(


### PR DESCRIPTION
### Closes: #22378

I went for a simple approach, using `parent_object` when present. I was thinking about doing the same for `.device` and `.group`, but wasn't convinced it would help much.

I was wondering, if there is some sort of convention on how a parent object should be referred to (see discussion #22403).

Removed the unused `render_url()` function as well.