### PR TITLE
Fixes #22662: Fix database overflow when saving Cables with large lengths

### DIFF
--- a/netbox/dcim/migrations/0238_alter_cable__abs_length.py
+++ b/netbox/dcim/migrations/0238_alter_cable__abs_length.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('dcim', '0237_module_remove_local_context_data'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='cable',
+            name='_abs_length',
+            field=models.DecimalField(blank=True, decimal_places=4, max_digits=14, null=True),
+        ),
+    ]

--- a/netbox/dcim/models/cables.py
+++ b/netbox/dcim/models/cables.py
@@ -133,7 +133,7 @@ class Cable(PrimaryModel):
     )
     # Stores the normalized length (in meters) for database ordering
     _abs_length = models.DecimalField(
-        max_digits=10,
+        max_digits=14,
         decimal_places=4,
         blank=True,
         null=True

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -1,3 +1,5 @@
+from decimal import Decimal
+
 from django.core.exceptions import ValidationError
 from django.db.models.signals import post_save
 from django.test import TestCase, tag
@@ -2226,6 +2228,32 @@ class CableTestCase(TestCase):
         cable = Cable.objects.first()
         interface = Interface(device=device, name='tmp', cable=cable)
         self.assertIsNone(interface.path)
+
+    def test_cable_length_normalization_large_kilometer_value(self):
+        """
+        A large kilometer length must pass validation and fit in the normalized length field.
+        """
+        cable = Cable.objects.first()
+        cable.length = Decimal('1234')
+        cable.length_unit = CableLengthUnitChoices.UNIT_KILOMETER
+        cable.full_clean()
+        cable.save()
+        cable.refresh_from_db()
+
+        self.assertEqual(cable._abs_length, Decimal('1234000.0000'))
+
+    def test_cable_length_normalization_maximum_mile_value(self):
+        """
+        The maximum length value expressed in miles must fit in the normalized length field.
+        """
+        cable = Cable.objects.first()
+        cable.length = Decimal('999999.99')
+        cable.length_unit = CableLengthUnitChoices.UNIT_MILE
+        cable.full_clean()
+        cable.save()
+        cable.refresh_from_db()
+
+        self.assertEqual(cable._abs_length, Decimal('1609343983.9066'))
 
 
 class CableTerminationTestCase(TestCase):


### PR DESCRIPTION
### Closes: netbox-community/netbox#22662

This PR increases `Cable._abs_length.max_digits` from 10 to 14, allowing the normalized field to accommodate the full range already supported by `Cable.length`, including large values expressed in kilometers or miles.

It also adds regression tests covering the reported large kilometer value and the maximum supported value in miles, ensuring both can be normalized without causing a database overflow.