### PR TITLE
Fixes #22697: Return to Scripts list when canceling ScriptModule creation

### DIFF
--- a/netbox/extras/tests/test_views.py
+++ b/netbox/extras/tests/test_views.py
@@ -1148,6 +1148,20 @@ class ScriptListViewTestCase(TestCase):
         self.assertTemplateUsed(response, 'extras/inc/script_list_content.html')
 
 
+class ScriptModuleCreateViewTestCase(TestCase):
+    user_permissions = ['core.add_managedfile', 'extras.add_scriptmodule']
+
+    @tag('regression')
+    def test_default_return_url(self):
+        """
+        The add view should fall back to the scripts list as its return URL.
+        """
+        response = self.client.get(reverse('extras:scriptmodule_add'))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context['return_url'], reverse('extras:script_list'))
+
+
 class ScriptValidationErrorTestCase(TestCase):
     user_permissions = ['extras.view_script', 'extras.run_script']
 

--- a/netbox/extras/views.py
+++ b/netbox/extras/views.py
@@ -1636,6 +1636,7 @@ class DashboardWidgetDeleteView(LoginRequiredMixin, View):
 class ScriptModuleCreateView(generic.ObjectEditView):
     queryset = ScriptModule.objects.all()
     form = forms.ScriptFileForm
+    default_return_url = 'extras:script_list'
 
     def alter_object(self, obj, *args, **kwargs):
         obj.file_root = ManagedFileRootPathChoices.SCRIPTS


### PR DESCRIPTION
### Closes: netbox-community/netbox#22697

Updates the ScriptModule add view to use the Scripts list as its default return URL when no explicit return URL is provided. This ensures that cancelling the form returns the user to the expected page instead of the NetBox home page.

Adds a regression test covering the default return URL.