### PR TITLE
Closes #22538: Add security note for HTTP_CLIENT_IP_HEADERS client-IP trust

### DIFF
--- a/docs/configuration/system.md
+++ b/docs/configuration/system.md
@@ -99,7 +99,7 @@ An ordered list of HTTP request headers inspected to determine the source IP add
 The client IP is used for source-address restrictions on API tokens and for logging failed login attempts.
 
 !!! warning "Client IP trust"
-    The headers listed here are trusted as the source of the client IP address. Trusting `X-Forwarded-For` or `X-Real-IP` is safe only when NetBox is deployed behind a reverse proxy that overwrites these headers with the real client address. If NetBox is reachable directly, or the proxy appends to or passes through a client-supplied value, a client can spoof its apparent IP address and defeat API token client IP restrictions. Deployments without a trusted proxy should set `HTTP_CLIENT_IP_HEADERS = ('REMOTE_ADDR',)`.
+    The headers listed here are trusted as the source of the client IP address. Trusting `X-Forwarded-For` (`HTTP_X_FORWARDED_FOR`) or `X-Real-IP` (`HTTP_X_REAL_IP`) is safe only when NetBox is deployed behind a reverse proxy that overwrites these headers with the real client address. If NetBox is reachable directly, or the proxy appends to or passes through a client-supplied value (NetBox uses the leftmost address, which the client controls when the proxy appends), a client can spoof its apparent IP address and defeat API token client IP restrictions. Deployments without a trusted proxy should set `HTTP_CLIENT_IP_HEADERS = ('REMOTE_ADDR',)`.
 
 ---
 

--- a/docs/configuration/system.md
+++ b/docs/configuration/system.md
@@ -98,6 +98,9 @@ An ordered list of HTTP request headers inspected to determine the source IP add
 
 The client IP is used for source-address restrictions on API tokens and for logging failed login attempts.
 
+!!! warning "Client IP trust"
+    The headers listed here are trusted as the source of the client IP address. Trusting `X-Forwarded-For` or `X-Real-IP` is safe only when NetBox is deployed behind a reverse proxy that overwrites these headers with the real client address. If NetBox is reachable directly, or the proxy appends to or passes through a client-supplied value, a client can spoof its apparent IP address and defeat API token client IP restrictions. Deployments without a trusted proxy should set `HTTP_CLIENT_IP_HEADERS = ('REMOTE_ADDR',)`.
+
 ---
 
 ## HTTP_PROXIES

--- a/docs/integrations/rest-api.md
+++ b/docs/integrations/rest-api.md
@@ -807,6 +807,8 @@ By default, a token can be used to perform all actions via the API that a user w
 
 Each API token can optionally be restricted by client IP address. If one or more allowed IP prefixes/addresses is defined for a token, authentication will fail for any client connecting from an IP address outside the defined range(s). This enables restricting the use a token to a specific client. (By default, any client IP address is permitted.)
 
+The client IP address is determined from the HTTP headers configured by [`HTTP_CLIENT_IP_HEADERS`](../configuration/system.md#http_client_ip_headers); see the security note there regarding header trust.
+
 #### Creating Tokens for Other Users
 
 It is possible to provision authentication tokens for other users via the REST API. To do, so the requesting user must have the `users.grant_token` permission assigned. While all users have inherent permission by default to create their own tokens, this permission is required to enable the creation of tokens for other users.


### PR DESCRIPTION
### Closes: #22538

Adds a security warning to the `HTTP_CLIENT_IP_HEADERS` section of the system configuration docs. The warning covers three points:

- The configured headers are trusted as the source of the client IP address.
- Trusting `X-Forwarded-For` or `X-Real-IP` is only safe behind a reverse proxy that overwrites those headers. A proxy that appends instead preserves the client-supplied value, because NetBox uses the leftmost address in the list.
- Deployments without a trusted proxy should set the parameter to `('REMOTE_ADDR',)`.

Also adds a pointer to this note from the "Client IP Restriction" section of the REST API docs, where token IP restrictions are documented.