### PR TITLE
Closes #22548: Improve sidebar action button styling (followup)

### DIFF
--- a/netbox/templates/inc/table_controls_htmx.html
+++ b/netbox/templates/inc/table_controls_htmx.html
@@ -18,7 +18,7 @@
     </div>
   </div>
 
-  {% if filter_form %}
+  {% if filter_form and filter_form.filter_id %}
     <div class="col-auto d-print-none">
       <div class="input-group">
         <label for="saved-filter-select" class="input-group-text">

--- a/netbox/utilities/templates/navigation/menu.html
+++ b/netbox/utilities/templates/navigation/menu.html
@@ -45,7 +45,7 @@
                   {% if buttons %}
                     <div class="dropdown-item-buttons d-inline-flex ms-1">
                       {% for button in buttons %}
-                        <a href="{{ button.url }}" class="btn btn-sm btn-ghost btn-{{ button.color|default:"secondary" }} px-2" title="{{ button.title }}" aria-label="{{ button.title }}">
+                        <a href="{{ button.url }}" class="btn btn-sm btn-ghost btn-{% if button.color and button.color != 'default' %}{{ button.color }}{% else %}secondary{% endif %} px-2" title="{{ button.title }}" aria-label="{{ button.title }}">
                           <i class="{{ button.icon_class }}" aria-hidden="true"></i>
                         </a>
                       {% endfor %}


### PR DESCRIPTION
### Closes: #22548

This PR includes two small UI fixes.

First, it normalizes navigation menu button styling so buttons using the default color are rendered with the secondary ghost style. This fixes plugin menu buttons that set their color to `"default"` instead of leaving it unset, while still preserving explicitly configured colors.

Second, it updates the saved filter dropdown in table controls so it is only rendered when the filter form includes a `filter_id` field. This prevents errors on views that provide a filter form but do not support saved filters, such as the connection list views.