### PR TITLE
Closes #18159: Expose snapshots to event rule condition evaluation

### DIFF
--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -145,7 +145,7 @@ You can also read pre- or post-change values directly using the `snapshots.prech
     Snapshot data uses the **model serializer format**, not the REST API format. Choice fields such as `status` are stored as raw strings (e.g. `"active"`) rather than nested objects (e.g. `{"value": "active", "label": "Active"}`). Use `attr: "snapshots.prechange.status"` — not `"snapshots.prechange.status.value"` — when referencing snapshot attributes. The `changed`/`unchanged` operators compare the same format on both sides, so they are not affected by this distinction.
 
 !!! note "Snapshot availability"
-    Snapshots are only populated for update and delete events. For create events, `prechange` is `null`. Conditions using the `changed` operator on a create event will evaluate to `true` (since the field went from non-existent to its initial value). Conditions using direct `snapshots.prechange.*` paths on a create event will fail and evaluate to `false`.
+    Snapshots are only populated for update and delete events. For create events, `prechange` is `null` — conditions using the `changed` operator on a create event evaluate to `true` (the field transitioned from non-existent to its initial value), while conditions using `snapshots.prechange.*` paths evaluate to `false`. For delete events, `postchange` is `null` — the `changed` operator evaluates to `true` for any attribute present in the prechange snapshot, and `unchanged` evaluates to `false`.
 
 ## Condition Sets
 

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -9,7 +9,7 @@ A condition is expressed as a JSON object with the following keys:
 | Key name | Required | Default | Description |
 |----------|----------|---------|-------------|
 | attr     | Yes      | -       | Name of the key within the data being evaluated |
-| value    | Yes      | -       | The reference value to which the given data will be compared |
+| value    | See note | -       | The reference value to which the given data will be compared. Not used by snapshot operators (`changed`, `unchanged`). |
 | op       | No       | `eq`    | The logical operation to be performed |
 | negate   | No       | False   | Negate (invert) the result of the condition's evaluation |
 
@@ -22,6 +22,9 @@ A condition is expressed as a JSON object with the following keys:
 * `lte`: Less than or equal to
 * `in`: Is present within a list of values
 * `contains`: Contains the specified value
+* `regex`: Matches a regular expression
+* `changed`: The attribute's value differs between the pre-change and post-change snapshots (no `value` required)
+* `unchanged`: The attribute's value is the same in both snapshots (no `value` required)
 
 ### Accessing Nested Keys
 
@@ -90,6 +93,59 @@ The following condition will evaluate as true:
 
 !!! note "Evaluating static choice fields"
     Pay close attention when evaluating static choice fields, such as the `status` field above. These fields typically render as a dictionary specifying both the field's raw value (`value`) and its human-friendly label (`label`). Be sure to specify on which of these you want to match.
+
+## Snapshot Conditions (Event Rules)
+
+When used in an [event rule](../features/event-rules.md), conditions can also inspect the **pre-change and post-change snapshots** captured at the time of the event. This allows rules to fire only when a specific field actually changes value, rather than whenever it has a particular value.
+
+### Snapshot Operators
+
+The `changed` and `unchanged` operators compare an attribute's value across the two snapshots. They do not accept a `value` key.
+
+Fire only when `status` changes (to any value):
+
+```json
+{
+  "attr": "status",
+  "op": "changed"
+}
+```
+
+### Combining with Standard Conditions
+
+The canonical use case — fire only when `status` changes **to** `active` — combines a standard value check with the `changed` operator:
+
+```json
+{
+  "and": [
+    {
+      "attr": "status.value",
+      "value": "active"
+    },
+    {
+      "attr": "status",
+      "op": "changed"
+    }
+  ]
+}
+```
+
+### Direct Snapshot Path Access
+
+You can also read pre- or post-change values directly using the `snapshots.prechange.<attr>` and `snapshots.postchange.<attr>` dot-path syntax with any standard operator:
+
+```json
+{
+  "attr": "snapshots.prechange.status",
+  "value": "planned"
+}
+```
+
+!!! warning "Snapshot serialization format"
+    Snapshot data uses the **model serializer format**, not the REST API format. Choice fields such as `status` are stored as raw strings (e.g. `"active"`) rather than nested objects (e.g. `{"value": "active", "label": "Active"}`). Use `attr: "snapshots.prechange.status"` — not `"snapshots.prechange.status.value"` — when referencing snapshot attributes. The `changed`/`unchanged` operators compare the same format on both sides, so they are not affected by this distinction.
+
+!!! note "Snapshot availability"
+    Snapshots are only populated for update and delete events. For create events, `prechange` is `null`. Conditions using the `changed` operator on a create event will evaluate to `true` (since the field went from non-existent to its initial value). Conditions using direct `snapshots.prechange.*` paths on a create event will fail and evaluate to `false`.
 
 ## Condition Sets
 

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -78,6 +78,13 @@ class Condition:
                 raise ValueError(_(
                     "The '{op}' operator compares snapshots and does not accept a value."
                 ).format(op=op))
+            if attr.startswith('snapshots.'):
+                raise ValueError(_(
+                    "The '{op}' operator resolves '{attr}' within each snapshot dict, not the "
+                    "top-level condition context. Use the bare attribute name (e.g. 'status') "
+                    "rather than a snapshot path (e.g. 'snapshots.prechange.status'), which is "
+                    "only valid with standard operators."
+                ).format(op=op, attr=attr))
             self.value = _MISSING
         else:
             if value is _MISSING:

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -131,7 +131,7 @@ class Condition:
                 else:
                     obj = operator.getitem(obj or {}, key)
             return obj
-        except KeyError:
+        except (KeyError, TypeError):
             return _MISSING
 
     def eval(self, data):
@@ -196,8 +196,11 @@ class Condition:
     # Snapshot comparison operators
     # These resolve self.attr in both the prechange and postchange snapshots and
     # compare the resulting values.  _MISSING is used when a snapshot is absent
-    # or does not contain the attribute, so that two absent values compare equal
-    # (nothing changed) and a present value differs from an absent one (changed).
+    # or does not contain the attribute.
+    #
+    # Fail-closed semantics:
+    #   changed:   False when attr is absent from both snapshots (field never existed)
+    #   unchanged: False when attr is absent from both snapshots (avoids silent pass on typos)
 
     def eval_changed(self, snapshots):
         pre = self._resolve_snapshot_attr(snapshots.get('prechange'))
@@ -207,6 +210,8 @@ class Condition:
     def eval_unchanged(self, snapshots):
         pre = self._resolve_snapshot_attr(snapshots.get('prechange'))
         post = self._resolve_snapshot_attr(snapshots.get('postchange'))
+        if pre is _MISSING and post is _MISSING:
+            return False
         return pre == post
 
 

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -133,7 +133,7 @@ class Condition:
         """
         if self.op in self.SNAPSHOT_OPERATORS:
             snapshots = data.get('snapshots') if isinstance(data, dict) else None
-            if not snapshots:
+            if snapshots is None:
                 raise InvalidCondition(
                     f"No snapshot data available for '{self.op}' operator. "
                     f"Snapshot operators are only meaningful on update and delete events."
@@ -141,10 +141,7 @@ class Condition:
             result = self.eval_func(snapshots)
             return not result if self.negate else result
 
-        try:
-            value = self._resolve_attr(data)
-        except InvalidCondition:
-            raise
+        value = self._resolve_attr(data)
         try:
             result = self.eval_func(value)
         except TypeError as e:

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -103,7 +103,8 @@ class Condition:
     def _resolve_attr(self, data):
         """
         Walk self.attr as a dotted key path through data. Raises InvalidCondition on
-        missing keys.
+        missing keys, or when an intermediate value can't be indexed by key (e.g. a
+        REST API-style path like 'status.value' applied to a raw snapshot value).
         """
         def _get(obj, key):
             if isinstance(obj, list):
@@ -114,6 +115,8 @@ class Condition:
             return functools.reduce(_get, self.attr.split('.'), data)
         except KeyError:
             raise InvalidCondition(f"Invalid key path: {self.attr}")
+        except TypeError as e:
+            raise InvalidCondition(f"Invalid key path: {self.attr} ({e})")
 
     def _resolve_snapshot_attr(self, snapshot):
         """

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -13,6 +13,12 @@ __all__ = (
 AND = 'and'
 OR = 'or'
 
+# Sentinel for a snapshot attribute that could not be resolved (missing key or
+# null snapshot).  Using a unique object ensures that two independently
+# unresolvable values compare equal to each other, which is the correct
+# semantics for the 'unchanged' operator when neither snapshot has the field.
+_MISSING = object()
+
 
 def is_ruleset(data):
     """
@@ -30,8 +36,9 @@ class Condition:
     An individual conditional rule that evaluates a single attribute and its value.
 
     :param attr: The name of the attribute being evaluated
-    :param value: The value being compared
+    :param value: The value being compared (not used by snapshot operators)
     :param op: The logical operation to use when evaluating the value (default: 'eq')
+    :param negate: Invert the result of evaluation
     """
     EQ = 'eq'
     GT = 'gt'
@@ -41,10 +48,15 @@ class Condition:
     IN = 'in'
     CONTAINS = 'contains'
     REGEX = 'regex'
+    CHANGED = 'changed'
+    UNCHANGED = 'unchanged'
 
     OPERATORS = (
-        EQ, GT, GTE, LT, LTE, IN, CONTAINS, REGEX
+        EQ, GT, GTE, LT, LTE, IN, CONTAINS, REGEX, CHANGED, UNCHANGED
     )
+
+    # Operators that compare pre/post snapshots and do not accept a value.
+    SNAPSHOT_OPERATORS = (CHANGED, UNCHANGED)
 
     TYPES = {
         str: (EQ, CONTAINS, REGEX),
@@ -55,25 +67,36 @@ class Condition:
         type(None): (EQ,)
     }
 
-    def __init__(self, attr, value, op=EQ, negate=False):
+    def __init__(self, attr, value=_MISSING, op=EQ, negate=False):
         if op not in self.OPERATORS:
             raise ValueError(_("Unknown operator: {op}. Must be one of: {operators}").format(
                 op=op, operators=', '.join(self.OPERATORS)
             ))
-        if type(value) not in self.TYPES:
-            raise ValueError(_("Unsupported value type: {value}").format(value=type(value)))
-        if op not in self.TYPES[type(value)]:
-            raise ValueError(_("Invalid type for {op} operation: {value}").format(op=op, value=type(value)))
+
+        if op in self.SNAPSHOT_OPERATORS:
+            if value is not _MISSING:
+                raise ValueError(_(
+                    "The '{op}' operator compares snapshots and does not accept a value."
+                ).format(op=op))
+            self.value = _MISSING
+        else:
+            if value is _MISSING:
+                raise ValueError(_("A value is required for the '{op}' operator.").format(op=op))
+            if type(value) not in self.TYPES:
+                raise ValueError(_("Unsupported value type: {value}").format(value=type(value)))
+            if op not in self.TYPES[type(value)]:
+                raise ValueError(_("Invalid type for {op} operation: {value}").format(op=op, value=type(value)))
+            self.value = value
 
         self.attr = attr
-        self.value = value
         self.op = op
         self.eval_func = getattr(self, f'eval_{op}')
         self.negate = negate
 
-    def eval(self, data):
+    def _resolve_attr(self, data):
         """
-        Evaluate the provided data to determine whether it matches the condition.
+        Walk self.attr as a dotted key path through data. Raises InvalidCondition on
+        missing keys.
         """
         def _get(obj, key):
             if isinstance(obj, list):
@@ -81,9 +104,47 @@ class Condition:
             return operator.getitem(obj or {}, key)
 
         try:
-            value = functools.reduce(_get, self.attr.split('.'), data)
+            return functools.reduce(_get, self.attr.split('.'), data)
         except KeyError:
             raise InvalidCondition(f"Invalid key path: {self.attr}")
+
+    def _resolve_snapshot_attr(self, snapshot):
+        """
+        Walk self.attr through a snapshot dict, returning _MISSING on any miss.
+        Snapshots use the model serializer format (raw field values), not the REST
+        API format, so e.g. status is stored as "active" not {"value": "active"}.
+        """
+        if snapshot is None:
+            return _MISSING
+        try:
+            obj = snapshot
+            for key in self.attr.split('.'):
+                if isinstance(obj, list):
+                    obj = [operator.getitem(item or {}, key) for item in obj]
+                else:
+                    obj = operator.getitem(obj or {}, key)
+            return obj
+        except KeyError:
+            return _MISSING
+
+    def eval(self, data):
+        """
+        Evaluate the provided data to determine whether it matches the condition.
+        """
+        if self.op in self.SNAPSHOT_OPERATORS:
+            snapshots = data.get('snapshots') if isinstance(data, dict) else None
+            if not snapshots:
+                raise InvalidCondition(
+                    f"No snapshot data available for '{self.op}' operator. "
+                    f"Snapshot operators are only meaningful on update and delete events."
+                )
+            result = self.eval_func(snapshots)
+            return not result if self.negate else result
+
+        try:
+            value = self._resolve_attr(data)
+        except InvalidCondition:
+            raise
         try:
             result = self.eval_func(value)
         except TypeError as e:
@@ -127,6 +188,22 @@ class Condition:
 
     def eval_regex(self, value):
         return re.match(self.value, value) is not None
+
+    # Snapshot comparison operators
+    # These resolve self.attr in both the prechange and postchange snapshots and
+    # compare the resulting values.  _MISSING is used when a snapshot is absent
+    # or does not contain the attribute, so that two absent values compare equal
+    # (nothing changed) and a present value differs from an absent one (changed).
+
+    def eval_changed(self, snapshots):
+        pre = self._resolve_snapshot_attr(snapshots.get('prechange'))
+        post = self._resolve_snapshot_attr(snapshots.get('postchange'))
+        return pre != post
+
+    def eval_unchanged(self, snapshots):
+        pre = self._resolve_snapshot_attr(snapshots.get('prechange'))
+        post = self._resolve_snapshot_attr(snapshots.get('postchange'))
+        return pre == post
 
 
 class ConditionSet:

--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -176,8 +176,13 @@ def process_event_rules(event_rules, object_type, event):
 
     for event_rule in event_rules:
 
-        # Evaluate event rule conditions (if any)
-        if not event_rule.eval_conditions(event['data']):
+        # Evaluate event rule conditions (if any).
+        # Snapshots are merged into the condition context so conditions can
+        # reference snapshots.prechange.<attr> and snapshots.postchange.<attr>
+        # using the standard dot-path syntax, and so the 'changed'/'unchanged'
+        # operators can access pre/post values.
+        condition_data = {**event['data'], 'snapshots': event.get('snapshots')}
+        if not event_rule.eval_conditions(condition_data):
             continue
 
         # Guard against action_data that is valid JSON but not a dict

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -346,6 +346,13 @@ class SnapshotConditionTestCase(TestCase):
         with self.assertRaises(ValueError):
             Condition('status', value='active', op='unchanged')
 
+    def test_snapshot_operator_rejects_snapshot_path_attr(self):
+        """Snapshot operators must not use a snapshots.prechange.* path — that's only for standard operators."""
+        with self.assertRaises(ValueError):
+            Condition('snapshots.prechange.status', op='changed')
+        with self.assertRaises(ValueError):
+            Condition('snapshots.postchange.status', op='unchanged')
+
     def test_standard_operator_requires_value(self):
         with self.assertRaises(ValueError):
             Condition('status', op='eq')
@@ -468,7 +475,7 @@ class SnapshotConditionTestCase(TestCase):
                 ]
             }
         )
-        site = Site.objects.create(name='Site 1', slug='site-1', status=SiteStatusChoices.STATUS_ACTIVE)
+        site = Site.objects.create(name='Site 2', slug='site-2', status=SiteStatusChoices.STATUS_ACTIVE)
 
         # status changed planned → active: should fire
         data_changed = self._make_condition_data(site, {
@@ -499,7 +506,7 @@ class SnapshotConditionTestCase(TestCase):
                 'value': SiteStatusChoices.STATUS_PLANNED,
             }
         )
-        site = Site.objects.create(name='Site 1', slug='site-1', status=SiteStatusChoices.STATUS_ACTIVE)
+        site = Site.objects.create(name='Site 3', slug='site-3', status=SiteStatusChoices.STATUS_ACTIVE)
         data = self._make_condition_data(site, {
             'prechange': {'status': SiteStatusChoices.STATUS_PLANNED},
             'postchange': {'status': SiteStatusChoices.STATUS_ACTIVE},

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -321,3 +321,187 @@ class ConditionSetTestCase(TestCase):
         })
 
         self.assertFalse(form.is_valid())
+
+
+class SnapshotConditionTestCase(TestCase):
+    """
+    Tests for snapshot-aware conditions: the 'changed'/'unchanged' operators and
+    direct snapshot attribute access via the snapshots.prechange.* / snapshots.postchange.*
+    dot-path syntax.
+    """
+
+    def _make_condition_data(self, site, snapshots):
+        """Return a condition evaluation context as produced by process_event_rules()."""
+        return {**serialize_for_event(site), 'snapshots': snapshots}
+
+    #
+    # Validation
+    #
+
+    def test_changed_operator_rejects_value(self):
+        with self.assertRaises(ValueError):
+            Condition('status', value='active', op='changed')
+
+    def test_unchanged_operator_rejects_value(self):
+        with self.assertRaises(ValueError):
+            Condition('status', value='active', op='unchanged')
+
+    def test_standard_operator_requires_value(self):
+        with self.assertRaises(ValueError):
+            Condition('status', op='eq')
+
+    #
+    # 'changed' operator
+    #
+
+    def test_changed_true_when_attr_differs(self):
+        c = Condition('status', op='changed')
+        snapshots = {
+            'prechange': {'status': 'planned'},
+            'postchange': {'status': 'active'},
+        }
+        self.assertTrue(c.eval({'snapshots': snapshots}))
+
+    def test_changed_false_when_attr_same(self):
+        c = Condition('status', op='changed')
+        snapshots = {
+            'prechange': {'status': 'active'},
+            'postchange': {'status': 'active'},
+        }
+        self.assertFalse(c.eval({'snapshots': snapshots}))
+
+    def test_changed_true_when_prechange_missing_attr(self):
+        # attr present in postchange but absent from prechange snapshot
+        c = Condition('description', op='changed')
+        snapshots = {
+            'prechange': {},
+            'postchange': {'description': 'hello'},
+        }
+        self.assertTrue(c.eval({'snapshots': snapshots}))
+
+    def test_changed_true_when_prechange_is_none(self):
+        # OBJECT_CREATED events have no prechange snapshot
+        c = Condition('status', op='changed')
+        snapshots = {
+            'prechange': None,
+            'postchange': {'status': 'active'},
+        }
+        self.assertTrue(c.eval({'snapshots': snapshots}))
+
+    def test_changed_false_when_both_snapshots_missing_attr(self):
+        # If neither snapshot has the attr, nothing changed
+        c = Condition('nonexistent', op='changed')
+        snapshots = {
+            'prechange': {'status': 'active'},
+            'postchange': {'status': 'active'},
+        }
+        self.assertFalse(c.eval({'snapshots': snapshots}))
+
+    def test_changed_negated(self):
+        c = Condition('status', op='changed', negate=True)
+        snapshots = {
+            'prechange': {'status': 'planned'},
+            'postchange': {'status': 'active'},
+        }
+        self.assertFalse(c.eval({'snapshots': snapshots}))
+
+    def test_changed_raises_when_no_snapshots(self):
+        c = Condition('status', op='changed')
+        with self.assertRaises(InvalidCondition):
+            c.eval({'status': {'value': 'active'}})
+
+    #
+    # 'unchanged' operator
+    #
+
+    def test_unchanged_true_when_attr_same(self):
+        c = Condition('status', op='unchanged')
+        snapshots = {
+            'prechange': {'status': 'active'},
+            'postchange': {'status': 'active'},
+        }
+        self.assertTrue(c.eval({'snapshots': snapshots}))
+
+    def test_unchanged_false_when_attr_differs(self):
+        c = Condition('status', op='unchanged')
+        snapshots = {
+            'prechange': {'status': 'planned'},
+            'postchange': {'status': 'active'},
+        }
+        self.assertFalse(c.eval({'snapshots': snapshots}))
+
+    #
+    # Direct snapshot path access (snapshots.prechange.* / snapshots.postchange.*)
+    #
+
+    def test_snapshot_path_access_prechange(self):
+        c = Condition('snapshots.prechange.status', value='planned', op='eq')
+        snapshots = {
+            'prechange': {'status': 'planned'},
+            'postchange': {'status': 'active'},
+        }
+        self.assertTrue(c.eval({'snapshots': snapshots}))
+
+    def test_snapshot_path_access_postchange(self):
+        c = Condition('snapshots.postchange.status', value='active', op='eq')
+        snapshots = {
+            'prechange': {'status': 'planned'},
+            'postchange': {'status': 'active'},
+        }
+        self.assertTrue(c.eval({'snapshots': snapshots}))
+
+    #
+    # EventRule.eval_conditions integration
+    #
+
+    def test_event_rule_changed_operator(self):
+        """
+        Verify the canonical use case: fire only when status changes to active.
+        """
+        event_rule = EventRule(
+            name='Notify on activation',
+            event_types=[OBJECT_UPDATED],
+            conditions={
+                'and': [
+                    {'attr': 'status.value', 'value': 'active'},
+                    {'attr': 'status', 'op': 'changed'},
+                ]
+            }
+        )
+        site = Site.objects.create(name='Site 1', slug='site-1', status=SiteStatusChoices.STATUS_ACTIVE)
+
+        # status changed planned → active: should fire
+        data_changed = self._make_condition_data(site, {
+            'prechange': {'status': SiteStatusChoices.STATUS_PLANNED},
+            'postchange': {'status': SiteStatusChoices.STATUS_ACTIVE},
+        })
+        self.assertTrue(event_rule.eval_conditions(data_changed))
+
+        # status already active, description updated: should NOT fire
+        data_unchanged = self._make_condition_data(site, {
+            'prechange': {'status': SiteStatusChoices.STATUS_ACTIVE},
+            'postchange': {'status': SiteStatusChoices.STATUS_ACTIVE},
+        })
+        self.assertFalse(event_rule.eval_conditions(data_unchanged))
+
+    def test_event_rule_snapshot_path_with_existing_operator(self):
+        """
+        Conditions can reference prechange/postchange data using the standard
+        snapshots.prechange.<attr> dot-path and existing operators.
+        Note: snapshot values use model serializer format (raw strings, not nested
+        dicts), so 'status' not 'status.value'.
+        """
+        event_rule = EventRule(
+            name='Was planned',
+            event_types=[OBJECT_UPDATED],
+            conditions={
+                'attr': 'snapshots.prechange.status',
+                'value': SiteStatusChoices.STATUS_PLANNED,
+            }
+        )
+        site = Site.objects.create(name='Site 1', slug='site-1', status=SiteStatusChoices.STATUS_ACTIVE)
+        data = self._make_condition_data(site, {
+            'prechange': {'status': SiteStatusChoices.STATUS_PLANNED},
+            'postchange': {'status': SiteStatusChoices.STATUS_ACTIVE},
+        })
+        self.assertTrue(event_rule.eval_conditions(data))

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -478,6 +478,20 @@ class SnapshotConditionTestCase(TestCase):
         }
         self.assertTrue(c.eval({'snapshots': snapshots}))
 
+    def test_snapshot_path_rest_api_style_attr_raises_invalid_condition(self):
+        """
+        Snapshots store raw values (e.g. status="planned"), not REST API-style nested
+        dicts (status={"value": "planned"}). A '.value' suffix on a snapshot path must
+        fail closed with InvalidCondition rather than raising a raw TypeError.
+        """
+        c = Condition('snapshots.prechange.status.value', value='planned', op='eq')
+        snapshots = {
+            'prechange': {'status': 'planned'},
+            'postchange': {'status': 'active'},
+        }
+        with self.assertRaises(InvalidCondition):
+            c.eval({'snapshots': snapshots})
+
     #
     # EventRule.eval_conditions integration
     #
@@ -533,3 +547,23 @@ class SnapshotConditionTestCase(TestCase):
             'postchange': {'status': SiteStatusChoices.STATUS_ACTIVE},
         })
         self.assertTrue(event_rule.eval_conditions(data))
+
+    def test_event_rule_snapshot_path_rest_api_style_attr_must_return_false(self):
+        """
+        An EventRule condition mistakenly using a REST API-style '.value' suffix on a
+        snapshot path must fail closed (return False) rather than crashing evaluation.
+        """
+        event_rule = EventRule(
+            name='Was planned (REST-style mistake)',
+            event_types=[OBJECT_UPDATED],
+            conditions={
+                'attr': 'snapshots.prechange.status.value',
+                'value': SiteStatusChoices.STATUS_PLANNED,
+            }
+        )
+        site = Site.objects.create(name='Site 4', slug='site-4', status=SiteStatusChoices.STATUS_ACTIVE)
+        data = self._make_condition_data(site, {
+            'prechange': {'status': SiteStatusChoices.STATUS_PLANNED},
+            'postchange': {'status': SiteStatusChoices.STATUS_ACTIVE},
+        })
+        self.assertFalse(event_rule.eval_conditions(data))

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -404,6 +404,17 @@ class SnapshotConditionTestCase(TestCase):
         }
         self.assertFalse(c.eval({'snapshots': snapshots}))
 
+    def test_changed_false_when_path_traverses_scalar(self):
+        # Snapshot choice fields are raw strings, not nested dicts. A path like
+        # 'status.value' hits a TypeError when traversing into the string; both
+        # sides resolve to _MISSING and the operator returns False (no change).
+        c = Condition('status.value', op='changed')
+        snapshots = {
+            'prechange': {'status': 'planned'},
+            'postchange': {'status': 'active'},
+        }
+        self.assertFalse(c.eval({'snapshots': snapshots}))
+
     def test_changed_negated(self):
         c = Condition('status', op='changed', negate=True)
         snapshots = {
@@ -433,6 +444,16 @@ class SnapshotConditionTestCase(TestCase):
         c = Condition('status', op='unchanged')
         snapshots = {
             'prechange': {'status': 'planned'},
+            'postchange': {'status': 'active'},
+        }
+        self.assertFalse(c.eval({'snapshots': snapshots}))
+
+    def test_unchanged_false_when_both_snapshots_missing_attr(self):
+        # Fail-closed: a typo or non-existent attr resolves to _MISSING on both
+        # sides; unchanged must return False rather than silently passing.
+        c = Condition('statsu', op='unchanged')
+        snapshots = {
+            'prechange': {'status': 'active'},
             'postchange': {'status': 'active'},
         }
         self.assertFalse(c.eval({'snapshots': snapshots}))

--- a/netbox/extras/tests/test_event_rules.py
+++ b/netbox/extras/tests/test_event_rules.py
@@ -109,6 +109,47 @@ class EventRuleTestCase(RQQueueTestMixin, APITestCase):
             Tag(name='Baz', slug='baz'),
         ))
 
+    def test_eventrule_snapshot_changed_condition(self):
+        """
+        An event rule using the 'changed' operator fires only when the attribute
+        transitions to the target value, not on subsequent updates that leave it
+        unchanged.  Exercises the full process_event_rules() path.
+        """
+        webhook = Webhook.objects.get(name='Webhook 1')
+        webhook_type = ObjectType.objects.get_for_model(Webhook)
+        site_type = ObjectType.objects.get_for_model(Site)
+        event_rule = EventRule.objects.create(
+            name='Status Change Rule',
+            event_types=[OBJECT_UPDATED],
+            action_type=EventRuleActionChoices.WEBHOOK,
+            action_object_type=webhook_type,
+            action_object_id=webhook.pk,
+            conditions={
+                'and': [
+                    {'attr': 'status.value', 'value': SiteStatusChoices.STATUS_ACTIVE},
+                    {'attr': 'status', 'op': 'changed'},
+                ]
+            }
+        )
+        event_rule.object_types.set([site_type])
+
+        site = Site.objects.create(name='Site Snapshot', slug='site-snapshot', status=SiteStatusChoices.STATUS_PLANNED)
+        url = reverse('dcim-api:site-detail', kwargs={'pk': site.pk})
+        self.add_permissions('dcim.change_site')
+
+        # planned → active: the 'changed' condition is satisfied; rule must fire
+        response = self.client.patch(url, {'status': SiteStatusChoices.STATUS_ACTIVE}, format='json', **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        rule_jobs = [j for j in self.queue.jobs if j.kwargs['event_rule'] == event_rule]
+        self.assertEqual(len(rule_jobs), 1, 'Expected rule to fire on status transition to active')
+        self.queue.empty()
+
+        # description update while status stays active: 'changed' condition fails; rule must not fire
+        response = self.client.patch(url, {'description': 'Updated'}, format='json', **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        rule_jobs = [j for j in self.queue.jobs if j.kwargs['event_rule'] == event_rule]
+        self.assertEqual(len(rule_jobs), 0, 'Expected rule not to fire when status is unchanged')
+
     def test_eventrule_conditions(self):
         """
         Test evaluation of EventRule conditions.


### PR DESCRIPTION
### Closes: #18159

## Summary

Event rule conditions previously evaluated only the current (post-change) REST API representation of the object. Snapshots — the pre- and post-change data captured at event time — were present in the event queue but never exposed to condition logic, making it impossible to express rules like "fire only when status *changes* to active."

This PR adds two complementary mechanisms:

**1. `changed` / `unchanged` operators**

New snapshot-comparison operators that check whether an attribute's value differs between the prechange and postchange snapshots. No `value` key is accepted.

```json
{
  "and": [
    { "attr": "status.value", "value": "active" },
    { "attr": "status", "op": "changed" }
  ]
}
```

This is the canonical solution for the issue's use case: the webhook fires only on the transition to active, not on subsequent updates that leave status unchanged.

**2. Direct snapshot path access**

Snapshots are merged into the condition evaluation context, so any existing operator can reference pre/post values via `snapshots.prechange.<attr>` and `snapshots.postchange.<attr>` dot-paths.

```json
{ "attr": "snapshots.prechange.status", "value": "planned" }
```

> **Note on serialization format:** Snapshot data uses the model serializer format (raw field values), not the REST API format. Choice fields like `status` appear as `"active"` in snapshots, not `{"value": "active", "label": "Active"}`. Use `attr: "status"` — not `"status.value"` — when referencing snapshot attributes. The `changed`/`unchanged` operators compare the same format on both sides, so they are unaffected by this distinction.

## Changes

| File | Change |
|---|---|
| `extras/conditions.py` | Add `CHANGED`/`UNCHANGED` operators; `_MISSING` sentinel; make `value` optional; `_resolve_snapshot_attr()` helper; `eval_changed()`/`eval_unchanged()` methods |
| `extras/events.py` | Merge snapshots into condition context in `process_event_rules()` |
| `extras/tests/test_conditions.py` | 16 new tests covering all new functionality and edge cases |
| `extras/tests/test_event_rules.py` | 1 new integration test exercising the full `process_event_rules()` path |
| `docs/reference/conditions.md` | Document new operators, snapshot path syntax, format caveat, and availability note |

## Comparison with community PR

A community implementation exists at https://github.com/kenancakir/netbox/pull/1/changes. Key differences from this PR:

| | Community PR | This PR |
|---|---|---|
| `changed`/`unchanged` operators | ✓ | ✓ |
| Snapshot access syntax | `prechange.status` (intercepts path prefix) | `snapshots.prechange.status` (transparent path merge) |
| `ConditionSet.eval()` signature | Modified (passes snapshots arg through chain) | Unchanged |
| Implementation complexity | Larger (routing logic, signature changes) | Minimal (one merge in `process_event_rules`, two eval methods) |
| Format inconsistency | Unclear | Documented; `changed`/`unchanged` are immune |
| Unit tests added | 0 | 17 |

The main tradeoff: `prechange.status` is marginally more ergonomic than `snapshots.prechange.status`, but requires special-casing the path prefix throughout the eval chain. Our approach falls out naturally from the existing dot-path traversal with no routing logic needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)