### PR TITLE
Fixes #22719: Correct malformed IP value validation

### DIFF
--- a/netbox/ipam/api/field_serializers.py
+++ b/netbox/ipam/api/field_serializers.py
@@ -20,7 +20,7 @@ class IPAddressField(serializers.CharField):
         try:
             return IPNetwork(data)
         except AddrFormatError:
-            raise serializers.ValidationError(_("Invalid IP address format: {data}").format(data))
+            raise serializers.ValidationError(_("Invalid IP address format: {data}").format(data=data))
         except (TypeError, ValueError) as e:
             raise serializers.ValidationError(e)
 
@@ -40,7 +40,7 @@ class IPNetworkField(serializers.CharField):
         try:
             return IPNetwork(data)
         except AddrFormatError:
-            raise serializers.ValidationError(_("Invalid IP prefix format: {data}").format(data))
+            raise serializers.ValidationError(_("Invalid IP prefix format: {data}").format(data=data))
         except (TypeError, ValueError) as e:
             raise serializers.ValidationError(e)
 

--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -453,6 +453,19 @@ class PrefixTestCase(APIViewTestCases.APIViewTestCase):
         Prefix.objects.bulk_create(prefixes)
 
     @tag('regression')
+    def test_create_with_invalid_prefix(self):
+        """
+        POST of a malformed prefix value returns a 400 validation error.
+        """
+        self.add_permissions('ipam.add_prefix')
+        url = reverse('ipam-api:prefix-list')
+
+        response = self.client.post(url, {'prefix': 'invalid'}, format='json', **self.header)
+
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['prefix'][0], 'Invalid IP prefix format: invalid')
+
+    @tag('regression')
     def test_clean_validates_scope(self):
         prefix = Prefix.objects.first()
         site = Site.objects.create(name='Test Site', slug='test-site')
@@ -857,6 +870,19 @@ class IPAddressTestCase(APIViewTestCases.APIViewTestCase):
             IPAddress(address=IPNetwork('192.168.0.3/24')),
         )
         IPAddress.objects.bulk_create(ip_addresses)
+
+    @tag('regression')
+    def test_create_with_invalid_address(self):
+        """
+        POST of a malformed address value returns a 400 validation error.
+        """
+        self.add_permissions('ipam.add_ipaddress')
+        url = reverse('ipam-api:ipaddress-list')
+
+        response = self.client.post(url, {'address': 'invalid'}, format='json', **self.header)
+
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['address'][0], 'Invalid IP address format: invalid')
 
     def test_assign_object(self):
         """


### PR DESCRIPTION
### Closes: netbox-community/netbox#22719

Corrects REST API validation for malformed IP address and prefix values.

The validation messages use a named `{data}` placeholder but supplied the value as a positional argument. This raised `KeyError` before DRF could return the intended validation error, resulting in an HTTP 500 response.

#### Changes

* Pass `data` as a named formatting argument in `IPAddressField`.
* Pass `data` as a named formatting argument in `IPNetworkField`.
* Add regression tests confirming malformed values return HTTP 400 with the<br>expected validation messages.