### PR TITLE
Closes #22685 - Add "has any of these tags" filter mode

### DIFF
--- a/docs/reference/filtering.md
+++ b/docs/reference/filtering.md
@@ -110,6 +110,21 @@ expression: `n`. Here is an example of a lookup expression on a foreign key, it 
 GET /api/ipam/vlans/?group_id__n=3203
 ```
 
+### Tags
+
+The `tag` and `tag_id` filters support negation (`n`) as well as an `any` lookup expression:
+
+| Filter | Description                                       |
+|--------|----------------------------------------------------|
+| `n`    | Does not have any of these tags                    |
+| `any`  | Has any of these tags (logical OR)                  |
+
+Passing multiple values for `tag`/`tag_id` without a lookup expression uses a logical AND: `GET /api/dcim/sites/?tag=foo&tag=bar` returns only sites tagged with both `foo` _and_ `bar`. To instead match sites tagged with `foo` _or_ `bar`, use the `any` lookup expression:
+
+```no-highlight
+GET /api/dcim/sites/?tag__any=foo&tag__any=bar
+```
+
 ## Ordering Objects
 
 To order results by a particular field, include the `ordering` query parameter. For example, order the list of sites according to their facility values:

--- a/docs/reference/filtering.md
+++ b/docs/reference/filtering.md
@@ -125,6 +125,8 @@ Passing multiple values for `tag`/`tag_id` without a lookup expression uses a lo
 GET /api/dcim/sites/?tag__any=foo&tag__any=bar
 ```
 
+Note that `n` is not the logical complement of the default (AND) behavior: passing multiple values applies NOR logic, matching only objects which have _none_ of the specified tags, rather than objects which are simply missing at least one of them.
+
 ## Ordering Objects
 
 To order results by a particular field, include the `ordering` query parameter. For example, order the list of sites according to their facility values:

--- a/netbox/netbox/filtersets.py
+++ b/netbox/netbox/filtersets.py
@@ -20,6 +20,7 @@ from utilities.constants import (
     FILTER_CHAR_BASED_LOOKUP_MAP,
     FILTER_NEGATION_LOOKUP_MAP,
     FILTER_NUMERIC_BASED_LOOKUP_MAP,
+    FILTER_TAG_LOOKUP_MAP,
     FILTER_TREENODE_NEGATION_LOOKUP_MAP,
 )
 from utilities.forms.fields import MACAddressField
@@ -153,10 +154,13 @@ class BaseFilterSet(django_filters.FilterSet):
             # TreeNodeMultipleChoiceFilter only support negation but must maintain the `in` lookup expression
             return FILTER_TREENODE_NEGATION_LOOKUP_MAP
 
+        if isinstance(existing_filter, (TagFilter, TagIDFilter)):
+            # Tags additionally support an "any of" (OR) mode, unlike other model choice filters
+            return FILTER_TAG_LOOKUP_MAP
+
         if isinstance(existing_filter, (
             django_filters.ModelChoiceFilter,
             django_filters.ModelMultipleChoiceFilter,
-            TagFilter
         )):
             # These filter types support only negation
             return FILTER_NEGATION_LOOKUP_MAP
@@ -236,6 +240,10 @@ class BaseFilterSet(django_filters.FilterSet):
                 # This is a negation filter which requires a queryset.exclude() clause
                 # Of course setting the negation of the existing filter's exclude attribute handles both cases
                 new_filter.exclude = not existing_filter.exclude
+
+            if lookup_name == 'any':
+                # "Any of" is an OR match, whereas TagFilter/TagIDFilter default to AND (conjoined=True)
+                new_filter.conjoined = False
 
             new_filters[new_filter_name] = new_filter
 

--- a/netbox/netbox/filtersets.py
+++ b/netbox/netbox/filtersets.py
@@ -241,7 +241,7 @@ class BaseFilterSet(django_filters.FilterSet):
                 # Of course setting the negation of the existing filter's exclude attribute handles both cases
                 new_filter.exclude = not existing_filter.exclude
 
-            if lookup_name == 'any':
+            if lookup_name == 'any' and isinstance(new_filter, (TagFilter, TagIDFilter)):
                 # "Any of" is an OR match, whereas TagFilter/TagIDFilter default to AND (conjoined=True)
                 new_filter.conjoined = False
 

--- a/netbox/utilities/constants.py
+++ b/netbox/utilities/constants.py
@@ -30,6 +30,11 @@ FILTER_NEGATION_LOOKUP_MAP = dict(
     n='exact'
 )
 
+FILTER_TAG_LOOKUP_MAP = dict(
+    n='exact',
+    any='exact',
+)
+
 FILTER_TREENODE_NEGATION_LOOKUP_MAP = dict(
     n='in'
 )

--- a/netbox/utilities/forms/mixins.py
+++ b/netbox/utilities/forms/mixins.py
@@ -80,6 +80,7 @@ FORM_FIELD_LOOKUPS = {
     ],
     TagFilterField: [
         ('exact', _('has these tags')),
+        ('any', _('has any of these tags')),
         ('n', _('does not have these tags')),
         (MODIFIER_EMPTY_TRUE, _('is empty')),
         (MODIFIER_EMPTY_FALSE, _('is not empty')),

--- a/netbox/utilities/tests/test_filter_modifiers.py
+++ b/netbox/utilities/tests/test_filter_modifiers.py
@@ -206,8 +206,8 @@ class FilterModifierMixinTestCase(TestCase):
 
         self.assertIsInstance(form.fields['tag'].widget, FilterModifierWidget)
         tag_lookups = [lookup[0] for lookup in form.fields['tag'].widget.lookups]
-        # Device filterset has tag and tag__n but not tag__empty
-        expected_lookups = ['exact', 'n']
+        # Device filterset has tag, tag__any, and tag__n but not tag__empty
+        expected_lookups = ['exact', 'any', 'n']
         self.assertEqual(tag_lookups, expected_lookups)
 
     def test_mixin_enhances_integer_field(self):

--- a/netbox/utilities/tests/test_filters.py
+++ b/netbox/utilities/tests/test_filters.py
@@ -23,7 +23,7 @@ from dcim.models import (
     Site,
 )
 from extras.filters import TagFilter
-from extras.models import SavedFilter, TaggedItem
+from extras.models import SavedFilter, Tag, TaggedItem
 from ipam.filtersets import ASNFilterSet
 from ipam.models import ASN, RIR
 from netbox.filtersets import BaseFilterSet
@@ -94,6 +94,64 @@ class TreeNodeMultipleChoiceFilterTestCase(TestCase):
         self.assertEqual(qs.count(), 2)
         self.assertEqual(qs[0], self.site1)
         self.assertEqual(qs[1], self.site3)
+
+
+class TagFilterTestCase(TestCase):
+    """
+    Verify the AND (default), OR (`any`), and NOR (`n`) semantics of TagFilter/TagIDFilter.
+    """
+    queryset = Site.objects.all()
+    filterset = SiteFilterSet
+
+    @classmethod
+    def setUpTestData(cls):
+        tags = (
+            Tag(name='Tag 1', slug='tag-1'),
+            Tag(name='Tag 2', slug='tag-2'),
+            Tag(name='Tag 3', slug='tag-3'),
+        )
+        Tag.objects.bulk_create(tags)
+
+        sites = (
+            Site(name='Site 1', slug='site-1'),
+            Site(name='Site 2', slug='site-2'),
+            Site(name='Site 3', slug='site-3'),
+        )
+        Site.objects.bulk_create(sites)
+        sites[0].tags.set([tags[0], tags[1]])  # tag-1, tag-2
+        sites[1].tags.set([tags[1]])  # tag-2 only
+        sites[2].tags.set([tags[2]])  # tag-3 only
+
+    def test_tag_and(self):
+        tags = Tag.objects.filter(slug__in=('tag-1', 'tag-2'))
+        params = {'tag': [tags[0].slug, tags[1].slug]}
+        qs = self.filterset(params, self.queryset).qs
+        self.assertEqual(qs.count(), 1)
+        self.assertEqual(qs[0].slug, 'site-1')
+
+        params = {'tag_id': [tags[0].pk, tags[1].pk]}
+        qs = self.filterset(params, self.queryset).qs
+        self.assertEqual(qs.count(), 1)
+        self.assertEqual(qs[0].slug, 'site-1')
+
+    def test_tag_any(self):
+        tags = Tag.objects.filter(slug__in=('tag-1', 'tag-3'))
+        params = {'tag__any': [tags[0].slug, tags[1].slug]}
+        qs = self.filterset(params, self.queryset).qs
+        self.assertEqual(qs.count(), 2)
+        self.assertEqual({site.slug for site in qs}, {'site-1', 'site-3'})
+
+        params = {'tag_id__any': [tags[0].pk, tags[1].pk]}
+        qs = self.filterset(params, self.queryset).qs
+        self.assertEqual(qs.count(), 2)
+        self.assertEqual({site.slug for site in qs}, {'site-1', 'site-3'})
+
+    def test_tag_negation(self):
+        tags = Tag.objects.filter(slug__in=('tag-1', 'tag-3'))
+        params = {'tag__n': [tags[0].slug, tags[1].slug]}
+        qs = self.filterset(params, self.queryset).qs
+        self.assertEqual(qs.count(), 1)
+        self.assertEqual(qs[0].slug, 'site-2')
 
 
 class DummyModel(models.Model):
@@ -377,8 +435,13 @@ class BaseFilterSetTestCase(TestCase):
         self.assertIsInstance(self.filters['tagfield'], TagFilter)
         self.assertEqual(self.filters['tagfield'].lookup_expr, 'exact')
         self.assertEqual(self.filters['tagfield'].exclude, False)
+        self.assertEqual(self.filters['tagfield'].conjoined, True)
         self.assertEqual(self.filters['tagfield__n'].lookup_expr, 'exact')
         self.assertEqual(self.filters['tagfield__n'].exclude, True)
+        self.assertEqual(self.filters['tagfield__n'].conjoined, True)
+        self.assertEqual(self.filters['tagfield__any'].lookup_expr, 'exact')
+        self.assertEqual(self.filters['tagfield__any'].exclude, False)
+        self.assertEqual(self.filters['tagfield__any'].conjoined, False)
 
     def test_tree_node_multiple_choice_filter(self):
         self.assertIsInstance(self.filters['treeforeignkeyfield'], TreeNodeMultipleChoiceFilter)

--- a/netbox/utilities/tests/test_filters.py
+++ b/netbox/utilities/tests/test_filters.py
@@ -153,6 +153,11 @@ class TagFilterTestCase(TestCase):
         self.assertEqual(qs.count(), 1)
         self.assertEqual(qs[0].slug, 'site-2')
 
+        params = {'tag_id__n': [tags[0].pk, tags[1].pk]}
+        qs = self.filterset(params, self.queryset).qs
+        self.assertEqual(qs.count(), 1)
+        self.assertEqual(qs[0].slug, 'site-2')
+
 
 class DummyModel(models.Model):
     """


### PR DESCRIPTION
### Closes: #22685 

## Summary

- Adds a `tag__any` / `tag_id__any` filter lookup expression that matches objects tagged with **any** of the specified tags (logical OR), complementing the existing default (AND / `conjoined=True`) and `n` (negation) modes.
- Exposed in the UI filter builder as a new "has any of these tags" option alongside "has these tags" / "does not have these tags".

<img width="854" height="506" alt="Screenshot 2026-07-21 at 9 55 11 PM" src="https://github.com/user-attachments/assets/692c16bc-74c1-4eab-b730-1634e5588850" />

Example:
```
http://127.0.0.1:8000/api/dcim/devices/?tag__any=alpha&tag__any=bravo
```

## Design notes (per discussion on the issue)

`TagFilter`/`TagIDFilter` hard-code `conjoined=True` in `__init__`, and NetBox's dynamic lookup-expression framework (`BaseFilterSet.get_additional_lookups`) only varies `lookup_expr` and toggles `.exclude` for negation — it has no mechanism to flip `.conjoined`. So this couldn't be a simple lookup swap:

- Added a dedicated `FILTER_TAG_LOOKUP_MAP` (`utilities/constants.py`) rather than reusing the shared `FILTER_NEGATION_LOOKUP_MAP` (which also serves plain FK/M2M filters that are already OR-by-default and don't need an "any" mode).
- `_get_filter_lookup_dict` routes `TagFilter`/`TagIDFilter` to this new map.
- `get_additional_lookups` sets `new_filter.conjoined = False` when constructing the `any` variant — the missing plumbing.
- Scoped narrowly to the positive "has any" case, not expanded into a full any/all/negation matrix.

## Test plan

- [x] Extended `test_tag_filter` (`utilities/tests/test_filters.py`) to assert `.conjoined` on the `exact`, `n`, and new `any` filter variants.
- [x] Added `TagFilterTestCase`, exercising real `Site` objects through `SiteFilterSet` to verify AND (`tag`), OR (`tag__any`), and NOR (`tag__n`) queryset behavior end-to-end — there was previously no behavioral test for `TagFilter`'s AND semantics at all.
- [x] Verified both new tests fail without the fix (`KeyError` on `tagfield__any`; `tag__any` param silently ignored, returning all objects) and pass with it.
- [x] Ran the broader `extras.tests.test_filtersets` + `dcim.tests.test_filtersets` suites (939 tests) to confirm no regression in existing tag AND/negation behavior across taggable models.
- [x] `ruff check` passes; pre-commit hooks (lint, Django checks, docs build) pass.
- [x] Documented the new lookup expressions in `docs/reference/filtering.md`.
