### PR TITLE
Closes #22569: Add explicit path for Script POST detail route

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # Python virtual environment created by the installation/upgrade workflow
 /venv/
+/.venv/
 
 # Frontend dependencies and Yarn logs generated during asset development/builds
 /netbox/project-static/node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ __pycache__/
 
 # Python virtual environment created by the installation/upgrade workflow
 /venv/
-/.venv/
 
 # Frontend dependencies and Yarn logs generated during asset development/builds
 /netbox/project-static/node_modules/

--- a/netbox/core/tests/test_openapi_schema.py
+++ b/netbox/core/tests/test_openapi_schema.py
@@ -3,6 +3,7 @@ Unit tests for OpenAPI schema generation.
 
 Refs: #20638
 """
+
 import json
 
 from django.test import TestCase
@@ -40,26 +41,20 @@ class OpenAPISchemaTestCase(TestCase):
                 request_schema = operation['requestBody']['content']['application/json']['schema']
 
                 # Should have oneOf with two options
-                self.assertIn('oneOf', request_schema, f"POST {path} should have oneOf schema")
-                self.assertEqual(
-                    len(request_schema['oneOf']), 2,
-                    f"POST {path} oneOf should have exactly 2 options"
-                )
+                self.assertIn('oneOf', request_schema, f'POST {path} should have oneOf schema')
+                self.assertEqual(len(request_schema['oneOf']), 2, f'POST {path} oneOf should have exactly 2 options')
 
                 # First option: single object (has $ref or properties)
                 single_schema = request_schema['oneOf'][0]
                 self.assertTrue(
                     '$ref' in single_schema or 'properties' in single_schema,
-                    f"POST {path} first oneOf option should be single object"
+                    f'POST {path} first oneOf option should be single object',
                 )
 
                 # Second option: array of objects
                 array_schema = request_schema['oneOf'][1]
-                self.assertEqual(
-                    array_schema['type'], 'array',
-                    f"POST {path} second oneOf option should be array"
-                )
-                self.assertIn('items', array_schema, f"POST {path} array should have items")
+                self.assertEqual(array_schema['type'], 'array', f'POST {path} second oneOf option should be array')
+                self.assertIn('items', array_schema, f'POST {path} array should have items')
 
     def test_bulk_update_operations_require_array_only(self):
         """
@@ -81,17 +76,10 @@ class OpenAPISchemaTestCase(TestCase):
 
                     # Should be array-only, not oneOf
                     self.assertNotIn(
-                        'oneOf', request_schema,
-                        f"{method.upper()} {path} should NOT have oneOf (array-only)"
+                        'oneOf', request_schema, f'{method.upper()} {path} should NOT have oneOf (array-only)'
                     )
-                    self.assertEqual(
-                        request_schema['type'], 'array',
-                        f"{method.upper()} {path} should require array"
-                    )
-                    self.assertIn(
-                        'items', request_schema,
-                        f"{method.upper()} {path} array should have items"
-                    )
+                    self.assertEqual(request_schema['type'], 'array', f'{method.upper()} {path} should require array')
+                    self.assertIn('items', request_schema, f'{method.upper()} {path} array should have items')
 
     def test_bulk_delete_requires_array(self):
         """
@@ -104,6 +92,26 @@ class OpenAPISchemaTestCase(TestCase):
         request_schema = operation['requestBody']['content']['application/json']['schema']
 
         # Should be array-only
-        self.assertNotIn('oneOf', request_schema, "DELETE should NOT have oneOf")
-        self.assertEqual(request_schema['type'], 'array', "DELETE should require array")
-        self.assertIn('items', request_schema, "DELETE array should have items")
+        self.assertNotIn('oneOf', request_schema, 'DELETE should NOT have oneOf')
+        self.assertEqual(request_schema['type'], 'array', 'DELETE should require array')
+        self.assertIn('items', request_schema, 'DELETE array should have items')
+
+    def test_script_post_operation_present(self):
+        """
+        POST on the Script detail route must appear in the generated schema.
+
+        DRF's router never maps 'post' into a detail route's actions dict by
+        default, so ScriptViewSet.post() — a custom, non-CRUD action reachable
+        only via Django's generic method dispatch — was previously invisible
+        to drf-spectacular even though the endpoint worked at runtime.
+
+        Refs: #22569
+        """
+        path = '/api/extras/scripts/{id}/'
+        operations = self.schema['paths'][path]
+
+        self.assertIn('post', operations, f'POST {path} is missing from the generated schema')
+
+        # Confirm the other detail-route methods are still present and untouched
+        for method in ('get', 'put', 'patch', 'delete'):
+            self.assertIn(method, operations, f'{method.upper()} {path} unexpectedly missing from schema')

--- a/netbox/core/tests/test_openapi_schema.py
+++ b/netbox/core/tests/test_openapi_schema.py
@@ -115,3 +115,25 @@ class OpenAPISchemaTestCase(TestCase):
         # Confirm the other detail-route methods are still present and untouched
         for method in ('get', 'put', 'patch', 'delete'):
             self.assertIn(method, operations, f'{method.upper()} {path} unexpectedly missing from schema')
+
+        post_op = operations['post']
+
+        self.assertEqual(
+            post_op['operationId'],
+            'extras_scripts_run',
+            'POST /api/extras/scripts/{id}/ should have a stable, distinct operationId',
+        )
+
+        request_schema = post_op['requestBody']['content']['application/json']['schema']
+        self.assertEqual(
+            request_schema.get('$ref'),
+            '#/components/schemas/ScriptInputRequest',
+            'POST request body should document ScriptInputSerializer, not ScriptSerializer',
+        )
+
+        response_schema = post_op['responses']['200']['content']['application/json']['schema']
+        self.assertEqual(
+            response_schema.get('$ref'),
+            '#/components/schemas/ScriptDetail',
+            'POST response should document ScriptDetailSerializer, not ScriptSerializer',
+        )

--- a/netbox/extras/api/urls.py
+++ b/netbox/extras/api/urls.py
@@ -32,5 +32,18 @@ router.register('scripts', views.ScriptViewSet, basename='script')
 app_name = 'extras-api'
 urlpatterns = [
     path('dashboard/', views.DashboardView.as_view(), name='dashboard'),
+    path(
+        'scripts/<str:pk>/',
+        views.ScriptViewSet.as_view(
+            {
+                'get': 'retrieve',
+                'put': 'update',
+                'patch': 'partial_update',
+                'delete': 'destroy',
+                'post': 'post',
+            }
+        ),
+        name='script-detail',
+    ),
     path('', include(router.urls)),
 ]

--- a/netbox/extras/api/urls.py
+++ b/netbox/extras/api/urls.py
@@ -33,6 +33,14 @@ app_name = 'extras-api'
 urlpatterns = [
     path('dashboard/', views.DashboardView.as_view(), name='dashboard'),
     path(
+        'scripts/upload/',
+        views.ScriptModuleViewSet.as_view(
+            {
+                'post': 'create',
+            }
+        ),
+    ),
+    path(
         'scripts/<str:pk>/',
         views.ScriptViewSet.as_view(
             {

--- a/netbox/extras/api/urls.py
+++ b/netbox/extras/api/urls.py
@@ -1,4 +1,5 @@
 from django.urls import include, path
+from rest_framework.routers import Route
 
 from netbox.api.routers import NetBoxRouter
 
@@ -27,31 +28,32 @@ router.register('config-contexts', views.ConfigContextViewSet)
 router.register('config-context-profiles', views.ConfigContextProfileViewSet)
 router.register('config-templates', views.ConfigTemplateViewSet)
 router.register('scripts/upload', views.ScriptModuleViewSet)
-router.register('scripts', views.ScriptViewSet, basename='script')
+
+
+class ScriptRouter(NetBoxRouter):
+    """
+    Router variant that extends the detail route's mapping to include
+    POST, so ScriptViewSet.post() (running a script) is dispatched
+    through the same router-generated detail URL as retrieve/update/
+    partial_update/destroy, rather than a separately hand-written path().
+    """
+    routes = NetBoxRouter.routes.copy()
+    _new_routes = []
+    for _route in routes:
+        if isinstance(_route, Route) and _route.mapping.get('get') == 'retrieve':
+            _mapping = dict(_route.mapping)
+            _mapping['post'] = 'post'
+            _route = _route._replace(mapping=_mapping)
+        _new_routes.append(_route)
+    routes = _new_routes
+
+
+script_router = ScriptRouter()
+script_router.register('scripts', views.ScriptViewSet, basename='script')
 
 app_name = 'extras-api'
 urlpatterns = [
     path('dashboard/', views.DashboardView.as_view(), name='dashboard'),
-    path(
-        'scripts/upload/',
-        views.ScriptModuleViewSet.as_view(
-            {
-                'post': 'create',
-            }
-        ),
-    ),
-    path(
-        'scripts/<str:pk>/',
-        views.ScriptViewSet.as_view(
-            {
-                'get': 'retrieve',
-                'put': 'update',
-                'patch': 'partial_update',
-                'delete': 'destroy',
-                'post': 'post',
-            }
-        ),
-        name='script-detail',
-    ),
     path('', include(router.urls)),
+    path('', include(script_router.urls)),
 ]

--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -34,6 +34,7 @@ class ExtrasRootView(APIRootView):
     """
     Extras API root view
     """
+
     def get_view_name(self):
         return 'Extras'
 
@@ -41,6 +42,7 @@ class ExtrasRootView(APIRootView):
 #
 # EventRules
 #
+
 
 class EventRuleViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
@@ -53,6 +55,7 @@ class EventRuleViewSet(NetBoxModelViewSet):
 # Webhooks
 #
 
+
 class WebhookViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
     queryset = Webhook.objects.all()
@@ -63,6 +66,7 @@ class WebhookViewSet(NetBoxModelViewSet):
 #
 # Custom fields
 #
+
 
 class CustomFieldViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
@@ -91,9 +95,7 @@ class CustomFieldChoiceSetViewSet(NetBoxModelViewSet):
 
         # Paginate data
         if page := self.paginate_queryset(choices):
-            data = [
-                {'id': c[0], 'display': c[1]} for c in page
-            ]
+            data = [{'id': c[0], 'display': c[1]} for c in page]
         else:
             data = []
 
@@ -103,6 +105,7 @@ class CustomFieldChoiceSetViewSet(NetBoxModelViewSet):
 #
 # Custom links
 #
+
 
 class CustomLinkViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
@@ -115,6 +118,7 @@ class CustomLinkViewSet(NetBoxModelViewSet):
 # Export templates
 #
 
+
 class ExportTemplateViewSet(SyncedDataMixin, NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
     queryset = ExportTemplate.objects.all()
@@ -125,6 +129,7 @@ class ExportTemplateViewSet(SyncedDataMixin, NetBoxModelViewSet):
 #
 # Saved filters
 #
+
 
 class SavedFilterViewSet(SharedObjectQuerySetMixin, NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
@@ -137,6 +142,7 @@ class SavedFilterViewSet(SharedObjectQuerySetMixin, NetBoxModelViewSet):
 # Table Configs
 #
 
+
 class TableConfigViewSet(SharedObjectQuerySetMixin, NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
     queryset = TableConfig.objects.all()
@@ -148,6 +154,7 @@ class TableConfigViewSet(SharedObjectQuerySetMixin, NetBoxModelViewSet):
 # Bookmarks
 #
 
+
 class BookmarkViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
     queryset = Bookmark.objects.all()
@@ -158,6 +165,7 @@ class BookmarkViewSet(NetBoxModelViewSet):
 #
 # Notifications & subscriptions
 #
+
 
 class NotificationViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
@@ -180,6 +188,7 @@ class SubscriptionViewSet(NetBoxModelViewSet):
 # Tags
 #
 
+
 class TagViewSet(NetBoxModelViewSet):
     queryset = Tag.objects.all()
     serializer_class = serializers.TagSerializer
@@ -187,9 +196,9 @@ class TagViewSet(NetBoxModelViewSet):
 
 
 class TaggedItemViewSet(RetrieveModelMixin, ListModelMixin, BaseViewSet):
-    queryset = TaggedItem.objects.prefetch_related(
-        'content_type', 'content_object', 'tag'
-    ).order_by('tag__weight', 'tag__name')
+    queryset = TaggedItem.objects.prefetch_related('content_type', 'content_object', 'tag').order_by(
+        'tag__weight', 'tag__name'
+    )
     serializer_class = serializers.TaggedItemSerializer
     filterset_class = filtersets.TaggedItemFilterSet
 
@@ -197,6 +206,7 @@ class TaggedItemViewSet(RetrieveModelMixin, ListModelMixin, BaseViewSet):
 #
 # Image attachments
 #
+
 
 class ImageAttachmentViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
@@ -209,6 +219,7 @@ class ImageAttachmentViewSet(NetBoxModelViewSet):
 # Journal entries
 #
 
+
 class JournalEntryViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
     queryset = JournalEntry.objects.all()
@@ -219,6 +230,7 @@ class JournalEntryViewSet(NetBoxModelViewSet):
 #
 # Config contexts
 #
+
 
 class ConfigContextProfileViewSet(SyncedDataMixin, NetBoxModelViewSet):
     queryset = ConfigContextProfile.objects.all()
@@ -235,6 +247,7 @@ class ConfigContextViewSet(SyncedDataMixin, NetBoxModelViewSet):
 #
 # Config templates
 #
+
 
 class ConfigTemplateViewSet(SyncedDataMixin, ConfigTemplateRenderMixin, NetBoxModelViewSet):
     queryset = ConfigTemplate.objects.all()
@@ -253,13 +266,13 @@ class ConfigTemplateViewSet(SyncedDataMixin, ConfigTemplateRenderMixin, NetBoxMo
             200: OpenApiResponse(
                 response=serializers.RenderedConfigSerializer,
                 description=_(
-                    "The rendered config template. When the client requests `text/plain`, the raw "
-                    "rendered content is returned in place of the JSON object."
+                    'The rendered config template. When the client requests `text/plain`, the raw '
+                    'rendered content is returned in place of the JSON object.'
                 ),
             ),
             500: OpenApiResponse(
                 response=OpenApiTypes.OBJECT,
-                description=_("An error occurred while rendering the config template."),
+                description=_('An error occurred while rendering the config template.'),
             ),
         },
     )
@@ -282,6 +295,7 @@ class ConfigTemplateViewSet(SyncedDataMixin, ConfigTemplateRenderMixin, NetBoxMo
 #
 # Scripts
 #
+
 
 class ScriptModuleViewSet(ObjectValidationMixin, CreateModelMixin, UpdateModelMixin, BaseViewSet):
     queryset = ScriptModule.objects.filter(file_root=ManagedFileRootPathChoices.SCRIPTS)
@@ -349,18 +363,16 @@ class ScriptViewSet(ModelViewSet):
 
     def post(self, request, pk):
         """
-        Run a Script identified by its numeric PK or module & name and return the pending Job as the result
+        Run a Script identified by its numeric PK or module & name and return the
+        Script object, including the resulting Job in the `result` field.
         """
 
         script = self._get_script(pk)
 
         if not request.user.has_perm('extras.run_script', obj=script):
-            raise PermissionDenied("This user does not have permission to run this script.")
+            raise PermissionDenied('This user does not have permission to run this script.')
 
-        input_serializer = serializers.ScriptInputSerializer(
-            data=request.data,
-            context={'script': script}
-        )
+        input_serializer = serializers.ScriptInputSerializer(data=request.data, context={'script': script})
 
         # Check that at least one RQ worker is running
         if not any_workers_for_queue('default'):
@@ -388,6 +400,7 @@ class ScriptViewSet(ModelViewSet):
 #
 # User dashboard
 #
+
 
 class DashboardView(RetrieveUpdateDestroyAPIView):
     queryset = Dashboard.objects.all()

--- a/netbox/extras/api/views.py
+++ b/netbox/extras/api/views.py
@@ -34,7 +34,6 @@ class ExtrasRootView(APIRootView):
     """
     Extras API root view
     """
-
     def get_view_name(self):
         return 'Extras'
 
@@ -42,7 +41,6 @@ class ExtrasRootView(APIRootView):
 #
 # EventRules
 #
-
 
 class EventRuleViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
@@ -55,7 +53,6 @@ class EventRuleViewSet(NetBoxModelViewSet):
 # Webhooks
 #
 
-
 class WebhookViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
     queryset = Webhook.objects.all()
@@ -66,7 +63,6 @@ class WebhookViewSet(NetBoxModelViewSet):
 #
 # Custom fields
 #
-
 
 class CustomFieldViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
@@ -95,7 +91,9 @@ class CustomFieldChoiceSetViewSet(NetBoxModelViewSet):
 
         # Paginate data
         if page := self.paginate_queryset(choices):
-            data = [{'id': c[0], 'display': c[1]} for c in page]
+            data = [
+                {'id': c[0], 'display': c[1]} for c in page
+            ]
         else:
             data = []
 
@@ -105,7 +103,6 @@ class CustomFieldChoiceSetViewSet(NetBoxModelViewSet):
 #
 # Custom links
 #
-
 
 class CustomLinkViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
@@ -118,7 +115,6 @@ class CustomLinkViewSet(NetBoxModelViewSet):
 # Export templates
 #
 
-
 class ExportTemplateViewSet(SyncedDataMixin, NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
     queryset = ExportTemplate.objects.all()
@@ -129,7 +125,6 @@ class ExportTemplateViewSet(SyncedDataMixin, NetBoxModelViewSet):
 #
 # Saved filters
 #
-
 
 class SavedFilterViewSet(SharedObjectQuerySetMixin, NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
@@ -142,7 +137,6 @@ class SavedFilterViewSet(SharedObjectQuerySetMixin, NetBoxModelViewSet):
 # Table Configs
 #
 
-
 class TableConfigViewSet(SharedObjectQuerySetMixin, NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
     queryset = TableConfig.objects.all()
@@ -154,7 +148,6 @@ class TableConfigViewSet(SharedObjectQuerySetMixin, NetBoxModelViewSet):
 # Bookmarks
 #
 
-
 class BookmarkViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
     queryset = Bookmark.objects.all()
@@ -165,7 +158,6 @@ class BookmarkViewSet(NetBoxModelViewSet):
 #
 # Notifications & subscriptions
 #
-
 
 class NotificationViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
@@ -188,7 +180,6 @@ class SubscriptionViewSet(NetBoxModelViewSet):
 # Tags
 #
 
-
 class TagViewSet(NetBoxModelViewSet):
     queryset = Tag.objects.all()
     serializer_class = serializers.TagSerializer
@@ -196,9 +187,9 @@ class TagViewSet(NetBoxModelViewSet):
 
 
 class TaggedItemViewSet(RetrieveModelMixin, ListModelMixin, BaseViewSet):
-    queryset = TaggedItem.objects.prefetch_related('content_type', 'content_object', 'tag').order_by(
-        'tag__weight', 'tag__name'
-    )
+    queryset = TaggedItem.objects.prefetch_related(
+        'content_type', 'content_object', 'tag'
+    ).order_by('tag__weight', 'tag__name')
     serializer_class = serializers.TaggedItemSerializer
     filterset_class = filtersets.TaggedItemFilterSet
 
@@ -206,7 +197,6 @@ class TaggedItemViewSet(RetrieveModelMixin, ListModelMixin, BaseViewSet):
 #
 # Image attachments
 #
-
 
 class ImageAttachmentViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
@@ -219,7 +209,6 @@ class ImageAttachmentViewSet(NetBoxModelViewSet):
 # Journal entries
 #
 
-
 class JournalEntryViewSet(NetBoxModelViewSet):
     metadata_class = ContentTypeMetadata
     queryset = JournalEntry.objects.all()
@@ -230,7 +219,6 @@ class JournalEntryViewSet(NetBoxModelViewSet):
 #
 # Config contexts
 #
-
 
 class ConfigContextProfileViewSet(SyncedDataMixin, NetBoxModelViewSet):
     queryset = ConfigContextProfile.objects.all()
@@ -247,7 +235,6 @@ class ConfigContextViewSet(SyncedDataMixin, NetBoxModelViewSet):
 #
 # Config templates
 #
-
 
 class ConfigTemplateViewSet(SyncedDataMixin, ConfigTemplateRenderMixin, NetBoxModelViewSet):
     queryset = ConfigTemplate.objects.all()
@@ -266,13 +253,13 @@ class ConfigTemplateViewSet(SyncedDataMixin, ConfigTemplateRenderMixin, NetBoxMo
             200: OpenApiResponse(
                 response=serializers.RenderedConfigSerializer,
                 description=_(
-                    'The rendered config template. When the client requests `text/plain`, the raw '
-                    'rendered content is returned in place of the JSON object.'
+                    "The rendered config template. When the client requests `text/plain`, the raw "
+                    "rendered content is returned in place of the JSON object."
                 ),
             ),
             500: OpenApiResponse(
                 response=OpenApiTypes.OBJECT,
-                description=_('An error occurred while rendering the config template.'),
+                description=_("An error occurred while rendering the config template."),
             ),
         },
     )
@@ -295,7 +282,6 @@ class ConfigTemplateViewSet(SyncedDataMixin, ConfigTemplateRenderMixin, NetBoxMo
 #
 # Scripts
 #
-
 
 class ScriptModuleViewSet(ObjectValidationMixin, CreateModelMixin, UpdateModelMixin, BaseViewSet):
     queryset = ScriptModule.objects.filter(file_root=ManagedFileRootPathChoices.SCRIPTS)
@@ -361,6 +347,11 @@ class ScriptViewSet(ModelViewSet):
 
         return Response(serializer.data)
 
+    @extend_schema(
+        operation_id='extras_scripts_run',
+        request=serializers.ScriptInputSerializer,
+        responses={200: serializers.ScriptDetailSerializer},
+    )
     def post(self, request, pk):
         """
         Run a Script identified by its numeric PK or module & name and return the
@@ -370,9 +361,12 @@ class ScriptViewSet(ModelViewSet):
         script = self._get_script(pk)
 
         if not request.user.has_perm('extras.run_script', obj=script):
-            raise PermissionDenied('This user does not have permission to run this script.')
+            raise PermissionDenied("This user does not have permission to run this script.")
 
-        input_serializer = serializers.ScriptInputSerializer(data=request.data, context={'script': script})
+        input_serializer = serializers.ScriptInputSerializer(
+            data=request.data,
+            context={'script': script}
+        )
 
         # Check that at least one RQ worker is running
         if not any_workers_for_queue('default'):
@@ -400,7 +394,6 @@ class ScriptViewSet(ModelViewSet):
 #
 # User dashboard
 #
-
 
 class DashboardView(RetrieveUpdateDestroyAPIView):
     queryset = Dashboard.objects.all()

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -1,3 +1,4 @@
+
 import datetime
 import hashlib
 import io

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -2236,3 +2236,21 @@ class ScriptModuleTestCase(APITestCase):
 
         self.assertHttpStatus(response, status.HTTP_200_OK)
         self.assertEqual(fake_storage.files['zz_lost_file.py'], updated_content)
+
+    def test_scripts_upload_route_not_shadowed(self):
+        """
+        POST /api/extras/scripts/upload/ and its format-suffixed variant must
+        still dispatch to ScriptModuleViewSet, not be captured by the Script
+        detail route's broader URL pattern.
+
+        Refs: #22569
+        """
+        for url in ('/api/extras/scripts/upload/', '/api/extras/scripts/upload.json/'):
+            with self.subTest(url=url):
+                response = self.client.post(url, {}, format='multipart')
+                # A 400/403 (missing file / permission) proves ScriptModuleViewSet
+                # handled the request; a 404 would mean it was misrouted to
+                # ScriptViewSet instead.
+                self.assertNotEqual(
+                    response.status_code, 404, f'{url} was misrouted — expected ScriptModuleViewSet, got 404'
+                )


### PR DESCRIPTION
Closes: netbox-community/netbox#22569

## Fix

DRF's router never maps `post` into a detail route's `actions` dict by<br>default, so `ScriptViewSet.post()` — reachable at runtime via Django's<br>generic method dispatch, not via the router — was invisible to<br>drf-spectacular's schema generation. Added an explicit `path()` in<br>`extras/api/urls.py` declaring all five methods for this route, including<br>`post`, placed before the router's `include()` so it takes precedence.

## Also fixed

`ScriptViewSet.post()`'s docstring claimed it returns "the pending Job,"<br>but it returns a Script object with the Job nested under `result` (per<br>`ScriptDetailSerializer`). Corrected to match.

## Testing

* Added `test_script_post_operation_present`, confirming POST appears in<br>the schema for this path.
* `extras.tests.test_api.ScriptTestCase` and<br>`core.tests.test_openapi_schema.OpenAPISchemaTestCase` both pass.