### PR TITLE
Fixes #22800: Fix filtering of Circuit Group Assignments by member type

### DIFF
--- a/netbox/circuits/filtersets.py
+++ b/netbox/circuits/filtersets.py
@@ -405,6 +405,11 @@ class CircuitGroupAssignmentFilterSet(NetBoxModelFilterSet):
         label=_('Search'),
     )
     member_type = MultiValueContentTypeFilter()
+    member_type_id = django_filters.ModelMultipleChoiceFilter(
+        field_name='member_type',
+        queryset=ContentType.objects.all(),
+        distinct=False,
+    )
     circuit = MultiValueCharFilter(
         method='filter_circuit',
         field_name='cid',
@@ -450,7 +455,7 @@ class CircuitGroupAssignmentFilterSet(NetBoxModelFilterSet):
 
     class Meta:
         model = CircuitGroupAssignment
-        fields = ('id', 'member_id', 'priority')
+        fields = ('id', 'member_type_id', 'member_id', 'priority')
 
     def search(self, queryset, name, value):
         if not value.strip():

--- a/netbox/circuits/tests/test_filtersets.py
+++ b/netbox/circuits/tests/test_filtersets.py
@@ -1,3 +1,4 @@
+from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase
 
 from circuits.choices import *
@@ -778,6 +779,30 @@ class CircuitGroupAssignmentTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
         params = {'virtual_circuit': [virtual_circuits[0].cid, virtual_circuits[1].cid]}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_member_type(self):
+        params = {'member_type': ['circuits.circuit']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+        params = {'member_type_id': [ContentType.objects.get_for_model(Circuit).pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+        params = {'member_type_id': [ContentType.objects.get_for_model(VirtualCircuit).pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+
+    def test_member(self):
+        """The member type and ID are matched together, so a matching ID of another type is excluded."""
+        circuit = Circuit.objects.first()
+        circuit_type = ContentType.objects.get_for_model(Circuit)
+        virtual_circuit_type = ContentType.objects.get_for_model(VirtualCircuit)
+        expected = self.queryset.get(member_type=circuit_type, member_id=circuit.pk)
+
+        # A virtual circuit assignment sharing the circuit's object ID must not match
+        group = CircuitGroup.objects.create(name='Circuit Group 4', slug='circuit-group-4')
+        CircuitGroupAssignment.objects.create(
+            group=group, member_type=virtual_circuit_type, member_id=circuit.pk
+        )
+
+        params = {'member_type_id': [circuit_type.pk], 'member_id': [circuit.pk]}
+        self.assertEqual(list(self.filterset(params, self.queryset).qs), [expected])
 
     def test_provider(self):
         providers = Provider.objects.all()[:2]


### PR DESCRIPTION
### Closes: netbox-community/netbox#22800

Adds the missing `member_type_id` filter to `CircuitGroupAssignmentFilterSet`, allowing assignments to be filtered by their numeric ContentType ID alongside the existing `member_type` filter.

Also adds regression coverage to verify that `member_type_id` is handled correctly and that the member type and member ID filters are applied together when an assignment of another member type uses the same stored member ID.