### PR TITLE
Fix #22671 : Enable multi-selection for Site Groups and other scopes in VLAN Groups filter

### DIFF
--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -1227,7 +1227,6 @@ class ServiceTemplateFilterSet(PrimaryModelFilterSet):
         )
         return queryset.filter(qs_filter)
 
-
 @register_filterset
 class ServiceFilterSet(ContactModelFilterSet, PrimaryModelFilterSet):
     parent_object_type = MultiValueContentTypeFilter()

--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -946,7 +946,6 @@ class FHRPGroupAssignmentFilterSet(ChangeLoggedModelFilterSet):
 @register_filterset
 class VLANGroupFilterSet(OrganizationalModelFilterSet, TenancyFilterSet):
     scope_type = MultiValueContentTypeFilter()
-
     region = MultiValueNumberFilter(
         method='filter_scope'
     )
@@ -991,6 +990,8 @@ class VLANGroupFilterSet(OrganizationalModelFilterSet, TenancyFilterSet):
 
     def filter_scope(self, queryset, name, value):
         model_name = name.replace('_', '')
+        if not isinstance(value, (list, tuple, set)):
+            value = [value]
         return queryset.filter(
             scope_type=ContentType.objects.get(model=model_name),
             scope_id__in=value
@@ -1226,6 +1227,7 @@ class ServiceTemplateFilterSet(PrimaryModelFilterSet):
             Q(description__icontains=value)
         )
         return queryset.filter(qs_filter)
+
 
 @register_filterset
 class ServiceFilterSet(ContactModelFilterSet, PrimaryModelFilterSet):

--- a/netbox/ipam/filtersets.py
+++ b/netbox/ipam/filtersets.py
@@ -946,28 +946,29 @@ class FHRPGroupAssignmentFilterSet(ChangeLoggedModelFilterSet):
 @register_filterset
 class VLANGroupFilterSet(OrganizationalModelFilterSet, TenancyFilterSet):
     scope_type = MultiValueContentTypeFilter()
-    region = django_filters.NumberFilter(
+
+    region = MultiValueNumberFilter(
         method='filter_scope'
     )
-    site_group = django_filters.NumberFilter(
+    site_group = MultiValueNumberFilter(
         method='filter_scope'
     )
-    site = django_filters.NumberFilter(
+    site = MultiValueNumberFilter(
         method='filter_scope'
     )
-    location = django_filters.NumberFilter(
+    location = MultiValueNumberFilter(
         method='filter_scope'
     )
-    rack_group = django_filters.NumberFilter(
+    rack_group = MultiValueNumberFilter(
         method='filter_scope'
     )
-    rack = django_filters.NumberFilter(
+    rack = MultiValueNumberFilter(
         method='filter_scope'
     )
-    cluster_group = django_filters.NumberFilter(
+    cluster_group = MultiValueNumberFilter(
         method='filter_scope'
     )
-    cluster = django_filters.NumberFilter(
+    cluster = MultiValueNumberFilter(
         method='filter_scope'
     )
     contains_vid = django_filters.NumberFilter(
@@ -992,7 +993,7 @@ class VLANGroupFilterSet(OrganizationalModelFilterSet, TenancyFilterSet):
         model_name = name.replace('_', '')
         return queryset.filter(
             scope_type=ContentType.objects.get(model=model_name),
-            scope_id=value
+            scope_id__in=value
         )
 
 


### PR DESCRIPTION
### Closes: netbox-community/netbox#22671

### Description

The filter form for VLAN Groups sends arrays of IDs for site groups and other scopes, but `VLANGroupFilterSet` was implementing them using `NumberFilter`. This caused the backend to drop multiple selections or fail to process them properly.

I replaced `NumberFilter` with `MultiValueNumberFilter` across all scope fields in `VLANGroupFilterSet` (including `site_group`, `region`, `site`, `location`, `rack_group`, `rack`, `cluster_group`, and `cluster`). I also refactored the `filter_scope` method to use `scope_id__in=value` so it can cleanly evaluate multiple lookups at once.

### Checklist

- [X] My code follows the code style of this project (self-documenting, no unnecessary comments).
- [X] Syntax checking passed successfully.