### PR TITLE
Fixes #22598: Fix ValueError exception when viewing background tasks

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ django-pglocks==1.0.4
 django-prometheus==2.4.0
 django-redis==7.0.0
 django-rich==2.2.0
-django-rq==4.1.0
+django-rq==4.1.1
 django-storages==1.14.6
 django-tables2==2.8.0
 django-taggit==6.1.0


### PR DESCRIPTION
### Fixes: #22598

Upgrade `django-rq` to [v4.1.1](https://github.com/rq/django-rq/releases/tag/v4.1.1), which should resolve the issue upstream.