### PR TITLE
Fixes #22767: Add comments field to search indexing for DeviceRole, MACAddress, Platform, and VLANTranslationPolicy

### DIFF
--- a/netbox/dcim/search.py
+++ b/netbox/dcim/search.py
@@ -84,6 +84,7 @@ class DeviceRoleIndex(SearchIndex):
         ('name', 100),
         ('slug', 110),
         ('description', 500),
+        ('comments', 5000),
     )
     display_attrs = ('description',)
 
@@ -117,6 +118,7 @@ class MACAddressIndex(SearchIndex):
     fields = (
         ('mac_address', 100),
         ('description', 500),
+        ('comments', 5000),
     )
     display_attrs = ('assigned_object', 'description')
 
@@ -239,6 +241,7 @@ class PlatformIndex(SearchIndex):
         ('name', 100),
         ('slug', 110),
         ('description', 500),
+        ('comments', 5000),
     )
     display_attrs = ('manufacturer', 'description')
 

--- a/netbox/ipam/search.py
+++ b/netbox/ipam/search.py
@@ -172,6 +172,7 @@ class VLANTranslationPolicyIndex(SearchIndex):
     fields = (
         ('name', 100),
         ('description', 500),
+        ('comments', 5000),
     )
     display_attrs = ('description',)
 


### PR DESCRIPTION
### Closes: netbox-community/netbox#22767

Include comments field with weight 5000 in search indexes for DeviceRole, MACAddress, Platform, and VLANTranslationPolicy models to enable full-text search on comment content.