### PR TITLE
#22640 - Enforce ALLOWED_URL_SCHEMES for URLs in custom fields

### DIFF
--- a/docs/configuration/security.md
+++ b/docs/configuration/security.md
@@ -6,7 +6,7 @@
 
 Default: `('file', 'ftp', 'ftps', 'http', 'https', 'irc', 'mailto', 'sftp', 'ssh', 'tel', 'telnet', 'tftp', 'vnc', 'xmpp')`
 
-A list of permitted URL schemes referenced when rendering links within NetBox. Note that only the schemes specified in this list will be accepted: If adding your own, be sure to replicate all the default values as well (excluding those schemes which are not desirable).
+A list of permitted URL schemes referenced when rendering links within NetBox. This list is also enforced when validating the value of URL custom fields. Note that only the schemes specified in this list will be accepted: If adding your own, be sure to replicate all the default values as well (excluding those schemes which are not desirable).
 
 ---
 

--- a/docs/customization/custom-fields.md
+++ b/docs/customization/custom-fields.md
@@ -17,7 +17,7 @@ Custom fields may be created by navigating to Customization > Custom Fields. Net
 * Boolean: True or false
 * Date: A date in ISO 8601 format (YYYY-MM-DD)
 * Date & time: A date and time in ISO 8601 format (YYYY-MM-DD HH:MM:SS)
-* URL: This will be presented as a link in the web UI. Values are restricted to the schemes permitted by [`ALLOWED_URL_SCHEMES`](../configuration/security.md#allowed_url_schemes).
+* URL: This will be presented as a link in the web UI. Values are restricted to the schemes permitted by [`ALLOWED_URL_SCHEMES`](../configuration/security.md#allowed_url_schemes). A value entered without a scheme (e.g. `example.com`) is assumed to use `https` and stored as an absolute URL (e.g. `https://example.com`), whether set via the web UI or the REST API.
 * JSON: Arbitrary data stored in JSON format
 * Selection: A selection of one of several pre-defined custom choices
 * Multiple selection: A selection field which supports the assignment of multiple values

--- a/docs/customization/custom-fields.md
+++ b/docs/customization/custom-fields.md
@@ -17,7 +17,7 @@ Custom fields may be created by navigating to Customization > Custom Fields. Net
 * Boolean: True or false
 * Date: A date in ISO 8601 format (YYYY-MM-DD)
 * Date & time: A date and time in ISO 8601 format (YYYY-MM-DD HH:MM:SS)
-* URL: This will be presented as a link in the web UI. Values are restricted to the schemes permitted by [`ALLOWED_URL_SCHEMES`](../configuration/security.md#allowed_url_schemes). A value entered without a scheme (e.g. `example.com`) is assumed to use `https` and stored as an absolute URL (e.g. `https://example.com`), whether set via the web UI or the REST API.
+* URL: This will be presented as a link in the web UI. Values are restricted to the schemes permitted by [`ALLOWED_URL_SCHEMES`](../configuration/security.md#allowed_url_schemes). A value entered without a scheme (e.g. `example.com`) is assumed to use `https` and stored as an absolute URL (e.g. `https://example.com`).
 * JSON: Arbitrary data stored in JSON format
 * Selection: A selection of one of several pre-defined custom choices
 * Multiple selection: A selection field which supports the assignment of multiple values

--- a/docs/customization/custom-fields.md
+++ b/docs/customization/custom-fields.md
@@ -17,7 +17,7 @@ Custom fields may be created by navigating to Customization > Custom Fields. Net
 * Boolean: True or false
 * Date: A date in ISO 8601 format (YYYY-MM-DD)
 * Date & time: A date and time in ISO 8601 format (YYYY-MM-DD HH:MM:SS)
-* URL: This will be presented as a link in the web UI
+* URL: This will be presented as a link in the web UI. Values are restricted to the schemes permitted by [`ALLOWED_URL_SCHEMES`](../configuration/security.md#allowed_url_schemes).
 * JSON: Arbitrary data stored in JSON format
 * Selection: A selection of one of several pre-defined custom choices
 * Multiple selection: A selection field which supports the assignment of multiple values

--- a/netbox/extras/api/customfields.py
+++ b/netbox/extras/api/customfields.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils.translation import gettext as _
 from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
@@ -8,6 +9,7 @@ from extras.choices import CustomFieldTypeChoices
 from extras.constants import CUSTOMFIELD_EMPTY_VALUES
 from extras.models import CustomField
 from utilities.api import get_serializer_for_model
+from utilities.forms.fields import LaxURLField
 
 #
 # Custom fields
@@ -119,6 +121,15 @@ class CustomFieldsDataField(Field):
                     data[cf.name] = [obj['id'] for obj in serializer.data] if many else serializer.data['id']
                 else:
                     raise ValidationError(_("Unknown related object(s): {name}").format(name=data[cf.name]))
+
+            # Normalize URL values the same way the UI does (LaxURLField with assume_scheme='https'), so a
+            # schemeless value (e.g. "example.com") is stored as an absolute URL ("https://example.com").
+            # Malformed values are left untouched for CustomField.validate() to report.
+            elif cf.type == CustomFieldTypeChoices.TYPE_URL and isinstance(data.get(cf.name), str) and data[cf.name]:
+                try:
+                    data[cf.name] = LaxURLField(assume_scheme='https').to_python(data[cf.name])
+                except DjangoValidationError:
+                    pass
 
         # If updating an existing instance, start with existing custom_field_data
         if self.parent.instance:

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -46,7 +46,7 @@ from utilities.forms.widgets import APISelect, APISelectMultiple, DatePicker, Da
 from utilities.jsonschema import validate_schema
 from utilities.querysets import RestrictedQuerySet
 from utilities.templatetags.builtins.filters import render_markdown
-from utilities.validators import EnhancedURLValidator, validate_regex
+from utilities.validators import url_scheme_is_allowed, validate_regex
 
 __all__ = (
     'CustomField',
@@ -796,9 +796,14 @@ class CustomField(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMo
             elif self.type == CustomFieldTypeChoices.TYPE_URL:
                 if type(value) is not str:
                     raise ValidationError(_("Value must be a string."))
-                # Validate the URL and its scheme against ALLOWED_URL_SCHEMES, as the UI does (LaxURLField).
-                # Instantiated per call so a runtime change to the (dynamic) setting is honored.
-                EnhancedURLValidator()(value)
+                # Enforce ALLOWED_URL_SCHEMES to guard against dangerous schemes (e.g. javascript:), using
+                # the same check applied when rendering the value. The UI and REST API both normalize a
+                # schemeless value to an absolute URL (LaxURLField with assume_scheme='https'); a schemeless
+                # value reaching this point directly (e.g. via a script) is permitted and treated as relative.
+                if not url_scheme_is_allowed(value):
+                    raise ValidationError(
+                        _("URLs must use a scheme permitted by ALLOWED_URL_SCHEMES.")
+                    )
                 if self.validation_regex and not re.match(self.validation_regex, value):
                     raise ValidationError(_("Value must match regex '{regex}'").format(regex=self.validation_regex))
 

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -22,6 +22,7 @@ from extras.choices import *
 from extras.constants import CUSTOMFIELD_DATA_BATCH_SIZE
 from extras.data import CHOICE_SETS
 from extras.fields import ChoiceSetField
+from netbox.config import get_config
 from netbox.context import query_cache
 from netbox.models import ChangeLoggedModel
 from netbox.models.features import CloningMixin, ExportTemplatesMixin
@@ -46,7 +47,7 @@ from utilities.forms.widgets import APISelect, APISelectMultiple, DatePicker, Da
 from utilities.jsonschema import validate_schema
 from utilities.querysets import RestrictedQuerySet
 from utilities.templatetags.builtins.filters import render_markdown
-from utilities.validators import EnhancedURLValidator, validate_regex
+from utilities.validators import get_url_scheme, is_url_scheme_allowed, validate_regex
 
 __all__ = (
     'CustomField',
@@ -797,7 +798,13 @@ class CustomField(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMo
                 if type(value) is not str:
                     raise ValidationError(_("Value must be a string."))
                 # Enforce the schemes permitted by ALLOWED_URL_SCHEMES
-                EnhancedURLValidator()(value)
+                if not is_url_scheme_allowed(value):
+                    raise ValidationError(
+                        _("URL scheme '{scheme}' is not permitted. Allowed schemes: {schemes}").format(
+                            scheme=get_url_scheme(value),
+                            schemes=', '.join(get_config().ALLOWED_URL_SCHEMES)
+                        )
+                    )
                 if self.validation_regex and not re.match(self.validation_regex, value):
                     raise ValidationError(_("Value must match regex '{regex}'").format(regex=self.validation_regex))
 

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -796,10 +796,8 @@ class CustomField(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMo
             elif self.type == CustomFieldTypeChoices.TYPE_URL:
                 if type(value) is not str:
                     raise ValidationError(_("Value must be a string."))
-                # Enforce ALLOWED_URL_SCHEMES to guard against dangerous schemes (e.g. javascript:), using
-                # the same check applied when rendering the value. The UI and REST API both normalize a
-                # schemeless value to an absolute URL (LaxURLField with assume_scheme='https'); a schemeless
-                # value reaching this point directly (e.g. via a script) is permitted and treated as relative.
+                # Enforce ALLOWED_URL_SCHEMES to guard against dangerous schemes (e.g. javascript:). A
+                # schemeless value is permitted and treated as relative.
                 if not url_scheme_is_allowed(value):
                     raise ValidationError(
                         _("URLs must use a scheme permitted by ALLOWED_URL_SCHEMES.")

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -46,7 +46,7 @@ from utilities.forms.widgets import APISelect, APISelectMultiple, DatePicker, Da
 from utilities.jsonschema import validate_schema
 from utilities.querysets import RestrictedQuerySet
 from utilities.templatetags.builtins.filters import render_markdown
-from utilities.validators import validate_regex
+from utilities.validators import EnhancedURLValidator, validate_regex
 
 __all__ = (
     'CustomField',
@@ -796,6 +796,8 @@ class CustomField(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMo
             elif self.type == CustomFieldTypeChoices.TYPE_URL:
                 if type(value) is not str:
                     raise ValidationError(_("Value must be a string."))
+                # Enforce the schemes permitted by ALLOWED_URL_SCHEMES
+                EnhancedURLValidator()(value)
                 if self.validation_regex and not re.match(self.validation_regex, value):
                     raise ValidationError(_("Value must match regex '{regex}'").format(regex=self.validation_regex))
 

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -22,7 +22,6 @@ from extras.choices import *
 from extras.constants import CUSTOMFIELD_DATA_BATCH_SIZE
 from extras.data import CHOICE_SETS
 from extras.fields import ChoiceSetField
-from netbox.config import get_config
 from netbox.context import query_cache
 from netbox.models import ChangeLoggedModel
 from netbox.models.features import CloningMixin, ExportTemplatesMixin
@@ -47,7 +46,7 @@ from utilities.forms.widgets import APISelect, APISelectMultiple, DatePicker, Da
 from utilities.jsonschema import validate_schema
 from utilities.querysets import RestrictedQuerySet
 from utilities.templatetags.builtins.filters import render_markdown
-from utilities.validators import get_url_scheme, is_url_scheme_allowed, validate_regex
+from utilities.validators import EnhancedURLValidator, validate_regex
 
 __all__ = (
     'CustomField',
@@ -797,14 +796,10 @@ class CustomField(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMo
             elif self.type == CustomFieldTypeChoices.TYPE_URL:
                 if type(value) is not str:
                     raise ValidationError(_("Value must be a string."))
-                # Enforce the schemes permitted by ALLOWED_URL_SCHEMES
-                if not is_url_scheme_allowed(value):
-                    raise ValidationError(
-                        _("URL scheme '{scheme}' is not permitted. Allowed schemes: {schemes}").format(
-                            scheme=get_url_scheme(value),
-                            schemes=', '.join(get_config().ALLOWED_URL_SCHEMES)
-                        )
-                    )
+                # Enforce a well-formed URL using a scheme permitted by ALLOWED_URL_SCHEMES. This applies
+                # the same validation used for values entered via the UI (LaxURLField), so the REST API and
+                # bulk import behave consistently with the form.
+                EnhancedURLValidator()(value)
                 if self.validation_regex and not re.match(self.validation_regex, value):
                     raise ValidationError(_("Value must match regex '{regex}'").format(regex=self.validation_regex))
 

--- a/netbox/extras/models/customfields.py
+++ b/netbox/extras/models/customfields.py
@@ -796,9 +796,8 @@ class CustomField(CloningMixin, ExportTemplatesMixin, OwnerMixin, ChangeLoggedMo
             elif self.type == CustomFieldTypeChoices.TYPE_URL:
                 if type(value) is not str:
                     raise ValidationError(_("Value must be a string."))
-                # Enforce a well-formed URL using a scheme permitted by ALLOWED_URL_SCHEMES. This applies
-                # the same validation used for values entered via the UI (LaxURLField), so the REST API and
-                # bulk import behave consistently with the form.
+                # Validate the URL and its scheme against ALLOWED_URL_SCHEMES, as the UI does (LaxURLField).
+                # Instantiated per call so a runtime change to the (dynamic) setting is honored.
                 EnhancedURLValidator()(value)
                 if self.validation_regex and not re.match(self.validation_regex, value):
                     raise ValidationError(_("Value must match regex '{regex}'").format(regex=self.validation_regex))

--- a/netbox/extras/tests/test_customfields.py
+++ b/netbox/extras/tests/test_customfields.py
@@ -1695,23 +1695,22 @@ class CustomFieldAPITestCase(APITestCase):
 
     def test_url_scheme_validation(self):
         """
-        Test that URL custom field values are restricted to ALLOWED_URL_SCHEMES (fixes #22640).
+        Test that URL custom field values must be well-formed URLs using a scheme permitted by
+        ALLOWED_URL_SCHEMES, consistent with the UI (fixes #22640).
         """
         site2 = Site.objects.get(name='Site 2')
         url = reverse('dcim-api:site-detail', kwargs={'pk': site2.pk})
         self.add_permissions('dcim.change_site')
 
-        # A disallowed scheme (not in ALLOWED_URL_SCHEMES) must be rejected with a scheme-specific error
+        # A dangerous scheme (e.g. javascript:) must be rejected
         data = {'custom_fields': {'url_field': 'javascript:alert(1)'}}
         response = self.client.patch(url, data, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
-        self.assertIn('javascript', str(response.data))
 
-        # A percent-encoded scheme has no scheme to a browser (it will not decode "%3A" to execute
-        # javascript:), so the value is treated as relative and accepted.
-        data = {'custom_fields': {'url_field': 'javascript%3Aalert(1)'}}
+        # A well-formed URL using a scheme outside ALLOWED_URL_SCHEMES must be rejected
+        data = {'custom_fields': {'url_field': 'gopher://example.com'}}
         response = self.client.patch(url, data, format='json', **self.header)
-        self.assertHttpStatus(response, status.HTTP_200_OK)
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
 
         # An allowed scheme must be accepted
         data = {'custom_fields': {'url_field': 'https://example.com'}}

--- a/netbox/extras/tests/test_customfields.py
+++ b/netbox/extras/tests/test_customfields.py
@@ -1707,11 +1707,11 @@ class CustomFieldAPITestCase(APITestCase):
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
         self.assertIn('javascript', str(response.data))
 
-        # A percent-encoded scheme must not evade the check
+        # A percent-encoded scheme has no scheme to a browser (it will not decode "%3A" to execute
+        # javascript:), so the value is treated as relative and accepted.
         data = {'custom_fields': {'url_field': 'javascript%3Aalert(1)'}}
         response = self.client.patch(url, data, format='json', **self.header)
-        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
-        self.assertIn('javascript', str(response.data))
+        self.assertHttpStatus(response, status.HTTP_200_OK)
 
         # An allowed scheme must be accepted
         data = {'custom_fields': {'url_field': 'https://example.com'}}

--- a/netbox/extras/tests/test_customfields.py
+++ b/netbox/extras/tests/test_customfields.py
@@ -1693,6 +1693,24 @@ class CustomFieldAPITestCase(APITestCase):
         response = self.client.patch(url, data, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
 
+    def test_url_scheme_validation(self):
+        """
+        Test that URL custom field values are restricted to ALLOWED_URL_SCHEMES (fixes #22640).
+        """
+        site2 = Site.objects.get(name='Site 2')
+        url = reverse('dcim-api:site-detail', kwargs={'pk': site2.pk})
+        self.add_permissions('dcim.change_site')
+
+        # A disallowed scheme (not in ALLOWED_URL_SCHEMES) must be rejected
+        data = {'custom_fields': {'url_field': 'javascript:alert(1)'}}
+        response = self.client.patch(url, data, format='json', **self.header)
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+
+        # An allowed scheme must be accepted
+        data = {'custom_fields': {'url_field': 'https://example.com'}}
+        response = self.client.patch(url, data, format='json', **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+
     def test_json_schema_validation(self):
         site2 = Site.objects.get(name='Site 2')
         url = reverse('dcim-api:site-detail', kwargs={'pk': site2.pk})

--- a/netbox/extras/tests/test_customfields.py
+++ b/netbox/extras/tests/test_customfields.py
@@ -1701,10 +1701,17 @@ class CustomFieldAPITestCase(APITestCase):
         url = reverse('dcim-api:site-detail', kwargs={'pk': site2.pk})
         self.add_permissions('dcim.change_site')
 
-        # A disallowed scheme (not in ALLOWED_URL_SCHEMES) must be rejected
+        # A disallowed scheme (not in ALLOWED_URL_SCHEMES) must be rejected with a scheme-specific error
         data = {'custom_fields': {'url_field': 'javascript:alert(1)'}}
         response = self.client.patch(url, data, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('javascript', str(response.data))
+
+        # A percent-encoded scheme must not evade the check
+        data = {'custom_fields': {'url_field': 'javascript%3Aalert(1)'}}
+        response = self.client.patch(url, data, format='json', **self.header)
+        self.assertHttpStatus(response, status.HTTP_400_BAD_REQUEST)
+        self.assertIn('javascript', str(response.data))
 
         # An allowed scheme must be accepted
         data = {'custom_fields': {'url_field': 'https://example.com'}}

--- a/netbox/extras/tests/test_customfields.py
+++ b/netbox/extras/tests/test_customfields.py
@@ -1695,8 +1695,9 @@ class CustomFieldAPITestCase(APITestCase):
 
     def test_url_scheme_validation(self):
         """
-        Test that URL custom field values must be well-formed URLs using a scheme permitted by
-        ALLOWED_URL_SCHEMES, consistent with the UI (fixes #22640).
+        Test that URL custom field values must use a scheme permitted by ALLOWED_URL_SCHEMES (fixes
+        #22640), and that a schemeless value is normalized to an absolute URL (assume_scheme='https'),
+        consistent with the UI.
         """
         site2 = Site.objects.get(name='Site 2')
         url = reverse('dcim-api:site-detail', kwargs={'pk': site2.pk})
@@ -1716,6 +1717,13 @@ class CustomFieldAPITestCase(APITestCase):
         data = {'custom_fields': {'url_field': 'https://example.com'}}
         response = self.client.patch(url, data, format='json', **self.header)
         self.assertHttpStatus(response, status.HTTP_200_OK)
+
+        # A schemeless value must be accepted and normalized to https, matching the UI
+        data = {'custom_fields': {'url_field': 'example.com'}}
+        response = self.client.patch(url, data, format='json', **self.header)
+        self.assertHttpStatus(response, status.HTTP_200_OK)
+        site2.refresh_from_db()
+        self.assertEqual(site2.custom_field_data['url_field'], 'https://example.com')
 
     def test_json_schema_validation(self):
         site2 = Site.objects.get(name='Site 2')

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -23,7 +23,7 @@ from utilities.object_types import object_type_identifier, object_type_name
 from utilities.permissions import get_permission_for_model
 from utilities.request import get_safe_request_context
 from utilities.templatetags.builtins.filters import render_markdown
-from utilities.validators import is_url_scheme_allowed
+from utilities.validators import url_scheme_is_allowed
 from utilities.views import get_action_url
 
 __all__ = (
@@ -566,7 +566,7 @@ class CustomFieldColumn(tables.Column):
             # Only render as a link if the scheme is permitted by ALLOWED_URL_SCHEMES, to guard against
             # dangerous schemes (e.g. javascript:) in values which bypassed validation. A schemeless
             # (relative) value is considered safe.
-            if is_url_scheme_allowed(value):
+            if url_scheme_is_allowed(value):
                 return mark_safe(f'<a href="{escape(value)}">{escape(value)}</a>')
             return escape(value)
         if self.customfield.type == CustomFieldTypeChoices.TYPE_SELECT:

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -1,6 +1,6 @@
 import zoneinfo
 from dataclasses import dataclass
-from urllib.parse import quote
+from urllib.parse import quote, urlparse
 
 import django_tables2 as tables
 from django.conf import settings
@@ -19,6 +19,7 @@ from django_tables2.columns import library
 from django_tables2.utils import Accessor
 
 from extras.choices import CustomFieldTypeChoices
+from netbox.config import get_config
 from utilities.object_types import object_type_identifier, object_type_name
 from utilities.permissions import get_permission_for_model
 from utilities.request import get_safe_request_context
@@ -562,7 +563,13 @@ class CustomFieldColumn(tables.Column):
         if self.customfield.type == CustomFieldTypeChoices.TYPE_BOOLEAN and value is False:
             return mark_safe('<i class="mdi mdi-close-thick text-danger"></i>')
         if self.customfield.type == CustomFieldTypeChoices.TYPE_URL:
-            return mark_safe(f'<a href="{escape(value)}">{escape(value)}</a>')
+            # Only render as a link if the scheme is permitted by ALLOWED_URL_SCHEMES, to guard against
+            # dangerous schemes (e.g. javascript:) in values which bypassed validation. A schemeless
+            # (relative) value is considered safe.
+            scheme = urlparse(value).scheme
+            if not scheme or scheme.lower() in get_config().ALLOWED_URL_SCHEMES:
+                return mark_safe(f'<a href="{escape(value)}">{escape(value)}</a>')
+            return escape(value)
         if self.customfield.type == CustomFieldTypeChoices.TYPE_SELECT:
             return self.customfield.get_choice_label(value)
         if self.customfield.type == CustomFieldTypeChoices.TYPE_MULTISELECT:

--- a/netbox/netbox/tables/columns.py
+++ b/netbox/netbox/tables/columns.py
@@ -1,6 +1,6 @@
 import zoneinfo
 from dataclasses import dataclass
-from urllib.parse import quote, urlparse
+from urllib.parse import quote
 
 import django_tables2 as tables
 from django.conf import settings
@@ -19,11 +19,11 @@ from django_tables2.columns import library
 from django_tables2.utils import Accessor
 
 from extras.choices import CustomFieldTypeChoices
-from netbox.config import get_config
 from utilities.object_types import object_type_identifier, object_type_name
 from utilities.permissions import get_permission_for_model
 from utilities.request import get_safe_request_context
 from utilities.templatetags.builtins.filters import render_markdown
+from utilities.validators import is_url_scheme_allowed
 from utilities.views import get_action_url
 
 __all__ = (
@@ -566,8 +566,7 @@ class CustomFieldColumn(tables.Column):
             # Only render as a link if the scheme is permitted by ALLOWED_URL_SCHEMES, to guard against
             # dangerous schemes (e.g. javascript:) in values which bypassed validation. A schemeless
             # (relative) value is considered safe.
-            scheme = urlparse(value).scheme
-            if not scheme or scheme.lower() in get_config().ALLOWED_URL_SCHEMES:
+            if is_url_scheme_allowed(value):
                 return mark_safe(f'<a href="{escape(value)}">{escape(value)}</a>')
             return escape(value)
         if self.customfield.type == CustomFieldTypeChoices.TYPE_SELECT:

--- a/netbox/netbox/tests/test_tables.py
+++ b/netbox/netbox/tests/test_tables.py
@@ -4,6 +4,8 @@ from django.test import RequestFactory, TestCase
 
 from dcim.models import Device, Site
 from dcim.tables import DeviceTable
+from extras.choices import CustomFieldTypeChoices
+from extras.models import CustomField
 from netbox.tables import NetBoxTable, columns
 from utilities.testing import create_tags, create_test_device, create_test_user
 
@@ -119,3 +121,23 @@ class TagColumnTestCase(TestCase):
             'table': table
         })
         template.render(context)
+
+
+class CustomFieldColumnTestCase(TestCase):
+    """
+    A URL custom field value is rendered directly into an href, so its scheme must be validated
+    against ALLOWED_URL_SCHEMES to avoid rendering dangerous schemes (e.g. javascript:) as clickable
+    links (fixes #22640).
+    """
+
+    def _render(self, value):
+        customfield = CustomField(name='url_field', type=CustomFieldTypeChoices.TYPE_URL)
+        return columns.CustomFieldColumn(customfield).render(value)
+
+    def test_url_allowed_scheme_rendered_as_link(self):
+        self.assertEqual(self._render('https://example.com'), '<a href="https://example.com">https://example.com</a>')
+
+    def test_url_disallowed_scheme_not_rendered_as_link(self):
+        rendered = self._render('javascript:alert(1)')
+        self.assertNotIn('href', rendered)
+        self.assertIn('javascript:alert(1)', rendered)

--- a/netbox/netbox/tests/test_tables.py
+++ b/netbox/netbox/tests/test_tables.py
@@ -141,3 +141,8 @@ class CustomFieldColumnTestCase(TestCase):
         rendered = self._render('javascript:alert(1)')
         self.assertNotIn('href', rendered)
         self.assertIn('javascript:alert(1)', rendered)
+
+    def test_url_percent_encoded_scheme_not_rendered_as_link(self):
+        # A percent-encoded scheme must not evade detection and become a clickable href.
+        rendered = self._render('javascript%3Aalert(1)')
+        self.assertNotIn('href', rendered)

--- a/netbox/netbox/tests/test_tables.py
+++ b/netbox/netbox/tests/test_tables.py
@@ -142,7 +142,8 @@ class CustomFieldColumnTestCase(TestCase):
         self.assertNotIn('href', rendered)
         self.assertIn('javascript:alert(1)', rendered)
 
-    def test_url_percent_encoded_scheme_not_rendered_as_link(self):
-        # A percent-encoded scheme must not evade detection and become a clickable href.
+    def test_url_percent_encoded_scheme_rendered_as_relative_link(self):
+        # A percent-encoded scheme is inert: a browser will not decode "%3A" to execute javascript:,
+        # so the value has no scheme and is rendered as a link as-is.
         rendered = self._render('javascript%3Aalert(1)')
-        self.assertNotIn('href', rendered)
+        self.assertEqual(rendered, '<a href="javascript%3Aalert(1)">javascript%3Aalert(1)</a>')

--- a/netbox/utilities/templates/builtins/customfield_value.html
+++ b/netbox/utilities/templates/builtins/customfield_value.html
@@ -15,7 +15,11 @@
 {% elif customfield.type == 'datetime' and value %}
   {{ value|isodatetime }}
 {% elif customfield.type == 'url' and value %}
-  <a href="{{ value }}">{{ value|truncatechars:70 }}</a>
+  {% if url_allowed %}
+    <a href="{{ value }}">{{ value|truncatechars:70 }}</a>
+  {% else %}
+    {{ value|truncatechars:70 }}
+  {% endif %}
 {% elif customfield.type == 'json' and value is not None %}
   <pre>{{ value|json }}</pre>
 {% elif customfield.type == 'select' and value %}

--- a/netbox/utilities/templatetags/builtins/tags.py
+++ b/netbox/utilities/templatetags/builtins/tags.py
@@ -7,7 +7,7 @@ from django.utils.safestring import mark_safe
 
 from extras.choices import CustomFieldTypeChoices
 from utilities.querydict import dict_to_querydict
-from utilities.validators import is_url_scheme_allowed
+from utilities.validators import url_scheme_is_allowed
 
 __all__ = (
     'badge',
@@ -65,7 +65,7 @@ def customfield_value(customfield, value):
             # Only render as a link if the scheme is permitted by ALLOWED_URL_SCHEMES. This guards against
             # dangerous schemes (e.g. javascript:) in values stored before validation was enforced or via
             # paths which bypass model validation. A schemeless (relative) value is considered safe.
-            url_allowed = is_url_scheme_allowed(value)
+            url_allowed = url_scheme_is_allowed(value)
     return {
         'customfield': customfield,
         'value': value,

--- a/netbox/utilities/templatetags/builtins/tags.py
+++ b/netbox/utilities/templatetags/builtins/tags.py
@@ -6,8 +6,8 @@ from django.templatetags.static import static
 from django.utils.safestring import mark_safe
 
 from extras.choices import CustomFieldTypeChoices
-from netbox.config import get_config
 from utilities.querydict import dict_to_querydict
+from utilities.validators import is_url_scheme_allowed
 
 __all__ = (
     'badge',
@@ -65,8 +65,7 @@ def customfield_value(customfield, value):
             # Only render as a link if the scheme is permitted by ALLOWED_URL_SCHEMES. This guards against
             # dangerous schemes (e.g. javascript:) in values stored before validation was enforced or via
             # paths which bypass model validation. A schemeless (relative) value is considered safe.
-            scheme = urlparse(value).scheme
-            url_allowed = not scheme or scheme.lower() in get_config().ALLOWED_URL_SCHEMES
+            url_allowed = is_url_scheme_allowed(value)
     return {
         'customfield': customfield,
         'value': value,

--- a/netbox/utilities/templatetags/builtins/tags.py
+++ b/netbox/utilities/templatetags/builtins/tags.py
@@ -6,6 +6,7 @@ from django.templatetags.static import static
 from django.utils.safestring import mark_safe
 
 from extras.choices import CustomFieldTypeChoices
+from netbox.config import get_config
 from utilities.querydict import dict_to_querydict
 
 __all__ = (
@@ -48,6 +49,8 @@ def customfield_value(customfield, value):
     """
     color = None
     value_has_colors = False
+    # Determines whether a URL value may be rendered as a clickable link
+    url_allowed = False
 
     if value:
         if customfield.type == CustomFieldTypeChoices.TYPE_SELECT:
@@ -58,11 +61,18 @@ def customfield_value(customfield, value):
             value_has_colors = any(choice_color for _, choice_color in value)
             if not value_has_colors:
                 value = [choice_label for choice_label, _ in value]
+        elif customfield.type == CustomFieldTypeChoices.TYPE_URL:
+            # Only render as a link if the scheme is permitted by ALLOWED_URL_SCHEMES. This guards against
+            # dangerous schemes (e.g. javascript:) in values stored before validation was enforced or via
+            # paths which bypass model validation. A schemeless (relative) value is considered safe.
+            scheme = urlparse(value).scheme
+            url_allowed = not scheme or scheme.lower() in get_config().ALLOWED_URL_SCHEMES
     return {
         'customfield': customfield,
         'value': value,
         'color': color,
         'value_has_colors': value_has_colors,
+        'url_allowed': url_allowed,
     }
 
 

--- a/netbox/utilities/tests/test_templatetags.py
+++ b/netbox/utilities/tests/test_templatetags.py
@@ -83,10 +83,11 @@ class CustomFieldValueTagTestCase(TestCase):
         self.assertNotIn('href', html)
         self.assertIn('javascript:alert(1)', html)
 
-    def test_url_percent_encoded_scheme_not_rendered_as_link(self):
-        # A percent-encoded scheme must not evade detection and become a clickable href.
+    def test_url_percent_encoded_scheme_rendered_as_relative_link(self):
+        # A percent-encoded scheme is inert: a browser will not decode "%3A" to execute javascript:,
+        # so the value has no scheme and is rendered as a link as-is.
         html = self._render(self.url_field, 'javascript%3Aalert(1)')
-        self.assertNotIn('href', html)
+        self.assertInHTML('<a href="javascript%3Aalert(1)">javascript%3Aalert(1)</a>', html)
 
 
 class StaticWithParamsTestCase(TestCase):

--- a/netbox/utilities/tests/test_templatetags.py
+++ b/netbox/utilities/tests/test_templatetags.py
@@ -39,6 +39,15 @@ class CustomFieldValueTagTestCase(TestCase):
         )
         cls.multiselect_field.object_types.set([object_type])
 
+        cls.url_field = CustomField.objects.create(
+            name='url_field',
+            type=CustomFieldTypeChoices.TYPE_URL,
+        )
+        cls.url_field.object_types.set([object_type])
+
+    def _render(self, customfield, value):
+        return render_to_string('builtins/customfield_value.html', customfield_value(customfield, value))
+
     def test_select_choice_context_includes_color(self):
         context = customfield_value(self.select_field, 'a')
 
@@ -62,6 +71,17 @@ class CustomFieldValueTagTestCase(TestCase):
 
         self.assertFalse(context['value_has_colors'])
         self.assertEqual(context['value'], ['Option B'])
+
+    def test_url_allowed_scheme_rendered_as_link(self):
+        html = self._render(self.url_field, 'https://example.com')
+        self.assertInHTML('<a href="https://example.com">https://example.com</a>', html)
+
+    def test_url_disallowed_scheme_not_rendered_as_link(self):
+        # A dangerous scheme (e.g. one stored before validation was enforced) must not become a
+        # clickable href (fixes #22640).
+        html = self._render(self.url_field, 'javascript:alert(1)')
+        self.assertNotIn('href', html)
+        self.assertIn('javascript:alert(1)', html)
 
 
 class StaticWithParamsTestCase(TestCase):

--- a/netbox/utilities/tests/test_templatetags.py
+++ b/netbox/utilities/tests/test_templatetags.py
@@ -83,6 +83,11 @@ class CustomFieldValueTagTestCase(TestCase):
         self.assertNotIn('href', html)
         self.assertIn('javascript:alert(1)', html)
 
+    def test_url_percent_encoded_scheme_not_rendered_as_link(self):
+        # A percent-encoded scheme must not evade detection and become a clickable href.
+        html = self._render(self.url_field, 'javascript%3Aalert(1)')
+        self.assertNotIn('href', html)
+
 
 class StaticWithParamsTestCase(TestCase):
     """

--- a/netbox/utilities/validators.py
+++ b/netbox/utilities/validators.py
@@ -1,6 +1,6 @@
 import decimal
 import re
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
 
 from django.core.exceptions import ValidationError
 from django.core.validators import BaseValidator, RegexValidator, URLValidator, _lazy_re_compile
@@ -77,10 +77,11 @@ class MultipleOfValidator(BaseValidator):
 
 def get_url_scheme(value):
     """
-    Return the (lower-cased) scheme of a URL, or an empty string if it has none. The value is unquoted
-    before parsing so that a percent-encoded scheme (e.g. "javascript%3A…") cannot evade detection.
+    Return the (lower-cased) scheme of a URL, or an empty string if it has none. A percent-encoded
+    scheme (e.g. "javascript%3A…") yields no scheme, matching browser behavior: a browser does not
+    decode the scheme portion of an href, so such a value is inert and is treated as relative.
     """
-    return urlparse(unquote(value)).scheme.lower()
+    return urlparse(value).scheme.lower()
 
 
 def is_url_scheme_allowed(value):

--- a/netbox/utilities/validators.py
+++ b/netbox/utilities/validators.py
@@ -1,5 +1,6 @@
 import decimal
 import re
+from urllib.parse import unquote, urlparse
 
 from django.core.exceptions import ValidationError
 from django.core.validators import BaseValidator, RegexValidator, URLValidator, _lazy_re_compile
@@ -12,6 +13,8 @@ __all__ = (
     'EnhancedURLValidator',
     'ExclusionValidator',
     'MultipleOfValidator',
+    'get_url_scheme',
+    'is_url_scheme_allowed',
     'validate_regex',
 )
 
@@ -70,6 +73,23 @@ class MultipleOfValidator(BaseValidator):
             raise ValidationError(
                 _("{value} must be a multiple of {multiple}.").format(value=value, multiple=self.multiple)
             )
+
+
+def get_url_scheme(value):
+    """
+    Return the (lower-cased) scheme of a URL, or an empty string if it has none. The value is unquoted
+    before parsing so that a percent-encoded scheme (e.g. "javascript%3A…") cannot evade detection.
+    """
+    return urlparse(unquote(value)).scheme.lower()
+
+
+def is_url_scheme_allowed(value):
+    """
+    Return True if the URL's scheme is permitted by ALLOWED_URL_SCHEMES. A schemeless (relative) value
+    is considered permitted.
+    """
+    scheme = get_url_scheme(value)
+    return not scheme or scheme in get_config().ALLOWED_URL_SCHEMES
 
 
 def validate_regex(value):

--- a/netbox/utilities/validators.py
+++ b/netbox/utilities/validators.py
@@ -13,8 +13,7 @@ __all__ = (
     'EnhancedURLValidator',
     'ExclusionValidator',
     'MultipleOfValidator',
-    'get_url_scheme',
-    'is_url_scheme_allowed',
+    'url_scheme_is_allowed',
     'validate_regex',
 )
 
@@ -75,21 +74,20 @@ class MultipleOfValidator(BaseValidator):
             )
 
 
-def get_url_scheme(value):
-    """
-    Return the (lower-cased) scheme of a URL, or an empty string if it has none. A percent-encoded
-    scheme (e.g. "javascript%3A…") yields no scheme, matching browser behavior: a browser does not
-    decode the scheme portion of an href, so such a value is inert and is treated as relative.
-    """
-    return urlparse(value).scheme.lower()
-
-
-def is_url_scheme_allowed(value):
+def url_scheme_is_allowed(value):
     """
     Return True if the URL's scheme is permitted by ALLOWED_URL_SCHEMES. A schemeless (relative) value
     is considered permitted.
+
+    The scheme is compared in lower case. A percent-encoded scheme (e.g. "javascript%3A…") yields no
+    scheme, matching browser behavior: a browser does not decode the scheme portion of an href, so such
+    a value is inert and is treated as relative. A malformed URL which cannot be parsed (e.g.
+    "http://[::1/foo") likewise yields no scheme.
     """
-    scheme = get_url_scheme(value)
+    try:
+        scheme = urlparse(value).scheme.lower()
+    except ValueError:
+        scheme = ''
     return not scheme or scheme in get_config().ALLOWED_URL_SCHEMES
 
 


### PR DESCRIPTION
### Closes: #22640

Enforce `ALLOWED_URL_SCHEMES` for URL custom fields at two layers:

- **Entry**: `CustomField.validate()` runs `EnhancedURLValidator`. The UI and REST API now have the same validation.
- **Render**: the `customfield_value` tag and `CustomFieldColumn` only emit a clickable `<a href>` for permitted schemes, otherwise showing the value as plain text.

**Note:** Previously REST and UI allowed different URLs, REST was more permissive.

### Notes

This is a breaking change: URL custom field values using a scheme outside `ALLOWED_URL_SCHEMES` are now rejected on save.
