### PR TITLE
Closes #22652: Force autoescape=False on ConfigTemplate rendering

### DIFF
--- a/netbox/extras/models/configs.py
+++ b/netbox/extras/models/configs.py
@@ -316,6 +316,16 @@ class ConfigTemplate(
         self.template_code = self.data_file.data_as_string
     sync_data.alters_data = True
 
+    def get_environment_params(self):
+        """
+        Config templates render plain text (network configs, scripts), not HTML. Force
+        autoescape off so environment_params cannot enable it and create a latent XSS sink
+        if output is ever rendered in an HTML context.
+        """
+        params = super().get_environment_params()
+        params['autoescape'] = False
+        return params
+
     def format_render_error(self, exc):
         """
         Return a formatted error string for a rendering exception. When debug is enabled, the full

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -1310,6 +1310,24 @@ class RenderTemplateMixinRenderTestCase(TestCase):
         self.assertNotEqual(plain.render(ctx), trimmed.render(ctx))
         self.assertEqual(trimmed.render(ctx).strip(), 'VALUE')
 
+    def test_configtemplate_autoescape_always_disabled(self):
+        """
+        ConfigTemplate renders plain text (network configs, scripts); autoescape must stay off
+        even if environment_params explicitly requests it (#22652).
+        """
+        t = ConfigTemplate(name='autoescape', template_code='{{ value }}', environment_params={'autoescape': True})
+        self.assertEqual(t.render({'value': '<script>'}), '<script>')
+
+    def test_exporttemplate_autoescape_is_configurable(self):
+        """
+        Unlike ConfigTemplate, ExportTemplate output may legitimately be HTML, so an explicit
+        autoescape=True in environment_params must be honored rather than forced off.
+        """
+        et = ExportTemplate(
+            name='autoescape', template_code='{{ value }}', environment_params={'autoescape': True}
+        )
+        self.assertEqual(et.render({'value': '<script>'}), '&lt;script&gt;')
+
     def test_environment_params_undefined_path_import(self):
         # Default Undefined renders nothing for a missing variable.
         default = ConfigTemplate(name='default', template_code='{{ missing }}')
@@ -1339,8 +1357,9 @@ class RenderTemplateMixinRenderTestCase(TestCase):
 
     def test_get_environment_params_handles_none(self):
         # The environment_params field may be cleared; ensure the mixin returns a dict (not None).
+        # ConfigTemplate always forces autoescape off (#22652).
         t = ConfigTemplate(name='empty', template_code='ok', environment_params=None)
-        self.assertEqual(t.get_environment_params(), {})
+        self.assertEqual(t.get_environment_params(), {'autoescape': False})
 
     def test_get_environment_params_resolves_path_imports(self):
         t = ConfigTemplate(
@@ -1666,9 +1685,11 @@ class JinjaEnvironmentParamsIntegrationTestCase(TestCase):
         self.assertEqual(template.environment_params['undefined'], 'jinja2.StrictUndefined')
 
     def test_none_environment_params(self):
+        # ConfigTemplate always forces autoescape off (#22652).
         template = self._make_template(None)
-        self.assertEqual(template.get_environment_params(), {})
+        self.assertEqual(template.get_environment_params(), {'autoescape': False})
 
     def test_empty_environment_params(self):
+        # ConfigTemplate always forces autoescape off (#22652).
         template = self._make_template({})
-        self.assertEqual(template.get_environment_params(), {})
+        self.assertEqual(template.get_environment_params(), {'autoescape': False})

--- a/netbox/utilities/jinja2.py
+++ b/netbox/utilities/jinja2.py
@@ -95,6 +95,11 @@ def render_jinja2(template_code, context, environment_params=None, data_file=Non
             loader = BaseLoader()
         environment_params['loader'] = loader
 
+    # Explicitly disable autoescape after unpacking user params. Config templates render plain text
+    # (network configs, scripts), not HTML. Forcing autoescape=False ensures user-supplied
+    # environment_params cannot inadvertently enable it and create a latent XSS sink if output
+    # is ever rendered in an HTML context.
+    environment_params['autoescape'] = False
     environment = SandboxedEnvironment(**environment_params)
 
     # Register default filters, then apply any user-defined filters. User-defined entries take precedence so that

--- a/netbox/utilities/jinja2.py
+++ b/netbox/utilities/jinja2.py
@@ -95,11 +95,6 @@ def render_jinja2(template_code, context, environment_params=None, data_file=Non
             loader = BaseLoader()
         environment_params['loader'] = loader
 
-    # Explicitly disable autoescape after unpacking user params. Config templates render plain text
-    # (network configs, scripts), not HTML. Forcing autoescape=False ensures user-supplied
-    # environment_params cannot inadvertently enable it and create a latent XSS sink if output
-    # is ever rendered in an HTML context.
-    environment_params['autoescape'] = False
     environment = SandboxedEnvironment(**environment_params)
 
     # Register default filters, then apply any user-defined filters. User-defined entries take precedence so that


### PR DESCRIPTION
### Closes: #22652

## Summary

Forces `autoescape=False` for `ConfigTemplate` rendering by overriding `get_environment_params()` on the model.

### Root cause

`render_jinja2()` unpacks a caller-supplied `environment_params` dict directly into `SandboxedEnvironment(...)` with no override of `autoescape`. Jinja2's default is `False`, so there is no current exploit, but the invariant is not enforced in code. A caller (or plugin) supplying `autoescape=True` in `environment_params` would produce an environment that HTML-escapes config template output. If that output is later rendered in a web context under the assumption it is already plain text, this creates a latent XSS sink.

### Fix

`render_jinja2()` is shared by both `ConfigTemplate` and `ExportTemplate` (via `RenderTemplateMixin`). An earlier version of this PR forced `autoescape=False` unconditionally inside `render_jinja2()` itself, which also silently overrode `ExportTemplate`'s `autoescape` setting — an explicitly supported, documented option (`JINJA_ENV_PARAMS_ALLOWED['autoescape']`) that export templates may legitimately set to `True` when producing HTML output.

The fix is now scoped to `ConfigTemplate.get_environment_params()`, which calls `super().get_environment_params()` and then forces `params['autoescape'] = False`. Config templates render plain text — network configurations, scripts — not HTML, so autoescaping must always be off there. `ExportTemplate` is untouched and continues to honor whatever `autoescape` value is supplied.

### Tests

Added two regression tests in `extras/tests/test_models.py`:
- `test_configtemplate_autoescape_always_disabled` — `ConfigTemplate` ignores an explicit `environment_params={'autoescape': True}` and never escapes output.
- `test_exporttemplate_autoescape_is_configurable` — `ExportTemplate` still honors an explicit `autoescape=True`.

Also updated three pre-existing tests (`test_get_environment_params_handles_none`, `test_none_environment_params`, `test_empty_environment_params`) whose exact-dict-equality assertions needed the new `autoescape: False` key that `ConfigTemplate.get_environment_params()` now always includes.
