### PR TITLE
Fixes #22690: Restore the left border on the quick search field

### DIFF
--- a/netbox/templates/inc/table_controls_htmx.html
+++ b/netbox/templates/inc/table_controls_htmx.html
@@ -7,8 +7,9 @@
 
 <div class="row mb-3" id="results">
   <div class="col-auto d-print-none">
-    <div class="input-group input-group-flat me-2 quicksearch" hx-disinherit="hx-select hx-swap">
       <label for="quicksearch" class="visually-hidden">{% trans "Quick search" %}</label>
+
+    <div class="input-group input-group-flat me-2 quicksearch" hx-disinherit="hx-select hx-swap">
       <input type="search" results="5" name="q" id="quicksearch" class="form-control" placeholder="{% trans "Quick search" %}"
           hx-get="{{ request.full_path }}" hx-target="#object_list" hx-trigger="keyup changed delay:500ms, search"/>
       <span class="input-group-text py-1">

--- a/netbox/templates/inc/table_controls_htmx.html
+++ b/netbox/templates/inc/table_controls_htmx.html
@@ -7,8 +7,7 @@
 
 <div class="row mb-3" id="results">
   <div class="col-auto d-print-none">
-      <label for="quicksearch" class="visually-hidden">{% trans "Quick search" %}</label>
-
+    <label for="quicksearch" class="visually-hidden">{% trans "Quick search" %}</label>
     <div class="input-group input-group-flat me-2 quicksearch" hx-disinherit="hx-select hx-swap">
       <input type="search" results="5" name="q" id="quicksearch" class="form-control" placeholder="{% trans "Quick search" %}"
           hx-get="{{ request.full_path }}" hx-target="#object_list" hx-trigger="keyup changed delay:500ms, search"/>


### PR DESCRIPTION
Closes #22690

## Summary

Moves the visually hidden label outside of the `.input-group` so that the quick search input remains the first child of the input group.

This restores the left border and border radius while preserving the accessible label association.