### PR TITLE
Closes #22687: Fix queryset truthiness check in RenderTemplateMixin.render_to_response()

### DIFF
--- a/netbox/extras/models/mixins.py
+++ b/netbox/extras/models/mixins.py
@@ -244,7 +244,7 @@ class RenderTemplateMixin(models.Model):
             extension = f'.{self.file_extension}' if self.file_extension else ''
             if self.file_name:
                 filename = self.file_name
-            elif queryset:
+            elif queryset is not None:
                 filename = filename_from_model(queryset.model)
             elif context:
                 filename = filename_from_object(context)

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -1449,13 +1449,7 @@ class RenderTemplateMixinResponseTestCase(TestCase):
         self.assertEqual(response['Content-Disposition'], 'attachment; filename="netbox_sites.txt"')
 
     def test_response_attachment_filename_from_empty_queryset(self):
-        """
-        Regression test (#22687): a non-None but empty queryset must still yield a
-        model-derived filename. A prior bug checked `elif queryset:` (truthiness)
-        instead of `elif queryset is not None:`; QuerySet.__bool__() returns False for
-        an empty queryset, so this branch was incorrectly skipped in favor of the
-        "output" fallback even though a valid queryset was provided.
-        """
+        """An empty (but non-None) queryset must still yield a model-derived filename."""
         t = ExportTemplate(
             name='t',
             template_code='{% for obj in queryset %}{{ obj.name }}{% endfor %}',
@@ -1466,13 +1460,7 @@ class RenderTemplateMixinResponseTestCase(TestCase):
         self.assertEqual(response['Content-Disposition'], 'attachment; filename="netbox_sites.txt"')
 
     def test_response_attachment_does_not_force_queryset_evaluation(self):
-        """
-        Regression test (#22687): render_to_response() must not force evaluation of the
-        queryset just to check its truthiness. The prior `elif queryset:` check triggered
-        QuerySet.__bool__() -> _fetch_all(), issuing an unbounded SELECT and caching every
-        matching row in memory -- even when (as here) the template never references
-        `queryset` and so would otherwise leave it unevaluated.
-        """
+        """A template that never references `queryset` must not force it to be evaluated."""
         Site.objects.bulk_create([Site(name=f'Site {i}', slug=f'site-{i}') for i in range(5)])
         t = ExportTemplate(
             name='t',
@@ -1483,10 +1471,11 @@ class RenderTemplateMixinResponseTestCase(TestCase):
         with CaptureQueriesContext(connection) as ctx:
             t.render_to_response(queryset=Site.objects.all())
 
-        site_queries = [q for q in ctx.captured_queries if 'dcim_site' in q['sql']]
+        table = Site._meta.db_table
+        site_queries = [q for q in ctx.captured_queries if table in q['sql']]
         self.assertEqual(
             site_queries, [],
-            f"render_to_response() queried dcim_site even though the template never "
+            f"render_to_response() queried {table} even though the template never "
             f"references `queryset`:\n{site_queries}"
         )
 

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -11,8 +11,10 @@ from django.contrib.contenttypes.models import ContentType
 from django.core.files.base import ContentFile
 from django.core.files.storage import Storage
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.db import connection
 from django.forms import ValidationError
 from django.test import TestCase, tag
+from django.test.utils import CaptureQueriesContext
 from jinja2 import DebugUndefined, StrictUndefined, TemplateError, TemplateSyntaxError, UndefinedError
 from PIL import Image
 
@@ -1445,6 +1447,48 @@ class RenderTemplateMixinResponseTestCase(TestCase):
         )
         response = t.render_to_response(queryset=Site.objects.all())
         self.assertEqual(response['Content-Disposition'], 'attachment; filename="netbox_sites.txt"')
+
+    def test_response_attachment_filename_from_empty_queryset(self):
+        """
+        Regression test (#22687): a non-None but empty queryset must still yield a
+        model-derived filename. A prior bug checked `elif queryset:` (truthiness)
+        instead of `elif queryset is not None:`; QuerySet.__bool__() returns False for
+        an empty queryset, so this branch was incorrectly skipped in favor of the
+        "output" fallback even though a valid queryset was provided.
+        """
+        t = ExportTemplate(
+            name='t',
+            template_code='{% for obj in queryset %}{{ obj.name }}{% endfor %}',
+            file_extension='txt',
+            as_attachment=True,
+        )
+        response = t.render_to_response(queryset=Site.objects.none())
+        self.assertEqual(response['Content-Disposition'], 'attachment; filename="netbox_sites.txt"')
+
+    def test_response_attachment_does_not_force_queryset_evaluation(self):
+        """
+        Regression test (#22687): render_to_response() must not force evaluation of the
+        queryset just to check its truthiness. The prior `elif queryset:` check triggered
+        QuerySet.__bool__() -> _fetch_all(), issuing an unbounded SELECT and caching every
+        matching row in memory -- even when (as here) the template never references
+        `queryset` and so would otherwise leave it unevaluated.
+        """
+        Site.objects.bulk_create([Site(name=f'Site {i}', slug=f'site-{i}') for i in range(5)])
+        t = ExportTemplate(
+            name='t',
+            template_code='static output',  # deliberately does not reference `queryset`
+            file_extension='txt',
+            as_attachment=True,
+        )
+        with CaptureQueriesContext(connection) as ctx:
+            t.render_to_response(queryset=Site.objects.all())
+
+        site_queries = [q for q in ctx.captured_queries if 'dcim_site' in q['sql']]
+        self.assertEqual(
+            site_queries, [],
+            f"render_to_response() queried dcim_site even though the template never "
+            f"references `queryset`:\n{site_queries}"
+        )
 
     def test_response_attachment_filename_from_device_context(self):
         t = ConfigTemplate(name='t', template_code='ok', as_attachment=True)


### PR DESCRIPTION
### Closes: #22687

## Summary

`RenderTemplateMixin.render_to_response()` (`netbox/extras/models/mixins.py`) checked `elif queryset:` to decide whether a queryset was supplied when deriving a default export filename. This is both a performance bug and a functional correctness bug.

## Root cause

`elif queryset:` relies on Python truthiness, which for a Django `QuerySet` calls `__bool__()` → `_fetch_all()` — forcing a full, unbounded evaluation of every matching row into memory, purely to check whether a queryset was provided at all.

`render_to_response()` is reachable from any model's list view via a configured `ExportTemplate`:
- `netbox/api/viewsets/mixins.py` — the REST API's `?export=<template>` action
- `netbox/views/generic/bulk_views.py` — the UI's "Export" button

Both pass the entire current (filtered) list-view queryset. `ExportTemplate.as_attachment` defaults to `True`, and `file_name` is an optional field most users leave blank, so this branch is the common path — meaning a large, unfiltered export could materialize an entire table's worth of rows in memory just to read `queryset.model`.

This is also a **functional bug**: an empty (but valid, non-`None`) queryset is falsy, so the branch was incorrectly skipped in favor of the `"output"` filename fallback even when a real queryset was supplied — producing the wrong default filename for any export that happens to match zero rows.

## Fix

Check `queryset is not None` instead of relying on truthiness.

## Tests

Added two regression tests to `RenderTemplateMixinResponseTestCase` in `extras/tests/test_models.py`:
- `test_response_attachment_filename_from_empty_queryset` — an empty queryset must still yield a model-derived filename, not the `"output"` fallback.
- `test_response_attachment_does_not_force_queryset_evaluation` — using a template that never references `queryset`, asserts via `CaptureQueriesContext` that no query against the underlying table is issued at all.

I verified both tests fail against the pre-fix code (one with the wrong filename, one with an unbounded full-table `SELECT`) and pass with the fix applied. Full `extras.tests.test_models` suite (109 tests) passes on a fresh test database; `ruff check` passes.
