### PR TITLE
Closes #22571: Migrate from django-pglocks to django-pgware

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -33,10 +33,9 @@ django-htmx
 # NetBox core runtime uses netbox.models.ltree.LtreeModel instead.
 django-mptt
 
-# Context managers for PostgreSQL advisory locks
-# https://github.com/Xof/django-pglocks/blob/main/CHANGELOG.md
-# django-pglocks has been merged into django-pgware (see #22571)
-django-pglocks==1.0.4
+# Context managers for PostgreSQL advisory locks (successor to django-pglocks)
+# https://github.com/Xof/django-pgware
+django-pgware
 
 # Prometheus metrics library for Django
 # https://github.com/korfuri/django-prometheus/blob/master/CHANGELOG.md

--- a/netbox/ipam/api/views.py
+++ b/netbox/ipam/api/views.py
@@ -5,7 +5,7 @@ from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.db import router, transaction
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext as _
-from django_pglocks import advisory_lock
+from django_pg_utils import advisory_lock
 from drf_spectacular.utils import extend_schema
 from netaddr import IPSet
 from rest_framework import status

--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -15,7 +15,7 @@ from django.http import Http404
 from django.utils import timezone
 from django.utils.functional import classproperty
 from django.utils.module_loading import import_string
-from django_pglocks import advisory_lock
+from django_pg_utils import advisory_lock
 from rest_framework.exceptions import APIException
 from rq.timeouts import JobTimeoutException
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ django-filter==25.2
 django-graphiql-debug-toolbar==0.2.0
 django-htmx==1.27.0
 django-mptt==0.18.0
-django-pglocks==1.0.4
+django-pgware==1.0.0
 django-prometheus==2.4.0
 django-redis==7.0.0
 django-rich==2.2.0


### PR DESCRIPTION
### Closes: #22571

`django-pglocks` v1.0.4 is its final release - it has been merged into its successor, `django-pgware`. This swaps the dependency and updates the two import sites.

The advisory_lock API is drop-in compatible (same call signature; works as both context manager and decorator). Note the package imports as django_pg_utils.