### PR TITLE
Closes #22623: Change DHCP IP address status color to purple

### DIFF
--- a/netbox/ipam/choices.py
+++ b/netbox/ipam/choices.py
@@ -69,7 +69,7 @@ class IPAddressStatusChoices(ChoiceSet):
         (STATUS_ACTIVE, _('Active'), 'blue'),
         (STATUS_RESERVED, _('Reserved'), 'cyan'),
         (STATUS_DEPRECATED, _('Deprecated'), 'red'),
-        (STATUS_DHCP, _('DHCP'), 'green'),
+        (STATUS_DHCP, _('DHCP'), 'purple'),
         (STATUS_SLAAC, _('SLAAC'), 'purple'),
     ]
 


### PR DESCRIPTION
### Closes: netbox-community/netbox#22623

This changes the DHCP IP address status color from green to purple.

Purple groups DHCP with SLAAC as automatic address configuration methods, while their labels continue to distinguish the specific mechanism. It also keeps DHCP visually distinct from blue Active and green Available entries without introducing a warning-oriented color.