### PR TITLE
#22678 - Add security note for Redis broker trust / RQ task deserialization

### DIFF
--- a/docs/configuration/required-parameters.md
+++ b/docs/configuration/required-parameters.md
@@ -146,6 +146,9 @@ REDIS = {
     It is highly recommended to keep the task and cache databases separate. Using the same database number on the
     same Redis instance for both may result in queued background tasks being lost during cache flushing events.
 
+!!! danger "Redis is a trusted component"
+    NetBox's background workers deserialize and execute jobs read from the `tasks` Redis database, so any party with write access to it can run arbitrary code on a worker. Redis must be treated as trusted infrastructure, on par with the PostgreSQL database: keep it bound to a private network and require authentication.
+
 ### UNIX Socket Support
 
 Redis may alternatively be configured by specifying a complete URL instead of individual components. This approach supports the use of a UNIX socket connection. For example:

--- a/docs/installation/2-redis.md
+++ b/docs/installation/2-redis.md
@@ -19,6 +19,12 @@ redis-server -v
 
 You may wish to modify the Redis configuration at `/etc/redis.conf` or `/etc/redis/redis.conf`, however in most cases the default configuration is sufficient.
 
+!!! danger "Restrict access to Redis"
+    NetBox's background workers execute jobs read from Redis, so anyone able to write to the `tasks` database can run
+    arbitrary code on a worker. Treat Redis as trusted infrastructure: keep it bound to `localhost` (the default) or a
+    private network, and enable authentication if it is reachable by any other host. See
+    [Redis configuration](../configuration/required-parameters.md#redis) for details.
+
 ## Verify Service Status
 
 Use the `redis-cli` utility to ensure the Redis service is functional:


### PR DESCRIPTION
### Closes: #22678

Added security note re Redis is a trusted component.