### PR TITLE
Closes #22593: Deprecate legacy fields on rack model

### DIFF
--- a/docs/models/dcim/rack.md
+++ b/docs/models/dcim/rack.md
@@ -28,6 +28,9 @@ The rack's name or identifier. Must be unique to the rack's location, if assigne
 
 The [physical type](./racktype.md) of this rack. The rack type defines physical attributes such as height and weight.
 
+!!! warning "Rack type assignment will become mandatory"
+    Beginning in NetBox v5.0, the assignment of a rack type will be required, and several physical attributes will be inferred from it rather than being set directly on the rack. See the note under [Physical Attributes](#physical-attributes) below.
+
 ### Status
 
 Operational status.
@@ -51,5 +54,18 @@ The unique physical serial number assigned to this rack.
 
 A unique, locally-administered label used to identify hardware resources.
 
-!!! note
-    Some additional fields pertaining to physical attributes such as height and weight can also be defined on each rack, but should generally be defined instead on the [rack type](./racktype.md).
+## Physical Attributes
+
+Several physical attributes may be defined on each rack, including its width, height, outer dimensions, mounting depth, and weight. These should generally be defined on the [rack type](./racktype.md) assigned to the rack rather than on the rack itself.
+
+!!! warning "Some rack fields are deprecated"
+    The following fields have been **deprecated** on the rack model and are planned for removal in NetBox v5.0:
+
+    * Form factor
+    * Width
+    * Outer width
+    * Outer height
+    * Outer depth
+    * Outer unit
+
+    In a future release, the values for these attributes will be inferred from the rack's assigned [rack type](./racktype.md), which will become a mandatory assignment. Users are strongly encouraged to define these attributes on a rack type and assign it to each rack. (Note that the U height, starting unit, descending units, and mounting depth fields will be retained on the rack model, as these may legitimately vary among individual racks of the same type.)

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -1,6 +1,7 @@
 from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.core.validators import EMPTY_VALUES
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
 from timezone_field import TimeZoneFormField
 
@@ -410,14 +411,36 @@ class RackForm(TenancyForm, PrimaryModelForm):
             for field_name in Rack.RACKTYPE_FIELDS:
                 del self.fields[field_name]
         else:
+            # The form_factor, width, and outer_* fields are deprecated on the Rack model and will be removed in
+            # NetBox v5.0. Their values should instead be defined on an assigned rack type. (See #22593.)
+            deprecation_warning = format_html(
+                '<span class="text-warning"><i class="mdi mdi-alert"></i> {}</span>',
+                _(
+                    'Deprecated and will be removed in NetBox v5.0. Assign a rack type to define this attribute '
+                    'instead.'
+                )
+            )
+            self.fields['form_factor'].help_text = deprecation_warning
+            self.fields['width'].help_text = deprecation_warning
+
             self.fieldsets = (
                 *self.fieldsets,
                 FieldSet(
-                    'form_factor', 'width', 'starting_unit', 'u_height',
-                    InlineFields('outer_width', 'outer_height', 'outer_depth', 'outer_unit',
-                                 label=_('Outer Dimensions')),
-                    InlineFields('weight', 'max_weight', 'weight_unit', label=_('Weight')),
-                    'mounting_depth', 'desc_units', name=_('Dimensions')
+                    'form_factor',
+                    'width',
+                    'starting_unit',
+                    'u_height',
+                    InlineFields(
+                        'outer_width', 'outer_height', 'outer_depth', 'outer_unit',
+                        label=_('Outer Dimensions'),
+                        help_text=deprecation_warning,
+                    ),
+                    InlineFields(
+                        'weight', 'max_weight', 'weight_unit', label=_('Weight'),
+                    ),
+                    'mounting_depth',
+                    'desc_units',
+                    name=_('Dimensions')
                 ),
             )
 


### PR DESCRIPTION
### Closes: #22593

Deprecate the following fields on `dcim.Rack`:

- `form_factor`
- `width`
- `outer_width`
- `outer_height`
- `outer_depth`
- `outer_unit`
