### PR TITLE
Fixes #22736: Add comments field to ASN search index

### DIFF
--- a/netbox/ipam/search.py
+++ b/netbox/ipam/search.py
@@ -22,6 +22,7 @@ class ASNIndex(SearchIndex):
         ('asn', 100),
         ('prefixed_name', 110),
         ('description', 500),
+        ('comments', 5000),
     )
     display_attrs = ('rir', 'role', 'tenant', 'description')
 


### PR DESCRIPTION
### Closes: netbox-community/netbox#22736

Adds the `comments` field (weight 5000) to `ASNIndex` so ASNs are included in global search results when the term matches their comments, consistent with every other comments-bearing search index (e.g. `ASNRangeIndex` in the same module)