### PR TITLE
Fixes #22588: Filter VLANs by Site Group scope when assigning to a prefix

### DIFF
--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -1045,6 +1045,7 @@ class VLANFilterSet(PrimaryModelFilterSet, TenancyFilterSet):
         field_name='group__slug',
         queryset=VLANGroup.objects.all(),
         distinct=False,
+        to_field_name='slug',
         label=_('Group'),
     )
     role_id = django_filters.ModelMultipleChoiceFilter(

--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -1136,7 +1136,6 @@ class VLANFilterSet(PrimaryModelFilterSet, TenancyFilterSet):
     @extend_schema_field(OpenApiTypes.STR)
     def get_for_site_group(self, queryset, name, value):
         return queryset.get_for_site_group(value)
-        
     @extend_schema_field(OpenApiTypes.STR)
     def get_for_device(self, queryset, name, value):
         return queryset.get_for_device(value)

--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -1045,7 +1045,6 @@ class VLANFilterSet(PrimaryModelFilterSet, TenancyFilterSet):
         field_name='group__slug',
         queryset=VLANGroup.objects.all(),
         distinct=False,
-        to_field_name='slug',
         label=_('Group'),
     )
     role_id = django_filters.ModelMultipleChoiceFilter(
@@ -1068,6 +1067,10 @@ class VLANFilterSet(PrimaryModelFilterSet, TenancyFilterSet):
     available_at_site = django_filters.ModelChoiceFilter(
         queryset=Site.objects.all(),
         method='get_for_site'
+    )
+    available_at_site_group = django_filters.ModelChoiceFilter(
+        queryset=SiteGroup.objects.all(),
+        method='get_for_site_group'
     )
     available_on_device = django_filters.ModelChoiceFilter(
         queryset=Device.objects.all(),
@@ -1130,6 +1133,10 @@ class VLANFilterSet(PrimaryModelFilterSet, TenancyFilterSet):
     def get_for_site(self, queryset, name, value):
         return queryset.get_for_site(value)
 
+    @extend_schema_field(OpenApiTypes.STR)
+    def get_for_site_group(self, queryset, name, value):
+        return queryset.get_for_site_group(value)
+        
     @extend_schema_field(OpenApiTypes.STR)
     def get_for_device(self, queryset, name, value):
         return queryset.get_for_device(value)

--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -1136,6 +1136,7 @@ class VLANFilterSet(PrimaryModelFilterSet, TenancyFilterSet):
     @extend_schema_field(OpenApiTypes.STR)
     def get_for_site_group(self, queryset, name, value):
         return queryset.get_for_site_group(value)
+
     @extend_schema_field(OpenApiTypes.STR)
     def get_for_device(self, queryset, name, value):
         return queryset.get_for_device(value)

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -5,7 +5,7 @@ from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
 
 from dcim.forms.mixins import ScopedForm
-from dcim.models import Device, Interface, Site
+from dcim.models import Device, Interface, Site, SiteGroup
 from ipam.choices import *
 from ipam.constants import *
 from ipam.formfields import IPNetworkFormField
@@ -245,12 +245,18 @@ class PrefixForm(TenancyForm, ScopedForm, PrimaryModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # #18605: only filter VLAN select list if scope field is a Site
+        # #18605: only filter VLAN select list if scope field is a Site or Site Group
         if scope_field := self.fields.get('scope', None):
-            if scope_field.queryset.model is not Site:
+            if scope_field.queryset.model is Site:
+                pass  # already filtered by available_at_site
+            elif scope_field.queryset.model is SiteGroup:
+                self.fields['vlan'].widget.dynamic_params.clear()
                 self.fields['vlan'].widget.attrs.pop('data-dynamic-params', None)
-
-
+                self.fields['vlan'].widget.add_query_params({
+                    'available_at_site_group': '$scope',
+                })
+            else:
+                self.fields['vlan'].widget.attrs.pop('data-dynamic-params', None)
 class PrefixBulkAddForm(PrefixForm):
     """
     Subclass of PrefixForm for bulk creation. The prefix field is inherited

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -257,6 +257,8 @@ class PrefixForm(TenancyForm, ScopedForm, PrimaryModelForm):
                 })
             else:
                 self.fields['vlan'].widget.attrs.pop('data-dynamic-params', None)
+
+
 class PrefixBulkAddForm(PrefixForm):
     """
     Subclass of PrefixForm for bulk creation. The prefix field is inherited

--- a/netbox/ipam/querysets.py
+++ b/netbox/ipam/querysets.py
@@ -290,6 +290,19 @@ class VLANQuerySet(RestrictedQuerySet):
             Q(group__isnull=True, site__isnull=True)  # Global VLANs
         )
 
+    def get_for_site_group(self, site_group):
+        """
+        Return all VLANs available to the specified site group.
+        """
+        from .models import VLANGroup
+        q = Q(
+            scope_type=ContentType.objects.get_by_natural_key('dcim', 'sitegroup'),
+            scope_id__in=site_group.get_ancestors(include_self=True)
+        )
+        return self.filter(
+            Q(group__in=VLANGroup.objects.filter(q))
+        )
+
     def get_for_device(self, device):
         """
         Return all VLANs available to the specified Device.

--- a/netbox/ipam/querysets.py
+++ b/netbox/ipam/querysets.py
@@ -302,7 +302,9 @@ class VLANQuerySet(RestrictedQuerySet):
             scope_id__in=site_group.get_ancestors(include_self=True)
         )
         return self.filter(
-            Q(group__in=VLANGroup.objects.filter(q))
+            Q(group__in=VLANGroup.objects.filter(q)) |
+            Q(group__scope_id__isnull=True, site__isnull=True) |  # Global group VLANs
+            Q(group__isnull=True, site__isnull=True)  # Global VLANs
         )
 
     def get_for_device(self, device):

--- a/netbox/ipam/querysets.py
+++ b/netbox/ipam/querysets.py
@@ -294,6 +294,8 @@ class VLANQuerySet(RestrictedQuerySet):
         """
         Return all VLANs available to the specified site group.
         """
+        if site_group is None:
+            return self.none()
         from .models import VLANGroup
         q = Q(
             scope_type=ContentType.objects.get_by_natural_key('dcim', 'sitegroup'),

--- a/netbox/ipam/tests/test_filtersets.py
+++ b/netbox/ipam/tests/test_filtersets.py
@@ -2201,6 +2201,11 @@ class VLANTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {'available_at_site': site_id}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 5)  # 4 scoped + 1 global group + 1 global
 
+    def test_available_at_site_group(self):
+        site_group = SiteGroup.objects.get(name='Site Group 1')
+        params = {'available_at_site_group': site_group.pk}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)  # 1 scoped + 1 global group + 1 global
+        
     def test_interface(self):
         interface_id = Interface.objects.first().pk
         params = {'interface_id': interface_id}

--- a/netbox/ipam/tests/test_filtersets.py
+++ b/netbox/ipam/tests/test_filtersets.py
@@ -2205,7 +2205,7 @@ class VLANTestCase(TestCase, ChangeLoggedFilterSetTests):
         site_group = SiteGroup.objects.get(name='Site Group 1')
         params = {'available_at_site_group': site_group.pk}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)  # 1 scoped + 1 global group + 1 global
-        
+
     def test_interface(self):
         interface_id = Interface.objects.first().pk
         params = {'interface_id': interface_id}

--- a/netbox/ipam/tests/test_forms.py
+++ b/netbox/ipam/tests/test_forms.py
@@ -29,19 +29,27 @@ class PrefixFormTestCase(TestCase):
 
         assert form.fields['vlan'].widget.attrs['data-dynamic-params'] == self.default_dynamic_params
 
+    def test_vlan_field_sets_dynamic_params_for_scope_site_group(self):
+        """data-dynamic-params present with available_at_site_group when scope type is Site Group"""
+        site_group = SiteGroup(name='Site Group 1', slug='site-group-1')
+        form = PrefixForm(data={
+            'scope_type': ContentType.objects.get_for_model(SiteGroup).id,
+            'scope': site_group,
+        })
+        expected = '[{"fieldName":"scope","queryParam":"available_at_site_group"}]'
+        assert form.fields['vlan'].widget.attrs['data-dynamic-params'] == expected
+
     def test_vlan_field_does_not_set_dynamic_params_for_other_scopes(self):
-        """data-dynamic-params not present when scope type is populated by is not Site"""
+        """data-dynamic-params not present when scope type is not Site or Site Group"""
         cases = [
             Region(name='Region 1', slug='region-1'),
             Location(site=self.site, name='Location 1', slug='location-1'),
-            SiteGroup(name='Site Group 1', slug='site-group-1'),
         ]
         for case in cases:
             form = PrefixForm(data={
                 'scope_type': ContentType.objects.get_for_model(case._meta.model).id,
                 'scope': case,
             })
-
             assert 'data-dynamic-params' not in form.fields['vlan'].widget.attrs
 
 

--- a/netbox/ipam/tests/test_forms.py
+++ b/netbox/ipam/tests/test_forms.py
@@ -31,7 +31,7 @@ class PrefixFormTestCase(TestCase):
 
     def test_vlan_field_sets_dynamic_params_for_scope_site_group(self):
         """data-dynamic-params present with available_at_site_group when scope type is Site Group"""
-        site_group = SiteGroup(name='Site Group 1', slug='site-group-1')
+        site_group = SiteGroup.objects.create(name='Site Group 1', slug='site-group-1')
         form = PrefixForm(data={
             'scope_type': ContentType.objects.get_for_model(SiteGroup).id,
             'scope': site_group,

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -603,16 +603,10 @@ class ComponentCreateView(GetReturnURLMixin, BaseObjectView):
                         ))
 
                         # Redirect user on success
-                        if '_addanother' in request.POST:
-                            redirect_url = request.path
-                            params = prepare_cloned_fields(new_objs[-1])
-                            if 'return_url' in request.GET:
-                                params['return_url'] = request.GET.get('return_url')
-                            if params:
-                                redirect_url += f"?{params.urlencode()}"
-                            if safe_for_redirect(redirect_url):
-                                return redirect(redirect_url)
+                        if '_addanother' in request.POST and safe_for_redirect(request.get_full_path()):
+                            return redirect(request.get_full_path())
                         return redirect(self.get_return_url(request))
+
                 except (AbortRequest, PermissionsViolation) as e:
                     logger.debug(e.message)
                     form.add_error(None, e.message)

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -603,10 +603,15 @@ class ComponentCreateView(GetReturnURLMixin, BaseObjectView):
                         ))
 
                         # Redirect user on success
-                        if '_addanother' in request.POST and safe_for_redirect(request.get_full_path()):
-                            return redirect(request.get_full_path())
+                        if '_addanother' in request.POST:
+                            redirect_url = request.path
+                            params = prepare_cloned_fields(new_objs[-1])
+                            if params:
+                                redirect_url += f"?{params.urlencode()}"
+                            if safe_for_redirect(redirect_url):
+                                return redirect(redirect_url)
                         return redirect(self.get_return_url(request))
-
+                        
                 except (AbortRequest, PermissionsViolation) as e:
                     logger.debug(e.message)
                     form.add_error(None, e.message)

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -606,12 +606,13 @@ class ComponentCreateView(GetReturnURLMixin, BaseObjectView):
                         if '_addanother' in request.POST:
                             redirect_url = request.path
                             params = prepare_cloned_fields(new_objs[-1])
+                            if 'return_url' in request.GET:
+                                params['return_url'] = request.GET.get('return_url')
                             if params:
                                 redirect_url += f"?{params.urlencode()}"
                             if safe_for_redirect(redirect_url):
                                 return redirect(redirect_url)
                         return redirect(self.get_return_url(request))
-                        
                 except (AbortRequest, PermissionsViolation) as e:
                     logger.debug(e.message)
                     form.add_error(None, e.message)


### PR DESCRIPTION
### Closes: #22588

When a prefix's scope is set to a Site Group, the VLAN dropdown was showing all VLANs regardless of scope. This PR fixes that by:

1. Adding a `get_for_site_group()` method to `VLANQuerySet` that filters VLANs to only those belonging to the VLAN Groups scoped to the specified Site Group (or its ancestors)
2. Adding an `available_at_site_group` filter to `VLANFilterSet` that calls this method
3. Updating `PrefixForm.__init__` to swap the `available_at_site` query param for `available_at_site_group` when the prefix scope is a Site Group