### PR TITLE
Reuse initialized FilterSet when checking for applied filters

### DIFF
--- a/netbox/ipam/tests/test_views.py
+++ b/netbox/ipam/tests/test_views.py
@@ -13,10 +13,11 @@ from dcim.constants import InterfaceTypeChoices
 from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
 from extras.choices import CustomFieldTypeChoices
 from extras.models import CustomField, SavedFilter
+from ipam import filtersets
 from ipam.choices import *
 from ipam.models import *
 from ipam.utils import AvailableIPSpace
-from ipam.views import AggregatePrefixesView, ChildAvailabilityMixin, PrefixPrefixesView
+from ipam.views import AggregatePrefixesView, PrefixPrefixesView
 from netbox.choices import CSVDelimiterChoices, ImportFormatChoices
 from tenancy.models import Tenant
 from users.models import Group, ObjectPermission
@@ -458,21 +459,6 @@ class AggregateTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         request.user = self.user
         return view._has_active_child_filters(request)
 
-    def test_is_filter_param_semantics(self):
-        """_is_filter_param recognizes declared filters, saved filter references, custom fields, and lookups."""
-        base_filters = {'description': None, 'tenant_id': None, 'mask_length__gte': None}
-
-        self.assertTrue(ChildAvailabilityMixin._is_filter_param('tenant_id', base_filters))
-        self.assertTrue(ChildAvailabilityMixin._is_filter_param('filter', base_filters))
-        self.assertTrue(ChildAvailabilityMixin._is_filter_param('filter_id', base_filters))
-        self.assertTrue(ChildAvailabilityMixin._is_filter_param('cf_anything', base_filters))
-        # A lookup variant may be registered only on the instance, so it is deliberately absent here.
-        self.assertTrue(ChildAvailabilityMixin._is_filter_param('description__empty', base_filters))
-        # A declared name may contain a lookup separator without a bare base filter.
-        self.assertTrue(ChildAvailabilityMixin._is_filter_param('mask_length__gte', base_filters))
-        self.assertFalse(ChildAvailabilityMixin._is_filter_param('page', base_filters))
-        self.assertFalse(ChildAvailabilityMixin._is_filter_param('unknown__empty', base_filters))
-
     def test_has_active_child_filters_declared_filters(self):
         """A declared filter with a real value counts as active filtering."""
         self.add_permissions('ipam.view_aggregate', 'ipam.view_prefix')
@@ -565,38 +551,48 @@ class AggregateTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         request.user = self.user
         self.assertFalse(view._has_active_child_filters(request))
 
-    def test_has_active_child_filters_skips_table_controls(self):
-        """Table controls do not build the detector's filterset."""
-        filterset_class = AggregatePrefixesView.filterset
+    def test_has_active_child_filters_reuses_view_filterset(self):
+        """The detector evaluates the FilterSet already bound by the view, not a fresh one."""
+        aggregate = Aggregate.objects.create(prefix=IPNetwork('203.0.115.0/24'), rir=RIR.objects.first())
+        tenant = Tenant.objects.create(name='Reuse Tenant', slug='reuse-tenant')
+
         view = AggregatePrefixesView()
-        request = RequestFactory().get('/', {
-            'page': '2',
-            'per_page': '100',
-            'sort': 'prefix',
-            'tableconfig_id': '1',
-        })
+        request = RequestFactory().get('/')
         request.user = self.user
 
-        with patch.object(AggregatePrefixesView, 'filterset') as mock_filterset:
-            # A bare mock reports no members, so the real filter names must be supplied.
-            mock_filterset.base_filters = filterset_class.base_filters
-            self.assertFalse(view._has_active_child_filters(request))
+        # The bound FilterSet is authoritative: it reports a filter the request itself does not carry.
+        view.filterset_instance = AggregatePrefixesView.filterset(
+            {'tenant_id': [str(tenant.pk)]}, view.get_children(request, aggregate), request=request
+        )
 
-        mock_filterset.assert_not_called()
-
-    def test_has_active_child_filters_skips_empty_filter_values(self):
-        """Filters submitted without a value do not build the detector's filterset."""
-        filterset_class = AggregatePrefixesView.filterset
-        view = AggregatePrefixesView()
-        request = RequestFactory().get('/', {'tenant_id': '', 'status': ''})
+        request = RequestFactory().get('/', {'page': '2'})
         request.user = self.user
+        self.assertTrue(view._has_active_child_filters(request))
 
-        with patch.object(AggregatePrefixesView, 'filterset') as mock_filterset:
-            # A bare mock reports no members, so the real filter names must be supplied.
-            mock_filterset.base_filters = filterset_class.base_filters
-            self.assertFalse(view._has_active_child_filters(request))
+    def test_child_tab_binds_filterset_once(self):
+        """A filtered child tab binds the FilterSet once; the detector reuses it instead of rebuilding."""
+        self.add_permissions('ipam.view_aggregate', 'ipam.view_prefix')
+        aggregate = Aggregate.objects.create(prefix=IPNetwork('203.0.116.0/24'), rir=RIR.objects.first())
+        tenant = Tenant.objects.create(name='Bind Once Tenant', slug='bind-once-tenant')
+        Prefix.objects.create(prefix=IPNetwork('203.0.116.0/26'), tenant=tenant)
 
-        mock_filterset.assert_not_called()
+        # Count only data-bound instantiations: the filter form separately builds an unbound
+        # FilterSet to resolve field modifiers, which is unrelated to filter detection.
+        bound = []
+        original_init = filtersets.PrefixFilterSet.__init__
+
+        def counting_init(fs, *args, **kwargs):
+            if args or 'data' in kwargs:
+                bound.append(fs)
+            original_init(fs, *args, **kwargs)
+
+        url = reverse('ipam:aggregate_prefixes', kwargs={'pk': aggregate.pk})
+        with patch.object(filtersets.PrefixFilterSet, '__init__', counting_init):
+            response = self.client.get(url, {'tenant_id': tenant.pk})
+
+        self.assertHttpStatus(response, 200)
+        self.assertEqual(len(bound), 1)
+        self.assertFalse(response.context['show_available'])
 
 
 class RoleTestCase(ViewTestCases.OrganizationalObjectViewTestCase):

--- a/netbox/ipam/views.py
+++ b/netbox/ipam/views.py
@@ -557,20 +557,21 @@ class ChildAvailabilityMixin:
     misrepresented as available space.
     """
 
-    @staticmethod
-    def _is_filter_param(param, base_filters):
+    def _get_detection_filterset(self, request):
         """
-        Return whether a query parameter could activate a filter. Saved filter references are read as
-        raw data rather than declared filters, and custom field filters are registered on the filterset
-        instance, so neither appears in base_filters.
+        Return the bound FilterSet used to evaluate the request, or None if the view declares no
+        filterset. ObjectChildrenView.get() has already built one and validated its form while
+        resolving the child queryset, so reuse it rather than paying for a second FilterSet:
+        get_filters() regenerates every dynamic lookup variant and NetBoxModelFilterSet.__init__
+        queries the custom fields for the model. Build one only for direct calls where get() has
+        not run.
         """
-        if param in base_filters or param.startswith('cf_') or param in ('filter', 'filter_id'):
-            return True
+        if self.filterset_instance is not None:
+            return self.filterset_instance
+        if self.filterset is None:
+            return None
 
-        # Lookup variants are named <filter>__<lookup> and some are generated after the class is
-        # built, so fall back to the base filter name.
-        base_name, separator, _ = param.rpartition('__')
-        return bool(separator) and base_name in base_filters
+        return self.filterset(request.GET, request=request)
 
     def _has_active_child_filters(self, request):
         """
@@ -585,21 +586,18 @@ class ChildAvailabilityMixin:
             return self._active_child_filters
 
         self._active_child_filters = False
-        if self.filterset is None or not request.GET:
+
+        # An empty request cannot activate a filter, so skip validating a form for nothing.
+        if not request.GET:
             return False
 
-        # A request holding only table controls, or only filters submitted without a value, cannot
-        # activate a filter, so it never builds a filterset.
-        base_filters = self.filterset.base_filters
-        if not any(
-            self._is_filter_param(param, base_filters) and any(request.GET.getlist(param))
-            for param in request.GET
-        ):
+        filterset = self._get_detection_filterset(request)
+        if filterset is None:
             return False
 
         # A non-empty cleaned value means the request activated a declared filter. Emptiness
         # follows each filter's own semantics, so absent multi-value fields stay inactive.
-        filterset = self.filterset(request.GET, request=request)
+        # This is a no-op for a reused FilterSet: .qs validated the form to build the queryset.
         filterset.form.is_valid()
         for name, value in filterset.form.cleaned_data.items():
             if isinstance(filterset.filters[name], django_filters.MultipleChoiceFilter):

--- a/netbox/netbox/views/generic/object_views.py
+++ b/netbox/netbox/views/generic/object_views.py
@@ -98,12 +98,14 @@ class ObjectChildrenView(ObjectView, ActionsMixin, TableMixin):
         table: The django-tables2 Table class used to render the child objects list
         filterset: A django-filter FilterSet that is applied to the queryset
         filterset_form: The form class used to render filter options
+        filterset_instance: The bound FilterSet built for the current request (set during get())
         actions: An iterable of ObjectAction subclasses (see ActionsMixin)
     """
     child_model = None
     table = None
     filterset = None
     filterset_form = None
+    filterset_instance = None
     actions = (CloneObject, EditObject, DeleteObject, BulkEdit, BulkDelete)
     template_name = 'generic/object_children.html'
 
@@ -142,7 +144,10 @@ class ObjectChildrenView(ObjectView, ActionsMixin, TableMixin):
         child_objects = self.get_children(request, instance)
 
         if self.filterset:
-            child_objects = self.filterset(request.GET, child_objects, request=request).qs
+            # Retain the bound FilterSet so that prep_table_data() and get_extra_context() can
+            # inspect the request's validated filter data without rebuilding it.
+            self.filterset_instance = self.filterset(request.GET, child_objects, request=request)
+            child_objects = self.filterset_instance.qs
 
         # Determine the available actions
         actions = self.get_permitted_actions(request.user, model=self.child_model)


### PR DESCRIPTION
Claude suggested this optimization during review of PR #22785. I've captured it in a separate PR here to easily convey the proposed changes without interfering with the branch itself. I'm normally hesitant to pursue opportunistic optimizations in the course of fixing a bug as they tend toward scope creep, but in this case I think it may be warranted because

1. It avoids a double initialization of the filterset, which can be mildly expensive (including a database query which checks for custom fields)
2. It sheds the somewhat fragile logic inside `_is_filter_param()`

I've included Claude's summary below. @pheus it's your call on whether you want to incorporate this change.

---

**1. `ObjectChildrenView` retains its bound FilterSet** (`object_views.py:104-150`) — one new class attribute and a two-line change in `get()`. The FilterSet was already being built and thrown away; now `prep_table_data()` and `get_extra_context()` can see it.

**2. `_get_detection_filterset()` replaces `_is_filter_param()`** (`ipam/views.py:560-574`). Reuse the view's instance when present; build one only for direct calls where `get()` hasn't run (the unit tests). All the heuristics are gone — no `cf_` prefix special-case, no `('filter', 'filter_id')` list, no `rpartition('__')` fallback, no dependence on the deliberately-stale class-level `base_filters`. The reused instance's `filters` dict is authoritative: custom-field filters were registered in `NetBoxModelFilterSet.__init__`, and post-`apps.ready` `__empty` lookups are in its per-instance `base_filters`.

**3. Detection is now free on the real path.** django-filter's `qs` property accesses `self.errors` before filtering (`filterset.py:244-252`), so the form is already validated by the time `prep_table_data()` runs. `filterset.form.is_valid()` hits Django's cached `_errors` and returns immediately — the loop over `cleaned_data` is all that's left. The `not request.GET` guard stays, since it still saves a full form validation on the fallback path.

## Measured before/after

One filtered `?tenant_id=…` request to an Aggregate's Prefixes tab, template rendering stubbed:

|                             | data-bound FilterSets | queries |
| --------------------------- | --------------------- | ------- |
| PR as submitted             | 2                     | 20      |
| with the changes            | 1                     | 18      |
| unfiltered request (either) | 0                     | 17      |

Two queries and one full `get_filters()` regeneration saved per filtered child-tab request. Unfiltered requests were already short-circuited, so they're unchanged — this confirms the win is confined to the filtered path, as expected.