### PR TITLE
Closes #22522: Render colored badges for Custom Field Choices in tables

### DIFF
--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -539,27 +539,35 @@ class CustomFieldColumn(tables.Column):
         if self.customfield.type == CustomFieldTypeChoices.TYPE_URL:
             return mark_safe(f'<a href="{escape(value)}">{escape(value)}</a>')
         if self.customfield.type == CustomFieldTypeChoices.TYPE_SELECT:
+            if value is None:
+                return self.default
             label = self.customfield.get_choice_label(value)
             color = self.customfield.get_choice_color(value)
-            if color:
-                return mark_safe(
-                    f'<span class="badge text-bg-{escape(color)}">{escape(label)}</span>'
+            return mark_safe(
+                    f'<span class="badge text-bg-{escape(color or "secondary")}">{escape(label)}</span>'
                 )
-            return label
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
+            has_color = False
             if not value:
-                return ''
+                return self.default
             parts = []
+            
             for v in value:
                 label = self.customfield.get_choice_label(v)
                 color = self.customfield.get_choice_color(v)
                 if color:
-                    parts.append(
-                        f'<span class="badge text-bg-{escape(color)}">{escape(label)}</span>'
-                    )
-                else:
-                    parts.append(escape(label))
-            return mark_safe(', '.join(parts))
+                    has_color = True
+                parts.append( (escape(label), color) )
+            if has_color:
+                badges = []
+                for label, color in parts:
+                    badges.append(
+                        f'<span class="badge text-bg-{escape(color or "secondary")}">{escape(label)}</span>'
+                        )
+                return mark_safe(' '.join(badges))
+            else:
+                return ', '.join(label for label, _ in parts)
+            
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
             return mark_safe(', '.join(
                 self._linkify_item(obj) for obj in self.customfield.deserialize(value)

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -53,11 +53,13 @@ __all__ = (
 # Django-tables2 overrides
 #
 
+
 @library.register
 class DateColumn(tables.Column):
     """
     Render a datetime.date in ISO 8601 format.
     """
+
     def render(self, value):
         if value:
             return value.isoformat()
@@ -83,6 +85,7 @@ class DateTimeColumn(tables.Column):
     Args:
         timespec: Granularity specification; passed through to datetime.isoformat()
     """
+
     def __init__(self, *args, timespec='seconds', **kwargs):
         self.timespec = timespec
         super().__init__(*args, **kwargs)
@@ -91,7 +94,7 @@ class DateTimeColumn(tables.Column):
         if value:
             current_tz = zoneinfo.ZoneInfo(settings.TIME_ZONE)
             value = value.astimezone(current_tz)
-            return f"{value.date().isoformat()} {value.time().isoformat(timespec=self.timespec)}"
+            return f'{value.date().isoformat()} {value.time().isoformat(timespec=self.timespec)}'
         return None
 
     def value(self, value):
@@ -110,6 +113,7 @@ class DurationColumn(tables.Column):
     """
     Express a duration of time (in minutes) in a human-friendly format. Example: 437 minutes becomes "7h 17m"
     """
+
     def render(self, value):
         ret = ''
         if days := value // 1440:
@@ -128,6 +132,7 @@ class ManyToManyColumn(tables.ManyToManyColumn):
     """
     Overrides django-tables2's stock ManyToManyColumn to ensure that value() returns only plaintext data.
     """
+
     def value(self, value):
         items = [self.transform(item) for item in self.filter(value)]
         return self.separator.join(items)
@@ -138,6 +143,7 @@ class TemplateColumn(tables.TemplateColumn):
     Overrides django-tables2's stock TemplateColumn class to render a placeholder symbol if the returned value
     is an empty string.
     """
+
     PLACEHOLDER = mark_safe('&mdash;')
 
     def __init__(self, export_raw=False, **kwargs):
@@ -170,10 +176,12 @@ class TemplateColumn(tables.TemplateColumn):
 # Custom columns
 #
 
+
 class ToggleColumn(tables.CheckBoxColumn):
     """
     Extend CheckBoxColumn to add a "toggle all" checkbox in the column header.
     """
+
     def __init__(self, *args, **kwargs):
         default = kwargs.pop('default', '')
         visible = kwargs.pop('visible', False)
@@ -189,7 +197,7 @@ class ToggleColumn(tables.CheckBoxColumn):
                 'input': {
                     'class': 'form-check-input',
                     'aria-label': lambda record, value: format_lazy(_('Select {object}'), object=record),
-                }
+                },
             }
         super().__init__(*args, default=default, visible=visible, **kwargs)
 
@@ -198,7 +206,8 @@ class ToggleColumn(tables.CheckBoxColumn):
         title_text = _('Toggle all')
         return format_html(
             '<input type="checkbox" class="toggle form-check-input" title="{}" aria-label="{}" />',
-            title_text, title_text,
+            title_text,
+            title_text,
         )
 
 
@@ -207,6 +216,7 @@ class BooleanColumn(tables.Column):
     Custom implementation of BooleanColumn to render a nicely-formatted checkmark or X icon instead of a Unicode
     character.
     """
+
     TRUE_MARK = mark_safe('<span class="text-success"><i class="mdi mdi-check-bold"></i></span>')
     FALSE_MARK = mark_safe('<span class="text-danger"><i class="mdi mdi-close-thick"></i></span>')
     EMPTY_MARK = mark_safe('<span class="text-muted">&mdash;</span>')  # Placeholder
@@ -247,13 +257,12 @@ class ActionsColumn(tables.Column):
     :param split_actions: When True, converts the actions dropdown menu into a split button with first action as the
         direct button link and icon (default: True)
     """
+
     attrs = {
         'th': {
             'aria-label': _('Actions'),
         },
-        'td': {
-            'class': 'text-end text-nowrap noprint p-1'
-        }
+        'td': {'class': 'text-end text-nowrap noprint p-1'},
     }
     empty_values = ()
     actions = {
@@ -269,9 +278,7 @@ class ActionsColumn(tables.Column):
         self.split_actions = split_actions
 
         # Determine which actions to enable
-        self.actions = {
-            name: self.actions[name] for name in actions
-        }
+        self.actions = {name: self.actions[name] for name in actions}
 
     def header(self):
         return ''
@@ -346,7 +353,7 @@ class ActionsColumn(tables.Column):
         # Render any extra buttons from template code
         if self.extra_buttons:
             template = Template(self.extra_buttons)
-            context = getattr(table, "context", Context())
+            context = getattr(table, 'context', Context())
             context.update({'record': record})
             html = template.render(context) + html
 
@@ -358,6 +365,7 @@ class ChoiceFieldColumn(tables.Column):
     Render a model's static ChoiceField with its value from `get_FOO_display()` as a colored badge. Background color is
     set by the instance's get_FOO_color() method, if defined, or can be overridden by a "color" callable.
     """
+
     DEFAULT_BG_COLOR = 'secondary'
 
     def __init__(self, *args, color=None, **kwargs):
@@ -387,6 +395,7 @@ class ContentTypeColumn(tables.Column):
     """
     Display a ContentType instance.
     """
+
     def render(self, value):
         if value is None:
             return None
@@ -402,6 +411,7 @@ class ContentTypesColumn(tables.ManyToManyColumn):
     """
     Display a list of ContentType instances.
     """
+
     def __init__(self, separator=None, *args, **kwargs):
         # Use a line break as the default separator
         if separator is None:
@@ -412,19 +422,16 @@ class ContentTypesColumn(tables.ManyToManyColumn):
         return object_type_name(obj, include_app=False)
 
     def value(self, value):
-        return ','.join([
-            object_type_identifier(ot) for ot in self.filter(value)
-        ])
+        return ','.join([object_type_identifier(ot) for ot in self.filter(value)])
 
 
 class ColorColumn(tables.Column):
     """
     Display an arbitrary color value, specified in RRGGBB format.
     """
+
     def render(self, value):
-        return mark_safe(
-            f'<span class="color-label" style="background-color: #{value}">&nbsp;</span>'
-        )
+        return mark_safe(f'<span class="color-label" style="background-color: #{value}">&nbsp;</span>')
 
     def value(self, value):
         return f'#{value}'
@@ -435,6 +442,7 @@ class ColoredLabelColumn(tables.TemplateColumn):
     Render a related object as a colored label. The related object must have a `color` attribute (specifying
     an RRGGBB value) and a `get_absolute_url()` method.
     """
+
     template_code = """
 {% load helpers %}
   {% if value %}
@@ -461,6 +469,7 @@ class LinkedCountColumn(tables.Column):
     :param view_kwargs: Additional kwargs to pass for URL resolution (optional)
     :param url_params: A dict of query parameters to append to the URL (e.g. ?foo=bar) (optional)
     """
+
     def __init__(self, viewname, *args, view_kwargs=None, url_params=None, default=0, **kwargs):
         self.viewname = viewname
         self.view_kwargs = view_kwargs or {}
@@ -471,10 +480,12 @@ class LinkedCountColumn(tables.Column):
         if value:
             url = reverse(self.viewname, kwargs=self.view_kwargs)
             if self.url_params:
-                url += '?' + '&'.join([
-                    f'{k}={getattr(record, v) or settings.FILTERS_NULL_CHOICE_VALUE}'
-                    for k, v in self.url_params.items()
-                ])
+                url += '?' + '&'.join(
+                    [
+                        f'{k}={getattr(record, v) or settings.FILTERS_NULL_CHOICE_VALUE}'
+                        for k, v in self.url_params.items()
+                    ]
+                )
             return mark_safe(f'<a href="{url}">{escape(value)}</a>')
         return value
 
@@ -486,6 +497,7 @@ class TagColumn(tables.TemplateColumn):
     """
     Display a list of Tags assigned to the object.
     """
+
     template_code = """
     {% load helpers %}
     {% for tag in value.all %}
@@ -504,23 +516,21 @@ class TagColumn(tables.TemplateColumn):
         )
 
     def value(self, value):
-        return ",".join([tag.name for tag in value.all()])
+        return ','.join([tag.name for tag in value.all()])
 
 
 class CustomFieldColumn(tables.Column):
     """
     Display custom fields in the appropriate format.
     """
+
     def __init__(self, customfield, *args, **kwargs):
         self.customfield = customfield
         kwargs['accessor'] = Accessor(f'custom_field_data__{customfield.name}')
         if 'verbose_name' not in kwargs:
             kwargs['verbose_name'] = customfield.label or customfield.name
         # We can't logically sort on FK values
-        if customfield.type in (
-            CustomFieldTypeChoices.TYPE_OBJECT,
-            CustomFieldTypeChoices.TYPE_MULTIOBJECT
-        ):
+        if customfield.type in (CustomFieldTypeChoices.TYPE_OBJECT, CustomFieldTypeChoices.TYPE_MULTIOBJECT):
             kwargs['orderable'] = False
 
         super().__init__(*args, **kwargs)
@@ -544,36 +554,30 @@ class CustomFieldColumn(tables.Column):
             label = self.customfield.get_choice_label(value)
             color = self.customfield.get_choice_color(value)
             if color:
-                return mark_safe(
-                    f'<span class="badge text-bg-{escape(color)}">{escape(label)}</span>'
-                )
+                return mark_safe(f'<span class="badge text-bg-{escape(color)}">{escape(label)}</span>')
             return label
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
             has_color = False
             if not value:
-                return ""
+                return ''
             parts = []
-            
+
             for v in value:
                 label = self.customfield.get_choice_label(v)
                 color = self.customfield.get_choice_color(v)
                 if color:
                     has_color = True
-                parts.append((label,color)) 
+                parts.append((label, color))
             if has_color:
                 badges = []
                 for label, color in parts:
-                    badges.append(
-                        f'<span class="badge text-bg-{escape(color or "secondary")}">{escape(label)}</span>'
-                        )
+                    badges.append(f'<span class="badge text-bg-{escape(color or "secondary")}">{escape(label)}</span>')
                 return mark_safe(' '.join(badges))
-            else:
-                return ', '.join(label for label, _ in parts)
-            
+
+            return ', '.join(label for label, _ in parts)
+
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
-            return mark_safe(', '.join(
-                self._linkify_item(obj) for obj in self.customfield.deserialize(value)
-            ))
+            return mark_safe(', '.join(self._linkify_item(obj) for obj in self.customfield.deserialize(value)))
         if self.customfield.type == CustomFieldTypeChoices.TYPE_LONGTEXT and value:
             return render_markdown(value)
         if self.customfield.type == CustomFieldTypeChoices.TYPE_DATE and value:
@@ -595,6 +599,7 @@ class CustomLinkColumn(tables.Column):
     """
     Render a custom link as a table column.
     """
+
     def __init__(self, customlink, *args, **kwargs):
         self.customlink = customlink
         kwargs.setdefault('accessor', Accessor('pk'))
@@ -610,10 +615,12 @@ class CustomLinkColumn(tables.Column):
         }
         if request := getattr(table, 'context', {}).get('request'):
             # If the request is available, include it as context
-            context.update({
-                'request': request,
-                **auth(request),
-            })
+            context.update(
+                {
+                    'request': request,
+                    **auth(request),
+                }
+            )
 
         return self.customlink.render(context)
 
@@ -639,6 +646,7 @@ class MPTTColumn(tables.TemplateColumn):
     """
     Display a nested hierarchy for MPTT-enabled models.
     """
+
     template_code = """
         {% load helpers %}
         {% if not table.order_by %}
@@ -648,12 +656,7 @@ class MPTTColumn(tables.TemplateColumn):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(
-            template_code=self.template_code,
-            attrs={'td': {'class': 'text-nowrap'}},
-            *args,
-            **kwargs
-        )
+        super().__init__(template_code=self.template_code, attrs={'td': {'class': 'text-nowrap'}}, *args, **kwargs)
 
     def value(self, value):
         return value
@@ -663,6 +666,7 @@ class UtilizationColumn(tables.TemplateColumn):
     """
     Display a colored utilization bar graph.
     """
+
     template_code = """{% load helpers %}{% if record.pk %}{% utilization_graph value %}{% endif %}"""
 
     def __init__(self, *args, **kwargs):
@@ -676,6 +680,7 @@ class MarkdownColumn(tables.TemplateColumn):
     """
     Render a Markdown string.
     """
+
     template_code = """
     {% if value %}
       {{ value|markdown }}
@@ -698,6 +703,7 @@ class ArrayColumn(tables.Column):
     """
     List array items as a comma-separated list.
     """
+
     def __init__(self, *args, max_items=None, func=str, **kwargs):
         self.max_items = max_items
         self.func = func
@@ -709,7 +715,7 @@ class ArrayColumn(tables.Column):
         # Limit the returned items to the specified maximum number (if any)
         if self.max_items:
             omitted_count = len(value) - self.max_items
-            value = value[:self.max_items - 1]
+            value = value[: self.max_items - 1]
 
         # Apply custom processing function (if any) per item
         if self.func:
@@ -726,6 +732,7 @@ class ChoicesColumn(tables.Column):
     """
     Display the human-friendly labels of a set of choices.
     """
+
     def __init__(self, *args, max_items=None, **kwargs):
         self.max_items = max_items
         super().__init__(*args, **kwargs)
@@ -737,7 +744,7 @@ class ChoicesColumn(tables.Column):
         # Limit the returned items to the specified maximum number (if any)
         if self.max_items:
             omitted_count = len(value) - self.max_items
-            value = value[:self.max_items - 1]
+            value = value[: self.max_items - 1]
 
         # Annotate omitted items (if applicable)
         if omitted_count > 0:
@@ -750,6 +757,7 @@ class DistanceColumn(TemplateColumn):
     """
     Distance with template code for formatting
     """
+
     template_code = """
     {% load helpers %}
     {% display_distance record.distance record.distance_unit record.abs_distance %}
@@ -763,8 +771,7 @@ class DictColumn(tables.Column):
     """
     Render a dictionary of data in a simple key: value format, one pair per line.
     """
+
     def render(self, value):
-        output = '<br />'.join([
-            f'{escape(k)}: {escape(v)}' for k, v in value.items()
-        ])
+        output = '<br />'.join([f'{escape(k)}: {escape(v)}' for k, v in value.items()])
         return mark_safe(output)

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -539,9 +539,27 @@ class CustomFieldColumn(tables.Column):
         if self.customfield.type == CustomFieldTypeChoices.TYPE_URL:
             return mark_safe(f'<a href="{escape(value)}">{escape(value)}</a>')
         if self.customfield.type == CustomFieldTypeChoices.TYPE_SELECT:
-            return self.customfield.get_choice_label(value)
+            label = self.customfield.get_choice_label(value)
+            color = self.customfield.get_choice_color(value)
+            if color:
+                return mark_safe(
+                    f'<span class="badge text-bg-{color}">{escape(label)}</span>'
+                )
+            return label
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
-            return ', '.join(self.customfield.get_choice_label(v) for v in value)
+            if not value:
+                return ''
+            parts = []
+            for v in value:
+                label = self.customfield.get_choice_label(v)
+                color = self.customfield.get_choice_color(v)
+                if color:
+                    parts.append(
+                        f'<span class="badge text-bg-{color}">{escape(label)}</span>'
+                    )
+                else:
+                    parts.append(escape(label))
+            return mark_safe(' '.join(parts))
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
             return mark_safe(', '.join(
                 self._linkify_item(obj) for obj in self.customfield.deserialize(value)

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -543,13 +543,15 @@ class CustomFieldColumn(tables.Column):
                 return self.default
             label = self.customfield.get_choice_label(value)
             color = self.customfield.get_choice_color(value)
-            return mark_safe(
-                    f'<span class="badge text-bg-{escape(color or "secondary")}">{escape(label)}</span>'
+            if color:
+                return mark_safe(
+                    f'<span class="badge text-bg-{escape(color)}">{escape(label)}</span>'
                 )
+            return label
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
             has_color = False
             if not value:
-                return self.default
+                return ""
             parts = []
             
             for v in value:
@@ -557,7 +559,7 @@ class CustomFieldColumn(tables.Column):
                 color = self.customfield.get_choice_color(v)
                 if color:
                     has_color = True
-                parts.append( (escape(label), color) )
+                parts.append((label,color)) 
             if has_color:
                 badges = []
                 for label, color in parts:

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -543,7 +543,7 @@ class CustomFieldColumn(tables.Column):
             color = self.customfield.get_choice_color(value)
             if color:
                 return mark_safe(
-                    f'<span class="badge text-bg-{color}">{escape(label)}</span>'
+                    f'<span class="badge text-bg-{escape(color)}">{escape(label)}</span>'
                 )
             return label
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
@@ -555,11 +555,11 @@ class CustomFieldColumn(tables.Column):
                 color = self.customfield.get_choice_color(v)
                 if color:
                     parts.append(
-                        f'<span class="badge text-bg-{color}">{escape(label)}</span>'
+                        f'<span class="badge text-bg-{escape(color)}">{escape(label)}</span>'
                     )
                 else:
                     parts.append(escape(label))
-            return mark_safe(' '.join(parts))
+            return mark_safe(', '.join(parts))
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
             return mark_safe(', '.join(
                 self._linkify_item(obj) for obj in self.customfield.deserialize(value)

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -553,13 +553,13 @@ class CustomFieldColumn(tables.Column):
             if not value:
                 return ""
             parts = []
-            
+
             for v in value:
                 label = self.customfield.get_choice_label(v)
                 color = self.customfield.get_choice_color(v)
                 if color:
                     has_color = True
-                parts.append((label,color)) 
+                parts.append((label, color))
             if has_color:
                 badges = []
                 for label, color in parts:
@@ -567,9 +567,8 @@ class CustomFieldColumn(tables.Column):
                         f'<span class="badge text-bg-{escape(color or "secondary")}">{escape(label)}</span>'
                         )
                 return mark_safe(' '.join(badges))
-            else:
-                return ', '.join(label for label, _ in parts)
-            
+            return ', '.join(label for label, _ in parts)
+
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
             return mark_safe(', '.join(
                 self._linkify_item(obj) for obj in self.customfield.deserialize(value)

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -53,13 +53,11 @@ __all__ = (
 # Django-tables2 overrides
 #
 
-
 @library.register
 class DateColumn(tables.Column):
     """
     Render a datetime.date in ISO 8601 format.
     """
-
     def render(self, value):
         if value:
             return value.isoformat()
@@ -85,7 +83,6 @@ class DateTimeColumn(tables.Column):
     Args:
         timespec: Granularity specification; passed through to datetime.isoformat()
     """
-
     def __init__(self, *args, timespec='seconds', **kwargs):
         self.timespec = timespec
         super().__init__(*args, **kwargs)
@@ -94,7 +91,7 @@ class DateTimeColumn(tables.Column):
         if value:
             current_tz = zoneinfo.ZoneInfo(settings.TIME_ZONE)
             value = value.astimezone(current_tz)
-            return f'{value.date().isoformat()} {value.time().isoformat(timespec=self.timespec)}'
+            return f"{value.date().isoformat()} {value.time().isoformat(timespec=self.timespec)}"
         return None
 
     def value(self, value):
@@ -113,7 +110,6 @@ class DurationColumn(tables.Column):
     """
     Express a duration of time (in minutes) in a human-friendly format. Example: 437 minutes becomes "7h 17m"
     """
-
     def render(self, value):
         ret = ''
         if days := value // 1440:
@@ -132,7 +128,6 @@ class ManyToManyColumn(tables.ManyToManyColumn):
     """
     Overrides django-tables2's stock ManyToManyColumn to ensure that value() returns only plaintext data.
     """
-
     def value(self, value):
         items = [self.transform(item) for item in self.filter(value)]
         return self.separator.join(items)
@@ -143,7 +138,6 @@ class TemplateColumn(tables.TemplateColumn):
     Overrides django-tables2's stock TemplateColumn class to render a placeholder symbol if the returned value
     is an empty string.
     """
-
     PLACEHOLDER = mark_safe('&mdash;')
 
     def __init__(self, export_raw=False, **kwargs):
@@ -176,12 +170,10 @@ class TemplateColumn(tables.TemplateColumn):
 # Custom columns
 #
 
-
 class ToggleColumn(tables.CheckBoxColumn):
     """
     Extend CheckBoxColumn to add a "toggle all" checkbox in the column header.
     """
-
     def __init__(self, *args, **kwargs):
         default = kwargs.pop('default', '')
         visible = kwargs.pop('visible', False)
@@ -197,7 +189,7 @@ class ToggleColumn(tables.CheckBoxColumn):
                 'input': {
                     'class': 'form-check-input',
                     'aria-label': lambda record, value: format_lazy(_('Select {object}'), object=record),
-                },
+                }
             }
         super().__init__(*args, default=default, visible=visible, **kwargs)
 
@@ -206,8 +198,7 @@ class ToggleColumn(tables.CheckBoxColumn):
         title_text = _('Toggle all')
         return format_html(
             '<input type="checkbox" class="toggle form-check-input" title="{}" aria-label="{}" />',
-            title_text,
-            title_text,
+            title_text, title_text,
         )
 
 
@@ -216,7 +207,6 @@ class BooleanColumn(tables.Column):
     Custom implementation of BooleanColumn to render a nicely-formatted checkmark or X icon instead of a Unicode
     character.
     """
-
     TRUE_MARK = mark_safe('<span class="text-success"><i class="mdi mdi-check-bold"></i></span>')
     FALSE_MARK = mark_safe('<span class="text-danger"><i class="mdi mdi-close-thick"></i></span>')
     EMPTY_MARK = mark_safe('<span class="text-muted">&mdash;</span>')  # Placeholder
@@ -257,12 +247,13 @@ class ActionsColumn(tables.Column):
     :param split_actions: When True, converts the actions dropdown menu into a split button with first action as the
         direct button link and icon (default: True)
     """
-
     attrs = {
         'th': {
             'aria-label': _('Actions'),
         },
-        'td': {'class': 'text-end text-nowrap noprint p-1'},
+        'td': {
+            'class': 'text-end text-nowrap noprint p-1'
+        }
     }
     empty_values = ()
     actions = {
@@ -278,7 +269,9 @@ class ActionsColumn(tables.Column):
         self.split_actions = split_actions
 
         # Determine which actions to enable
-        self.actions = {name: self.actions[name] for name in actions}
+        self.actions = {
+            name: self.actions[name] for name in actions
+        }
 
     def header(self):
         return ''
@@ -353,7 +346,7 @@ class ActionsColumn(tables.Column):
         # Render any extra buttons from template code
         if self.extra_buttons:
             template = Template(self.extra_buttons)
-            context = getattr(table, 'context', Context())
+            context = getattr(table, "context", Context())
             context.update({'record': record})
             html = template.render(context) + html
 
@@ -365,7 +358,6 @@ class ChoiceFieldColumn(tables.Column):
     Render a model's static ChoiceField with its value from `get_FOO_display()` as a colored badge. Background color is
     set by the instance's get_FOO_color() method, if defined, or can be overridden by a "color" callable.
     """
-
     DEFAULT_BG_COLOR = 'secondary'
 
     def __init__(self, *args, color=None, **kwargs):
@@ -395,7 +387,6 @@ class ContentTypeColumn(tables.Column):
     """
     Display a ContentType instance.
     """
-
     def render(self, value):
         if value is None:
             return None
@@ -411,7 +402,6 @@ class ContentTypesColumn(tables.ManyToManyColumn):
     """
     Display a list of ContentType instances.
     """
-
     def __init__(self, separator=None, *args, **kwargs):
         # Use a line break as the default separator
         if separator is None:
@@ -422,16 +412,19 @@ class ContentTypesColumn(tables.ManyToManyColumn):
         return object_type_name(obj, include_app=False)
 
     def value(self, value):
-        return ','.join([object_type_identifier(ot) for ot in self.filter(value)])
+        return ','.join([
+            object_type_identifier(ot) for ot in self.filter(value)
+        ])
 
 
 class ColorColumn(tables.Column):
     """
     Display an arbitrary color value, specified in RRGGBB format.
     """
-
     def render(self, value):
-        return mark_safe(f'<span class="color-label" style="background-color: #{value}">&nbsp;</span>')
+        return mark_safe(
+            f'<span class="color-label" style="background-color: #{value}">&nbsp;</span>'
+        )
 
     def value(self, value):
         return f'#{value}'
@@ -442,7 +435,6 @@ class ColoredLabelColumn(tables.TemplateColumn):
     Render a related object as a colored label. The related object must have a `color` attribute (specifying
     an RRGGBB value) and a `get_absolute_url()` method.
     """
-
     template_code = """
 {% load helpers %}
   {% if value %}
@@ -469,7 +461,6 @@ class LinkedCountColumn(tables.Column):
     :param view_kwargs: Additional kwargs to pass for URL resolution (optional)
     :param url_params: A dict of query parameters to append to the URL (e.g. ?foo=bar) (optional)
     """
-
     def __init__(self, viewname, *args, view_kwargs=None, url_params=None, default=0, **kwargs):
         self.viewname = viewname
         self.view_kwargs = view_kwargs or {}
@@ -480,12 +471,10 @@ class LinkedCountColumn(tables.Column):
         if value:
             url = reverse(self.viewname, kwargs=self.view_kwargs)
             if self.url_params:
-                url += '?' + '&'.join(
-                    [
-                        f'{k}={getattr(record, v) or settings.FILTERS_NULL_CHOICE_VALUE}'
-                        for k, v in self.url_params.items()
-                    ]
-                )
+                url += '?' + '&'.join([
+                    f'{k}={getattr(record, v) or settings.FILTERS_NULL_CHOICE_VALUE}'
+                    for k, v in self.url_params.items()
+                ])
             return mark_safe(f'<a href="{url}">{escape(value)}</a>')
         return value
 
@@ -497,7 +486,6 @@ class TagColumn(tables.TemplateColumn):
     """
     Display a list of Tags assigned to the object.
     """
-
     template_code = """
     {% load helpers %}
     {% for tag in value.all %}
@@ -516,21 +504,23 @@ class TagColumn(tables.TemplateColumn):
         )
 
     def value(self, value):
-        return ','.join([tag.name for tag in value.all()])
+        return ",".join([tag.name for tag in value.all()])
 
 
 class CustomFieldColumn(tables.Column):
     """
     Display custom fields in the appropriate format.
     """
-
     def __init__(self, customfield, *args, **kwargs):
         self.customfield = customfield
         kwargs['accessor'] = Accessor(f'custom_field_data__{customfield.name}')
         if 'verbose_name' not in kwargs:
             kwargs['verbose_name'] = customfield.label or customfield.name
         # We can't logically sort on FK values
-        if customfield.type in (CustomFieldTypeChoices.TYPE_OBJECT, CustomFieldTypeChoices.TYPE_MULTIOBJECT):
+        if customfield.type in (
+            CustomFieldTypeChoices.TYPE_OBJECT,
+            CustomFieldTypeChoices.TYPE_MULTIOBJECT
+        ):
             kwargs['orderable'] = False
 
         super().__init__(*args, **kwargs)
@@ -554,30 +544,36 @@ class CustomFieldColumn(tables.Column):
             label = self.customfield.get_choice_label(value)
             color = self.customfield.get_choice_color(value)
             if color:
-                return mark_safe(f'<span class="badge text-bg-{escape(color)}">{escape(label)}</span>')
+                return mark_safe(
+                    f'<span class="badge text-bg-{escape(color)}">{escape(label)}</span>'
+                )
             return label
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
             has_color = False
             if not value:
-                return ''
+                return ""
             parts = []
-
+            
             for v in value:
                 label = self.customfield.get_choice_label(v)
                 color = self.customfield.get_choice_color(v)
                 if color:
                     has_color = True
-                parts.append((label, color))
+                parts.append((label,color)) 
             if has_color:
                 badges = []
                 for label, color in parts:
-                    badges.append(f'<span class="badge text-bg-{escape(color or "secondary")}">{escape(label)}</span>')
+                    badges.append(
+                        f'<span class="badge text-bg-{escape(color or "secondary")}">{escape(label)}</span>'
+                        )
                 return mark_safe(' '.join(badges))
-
-            return ', '.join(label for label, _ in parts)
-
+            else:
+                return ', '.join(label for label, _ in parts)
+            
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTIOBJECT:
-            return mark_safe(', '.join(self._linkify_item(obj) for obj in self.customfield.deserialize(value)))
+            return mark_safe(', '.join(
+                self._linkify_item(obj) for obj in self.customfield.deserialize(value)
+            ))
         if self.customfield.type == CustomFieldTypeChoices.TYPE_LONGTEXT and value:
             return render_markdown(value)
         if self.customfield.type == CustomFieldTypeChoices.TYPE_DATE and value:
@@ -599,7 +595,6 @@ class CustomLinkColumn(tables.Column):
     """
     Render a custom link as a table column.
     """
-
     def __init__(self, customlink, *args, **kwargs):
         self.customlink = customlink
         kwargs.setdefault('accessor', Accessor('pk'))
@@ -615,12 +610,10 @@ class CustomLinkColumn(tables.Column):
         }
         if request := getattr(table, 'context', {}).get('request'):
             # If the request is available, include it as context
-            context.update(
-                {
-                    'request': request,
-                    **auth(request),
-                }
-            )
+            context.update({
+                'request': request,
+                **auth(request),
+            })
 
         return self.customlink.render(context)
 
@@ -646,7 +639,6 @@ class MPTTColumn(tables.TemplateColumn):
     """
     Display a nested hierarchy for MPTT-enabled models.
     """
-
     template_code = """
         {% load helpers %}
         {% if not table.order_by %}
@@ -656,7 +648,12 @@ class MPTTColumn(tables.TemplateColumn):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(template_code=self.template_code, attrs={'td': {'class': 'text-nowrap'}}, *args, **kwargs)
+        super().__init__(
+            template_code=self.template_code,
+            attrs={'td': {'class': 'text-nowrap'}},
+            *args,
+            **kwargs
+        )
 
     def value(self, value):
         return value
@@ -666,7 +663,6 @@ class UtilizationColumn(tables.TemplateColumn):
     """
     Display a colored utilization bar graph.
     """
-
     template_code = """{% load helpers %}{% if record.pk %}{% utilization_graph value %}{% endif %}"""
 
     def __init__(self, *args, **kwargs):
@@ -680,7 +676,6 @@ class MarkdownColumn(tables.TemplateColumn):
     """
     Render a Markdown string.
     """
-
     template_code = """
     {% if value %}
       {{ value|markdown }}
@@ -703,7 +698,6 @@ class ArrayColumn(tables.Column):
     """
     List array items as a comma-separated list.
     """
-
     def __init__(self, *args, max_items=None, func=str, **kwargs):
         self.max_items = max_items
         self.func = func
@@ -715,7 +709,7 @@ class ArrayColumn(tables.Column):
         # Limit the returned items to the specified maximum number (if any)
         if self.max_items:
             omitted_count = len(value) - self.max_items
-            value = value[: self.max_items - 1]
+            value = value[:self.max_items - 1]
 
         # Apply custom processing function (if any) per item
         if self.func:
@@ -732,7 +726,6 @@ class ChoicesColumn(tables.Column):
     """
     Display the human-friendly labels of a set of choices.
     """
-
     def __init__(self, *args, max_items=None, **kwargs):
         self.max_items = max_items
         super().__init__(*args, **kwargs)
@@ -744,7 +737,7 @@ class ChoicesColumn(tables.Column):
         # Limit the returned items to the specified maximum number (if any)
         if self.max_items:
             omitted_count = len(value) - self.max_items
-            value = value[: self.max_items - 1]
+            value = value[:self.max_items - 1]
 
         # Annotate omitted items (if applicable)
         if omitted_count > 0:
@@ -757,7 +750,6 @@ class DistanceColumn(TemplateColumn):
     """
     Distance with template code for formatting
     """
-
     template_code = """
     {% load helpers %}
     {% display_distance record.distance record.distance_unit record.abs_distance %}
@@ -771,7 +763,8 @@ class DictColumn(tables.Column):
     """
     Render a dictionary of data in a simple key: value format, one pair per line.
     """
-
     def render(self, value):
-        output = '<br />'.join([f'{escape(k)}: {escape(v)}' for k, v in value.items()])
+        output = '<br />'.join([
+            f'{escape(k)}: {escape(v)}' for k, v in value.items()
+        ])
         return mark_safe(output)

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -550,7 +550,7 @@ class CustomFieldColumn(tables.Column):
             return label
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
             if not value:
-                return ""
+                return ''
 
             has_color = False
             parts = []

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -549,9 +549,10 @@ class CustomFieldColumn(tables.Column):
                 )
             return label
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTISELECT:
-            has_color = False
             if not value:
                 return ""
+
+            has_color = False
             parts = []
 
             for v in value:
@@ -565,7 +566,7 @@ class CustomFieldColumn(tables.Column):
                 for label, color in parts:
                     badges.append(
                         f'<span class="badge text-bg-{escape(color or "secondary")}">{escape(label)}</span>'
-                        )
+                    )
                 return mark_safe(' '.join(badges))
             return ', '.join(label for label, _ in parts)
 

--- a/netbox/netbox/tests/test_tables.py
+++ b/netbox/netbox/tests/test_tables.py
@@ -4,6 +4,9 @@ from django.test import RequestFactory, TestCase
 
 from dcim.models import Device, Site
 from dcim.tables import DeviceTable
+from extras.choices import CustomFieldChoiceColorChoices, CustomFieldTypeChoices
+from extras.models import CustomField, CustomFieldChoiceSet
+from core.models import ObjectType
 from netbox.tables import NetBoxTable, columns
 from utilities.testing import create_tags, create_test_device, create_test_user
 
@@ -119,3 +122,127 @@ class TagColumnTestCase(TestCase):
             'table': table
         })
         template.render(context)
+
+
+class CustomFieldColumnTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.object_type = ObjectType.objects.get_for_model(Site)
+
+        # Choice set containing one colored and one uncolored choice
+        cls.mixed_choice_set = CustomFieldChoiceSet.objects.create(
+            name="Mixed Choice Set",
+            extra_choices=(
+                ("a", "Option A"),
+                ("b", "Option B"),
+            ),
+            choice_colors={
+                "a": CustomFieldChoiceColorChoices.RED,
+            },
+        )
+
+        # Choice set with no configured colors
+        cls.plain_choice_set = CustomFieldChoiceSet.objects.create(
+            name="Plain Choice Set",
+            extra_choices=(
+                ("a", "Option A"),
+                ("b", "Option B"),
+            ),
+        )
+
+        cls.select_cf = CustomField.objects.create(
+            name="select_field",
+            type=CustomFieldTypeChoices.TYPE_SELECT,
+            choice_set=cls.mixed_choice_set,
+            required=False,
+        )
+        cls.select_cf.object_types.set([cls.object_type])
+
+        cls.multiselect_cf = CustomField.objects.create(
+            name="multiselect_field",
+            type=CustomFieldTypeChoices.TYPE_MULTISELECT,
+            choice_set=cls.mixed_choice_set,
+            required=False,
+        )
+        cls.multiselect_cf.object_types.set([cls.object_type])
+
+        cls.plain_multiselect_cf = CustomField.objects.create(
+            name="plain_multiselect_field",
+            type=CustomFieldTypeChoices.TYPE_MULTISELECT,
+            choice_set=cls.plain_choice_set,
+            required=False,
+        )
+        cls.plain_multiselect_cf.object_types.set([cls.object_type])
+
+    def test_colored_single_select(self):
+        column = columns.CustomFieldColumn(self.select_cf)
+
+        rendered = str(column.render("a"))
+
+        self.assertIn("badge", rendered)
+        self.assertIn("text-bg-red", rendered)
+        self.assertIn("Option A", rendered)
+
+    def test_uncolored_single_select(self):
+        column = columns.CustomFieldColumn(self.select_cf)
+
+        rendered = str(column.render("b"))
+
+        self.assertEqual(rendered, "Option B")
+        self.assertNotIn("badge", rendered)
+
+    def test_empty_multiselect(self):
+        column = columns.CustomFieldColumn(self.multiselect_cf)
+
+        rendered = column.render([])
+
+        self.assertEqual(rendered, "")
+
+    def test_multiselect_without_colored_choices(self):
+        column = columns.CustomFieldColumn(self.plain_multiselect_cf)
+
+        rendered = str(column.render(["a", "b"]))
+
+        self.assertEqual(rendered, "Option A, Option B")
+        self.assertNotIn("badge", rendered)
+
+    def test_multiselect_with_mixed_colored_choices(self):
+        column = columns.CustomFieldColumn(self.multiselect_cf)
+
+        rendered = str(column.render(["a", "b"]))
+
+        self.assertIn("Option A", rendered)
+        self.assertIn("Option B", rendered)
+
+        self.assertIn("text-bg-red", rendered)
+        self.assertIn("text-bg-secondary", rendered)
+
+        self.assertNotIn(",", rendered)
+
+    def test_html_sensitive_choice_labels(self):
+        choice_set = CustomFieldChoiceSet.objects.create(
+            name="HTML Choice Set",
+            extra_choices=(
+                ("x", "<b>Bold Option</b>"),
+                ("y", "<script>alert('xss')</script>"),
+            ),
+            choice_colors={
+                "x": CustomFieldChoiceColorChoices.RED,
+            },
+        )
+
+        custom_field = CustomField.objects.create(
+            name="html_select_field",
+            type=CustomFieldTypeChoices.TYPE_SELECT,
+            choice_set=choice_set,
+            required=False,
+        )
+        custom_field.object_types.set([self.object_type])
+
+        column = columns.CustomFieldColumn(custom_field)
+
+        rendered = str(column.render("x"))
+
+        self.assertIn("&lt;b&gt;Bold Option&lt;/b&gt;", rendered)
+        self.assertNotIn("&amp;lt;", rendered)

--- a/netbox/netbox/tests/test_tables.py
+++ b/netbox/netbox/tests/test_tables.py
@@ -2,17 +2,16 @@ from django.contrib.auth.models import AnonymousUser
 from django.template import Context, Template
 from django.test import RequestFactory, TestCase
 
+from core.models import ObjectType
 from dcim.models import Device, Site
 from dcim.tables import DeviceTable
 from extras.choices import CustomFieldChoiceColorChoices, CustomFieldTypeChoices
 from extras.models import CustomField, CustomFieldChoiceSet
-from core.models import ObjectType
 from netbox.tables import NetBoxTable, columns
 from utilities.testing import create_tags, create_test_device, create_test_user
 
 
 class BaseTableTestCase(TestCase):
-
     @classmethod
     def setUpTestData(cls):
         create_test_device('Test Device 1')
@@ -73,9 +72,7 @@ class BaseTableTestCase(TestCase):
 
         # Simulate the CSV "All data" export path: re-apply prefetching for every column that
         # will be included in the export, regardless of visibility.
-        export_columns = [
-            col_name for col_name, _ in table.selected_columns + table.available_columns
-        ]
+        export_columns = [col_name for col_name, _ in table.selected_columns + table.available_columns]
         table._apply_prefetching(columns=export_columns)
 
         prefetch_lookups = table.data.data._prefetch_related_lookups
@@ -98,19 +95,20 @@ class TagColumnTable(NetBoxTable):
 
     class Meta(NetBoxTable.Meta):
         model = Site
-        fields = ('pk', 'name', 'tags',)
+        fields = (
+            'pk',
+            'name',
+            'tags',
+        )
         default_columns = fields
 
 
 class TagColumnTestCase(TestCase):
-
     @classmethod
     def setUpTestData(cls):
         tags = create_tags('Alpha', 'Bravo', 'Charlie')
 
-        sites = [
-            Site(name=f'Site {i}', slug=f'site-{i}') for i in range(1, 6)
-        ]
+        sites = [Site(name=f'Site {i}', slug=f'site-{i}') for i in range(1, 6)]
         Site.objects.bulk_create(sites)
         for site in sites:
             site.tags.add(*tags)
@@ -118,41 +116,30 @@ class TagColumnTestCase(TestCase):
     def test_tagcolumn(self):
         template = Template('{% load render_table from django_tables2 %}{% render_table table %}')
         table = TagColumnTable(Site.objects.all(), orderable=False)
-        context = Context({
-            'table': table
-        })
+        context = Context({'table': table})
         template.render(context)
 
 
 class CustomFieldColumnTestCase(TestCase):
-
     @classmethod
     def setUpTestData(cls):
         cls.object_type = ObjectType.objects.get_for_model(Site)
 
-        # Choice set containing one colored and one uncolored choice
+        # Choice set containing one colored and two uncolored choices
         cls.mixed_choice_set = CustomFieldChoiceSet.objects.create(
-            name="Mixed Choice Set",
+            name='Mixed Choice Set',
             extra_choices=(
-                ("a", "Option A"),
-                ("b", "Option B"),
+                ('a', 'Option A'),
+                ('b', 'Option B'),
+                ('c', 'Option C'),
             ),
             choice_colors={
-                "a": CustomFieldChoiceColorChoices.RED,
+                'a': CustomFieldChoiceColorChoices.RED,
             },
         )
 
-        # Choice set with no configured colors
-        cls.plain_choice_set = CustomFieldChoiceSet.objects.create(
-            name="Plain Choice Set",
-            extra_choices=(
-                ("a", "Option A"),
-                ("b", "Option B"),
-            ),
-        )
-
         cls.select_cf = CustomField.objects.create(
-            name="select_field",
+            name='select_field',
             type=CustomFieldTypeChoices.TYPE_SELECT,
             choice_set=cls.mixed_choice_set,
             required=False,
@@ -160,81 +147,73 @@ class CustomFieldColumnTestCase(TestCase):
         cls.select_cf.object_types.set([cls.object_type])
 
         cls.multiselect_cf = CustomField.objects.create(
-            name="multiselect_field",
+            name='multiselect_field',
             type=CustomFieldTypeChoices.TYPE_MULTISELECT,
             choice_set=cls.mixed_choice_set,
             required=False,
         )
         cls.multiselect_cf.object_types.set([cls.object_type])
 
-        cls.plain_multiselect_cf = CustomField.objects.create(
-            name="plain_multiselect_field",
-            type=CustomFieldTypeChoices.TYPE_MULTISELECT,
-            choice_set=cls.plain_choice_set,
-            required=False,
-        )
-        cls.plain_multiselect_cf.object_types.set([cls.object_type])
-
     def test_colored_single_select(self):
         column = columns.CustomFieldColumn(self.select_cf)
 
-        rendered = str(column.render("a"))
+        rendered = str(column.render('a'))
 
-        self.assertIn("badge", rendered)
-        self.assertIn("text-bg-red", rendered)
-        self.assertIn("Option A", rendered)
+        self.assertIn('badge', rendered)
+        self.assertIn('text-bg-red', rendered)
+        self.assertIn('Option A', rendered)
 
     def test_uncolored_single_select(self):
         column = columns.CustomFieldColumn(self.select_cf)
 
-        rendered = str(column.render("b"))
+        rendered = str(column.render('b'))
 
-        self.assertEqual(rendered, "Option B")
-        self.assertNotIn("badge", rendered)
+        self.assertEqual(rendered, 'Option B')
+        self.assertNotIn('badge', rendered)
 
     def test_empty_multiselect(self):
         column = columns.CustomFieldColumn(self.multiselect_cf)
 
         rendered = column.render([])
 
-        self.assertEqual(rendered, "")
+        self.assertEqual(rendered, '')
 
-    def test_multiselect_without_colored_choices(self):
-        column = columns.CustomFieldColumn(self.plain_multiselect_cf)
+    def test_multiselect_without_selected_colored_choices(self):
+        column = columns.CustomFieldColumn(self.multiselect_cf)
 
-        rendered = str(column.render(["a", "b"]))
+        rendered = str(column.render(['b', 'c']))
 
-        self.assertEqual(rendered, "Option A, Option B")
-        self.assertNotIn("badge", rendered)
+        self.assertEqual(rendered, 'Option B, Option C')
+        self.assertNotIn('badge', rendered)
 
     def test_multiselect_with_mixed_colored_choices(self):
         column = columns.CustomFieldColumn(self.multiselect_cf)
 
-        rendered = str(column.render(["a", "b"]))
+        rendered = str(column.render(['a', 'b']))
 
-        self.assertIn("Option A", rendered)
-        self.assertIn("Option B", rendered)
+        self.assertIn('Option A', rendered)
+        self.assertIn('Option B', rendered)
 
-        self.assertIn("text-bg-red", rendered)
-        self.assertIn("text-bg-secondary", rendered)
+        self.assertIn('text-bg-red', rendered)
+        self.assertIn('text-bg-secondary', rendered)
 
-        self.assertNotIn(",", rendered)
+        self.assertNotIn(',', rendered)
 
-    def test_html_sensitive_choice_labels(self):
+    def test_html_sensitive_multiselect_labels(self):
         choice_set = CustomFieldChoiceSet.objects.create(
-            name="HTML Choice Set",
+            name='HTML Choice Set',
             extra_choices=(
-                ("x", "<b>Bold Option</b>"),
-                ("y", "<script>alert('xss')</script>"),
+                ('x', '<b>Bold Option</b>'),
+                ('y', "<script>alert('xss')</script>"),
             ),
             choice_colors={
-                "x": CustomFieldChoiceColorChoices.RED,
+                'x': CustomFieldChoiceColorChoices.RED,
             },
         )
 
         custom_field = CustomField.objects.create(
-            name="html_select_field",
-            type=CustomFieldTypeChoices.TYPE_SELECT,
+            name='html_multiselect_field',
+            type=CustomFieldTypeChoices.TYPE_MULTISELECT,
             choice_set=choice_set,
             required=False,
         )
@@ -242,7 +221,10 @@ class CustomFieldColumnTestCase(TestCase):
 
         column = columns.CustomFieldColumn(custom_field)
 
-        rendered = str(column.render("x"))
+        rendered = str(column.render(['x', 'y']))
 
-        self.assertIn("&lt;b&gt;Bold Option&lt;/b&gt;", rendered)
-        self.assertNotIn("&amp;lt;", rendered)
+        self.assertIn('&lt;b&gt;Bold Option&lt;/b&gt;', rendered)
+        self.assertNotIn('&amp;lt;', rendered)
+
+        self.assertIn('text-bg-red', rendered)
+        self.assertIn('text-bg-secondary', rendered)

--- a/netbox/netbox/tests/test_tables.py
+++ b/netbox/netbox/tests/test_tables.py
@@ -125,34 +125,25 @@ class TagColumnTestCase(TestCase):
 
 
 class CustomFieldColumnTestCase(TestCase):
-
     @classmethod
     def setUpTestData(cls):
         cls.object_type = ObjectType.objects.get_for_model(Site)
 
-        # Choice set containing one colored and one uncolored choice
+        # Choice set containing one colored and two uncolored choices
         cls.mixed_choice_set = CustomFieldChoiceSet.objects.create(
-            name="Mixed Choice Set",
+            name='Mixed Choice Set',
             extra_choices=(
-                ("a", "Option A"),
-                ("b", "Option B"),
+                ('a', 'Option A'),
+                ('b', 'Option B'),
+                ('c', 'Option C'),
             ),
             choice_colors={
-                "a": CustomFieldChoiceColorChoices.RED,
+                'a': CustomFieldChoiceColorChoices.RED,
             },
         )
 
-        # Choice set with no configured colors
-        cls.plain_choice_set = CustomFieldChoiceSet.objects.create(
-            name="Plain Choice Set",
-            extra_choices=(
-                ("a", "Option A"),
-                ("b", "Option B"),
-            ),
-        )
-
         cls.select_cf = CustomField.objects.create(
-            name="select_field",
+            name='select_field',
             type=CustomFieldTypeChoices.TYPE_SELECT,
             choice_set=cls.mixed_choice_set,
             required=False,
@@ -160,81 +151,73 @@ class CustomFieldColumnTestCase(TestCase):
         cls.select_cf.object_types.set([cls.object_type])
 
         cls.multiselect_cf = CustomField.objects.create(
-            name="multiselect_field",
+            name='multiselect_field',
             type=CustomFieldTypeChoices.TYPE_MULTISELECT,
             choice_set=cls.mixed_choice_set,
             required=False,
         )
         cls.multiselect_cf.object_types.set([cls.object_type])
 
-        cls.plain_multiselect_cf = CustomField.objects.create(
-            name="plain_multiselect_field",
-            type=CustomFieldTypeChoices.TYPE_MULTISELECT,
-            choice_set=cls.plain_choice_set,
-            required=False,
-        )
-        cls.plain_multiselect_cf.object_types.set([cls.object_type])
-
     def test_colored_single_select(self):
         column = columns.CustomFieldColumn(self.select_cf)
 
-        rendered = str(column.render("a"))
+        rendered = str(column.render('a'))
 
-        self.assertIn("badge", rendered)
-        self.assertIn("text-bg-red", rendered)
-        self.assertIn("Option A", rendered)
+        self.assertIn('badge', rendered)
+        self.assertIn('text-bg-red', rendered)
+        self.assertIn('Option A', rendered)
 
     def test_uncolored_single_select(self):
         column = columns.CustomFieldColumn(self.select_cf)
 
-        rendered = str(column.render("b"))
+        rendered = str(column.render('b'))
 
-        self.assertEqual(rendered, "Option B")
-        self.assertNotIn("badge", rendered)
+        self.assertEqual(rendered, 'Option B')
+        self.assertNotIn('badge', rendered)
 
     def test_empty_multiselect(self):
         column = columns.CustomFieldColumn(self.multiselect_cf)
 
         rendered = column.render([])
 
-        self.assertEqual(rendered, "")
+        self.assertEqual(rendered, '')
 
-    def test_multiselect_without_colored_choices(self):
-        column = columns.CustomFieldColumn(self.plain_multiselect_cf)
+    def test_multiselect_without_selected_colored_choices(self):
+        column = columns.CustomFieldColumn(self.multiselect_cf)
 
-        rendered = str(column.render(["a", "b"]))
+        rendered = str(column.render(['b', 'c']))
 
-        self.assertEqual(rendered, "Option A, Option B")
-        self.assertNotIn("badge", rendered)
+        self.assertEqual(rendered, 'Option B, Option C')
+        self.assertNotIn('badge', rendered)
 
     def test_multiselect_with_mixed_colored_choices(self):
         column = columns.CustomFieldColumn(self.multiselect_cf)
 
-        rendered = str(column.render(["a", "b"]))
+        rendered = str(column.render(['a', 'b']))
 
-        self.assertIn("Option A", rendered)
-        self.assertIn("Option B", rendered)
+        self.assertIn('Option A', rendered)
+        self.assertIn('Option B', rendered)
 
-        self.assertIn("text-bg-red", rendered)
-        self.assertIn("text-bg-secondary", rendered)
+        self.assertIn('text-bg-red', rendered)
+        self.assertIn('text-bg-secondary', rendered)
 
-        self.assertNotIn(",", rendered)
+        self.assertNotIn(',', rendered)
 
-    def test_html_sensitive_choice_labels(self):
+    def test_html_sensitive_multiselect_labels(self):
         choice_set = CustomFieldChoiceSet.objects.create(
-            name="HTML Choice Set",
+            name='HTML Choice Set',
             extra_choices=(
-                ("x", "<b>Bold Option</b>"),
-                ("y", "<script>alert('xss')</script>"),
+                ('x', '<b>Bold Option</b>'),
+                ('y', "<script>alert('xss')</script>"),
             ),
             choice_colors={
-                "x": CustomFieldChoiceColorChoices.RED,
+                'x': CustomFieldChoiceColorChoices.RED,
             },
         )
 
         custom_field = CustomField.objects.create(
-            name="html_select_field",
-            type=CustomFieldTypeChoices.TYPE_SELECT,
+            name='html_multiselect_field',
+            type=CustomFieldTypeChoices.TYPE_MULTISELECT,
             choice_set=choice_set,
             required=False,
         )
@@ -242,7 +225,12 @@ class CustomFieldColumnTestCase(TestCase):
 
         column = columns.CustomFieldColumn(custom_field)
 
-        rendered = str(column.render("x"))
+        rendered = str(column.render(['x', 'y']))
 
-        self.assertIn("&lt;b&gt;Bold Option&lt;/b&gt;", rendered)
-        self.assertNotIn("&amp;lt;", rendered)
+        self.assertIn('&lt;b&gt;Bold Option&lt;/b&gt;', rendered)
+        self.assertNotIn('&amp;lt;', rendered)
+        self.assertIn("&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;", rendered,)
+        self.assertNotIn("<script>", rendered)
+
+        self.assertIn('text-bg-red', rendered)
+        self.assertIn('text-bg-secondary', rendered)

--- a/netbox/netbox/tests/test_tables.py
+++ b/netbox/netbox/tests/test_tables.py
@@ -2,11 +2,11 @@ from django.contrib.auth.models import AnonymousUser
 from django.template import Context, Template
 from django.test import RequestFactory, TestCase
 
+from core.models import ObjectType
 from dcim.models import Device, Site
 from dcim.tables import DeviceTable
 from extras.choices import CustomFieldChoiceColorChoices, CustomFieldTypeChoices
 from extras.models import CustomField, CustomFieldChoiceSet
-from core.models import ObjectType
 from netbox.tables import NetBoxTable, columns
 from utilities.testing import create_tags, create_test_device, create_test_user
 
@@ -229,8 +229,8 @@ class CustomFieldColumnTestCase(TestCase):
 
         self.assertIn('&lt;b&gt;Bold Option&lt;/b&gt;', rendered)
         self.assertNotIn('&amp;lt;', rendered)
-        self.assertIn("&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;", rendered,)
-        self.assertNotIn("<script>", rendered)
+        self.assertIn('&lt;script&gt;alert(&#x27;xss&#x27;)&lt;/script&gt;', rendered,)
+        self.assertNotIn('<script>', rendered)
 
         self.assertIn('text-bg-red', rendered)
         self.assertIn('text-bg-secondary', rendered)

--- a/netbox/netbox/tests/test_tables.py
+++ b/netbox/netbox/tests/test_tables.py
@@ -2,16 +2,17 @@ from django.contrib.auth.models import AnonymousUser
 from django.template import Context, Template
 from django.test import RequestFactory, TestCase
 
-from core.models import ObjectType
 from dcim.models import Device, Site
 from dcim.tables import DeviceTable
 from extras.choices import CustomFieldChoiceColorChoices, CustomFieldTypeChoices
 from extras.models import CustomField, CustomFieldChoiceSet
+from core.models import ObjectType
 from netbox.tables import NetBoxTable, columns
 from utilities.testing import create_tags, create_test_device, create_test_user
 
 
 class BaseTableTestCase(TestCase):
+
     @classmethod
     def setUpTestData(cls):
         create_test_device('Test Device 1')
@@ -72,7 +73,9 @@ class BaseTableTestCase(TestCase):
 
         # Simulate the CSV "All data" export path: re-apply prefetching for every column that
         # will be included in the export, regardless of visibility.
-        export_columns = [col_name for col_name, _ in table.selected_columns + table.available_columns]
+        export_columns = [
+            col_name for col_name, _ in table.selected_columns + table.available_columns
+        ]
         table._apply_prefetching(columns=export_columns)
 
         prefetch_lookups = table.data.data._prefetch_related_lookups
@@ -95,20 +98,19 @@ class TagColumnTable(NetBoxTable):
 
     class Meta(NetBoxTable.Meta):
         model = Site
-        fields = (
-            'pk',
-            'name',
-            'tags',
-        )
+        fields = ('pk', 'name', 'tags',)
         default_columns = fields
 
 
 class TagColumnTestCase(TestCase):
+
     @classmethod
     def setUpTestData(cls):
         tags = create_tags('Alpha', 'Bravo', 'Charlie')
 
-        sites = [Site(name=f'Site {i}', slug=f'site-{i}') for i in range(1, 6)]
+        sites = [
+            Site(name=f'Site {i}', slug=f'site-{i}') for i in range(1, 6)
+        ]
         Site.objects.bulk_create(sites)
         for site in sites:
             site.tags.add(*tags)
@@ -116,30 +118,41 @@ class TagColumnTestCase(TestCase):
     def test_tagcolumn(self):
         template = Template('{% load render_table from django_tables2 %}{% render_table table %}')
         table = TagColumnTable(Site.objects.all(), orderable=False)
-        context = Context({'table': table})
+        context = Context({
+            'table': table
+        })
         template.render(context)
 
 
 class CustomFieldColumnTestCase(TestCase):
+
     @classmethod
     def setUpTestData(cls):
         cls.object_type = ObjectType.objects.get_for_model(Site)
 
-        # Choice set containing one colored and two uncolored choices
+        # Choice set containing one colored and one uncolored choice
         cls.mixed_choice_set = CustomFieldChoiceSet.objects.create(
-            name='Mixed Choice Set',
+            name="Mixed Choice Set",
             extra_choices=(
-                ('a', 'Option A'),
-                ('b', 'Option B'),
-                ('c', 'Option C'),
+                ("a", "Option A"),
+                ("b", "Option B"),
             ),
             choice_colors={
-                'a': CustomFieldChoiceColorChoices.RED,
+                "a": CustomFieldChoiceColorChoices.RED,
             },
         )
 
+        # Choice set with no configured colors
+        cls.plain_choice_set = CustomFieldChoiceSet.objects.create(
+            name="Plain Choice Set",
+            extra_choices=(
+                ("a", "Option A"),
+                ("b", "Option B"),
+            ),
+        )
+
         cls.select_cf = CustomField.objects.create(
-            name='select_field',
+            name="select_field",
             type=CustomFieldTypeChoices.TYPE_SELECT,
             choice_set=cls.mixed_choice_set,
             required=False,
@@ -147,73 +160,81 @@ class CustomFieldColumnTestCase(TestCase):
         cls.select_cf.object_types.set([cls.object_type])
 
         cls.multiselect_cf = CustomField.objects.create(
-            name='multiselect_field',
+            name="multiselect_field",
             type=CustomFieldTypeChoices.TYPE_MULTISELECT,
             choice_set=cls.mixed_choice_set,
             required=False,
         )
         cls.multiselect_cf.object_types.set([cls.object_type])
 
+        cls.plain_multiselect_cf = CustomField.objects.create(
+            name="plain_multiselect_field",
+            type=CustomFieldTypeChoices.TYPE_MULTISELECT,
+            choice_set=cls.plain_choice_set,
+            required=False,
+        )
+        cls.plain_multiselect_cf.object_types.set([cls.object_type])
+
     def test_colored_single_select(self):
         column = columns.CustomFieldColumn(self.select_cf)
 
-        rendered = str(column.render('a'))
+        rendered = str(column.render("a"))
 
-        self.assertIn('badge', rendered)
-        self.assertIn('text-bg-red', rendered)
-        self.assertIn('Option A', rendered)
+        self.assertIn("badge", rendered)
+        self.assertIn("text-bg-red", rendered)
+        self.assertIn("Option A", rendered)
 
     def test_uncolored_single_select(self):
         column = columns.CustomFieldColumn(self.select_cf)
 
-        rendered = str(column.render('b'))
+        rendered = str(column.render("b"))
 
-        self.assertEqual(rendered, 'Option B')
-        self.assertNotIn('badge', rendered)
+        self.assertEqual(rendered, "Option B")
+        self.assertNotIn("badge", rendered)
 
     def test_empty_multiselect(self):
         column = columns.CustomFieldColumn(self.multiselect_cf)
 
         rendered = column.render([])
 
-        self.assertEqual(rendered, '')
+        self.assertEqual(rendered, "")
 
-    def test_multiselect_without_selected_colored_choices(self):
-        column = columns.CustomFieldColumn(self.multiselect_cf)
+    def test_multiselect_without_colored_choices(self):
+        column = columns.CustomFieldColumn(self.plain_multiselect_cf)
 
-        rendered = str(column.render(['b', 'c']))
+        rendered = str(column.render(["a", "b"]))
 
-        self.assertEqual(rendered, 'Option B, Option C')
-        self.assertNotIn('badge', rendered)
+        self.assertEqual(rendered, "Option A, Option B")
+        self.assertNotIn("badge", rendered)
 
     def test_multiselect_with_mixed_colored_choices(self):
         column = columns.CustomFieldColumn(self.multiselect_cf)
 
-        rendered = str(column.render(['a', 'b']))
+        rendered = str(column.render(["a", "b"]))
 
-        self.assertIn('Option A', rendered)
-        self.assertIn('Option B', rendered)
+        self.assertIn("Option A", rendered)
+        self.assertIn("Option B", rendered)
 
-        self.assertIn('text-bg-red', rendered)
-        self.assertIn('text-bg-secondary', rendered)
+        self.assertIn("text-bg-red", rendered)
+        self.assertIn("text-bg-secondary", rendered)
 
-        self.assertNotIn(',', rendered)
+        self.assertNotIn(",", rendered)
 
-    def test_html_sensitive_multiselect_labels(self):
+    def test_html_sensitive_choice_labels(self):
         choice_set = CustomFieldChoiceSet.objects.create(
-            name='HTML Choice Set',
+            name="HTML Choice Set",
             extra_choices=(
-                ('x', '<b>Bold Option</b>'),
-                ('y', "<script>alert('xss')</script>"),
+                ("x", "<b>Bold Option</b>"),
+                ("y", "<script>alert('xss')</script>"),
             ),
             choice_colors={
-                'x': CustomFieldChoiceColorChoices.RED,
+                "x": CustomFieldChoiceColorChoices.RED,
             },
         )
 
         custom_field = CustomField.objects.create(
-            name='html_multiselect_field',
-            type=CustomFieldTypeChoices.TYPE_MULTISELECT,
+            name="html_select_field",
+            type=CustomFieldTypeChoices.TYPE_SELECT,
             choice_set=choice_set,
             required=False,
         )
@@ -221,10 +242,7 @@ class CustomFieldColumnTestCase(TestCase):
 
         column = columns.CustomFieldColumn(custom_field)
 
-        rendered = str(column.render(['x', 'y']))
+        rendered = str(column.render("x"))
 
-        self.assertIn('&lt;b&gt;Bold Option&lt;/b&gt;', rendered)
-        self.assertNotIn('&amp;lt;', rendered)
-
-        self.assertIn('text-bg-red', rendered)
-        self.assertIn('text-bg-secondary', rendered)
+        self.assertIn("&lt;b&gt;Bold Option&lt;/b&gt;", rendered)
+        self.assertNotIn("&amp;lt;", rendered)


### PR DESCRIPTION
Render select and multiselect custom field values as colored badges in table views when a color is defined on the associated choice set.

This aligns table rendering with object detail pages, which already display colored choice values as badges.


<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22522

<!--
    Please include a summary of the proposed changes below.
-->
##
