### PR TITLE
Fix: Interface "Create & Add Another" does not pre-populate previous values (#22656)

### DIFF
--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -603,10 +603,15 @@ class ComponentCreateView(GetReturnURLMixin, BaseObjectView):
                         ))
 
                         # Redirect user on success
-                        if '_addanother' in request.POST and safe_for_redirect(request.get_full_path()):
-                            return redirect(request.get_full_path())
+                        if '_addanother' in request.POST:
+                            redirect_url = request.path
+                            params = prepare_cloned_fields(new_objs[-1])
+                            if params:
+                                redirect_url += f"?{params.urlencode()}"
+                            if safe_for_redirect(redirect_url):
+                                return redirect(redirect_url)
                         return redirect(self.get_return_url(request))
-
+                        
                 except (AbortRequest, PermissionsViolation) as e:
                     logger.debug(e.message)
                     form.add_error(None, e.message)

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -606,12 +606,13 @@ class ComponentCreateView(GetReturnURLMixin, BaseObjectView):
                         if '_addanother' in request.POST:
                             redirect_url = request.path
                             params = prepare_cloned_fields(new_objs[-1])
+                            if 'return_url' in request.GET:
+                                params['return_url'] = request.GET.get('return_url')
                             if params:
                                 redirect_url += f"?{params.urlencode()}"
                             if safe_for_redirect(redirect_url):
                                 return redirect(redirect_url)
                         return redirect(self.get_return_url(request))
-                        
                 except (AbortRequest, PermissionsViolation) as e:
                     logger.debug(e.message)
                     form.add_error(None, e.message)


### PR DESCRIPTION
Fixes #22656

## Problem
When adding an Interface (or other device components created via `ComponentCreateView`, e.g. Console Ports, Power Ports), clicking "Create & Add Another" did not carry forward previously entered values such as Type, MTU, Speed, or Duplex — despite the `Interface` model's `clone_fields` explicitly listing these fields for cloning.

## Root Cause
`ObjectEditView` builds its "add another" redirect using `prepare_cloned_fields()`, which reads the model's `clone_fields` and appends them as URL query parameters on the redirect. `ComponentCreateView` (used for Interfaces and other components) was instead redirected to `request.get_full_path()` — the original page URL — without applying `prepare_cloned_fields()` at all, so none of the submitted values were passed forward.

## Fix
Updated `ComponentCreateView.post()` to build the redirect URL the same way `ObjectEditView` does: using `prepare_cloned_fields()` on the last created object, consistent with existing behavior elsewhere in the codebase.

## Testing
Manually verified locally using `netbox-docker`:
- Created an Interface with Type, Speed, Duplex, and MTU set, then clicked "Create & Add Another" and all four values are correctly pre-populated on the new form.
- Confirmed Name, Label, and Description remain blank.
- Repeated the flow multiple times to confirm consistent behavior across repeated "Create & Add Another" clicks.