### PR TITLE
Closes #22748: ContentTypeField.to_internal_value() must respect its declared queryset

### DIFF
--- a/netbox/netbox/api/fields.py
+++ b/netbox/netbox/api/fields.py
@@ -1,4 +1,3 @@
-from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import ObjectDoesNotExist
 from django.db.backends.postgresql.psycopg_any import NumericRange
 from django.utils.translation import gettext as _
@@ -112,7 +111,10 @@ class ContentTypeField(RelatedField):
     def to_internal_value(self, data):
         try:
             app_label, model = data.split('.')
-            return ContentType.objects.get_by_natural_key(app_label=app_label, model=model)
+            # Resolve against the field's own declared queryset (e.g. ObjectType.objects.with_feature(...))
+            # rather than the raw, unfiltered ContentType table, so a caller can't reference a content type
+            # outside the set the serializer actually intends to permit (e.g. Django/NetBox-internal models).
+            return self.get_queryset().get(app_label=app_label, model=model)
         except ObjectDoesNotExist:
             self.fail('does_not_exist', content_type=data)
         except (AttributeError, TypeError, ValueError):

--- a/netbox/netbox/api/fields.py
+++ b/netbox/netbox/api/fields.py
@@ -111,9 +111,7 @@ class ContentTypeField(RelatedField):
     def to_internal_value(self, data):
         try:
             app_label, model = data.split('.')
-            # Resolve against the field's own declared queryset (e.g. ObjectType.objects.with_feature(...))
-            # rather than the raw, unfiltered ContentType table, so a caller can't reference a content type
-            # outside the set the serializer actually intends to permit (e.g. Django/NetBox-internal models).
+            # Scoped to the field's declared queryset, not the raw ContentType table (#22748).
             return self.get_queryset().get(app_label=app_label, model=model)
         except ObjectDoesNotExist:
             self.fail('does_not_exist', content_type=data)

--- a/netbox/netbox/tests/test_api.py
+++ b/netbox/netbox/tests/test_api.py
@@ -1,5 +1,6 @@
 import uuid
 
+from django.contrib.contenttypes.models import ContentType
 from django.db.backends.postgresql.psycopg_any import NumericRange
 from django.test import RequestFactory, TestCase
 from django.urls import reverse
@@ -7,8 +8,9 @@ from rest_framework.exceptions import ValidationError
 from rest_framework.request import Request
 
 from dcim.api.serializers import RackSerializer
+from dcim.models import Device, Site
 from netbox.api.exceptions import QuerySetNotOrdered
-from netbox.api.fields import IntegerRangeSerializer, RelatedObjectCountField
+from netbox.api.fields import ContentTypeField, IntegerRangeSerializer, RelatedObjectCountField
 from netbox.api.pagination import NetBoxPagination
 from users.models import Token
 from utilities.testing import APITestCase
@@ -178,3 +180,47 @@ class IntegerRangeSerializerTestCase(TestCase):
             serializer.to_internal_value(['100', '200'])
         with self.assertRaises(ValidationError):
             serializer.to_internal_value([100.5, 200.5])
+
+
+class ContentTypeFieldTestCase(TestCase):
+
+    def test_to_internal_value_resolves_content_type_within_queryset(self):
+        """A content type present in the field's declared queryset resolves successfully."""
+        site_ct = ContentType.objects.get_for_model(Site)
+        field = ContentTypeField(queryset=ContentType.objects.filter(pk=site_ct.pk))
+        self.assertEqual(field.to_internal_value('dcim.site'), site_ct)
+
+    def test_to_internal_value_rejects_content_type_outside_queryset(self):
+        """
+        Regression test for #22748: ContentTypeField.to_internal_value() previously resolved
+        against the raw, unfiltered ContentType table via get_by_natural_key(), ignoring the
+        field's own declared queryset entirely. A content type that is real and resolvable in
+        general, but falls outside the specific queryset a given field declares, must be
+        rejected rather than silently accepted.
+        """
+        site_ct = ContentType.objects.get_for_model(Site)
+        device_ct = ContentType.objects.get_for_model(Device)
+
+        # Scope the field to a single, unrelated content type so `dcim.site` is guaranteed to
+        # fall outside it.
+        field = ContentTypeField(queryset=ContentType.objects.filter(pk=device_ct.pk))
+        with self.assertRaises(ValidationError):
+            field.to_internal_value('dcim.site')
+
+        # Sanity check: the rejected content type is a genuine, generally-resolvable content
+        # type, so the rejection above is attributable to queryset scoping and not a bogus value.
+        self.assertTrue(ContentType.objects.filter(pk=site_ct.pk).exists())
+
+    def test_to_internal_value_rejects_malformed_input(self):
+        """Input must be exactly '<app_label>.<model>'."""
+        field = ContentTypeField(queryset=ContentType.objects.all())
+        with self.assertRaises(ValidationError):
+            field.to_internal_value('not-a-valid-format')
+        with self.assertRaises(ValidationError):
+            field.to_internal_value('too.many.dots')
+
+    def test_to_internal_value_rejects_nonexistent_content_type(self):
+        """A syntactically valid but nonexistent content type must be rejected."""
+        field = ContentTypeField(queryset=ContentType.objects.all())
+        with self.assertRaises(ValidationError):
+            field.to_internal_value('nonexistent_app.nonexistent_model')

--- a/netbox/netbox/tests/test_api.py
+++ b/netbox/netbox/tests/test_api.py
@@ -224,3 +224,16 @@ class ContentTypeFieldTestCase(TestCase):
         field = ContentTypeField(queryset=ContentType.objects.all())
         with self.assertRaises(ValidationError):
             field.to_internal_value('nonexistent_app.nonexistent_model')
+
+    def test_to_internal_value_many_rejects_content_type_outside_queryset(self):
+        """
+        many=True wraps the field in a ManyRelatedField, which delegates per-item validation to
+        the child field's to_internal_value() unconditionally; the same queryset scoping must
+        hold there too.
+        """
+        device_ct = ContentType.objects.get_for_model(Device)
+        field = ContentTypeField(queryset=ContentType.objects.filter(pk=device_ct.pk), many=True)
+
+        self.assertEqual(field.to_internal_value(['dcim.device']), [device_ct])
+        with self.assertRaises(ValidationError):
+            field.to_internal_value(['dcim.device', 'dcim.site'])


### PR DESCRIPTION
### Closes: #22748 

## Summary

`ContentTypeField.to_internal_value()` (`netbox/api/fields.py`) resolved input via `ContentType.objects.get_by_natural_key()` — the raw, unfiltered `ContentType` table — completely bypassing `self.get_queryset()`. Nearly every REST API serializer using this field (~25 call sites) passes a `queryset` argument intended to scope which content types are acceptable, e.g.:

```python
object_type = ContentTypeField(
    queryset=ObjectType.objects.with_feature('bookmarks'),
)
```

`ObjectType.objects.with_feature(...)`/`.all()` return a much smaller set than Django's raw `ContentType.objects.all()` — only content types NetBox has registered for its own models. Since `to_internal_value()` never consulted this queryset, any resolvable Django content type — including non-public NetBox internals like `auth.permission`, `admin.logentry`, `sessions.session`, `contenttypes.contenttype` — validated successfully regardless of what the serializer declared.

**Impact varies by endpoint.** Some consumers (`Bookmark.clean()`, `JournalEntry.clean()`) happen to add a redundant model-level `has_feature(...)` check and were not exploitable end-to-end despite the field-level defect. Others — e.g. `ImageAttachment`, which has no `clean()` override validating `object_type` at all — have no compensating control.

## Fix

`to_internal_value()` now resolves against `self.get_queryset().get(app_label=..., model=...)` instead of the raw `ContentType` manager — mirroring the pattern already used correctly by the CSV-import counterpart (`CSVContentTypeField.to_python()` in `utilities/forms/fields/csv.py`), which was never affected by this bug. Since DRF wraps `many=True` fields in `ManyRelatedField` (which calls the child field's `to_internal_value()` per item), this also closes the same gap for M2M usages (`Tag.object_types`, `CustomLink.object_types`, `SavedFilter.object_types`, `ExportTemplate.object_types`), not just scalar FK usages.

`ContentType.objects.get_by_natural_key()`'s process-level cache is lost as an inherent consequence: a scoped queryset (e.g. `.with_feature(...)`) can't reuse an unscoped natural-key cache without also bypassing the scoping, which is the bug itself. None of the `ObjectType`-based consumers (the majority) were ever benefiting from that cache in the first place, since `ObjectType.objects.all()`/`.with_feature(...)` already hit the database (a joined/filtered queryset, not the raw `ContentType` manager).

## Test plan

- [x] Added `ContentTypeFieldTestCase` (`netbox/tests/test_api.py`) covering: acceptance within the declared queryset, rejection of a real, resolvable content type outside the declared queryset (the regression case), rejection of malformed input, and rejection of a nonexistent content type.
- [x] Verified the new regression test fails with `AssertionError: ValidationError not raised` against the pre-fix code, and passes with the fix.
- [x] Ran the full API test suites for every app using `ContentTypeField` (`extras`, `core`, `dcim`, `ipam`, `tenancy`, `users`, `virtualization`, `vpn`, `wireless`, `circuits` — 3062 tests) to confirm no regression in any of the ~25 real-world call sites.
- [x] `ruff check` passes; `manage.py check` passes.

