### PR TITLE
22677 - Fix cable form validation errors

### DIFF
--- a/netbox/templates/dcim/htmx/cable_edit.html
+++ b/netbox/templates/dcim/htmx/cable_edit.html
@@ -59,13 +59,23 @@
   {% render_field form.label %}
   {% render_field form.description %}
   {% render_field form.color %}
-  <div class="row mb-3">
+  <div class="row mb-3{% if form.length.errors or form.length_unit.errors %} has-errors{% endif %}">
     <label class="col-sm-3 col-form-label text-lg-end">{{ form.length.label }}</label>
     <div class="col-md-5">
       {{ form.length }}
+      {% if form.length.errors %}
+        <div class="form-text text-danger" id="{{ form.length.auto_id }}_errors" role="alert">
+          {% for error in form.length.errors %}{{ error }}{% if not forloop.last %}<br />{% endif %}{% endfor %}
+        </div>
+      {% endif %}
     </div>
     <div class="col-md-4">
       {{ form.length_unit }}
+      {% if form.length_unit.errors %}
+        <div class="form-text text-danger" id="{{ form.length_unit.auto_id }}_errors" role="alert">
+          {% for error in form.length_unit.errors %}{{ error }}{% if not forloop.last %}<br />{% endif %}{% endfor %}
+        </div>
+      {% endif %}
     </div>
   </div>
   {% render_field form.tags %}

--- a/netbox/templates/dcim/htmx/cable_edit.html
+++ b/netbox/templates/dcim/htmx/cable_edit.html
@@ -62,7 +62,7 @@
   <div class="row mb-3{% if form.length.errors or form.length_unit.errors %} has-errors{% endif %}">
     <label class="col-sm-3 col-form-label text-lg-end">{{ form.length.label }}</label>
     <div class="col-md-5">
-      {{ form.length }}
+      {% render_field_with_aria form.length %}
       {% if form.length.errors %}
         <div class="form-text text-danger" id="{{ form.length.auto_id }}_errors" role="alert">
           {% for error in form.length.errors %}{{ error }}{% if not forloop.last %}<br />{% endif %}{% endfor %}
@@ -70,7 +70,7 @@
       {% endif %}
     </div>
     <div class="col-md-4">
-      {{ form.length_unit }}
+      {% render_field_with_aria form.length_unit %}
       {% if form.length_unit.errors %}
         <div class="form-text text-danger" id="{{ form.length_unit.auto_id }}_errors" role="alert">
           {% for error in form.length_unit.errors %}{{ error }}{% if not forloop.last %}<br />{% endif %}{% endfor %}


### PR DESCRIPTION
### Closes: #22677

The Cable HTMX form template (dcim/htmx/cable_edit.html) renders length and length_unit manually. Fix was to inline error display for length and length_unit, matching the render_field.html pattern. The Cable form was the only one that looked like it had this issue.
