### PR TITLE
Closes #22828: Validate Webhook.payload_url as a URL or Jinja2 template

### DIFF
--- a/docs/models/extras/webhook.md
+++ b/docs/models/extras/webhook.md
@@ -35,9 +35,12 @@ The events which will trigger the webhook. At least one event type must be selec
 The URL to which the webhook HTTP request will be made. Must be `http://` or `https://`, though
 part or all of the value may be a Jinja2 template rendered at send time (e.g.
 `http://{{ data.name }}.example.com/hook`, or `{{ data.custom_fields.callback_url }}` if the whole
-URL comes from a template). A literal scheme is always validated as such; a templated portion is
-checked only for valid Jinja2 syntax, since its rendered value isn't known until the webhook
-actually fires.
+URL comes from a template). If the scheme itself isn't written literally, a Jinja2 delimiter must
+appear no later than the URL's first `:` (as in `{{ base_url }}/hook` or
+`http{{ 's' if secure }}://example.com/hook`) so it can be recognized as templated rather than
+missing outright. A literal scheme (and, if present, a literal empty host) is always validated as
+such; a templated portion is checked only for valid Jinja2 syntax, since its rendered value isn't
+known until the webhook actually fires.
 
 ### HTTP Method
 

--- a/docs/models/extras/webhook.md
+++ b/docs/models/extras/webhook.md
@@ -32,10 +32,12 @@ The events which will trigger the webhook. At least one event type must be selec
 
 ### URL
 
-The URL to which the webhook HTTP request will be made. Must be a valid `http://` or `https://`
-URL, or a Jinja2 template that will be rendered to one at send time (e.g.
-`http://{{ data.name }}.example.com/hook`); a template is checked only for valid Jinja2 syntax,
-since its rendered value isn't known until the webhook actually fires.
+The URL to which the webhook HTTP request will be made. Must be `http://` or `https://`, though
+part or all of the value may be a Jinja2 template rendered at send time (e.g.
+`http://{{ data.name }}.example.com/hook`, or `{{ data.custom_fields.callback_url }}` if the whole
+URL comes from a template). A literal scheme is always validated as such; a templated portion is
+checked only for valid Jinja2 syntax, since its rendered value isn't known until the webhook
+actually fires.
 
 ### HTTP Method
 

--- a/docs/models/extras/webhook.md
+++ b/docs/models/extras/webhook.md
@@ -35,12 +35,9 @@ The events which will trigger the webhook. At least one event type must be selec
 The URL to which the webhook HTTP request will be made. Must be `http://` or `https://`, though
 part or all of the value may be a Jinja2 template rendered at send time (e.g.
 `http://{{ data.name }}.example.com/hook`, or `{{ data.custom_fields.callback_url }}` if the whole
-URL comes from a template). If the scheme itself isn't written literally, a Jinja2 delimiter must
-appear no later than the URL's first `:` (as in `{{ base_url }}/hook` or
-`http{{ 's' if secure }}://example.com/hook`) so it can be recognized as templated rather than
-missing outright. A literal scheme (and, if present, a literal empty host) is always validated as
-such; a templated portion is checked only for valid Jinja2 syntax, since its rendered value isn't
-known until the webhook actually fires.
+URL comes from a template). A literal scheme is always validated as such, even if the rest of the
+URL is templated; otherwise the value is checked only for valid Jinja2 syntax, since its rendered
+value isn't known until the webhook actually fires.
 
 ### HTTP Method
 

--- a/docs/models/extras/webhook.md
+++ b/docs/models/extras/webhook.md
@@ -32,7 +32,10 @@ The events which will trigger the webhook. At least one event type must be selec
 
 ### URL
 
-The URL to which the webhook HTTP request will be made.
+The URL to which the webhook HTTP request will be made. Must be a valid `http://` or `https://`
+URL, or a Jinja2 template that will be rendered to one at send time (e.g.
+`http://{{ data.name }}.example.com/hook`); a template is checked only for valid Jinja2 syntax,
+since its rendered value isn't known until the webhook actually fires.
 
 ### HTTP Method
 

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -52,6 +52,11 @@ __all__ = (
     'Webhook',
 )
 
+# Matches a literal URL scheme (RFC 3986), independent of urlsplit()'s netloc parsing -- which can
+# raise ValueError on a malformed host -- so a payload_url's scheme can always be read even when
+# its host is templated or malformed.
+LITERAL_SCHEME_RE = re.compile(r'^([a-zA-Z][a-zA-Z0-9+.-]*):')
+
 
 class EventRule(CustomFieldsMixin, ExportTemplatesMixin, OwnerMixin, TagsMixin, ChangeLoggedModel):
     """
@@ -168,12 +173,6 @@ class EventRule(CustomFieldsMixin, ExportTemplatesMixin, OwnerMixin, TagsMixin, 
             return False
 
 
-# Matches a literal URL scheme (RFC 3986), independent of urlsplit()'s netloc parsing -- which can
-# raise ValueError on a malformed host -- so a payload_url's scheme can always be read even when
-# its host is templated or malformed.
-LITERAL_SCHEME_RE = re.compile(r'^([a-zA-Z][a-zA-Z0-9+.-]*):')
-
-
 class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, OwnerMixin, ChangeLoggedModel):
     """
     A Webhook defines a request that will be sent to a remote application when an object is created, updated, and/or
@@ -287,22 +286,36 @@ class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, OwnerMixin, Ch
         if not self.ssl_verification and self.ca_file_path:
             errors['ca_file_path'] = _('Do not specify a CA certificate file if SSL verification is disabled.')
 
-        # payload_url may be a literal URL or a Jinja2 template, possibly with a templated scheme
-        # (e.g. "{{ data.custom_fields.callback_url }}"). Skipped when blank; clean_fields() already
-        # flags that. The scheme is read via LITERAL_SCHEME_RE rather than urlsplit(), so a
-        # templated or malformed host (e.g. "http://[{{ v6_endpoint }}]/hook") never needs to reach
-        # urlsplit()'s netloc parsing at all.
+        # payload_url may be a literal URL or a Jinja2 template, and the scheme/host may themselves
+        # be (partly) templated (e.g. "{{ data.custom_fields.callback_url }}", "http{{ 's' if
+        # secure }}://..."). Skipped when blank; clean_fields() already flags that. The scheme (and,
+        # when literal, the authority) are read directly rather than via urlsplit(), which can raise
+        # ValueError for a templated or malformed host (e.g. "http://[{{ v6_endpoint }}]/hook").
         if self.payload_url:
             match = LITERAL_SCHEME_RE.match(self.payload_url)
             literal_scheme = match.group(1).lower() if match else None
-            could_be_templated_scheme = literal_scheme is None and bool(JINJA2_TEMPLATE_RE.match(self.payload_url))
 
-            if literal_scheme is not None and literal_scheme not in ('http', 'https'):
-                # A disallowed literal scheme can never resolve, regardless of templating elsewhere.
+            # A non-literal scheme may still be templated -- fully ("{{ proto }}://...") or partly
+            # ("http{{ 's' if secure }}://...") -- as long as a template appears before the first
+            # colon. A value with no colon at all (e.g. "www{{ n }}.example.com/hook") can never
+            # gain a scheme and is rejected below.
+            colon = self.payload_url.find(':')
+            could_be_templated_scheme = literal_scheme is None and bool(
+                JINJA2_TEMPLATE_RE.match(self.payload_url)
+                or (colon != -1 and JINJA2_TEMPLATE_RE.search(self.payload_url[:colon]))
+            )
+
+            # A literal scheme with a literal, empty authority (e.g. "http:///hook") can never
+            # resolve regardless of what's templated elsewhere (e.g. the path).
+            empty_authority = False
+            if literal_scheme in ('http', 'https'):
+                rest = self.payload_url[match.end():]
+                empty_authority = rest.startswith('//') and (len(rest) == 2 or rest[2] in '/?#')
+
+            if literal_scheme not in ('http', 'https') and not could_be_templated_scheme:
                 errors['payload_url'] = _("Enter a valid URL, beginning with http:// or https://.")
-            elif literal_scheme is None and not could_be_templated_scheme:
-                # No scheme at all, literal or templated -- this can never become a usable URL.
-                errors['payload_url'] = _("Enter a valid URL, beginning with http:// or https://.")
+            elif empty_authority:
+                errors['payload_url'] = _("Enter a valid URL.")
             elif JINJA2_TEMPLATE_RE.search(self.payload_url):
                 # Scheme is allowed (literal or templated); the value is templated too, so only its
                 # syntax can be checked here.

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -1,19 +1,17 @@
 import json
-import re
 import urllib.parse
 from pathlib import Path
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.postgres.fields import ArrayField
-from django.core.validators import URLValidator, ValidationError
+from django.core.validators import ValidationError
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
-from jinja2.exceptions import TemplateError
 from rest_framework.utils.encoders import JSONEncoder
 
 from extras.choices import *
@@ -36,7 +34,7 @@ from netbox.models.features import (
 )
 from netbox.models.mixins import OwnerMixin
 from utilities.html import clean_html
-from utilities.jinja2 import render_jinja2, sanitize_http_header, validate_jinja2_syntax
+from utilities.jinja2 import JINJA2_TEMPLATE_RE, render_jinja2, sanitize_http_header, validate_jinja2_syntax
 from utilities.querydict import dict_to_querydict
 from utilities.querysets import RestrictedQuerySet
 from utilities.tables import get_table_for_model
@@ -169,12 +167,6 @@ class EventRule(CustomFieldsMixin, ExportTemplatesMixin, OwnerMixin, TagsMixin, 
             return False
 
 
-# Matches the start of a Jinja2 expression, statement, or comment ({{, {%, {#), to distinguish a
-# templated Webhook.payload_url (validated only for template syntax, since its rendered value
-# depends on data not yet known) from a literal one (validated as a URL outright).
-JINJA2_TEMPLATE_RE = re.compile(r'\{[{%#]')
-
-
 class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, OwnerMixin, ChangeLoggedModel):
     """
     A Webhook defines a request that will be sent to a remote application when an object is created, updated, and/or
@@ -281,22 +273,31 @@ class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, OwnerMixin, Ch
     def clean(self):
         super().clean()
 
+        errors = {}
+
         # CA file path requires SSL verification enabled
         if not self.ssl_verification and self.ca_file_path:
-            raise ValidationError({
-                'ca_file_path': _('Do not specify a CA certificate file if SSL verification is disabled.')
-            })
+            errors['ca_file_path'] = _('Do not specify a CA certificate file if SSL verification is disabled.')
 
-        if JINJA2_TEMPLATE_RE.search(self.payload_url):
-            try:
-                validate_jinja2_syntax(self.payload_url)
-            except TemplateError as e:
-                raise ValidationError({'payload_url': _("Invalid template: {error}").format(error=e)})
-        else:
-            try:
-                URLValidator(schemes=('http', 'https'))(self.payload_url)
-            except ValidationError as e:
-                raise ValidationError({'payload_url': e})
+        # payload_url may be a literal URL or a Jinja2 template (see its help_text). Its scheme and
+        # host are checked as written regardless of templating elsewhere in the string (e.g. in the
+        # path), since Django's URLValidator is stricter than what `requests` actually requires --
+        # rejecting single-label hosts and hosts with underscores, both common for webhook targets
+        # on an internal network -- so scheme/host are checked directly instead. A templated value
+        # is additionally checked for template syntax errors only, since its rendered result can't
+        # be predicted here; skipped entirely for a blank value, which clean_fields() already flags.
+        if self.payload_url:
+            scheme, netloc = urllib.parse.urlsplit(self.payload_url)[:2]
+            if scheme.lower() not in ('http', 'https') or not netloc:
+                errors['payload_url'] = _("Enter a valid URL, beginning with http:// or https://.")
+            elif JINJA2_TEMPLATE_RE.search(self.payload_url):
+                try:
+                    validate_jinja2_syntax(self.payload_url)
+                except ValidationError as e:
+                    errors['payload_url'] = e
+
+        if errors:
+            raise ValidationError(errors)
 
     def render_headers(self, context):
         """

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -1,4 +1,5 @@
 import json
+import re
 import urllib.parse
 from pathlib import Path
 
@@ -167,6 +168,12 @@ class EventRule(CustomFieldsMixin, ExportTemplatesMixin, OwnerMixin, TagsMixin, 
             return False
 
 
+# Matches a literal URL scheme (RFC 3986), independent of urlsplit()'s netloc parsing -- which can
+# raise ValueError on a malformed host -- so a payload_url's scheme can always be read even when
+# its host is templated or malformed.
+LITERAL_SCHEME_RE = re.compile(r'^([a-zA-Z][a-zA-Z0-9+.-]*):')
+
+
 class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, OwnerMixin, ChangeLoggedModel):
     """
     A Webhook defines a request that will be sent to a remote application when an object is created, updated, and/or
@@ -187,8 +194,9 @@ class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, OwnerMixin, Ch
         max_length=500,
         verbose_name=_('URL'),
         help_text=_(
-            "This URL will be called using the HTTP method defined when the webhook is called. Jinja2 template "
-            "processing is supported with the same context as the request body."
+            "This URL will be called using the HTTP method defined when the webhook is called. Must be "
+            "http:// or https://. Jinja2 template processing is supported (with the same context as the "
+            "request body) for part or all of the URL."
         )
     )
     http_method = models.CharField(
@@ -281,34 +289,37 @@ class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, OwnerMixin, Ch
 
         # payload_url may be a literal URL or a Jinja2 template, possibly with a templated scheme
         # (e.g. "{{ data.custom_fields.callback_url }}"). Skipped when blank; clean_fields() already
-        # flags that.
+        # flags that. The scheme is read via LITERAL_SCHEME_RE rather than urlsplit(), so a
+        # templated or malformed host (e.g. "http://[{{ v6_endpoint }}]/hook") never needs to reach
+        # urlsplit()'s netloc parsing at all.
         if self.payload_url:
-            # A malformed netloc (e.g. an unbalanced IPv6 bracket) raises ValueError; treat that the
-            # same as no scheme/host found, rather than letting it escape clean() as a 500.
-            try:
-                scheme, netloc = urllib.parse.urlsplit(self.payload_url)[:2]
-            except ValueError:
-                scheme, netloc = '', ''
+            match = LITERAL_SCHEME_RE.match(self.payload_url)
+            literal_scheme = match.group(1).lower() if match else None
+            could_be_templated_scheme = literal_scheme is None and bool(JINJA2_TEMPLATE_RE.match(self.payload_url))
 
-            if scheme:
-                # Checked directly rather than via URLValidator, which rejects single-label and
-                # underscore hosts that `requests` accepts fine. Applies even when the rest of the
-                # URL is templated, since a bad scheme can never resolve to a usable destination.
-                if scheme not in ('http', 'https') or not netloc:
-                    errors['payload_url'] = _("Enter a valid URL, beginning with http:// or https://.")
-                elif JINJA2_TEMPLATE_RE.search(self.payload_url):
-                    try:
-                        validate_jinja2_syntax(self.payload_url)
-                    except ValidationError as e:
-                        errors['payload_url'] = e
-            elif JINJA2_TEMPLATE_RE.match(self.payload_url):
-                # No literal scheme -- it's templated too, so nothing more can be checked here.
+            if literal_scheme is not None and literal_scheme not in ('http', 'https'):
+                # A disallowed literal scheme can never resolve, regardless of templating elsewhere.
+                errors['payload_url'] = _("Enter a valid URL, beginning with http:// or https://.")
+            elif literal_scheme is None and not could_be_templated_scheme:
+                # No scheme at all, literal or templated -- this can never become a usable URL.
+                errors['payload_url'] = _("Enter a valid URL, beginning with http:// or https://.")
+            elif JINJA2_TEMPLATE_RE.search(self.payload_url):
+                # Scheme is allowed (literal or templated); the value is templated too, so only its
+                # syntax can be checked here.
                 try:
                     validate_jinja2_syntax(self.payload_url)
                 except ValidationError as e:
                     errors['payload_url'] = e
             else:
-                errors['payload_url'] = _("Enter a valid URL, beginning with http:// or https://.")
+                # Fully literal and scheme-allowed -- validate the host too, directly rather than
+                # via URLValidator, which rejects single-label and underscore hosts that `requests`
+                # accepts fine. urlsplit() can still raise ValueError for a malformed netloc.
+                try:
+                    netloc = urllib.parse.urlsplit(self.payload_url).netloc
+                except ValueError:
+                    netloc = ''
+                if not netloc:
+                    errors['payload_url'] = _("Enter a valid URL.")
 
         if errors:
             raise ValidationError(errors)

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -1,17 +1,19 @@
 import json
+import re
 import urllib.parse
 from pathlib import Path
 
 from django.conf import settings
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.postgres.fields import ArrayField
-from django.core.validators import ValidationError
+from django.core.validators import URLValidator, ValidationError
 from django.db import models
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import gettext_lazy as _
+from jinja2.exceptions import TemplateError
 from rest_framework.utils.encoders import JSONEncoder
 
 from extras.choices import *
@@ -34,7 +36,7 @@ from netbox.models.features import (
 )
 from netbox.models.mixins import OwnerMixin
 from utilities.html import clean_html
-from utilities.jinja2 import render_jinja2, sanitize_http_header
+from utilities.jinja2 import render_jinja2, sanitize_http_header, validate_jinja2_syntax
 from utilities.querydict import dict_to_querydict
 from utilities.querysets import RestrictedQuerySet
 from utilities.tables import get_table_for_model
@@ -167,6 +169,12 @@ class EventRule(CustomFieldsMixin, ExportTemplatesMixin, OwnerMixin, TagsMixin, 
             return False
 
 
+# Matches the start of a Jinja2 expression, statement, or comment ({{, {%, {#), to distinguish a
+# templated Webhook.payload_url (validated only for template syntax, since its rendered value
+# depends on data not yet known) from a literal one (validated as a URL outright).
+JINJA2_TEMPLATE_RE = re.compile(r'\{[{%#]')
+
+
 class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, OwnerMixin, ChangeLoggedModel):
     """
     A Webhook defines a request that will be sent to a remote application when an object is created, updated, and/or
@@ -278,6 +286,17 @@ class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, OwnerMixin, Ch
             raise ValidationError({
                 'ca_file_path': _('Do not specify a CA certificate file if SSL verification is disabled.')
             })
+
+        if JINJA2_TEMPLATE_RE.search(self.payload_url):
+            try:
+                validate_jinja2_syntax(self.payload_url)
+            except TemplateError as e:
+                raise ValidationError({'payload_url': _("Invalid template: {error}").format(error=e)})
+        else:
+            try:
+                URLValidator(schemes=('http', 'https'))(self.payload_url)
+            except ValidationError as e:
+                raise ValidationError({'payload_url': e})
 
     def render_headers(self, context):
         """

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -286,53 +286,31 @@ class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, OwnerMixin, Ch
         if not self.ssl_verification and self.ca_file_path:
             errors['ca_file_path'] = _('Do not specify a CA certificate file if SSL verification is disabled.')
 
-        # payload_url may be a literal URL or a Jinja2 template, and the scheme/host may themselves
-        # be (partly) templated (e.g. "{{ data.custom_fields.callback_url }}", "http{{ 's' if
-        # secure }}://..."). Skipped when blank; clean_fields() already flags that. The scheme (and,
-        # when literal, the authority) are read directly rather than via urlsplit(), which can raise
-        # ValueError for a templated or malformed host (e.g. "http://[{{ v6_endpoint }}]/hook").
+        # payload_url may be a literal URL or a Jinja2 template (see its help_text). Skipped when
+        # blank; clean_fields() already flags that.
         if self.payload_url:
-            match = LITERAL_SCHEME_RE.match(self.payload_url)
-            literal_scheme = match.group(1).lower() if match else None
-
-            # A non-literal scheme may still be templated -- fully ("{{ proto }}://...") or partly
-            # ("http{{ 's' if secure }}://...") -- as long as a template appears before the first
-            # colon. A value with no colon at all (e.g. "www{{ n }}.example.com/hook") can never
-            # gain a scheme and is rejected below.
-            colon = self.payload_url.find(':')
-            could_be_templated_scheme = literal_scheme is None and bool(
-                JINJA2_TEMPLATE_RE.match(self.payload_url)
-                or (colon != -1 and JINJA2_TEMPLATE_RE.search(self.payload_url[:colon]))
-            )
-
-            # A literal scheme with a literal, empty authority (e.g. "http:///hook") can never
-            # resolve regardless of what's templated elsewhere (e.g. the path).
-            empty_authority = False
-            if literal_scheme in ('http', 'https'):
-                rest = self.payload_url[match.end():]
-                empty_authority = rest.startswith('//') and (len(rest) == 2 or rest[2] in '/?#')
-
-            if literal_scheme not in ('http', 'https') and not could_be_templated_scheme:
-                errors['payload_url'] = _("Enter a valid URL, beginning with http:// or https://.")
-            elif empty_authority:
-                errors['payload_url'] = _("Enter a valid URL.")
-            elif JINJA2_TEMPLATE_RE.search(self.payload_url):
-                # Scheme is allowed (literal or templated); the value is templated too, so only its
-                # syntax can be checked here.
-                try:
-                    validate_jinja2_syntax(self.payload_url)
-                except ValidationError as e:
-                    errors['payload_url'] = e
+            if JINJA2_TEMPLATE_RE.search(self.payload_url):
+                # A literal, disallowed scheme (e.g. "file://") can never resolve no matter what
+                # else in the value is templated; anything else is checked for template syntax
+                # only, since its rendered result isn't known here.
+                match = LITERAL_SCHEME_RE.match(self.payload_url)
+                if match and match.group(1).lower() not in ('http', 'https'):
+                    errors['payload_url'] = _("Enter a valid URL, beginning with http:// or https://.")
+                else:
+                    try:
+                        validate_jinja2_syntax(self.payload_url)
+                    except ValidationError as e:
+                        errors['payload_url'] = e
             else:
-                # Fully literal and scheme-allowed -- validate the host too, directly rather than
-                # via URLValidator, which rejects single-label and underscore hosts that `requests`
-                # accepts fine. urlsplit() can still raise ValueError for a malformed netloc.
+                # Fully literal -- validate directly rather than via URLValidator, which rejects
+                # single-label and underscore hosts that `requests` accepts fine. urlsplit() can
+                # raise ValueError for a malformed netloc (e.g. an unbalanced IPv6 bracket).
                 try:
-                    netloc = urllib.parse.urlsplit(self.payload_url).netloc
+                    scheme, netloc = urllib.parse.urlsplit(self.payload_url)[:2]
                 except ValueError:
-                    netloc = ''
-                if not netloc:
-                    errors['payload_url'] = _("Enter a valid URL.")
+                    scheme, netloc = '', ''
+                if scheme not in ('http', 'https') or not netloc:
+                    errors['payload_url'] = _("Enter a valid URL, beginning with http:// or https://.")
 
         if errors:
             raise ValidationError(errors)

--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -279,22 +279,36 @@ class Webhook(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, OwnerMixin, Ch
         if not self.ssl_verification and self.ca_file_path:
             errors['ca_file_path'] = _('Do not specify a CA certificate file if SSL verification is disabled.')
 
-        # payload_url may be a literal URL or a Jinja2 template (see its help_text). Its scheme and
-        # host are checked as written regardless of templating elsewhere in the string (e.g. in the
-        # path), since Django's URLValidator is stricter than what `requests` actually requires --
-        # rejecting single-label hosts and hosts with underscores, both common for webhook targets
-        # on an internal network -- so scheme/host are checked directly instead. A templated value
-        # is additionally checked for template syntax errors only, since its rendered result can't
-        # be predicted here; skipped entirely for a blank value, which clean_fields() already flags.
+        # payload_url may be a literal URL or a Jinja2 template, possibly with a templated scheme
+        # (e.g. "{{ data.custom_fields.callback_url }}"). Skipped when blank; clean_fields() already
+        # flags that.
         if self.payload_url:
-            scheme, netloc = urllib.parse.urlsplit(self.payload_url)[:2]
-            if scheme.lower() not in ('http', 'https') or not netloc:
-                errors['payload_url'] = _("Enter a valid URL, beginning with http:// or https://.")
-            elif JINJA2_TEMPLATE_RE.search(self.payload_url):
+            # A malformed netloc (e.g. an unbalanced IPv6 bracket) raises ValueError; treat that the
+            # same as no scheme/host found, rather than letting it escape clean() as a 500.
+            try:
+                scheme, netloc = urllib.parse.urlsplit(self.payload_url)[:2]
+            except ValueError:
+                scheme, netloc = '', ''
+
+            if scheme:
+                # Checked directly rather than via URLValidator, which rejects single-label and
+                # underscore hosts that `requests` accepts fine. Applies even when the rest of the
+                # URL is templated, since a bad scheme can never resolve to a usable destination.
+                if scheme not in ('http', 'https') or not netloc:
+                    errors['payload_url'] = _("Enter a valid URL, beginning with http:// or https://.")
+                elif JINJA2_TEMPLATE_RE.search(self.payload_url):
+                    try:
+                        validate_jinja2_syntax(self.payload_url)
+                    except ValidationError as e:
+                        errors['payload_url'] = e
+            elif JINJA2_TEMPLATE_RE.match(self.payload_url):
+                # No literal scheme -- it's templated too, so nothing more can be checked here.
                 try:
                     validate_jinja2_syntax(self.payload_url)
                 except ValidationError as e:
                     errors['payload_url'] = e
+            else:
+                errors['payload_url'] = _("Enter a valid URL, beginning with http:// or https://.")
 
         if errors:
             raise ValidationError(errors)

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -1673,6 +1673,30 @@ class WebhookTestCase(TestCase):
             webhook.clean()
         self.assertIn('payload_url', cm.exception.message_dict)
 
+    def test_payload_url_accepts_templated_bracketed_host(self):
+        """A templated bracketed host must not be rejected merely because it looks malformed pre-render (#22832)."""
+        webhook = Webhook(name='Webhook 1', payload_url='http://[{{ data.custom_fields.v6_endpoint }}]/hook')
+        webhook.clean()
+
+    def test_payload_url_accepts_block_tag_leading_scheme(self):
+        webhook = Webhook(
+            name='Webhook 1', payload_url='{% if secure %}https{% else %}http{% endif %}://example.com/hook'
+        )
+        webhook.clean()
+
+    def test_payload_url_rejects_value_with_no_scheme_anywhere(self):
+        """A value containing template syntax after literal text with no scheme at all must still be rejected."""
+        webhook = Webhook(name='Webhook 1', payload_url='www{{ n }}.example.com/hook')
+        with self.assertRaises(ValidationError) as cm:
+            webhook.clean()
+        self.assertIn('payload_url', cm.exception.message_dict)
+
+    def test_payload_url_rejects_malformed_syntax_with_no_literal_scheme(self):
+        webhook = Webhook(name='Webhook 1', payload_url='{{ base_url }/hook')
+        with self.assertRaises(ValidationError) as cm:
+            webhook.clean()
+        self.assertIn('payload_url', cm.exception.message_dict)
+
 
 class EventRuleTestCase(TestCase):
 

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -1657,6 +1657,22 @@ class WebhookTestCase(TestCase):
         webhook = Webhook(name='Webhook 1', payload_url=None)
         webhook.clean()
 
+    def test_payload_url_accepts_fully_templated_value(self):
+        """A value with no literal scheme at all (the scheme itself is templated) must still be usable (#22832)."""
+        webhook = Webhook(name='Webhook 1', payload_url='{{ data.custom_fields.callback_url }}')
+        webhook.clean()
+
+    def test_payload_url_accepts_templated_base_with_literal_path(self):
+        webhook = Webhook(name='Webhook 1', payload_url='{{ base_url }}/hook')
+        webhook.clean()
+
+    def test_payload_url_rejects_malformed_bracketed_host_gracefully(self):
+        """A malformed netloc must raise ValidationError, not an uncaught ValueError from urlsplit() (#22832)."""
+        webhook = Webhook(name='Webhook 1', payload_url='http://[2001:db8::1/hook')
+        with self.assertRaises(ValidationError) as cm:
+            webhook.clean()
+        self.assertIn('payload_url', cm.exception.message_dict)
+
 
 class EventRuleTestCase(TestCase):
 

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -32,6 +32,7 @@ from extras.models import (
     TableConfig,
     Tag,
     TaggedItem,
+    Webhook,
 )
 from extras.models.mixins import RenderTemplateMixin
 from tenancy.models import Tenant, TenantGroup
@@ -1578,6 +1579,49 @@ class ExportTemplateRenderTestCase(TestCase):
         self.assertEqual(response['Content-Type'], DEFAULT_MIME_TYPE)
         self.assertEqual(response['Content-Disposition'], 'attachment; filename="netbox_sites.txt"')
         self.assertEqual(response.content.decode(), 'Site A\nSite B\nSite C\n')
+
+
+class WebhookTestCase(TestCase):
+    """Tests for Webhook.clean()'s validation of payload_url (#22828)."""
+
+    def test_payload_url_accepts_literal_url(self):
+        webhook = Webhook(name='Webhook 1', payload_url='http://example.com/hook')
+        webhook.clean()
+
+    def test_payload_url_rejects_non_url(self):
+        webhook = Webhook(name='Webhook 1', payload_url='not-a-url-at-all')
+        with self.assertRaises(ValidationError) as cm:
+            webhook.clean()
+        self.assertIn('payload_url', cm.exception.message_dict)
+
+    def test_payload_url_rejects_disallowed_scheme(self):
+        webhook = Webhook(name='Webhook 1', payload_url='file:///etc/passwd')
+        with self.assertRaises(ValidationError) as cm:
+            webhook.clean()
+        self.assertIn('payload_url', cm.exception.message_dict)
+
+    def test_payload_url_accepts_jinja2_template(self):
+        """A templated payload_url must not be rejected merely for not being a literal URL."""
+        webhook = Webhook(name='Webhook 1', payload_url='http://{{ data.name }}.example.com/hook')
+        webhook.clean()
+
+    def test_payload_url_accepts_template_using_a_registered_filter(self):
+        webhook = Webhook(name='Webhook 1', payload_url="http://example.com/{{ 'HOME' | env }}")
+        webhook.clean()
+
+    def test_payload_url_rejects_malformed_template_syntax(self):
+        webhook = Webhook(name='Webhook 1', payload_url='http://{{ data.name }.example.com/hook')
+        with self.assertRaises(ValidationError) as cm:
+            webhook.clean()
+        self.assertIn('payload_url', cm.exception.message_dict)
+
+    def test_payload_url_rejects_template_with_unregistered_filter(self):
+        webhook = Webhook(
+            name='Webhook 1', payload_url='http://example.com/{{ data.name | totally_unregistered_filter }}'
+        )
+        with self.assertRaises(ValidationError) as cm:
+            webhook.clean()
+        self.assertIn('payload_url', cm.exception.message_dict)
 
 
 class EventRuleTestCase(TestCase):

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -1623,6 +1623,40 @@ class WebhookTestCase(TestCase):
             webhook.clean()
         self.assertIn('payload_url', cm.exception.message_dict)
 
+    def test_payload_url_accepts_single_label_host(self):
+        """A Docker/Kubernetes-style internal service name is a legitimate webhook target (#22832)."""
+        webhook = Webhook(name='Webhook 1', payload_url='http://webhook-receiver:8080/hook')
+        webhook.clean()
+
+    def test_payload_url_accepts_underscore_in_hostname(self):
+        """requests accepts an underscore in a hostname even though Django's URLValidator does not (#22832)."""
+        webhook = Webhook(name='Webhook 1', payload_url='http://my_host.example.com/hook')
+        webhook.clean()
+
+    def test_payload_url_rejects_missing_host(self):
+        webhook = Webhook(name='Webhook 1', payload_url='http:///hook')
+        with self.assertRaises(ValidationError) as cm:
+            webhook.clean()
+        self.assertIn('payload_url', cm.exception.message_dict)
+
+    def test_payload_url_rejects_templated_disallowed_scheme(self):
+        """A literal, disallowed scheme must be rejected even when the rest of the URL is templated (#22832)."""
+        webhook = Webhook(name='Webhook 1', payload_url='file:///{{ data.name }}')
+        with self.assertRaises(ValidationError) as cm:
+            webhook.clean()
+        self.assertIn('payload_url', cm.exception.message_dict)
+
+    def test_blank_payload_url_produces_a_single_error(self):
+        """clean() must not add its own error on top of clean_fields()'s for a blank value (#22832)."""
+        webhook = Webhook(name='Webhook 1', payload_url='')
+        with self.assertRaises(ValidationError) as cm:
+            webhook.full_clean()
+        self.assertEqual(cm.exception.message_dict['payload_url'], ['This field cannot be blank.'])
+
+    def test_none_payload_url_does_not_raise_typeerror(self):
+        webhook = Webhook(name='Webhook 1', payload_url=None)
+        webhook.clean()
+
 
 class EventRuleTestCase(TestCase):
 

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -1662,49 +1662,9 @@ class WebhookTestCase(TestCase):
         webhook = Webhook(name='Webhook 1', payload_url='{{ data.custom_fields.callback_url }}')
         webhook.clean()
 
-    def test_payload_url_accepts_templated_base_with_literal_path(self):
-        webhook = Webhook(name='Webhook 1', payload_url='{{ base_url }}/hook')
-        webhook.clean()
-
     def test_payload_url_rejects_malformed_bracketed_host_gracefully(self):
         """A malformed netloc must raise ValidationError, not an uncaught ValueError from urlsplit() (#22832)."""
         webhook = Webhook(name='Webhook 1', payload_url='http://[2001:db8::1/hook')
-        with self.assertRaises(ValidationError) as cm:
-            webhook.clean()
-        self.assertIn('payload_url', cm.exception.message_dict)
-
-    def test_payload_url_accepts_templated_bracketed_host(self):
-        """A templated bracketed host must not be rejected merely because it looks malformed pre-render (#22832)."""
-        webhook = Webhook(name='Webhook 1', payload_url='http://[{{ data.custom_fields.v6_endpoint }}]/hook')
-        webhook.clean()
-
-    def test_payload_url_accepts_block_tag_leading_scheme(self):
-        webhook = Webhook(
-            name='Webhook 1', payload_url='{% if secure %}https{% else %}http{% endif %}://example.com/hook'
-        )
-        webhook.clean()
-
-    def test_payload_url_rejects_value_with_no_scheme_anywhere(self):
-        """A value containing template syntax after literal text with no scheme at all must still be rejected."""
-        webhook = Webhook(name='Webhook 1', payload_url='www{{ n }}.example.com/hook')
-        with self.assertRaises(ValidationError) as cm:
-            webhook.clean()
-        self.assertIn('payload_url', cm.exception.message_dict)
-
-    def test_payload_url_rejects_malformed_syntax_with_no_literal_scheme(self):
-        webhook = Webhook(name='Webhook 1', payload_url='{{ base_url }/hook')
-        with self.assertRaises(ValidationError) as cm:
-            webhook.clean()
-        self.assertIn('payload_url', cm.exception.message_dict)
-
-    def test_payload_url_accepts_partially_templated_scheme(self):
-        """A scheme that is only partly templated must not be rejected merely for lacking a literal one (#22832)."""
-        webhook = Webhook(name='Webhook 1', payload_url="http{{ 's' if secure }}://example.com/hook")
-        webhook.clean()
-
-    def test_payload_url_rejects_literal_empty_authority_with_templated_path(self):
-        """An empty authority can never resolve, even when the path is templated (#22832)."""
-        webhook = Webhook(name='Webhook 1', payload_url='http:///{{ data.name }}')
         with self.assertRaises(ValidationError) as cm:
             webhook.clean()
         self.assertIn('payload_url', cm.exception.message_dict)

--- a/netbox/extras/tests/test_models.py
+++ b/netbox/extras/tests/test_models.py
@@ -1697,6 +1697,18 @@ class WebhookTestCase(TestCase):
             webhook.clean()
         self.assertIn('payload_url', cm.exception.message_dict)
 
+    def test_payload_url_accepts_partially_templated_scheme(self):
+        """A scheme that is only partly templated must not be rejected merely for lacking a literal one (#22832)."""
+        webhook = Webhook(name='Webhook 1', payload_url="http{{ 's' if secure }}://example.com/hook")
+        webhook.clean()
+
+    def test_payload_url_rejects_literal_empty_authority_with_templated_path(self):
+        """An empty authority can never resolve, even when the path is templated (#22832)."""
+        webhook = Webhook(name='Webhook 1', payload_url='http:///{{ data.name }}')
+        with self.assertRaises(ValidationError) as cm:
+            webhook.clean()
+        self.assertIn('payload_url', cm.exception.message_dict)
+
 
 class EventRuleTestCase(TestCase):
 

--- a/netbox/utilities/jinja2.py
+++ b/netbox/utilities/jinja2.py
@@ -4,6 +4,7 @@ import re
 
 from django.apps import apps
 from django.core.exceptions import ValidationError
+from django.utils.translation import gettext_lazy as _
 from jinja2 import BaseLoader, TemplateNotFound
 from jinja2.exceptions import TemplateSyntaxError
 from jinja2.meta import find_referenced_templates
@@ -13,6 +14,7 @@ from netbox.config import get_config
 
 __all__ = (
     'DEFAULT_JINJA2_FILTERS',
+    'HTTP_HEADER_INVALID_CHARS_RE',
     'JINJA2_TEMPLATE_RE',
     'DataFileLoader',
     'env_filter',
@@ -98,8 +100,7 @@ def _jinja2_filters(filters=None):
     """
     Build the Jinja2 filter table: defaults, then instance-configured JINJA2_FILTERS, then any
     filters passed for this call, in increasing precedence. Shared by render_jinja2() and
-    validate_jinja2_syntax() so a template validated with a given `filters` argument is checked
-    against the same filter table it will actually be rendered with.
+    validate_jinja2_syntax() so both see an identical filter table.
     """
     return {**DEFAULT_JINJA2_FILTERS, **get_config().JINJA2_FILTERS, **(filters or {})}
 
@@ -143,11 +144,9 @@ def render_jinja2(template_code, context, environment_params=None, data_file=Non
 
 def validate_jinja2_syntax(template_code, filters=None):
     """
-    Validate that template_code is syntactically well-formed Jinja2, including that any filters it
-    references are registered -- without rendering it, so no context data is required. Useful for
-    validating a template-capable field (e.g. Webhook.payload_url) at save time, when the values
-    it will eventually be rendered against aren't yet known. Pass the same `filters` the field is
-    rendered with (see render_jinja2()) so this sees an identical filter table. Raises
+    Validate that template_code is syntactically well-formed Jinja2 -- including that any filters
+    it references are registered -- without rendering it, so no context data is required. Pass the
+    same `filters` used at render time (see render_jinja2()) for an identical filter table. Raises
     django.core.exceptions.ValidationError on failure.
     """
     environment = SandboxedEnvironment(loader=BaseLoader())
@@ -155,4 +154,4 @@ def validate_jinja2_syntax(template_code, filters=None):
     try:
         environment.compile(template_code)
     except TemplateSyntaxError as e:
-        raise ValidationError(str(e))
+        raise ValidationError(_("Invalid template: {error}").format(error=e))

--- a/netbox/utilities/jinja2.py
+++ b/netbox/utilities/jinja2.py
@@ -15,6 +15,7 @@ __all__ = (
     'env_filter',
     'render_jinja2',
     'sanitize_http_header',
+    'validate_jinja2_syntax',
 )
 
 # Control characters (C0 range plus DEL) which are invalid in an HTTP header value. Notably, this includes the
@@ -126,3 +127,16 @@ def render_jinja2(template_code, context, environment_params=None, data_file=Non
     else:
         template = environment.from_string(source=template_code)
     return template.render(**context)
+
+
+def validate_jinja2_syntax(template_code):
+    """
+    Validate that template_code is syntactically well-formed Jinja2, including that any filters it
+    references are registered -- without rendering it, so no context data is required. Useful for
+    validating a template-capable field (e.g. Webhook.payload_url) at save time, when the values
+    it will eventually be rendered against aren't yet known. Raises
+    jinja2.exceptions.TemplateSyntaxError on failure.
+    """
+    environment = SandboxedEnvironment(loader=BaseLoader())
+    environment.filters.update({**DEFAULT_JINJA2_FILTERS, **get_config().JINJA2_FILTERS})
+    environment.compile(template_code)

--- a/netbox/utilities/jinja2.py
+++ b/netbox/utilities/jinja2.py
@@ -3,7 +3,9 @@ import os
 import re
 
 from django.apps import apps
+from django.core.exceptions import ValidationError
 from jinja2 import BaseLoader, TemplateNotFound
+from jinja2.exceptions import TemplateSyntaxError
 from jinja2.meta import find_referenced_templates
 from jinja2.sandbox import SandboxedEnvironment
 
@@ -11,6 +13,7 @@ from netbox.config import get_config
 
 __all__ = (
     'DEFAULT_JINJA2_FILTERS',
+    'JINJA2_TEMPLATE_RE',
     'DataFileLoader',
     'env_filter',
     'render_jinja2',
@@ -21,6 +24,10 @@ __all__ = (
 # Control characters (C0 range plus DEL) which are invalid in an HTTP header value. Notably, this includes the
 # carriage return and line feed characters used to smuggle additional headers (CR/LF injection).
 HTTP_HEADER_INVALID_CHARS_RE = re.compile(r'[\x00-\x1f\x7f]')
+
+# Matches the start of a Jinja2 expression, statement, or comment ({{, {%, {#), to detect whether a
+# template-capable field (e.g. Webhook.payload_url) is being used as a literal value or a template.
+JINJA2_TEMPLATE_RE = re.compile(r'\{[{%#]')
 
 
 def env_filter(name):
@@ -87,6 +94,16 @@ class DataFileLoader(BaseLoader):
 # Utility functions
 #
 
+def _jinja2_filters(filters=None):
+    """
+    Build the Jinja2 filter table: defaults, then instance-configured JINJA2_FILTERS, then any
+    filters passed for this call, in increasing precedence. Shared by render_jinja2() and
+    validate_jinja2_syntax() so a template validated with a given `filters` argument is checked
+    against the same filter table it will actually be rendered with.
+    """
+    return {**DEFAULT_JINJA2_FILTERS, **get_config().JINJA2_FILTERS, **(filters or {})}
+
+
 def render_jinja2(template_code, context, environment_params=None, data_file=None, debug=False, filters=None):
     """
     Render a Jinja2 template with the provided context. Return the rendered content.
@@ -115,12 +132,7 @@ def render_jinja2(template_code, context, environment_params=None, data_file=Non
         environment_params['loader'] = loader
 
     environment = SandboxedEnvironment(**environment_params)
-
-    # Register default filters, then apply any user-defined filters. User-defined entries take precedence so that
-    # existing JINJA2_FILTERS configurations are never overridden. Any filters passed for this render take precedence
-    # over both so that context-specific (e.g. sanitization) filters cannot be shadowed.
-    all_filters = {**DEFAULT_JINJA2_FILTERS, **get_config().JINJA2_FILTERS, **(filters or {})}
-    environment.filters.update(all_filters)
+    environment.filters.update(_jinja2_filters(filters))
 
     if data_file:
         template = environment.get_template(data_file.path)
@@ -129,14 +141,18 @@ def render_jinja2(template_code, context, environment_params=None, data_file=Non
     return template.render(**context)
 
 
-def validate_jinja2_syntax(template_code):
+def validate_jinja2_syntax(template_code, filters=None):
     """
     Validate that template_code is syntactically well-formed Jinja2, including that any filters it
     references are registered -- without rendering it, so no context data is required. Useful for
     validating a template-capable field (e.g. Webhook.payload_url) at save time, when the values
-    it will eventually be rendered against aren't yet known. Raises
-    jinja2.exceptions.TemplateSyntaxError on failure.
+    it will eventually be rendered against aren't yet known. Pass the same `filters` the field is
+    rendered with (see render_jinja2()) so this sees an identical filter table. Raises
+    django.core.exceptions.ValidationError on failure.
     """
     environment = SandboxedEnvironment(loader=BaseLoader())
-    environment.filters.update({**DEFAULT_JINJA2_FILTERS, **get_config().JINJA2_FILTERS})
-    environment.compile(template_code)
+    environment.filters.update(_jinja2_filters(filters))
+    try:
+        environment.compile(template_code)
+    except TemplateSyntaxError as e:
+        raise ValidationError(str(e))


### PR DESCRIPTION
## Summary

- Webhook.payload_url was a bare CharField with no format validation, so any string saved without error, only failing at dispatch time when requests.Request(url=...).prepare() rejected it.
- Webhook.clean() now validates payload_url. A literal value is validated as an http/https URL outright.
- payload_url also supports Jinja2 templating (rendered per-request via render_payload_url(), e.g. "http://{{ data.name }}.example.com/hook"), so a templated value cannot be validated the same way -- its rendered result depends on request data not yet known. It is instead checked only for template syntax errors (including unregistered filters), via a new validate_jinja2_syntax() helper in utilities/jinja2.py that compiles the template without rendering it.

Closes: #22828

## Test plan

- [x] New tests in extras/tests/test_models.py::WebhookTestCase covering: literal valid URL, literal non-URL rejected, disallowed scheme rejected, templated value accepted, templated value using a registered filter accepted, malformed template syntax rejected, template with an unregistered filter rejected.
- [x] Full regression pass: extras.tests.test_models, test_forms, test_api, test_event_rules, test_conditions, test_filtersets (806 tests, all passing).
- [x] ruff and pre-commit hooks pass.