### PR TITLE
Add optional Front Image, Rear Image, and Image Count columns to Device Type and Module Type tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ yarn-error.log*
 /dist/
 /build/
 *.egg-info/
+
+# Ruff's locally generated cache
+.ruff_cache

--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -722,6 +722,10 @@ class DeviceTypeFilterSet(PrimaryModelFilterSet):
         method='_inventory_items',
         label=_('Has inventory items'),
     )
+    has_images = django_filters.BooleanFilter(
+        method='_has_images',
+        label=('Has images'),
+    )
 
     class Meta:
         model = DeviceType
@@ -793,6 +797,9 @@ class DeviceTypeFilterSet(PrimaryModelFilterSet):
 
     def _inventory_items(self, queryset, name, value):
         return queryset.exclude(inventoryitemtemplates__isnull=value)
+
+    def _has_images(self, queryset, name, value):
+        return queryset.exclude(images__isnull=value)
 
 
 @register_filterset
@@ -866,6 +873,10 @@ class ModuleTypeFilterSet(AttributeFiltersMixin, PrimaryModelFilterSet):
         method='_module_bays',
         label=_('Has module bays'),
     )
+    has_images = django_filters.BooleanFilter(
+        method='_has_images',
+        label=_('Has images'),
+    )
 
     class Meta:
         model = ModuleType
@@ -918,6 +929,9 @@ class ModuleTypeFilterSet(AttributeFiltersMixin, PrimaryModelFilterSet):
 
     def _module_bays(self, queryset, name, value):
         return queryset.exclude(modulebaytemplates__isnull=value)
+
+    def _has_images(self, queryset, name, value):
+        return queryset.exclude(images__isnull=value)
 
 
 class DeviceTypeComponentFilterSet(django_filters.FilterSet):

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -563,7 +563,7 @@ class DeviceTypeFilterForm(PrimaryModelFilterSetForm):
             'manufacturer_id', 'default_platform_id', 'part_number', 'device_count',
             'subdevice_role', 'airflow', name=_('Hardware')
         ),
-        FieldSet('has_front_image', 'has_rear_image', name=_('Images')),
+        FieldSet('has_front_image', 'has_rear_image', 'has_images', name=_('Images')),
         FieldSet(
             'console_ports', 'console_server_ports', 'power_ports', 'power_outlets', 'interfaces',
             'pass_through_ports', 'device_bays', 'module_bays', 'inventory_items', name=_('Components')
@@ -615,6 +615,13 @@ class DeviceTypeFilterForm(PrimaryModelFilterSetForm):
             choices=BOOLEAN_WITH_BLANK_CHOICES
         )
     )
+    has_images = forms.NullBooleanField(
+        required=False,
+        label=_('Has images'),
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        )
+    ) 
     console_ports = forms.NullBooleanField(
         required=False,
         label=_('Has console ports'),
@@ -712,6 +719,7 @@ class ModuleTypeFilterForm(PrimaryModelFilterSetForm):
             'console_ports', 'console_server_ports', 'power_ports', 'power_outlets', 'interfaces',
             'pass_through_ports', 'module_bays', name=_('Components')
         ),
+        FieldSet('has_images', name=_('Images')),
         FieldSet('weight', 'weight_unit', name=_('Weight')),
         FieldSet('owner_group_id', 'owner_id', name=_('Ownership')),
     )
@@ -799,6 +807,13 @@ class ModuleTypeFilterForm(PrimaryModelFilterSetForm):
         label=_('Weight unit'),
         choices=add_blank_choice(WeightUnitChoices),
         required=False
+    )
+    has_images = forms.NullBooleanField(
+        required=False,
+        label=_('Has images'),
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        )
     )
 
 

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -621,7 +621,7 @@ class DeviceTypeFilterForm(PrimaryModelFilterSetForm):
         widget=forms.Select(
             choices=BOOLEAN_WITH_BLANK_CHOICES
         )
-    ) 
+    )
     console_ports = forms.NullBooleanField(
         required=False,
         label=_('Has console ports'),

--- a/netbox/dcim/tables/devicetypes.py
+++ b/netbox/dcim/tables/devicetypes.py
@@ -155,7 +155,8 @@ class DeviceTypeTable(PrimaryModelTable):
         false_mark=None
     )
     image_count = tables.Column(
-        verbose_name=_('Images')
+        verbose_name=_('Images'),
+        orderable=False,
     )
 
     class Meta(PrimaryModelTable.Meta):
@@ -163,7 +164,7 @@ class DeviceTypeTable(PrimaryModelTable):
         fields = (
             'pk', 'id', 'model', 'manufacturer', 'default_platform', 'slug', 'part_number', 'u_height',
             'exclude_from_utilization', 'is_full_depth', 'subdevice_role', 'airflow', 'weight',
-            'description', 'comments', 'device_count', 'tags', 'created', 'last_updated', 
+            'description', 'comments', 'device_count', 'tags', 'created', 'last_updated',
             'front_image', 'rear_image', 'image_count',
         )
         default_columns = (

--- a/netbox/dcim/tables/devicetypes.py
+++ b/netbox/dcim/tables/devicetypes.py
@@ -146,13 +146,25 @@ class DeviceTypeTable(PrimaryModelTable):
     inventory_item_template_count = tables.Column(
         verbose_name=_('Inventory Items')
     )
+    front_image = columns.BooleanColumn(
+        verbose_name=_('Front Image'),
+        false_mark=None
+    )
+    rear_image = columns.BooleanColumn(
+        verbose_name=_('Rear Image'),
+        false_mark=None
+    )
+    image_count = tables.Column(
+        verbose_name=_('Images')
+    )
 
     class Meta(PrimaryModelTable.Meta):
         model = models.DeviceType
         fields = (
             'pk', 'id', 'model', 'manufacturer', 'default_platform', 'slug', 'part_number', 'u_height',
             'exclude_from_utilization', 'is_full_depth', 'subdevice_role', 'airflow', 'weight',
-            'description', 'comments', 'device_count', 'tags', 'created', 'last_updated',
+            'description', 'comments', 'device_count', 'tags', 'created', 'last_updated', 
+            'front_image', 'rear_image', 'image_count',
         )
         default_columns = (
             'pk', 'model', 'manufacturer', 'part_number', 'u_height', 'is_full_depth', 'device_count',

--- a/netbox/dcim/tables/modules.py
+++ b/netbox/dcim/tables/modules.py
@@ -68,7 +68,8 @@ class ModuleTypeTable(PrimaryModelTable):
         url_name='dcim:moduletype_list'
     )
     image_count = tables.Column(
-        verbose_name=_('Images')
+        verbose_name=_('Images'),
+        orderable=False,
     )
 
     class Meta(PrimaryModelTable.Meta):

--- a/netbox/dcim/tables/modules.py
+++ b/netbox/dcim/tables/modules.py
@@ -67,12 +67,15 @@ class ModuleTypeTable(PrimaryModelTable):
     tags = columns.TagColumn(
         url_name='dcim:moduletype_list'
     )
+    image_count = tables.Column(
+        verbose_name=_('Images')
+    )
 
     class Meta(PrimaryModelTable.Meta):
         model = ModuleType
         fields = (
             'pk', 'id', 'model', 'profile', 'manufacturer', 'part_number', 'airflow', 'weight', 'description',
-            'attributes', 'module_count', 'comments', 'tags', 'created', 'last_updated',
+            'attributes', 'module_count', 'comments', 'tags', 'created', 'last_updated', 'image_count',
         )
         default_columns = (
             'pk', 'model', 'profile', 'manufacturer', 'part_number', 'module_count',

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -1408,11 +1408,11 @@ class DeviceTypeListView(generic.ObjectListView):
     filterset = filtersets.DeviceTypeFilterSet
     filterset_form = forms.DeviceTypeFilterForm
     table = tables.DeviceTypeTable
-    
+
     def get_table(self, data, request, bulk_actions=True):
-    #Figures out which columns the user has picked before building the tables,
-    #because configure() tries to apply an existing sort, that may include image_count
-    #and it needs the existing annotation from the queryset.
+        # Figures out which columns the user has picked before building the tables,
+        # because configure() tries to apply an existing sort, that may include image_count
+        # and it needs the existing annotation from the queryset.
         if request.user.is_authenticated:
             selected_columns = request.user.config.get(f'tables.{self.table.__name__}.columns')
         else:
@@ -1424,7 +1424,7 @@ class DeviceTypeListView(generic.ObjectListView):
             data = data.annotate(image_count=Count('images'))
 
         return super().get_table(data, request, bulk_actions)
-    
+
 
 @register_model_view(DeviceType)
 class DeviceTypeView(GetRelatedModelsMixin, generic.ObjectView):
@@ -1774,11 +1774,11 @@ class ModuleTypeListView(generic.ObjectListView):
     filterset = filtersets.ModuleTypeFilterSet
     filterset_form = forms.ModuleTypeFilterForm
     table = tables.ModuleTypeTable
-    
+
     def get_table(self, data, request, bulk_actions=True):
-    #Figures out which columns the user has picked before building the tables,
-    #because configure() tries to apply an existing sort, that may include image_count
-    #and it needs the existing annotation from the queryset.
+        # Figures out which columns the user has picked before building the tables,
+        # because configure() tries to apply an existing sort, that may include image_count
+        # and it needs the existing annotation from the queryset.
         if request.user.is_authenticated:
             selected_columns = request.user.config.get(f'tables.{self.table.__name__}.columns')
         else:

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -3,7 +3,7 @@ from django.contrib import messages
 from django.contrib.contenttypes.models import ContentType
 from django.core.paginator import EmptyPage, PageNotAnInteger
 from django.db import router, transaction
-from django.db.models import Func, IntegerField, Prefetch
+from django.db.models import Count, Func, IntegerField, Prefetch
 from django.forms import ModelMultipleChoiceField, MultipleHiddenInput, modelformset_factory
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -1408,7 +1408,23 @@ class DeviceTypeListView(generic.ObjectListView):
     filterset = filtersets.DeviceTypeFilterSet
     filterset_form = forms.DeviceTypeFilterForm
     table = tables.DeviceTypeTable
+    
+    def get_table(self, data, request, bulk_actions=True):
+    #Figures out which columns the user has picked before building the tables,
+    #because configure() tries to apply an existing sort, that may include image_count
+    #and it needs the existing annotation from the queryset.
+        if request.user.is_authenticated:
+            selected_columns = request.user.config.get(f'tables.{self.table.__name__}.columns')
+        else:
+            selected_columns = None
+        if selected_columns is None:
+            selected_columns = self.table.Meta.default_columns
 
+        if 'image_count' in selected_columns:
+            data = data.annotate(image_count=Count('images'))
+
+        return super().get_table(data, request, bulk_actions)
+    
 
 @register_model_view(DeviceType)
 class DeviceTypeView(GetRelatedModelsMixin, generic.ObjectView):
@@ -1758,6 +1774,22 @@ class ModuleTypeListView(generic.ObjectListView):
     filterset = filtersets.ModuleTypeFilterSet
     filterset_form = forms.ModuleTypeFilterForm
     table = tables.ModuleTypeTable
+    
+    def get_table(self, data, request, bulk_actions=True):
+    #Figures out which columns the user has picked before building the tables,
+    #because configure() tries to apply an existing sort, that may include image_count
+    #and it needs the existing annotation from the queryset.
+        if request.user.is_authenticated:
+            selected_columns = request.user.config.get(f'tables.{self.table.__name__}.columns')
+        else:
+            selected_columns = None
+        if selected_columns is None:
+            selected_columns = self.table.Meta.default_columns
+
+        if 'image_count' in selected_columns:
+            data = data.annotate(image_count=Count('images'))
+
+        return super().get_table(data, request, bulk_actions)
 
 
 @register_model_view(ModuleType)


### PR DESCRIPTION
### Closes: #22030

## What this PR does

Adds three optional columns to the Device Type list view (Front Image, Rear Image and Images as the attached images counter) and one optional column to the Module Type list view (Images column, as the attached images counter)

## Changes
- Added `front_image`, `rear_image` and `image_count` columns to the Device Type table and `image_count` for Module Type table
- Updated the corresponding filterset and view logic to support these columns
- Columns are opt-in via the existing "Configure table" UI, consistent with other optional columns in Netbox

## Testing 
Verified manually and via local Cypress tests that:
- The three columns appear as available options in "Configure Table"
- Selecting and applying them renders the correct data in the table
- Existing table behavior is unaffected

## Screenshots
- Device Type with changes
<img width="924" height="391" alt="WhatsApp Image 2026-07-17 at 11 46 44" src="https://github.com/user-attachments/assets/948414cf-0fd2-47a4-a27a-cfcd9fed38a7" />
<img width="926" height="676" alt="WhatsApp Image 2026-07-17 at 11 45 59" src="https://github.com/user-attachments/assets/b5ea15ce-472b-4c30-854c-950bd12951ed" />

- Module Type with changes
<img width="936" height="371" alt="WhatsApp Image 2026-07-17 at 11 47 08" src="https://github.com/user-attachments/assets/e6d8c9d1-0d85-43c5-993c-84c8973b7e58" />
<img width="938" height="845" alt="WhatsApp Image 2026-07-17 at 11 43 48" src="https://github.com/user-attachments/assets/60bbd546-ec7f-4844-a8a9-6232f6878594" />

---

Co-authored by: Christiane Giestas <christianegiestas@gmail.com>