### PR TITLE
Closes #22589: Cache serializers

### DIFF
--- a/netbox/netbox/api/serializers/generic.py
+++ b/netbox/netbox/api/serializers/generic.py
@@ -22,6 +22,10 @@ class GenericObjectSerializer(serializers.Serializer):
     object_id = serializers.IntegerField()
     object = serializers.SerializerMethodField(read_only=True)
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._serializer_cache = {}
+
     def to_internal_value(self, data):
         data = super().to_internal_value(data)
         model = data['object_type'].model_class()
@@ -40,5 +44,7 @@ class GenericObjectSerializer(serializers.Serializer):
 
     @extend_schema_field(serializers.JSONField(allow_null=True))
     def get_object(self, obj):
-        serializer = get_serializer_for_model(obj)
-        return serializer(obj, nested=True, context=self.context).data
+        if obj.__class__ not in self._serializer_cache:
+            self._serializer_cache[obj.__class__] = get_serializer_for_model(obj)(nested=True, context=self.context)
+        serializer = self._serializer_cache[obj.__class__]
+        return serializer.to_representation(obj)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22589

This change introduces caching for serializers to avoid the overhead of enumerating the fields. This will improve the performance of the cables API listing endpoint.