### PR TITLE
Closes #22727: Support for multiple WWNs

### DIFF
--- a/docs/features/devices-cabling.md
+++ b/docs/features/devices-cabling.md
@@ -19,6 +19,7 @@ click DeviceRole "../../models/dcim/devicerole/"
 click DeviceType "../../models/dcim/devicetype/"
 click Interface "../../models/dcim/interface/"
 click MACAddress "../../models/dcim/macaddress/"
+click WWNAddress "../../models/dcim/wwnaddress/"
 click Manufacturer "../../models/dcim/manufacturer/"
 click Module "../../models/dcim/module/"
 click ModuleType "../../models/dcim/moduletype/"
@@ -90,6 +91,10 @@ One especially nice feature of modules is that templated components can be autom
 ## MAC Addresses
 
 [MAC addresses](../models/dcim/macaddress.md) are modeled as first-class objects in NetBox so that an interface may have multiple MAC addresses assigned to it, with one optionally designated as the interface's primary MAC. This accommodates virtual interfaces and modular hardware where the link-layer address is not necessarily fixed at the factory. MAC addresses can be assigned to both [device interfaces](../models/dcim/interface.md) and [virtual machine interfaces](../models/virtualization/vminterface.md).
+
+## WWN Addresses
+
+[WWN addresses](../models/dcim/wwnaddress.md) are modeled as first-class objects in NetBox so that an interface may have multiple WWN addresses assigned to it, with one optionally designated as the interface's primary WWN. This accommodates virtual interfaces and modular hardware where the link-layer address is not necessarily fixed at the factory. WWN addresses can be assigned to both [device interfaces](../models/dcim/interface.md) and [virtual machine interfaces](../models/virtualization/vminterface.md).
 
 ## Cables
 

--- a/docs/models/dcim/interface.md
+++ b/docs/models/dcim/interface.md
@@ -52,9 +52,12 @@ The [MAC address](./macaddress.md) assigned to this interface which is designate
 !!! note "Changed in NetBox v4.2"
     The MAC address of an interface (formerly a concrete database field) is available as a property, `mac_address`, which reflects the value of the primary linked [MAC address](./macaddress.md) object.
 
-### WWN
+### Primary WWN Address
 
-The 64-bit world-wide name (for Fibre Channel interfaces).
+The [WWN address](./wwnaddress.md) assigned to this interface which is designated as its primary.
+
+!!! note "Changed in NetBox v4.7"
+    The WWN address of an interface (formerly a concrete database field) is available as a property, `wwn_address`, which reflects the value of the primary linked [WWN address](./wwnaddress.md) object.
 
 ### MTU
 

--- a/docs/models/dcim/wwnaddress.md
+++ b/docs/models/dcim/wwnaddress.md
@@ -1,0 +1,25 @@
+# WWN Addresses
+
+A WWN address object in NetBox represents a single Fibre Channel World Wide Name (WWN) as reported by or assigned to a network interface. WWN addresses can be assigned to [device interfaces](./interface.md) and [virtual machine interfaces](../virtualization/vminterface.md), and any one of an interface's assigned WWN addresses may be designated as its **primary** WWN address.
+
+Most physical Fibre Channel interfaces have only a single WWN address, hard-coded at the factory. However, some interfaces (particularly virtual interfaces and modular hardware) support multiple or reassignable WWN addresses. To accommodate this, NetBox models WWN addresses as first-class objects which may be created, modified, and reassigned independently of any specific interface.
+
+## Fields
+
+### WWN Address
+
+The 64-bit WWN address, expressed in colon-hexadecimal notation (for example, `aa:bb:cc:dd:11:22:33:44`).
+
+### Assigned Object
+
+A generic reference to the [device interface](./interface.md) or [virtual machine interface](../virtualization/vminterface.md) to which this WWN address is assigned. A WWN address may exist without being assigned to any interface.
+
+A WWN address that is currently designated as the primary WWN of its parent interface cannot be reassigned to (or unassigned from) another interface without first clearing the primary designation.
+
+### Description
+
+An optional human-readable description of the WWN address.
+
+### Comments
+
+Free-form Markdown-supported notes regarding the WWN address.

--- a/docs/models/virtualization/vminterface.md
+++ b/docs/models/virtualization/vminterface.md
@@ -39,7 +39,7 @@ The [MAC address](../dcim/macaddress.md) assigned to this interface which is des
 The [WWN address](../dcim/wwnaddress.md) assigned to this interface which is designated as its primary.
 
 !!! note "Changed in NetBox v4.7"
-    The WWN address of an interface (formerly a concrete database field) is available as a property, `wwn_address`, which reflects the value of the primary linked [WWN address](./dcim/wwnaddress.md) object.
+    The WWN address of an interface (formerly a concrete database field) is available as a property, `wwn_address`, which reflects the value of the primary linked [WWN address](../dcim/wwnaddress.md) object.
 
 ### MTU
 

--- a/docs/models/virtualization/vminterface.md
+++ b/docs/models/virtualization/vminterface.md
@@ -34,6 +34,13 @@ The [MAC address](../dcim/macaddress.md) assigned to this interface which is des
 !!! note "Changed in NetBox v4.2"
     The MAC address of an interface (formerly a concrete database field) is available as a property, `mac_address`, which reflects the value of the primary linked [MAC address](../dcim/macaddress.md) object.
 
+### Primary WWN Address
+
+The [WWN address](../dcim/wwnaddress.md) assigned to this interface which is designated as its primary.
+
+!!! note "Changed in NetBox v4.7"
+    The WWN address of an interface (formerly a concrete database field) is available as a property, `wwn_address`, which reflects the value of the primary linked [WWN address](./dcim/wwnaddress.md) object.
+
 ### MTU
 
 The interface's configured maximum transmissible unit (MTU).

--- a/docs/plugins/development/forms.md
+++ b/docs/plugins/development/forms.md
@@ -206,6 +206,10 @@ In addition to the [form fields provided by Django](https://docs.djangoproject.c
     options:
       members: false
 
+::: utilities.forms.fields.WWNAddressField
+    options:
+      members: false
+
 ::: utilities.forms.fields.SlugField
     options:
       members: false

--- a/netbox/dcim/api/serializers_/device_components.py
+++ b/netbox/dcim/api/serializers_/device_components.py
@@ -33,7 +33,13 @@ from wireless.models import WirelessLAN
 
 from .base import ConnectedEndpointsSerializer, PortSerializer
 from .cables import CabledObjectSerializer
-from .devices import DeviceSerializer, MACAddressSerializer, ModuleSerializer, VirtualDeviceContextSerializer, WWNAddressSerializer
+from .devices import (
+    DeviceSerializer,
+    MACAddressSerializer,
+    ModuleSerializer,
+    VirtualDeviceContextSerializer,
+    WWNAddressSerializer,
+)
 from .manufacturers import ManufacturerSerializer
 from .nested import NestedInterfaceSerializer
 from .roles import InventoryItemRoleSerializer

--- a/netbox/dcim/api/serializers_/device_components.py
+++ b/netbox/dcim/api/serializers_/device_components.py
@@ -33,7 +33,7 @@ from wireless.models import WirelessLAN
 
 from .base import ConnectedEndpointsSerializer, PortSerializer
 from .cables import CabledObjectSerializer
-from .devices import DeviceSerializer, MACAddressSerializer, ModuleSerializer, VirtualDeviceContextSerializer
+from .devices import DeviceSerializer, MACAddressSerializer, ModuleSerializer, VirtualDeviceContextSerializer, WWNAddressSerializer
 from .manufacturers import ManufacturerSerializer
 from .nested import NestedInterfaceSerializer
 from .roles import InventoryItemRoleSerializer
@@ -253,19 +253,22 @@ class InterfaceSerializer(
     mac_address = serializers.CharField(allow_null=True, read_only=True)
     primary_mac_address = MACAddressSerializer(nested=True, required=False, allow_null=True)
     mac_addresses = MACAddressSerializer(many=True, nested=True, read_only=True, allow_null=True)
-    wwn = serializers.CharField(required=False, default=None, allow_blank=True, allow_null=True)
+    wwn_address = serializers.CharField(allow_null=True, read_only=True)
+    primary_wwn_address = WWNAddressSerializer(nested=True, required=False, allow_null=True)
+    wwn_addresses = WWNAddressSerializer(many=True, nested=True, read_only=True, allow_null=True)
 
     class Meta:
         model = Interface
         fields = [
             'id', 'url', 'display_url', 'display', 'device', 'vdcs', 'module', 'name', 'label', 'type', 'enabled',
             'parent', 'bridge', 'bridge_interfaces', 'lag', 'mtu', 'mac_address', 'primary_mac_address',
-            'mac_addresses', 'speed', 'duplex', 'wwn', 'mgmt_only', 'description', 'mode', 'rf_role', 'rf_channel',
-            'poe_mode', 'poe_type', 'rf_channel_frequency', 'rf_channel_width', 'tx_power', 'untagged_vlan',
-            'tagged_vlans', 'qinq_svlan', 'vlan_translation_policy', 'mark_connected', 'cable', 'cable_end',
-            'wireless_link', 'link_peers', 'link_peers_type', 'wireless_lans', 'vrf', 'l2vpn_termination',
-            'connected_endpoints', 'connected_endpoints_type', 'connected_endpoints_reachable', 'owner', 'tags',
-            'custom_fields', 'created', 'last_updated', 'count_ipaddresses', 'count_fhrp_groups', '_occupied',
+            'mac_addresses', 'speed', 'duplex', 'wwn_address', 'primary_wwn_address', 'wwn_addresses', 'mgmt_only',
+            'description', 'mode', 'rf_role', 'rf_channel', 'poe_mode', 'poe_type', 'rf_channel_frequency',
+            'rf_channel_width', 'tx_power', 'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'vlan_translation_policy',
+            'mark_connected', 'cable', 'cable_end', 'wireless_link', 'link_peers', 'link_peers_type', 'wireless_lans',
+            'vrf', 'l2vpn_termination', 'connected_endpoints', 'connected_endpoints_type',
+            'connected_endpoints_reachable', 'owner', 'tags', 'custom_fields', 'created', 'last_updated',
+            'count_ipaddresses', 'count_fhrp_groups', '_occupied',
         ]
         brief_fields = ('id', 'url', 'display', 'device', 'name', 'description', 'cable', '_occupied')
 

--- a/netbox/dcim/api/serializers_/devices.py
+++ b/netbox/dcim/api/serializers_/devices.py
@@ -6,8 +6,8 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from dcim.choices import *
-from dcim.constants import MACADDRESS_ASSIGNMENT_MODELS, MODULE_TOKEN
-from dcim.models import Device, DeviceBay, MACAddress, Module, VirtualDeviceContext
+from dcim.constants import MACADDRESS_ASSIGNMENT_MODELS, MODULE_TOKEN, WWNADDRESS_ASSIGNMENT_MODELS
+from dcim.models import Device, DeviceBay, MACAddress, Module, VirtualDeviceContext, WWNAddress
 from dcim.utils import get_module_bay_positions, resolve_module_placeholder
 from extras.api.serializers_.configtemplates import ConfigTemplateSerializer
 from ipam.api.serializers_.ip import IPAddressSerializer
@@ -31,6 +31,7 @@ __all__ = (
     'MACAddressSerializer',
     'ModuleSerializer',
     'VirtualDeviceContextSerializer',
+    'WWNAddressSerializer',
 )
 
 
@@ -328,3 +329,20 @@ class MACAddressSerializer(PrimaryModelSerializer):
             'assigned_object', 'description', 'owner', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
         ]
         brief_fields = ('id', 'url', 'display', 'mac_address', 'description')
+
+
+class WWNAddressSerializer(PrimaryModelSerializer):
+    assigned_object_type = ContentTypeField(
+        queryset=ContentType.objects.filter(WWNADDRESS_ASSIGNMENT_MODELS),
+        required=False,
+        allow_null=True
+    )
+    assigned_object = GFKSerializerField(read_only=True)
+
+    class Meta:
+        model = WWNAddress
+        fields = [
+            'id', 'url', 'display_url', 'display', 'wwn_address', 'assigned_object_type', 'assigned_object_id',
+            'assigned_object', 'description', 'owner', 'comments', 'tags', 'custom_fields', 'created', 'last_updated',
+        ]
+        brief_fields = ('id', 'url', 'display', 'wwn_address', 'description')

--- a/netbox/dcim/api/urls.py
+++ b/netbox/dcim/api/urls.py
@@ -60,6 +60,7 @@ router.register('inventory-item-roles', views.InventoryItemRoleViewSet)
 
 # Addressing
 router.register('mac-addresses', views.MACAddressViewSet)
+router.register('wwn-addresses', views.WWNAddressViewSet)
 
 # Cables
 router.register('cables', views.CableViewSet)

--- a/netbox/dcim/api/views.py
+++ b/netbox/dcim/api/views.py
@@ -569,6 +569,12 @@ class MACAddressViewSet(NetBoxModelViewSet):
     filterset_class = filtersets.MACAddressFilterSet
 
 
+class WWNAddressViewSet(NetBoxModelViewSet):
+    queryset = WWNAddress.objects.all()
+    serializer_class = serializers.WWNAddressSerializer
+    filterset_class = filtersets.WWNAddressFilterSet
+
+
 #
 # Cables
 #

--- a/netbox/dcim/constants.py
+++ b/netbox/dcim/constants.py
@@ -157,3 +157,12 @@ MACADDRESS_ASSIGNMENT_MODELS = Q(
     Q(app_label='dcim', model='interface') |
     Q(app_label='virtualization', model='vminterface')
 )
+
+#
+# WWN addresses
+#
+
+WWNADDRESS_ASSIGNMENT_MODELS = Q(
+    Q(app_label='dcim', model='interface') |
+    Q(app_label='virtualization', model='vminterface')
+)

--- a/netbox/dcim/fields.py
+++ b/netbox/dcim/fields.py
@@ -9,7 +9,7 @@ from .lookups import PathContains
 __all__ = (
     'MACAddressField',
     'PathField',
-    'WWNField',
+    'WWNAddressField',
 )
 
 
@@ -56,7 +56,7 @@ class MACAddressField(models.Field):
         return str(self.to_python(value))
 
 
-class WWNField(models.Field):
+class WWNAddressField(models.Field):
     description = 'World Wide Name field'
 
     def python_type(self):

--- a/netbox/dcim/filtersets.py
+++ b/netbox/dcim/filtersets.py
@@ -32,7 +32,7 @@ from utilities.filters import (
     MultiValueContentTypeFilter,
     MultiValueMACAddressFilter,
     MultiValueNumberFilter,
-    MultiValueWWNFilter,
+    MultiValueWWNAddressFilter,
     NumericArrayFilter,
     TreeNodeMultipleChoiceFilter,
 )
@@ -99,6 +99,7 @@ __all__ = (
     'SiteGroupFilterSet',
     'VirtualChassisFilterSet',
     'VirtualDeviceContextFilterSet',
+    'WWNAddressFilterSet',
 )
 
 
@@ -1393,6 +1394,10 @@ class DeviceFilterSet(
         field_name='interfaces__mac_addresses__mac_address',
         label=_('MAC address'),
     )
+    wwn_address = MultiValueWWNAddressFilter(
+        field_name='interfaces__wwn_addresses__wwn_address',
+        label=_('WWN address'),
+    )
     serial = MultiValueCharFilter(
         lookup_expr='iexact'
     )
@@ -2137,6 +2142,118 @@ class MACAddressFilterSet(PrimaryModelFilterSet):
         return queryset.exclude(query)
 
 
+@register_filterset
+class WWNAddressFilterSet(PrimaryModelFilterSet):
+    wwn_address = MultiValueWWNAddressFilter()
+    assigned_object_type = MultiValueContentTypeFilter()
+    device = MultiValueCharFilter(
+        method='filter_device',
+        field_name='name',
+        label=_('Device (name)'),
+    )
+    device_id = MultiValueNumberFilter(
+        method='filter_device',
+        field_name='pk',
+        label=_('Device (ID)'),
+    )
+    virtual_machine = MultiValueCharFilter(
+        method='filter_virtual_machine',
+        field_name='name',
+        label=_('Virtual machine (name)'),
+    )
+    virtual_machine_id = MultiValueNumberFilter(
+        method='filter_virtual_machine',
+        field_name='pk',
+        label=_('Virtual machine (ID)'),
+    )
+    interface = django_filters.ModelMultipleChoiceFilter(
+        field_name='interface__name',
+        queryset=Interface.objects.all(),
+        to_field_name='name',
+        label=_('Interface (name)'),
+    )
+    interface_id = django_filters.ModelMultipleChoiceFilter(
+        field_name='interface',
+        queryset=Interface.objects.all(),
+        label=_('Interface (ID)'),
+    )
+    vminterface = django_filters.ModelMultipleChoiceFilter(
+        field_name='vminterface__name',
+        queryset=VMInterface.objects.all(),
+        to_field_name='name',
+        label=_('VM interface (name)'),
+    )
+    vminterface_id = django_filters.ModelMultipleChoiceFilter(
+        field_name='vminterface',
+        queryset=VMInterface.objects.all(),
+        label=_('VM interface (ID)'),
+    )
+    assigned = django_filters.BooleanFilter(
+        method='filter_assigned',
+        label=_('Is assigned'),
+    )
+    primary = django_filters.BooleanFilter(
+        method='filter_primary',
+        label=_('Is primary'),
+    )
+
+    class Meta:
+        model = WWNAddress
+        fields = ('id', 'description', 'assigned_object_type', 'assigned_object_id')
+
+    def search(self, queryset, name, value):
+        if not value.strip():
+            return queryset
+        qs_filter = (
+            Q(wwn_address__icontains=value) |
+            Q(description__icontains=value)
+        )
+        return queryset.filter(qs_filter)
+
+    def filter_device(self, queryset, name, value):
+        devices = Device.objects.filter(**{f'{name}__in': value})
+        if not devices.exists():
+            return queryset.none()
+        interface_ids = []
+        for device in devices:
+            interface_ids.extend(device.vc_interfaces().values_list('id', flat=True))
+        return queryset.filter(
+            interface__in=interface_ids
+        )
+
+    def filter_virtual_machine(self, queryset, name, value):
+        virtual_machines = VirtualMachine.objects.filter(**{f'{name}__in': value})
+        if not virtual_machines.exists():
+            return queryset.none()
+        interface_ids = []
+        for vm in virtual_machines:
+            interface_ids.extend(vm.interfaces.values_list('id', flat=True))
+        return queryset.filter(
+            vminterface__in=interface_ids
+        )
+
+    def filter_assigned(self, queryset, name, value):
+        params = {
+            'assigned_object_type__isnull': True,
+            'assigned_object_id__isnull': True,
+        }
+        if value:
+            return queryset.exclude(**params)
+        return queryset.filter(**params)
+
+    def filter_primary(self, queryset, name, value):
+        interface_wwn_ids = Interface.objects.filter(primary_wwn_address_id__isnull=False).values_list(
+            'primary_wwn_address_id', flat=True
+        )
+        vminterface_wwn_ids = VMInterface.objects.filter(primary_wwn_address_id__isnull=False).values_list(
+            'primary_wwn_address_id', flat=True
+        )
+        query = Q(pk__in=interface_wwn_ids) | Q(pk__in=vminterface_wwn_ids)
+        if value:
+            return queryset.filter(query)
+        return queryset.exclude(query)
+
+
 class CommonInterfaceFilterSet(django_filters.FilterSet):
     mode = django_filters.MultipleChoiceFilter(
         choices=InterfaceModeChoices,
@@ -2281,7 +2398,23 @@ class InterfaceFilterSet(
         to_field_name='mac_address',
         label=_('Primary MAC address'),
     )
-    wwn = MultiValueWWNFilter()
+    mac_address = MultiValueMACAddressFilter(
+        field_name='mac_addresses__mac_address',
+        label=_('MAC Address')
+    )
+    primary_wwn_address_id = django_filters.ModelMultipleChoiceFilter(
+        field_name='primary_wwn_address',
+        queryset=WWNAddress.objects.all(),
+        distinct=False,
+        label=_('Primary WWN address (ID)'),
+    )
+    primary_wwn_address = django_filters.ModelMultipleChoiceFilter(
+        field_name='primary_wwn_address__wwn_address',
+        queryset=WWNAddress.objects.all(),
+        distinct=False,
+        to_field_name='wwn_address',
+        label=_('Primary WWN address'),
+    )
     poe_mode = django_filters.MultipleChoiceFilter(
         choices=InterfacePoEModeChoices,
         distinct=False,

--- a/netbox/dcim/forms/bulk_edit.py
+++ b/netbox/dcim/forms/bulk_edit.py
@@ -78,7 +78,8 @@ __all__ = (
     'SiteBulkEditForm',
     'SiteGroupBulkEditForm',
     'VirtualChassisBulkEditForm',
-    'VirtualDeviceContextBulkEditForm'
+    'VirtualDeviceContextBulkEditForm',
+    'WWNAddressBulkEditForm',
 )
 
 
@@ -1433,7 +1434,7 @@ class PowerOutletBulkEditForm(
 class InterfaceBulkEditForm(
     ComponentBulkEditForm,
     form_from_model(Interface, [
-        'label', 'type', 'parent', 'bridge', 'lag', 'speed', 'duplex', 'wwn', 'mtu', 'mgmt_only', 'mark_connected',
+        'label', 'type', 'parent', 'bridge', 'lag', 'speed', 'duplex', 'mtu', 'mgmt_only', 'mark_connected',
         'description', 'mode', 'rf_role', 'rf_channel', 'rf_channel_frequency', 'rf_channel_width', 'tx_power',
         'wireless_lans', 'vlan_translation_policy'
     ])
@@ -1584,7 +1585,7 @@ class InterfaceBulkEditForm(
     model = Interface
     fieldsets = (
         FieldSet('module', 'type', 'label', 'speed', 'duplex', 'description'),
-        FieldSet('vrf', 'wwn', name=_('Addressing')),
+        FieldSet('vrf', name=_('Addressing')),
         FieldSet('vdcs', 'mtu', 'tx_power', 'enabled', 'mgmt_only', 'mark_connected', name=_('Operation')),
         FieldSet('poe_mode', 'poe_type', name=_('PoE')),
         FieldSet('parent', 'bridge', 'lag', name=_('Related Interfaces')),
@@ -1603,7 +1604,7 @@ class InterfaceBulkEditForm(
         ),
     )
     nullable_fields = (
-        'module', 'label', 'parent', 'bridge', 'lag', 'speed', 'duplex', 'wwn', 'vdcs', 'mtu', 'description',
+        'module', 'label', 'parent', 'bridge', 'lag', 'speed', 'duplex', 'vdcs', 'mtu', 'description',
         'poe_mode', 'poe_type', 'mode', 'rf_channel', 'rf_channel_frequency', 'rf_channel_width', 'tx_power',
         'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'vrf', 'wireless_lans', 'vlan_translation_policy',
     )
@@ -1818,6 +1819,14 @@ class VirtualDeviceContextBulkEditForm(PrimaryModelBulkEditForm):
 
 class MACAddressBulkEditForm(PrimaryModelBulkEditForm):
     model = MACAddress
+    fieldsets = (
+        FieldSet('description'),
+    )
+    nullable_fields = ('description', 'comments')
+
+
+class WWNAddressBulkEditForm(PrimaryModelBulkEditForm):
+    model = WWNAddress
     fieldsets = (
         FieldSet('description'),
     )

--- a/netbox/dcim/forms/bulk_import.py
+++ b/netbox/dcim/forms/bulk_import.py
@@ -69,7 +69,8 @@ __all__ = (
     'SiteGroupImportForm',
     'SiteImportForm',
     'VirtualChassisImportForm',
-    'VirtualDeviceContextImportForm'
+    'VirtualDeviceContextImportForm',
+    'WWNAddressImportForm'
 )
 
 
@@ -1065,7 +1066,7 @@ class InterfaceImportForm(OwnerCSVMixin, NetBoxModelImportForm):
         model = Interface
         fields = (
             'device', 'name', 'label', 'parent', 'bridge', 'lag', 'type', 'speed', 'duplex', 'enabled',
-            'mark_connected', 'wwn', 'vdcs', 'mtu', 'mgmt_only', 'description', 'poe_mode', 'poe_type', 'mode',
+            'mark_connected', 'vdcs', 'mtu', 'mgmt_only', 'description', 'poe_mode', 'poe_type', 'mode',
             'vlan_group', 'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'vrf', 'rf_role', 'rf_channel',
             'rf_channel_frequency', 'rf_channel_width', 'tx_power', 'owner', 'tags'
         )
@@ -1509,6 +1510,88 @@ class MACAddressImportForm(PrimaryModelImportForm):
         return instance
 
 
+class WWNAddressImportForm(PrimaryModelImportForm):
+    device = CSVModelChoiceField(
+        label=_('Device'),
+        queryset=Device.objects.all(),
+        required=False,
+        to_field_name='name',
+        help_text=_('Parent device of assigned interface (if any)')
+    )
+    virtual_machine = CSVModelChoiceField(
+        label=_('Virtual machine'),
+        queryset=VirtualMachine.objects.all(),
+        required=False,
+        to_field_name='name',
+        help_text=_('Parent VM of assigned interface (if any)')
+    )
+    interface = CSVModelChoiceField(
+        label=_('Interface'),
+        queryset=Interface.objects.none(),  # Can also refer to VMInterface
+        required=False,
+        to_field_name='name',
+        help_text=_('Assigned interface')
+    )
+    is_primary = forms.BooleanField(
+        label=_('Is primary'),
+        help_text=_('Make this the primary WWN for the assigned interface'),
+        required=False
+    )
+
+    class Meta:
+        model = WWNAddress
+        fields = [
+            'wwn_address', 'device', 'virtual_machine', 'interface', 'is_primary', 'description', 'owner', 'comments',
+            'tags',
+        ]
+
+    def __init__(self, data=None, *args, **kwargs):
+        super().__init__(data, *args, **kwargs)
+
+        if data:
+
+            # Limit interface queryset by assigned device
+            if data.get('device'):
+                self.fields['interface'].queryset = Interface.objects.filter(
+                    **{f"device__{self.fields['device'].to_field_name}": data['device']}
+                )
+
+            # Limit interface queryset by assigned device
+            elif data.get('virtual_machine'):
+                self.fields['interface'].queryset = VMInterface.objects.filter(
+                    **{f"virtual_machine__{self.fields['virtual_machine'].to_field_name}": data['virtual_machine']}
+                )
+
+    def clean(self):
+        super().clean()
+
+        device = self.cleaned_data.get('device')
+        virtual_machine = self.cleaned_data.get('virtual_machine')
+        interface = self.cleaned_data.get('interface')
+
+        # Validate interface assignment
+        if interface and not device and not virtual_machine:
+            raise forms.ValidationError({
+                "interface": _("Must specify the parent device or VM when assigning an interface")
+            })
+
+    def save(self, *args, **kwargs):
+
+        # Set interface assignment
+        if interface := self.cleaned_data.get('interface'):
+            self.instance.assigned_object = interface
+
+        instance = super().save(*args, **kwargs)
+
+        # Assign the WWN as primary for its interface, if designated as such
+        if interface and self.cleaned_data['is_primary'] and self.instance.pk:
+            interface.snapshot()
+            interface.primary_wwn_address = self.instance
+            interface.save()
+
+        return instance
+
+
 #
 # Cables
 #
@@ -1761,6 +1844,8 @@ class CableImportForm(PrimaryModelImportForm):
     def clean_color(self):
         color = self.cleaned_data.get('color', None)
         return self._clean_color(color) if color is not None else ''
+
+
 #
 # Virtual chassis
 #

--- a/netbox/dcim/forms/common.py
+++ b/netbox/dcim/forms/common.py
@@ -39,6 +39,7 @@ class InterfaceCommonForm(forms.Form):
         if self.instance and self.instance.pk:
             filter_name = f'{self._meta.model._meta.model_name}_id'
             self.fields['primary_mac_address'].widget.add_query_param(filter_name, self.instance.pk)
+            self.fields['primary_wwn_address'].widget.add_query_param(filter_name, self.instance.pk)
 
     def clean(self):
         super().clean()

--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -76,6 +76,7 @@ __all__ = (
     'SiteGroupFilterForm',
     'VirtualChassisFilterForm',
     'VirtualDeviceContextFilterForm',
+    'WWNAddressFilterForm',
 )
 
 
@@ -1639,7 +1640,7 @@ class InterfaceFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet('name', 'label', 'kind', 'type', 'speed', 'duplex', 'enabled', 'mgmt_only', name=_('Attributes')),
-        FieldSet('vrf_id', 'l2vpn_id', 'mac_address', 'wwn', name=_('Addressing')),
+        FieldSet('vrf_id', 'l2vpn_id', 'mac_address', name=_('Addressing')),
         FieldSet('poe_mode', 'poe_type', name=_('PoE')),
         FieldSet('mode', 'vlan_translation_policy_id', name=_('802.1Q Switching')),
         FieldSet('rf_role', 'rf_channel', 'rf_channel_width', 'tx_power', name=_('Wireless')),
@@ -1701,9 +1702,9 @@ class InterfaceFilterForm(PathEndpointFilterForm, DeviceComponentFilterForm):
         required=False,
         label=_('MAC address')
     )
-    wwn = forms.CharField(
+    wwn_address = forms.CharField(
         required=False,
-        label=_('WWN')
+        label=_('WWN address')
     )
     poe_mode = forms.MultipleChoiceField(
         choices=InterfacePoEModeChoices,
@@ -2086,6 +2087,46 @@ class MACAddressFilterForm(PrimaryModelFilterSetForm):
     primary = forms.NullBooleanField(
         required=False,
         label=_('Primary MAC of an interface'),
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        ),
+    )
+    tag = TagFilterField(model)
+
+
+class WWNAddressFilterForm(PrimaryModelFilterSetForm):
+    model = WWNAddress
+    fieldsets = (
+        FieldSet('q', 'filter_id', 'tag'),
+        FieldSet('wwn_address', name=_('Attributes')),
+        FieldSet('device_id', 'virtual_machine_id', 'assigned', 'primary', name=_('Assignments')),
+        FieldSet('owner_group_id', 'owner_id', name=_('Ownership')),
+    )
+    selector_fields = ('filter_id', 'q', 'device_id', 'virtual_machine_id')
+    wwn_address = forms.CharField(
+        required=False,
+        label=_('WWN address'),
+    )
+    device_id = DynamicModelMultipleChoiceField(
+        queryset=Device.objects.all(),
+        required=False,
+        label=_('Assigned Device'),
+    )
+    virtual_machine_id = DynamicModelMultipleChoiceField(
+        queryset=VirtualMachine.objects.all(),
+        required=False,
+        label=_('Assigned VM'),
+    )
+    assigned = forms.NullBooleanField(
+        required=False,
+        label=_('Assigned to an interface'),
+        widget=forms.Select(
+            choices=BOOLEAN_WITH_BLANK_CHOICES
+        ),
+    )
+    primary = forms.NullBooleanField(
+        required=False,
+        label=_('Primary WWN of an interface'),
         widget=forms.Select(
             choices=BOOLEAN_WITH_BLANK_CHOICES
         ),

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -86,86 +86,71 @@ __all__ = (
     'SiteGroupForm',
     'VCMemberSelectForm',
     'VirtualChassisForm',
-    'VirtualDeviceContextForm'
+    'VirtualDeviceContextForm',
+    'WWNAddressForm',
 )
 
 
 class RegionForm(NestedGroupModelForm):
-    parent = DynamicModelChoiceField(
-        label=_('Parent'),
-        queryset=Region.objects.all(),
-        required=False
-    )
+    parent = DynamicModelChoiceField(label=_('Parent'), queryset=Region.objects.all(), required=False)
 
-    fieldsets = (
-        FieldSet('parent', 'name', 'slug', 'description', 'tags'),
-    )
+    fieldsets = (FieldSet('parent', 'name', 'slug', 'description', 'tags'),)
 
     class Meta:
         model = Region
         fields = (
-            'parent', 'name', 'slug', 'description', 'owner', 'tags', 'comments',
+            'parent',
+            'name',
+            'slug',
+            'description',
+            'owner',
+            'tags',
+            'comments',
         )
 
 
 class SiteGroupForm(NestedGroupModelForm):
-    parent = DynamicModelChoiceField(
-        label=_('Parent'),
-        queryset=SiteGroup.objects.all(),
-        required=False
-    )
+    parent = DynamicModelChoiceField(label=_('Parent'), queryset=SiteGroup.objects.all(), required=False)
 
-    fieldsets = (
-        FieldSet('parent', 'name', 'slug', 'description', 'tags'),
-    )
+    fieldsets = (FieldSet('parent', 'name', 'slug', 'description', 'tags'),)
 
     class Meta:
         model = SiteGroup
         fields = (
-            'parent', 'name', 'slug', 'description', 'owner', 'comments', 'tags',
+            'parent',
+            'name',
+            'slug',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         )
 
 
 class SiteForm(TenancyForm, PrimaryModelForm):
-    region = DynamicModelChoiceField(
-        label=_('Region'),
-        queryset=Region.objects.all(),
-        required=False,
-        quick_add=True
-    )
-    group = DynamicModelChoiceField(
-        label=_('Group'),
-        queryset=SiteGroup.objects.all(),
-        required=False,
-        quick_add=True
-    )
-    asns = DynamicModelMultipleChoiceField(
-        queryset=ASN.objects.all(),
-        label=_('ASNs'),
-        required=False
-    )
-    add_asns = DynamicModelMultipleChoiceField(
-        queryset=ASN.objects.all(),
-        label=_('Add ASNs'),
-        required=False
-    )
-    remove_asns = DynamicModelMultipleChoiceField(
-        queryset=ASN.objects.all(),
-        label=_('Remove ASNs'),
-        required=False
-    )
+    region = DynamicModelChoiceField(label=_('Region'), queryset=Region.objects.all(), required=False, quick_add=True)
+    group = DynamicModelChoiceField(label=_('Group'), queryset=SiteGroup.objects.all(), required=False, quick_add=True)
+    asns = DynamicModelMultipleChoiceField(queryset=ASN.objects.all(), label=_('ASNs'), required=False)
+    add_asns = DynamicModelMultipleChoiceField(queryset=ASN.objects.all(), label=_('Add ASNs'), required=False)
+    remove_asns = DynamicModelMultipleChoiceField(queryset=ASN.objects.all(), label=_('Remove ASNs'), required=False)
     slug = SlugField()
     time_zone = TimeZoneFormField(
-        label=_('Time zone'),
-        choices=add_blank_choice(TimeZoneFormField().choices),
-        required=False
+        label=_('Time zone'), choices=add_blank_choice(TimeZoneFormField().choices), required=False
     )
 
     fieldsets = (
         FieldSet(
-            'name', 'slug', 'status', 'region', 'group', 'facility', M2MAddRemoveFields('asns'), 'time_zone',
-            'description', 'tags',
-            name=_('Site')
+            'name',
+            'slug',
+            'status',
+            'region',
+            'group',
+            'facility',
+            M2MAddRemoveFields('asns'),
+            'time_zone',
+            'description',
+            'tags',
+            name=_('Site'),
         ),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
         FieldSet('physical_address', 'shipping_address', 'latitude', 'longitude', name=_('Contact Info')),
@@ -174,8 +159,23 @@ class SiteForm(TenancyForm, PrimaryModelForm):
     class Meta:
         model = Site
         fields = (
-            'name', 'slug', 'status', 'region', 'group', 'tenant_group', 'tenant', 'facility', 'time_zone',
-            'description', 'physical_address', 'shipping_address', 'latitude', 'longitude', 'owner', 'comments', 'tags',
+            'name',
+            'slug',
+            'status',
+            'region',
+            'group',
+            'tenant_group',
+            'tenant',
+            'facility',
+            'time_zone',
+            'description',
+            'physical_address',
+            'shipping_address',
+            'latitude',
+            'longitude',
+            'owner',
+            'comments',
+            'tags',
         )
         widgets = {
             'physical_address': forms.Textarea(
@@ -197,7 +197,7 @@ class SiteForm(TenancyForm, PrimaryModelForm):
             self.fields.pop('asns')
             self.fields['add_asns'].widget.add_query_param('site_id__n', self.instance.pk)
             self.fields['remove_asns'].widget.add_query_param('site_id', self.instance.pk)
-            self.fields['remove_asns'].help_text = _("{count} ASNs currently assigned").format(count=count)
+            self.fields['remove_asns'].help_text = _('{count} ASNs currently assigned').format(count=count)
         else:
             # Simple mode for new objects or small M2M sets
             self.fields.pop('add_asns')
@@ -207,18 +207,9 @@ class SiteForm(TenancyForm, PrimaryModelForm):
 
 
 class LocationForm(TenancyForm, NestedGroupModelForm):
-    site = DynamicModelChoiceField(
-        label=_('Site'),
-        queryset=Site.objects.all(),
-        selector=True
-    )
+    site = DynamicModelChoiceField(label=_('Site'), queryset=Site.objects.all(), selector=True)
     parent = DynamicModelChoiceField(
-        label=_('Parent'),
-        queryset=Location.objects.all(),
-        required=False,
-        query_params={
-            'site_id': '$site'
-        }
+        label=_('Parent'), queryset=Location.objects.all(), required=False, query_params={'site_id': '$site'}
     )
 
     fieldsets = (
@@ -229,53 +220,65 @@ class LocationForm(TenancyForm, NestedGroupModelForm):
     class Meta:
         model = Location
         fields = (
-            'site', 'parent', 'name', 'slug', 'status', 'description', 'tenant_group', 'tenant', 'facility', 'owner',
-            'comments', 'tags',
+            'site',
+            'parent',
+            'name',
+            'slug',
+            'status',
+            'description',
+            'tenant_group',
+            'tenant',
+            'facility',
+            'owner',
+            'comments',
+            'tags',
         )
 
 
 class RackGroupForm(OrganizationalModelForm):
-    fieldsets = (
-        FieldSet('name', 'slug', 'description', 'tags', name=_('Rack Group')),
-    )
+    fieldsets = (FieldSet('name', 'slug', 'description', 'tags', name=_('Rack Group')),)
 
     class Meta:
         model = RackGroup
         fields = [
-            'name', 'slug', 'description', 'owner', 'comments', 'tags',
+            'name',
+            'slug',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
 
 
 class RackRoleForm(OrganizationalModelForm):
-    fieldsets = (
-        FieldSet('name', 'slug', 'color', 'description', 'tags', name=_('Rack Role')),
-    )
+    fieldsets = (FieldSet('name', 'slug', 'color', 'description', 'tags', name=_('Rack Role')),)
 
     class Meta:
         model = RackRole
         fields = [
-            'name', 'slug', 'color', 'description', 'owner', 'comments', 'tags',
+            'name',
+            'slug',
+            'color',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
 
 
 class RackTypeForm(PrimaryModelForm):
-    manufacturer = DynamicModelChoiceField(
-        label=_('Manufacturer'),
-        queryset=Manufacturer.objects.all(),
-        quick_add=True
-    )
-    slug = SlugField(
-        label=_('Slug'),
-        slug_source='model'
-    )
+    manufacturer = DynamicModelChoiceField(label=_('Manufacturer'), queryset=Manufacturer.objects.all(), quick_add=True)
+    slug = SlugField(label=_('Slug'), slug_source='model')
 
     fieldsets = (
         FieldSet('manufacturer', 'model', 'slug', 'description', 'form_factor', 'tags', name=_('Rack Type')),
         FieldSet(
-            'width', 'u_height',
+            'width',
+            'u_height',
             InlineFields('outer_width', 'outer_height', 'outer_depth', 'outer_unit', label=_('Outer Dimensions')),
             InlineFields('weight', 'max_weight', 'weight_unit', label=_('Weight')),
-            'mounting_depth', name=_('Dimensions')
+            'mounting_depth',
+            name=_('Dimensions'),
         ),
         FieldSet('starting_unit', 'desc_units', name=_('Numbering')),
     )
@@ -283,48 +286,57 @@ class RackTypeForm(PrimaryModelForm):
     class Meta:
         model = RackType
         fields = [
-            'manufacturer', 'model', 'slug', 'form_factor', 'width', 'u_height', 'starting_unit', 'desc_units',
-            'outer_width', 'outer_height', 'outer_depth', 'outer_unit', 'mounting_depth', 'weight', 'max_weight',
-            'weight_unit', 'description', 'owner', 'comments', 'tags',
+            'manufacturer',
+            'model',
+            'slug',
+            'form_factor',
+            'width',
+            'u_height',
+            'starting_unit',
+            'desc_units',
+            'outer_width',
+            'outer_height',
+            'outer_depth',
+            'outer_unit',
+            'mounting_depth',
+            'weight',
+            'max_weight',
+            'weight_unit',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
 
 
 class RackForm(TenancyForm, PrimaryModelForm):
-    site = DynamicModelChoiceField(
-        label=_('Site'),
-        queryset=Site.objects.all(),
-        selector=True
-    )
+    site = DynamicModelChoiceField(label=_('Site'), queryset=Site.objects.all(), selector=True)
     location = DynamicModelChoiceField(
-        label=_('Location'),
-        queryset=Location.objects.all(),
-        required=False,
-        query_params={
-            'site_id': '$site'
-        }
+        label=_('Location'), queryset=Location.objects.all(), required=False, query_params={'site_id': '$site'}
     )
-    group = DynamicModelChoiceField(
-        label=_('Rack Group'),
-        queryset=RackGroup.objects.all(),
-        required=False
-    )
-    role = DynamicModelChoiceField(
-        label=_('Role'),
-        queryset=RackRole.objects.all(),
-        required=False
-    )
+    group = DynamicModelChoiceField(label=_('Rack Group'), queryset=RackGroup.objects.all(), required=False)
+    role = DynamicModelChoiceField(label=_('Role'), queryset=RackRole.objects.all(), required=False)
     rack_type = DynamicModelChoiceField(
         label=_('Rack Type'),
         queryset=RackType.objects.all(),
         required=False,
         selector=True,
-        help_text=_("Select a pre-defined rack type, or set physical characteristics below."),
+        help_text=_('Select a pre-defined rack type, or set physical characteristics below.'),
     )
 
     fieldsets = (
         FieldSet(
-            'site', 'location', 'group', 'name', 'status', 'role', 'rack_type', 'description', 'airflow', 'tags',
-            name=_('Rack')
+            'site',
+            'location',
+            'group',
+            'name',
+            'status',
+            'role',
+            'rack_type',
+            'description',
+            'airflow',
+            'tags',
+            name=_('Rack'),
         ),
         FieldSet('facility_id', 'serial', 'asset_tag', name=_('Inventory Control')),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
@@ -333,21 +345,49 @@ class RackForm(TenancyForm, PrimaryModelForm):
     class Meta:
         model = Rack
         fields = [
-            'site', 'location', 'group', 'name', 'facility_id', 'tenant_group', 'tenant', 'status', 'role', 'serial',
-            'asset_tag', 'rack_type', 'form_factor', 'width', 'u_height', 'starting_unit', 'desc_units', 'outer_width',
-            'outer_height', 'outer_depth', 'outer_unit', 'mounting_depth', 'airflow', 'weight', 'max_weight',
-            'weight_unit', 'description', 'owner', 'comments', 'tags',
+            'site',
+            'location',
+            'group',
+            'name',
+            'facility_id',
+            'tenant_group',
+            'tenant',
+            'status',
+            'role',
+            'serial',
+            'asset_tag',
+            'rack_type',
+            'form_factor',
+            'width',
+            'u_height',
+            'starting_unit',
+            'desc_units',
+            'outer_width',
+            'outer_height',
+            'outer_depth',
+            'outer_unit',
+            'mounting_depth',
+            'airflow',
+            'weight',
+            'max_weight',
+            'weight_unit',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # Mimic HTMXSelect()
-        self.fields['rack_type'].widget.attrs.update({
-            'hx-get': '.',
-            'hx-include': '#form_fields',
-            'hx-target': '#form_fields',
-        })
+        self.fields['rack_type'].widget.attrs.update(
+            {
+                'hx-get': '.',
+                'hx-include': '#form_fields',
+                'hx-target': '#form_fields',
+            }
+        )
 
         # Omit RackType-defined fields if rack_type is set
         if get_field_value(self, 'rack_type'):
@@ -357,30 +397,29 @@ class RackForm(TenancyForm, PrimaryModelForm):
             self.fieldsets = (
                 *self.fieldsets,
                 FieldSet(
-                    'form_factor', 'width', 'starting_unit', 'u_height',
-                    InlineFields('outer_width', 'outer_height', 'outer_depth', 'outer_unit',
-                                 label=_('Outer Dimensions')),
+                    'form_factor',
+                    'width',
+                    'starting_unit',
+                    'u_height',
+                    InlineFields(
+                        'outer_width', 'outer_height', 'outer_depth', 'outer_unit', label=_('Outer Dimensions')
+                    ),
                     InlineFields('weight', 'max_weight', 'weight_unit', label=_('Weight')),
-                    'mounting_depth', 'desc_units', name=_('Dimensions')
+                    'mounting_depth',
+                    'desc_units',
+                    name=_('Dimensions'),
                 ),
             )
 
 
 class RackReservationForm(TenancyForm, PrimaryModelForm):
-    rack = DynamicModelChoiceField(
-        label=_('Rack'),
-        queryset=Rack.objects.all(),
-        selector=True
-    )
+    rack = DynamicModelChoiceField(label=_('Rack'), queryset=Rack.objects.all(), selector=True)
     units = NumericArrayField(
         label=_('Units'),
         base_field=forms.IntegerField(),
-        help_text=_("Comma-separated list of numeric unit IDs. A range may be specified using a hyphen.")
+        help_text=_('Comma-separated list of numeric unit IDs. A range may be specified using a hyphen.'),
     )
-    user = forms.ModelChoiceField(
-        label=_('User'),
-        queryset=User.objects.order_by('username')
-    )
+    user = forms.ModelChoiceField(label=_('User'), queryset=User.objects.order_by('username'))
 
     fieldsets = (
         FieldSet('rack', 'units', 'status', 'user', 'description', 'tags', name=_('Reservation')),
@@ -390,28 +429,36 @@ class RackReservationForm(TenancyForm, PrimaryModelForm):
     class Meta:
         model = RackReservation
         fields = [
-            'rack', 'units', 'status', 'user', 'tenant_group', 'tenant', 'description', 'owner', 'comments', 'tags',
+            'rack',
+            'units',
+            'status',
+            'user',
+            'tenant_group',
+            'tenant',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
 
 
 class ManufacturerForm(OrganizationalModelForm):
-    fieldsets = (
-        FieldSet('name', 'slug', 'description', 'tags', name=_('Manufacturer')),
-    )
+    fieldsets = (FieldSet('name', 'slug', 'description', 'tags', name=_('Manufacturer')),)
 
     class Meta:
         model = Manufacturer
         fields = [
-            'name', 'slug', 'description', 'owner', 'comments', 'tags',
+            'name',
+            'slug',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
 
 
 class DeviceTypeForm(PrimaryModelForm):
-    manufacturer = DynamicModelChoiceField(
-        label=_('Manufacturer'),
-        queryset=Manufacturer.objects.all(),
-        quick_add=True
-    )
+    manufacturer = DynamicModelChoiceField(label=_('Manufacturer'), queryset=Manufacturer.objects.all(), quick_add=True)
     default_platform = DynamicModelChoiceField(
         label=_('Default platform'),
         queryset=Platform.objects.all(),
@@ -419,18 +466,22 @@ class DeviceTypeForm(PrimaryModelForm):
         selector=True,
         query_params={
             'manufacturer_id': ['$manufacturer', 'null'],
-        }
+        },
     )
-    slug = SlugField(
-        label=_('Slug'),
-        slug_source='model'
-    )
+    slug = SlugField(label=_('Slug'), slug_source='model')
 
     fieldsets = (
         FieldSet('manufacturer', 'model', 'slug', 'default_platform', 'description', 'tags', name=_('Device Type')),
         FieldSet(
-            'u_height', 'exclude_from_utilization', 'is_full_depth', 'part_number', 'subdevice_role', 'airflow',
-            'weight', 'weight_unit', name=_('Chassis')
+            'u_height',
+            'exclude_from_utilization',
+            'is_full_depth',
+            'part_number',
+            'subdevice_role',
+            'airflow',
+            'weight',
+            'weight_unit',
+            name=_('Chassis'),
         ),
         FieldSet('front_image', 'rear_image', name=_('Images')),
     )
@@ -438,63 +489,78 @@ class DeviceTypeForm(PrimaryModelForm):
     class Meta:
         model = DeviceType
         fields = [
-            'manufacturer', 'model', 'slug', 'default_platform', 'part_number', 'u_height', 'exclude_from_utilization',
-            'is_full_depth', 'subdevice_role', 'airflow', 'weight', 'weight_unit', 'front_image', 'rear_image',
-            'description', 'owner', 'comments', 'tags',
+            'manufacturer',
+            'model',
+            'slug',
+            'default_platform',
+            'part_number',
+            'u_height',
+            'exclude_from_utilization',
+            'is_full_depth',
+            'subdevice_role',
+            'airflow',
+            'weight',
+            'weight_unit',
+            'front_image',
+            'rear_image',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
         widgets = {
-            'front_image': ClearableFileInput(attrs={
-                'accept': DEVICETYPE_IMAGE_FORMATS
-            }),
-            'rear_image': ClearableFileInput(attrs={
-                'accept': DEVICETYPE_IMAGE_FORMATS
-            }),
+            'front_image': ClearableFileInput(attrs={'accept': DEVICETYPE_IMAGE_FORMATS}),
+            'rear_image': ClearableFileInput(attrs={'accept': DEVICETYPE_IMAGE_FORMATS}),
         }
 
 
 class ModuleTypeProfileForm(PrimaryModelForm):
     schema = JSONField(
-        label=_('Schema'),
-        required=False,
-        help_text=_("Enter a valid JSON schema to define supported attributes.")
+        label=_('Schema'), required=False, help_text=_('Enter a valid JSON schema to define supported attributes.')
     )
 
-    fieldsets = (
-        FieldSet('name', 'description', 'schema', 'tags', name=_('Profile')),
-    )
+    fieldsets = (FieldSet('name', 'description', 'schema', 'tags', name=_('Profile')),)
 
     class Meta:
         model = ModuleTypeProfile
         fields = [
-            'name', 'description', 'schema', 'owner', 'comments', 'tags',
+            'name',
+            'description',
+            'schema',
+            'owner',
+            'comments',
+            'tags',
         ]
 
 
 class ModuleTypeForm(PrimaryModelForm):
     profile = forms.ModelChoiceField(
-        queryset=ModuleTypeProfile.objects.all(),
-        label=_('Profile'),
-        required=False,
-        widget=HTMXSelect()
+        queryset=ModuleTypeProfile.objects.all(), label=_('Profile'), required=False, widget=HTMXSelect()
     )
-    manufacturer = DynamicModelChoiceField(
-        label=_('Manufacturer'),
-        queryset=Manufacturer.objects.all()
-    )
+    manufacturer = DynamicModelChoiceField(label=_('Manufacturer'), queryset=Manufacturer.objects.all())
 
     @property
     def fieldsets(self):
         return [
             FieldSet('manufacturer', 'model', 'part_number', 'description', 'tags', name=_('Module Type')),
             FieldSet('airflow', 'weight', 'weight_unit', name=_('Hardware')),
-            FieldSet('profile', *self.attr_fields, name=_('Profile & Attributes'))
+            FieldSet('profile', *self.attr_fields, name=_('Profile & Attributes')),
         ]
 
     class Meta:
         model = ModuleType
         fields = [
-            'profile', 'manufacturer', 'model', 'part_number', 'description', 'airflow', 'weight', 'weight_unit',
-            'owner', 'comments', 'tags',
+            'profile',
+            'manufacturer',
+            'model',
+            'part_number',
+            'description',
+            'airflow',
+            'weight',
+            'weight_unit',
+            'owner',
+            'comments',
+            'tags',
         ]
 
     def __init__(self, *args, **kwargs):
@@ -551,9 +617,7 @@ class ModuleTypeForm(PrimaryModelForm):
 
 class DeviceRoleForm(NestedGroupModelForm):
     config_template = DynamicModelChoiceField(
-        label=_('Config template'),
-        queryset=ConfigTemplate.objects.all(),
-        required=False
+        label=_('Config template'), queryset=ConfigTemplate.objects.all(), required=False
     )
     parent = DynamicModelChoiceField(
         label=_('Parent'),
@@ -563,15 +627,31 @@ class DeviceRoleForm(NestedGroupModelForm):
 
     fieldsets = (
         FieldSet(
-            'name', 'slug', 'parent', 'color', 'vm_role', 'config_template', 'description',
-            'tags', name=_('Device Role')
+            'name',
+            'slug',
+            'parent',
+            'color',
+            'vm_role',
+            'config_template',
+            'description',
+            'tags',
+            name=_('Device Role'),
         ),
     )
 
     class Meta:
         model = DeviceRole
         fields = [
-            'name', 'slug', 'parent', 'color', 'vm_role', 'config_template', 'description', 'owner', 'comments', 'tags',
+            'name',
+            'slug',
+            'parent',
+            'color',
+            'vm_role',
+            'config_template',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
 
 
@@ -582,50 +662,49 @@ class PlatformForm(NestedGroupModelForm):
         required=False,
     )
     manufacturer = DynamicModelChoiceField(
-        label=_('Manufacturer'),
-        queryset=Manufacturer.objects.all(),
-        required=False,
-        quick_add=True
+        label=_('Manufacturer'), queryset=Manufacturer.objects.all(), required=False, quick_add=True
     )
     config_template = DynamicModelChoiceField(
-        label=_('Config template'),
-        queryset=ConfigTemplate.objects.all(),
-        required=False
+        label=_('Config template'), queryset=ConfigTemplate.objects.all(), required=False
     )
-    slug = SlugField(
-        label=_('Slug'),
-        max_length=64
-    )
+    slug = SlugField(label=_('Slug'), max_length=64)
 
     fieldsets = (
         FieldSet(
-            'name', 'slug', 'parent', 'manufacturer', 'config_template', 'description', 'tags', name=_('Platform'),
+            'name',
+            'slug',
+            'parent',
+            'manufacturer',
+            'config_template',
+            'description',
+            'tags',
+            name=_('Platform'),
         ),
     )
 
     class Meta:
         model = Platform
         fields = [
-            'name', 'slug', 'parent', 'manufacturer', 'config_template', 'description', 'owner', 'comments', 'tags',
+            'name',
+            'slug',
+            'parent',
+            'manufacturer',
+            'config_template',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
 
 
 class DeviceForm(TenancyForm, PrimaryModelForm):
-    site = DynamicModelChoiceField(
-        label=_('Site'),
-        queryset=Site.objects.all(),
-        selector=True
-    )
+    site = DynamicModelChoiceField(label=_('Site'), queryset=Site.objects.all(), selector=True)
     location = DynamicModelChoiceField(
         label=_('Location'),
         queryset=Location.objects.all(),
         required=False,
-        query_params={
-            'site_id': '$site'
-        },
-        initial_params={
-            'racks': '$rack'
-        }
+        query_params={'site_id': '$site'},
+        initial_params={'racks': '$rack'},
     )
     rack = DynamicModelChoiceField(
         label=_('Rack'),
@@ -634,28 +713,23 @@ class DeviceForm(TenancyForm, PrimaryModelForm):
         query_params={
             'site_id': '$site',
             'location_id': '$location',
-        }
+        },
     )
     position = forms.DecimalField(
         label=_('Position'),
         required=False,
-        help_text=_("The lowest-numbered unit occupied by the device"),
+        help_text=_('The lowest-numbered unit occupied by the device'),
         localize=True,
         widget=APISelect(
             api_url='/api/dcim/racks/{{rack}}/elevation/',
-            attrs={
-                'ts-disabled-field': 'device',
-                'data-dynamic-params': '[{"fieldName":"face","queryParam":"face"}]'
-            },
-        )
+            attrs={'ts-disabled-field': 'device', 'data-dynamic-params': '[{"fieldName":"face","queryParam":"face"}]'},
+        ),
     )
     face = forms.ChoiceField(
         label=_('Face'),
         choices=add_blank_choice(DeviceFaceChoices),
         required=False,
-        widget=ClearableSelect(
-            requires_fields=['rack']
-        )
+        widget=ClearableSelect(requires_fields=['rack']),
     )
     device_type = DynamicModelChoiceField(
         label=_('Device type'),
@@ -663,13 +737,9 @@ class DeviceForm(TenancyForm, PrimaryModelForm):
         context={
             'parent': 'manufacturer',
         },
-        selector=True
+        selector=True,
     )
-    role = DynamicModelChoiceField(
-        label=_('Device role'),
-        queryset=DeviceRole.objects.all(),
-        quick_add=True
-    )
+    role = DynamicModelChoiceField(label=_('Device role'), queryset=DeviceRole.objects.all(), quick_add=True)
     platform = DynamicModelChoiceField(
         label=_('Platform'),
         queryset=Platform.objects.all(),
@@ -677,21 +747,17 @@ class DeviceForm(TenancyForm, PrimaryModelForm):
         selector=True,
         query_params={
             'available_for_device_type': '$device_type',
-        }
+        },
     )
     cluster = DynamicModelChoiceField(
         label=_('Cluster'),
         queryset=Cluster.objects.all(),
         required=False,
         selector=True,
-        query_params={
-            'site_id': ['$site', 'null']
-        },
+        query_params={'site_id': ['$site', 'null']},
     )
     local_context_data = JSONField(
-        required=False,
-        label='',
-        widget=forms.Textarea(attrs={'aria-label': _('Local config context data')})
+        required=False, label='', widget=forms.Textarea(attrs={'aria-label': _('Local config context data')})
     )
     virtual_chassis = DynamicModelChoiceField(
         label=_('Virtual chassis'),
@@ -700,38 +766,59 @@ class DeviceForm(TenancyForm, PrimaryModelForm):
         context={
             'parent': 'master',
         },
-        selector=True
+        selector=True,
     )
     vc_position = forms.IntegerField(
         required=False,
         label=_('Position'),
-        help_text=_("The position in the virtual chassis this device is identified by")
+        help_text=_('The position in the virtual chassis this device is identified by'),
     )
     vc_priority = forms.IntegerField(
-        required=False,
-        label=_('Priority'),
-        help_text=_("The priority of the device in the virtual chassis")
+        required=False, label=_('Priority'), help_text=_('The priority of the device in the virtual chassis')
     )
     config_template = DynamicModelChoiceField(
-        label=_('Config template'),
-        queryset=ConfigTemplate.objects.all(),
-        required=False
+        label=_('Config template'), queryset=ConfigTemplate.objects.all(), required=False
     )
 
     class Meta:
         model = Device
         fields = [
-            'name', 'role', 'device_type', 'serial', 'asset_tag', 'site', 'rack', 'location', 'position', 'face',
-            'latitude', 'longitude', 'status', 'airflow', 'platform', 'primary_ip4', 'primary_ip6', 'oob_ip', 'cluster',
-            'tenant_group', 'tenant', 'virtual_chassis', 'vc_position', 'vc_priority', 'description', 'config_template',
-            'owner', 'comments', 'tags', 'local_context_data',
+            'name',
+            'role',
+            'device_type',
+            'serial',
+            'asset_tag',
+            'site',
+            'rack',
+            'location',
+            'position',
+            'face',
+            'latitude',
+            'longitude',
+            'status',
+            'airflow',
+            'platform',
+            'primary_ip4',
+            'primary_ip6',
+            'oob_ip',
+            'cluster',
+            'tenant_group',
+            'tenant',
+            'virtual_chassis',
+            'vc_position',
+            'vc_priority',
+            'description',
+            'config_template',
+            'owner',
+            'comments',
+            'tags',
+            'local_context_data',
         ]
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         if self.instance.pk:
-
             # Compile list of choices for primary IPv4 and IPv6 addresses
             oob_ip_choices = [(None, '---------')]
             for family in [4, 6]:
@@ -744,18 +831,22 @@ class DeviceForm(TenancyForm, PrimaryModelForm):
                 interface_ips = IPAddress.objects.filter(
                     address__family=family,
                     assigned_object_type=ContentType.objects.get_for_model(Interface),
-                    assigned_object_id__in=interface_ids
+                    assigned_object_id__in=interface_ids,
                 ).prefetch_related('assigned_object')
                 if interface_ips:
                     ip_list = [(ip.id, f'{ip.address} ({ip.assigned_object})') for ip in interface_ips]
                     ip_choices.append(('Interface IPs', ip_list))
                     oob_ip_choices.extend(ip_list)
                 # Collect NAT IPs
-                nat_ips = IPAddress.objects.prefetch_related('nat_inside').filter(
-                    address__family=family,
-                    nat_inside__assigned_object_type=ContentType.objects.get_for_model(Interface),
-                    nat_inside__assigned_object_id__in=interface_ids
-                ).prefetch_related('assigned_object')
+                nat_ips = (
+                    IPAddress.objects.prefetch_related('nat_inside')
+                    .filter(
+                        address__family=family,
+                        nat_inside__assigned_object_type=ContentType.objects.get_for_model(Interface),
+                        nat_inside__assigned_object_id__in=interface_ids,
+                    )
+                    .prefetch_related('assigned_object')
+                )
                 if nat_ips:
                     ip_list = [(ip.id, f'{ip.address} (NAT)') for ip in nat_ips]
                     ip_choices.append(('NAT IPs', ip_list))
@@ -774,7 +865,6 @@ class DeviceForm(TenancyForm, PrimaryModelForm):
                 self.initial['rack'] = self.instance.parent_bay.device.rack_id
 
         else:
-
             # An object that doesn't exist yet can't have any IPs assigned to it
             self.fields['primary_ip4'].choices = []
             self.fields['primary_ip4'].widget.attrs['readonly'] = True
@@ -791,11 +881,7 @@ class DeviceForm(TenancyForm, PrimaryModelForm):
 
 class ModuleForm(ModuleCommonForm, PrimaryModelForm):
     device = DynamicModelChoiceField(
-        label=_('Device'),
-        queryset=Device.objects.all(),
-        initial_params={
-            'modulebays': '$module_bay'
-        }
+        label=_('Device'), queryset=Device.objects.all(), initial_params={'modulebays': '$module_bay'}
     )
     module_bay = DynamicModelChoiceField(
         label=_('Module bay'),
@@ -813,19 +899,16 @@ class ModuleForm(ModuleCommonForm, PrimaryModelForm):
         context={
             'parent': 'manufacturer',
         },
-        selector=True
+        selector=True,
     )
     replicate_components = forms.BooleanField(
         label=_('Replicate components'),
         required=False,
         initial=True,
-        help_text=_("Automatically populate components associated with this module type")
+        help_text=_('Automatically populate components associated with this module type'),
     )
     adopt_components = forms.BooleanField(
-        label=_('Adopt components'),
-        required=False,
-        initial=False,
-        help_text=_("Adopt already existing components")
+        label=_('Adopt components'), required=False, initial=False, help_text=_('Adopt already existing components')
     )
 
     fieldsets = (
@@ -836,8 +919,18 @@ class ModuleForm(ModuleCommonForm, PrimaryModelForm):
     class Meta:
         model = Module
         fields = [
-            'device', 'module_bay', 'module_type', 'status', 'serial', 'asset_tag', 'tags', 'replicate_components',
-            'adopt_components', 'description', 'owner', 'comments',
+            'device',
+            'module_bay',
+            'module_type',
+            'status',
+            'serial',
+            'asset_tag',
+            'tags',
+            'replicate_components',
+            'adopt_components',
+            'description',
+            'owner',
+            'comments',
         ]
 
     def __init__(self, *args, **kwargs):
@@ -852,17 +945,16 @@ class ModuleForm(ModuleCommonForm, PrimaryModelForm):
 
 
 def get_termination_type_choices():
-    return add_blank_choice([
-        (f'{ct.app_label}.{ct.model}', ct.model_class()._meta.verbose_name.title())
-        for ct in ContentType.objects.filter(CABLE_TERMINATION_MODELS)
-    ])
+    return add_blank_choice(
+        [
+            (f'{ct.app_label}.{ct.model}', ct.model_class()._meta.verbose_name.title())
+            for ct in ContentType.objects.filter(CABLE_TERMINATION_MODELS)
+        ]
+    )
 
 
 class CableBundleForm(PrimaryModelForm):
-
-    fieldsets = (
-        FieldSet('name', 'description', 'tags', name=_('Cable Bundle')),
-    )
+    fieldsets = (FieldSet('name', 'description', 'tags', name=_('Cable Bundle')),)
 
     class Meta:
         model = CableBundle
@@ -871,16 +963,10 @@ class CableBundleForm(PrimaryModelForm):
 
 class CableForm(TenancyForm, PrimaryModelForm):
     a_terminations_type = forms.ChoiceField(
-        choices=get_termination_type_choices,
-        required=False,
-        widget=HTMXSelect(),
-        label=_('Type')
+        choices=get_termination_type_choices, required=False, widget=HTMXSelect(), label=_('Type')
     )
     b_terminations_type = forms.ChoiceField(
-        choices=get_termination_type_choices,
-        required=False,
-        widget=HTMXSelect(),
-        label=_('Type')
+        choices=get_termination_type_choices, required=False, widget=HTMXSelect(), label=_('Type')
     )
     bundle = DynamicModelChoiceField(
         queryset=CableBundle.objects.all(),
@@ -891,55 +977,63 @@ class CableForm(TenancyForm, PrimaryModelForm):
     class Meta:
         model = Cable
         fields = [
-            'a_terminations_type', 'b_terminations_type', 'type', 'status', 'profile', 'tenant_group', 'tenant',
-            'bundle', 'label', 'color', 'length', 'length_unit', 'description', 'owner', 'comments', 'tags',
+            'a_terminations_type',
+            'b_terminations_type',
+            'type',
+            'status',
+            'profile',
+            'tenant_group',
+            'tenant',
+            'bundle',
+            'label',
+            'color',
+            'length',
+            'length_unit',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
 
 
 class PowerPanelForm(PrimaryModelForm):
-    site = DynamicModelChoiceField(
-        label=_('Site'),
-        queryset=Site.objects.all(),
-        selector=True
-    )
+    site = DynamicModelChoiceField(label=_('Site'), queryset=Site.objects.all(), selector=True)
     location = DynamicModelChoiceField(
-        label=_('Location'),
-        queryset=Location.objects.all(),
-        required=False,
-        query_params={
-            'site_id': '$site'
-        }
+        label=_('Location'), queryset=Location.objects.all(), required=False, query_params={'site_id': '$site'}
     )
 
-    fieldsets = (
-        FieldSet('site', 'location', 'name', 'description', 'tags', name=_('Power Panel')),
-    )
+    fieldsets = (FieldSet('site', 'location', 'name', 'description', 'tags', name=_('Power Panel')),)
 
     class Meta:
         model = PowerPanel
         fields = [
-            'site', 'location', 'name', 'description', 'owner', 'comments', 'tags',
+            'site',
+            'location',
+            'name',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
 
 
 class PowerFeedForm(TenancyForm, PrimaryModelForm):
     power_panel = DynamicModelChoiceField(
-        label=_('Power panel'),
-        queryset=PowerPanel.objects.all(),
-        selector=True,
-        quick_add=True
+        label=_('Power panel'), queryset=PowerPanel.objects.all(), selector=True, quick_add=True
     )
-    rack = DynamicModelChoiceField(
-        label=_('Rack'),
-        queryset=Rack.objects.all(),
-        required=False,
-        selector=True
-    )
+    rack = DynamicModelChoiceField(label=_('Rack'), queryset=Rack.objects.all(), required=False, selector=True)
 
     fieldsets = (
         FieldSet(
-            'power_panel', 'rack', 'name', 'status', 'type', 'description', 'mark_connected', 'tags',
-            name=_('Power Feed')
+            'power_panel',
+            'rack',
+            'name',
+            'status',
+            'type',
+            'description',
+            'mark_connected',
+            'tags',
+            name=_('Power Feed'),
         ),
         FieldSet('supply', 'voltage', 'amperage', 'phase', 'max_utilization', name=_('Characteristics')),
         FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
@@ -948,14 +1042,30 @@ class PowerFeedForm(TenancyForm, PrimaryModelForm):
     class Meta:
         model = PowerFeed
         fields = [
-            'power_panel', 'rack', 'name', 'status', 'type', 'mark_connected', 'supply', 'phase', 'voltage', 'amperage',
-            'max_utilization', 'tenant_group', 'tenant', 'description', 'owner', 'comments', 'tags'
+            'power_panel',
+            'rack',
+            'name',
+            'status',
+            'type',
+            'mark_connected',
+            'supply',
+            'phase',
+            'voltage',
+            'amperage',
+            'max_utilization',
+            'tenant_group',
+            'tenant',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
 
 
 #
 # Virtual chassis
 #
+
 
 class VirtualChassisForm(PrimaryModelForm):
     master = forms.ModelChoiceField(
@@ -967,7 +1077,13 @@ class VirtualChassisForm(PrimaryModelForm):
     class Meta:
         model = VirtualChassis
         fields = [
-            'name', 'domain', 'master', 'description', 'owner', 'comments', 'tags',
+            'name',
+            'domain',
+            'master',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
         widgets = {
             'master': SelectWithPK(),
@@ -983,7 +1099,8 @@ class DeviceVCMembershipForm(forms.ModelForm):
     class Meta:
         model = Device
         fields = [
-            'vc_position', 'vc_priority',
+            'vc_position',
+            'vc_priority',
         ]
         labels = {
             'vc_position': 'Position',
@@ -1009,8 +1126,7 @@ class DeviceVCMembershipForm(forms.ModelForm):
 
         if self.validate_vc_position:
             conflicting_members = Device.objects.filter(
-                virtual_chassis=self.instance.virtual_chassis,
-                vc_position=vc_position
+                virtual_chassis=self.instance.virtual_chassis, vc_position=vc_position
             )
             if conflicting_members.exists():
                 raise forms.ValidationError(
@@ -1027,15 +1143,13 @@ class VCMemberSelectForm(forms.Form):
         query_params={
             'virtual_chassis_id': 'null',
         },
-        selector=True
+        selector=True,
     )
 
     def clean_device(self):
         device = self.cleaned_data['device']
         if device.virtual_chassis is not None:
-            raise forms.ValidationError(
-                f"Device {device} is already assigned to a virtual chassis."
-            )
+            raise forms.ValidationError(f'Device {device} is already assigned to a virtual chassis.')
         return device
 
 
@@ -1043,13 +1157,14 @@ class VCMemberSelectForm(forms.Form):
 # Device component templates
 #
 
+
 class ComponentTemplateForm(ChangelogMessageMixin, forms.ModelForm):
     device_type = DynamicModelChoiceField(
         label=_('Device type'),
         queryset=DeviceType.objects.all(),
         context={
             'parent': 'manufacturer',
-        }
+        },
     )
 
     def __init__(self, *args, **kwargs):
@@ -1067,7 +1182,7 @@ class ModularComponentTemplateForm(ComponentTemplateForm):
         required=False,
         context={
             'parent': 'manufacturer',
-        }
+        },
     )
     module_type = DynamicModelChoiceField(
         label=_('Module type'),
@@ -1075,7 +1190,7 @@ class ModularComponentTemplateForm(ComponentTemplateForm):
         required=False,
         context={
             'parent': 'manufacturer',
-        }
+        },
     )
 
     fieldsets = (
@@ -1084,7 +1199,10 @@ class ModularComponentTemplateForm(ComponentTemplateForm):
                 FieldSet('device_type', name=_('Device Type')),
                 FieldSet('module_type', name=_('Module Type')),
             ),
-            'name', 'label', 'type', 'description'
+            'name',
+            'label',
+            'type',
+            'description',
         ),
     )
 
@@ -1097,11 +1215,11 @@ class ModularComponentTemplateForm(ComponentTemplateForm):
 
         # Components attached to a module need to present this standardized substitution help text.
         self.fields['name'].help_text = _(
-            "Alphanumeric ranges are supported for bulk creation. Mixed cases and types within a single range are not "
-            "supported (example: <code>[ge,xe]-0/0/[0-9]</code>). The token <code>{module}</code>, if present, will be "
-            "automatically replaced with the position value when creating a new module. "
+            'Alphanumeric ranges are supported for bulk creation. Mixed cases and types within a single range are not '
+            'supported (example: <code>[ge,xe]-0/0/[0-9]</code>). The token <code>{module}</code>, if present, will be '
+            'automatically replaced with the position value when creating a new module. '
             "The token <code>{vc_position}</code> will be replaced with the device's Virtual Chassis position "
-            "(use <code>{vc_position:1}</code> to specify a fallback (default is 0))"
+            '(use <code>{vc_position:1}</code> to specify a fallback (default is 0))'
         )
 
 
@@ -1109,7 +1227,12 @@ class ConsolePortTemplateForm(ModularComponentTemplateForm):
     class Meta:
         model = ConsolePortTemplate
         fields = [
-            'device_type', 'module_type', 'name', 'label', 'type', 'description',
+            'device_type',
+            'module_type',
+            'name',
+            'label',
+            'type',
+            'description',
         ]
 
 
@@ -1117,7 +1240,12 @@ class ConsoleServerPortTemplateForm(ModularComponentTemplateForm):
     class Meta:
         model = ConsoleServerPortTemplate
         fields = [
-            'device_type', 'module_type', 'name', 'label', 'type', 'description',
+            'device_type',
+            'module_type',
+            'name',
+            'label',
+            'type',
+            'description',
         ]
 
 
@@ -1128,14 +1256,26 @@ class PowerPortTemplateForm(ModularComponentTemplateForm):
                 FieldSet('device_type', name=_('Device Type')),
                 FieldSet('module_type', name=_('Module Type')),
             ),
-            'name', 'label', 'type', 'maximum_draw', 'allocated_draw', 'description',
+            'name',
+            'label',
+            'type',
+            'maximum_draw',
+            'allocated_draw',
+            'description',
         ),
     )
 
     class Meta:
         model = PowerPortTemplate
         fields = [
-            'device_type', 'module_type', 'name', 'label', 'type', 'maximum_draw', 'allocated_draw', 'description',
+            'device_type',
+            'module_type',
+            'name',
+            'label',
+            'type',
+            'maximum_draw',
+            'allocated_draw',
+            'description',
         ]
 
 
@@ -1146,7 +1286,7 @@ class PowerOutletTemplateForm(ModularComponentTemplateForm):
         required=False,
         query_params={
             'device_type_id': '$device_type',
-        }
+        },
     )
 
     fieldsets = (
@@ -1155,14 +1295,28 @@ class PowerOutletTemplateForm(ModularComponentTemplateForm):
                 FieldSet('device_type', name=_('Device Type')),
                 FieldSet('module_type', name=_('Module Type')),
             ),
-            'name', 'label', 'type', 'color', 'power_port', 'feed_leg', 'description',
+            'name',
+            'label',
+            'type',
+            'color',
+            'power_port',
+            'feed_leg',
+            'description',
         ),
     )
 
     class Meta:
         model = PowerOutletTemplate
         fields = [
-            'device_type', 'module_type', 'name', 'label', 'type', 'color', 'power_port', 'feed_leg', 'description',
+            'device_type',
+            'module_type',
+            'name',
+            'label',
+            'type',
+            'color',
+            'power_port',
+            'feed_leg',
+            'description',
         ]
 
 
@@ -1174,7 +1328,7 @@ class InterfaceTemplateForm(ModularComponentTemplateForm):
         query_params={
             'device_type_id': '$device_type',
             'module_type_id': '$module_type',
-        }
+        },
     )
 
     fieldsets = (
@@ -1183,7 +1337,13 @@ class InterfaceTemplateForm(ModularComponentTemplateForm):
                 FieldSet('device_type', name=_('Device Type')),
                 FieldSet('module_type', name=_('Module Type')),
             ),
-            'name', 'label', 'type', 'enabled', 'mgmt_only', 'description', 'bridge',
+            'name',
+            'label',
+            'type',
+            'enabled',
+            'mgmt_only',
+            'description',
+            'bridge',
         ),
         FieldSet('poe_mode', 'poe_type', name=_('PoE')),
         FieldSet('rf_role', name=_('Wireless')),
@@ -1192,8 +1352,18 @@ class InterfaceTemplateForm(ModularComponentTemplateForm):
     class Meta:
         model = InterfaceTemplate
         fields = [
-            'device_type', 'module_type', 'name', 'label', 'type', 'mgmt_only', 'enabled', 'description', 'poe_mode',
-            'poe_type', 'bridge', 'rf_role',
+            'device_type',
+            'module_type',
+            'name',
+            'label',
+            'type',
+            'mgmt_only',
+            'enabled',
+            'description',
+            'poe_mode',
+            'poe_type',
+            'bridge',
+            'rf_role',
         ]
 
 
@@ -1204,7 +1374,13 @@ class FrontPortTemplateForm(FrontPortFormMixin, ModularComponentTemplateForm):
                 FieldSet('device_type', name=_('Device Type')),
                 FieldSet('module_type', name=_('Module Type')),
             ),
-            'name', 'label', 'type', 'color', 'positions', 'rear_ports', 'description',
+            'name',
+            'label',
+            'type',
+            'color',
+            'positions',
+            'rear_ports',
+            'description',
         ),
     )
 
@@ -1214,7 +1390,14 @@ class FrontPortTemplateForm(FrontPortFormMixin, ModularComponentTemplateForm):
     class Meta:
         model = FrontPortTemplate
         fields = [
-            'device_type', 'module_type', 'name', 'label', 'type', 'color', 'positions', 'description',
+            'device_type',
+            'module_type',
+            'name',
+            'label',
+            'type',
+            'color',
+            'positions',
+            'description',
         ]
 
     def __init__(self, *args, **kwargs):
@@ -1244,14 +1427,26 @@ class RearPortTemplateForm(ModularComponentTemplateForm):
                 FieldSet('device_type', name=_('Device Type')),
                 FieldSet('module_type', name=_('Module Type')),
             ),
-            'name', 'label', 'type', 'color', 'positions', 'description',
+            'name',
+            'label',
+            'type',
+            'color',
+            'positions',
+            'description',
         ),
     )
 
     class Meta:
         model = RearPortTemplate
         fields = [
-            'device_type', 'module_type', 'name', 'label', 'type', 'color', 'positions', 'description',
+            'device_type',
+            'module_type',
+            'name',
+            'label',
+            'type',
+            'color',
+            'positions',
+            'description',
         ]
 
 
@@ -1262,26 +1457,38 @@ class ModuleBayTemplateForm(ModularComponentTemplateForm):
                 FieldSet('device_type', name=_('Device Type')),
                 FieldSet('module_type', name=_('Module Type')),
             ),
-            'name', 'label', 'position', 'enabled', 'description',
+            'name',
+            'label',
+            'position',
+            'enabled',
+            'description',
         ),
     )
 
     class Meta:
         model = ModuleBayTemplate
         fields = [
-            'device_type', 'module_type', 'name', 'label', 'position', 'enabled', 'description',
+            'device_type',
+            'module_type',
+            'name',
+            'label',
+            'position',
+            'enabled',
+            'description',
         ]
 
 
 class DeviceBayTemplateForm(ComponentTemplateForm):
-    fieldsets = (
-        FieldSet('device_type', 'name', 'label', 'enabled', 'description'),
-    )
+    fieldsets = (FieldSet('device_type', 'name', 'label', 'enabled', 'description'),)
 
     class Meta:
         model = DeviceBayTemplate
         fields = [
-            'device_type', 'name', 'label', 'enabled', 'description',
+            'device_type',
+            'name',
+            'label',
+            'enabled',
+            'description',
         ]
 
 
@@ -1290,82 +1497,65 @@ class InventoryItemTemplateForm(ComponentTemplateForm):
         label=_('Parent'),
         queryset=InventoryItemTemplate.objects.all(),
         required=False,
-        query_params={
-            'device_type_id': '$device_type'
-        }
+        query_params={'device_type_id': '$device_type'},
     )
-    role = DynamicModelChoiceField(
-        label=_('Role'),
-        queryset=InventoryItemRole.objects.all(),
-        required=False
-    )
-    manufacturer = DynamicModelChoiceField(
-        label=_('Manufacturer'),
-        queryset=Manufacturer.objects.all(),
-        required=False
-    )
+    role = DynamicModelChoiceField(label=_('Role'), queryset=InventoryItemRole.objects.all(), required=False)
+    manufacturer = DynamicModelChoiceField(label=_('Manufacturer'), queryset=Manufacturer.objects.all(), required=False)
 
     # Assigned component selectors
     consoleporttemplate = DynamicModelChoiceField(
         queryset=ConsolePortTemplate.objects.all(),
         required=False,
-        query_params={
-            'device_type_id': '$device_type'
-        },
-        label=_('Console port template')
+        query_params={'device_type_id': '$device_type'},
+        label=_('Console port template'),
     )
     consoleserverporttemplate = DynamicModelChoiceField(
         queryset=ConsoleServerPortTemplate.objects.all(),
         required=False,
-        query_params={
-            'device_type_id': '$device_type'
-        },
-        label=_('Console server port template')
+        query_params={'device_type_id': '$device_type'},
+        label=_('Console server port template'),
     )
     frontporttemplate = DynamicModelChoiceField(
         queryset=FrontPortTemplate.objects.all(),
         required=False,
-        query_params={
-            'device_type_id': '$device_type'
-        },
-        label=_('Front port template')
+        query_params={'device_type_id': '$device_type'},
+        label=_('Front port template'),
     )
     interfacetemplate = DynamicModelChoiceField(
         queryset=InterfaceTemplate.objects.all(),
         required=False,
-        query_params={
-            'device_type_id': '$device_type'
-        },
-        label=_('Interface template')
+        query_params={'device_type_id': '$device_type'},
+        label=_('Interface template'),
     )
     poweroutlettemplate = DynamicModelChoiceField(
         queryset=PowerOutletTemplate.objects.all(),
         required=False,
-        query_params={
-            'device_type_id': '$device_type'
-        },
-        label=_('Power outlet template')
+        query_params={'device_type_id': '$device_type'},
+        label=_('Power outlet template'),
     )
     powerporttemplate = DynamicModelChoiceField(
         queryset=PowerPortTemplate.objects.all(),
         required=False,
-        query_params={
-            'device_type_id': '$device_type'
-        },
-        label=_('Power port template')
+        query_params={'device_type_id': '$device_type'},
+        label=_('Power port template'),
     )
     rearporttemplate = DynamicModelChoiceField(
         queryset=RearPortTemplate.objects.all(),
         required=False,
-        query_params={
-            'device_type_id': '$device_type'
-        },
-        label=_('Rear port template')
+        query_params={'device_type_id': '$device_type'},
+        label=_('Rear port template'),
     )
 
     fieldsets = (
         FieldSet(
-            'device_type', 'parent', 'name', 'label', 'role', 'manufacturer', 'part_id', 'description',
+            'device_type',
+            'parent',
+            'name',
+            'label',
+            'role',
+            'manufacturer',
+            'part_id',
+            'description',
         ),
         FieldSet(
             TabbedGroups(
@@ -1377,14 +1567,21 @@ class InventoryItemTemplateForm(ComponentTemplateForm):
                 FieldSet('powerporttemplate', name=_('Power Port')),
                 FieldSet('poweroutlettemplate', name=_('Power Outlet')),
             ),
-            name=_('Component Assignment')
-        )
+            name=_('Component Assignment'),
+        ),
     )
 
     class Meta:
         model = InventoryItemTemplate
         fields = [
-            'device_type', 'parent', 'name', 'label', 'role', 'manufacturer', 'part_id', 'description',
+            'device_type',
+            'parent',
+            'name',
+            'label',
+            'role',
+            'manufacturer',
+            'part_id',
+            'description',
         ]
 
     def __init__(self, *args, **kwargs):
@@ -1401,9 +1598,9 @@ class InventoryItemTemplateForm(ComponentTemplateForm):
                     break
         elif component_type and component_id:
             # When adding the InventoryItem from a component page
-            content_type = ContentType.objects.filter(
-                MODULAR_COMPONENT_TEMPLATE_MODELS
-            ).filter(pk=component_type).first()
+            content_type = (
+                ContentType.objects.filter(MODULAR_COMPONENT_TEMPLATE_MODELS).filter(pk=component_type).first()
+            )
             if content_type:
                 if component := content_type.model_class().objects.filter(pk=component_id).first():
                     initial[content_type.model] = component
@@ -1417,13 +1614,20 @@ class InventoryItemTemplateForm(ComponentTemplateForm):
 
         # Handle object assignment
         selected_objects = [
-            field for field in (
-                'consoleporttemplate', 'consoleserverporttemplate', 'frontporttemplate', 'interfacetemplate',
-                'poweroutlettemplate', 'powerporttemplate', 'rearporttemplate'
-            ) if self.cleaned_data[field]
+            field
+            for field in (
+                'consoleporttemplate',
+                'consoleserverporttemplate',
+                'frontporttemplate',
+                'interfacetemplate',
+                'poweroutlettemplate',
+                'powerporttemplate',
+                'rearporttemplate',
+            )
+            if self.cleaned_data[field]
         ]
         if len(selected_objects) > 1:
-            raise forms.ValidationError(_("An InventoryItem can only be assigned to a single component."))
+            raise forms.ValidationError(_('An InventoryItem can only be assigned to a single component.'))
         if selected_objects:
             self.instance.component = self.cleaned_data[selected_objects[0]]
         else:
@@ -1434,12 +1638,9 @@ class InventoryItemTemplateForm(ComponentTemplateForm):
 # Device components
 #
 
+
 class DeviceComponentForm(OwnerMixin, NetBoxModelForm):
-    device = DynamicModelChoiceField(
-        label=_('Device'),
-        queryset=Device.objects.all(),
-        selector=True
-    )
+    device = DynamicModelChoiceField(label=_('Device'), queryset=Device.objects.all(), selector=True)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -1456,51 +1657,102 @@ class ModularDeviceComponentForm(DeviceComponentForm):
         required=False,
         query_params={
             'device_id': '$device',
-        }
+        },
     )
 
 
 class ConsolePortForm(ModularDeviceComponentForm):
     fieldsets = (
         FieldSet(
-            'device', 'module', 'name', 'label', 'type', 'speed', 'mark_connected', 'description', 'tags',
+            'device',
+            'module',
+            'name',
+            'label',
+            'type',
+            'speed',
+            'mark_connected',
+            'description',
+            'tags',
         ),
     )
 
     class Meta:
         model = ConsolePort
         fields = [
-            'device', 'module', 'name', 'label', 'type', 'speed', 'mark_connected', 'description', 'owner', 'tags',
+            'device',
+            'module',
+            'name',
+            'label',
+            'type',
+            'speed',
+            'mark_connected',
+            'description',
+            'owner',
+            'tags',
         ]
 
 
 class ConsoleServerPortForm(ModularDeviceComponentForm):
     fieldsets = (
         FieldSet(
-            'device', 'module', 'name', 'label', 'type', 'speed', 'mark_connected', 'description', 'tags',
+            'device',
+            'module',
+            'name',
+            'label',
+            'type',
+            'speed',
+            'mark_connected',
+            'description',
+            'tags',
         ),
     )
 
     class Meta:
         model = ConsoleServerPort
         fields = [
-            'device', 'module', 'name', 'label', 'type', 'speed', 'mark_connected', 'description', 'owner', 'tags',
+            'device',
+            'module',
+            'name',
+            'label',
+            'type',
+            'speed',
+            'mark_connected',
+            'description',
+            'owner',
+            'tags',
         ]
 
 
 class PowerPortForm(ModularDeviceComponentForm):
     fieldsets = (
         FieldSet(
-            'device', 'module', 'name', 'label', 'type', 'maximum_draw', 'allocated_draw', 'mark_connected',
-            'description', 'tags',
+            'device',
+            'module',
+            'name',
+            'label',
+            'type',
+            'maximum_draw',
+            'allocated_draw',
+            'mark_connected',
+            'description',
+            'tags',
         ),
     )
 
     class Meta:
         model = PowerPort
         fields = [
-            'device', 'module', 'name', 'label', 'type', 'maximum_draw', 'allocated_draw', 'mark_connected',
-            'description', 'owner', 'tags',
+            'device',
+            'module',
+            'name',
+            'label',
+            'type',
+            'maximum_draw',
+            'allocated_draw',
+            'mark_connected',
+            'description',
+            'owner',
+            'tags',
         ]
 
 
@@ -1511,21 +1763,42 @@ class PowerOutletForm(ModularDeviceComponentForm):
         required=False,
         query_params={
             'device_id': '$device',
-        }
+        },
     )
 
     fieldsets = (
         FieldSet(
-            'device', 'module', 'name', 'label', 'type', 'status', 'color', 'power_port', 'feed_leg', 'mark_connected',
-            'description', 'owner', 'tags',
+            'device',
+            'module',
+            'name',
+            'label',
+            'type',
+            'status',
+            'color',
+            'power_port',
+            'feed_leg',
+            'mark_connected',
+            'description',
+            'owner',
+            'tags',
         ),
     )
 
     class Meta:
         model = PowerOutlet
         fields = [
-            'device', 'module', 'name', 'label', 'type', 'status', 'color', 'power_port', 'feed_leg', 'mark_connected',
-            'description', 'tags',
+            'device',
+            'module',
+            'name',
+            'label',
+            'type',
+            'status',
+            'color',
+            'power_port',
+            'feed_leg',
+            'mark_connected',
+            'description',
+            'tags',
         ]
 
 
@@ -1539,7 +1812,7 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
         },
         query_params={
             'device_id': '$device',
-        }
+        },
     )
     parent = DynamicModelChoiceField(
         queryset=Interface.objects.all(),
@@ -1547,7 +1820,7 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
         label=_('Parent interface'),
         query_params={
             'virtual_chassis_member_id': '$device',
-        }
+        },
     )
     bridge = DynamicModelChoiceField(
         queryset=Interface.objects.all(),
@@ -1555,7 +1828,7 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
         label=_('Bridged interface'),
         query_params={
             'virtual_chassis_member_id': '$device',
-        }
+        },
     )
     lag = DynamicModelChoiceField(
         queryset=Interface.objects.all(),
@@ -1564,12 +1837,10 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
         query_params={
             'virtual_chassis_member_id': '$device',
             'type': 'lag',
-        }
+        },
     )
     wireless_lan_group = DynamicModelChoiceField(
-        queryset=WirelessLANGroup.objects.all(),
-        required=False,
-        label=_('Wireless LAN group')
+        queryset=WirelessLANGroup.objects.all(), required=False, label=_('Wireless LAN group')
     )
     wireless_lans = DynamicModelMultipleChoiceField(
         queryset=WirelessLAN.objects.all(),
@@ -1577,13 +1848,13 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
         label=_('Wireless LANs'),
         query_params={
             'group_id': '$wireless_lan_group',
-        }
+        },
     )
     vlan_group = DynamicModelChoiceField(
         queryset=VLANGroup.objects.all(),
         required=False,
         label=_('VLAN group'),
-        help_text=_("Filter VLANs available for assignment by group.")
+        help_text=_('Filter VLANs available for assignment by group.'),
     )
     untagged_vlan = DynamicModelChoiceField(
         queryset=VLAN.objects.all(),
@@ -1592,7 +1863,7 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
         query_params={
             'group_id': '$vlan_group',
             'available_on_device': '$device',
-        }
+        },
     )
     tagged_vlans = DynamicModelMultipleChoiceField(
         queryset=VLAN.objects.all(),
@@ -1601,7 +1872,7 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
         query_params={
             'group_id': '$vlan_group',
             'available_on_device': '$device',
-        }
+        },
     )
     qinq_svlan = DynamicModelChoiceField(
         queryset=VLAN.objects.all(),
@@ -1611,62 +1882,95 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
             'group_id': '$vlan_group',
             'available_on_device': '$device',
             'qinq_role': VLANQinQRoleChoices.ROLE_SERVICE,
-        }
+        },
     )
-    vrf = DynamicModelChoiceField(
-        queryset=VRF.objects.all(),
-        required=False,
-        label=_('VRF')
-    )
+    vrf = DynamicModelChoiceField(queryset=VRF.objects.all(), required=False, label=_('VRF'))
     primary_mac_address = DynamicModelChoiceField(
         queryset=MACAddress.objects.all(),
         label=_('Primary MAC address'),
         required=False,
         quick_add=True,
-        quick_add_params={'interface': '$pk'}
+        quick_add_params={'interface': '$pk'},
     )
-    wwn = forms.CharField(
-        empty_value=None,
+    primary_wwn_address = DynamicModelChoiceField(
+        queryset=WWNAddress.objects.all(),
+        label=_('Primary WWN address'),
         required=False,
-        label=_('WWN')
+        quick_add=True,
+        quick_add_params={'interface': '$pk'},
     )
     vlan_translation_policy = DynamicModelChoiceField(
-        queryset=VLANTranslationPolicy.objects.all(),
-        required=False,
-        label=_('VLAN Translation Policy')
+        queryset=VLANTranslationPolicy.objects.all(), required=False, label=_('VLAN Translation Policy')
     )
 
     fieldsets = (
         FieldSet(
             'device', 'module', 'name', 'label', 'type', 'speed', 'duplex', 'description', 'tags', name=_('Interface')
         ),
-        FieldSet('vrf', 'primary_mac_address', 'wwn', name=_('Addressing')),
+        FieldSet('vrf', 'primary_mac_address', 'primary_wwn_address', name=_('Addressing')),
         FieldSet('vdcs', 'mtu', 'tx_power', 'enabled', 'mgmt_only', 'mark_connected', name=_('Operation')),
         FieldSet('parent', 'bridge', 'lag', name=_('Related Interfaces')),
         FieldSet('poe_mode', 'poe_type', name=_('PoE')),
         FieldSet(
-            'mode', 'vlan_group', 'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'vlan_translation_policy',
-            name=_('802.1Q Switching')
+            'mode',
+            'vlan_group',
+            'untagged_vlan',
+            'tagged_vlans',
+            'qinq_svlan',
+            'vlan_translation_policy',
+            name=_('802.1Q Switching'),
         ),
         FieldSet(
-            'rf_role', 'rf_channel', 'rf_channel_frequency', 'rf_channel_width', 'wireless_lan_group', 'wireless_lans',
-            name=_('Wireless')
+            'rf_role',
+            'rf_channel',
+            'rf_channel_frequency',
+            'rf_channel_width',
+            'wireless_lan_group',
+            'wireless_lans',
+            name=_('Wireless'),
         ),
     )
 
     class Meta:
         model = Interface
         fields = [
-            'device', 'module', 'vdcs', 'name', 'label', 'type', 'speed', 'duplex', 'enabled', 'parent', 'bridge',
-            'lag', 'wwn', 'mtu', 'mgmt_only', 'mark_connected', 'description', 'poe_mode', 'poe_type', 'mode',
-            'rf_role', 'rf_channel', 'rf_channel_frequency', 'rf_channel_width', 'tx_power', 'wireless_lans',
-            'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'vlan_translation_policy', 'vrf', 'primary_mac_address',
-            'owner', 'tags',
+            'device',
+            'module',
+            'vdcs',
+            'name',
+            'label',
+            'type',
+            'speed',
+            'duplex',
+            'enabled',
+            'parent',
+            'bridge',
+            'lag',
+            'mtu',
+            'mgmt_only',
+            'mark_connected',
+            'description',
+            'poe_mode',
+            'poe_type',
+            'mode',
+            'rf_role',
+            'rf_channel',
+            'rf_channel_frequency',
+            'rf_channel_width',
+            'tx_power',
+            'wireless_lans',
+            'untagged_vlan',
+            'tagged_vlans',
+            'qinq_svlan',
+            'vlan_translation_policy',
+            'vrf',
+            'primary_mac_address',
+            'primary_wwn_address',
+            'owner',
+            'tags',
         ]
         widgets = {
-            'speed': NumberWithOptions(
-                options=InterfaceSpeedChoices
-            ),
+            'speed': NumberWithOptions(options=InterfaceSpeedChoices),
             'mode': HTMXSelect(),
         }
         labels = {
@@ -1677,8 +1981,17 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
 class FrontPortForm(FrontPortFormMixin, ModularDeviceComponentForm):
     fieldsets = (
         FieldSet(
-            'device', 'module', 'name', 'label', 'type', 'color', 'positions', 'rear_ports', 'mark_connected',
-            'description', 'tags',
+            'device',
+            'module',
+            'name',
+            'label',
+            'type',
+            'color',
+            'positions',
+            'rear_ports',
+            'mark_connected',
+            'description',
+            'tags',
         ),
     )
 
@@ -1688,7 +2001,16 @@ class FrontPortForm(FrontPortFormMixin, ModularDeviceComponentForm):
     class Meta:
         model = FrontPort
         fields = [
-            'device', 'module', 'name', 'label', 'type', 'color', 'positions', 'mark_connected', 'description', 'owner',
+            'device',
+            'module',
+            'name',
+            'label',
+            'type',
+            'color',
+            'positions',
+            'mark_connected',
+            'description',
+            'owner',
             'tags',
         ]
 
@@ -1713,39 +2035,87 @@ class FrontPortForm(FrontPortFormMixin, ModularDeviceComponentForm):
 class RearPortForm(ModularDeviceComponentForm):
     fieldsets = (
         FieldSet(
-            'device', 'module', 'name', 'label', 'type', 'color', 'positions', 'mark_connected', 'description', 'tags',
+            'device',
+            'module',
+            'name',
+            'label',
+            'type',
+            'color',
+            'positions',
+            'mark_connected',
+            'description',
+            'tags',
         ),
     )
 
     class Meta:
         model = RearPort
         fields = [
-            'device', 'module', 'name', 'label', 'type', 'color', 'positions', 'mark_connected', 'description', 'owner',
+            'device',
+            'module',
+            'name',
+            'label',
+            'type',
+            'color',
+            'positions',
+            'mark_connected',
+            'description',
+            'owner',
             'tags',
         ]
 
 
 class ModuleBayForm(ModularDeviceComponentForm):
     fieldsets = (
-        FieldSet('device', 'module', 'name', 'label', 'position', 'enabled', 'description', 'tags',),
+        FieldSet(
+            'device',
+            'module',
+            'name',
+            'label',
+            'position',
+            'enabled',
+            'description',
+            'tags',
+        ),
     )
 
     class Meta:
         model = ModuleBay
         fields = [
-            'device', 'module', 'name', 'label', 'position', 'enabled', 'description', 'owner', 'tags',
+            'device',
+            'module',
+            'name',
+            'label',
+            'position',
+            'enabled',
+            'description',
+            'owner',
+            'tags',
         ]
 
 
 class DeviceBayForm(DeviceComponentForm):
     fieldsets = (
-        FieldSet('device', 'name', 'label', 'enabled', 'description', 'tags',),
+        FieldSet(
+            'device',
+            'name',
+            'label',
+            'enabled',
+            'description',
+            'tags',
+        ),
     )
 
     class Meta:
         model = DeviceBay
         fields = [
-            'device', 'name', 'label', 'enabled', 'description', 'owner', 'tags',
+            'device',
+            'name',
+            'label',
+            'enabled',
+            'description',
+            'owner',
+            'tags',
         ]
 
 
@@ -1753,7 +2123,7 @@ class PopulateDeviceBayForm(forms.Form):
     installed_device = forms.ModelChoiceField(
         queryset=Device.objects.all(),
         label=_('Child Device'),
-        help_text=_("Child devices must first be created and assigned to the site and rack of the parent device.")
+        help_text=_('Child devices must first be created and assigned to the site and rack of the parent device.'),
     )
 
     def __init__(self, device_bay, *args, **kwargs):
@@ -1764,92 +2134,52 @@ class PopulateDeviceBayForm(forms.Form):
             rack=device_bay.device.rack,
             parent_bay__isnull=True,
             device_type__u_height=0,
-            device_type__subdevice_role=SubdeviceRoleChoices.ROLE_CHILD
+            device_type__subdevice_role=SubdeviceRoleChoices.ROLE_CHILD,
         ).exclude(pk=device_bay.device.pk)
 
 
 class InventoryItemForm(DeviceComponentForm):
     parent = DynamicModelChoiceField(
-        label=_('Parent'),
-        queryset=InventoryItem.objects.all(),
-        required=False,
-        query_params={
-            'device_id': '$device'
-        }
+        label=_('Parent'), queryset=InventoryItem.objects.all(), required=False, query_params={'device_id': '$device'}
     )
-    role = DynamicModelChoiceField(
-        label=_('Role'),
-        queryset=InventoryItemRole.objects.all(),
-        required=False
-    )
-    manufacturer = DynamicModelChoiceField(
-        label=_('Manufacturer'),
-        queryset=Manufacturer.objects.all(),
-        required=False
-    )
+    role = DynamicModelChoiceField(label=_('Role'), queryset=InventoryItemRole.objects.all(), required=False)
+    manufacturer = DynamicModelChoiceField(label=_('Manufacturer'), queryset=Manufacturer.objects.all(), required=False)
 
     # Assigned component selectors
     consoleport = DynamicModelChoiceField(
         queryset=ConsolePort.objects.all(),
         required=False,
-        query_params={
-            'device_id': '$device'
-        },
-        label=_('Console port')
+        query_params={'device_id': '$device'},
+        label=_('Console port'),
     )
     consoleserverport = DynamicModelChoiceField(
         queryset=ConsoleServerPort.objects.all(),
         required=False,
-        query_params={
-            'device_id': '$device'
-        },
-        label=_('Console server port')
+        query_params={'device_id': '$device'},
+        label=_('Console server port'),
     )
     frontport = DynamicModelChoiceField(
-        queryset=FrontPort.objects.all(),
-        required=False,
-        query_params={
-            'device_id': '$device'
-        },
-        label=_('Front port')
+        queryset=FrontPort.objects.all(), required=False, query_params={'device_id': '$device'}, label=_('Front port')
     )
     interface = DynamicModelChoiceField(
-        queryset=Interface.objects.all(),
-        required=False,
-        query_params={
-            'device_id': '$device'
-        },
-        label=_('Interface')
+        queryset=Interface.objects.all(), required=False, query_params={'device_id': '$device'}, label=_('Interface')
     )
     poweroutlet = DynamicModelChoiceField(
         queryset=PowerOutlet.objects.all(),
         required=False,
-        query_params={
-            'device_id': '$device'
-        },
-        label=_('Power outlet')
+        query_params={'device_id': '$device'},
+        label=_('Power outlet'),
     )
     powerport = DynamicModelChoiceField(
-        queryset=PowerPort.objects.all(),
-        required=False,
-        query_params={
-            'device_id': '$device'
-        },
-        label=_('Power port')
+        queryset=PowerPort.objects.all(), required=False, query_params={'device_id': '$device'}, label=_('Power port')
     )
     rearport = DynamicModelChoiceField(
-        queryset=RearPort.objects.all(),
-        required=False,
-        query_params={
-            'device_id': '$device'
-        },
-        label=_('Rear port')
+        queryset=RearPort.objects.all(), required=False, query_params={'device_id': '$device'}, label=_('Rear port')
     )
 
     fieldsets = (
         FieldSet(
-            'device', 'parent', 'name', 'label', 'status', 'role', 'description', 'tags',
-            name=_('Inventory Item')
+            'device', 'parent', 'name', 'label', 'status', 'role', 'description', 'tags', name=_('Inventory Item')
         ),
         FieldSet('manufacturer', 'part_id', 'serial', 'asset_tag', name=_('Hardware')),
         FieldSet(
@@ -1862,15 +2192,26 @@ class InventoryItemForm(DeviceComponentForm):
                 FieldSet('powerport', name=_('Power Port')),
                 FieldSet('poweroutlet', name=_('Power Outlet')),
             ),
-            name=_('Component Assignment')
-        )
+            name=_('Component Assignment'),
+        ),
     )
 
     class Meta:
         model = InventoryItem
         fields = [
-            'device', 'parent', 'name', 'label', 'role', 'manufacturer', 'part_id', 'serial', 'asset_tag',
-            'status', 'description', 'owner', 'tags',
+            'device',
+            'parent',
+            'name',
+            'label',
+            'role',
+            'manufacturer',
+            'part_id',
+            'serial',
+            'asset_tag',
+            'status',
+            'description',
+            'owner',
+            'tags',
         ]
 
     def __init__(self, *args, **kwargs):
@@ -1904,12 +2245,20 @@ class InventoryItemForm(DeviceComponentForm):
 
         # Handle object assignment
         selected_objects = [
-            field for field in (
-                'consoleport', 'consoleserverport', 'frontport', 'interface', 'poweroutlet', 'powerport', 'rearport'
-            ) if self.cleaned_data[field]
+            field
+            for field in (
+                'consoleport',
+                'consoleserverport',
+                'frontport',
+                'interface',
+                'poweroutlet',
+                'powerport',
+                'rearport',
+            )
+            if self.cleaned_data[field]
         ]
         if len(selected_objects) > 1:
-            raise forms.ValidationError(_("An InventoryItem can only be assigned to a single component."))
+            raise forms.ValidationError(_('An InventoryItem can only be assigned to a single component.'))
         if selected_objects:
             self.instance.component = self.cleaned_data[selected_objects[0]]
         else:
@@ -1917,23 +2266,23 @@ class InventoryItemForm(DeviceComponentForm):
 
 
 class InventoryItemRoleForm(OrganizationalModelForm):
-    fieldsets = (
-        FieldSet('name', 'slug', 'color', 'description', 'tags', name=_('Inventory Item Role')),
-    )
+    fieldsets = (FieldSet('name', 'slug', 'color', 'description', 'tags', name=_('Inventory Item Role')),)
 
     class Meta:
         model = InventoryItemRole
         fields = [
-            'name', 'slug', 'color', 'description', 'owner', 'comments', 'tags',
+            'name',
+            'slug',
+            'color',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
 
 
 class VirtualDeviceContextForm(TenancyForm, PrimaryModelForm):
-    device = DynamicModelChoiceField(
-        label=_('Device'),
-        queryset=Device.objects.all(),
-        selector=True
-    )
+    device = DynamicModelChoiceField(label=_('Device'), queryset=Device.objects.all(), selector=True)
     primary_ip4 = DynamicModelChoiceField(
         queryset=IPAddress.objects.all(),
         label=_('Primary IPv4'),
@@ -1941,7 +2290,7 @@ class VirtualDeviceContextForm(TenancyForm, PrimaryModelForm):
         query_params={
             'device_id': '$device',
             'family': '4',
-        }
+        },
     )
     primary_ip6 = DynamicModelChoiceField(
         queryset=IPAddress.objects.all(),
@@ -1950,22 +2299,37 @@ class VirtualDeviceContextForm(TenancyForm, PrimaryModelForm):
         query_params={
             'device_id': '$device',
             'family': '6',
-        }
+        },
     )
 
     fieldsets = (
         FieldSet(
-            'device', 'name', 'status', 'identifier', 'primary_ip4', 'primary_ip6', 'tags',
-            name=_('Virtual Device Context')
+            'device',
+            'name',
+            'status',
+            'identifier',
+            'primary_ip4',
+            'primary_ip6',
+            'tags',
+            name=_('Virtual Device Context'),
         ),
-        FieldSet('tenant_group', 'tenant', name=_('Tenancy'))
+        FieldSet('tenant_group', 'tenant', name=_('Tenancy')),
     )
 
     class Meta:
         model = VirtualDeviceContext
         fields = [
-            'device', 'name', 'status', 'identifier', 'primary_ip4', 'primary_ip6', 'tenant_group', 'tenant', 'owner',
-            'comments', 'tags'
+            'device',
+            'name',
+            'status',
+            'identifier',
+            'primary_ip4',
+            'primary_ip6',
+            'tenant_group',
+            'tenant',
+            'owner',
+            'comments',
+            'tags',
         ]
 
 
@@ -1973,11 +2337,9 @@ class VirtualDeviceContextForm(TenancyForm, PrimaryModelForm):
 # Addressing
 #
 
+
 class MACAddressForm(PrimaryModelForm):
-    mac_address = forms.CharField(
-        required=True,
-        label=_('MAC address')
-    )
+    mac_address = forms.CharField(required=True, label=_('MAC address'))
     interface = DynamicModelChoiceField(
         label=_('Interface'),
         queryset=Interface.objects.all(),
@@ -1999,7 +2361,9 @@ class MACAddressForm(PrimaryModelForm):
 
     fieldsets = (
         FieldSet(
-            'mac_address', 'description', 'tags',
+            'mac_address',
+            'description',
+            'tags',
         ),
         FieldSet(
             TabbedGroups(
@@ -2012,7 +2376,13 @@ class MACAddressForm(PrimaryModelForm):
     class Meta:
         model = MACAddress
         fields = [
-            'mac_address', 'interface', 'vminterface', 'description', 'owner', 'comments', 'tags',
+            'mac_address',
+            'interface',
+            'vminterface',
+            'description',
+            'owner',
+            'comments',
+            'tags',
         ]
 
     def __init__(self, *args, **kwargs):
@@ -2038,13 +2408,92 @@ class MACAddressForm(PrimaryModelForm):
         super().clean()
 
         # Handle object assignment
-        selected_objects = [
-            field for field in ('interface', 'vminterface') if self.cleaned_data[field]
-        ]
+        selected_objects = [field for field in ('interface', 'vminterface') if self.cleaned_data[field]]
         if len(selected_objects) > 1:
-            raise forms.ValidationError({
-                selected_objects[1]: _("A MAC address can only be assigned to a single object.")
-            })
+            raise forms.ValidationError(
+                {selected_objects[1]: _('A MAC address can only be assigned to a single object.')}
+            )
+        if selected_objects:
+            self.instance.assigned_object = self.cleaned_data[selected_objects[0]]
+        else:
+            self.instance.assigned_object = None
+
+
+class WWNAddressForm(PrimaryModelForm):
+    wwn_address = forms.CharField(required=True, label=_('WWN address'))
+    interface = DynamicModelChoiceField(
+        label=_('Interface'),
+        queryset=Interface.objects.all(),
+        required=False,
+        selector=True,
+        context={
+            'parent': 'device',
+        },
+    )
+    vminterface = DynamicModelChoiceField(
+        label=_('VM Interface'),
+        queryset=VMInterface.objects.all(),
+        required=False,
+        selector=True,
+        context={
+            'parent': 'virtual_machine',
+        },
+    )
+
+    fieldsets = (
+        FieldSet(
+            'wwn_address',
+            'description',
+            'tags',
+        ),
+        FieldSet(
+            TabbedGroups(
+                FieldSet('interface', name=_('Device')),
+                FieldSet('vminterface', name=_('Virtual Machine')),
+            ),
+        ),
+    )
+
+    class Meta:
+        model = WWNAddress
+        fields = [
+            'wwn_address',
+            'interface',
+            'vminterface',
+            'description',
+            'owner',
+            'comments',
+            'tags',
+        ]
+
+    def __init__(self, *args, **kwargs):
+
+        # Initialize helper selectors
+        instance = kwargs.get('instance')
+        initial = kwargs.get('initial', {}).copy()
+        if instance:
+            if type(instance.assigned_object) is Interface:
+                initial['interface'] = instance.assigned_object
+            elif type(instance.assigned_object) is VMInterface:
+                initial['vminterface'] = instance.assigned_object
+        kwargs['initial'] = initial
+
+        super().__init__(*args, **kwargs)
+
+        if instance and instance.assigned_object and instance.assigned_object.primary_wwn_address:
+            if instance.assigned_object.primary_wwn_address.pk == instance.pk:
+                self.fields['interface'].disabled = True
+                self.fields['vminterface'].disabled = True
+
+    def clean(self):
+        super().clean()
+
+        # Handle object assignment
+        selected_objects = [field for field in ('interface', 'vminterface') if self.cleaned_data[field]]
+        if len(selected_objects) > 1:
+            raise forms.ValidationError(
+                {selected_objects[1]: _('A WWN address can only be assigned to a single object.')}
+            )
         if selected_objects:
             self.instance.assigned_object = self.cleaned_data[selected_objects[0]]
         else:

--- a/netbox/dcim/graphql/filter_mixins.py
+++ b/netbox/dcim/graphql/filter_mixins.py
@@ -145,6 +145,10 @@ class InterfaceBaseFilterMixin:
         strawberry_django.filter_field()
     )
     primary_mac_address_id: ID | None = strawberry_django.filter_field()
+    primary_wwn_address: Annotated['WWNAddressFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
+        strawberry_django.filter_field()
+    )
+    primary_wwn_address_id: ID | None = strawberry_django.filter_field()
 
 
 @dataclass

--- a/netbox/dcim/graphql/filters.py
+++ b/netbox/dcim/graphql/filters.py
@@ -111,6 +111,7 @@ __all__ = (
     'SiteGroupFilter',
     'VirtualChassisFilter',
     'VirtualDeviceContextFilter',
+    'WWNAddressFilter',
 )
 
 
@@ -516,7 +517,6 @@ class MACAddressFilter(PrimaryModelFilter):
             return Q(query)
         return ~Q(query)
 
-
 @strawberry_django.filter_type(models.Interface, lookups=True)
 class InterfaceFilter(
     ModularComponentFilterMixin,
@@ -578,6 +578,9 @@ class InterfaceFilter(
         strawberry_django.filter_field()
     )
     mac_addresses: Annotated['MACAddressFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
+        strawberry_django.filter_field()
+    )
+    wwn_addresses: Annotated['WWNAddressFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
         strawberry_django.filter_field()
     )
     fhrp_group_assignments: Annotated['FHRPGroupAssignmentFilter', strawberry.lazy('ipam.graphql.filters')] | None = (
@@ -1138,3 +1141,29 @@ class VirtualDeviceContextFilter(TenancyFilterMixin, PrimaryModelFilter):
     interfaces: (
         Annotated['InterfaceFilter', strawberry.lazy('dcim.graphql.filters')] | None
     ) = strawberry_django.filter_field()
+
+
+@strawberry_django.filter_type(models.WWNAddress, lookups=True)
+class WWNAddressFilter(PrimaryModelFilter):
+    wwn_address: StrFilterLookup | None = strawberry_django.filter_field()
+    assigned_object_type: Annotated['ContentTypeFilter', strawberry.lazy('core.graphql.filters')] | None = (
+        strawberry_django.filter_field()
+    )
+    assigned_object_id: ID | None = strawberry_django.filter_field()
+
+    @strawberry_django.filter_field()
+    def assigned(self, value: bool, prefix) -> Q:
+        return Q(**{f'{prefix}assigned_object_id__isnull': (not value)})
+
+    @strawberry_django.filter_field()
+    def primary(self, value: bool, prefix) -> Q:
+        interface_wwn_ids = models.Interface.objects.filter(primary_wwn_address_id__isnull=False).values_list(
+            'primary_wwn_address_id', flat=True
+        )
+        vminterface_wwn_ids = VMInterface.objects.filter(primary_wwn_address_id__isnull=False).values_list(
+            'primary_wwn_address_id', flat=True
+        )
+        query = Q(**{f'{prefix}pk__in': interface_wwn_ids}) | Q(**{f'{prefix}pk__in': vminterface_wwn_ids})
+        if value:
+            return Q(query)
+        return ~Q(query)

--- a/netbox/dcim/graphql/filters.py
+++ b/netbox/dcim/graphql/filters.py
@@ -517,6 +517,7 @@ class MACAddressFilter(PrimaryModelFilter):
             return Q(query)
         return ~Q(query)
 
+
 @strawberry_django.filter_type(models.Interface, lookups=True)
 class InterfaceFilter(
     ModularComponentFilterMixin,

--- a/netbox/dcim/graphql/schema.py
+++ b/netbox/dcim/graphql/schema.py
@@ -140,3 +140,6 @@ class DCIMQuery:
 
     virtual_device_context: VirtualDeviceContextType = strawberry_django.field()
     virtual_device_context_list: list[VirtualDeviceContextType] = strawberry_django.field()
+
+    wwn_address: WWNAddressType = strawberry_django.field()
+    wwn_address_list: list[WWNAddressType] = strawberry_django.field()

--- a/netbox/dcim/graphql/types.py
+++ b/netbox/dcim/graphql/types.py
@@ -90,6 +90,7 @@ __all__ = (
     'SiteType',
     'VirtualChassisType',
     'VirtualDeviceContextType',
+    'WWNAddressType',
 )
 
 
@@ -1015,3 +1016,21 @@ class VirtualDeviceContextType(PrimaryObjectType):
     tenant: Annotated["TenantType", strawberry.lazy('tenancy.graphql.types')] | None
 
     interfaces: list[Annotated["InterfaceType", strawberry.lazy('dcim.graphql.types')]]
+
+
+@strawberry_django.type(
+    models.WWNAddress,
+    exclude=['assigned_object_type', 'assigned_object_id'],
+    filters=WWNAddressFilter,
+    pagination=True
+)
+class WWNAddressType(PrimaryObjectType):
+    wwn_address: str
+
+    @strawberry_django.field(prefetch_related='assigned_object')
+    def assigned_object(self) -> Annotated[
+        Annotated['InterfaceType', strawberry.lazy('dcim.graphql.types')]
+        | Annotated['VMInterfaceType', strawberry.lazy('virtualization.graphql.types')],
+        strawberry.union('WWNAddressAssignmentType'),
+    ] | None:
+        return self.assigned_object

--- a/netbox/dcim/migrations/0001_squashed.py
+++ b/netbox/dcim/migrations/0001_squashed.py
@@ -348,6 +348,7 @@ class Migration(migrations.Migration):
                 ('mark_connected', models.BooleanField(default=False)),
                 ('enabled', models.BooleanField(default=True)),
                 ('mac_address', dcim.fields.MACAddressField(blank=True, null=True)),
+                ('wwn', dcim.fields.WWNAddressField(blank=True, null=True)),
                 (
                     'mtu',
                     models.PositiveIntegerField(

--- a/netbox/dcim/migrations/0131_squashed_0159.py
+++ b/netbox/dcim/migrations/0131_squashed_0159.py
@@ -4,7 +4,6 @@ import mptt.fields
 import taggit.managers
 from django.db import migrations, models
 
-import dcim.fields
 import utilities.fields
 import utilities.json
 import utilities.ordering

--- a/netbox/dcim/migrations/0131_squashed_0159.py
+++ b/netbox/dcim/migrations/0131_squashed_0159.py
@@ -90,11 +90,6 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='interface',
-            name='wwn',
-            field=dcim.fields.WWNField(blank=True, null=True),
-        ),
-        migrations.AddField(
-            model_name='interface',
             name='bridge',
             field=models.ForeignKey(
                 blank=True,

--- a/netbox/dcim/migrations/0242_wwnaddress.py
+++ b/netbox/dcim/migrations/0242_wwnaddress.py
@@ -1,0 +1,51 @@
+import django.db.models.deletion
+import taggit.managers
+from django.db import migrations, models
+
+import dcim.fields
+import utilities.json
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('dcim', '0241_nullify_empty_cable_end'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='WWNAddress',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False)),
+                ('created', models.DateTimeField(auto_now_add=True, null=True)),
+                ('last_updated', models.DateTimeField(auto_now=True, null=True)),
+                (
+                    'custom_field_data',
+                    models.JSONField(blank=True, default=dict, encoder=utilities.json.CustomFieldJSONEncoder),
+                ),
+                ('description', models.CharField(blank=True, max_length=200)),
+                ('comments', models.TextField(blank=True)),
+                ('wwn_address', dcim.fields.WWNAddressField()),
+                ('assigned_object_id', models.PositiveBigIntegerField(blank=True, null=True)),
+                (
+                    'assigned_object_type',
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name='+',
+                        to='contenttypes.contenttype',
+                    ),
+                ),
+                ('owner', models.ForeignKey(
+                    blank=True, null=True, on_delete=django.db.models.deletion.PROTECT, to='users.owner')
+                 ),
+                ('tags', taggit.managers.TaggableManager(through='extras.TaggedItem', to='extras.Tag')),
+            ],
+            options={
+                'abstract': False,
+                'ordering': ('wwn_address', 'pk'),
+                'verbose_name': 'WWN address',
+                'verbose_name_plural': 'WWN addresses'
+            },
+        ),
+    ]

--- a/netbox/dcim/migrations/0243_populate_wwn_addresses.py
+++ b/netbox/dcim/migrations/0243_populate_wwn_addresses.py
@@ -1,0 +1,95 @@
+import django.db.models.deletion
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+from django.db import migrations, models
+
+
+def populate_wwn_addresses(apps, schema_editor):
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    Interface = apps.get_model('dcim', 'Interface')
+    WWNAddress = apps.get_model('dcim', 'WWNAddress')
+    db_alias = schema_editor.connection.alias
+    interface_ct = ContentType.objects.get_for_model(Interface)
+
+    wwn_addresses = [
+        WWNAddress(
+            wwn_address=interface.wwn,
+            assigned_object_type=interface_ct,
+            assigned_object_id=interface.pk
+        )
+        for interface in Interface.objects.using(db_alias).filter(wwn__isnull=False)
+    ]
+    WWNAddress.objects.using(db_alias).bulk_create(wwn_addresses, batch_size=100)
+
+    # TODO: Optimize interface updates
+    for wwn_address in wwn_addresses:
+        Interface.objects.using(db_alias).filter(
+            pk=wwn_address.assigned_object_id
+        ).update(
+            primary_wwn_address=wwn_address
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('dcim', '0242_wwnaddress'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='interface',
+            name='primary_wwn_address',
+            field=models.OneToOneField(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='+',
+                to='dcim.wwnaddress',
+            ),
+        ),
+        migrations.RunPython(code=populate_wwn_addresses, reverse_code=migrations.RunPython.noop),
+        migrations.RemoveField(
+            model_name='interface',
+            name='wwn',
+        ),
+    ]
+
+
+# See peer migrator in virtualization.0058_populate_wwn_addresses before making changes
+def oc_interface_primary_wwn_address(objectchange, reverting):
+    WWNAddress = apps.get_model('dcim', 'WWNAddress')
+    interface_ct = ContentType.objects.get_by_natural_key('dcim', 'interface')
+
+    # Swap data order if the change is being reverted
+    if not reverting:
+        before, after = objectchange.prechange_data, objectchange.postchange_data
+    else:
+        before, after = objectchange.postchange_data, objectchange.prechange_data
+
+    if after.get('wwn') != before.get('wwn'):
+        # Create & assign the new WWNAddress (if any)
+        if after.get('wwn'):
+            wwn = WWNAddress.objects.create(
+                wwn_address=after['wwn'],
+                assigned_object_type=interface_ct,
+                assigned_object_id=objectchange.changed_object_id,
+            )
+            after['primary_wwn_address'] = wwn.pk
+        else:
+            after['primary_wwn_address'] = None
+        # Delete the old WWNAddress (if any)
+        if before.get('wwn'):
+            WWNAddress.objects.filter(
+                wwn_address=before['wwn'],
+                assigned_object_type=interface_ct,
+                assigned_object_id=objectchange.changed_object_id,
+            ).delete()
+        before['primary_wwn_address'] = None
+
+    before.pop('wwn', None)
+    after.pop('wwn', None)
+
+
+objectchange_migrators = {
+    'dcim.interface': oc_interface_primary_wwn_address,
+}

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -10,7 +10,6 @@ from mptt.models import MPTTModel, TreeForeignKey
 
 from dcim.choices import *
 from dcim.constants import *
-from dcim.fields import WWNField
 from dcim.models.base import PortMappingBase
 from dcim.models.mixins import InterfaceValidationMixin
 from netbox.choices import ColorChoices
@@ -766,6 +765,14 @@ class BaseInterface(models.Model):
         null=True,
         verbose_name=_('primary MAC address')
     )
+    primary_wwn_address = models.OneToOneField(
+        to='dcim.WWNAddress',
+        on_delete=models.SET_NULL,
+        related_name='+',
+        blank=True,
+        null=True,
+        verbose_name=_('primary WWN address')
+    )
 
     class Meta:
         abstract = True
@@ -791,6 +798,21 @@ class BaseInterface(models.Model):
                 ).format(
                     mac_address=self.primary_mac_address,
                     interface=self.primary_mac_address.assigned_object,
+                )
+            })
+
+        # Check that the primary WWN address (if any) is assigned to this interface
+        if (
+                self.primary_wwn_address and
+                self.primary_wwn_address.assigned_object is not None and
+                self.primary_wwn_address.assigned_object != self
+        ):
+            raise ValidationError({
+                'primary_wwn_address': _(
+                    "WWN address {wwn_address} is assigned to a different interface ({interface})."
+                ).format(
+                    wwn_address=self.primary_wwn_address,
+                    interface=self.primary_wwn_address.assigned_object,
                 )
             })
 
@@ -877,12 +899,6 @@ class Interface(
         null=True,
         choices=InterfaceDuplexChoices
     )
-    wwn = WWNField(
-        null=True,
-        blank=True,
-        verbose_name=_('WWN'),
-        help_text=_('64-bit World Wide Name')
-    )
     rf_role = models.CharField(
         max_length=30,
         choices=WirelessRoleChoices,
@@ -965,6 +981,12 @@ class Interface(
     )
     mac_addresses = GenericRelation(
         to='dcim.MACAddress',
+        content_type_field='assigned_object_type',
+        object_id_field='assigned_object_id',
+        related_query_name='interface'
+    )
+    wwn_addresses = GenericRelation(
+        to='dcim.WWNAddress',
         content_type_field='assigned_object_type',
         object_id_field='assigned_object_id',
         related_query_name='interface'

--- a/netbox/dcim/models/devices.py
+++ b/netbox/dcim/models/devices.py
@@ -17,7 +17,7 @@ from django.utils.translation import gettext_lazy as _
 
 from dcim.choices import *
 from dcim.constants import *
-from dcim.fields import MACAddressField
+from dcim.fields import MACAddressField, WWNAddressField
 from dcim.utils import create_port_mappings, update_interface_bridges
 from extras.models import ConfigContextModel, CustomField
 from extras.querysets import ConfigContextModelQuerySet
@@ -44,6 +44,7 @@ __all__ = (
     'Platform',
     'VirtualChassis',
     'VirtualDeviceContext',
+    'WWNAddress',
 )
 
 
@@ -1421,4 +1422,71 @@ class MACAddress(PrimaryModel):
                 if original_assigned_object != assigned_object:
                     raise ValidationError(
                         _("Cannot reassign MAC Address while it is designated as the primary MAC for an object")
+                    )
+
+
+class WWNAddress(PrimaryModel):
+    wwn_address = WWNAddressField(
+        verbose_name=_('WWN address')
+    )
+    assigned_object_type = models.ForeignKey(
+        to='contenttypes.ContentType',
+        on_delete=models.PROTECT,
+        related_name='+',
+        blank=True,
+        null=True
+    )
+    assigned_object_id = models.PositiveBigIntegerField(
+        blank=True,
+        null=True
+    )
+    assigned_object = GenericForeignKey(
+        ct_field='assigned_object_type',
+        fk_field='assigned_object_id'
+    )
+
+    class Meta:
+        ordering = ('wwn_address', 'pk')
+        indexes = (
+            models.Index(fields=('wwn_address', 'id')),  # Default ordering
+            models.Index(fields=('assigned_object_type', 'assigned_object_id')),
+        )
+        verbose_name = _('WWN address')
+        verbose_name_plural = _('WWN addresses')
+
+    def __str__(self):
+        return str(self.wwn_address)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Denote the original assigned object (if any) for validation in clean()
+        self._original_assigned_object_id = self.__dict__.get('assigned_object_id')
+        self._original_assigned_object_type_id = self.__dict__.get('assigned_object_type_id')
+
+    @cached_property
+    def is_primary(self):
+        if self.assigned_object and hasattr(self.assigned_object, 'primary_wwn_address'):
+            if self.assigned_object.primary_wwn_address and self.assigned_object.primary_wwn_address.pk == self.pk:
+                return True
+        return False
+
+    def clean(self, *args, **kwargs):
+        super().clean()
+        if self._original_assigned_object_id and self._original_assigned_object_type_id:
+            assigned_object = self.assigned_object
+            ct = ContentType.objects.get_for_id(self._original_assigned_object_type_id)
+            original_assigned_object = ct.get_object_for_this_type(pk=self._original_assigned_object_id)
+
+            if (
+                original_assigned_object.primary_wwn_address
+                and original_assigned_object.primary_wwn_address.pk == self.pk
+            ):
+                if not assigned_object:
+                    raise ValidationError(
+                        _("Cannot unassign WWN Address while it is designated as the primary WWN for an object")
+                    )
+                if original_assigned_object != assigned_object:
+                    raise ValidationError(
+                        _("Cannot reassign WWN Address while it is designated as the primary WWN for an object")
                     )

--- a/netbox/dcim/search.py
+++ b/netbox/dcim/search.py
@@ -122,6 +122,16 @@ class MACAddressIndex(SearchIndex):
     )
     display_attrs = ('assigned_object', 'description')
 
+@register_search
+class WWNAddressIndex(SearchIndex):
+    model = models.WWNAddress
+    fields = (
+        ('wwn_address', 100),
+        ('description', 500),
+        ('comments', 5000),
+    )
+    display_attrs = ('assigned_object', 'description')
+
 
 @register_search
 class InterfaceIndex(SearchIndex):
@@ -129,12 +139,11 @@ class InterfaceIndex(SearchIndex):
     fields = (
         ('name', 100),
         ('label', 200),
-        ('wwn', 300),
         ('description', 500),
         ('mtu', 2000),
         ('speed', 2000),
     )
-    display_attrs = ('device', 'label', 'type', 'wwn', 'description')
+    display_attrs = ('device', 'label', 'type', 'description')
 
 
 @register_search

--- a/netbox/dcim/search.py
+++ b/netbox/dcim/search.py
@@ -122,6 +122,7 @@ class MACAddressIndex(SearchIndex):
     )
     display_attrs = ('assigned_object', 'description')
 
+
 @register_search
 class WWNAddressIndex(SearchIndex):
     model = models.WWNAddress

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -304,6 +304,7 @@ def update_mac_address_interface(instance, created, raw, **kwargs):
         instance.primary_mac_address.assigned_object = instance
         instance.primary_mac_address.save()
 
+
 @receiver(post_save, sender=Interface)
 @receiver(post_save, sender=VMInterface)
 def update_wwn_address_interface(instance, created, raw, **kwargs):
@@ -314,6 +315,7 @@ def update_wwn_address_interface(instance, created, raw, **kwargs):
     if created and not raw and instance.primary_wwn_address:
         instance.primary_wwn_address.assigned_object = instance
         instance.primary_wwn_address.save()
+
 
 @receiver(post_save, sender=Location)
 @receiver(post_save, sender=Site)

--- a/netbox/dcim/signals.py
+++ b/netbox/dcim/signals.py
@@ -304,6 +304,16 @@ def update_mac_address_interface(instance, created, raw, **kwargs):
         instance.primary_mac_address.assigned_object = instance
         instance.primary_mac_address.save()
 
+@receiver(post_save, sender=Interface)
+@receiver(post_save, sender=VMInterface)
+def update_wwn_address_interface(instance, created, raw, **kwargs):
+    """
+    When creating a new Interface or VMInterface, check whether a WWNAddress has been designated as its primary. If so,
+    assign the WWNAddress to the interface.
+    """
+    if created and not raw and instance.primary_wwn_address:
+        instance.primary_wwn_address.assigned_object = instance
+        instance.primary_wwn_address.save()
 
 @receiver(post_save, sender=Location)
 @receiver(post_save, sender=Site)

--- a/netbox/dcim/tables/devices.py
+++ b/netbox/dcim/tables/devices.py
@@ -38,7 +38,8 @@ __all__ = (
     'PowerPortTable',
     'RearPortTable',
     'VirtualChassisTable',
-    'VirtualDeviceContextTable'
+    'VirtualDeviceContextTable',
+    'WWNAddressTable'
 )
 
 MODULEBAY_STATUS = """
@@ -53,6 +54,16 @@ MACADDRESS_LINK = """
 
 MACADDRESS_COPY_BUTTON = """
 {% copy_content record.pk prefix="macaddress_" %}
+"""
+
+WWNADDRESS_LINK = """
+{% if record.pk %}
+    <a href="{{ record.get_absolute_url }}" id="wwnaddress_{{ record.pk }}">{{ record.wwn_address }}</a>
+{% endif %}
+"""
+
+WWNADDRESS_COPY_BUTTON = """
+{% copy_content record.pk prefix="wwnaddress_" %}
 """
 
 
@@ -605,6 +616,15 @@ class BaseInterfaceTable(NetBoxTable):
         linkify_item=True,
         verbose_name=_('MAC Addresses')
     )
+    primary_wwn_address = tables.Column(
+        verbose_name=_('Primary WWN'),
+        linkify=True
+    )
+    wwn_addresses = columns.ManyToManyColumn(
+        orderable=False,
+        linkify_item=True,
+        verbose_name=_('WWN Addresses')
+    )
     fhrp_groups = tables.TemplateColumn(
         accessor=Accessor('fhrp_group_assignments'),
         template_code=INTERFACE_FHRPGROUPS,
@@ -707,11 +727,11 @@ class InterfaceTable(BaseInterfaceTable, ModularDeviceComponentTable, PathEndpoi
         model = models.Interface
         fields = (
             'pk', 'id', 'name', 'device', 'module_bay', 'module', 'label', 'enabled', 'type', 'mgmt_only', 'mtu',
-            'speed', 'speed_formatted', 'duplex', 'mode', 'mac_addresses', 'primary_mac_address', 'wwn',
-            'poe_mode', 'poe_type', 'rf_role', 'rf_channel', 'rf_channel_frequency', 'rf_channel_width', 'tx_power',
-            'description', 'mark_connected', 'cable', 'cable_color', 'wireless_link', 'wireless_lans', 'link_peer',
-            'connection', 'tags', 'vdcs', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups',
-            'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'inventory_items', 'created', 'last_updated',
+            'speed', 'speed_formatted', 'duplex', 'mode', 'mac_addresses', 'primary_mac_address', 'wwn_addresses',
+            'primary_wwn_address', 'poe_mode', 'poe_type', 'rf_role', 'rf_channel', 'rf_channel_frequency',
+            'rf_channel_width', 'tx_power', 'description', 'mark_connected', 'cable', 'cable_color', 'wireless_link',
+            'wireless_lans', 'link_peer', 'connection', 'tags', 'vdcs', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses',
+            'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'inventory_items', 'created', 'last_updated',
             'vlan_translation_policy',
         )
         default_columns = ('pk', 'name', 'device', 'label', 'enabled', 'type', 'description')
@@ -773,11 +793,11 @@ class DeviceInterfaceTable(InterfaceTable):
         model = models.Interface
         fields = (
             'pk', 'id', 'name', 'module_bay', 'module', 'label', 'enabled', 'type', 'parent', 'bridge', 'lag',
-            'mgmt_only', 'mtu', 'mode', 'mac_addresses', 'primary_mac_address', 'wwn', 'rf_role', 'rf_channel',
-            'rf_channel_frequency', 'rf_channel_width', 'tx_power', 'description', 'mark_connected', 'cable',
-            'cable_color', 'wireless_link', 'wireless_lans', 'link_peer', 'connection', 'tags', 'vdcs', 'vrf',
-            'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans', 'qinq_svlan',
-            'actions',
+            'mgmt_only', 'mtu', 'mode', 'mac_addresses', 'primary_mac_address', 'wwn_addresses', 'primary_wwn_address',
+            'rf_role', 'rf_channel', 'rf_channel_frequency', 'rf_channel_width', 'tx_power', 'description',
+            'mark_connected', 'cable', 'cable_color', 'wireless_link', 'wireless_lans', 'link_peer', 'connection',
+            'tags', 'vdcs', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans',
+            'qinq_svlan', 'actions',
         )
         default_columns = (
             'pk', 'name', 'label', 'enabled', 'type', 'parent', 'lag', 'mtu', 'mode', 'description', 'ip_addresses',
@@ -1253,4 +1273,42 @@ class MACAddressTable(PrimaryModelTable):
         )
         default_columns = (
             'pk', 'mac_address', 'is_primary', 'assigned_object_parent', 'assigned_object', 'description',
+        )
+
+
+class WWNAddressTable(PrimaryModelTable):
+    wwn_address = tables.TemplateColumn(
+        template_code=WWNADDRESS_LINK,
+        verbose_name=_('WWN Address')
+    )
+    assigned_object = tables.Column(
+        linkify=True,
+        orderable=False,
+        verbose_name=_('Interface')
+    )
+    assigned_object_parent = tables.Column(
+        accessor='assigned_object__parent_object',
+        linkify=True,
+        orderable=False,
+        verbose_name=_('Parent')
+    )
+    is_primary = columns.BooleanColumn(
+        verbose_name=_('Primary'),
+        orderable=False,
+    )
+    tags = columns.TagColumn(
+        url_name='dcim:wwnaddress_list'
+    )
+    actions = columns.ActionsColumn(
+        extra_buttons=WWNADDRESS_COPY_BUTTON
+    )
+
+    class Meta(PrimaryModelTable.Meta):
+        model = models.WWNAddress
+        fields = (
+            'pk', 'id', 'wwn_address', 'assigned_object_parent', 'assigned_object', 'description', 'is_primary',
+            'comments', 'tags', 'created', 'last_updated',
+        )
+        default_columns = (
+            'pk', 'wwn_address', 'is_primary', 'assigned_object_parent', 'assigned_object', 'description',
         )

--- a/netbox/dcim/tables/template_code.py
+++ b/netbox/dcim/tables/template_code.py
@@ -356,6 +356,9 @@ INTERFACE_BUTTONS = """
       {% if perms.dcim.add_macaddress %}
         <li><a class="dropdown-item" href="{% url 'dcim:macaddress_add' %}?interface={{ record.pk }}&return_url={% url 'dcim:device_interfaces' pk=object.pk %}">MAC Address</a></li>
       {% endif %}
+      {% if perms.dcim.add_wwnaddress %}
+        <li><a class="dropdown-item" href="{% url 'dcim:wwnaddress_add' %}?interface={{ record.pk }}&return_url={% url 'dcim:device_interfaces' pk=object.pk %}">WWN Address</a></li>
+      {% endif %}
       {% if perms.dcim.add_inventoryitem %}
         <li><a class="dropdown-item" href="{% url 'dcim:inventoryitem_add' %}?device={{ record.device_id }}&component_type={{ record|content_type_id }}&component_id={{ record.pk }}&return_url={% url 'dcim:device_interfaces' pk=object.pk %}">Inventory Item</a></li>
       {% endif %}

--- a/netbox/dcim/tests/query_counts.json
+++ b/netbox/dcim/tests/query_counts.json
@@ -82,5 +82,7 @@
   "virtualchassis:api_list_objects": 16,
   "virtualchassis:list_objects_with_permission": 21,
   "virtualdevicecontext:api_list_objects": 14,
-  "virtualdevicecontext:list_objects_with_permission": 20
+  "virtualdevicecontext:list_objects_with_permission": 20,
+  "wwnaddress:api_list_objects": 17,
+  "wwnaddress:list_objects_with_permission": 24
 }

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -4011,3 +4011,46 @@ class MACAddressTestCase(APIViewTestCases.APIViewTestCase):
                 'mac_address': '00:00:00:00:00:06',
             },
         ]
+
+
+class WWNAddressTestCase(APIViewTestCases.APIViewTestCase):
+    model = WWNAddress
+    brief_fields = ['description', 'display', 'id', 'wwn_address', 'url']
+    bulk_update_data = {
+        'description': 'New description',
+    }
+
+    @classmethod
+    def setUpTestData(cls):
+        device = create_test_device(name='Device 1')
+        interfaces = (
+            Interface(device=device, name='Interface 1', type='32gfc-sfp28'),
+            Interface(device=device, name='Interface 2', type='32gfc-sfp28'),
+            Interface(device=device, name='Interface 3', type='32gfc-sfp28'),
+            Interface(device=device, name='Interface 4', type='32gfc-sfp28'),
+            Interface(device=device, name='Interface 5', type='32gfc-sfp28'),
+        )
+        Interface.objects.bulk_create(interfaces)
+
+        wwn_addresses = (
+            WWNAddress(wwn_address='00:00:00:00:00:00:00:01', assigned_object=interfaces[0]),
+            WWNAddress(wwn_address='00:00:00:00:00:00:00:02', assigned_object=interfaces[1]),
+            WWNAddress(wwn_address='00:00:00:00:00:00:00:03', assigned_object=interfaces[2]),
+        )
+        WWNAddress.objects.bulk_create(wwn_addresses)
+
+        cls.create_data = [
+            {
+                'wwn_address': '00:00:00:00:00:00:00:04',
+                'assigned_object_type': 'dcim.interface',
+                'assigned_object_id': interfaces[3].pk,
+            },
+            {
+                'wwn_address': '00:00:00:00:00:00:00:05',
+                'assigned_object_type': 'dcim.interface',
+                'assigned_object_id': interfaces[4].pk,
+            },
+            {
+                'wwn_address': '00:00:00:00:00:00:00:06',
+            },
+        ]

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -7741,6 +7741,7 @@ class MACAddressTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {'primary': False}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
+
 class WWNAddressTestCase(TestCase, ChangeLoggedFilterSetTests):
     queryset = WWNAddress.objects.all()
     filterset = WWNAddressFilterSet

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -2860,6 +2860,13 @@ class DeviceTestCase(TestCase, ChangeLoggedFilterSetTests):
         MACAddress.objects.bulk_create(mac_addresses)
         interfaces[0].mac_addresses.set([mac_addresses[0]])
         interfaces[1].mac_addresses.set([mac_addresses[1]])
+        wwn_addresses = (
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-01', assigned_object=interfaces[0]),
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-02', assigned_object=interfaces[1]),
+        )
+        WWNAddress.objects.bulk_create(wwn_addresses)
+        interfaces[0].wwn_addresses.set([wwn_addresses[0]])
+        interfaces[1].wwn_addresses.set([wwn_addresses[1]])
         rear_ports = (
             RearPort(device=devices[0], name='Rear Port 1', type=PortTypeChoices.TYPE_8P8C),
             RearPort(device=devices[1], name='Rear Port 2', type=PortTypeChoices.TYPE_8P8C),
@@ -3038,6 +3045,10 @@ class DeviceTestCase(TestCase, ChangeLoggedFilterSetTests):
 
     def test_mac_address(self):
         params = {'mac_address': ['00-00-00-00-00-01', '00-00-00-00-00-02']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_wwn_address(self):
+        params = {'wwn_address': ['00-00-00-00-00-00-00-01', '00-00-00-00-00-00-00-02']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_serial(self):
@@ -4692,6 +4703,13 @@ class InterfaceTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFil
         )
         MACAddress.objects.bulk_create(mac_addresses)
 
+        wwn_addresses = (
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-01'),
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-02'),
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-03'),
+        )
+        WWNAddress.objects.bulk_create(wwn_addresses)
+
         vlans = (
             VLAN(name='SVLAN 1', vid=1001, qinq_role=VLANQinQRoleChoices.ROLE_SERVICE),
             VLAN(name='SVLAN 2', vid=1002, qinq_role=VLANQinQRoleChoices.ROLE_SERVICE),
@@ -5199,6 +5217,10 @@ class InterfaceTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFil
 
     def test_mac_address(self):
         params = {'mac_address': ['00-00-00-00-00-01', '00-00-00-00-00-02']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_wwn_address(self):
+        params = {'wwn_address': ['00-00-00-00-00-00-00-01', '00-00-00-00-00-00-00-02']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_type(self):
@@ -7677,6 +7699,105 @@ class MACAddressTestCase(TestCase, ChangeLoggedFilterSetTests):
 
     def test_mac_address(self):
         params = {'mac_address': ['00-00-00-01-01-01', '00-00-00-02-01-01']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_device(self):
+        devices = Device.objects.all()[:2]
+        params = {'device_id': [devices[0].pk, devices[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'device': [devices[0].name, devices[1].name]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_virtual_machine(self):
+        virtual_machines = VirtualMachine.objects.all()[:2]
+        params = {'virtual_machine_id': [virtual_machines[0].pk, virtual_machines[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'virtual_machine': [virtual_machines[0].name, virtual_machines[1].name]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_interface(self):
+        interfaces = Interface.objects.all()[:2]
+        params = {'interface_id': [interfaces[0].pk, interfaces[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'interface': [interfaces[0].name, interfaces[1].name]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_vminterface(self):
+        vm_interfaces = VMInterface.objects.all()[:2]
+        params = {'vminterface_id': [vm_interfaces[0].pk, vm_interfaces[1].pk]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+        params = {'vminterface': [vm_interfaces[0].name, vm_interfaces[1].name]}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_assigned(self):
+        params = {'assigned': True}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
+        params = {'assigned': False}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
+
+    def test_primary(self):
+        params = {'primary': True}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
+        params = {'primary': False}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
+
+class WWNAddressTestCase(TestCase, ChangeLoggedFilterSetTests):
+    queryset = WWNAddress.objects.all()
+    filterset = WWNAddressFilterSet
+
+    @classmethod
+    def setUpTestData(cls):
+        devices = (
+            create_test_device('Device 1'),
+            create_test_device('Device 2'),
+            create_test_device('Device 3'),
+        )
+        interfaces = (
+            Interface(device=devices[0], name='Interface 1', type=InterfaceTypeChoices.TYPE_1GFC_SFP),
+            Interface(device=devices[1], name='Interface 2', type=InterfaceTypeChoices.TYPE_1GFC_SFP),
+            Interface(device=devices[2], name='Interface 3', type=InterfaceTypeChoices.TYPE_1GFC_SFP),
+        )
+        Interface.objects.bulk_create(interfaces)
+
+        virtual_machines = (
+            create_test_virtualmachine('Virtual Machine 1'),
+            create_test_virtualmachine('Virtual Machine 2'),
+            create_test_virtualmachine('Virtual Machine 3'),
+        )
+        vm_interfaces = (
+            VMInterface(virtual_machine=virtual_machines[0], name='Interface 1'),
+            VMInterface(virtual_machine=virtual_machines[1], name='Interface 2'),
+            VMInterface(virtual_machine=virtual_machines[2], name='Interface 3'),
+        )
+        VMInterface.objects.bulk_create(vm_interfaces)
+
+        wwn_addresses = (
+            # Device WWNs
+            WWNAddress(wwn_address='00-00-00-00-00-01-01-01', assigned_object=interfaces[0]),
+            WWNAddress(wwn_address='00-00-00-00-00-02-01-01', assigned_object=interfaces[1]),
+            WWNAddress(wwn_address='00-00-00-00-00-03-01-01', assigned_object=interfaces[2]),
+            WWNAddress(wwn_address='00-00-00-00-00-03-01-02', assigned_object=interfaces[2]),
+            # VM WWNs
+            WWNAddress(wwn_address='00-00-00-00-00-04-01-01', assigned_object=vm_interfaces[0]),
+            WWNAddress(wwn_address='00-00-00-00-00-05-01-01', assigned_object=vm_interfaces[1]),
+            WWNAddress(wwn_address='00-00-00-00-00-06-01-01', assigned_object=vm_interfaces[2]),
+            WWNAddress(wwn_address='00-00-00-00-00-06-01-02', assigned_object=vm_interfaces[2]),
+            # unassigned
+            WWNAddress(wwn_address='00-00-00-00-00-07-01-01'),
+        )
+        WWNAddress.objects.bulk_create(wwn_addresses)
+
+        # Set WWN addresses as primary
+        for idx, interface in enumerate(interfaces):
+            interface.primary_wwn_address = wwn_addresses[idx]
+            interface.save()
+        for idx, vm_interface in enumerate(vm_interfaces):
+            # Offset by 4 for device WWNs
+            vm_interface.primary_wwn_address = wwn_addresses[idx + 4]
+            vm_interface.save()
+
+    def test_wwn_address(self):
+        params = {'wwn_address': ['00-00-00-00-00-01-01-01', '00-00-00-00-00-02-01-01']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_device(self):

--- a/netbox/dcim/tests/test_models.py
+++ b/netbox/dcim/tests/test_models.py
@@ -55,6 +55,43 @@ class MACAddressTestCase(TestCase):
         self.mac_b.clean()
 
 
+class WWNAddressTestCase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        site = Site.objects.create(name='Test Site 1', slug='test-site-1')
+        manufacturer = Manufacturer.objects.create(name='Test Manufacturer 1', slug='test-manufacturer-1')
+        device_type = DeviceType.objects.create(
+            manufacturer=manufacturer, model='Test Device Type 1', slug='test-device-type-1'
+        )
+        device_role = DeviceRole.objects.create(name='Test Role 1', slug='test-role-1')
+        device = Device.objects.create(
+            name='Device 1', device_type=device_type, role=device_role, site=site,
+        )
+        cls.interface = Interface.objects.create(
+            device=device,
+            name='Interface 1',
+            type=InterfaceTypeChoices.TYPE_1GE_FIXED,
+            mgmt_only=True
+        )
+
+        cls.wwn_a = WWNAddress.objects.create(wwn_address='1234567890abcdef', assigned_object=cls.interface)
+        cls.wwn_b = WWNAddress.objects.create(wwn_address='1234567890bacdef', assigned_object=cls.interface)
+
+        cls.interface.primary_wwn_address = cls.wwn_a
+        cls.interface.save()
+
+    @tag('regression')
+    def test_clean_will_not_allow_removal_of_assigned_object_if_primary(self):
+        self.wwn_a.assigned_object = None
+        with self.assertRaisesMessage(ValidationError, 'Cannot unassign WWN Address while'):
+            self.wwn_a.clean()
+
+    @tag('regression')
+    def test_clean_will_allow_removal_of_assigned_object_if_not_primary(self):
+        self.wwn_b.assigned_object = None
+        self.wwn_b.clean()
+
+
 class LocationTestCase(TestCase):
 
     def test_change_location_site(self):

--- a/netbox/dcim/tests/test_signals.py
+++ b/netbox/dcim/tests/test_signals.py
@@ -27,6 +27,7 @@ from dcim.models import (
     Site,
     SiteGroup,
     VirtualChassis,
+    WWNAddress,
 )
 from ipam.models import Prefix
 from virtualization.models import Cluster, ClusterType
@@ -416,6 +417,51 @@ class MACAddressInterfaceSignalTestCase(TestCase):
         mac.refresh_from_db()
         # Updating an existing interface should not re-assign the MAC.
         self.assertIsNone(mac.assigned_object)
+
+
+class WWNAddressInterfaceSignalTestCase(TestCase):
+    """
+    Verify dcim.signals.update_wwn_address_interface assigns a designated primary WWN to
+    the newly-created Interface or VMInterface.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.site = Site.objects.create(name='Site', slug='site')
+        manufacturer = Manufacturer.objects.create(name='Manufacturer', slug='manufacturer')
+        device_type = DeviceType.objects.create(manufacturer=manufacturer, model='Device Type')
+        role = DeviceRole.objects.create(name='Device Role', slug='device-role')
+        cls.device = Device.objects.create(
+            name='Device',
+            site=cls.site,
+            device_type=device_type,
+            role=role,
+        )
+
+    def test_primary_wwn_is_assigned_to_new_interface(self):
+        wwn = WWNAddress.objects.create(wwn_address='00:11:22:33:44:55:66:77')
+        interface = Interface(device=self.device, name='Interface 1', primary_wwn_address=wwn)
+        interface.save()
+
+        wwn.refresh_from_db()
+        self.assertEqual(wwn.assigned_object, interface)
+
+    def test_primary_wwn_is_not_reassigned_on_interface_update(self):
+        wwn = WWNAddress.objects.create(wwn_address='00:11:22:33:44:55:66:77')
+        interface = Interface.objects.create(device=self.device, name='Interface 1')
+        wwn.assigned_object = interface
+        wwn.save()
+        # Detach (simulate the WWN having been moved off the interface).
+        wwn.assigned_object = None
+        wwn.save()
+
+        interface.primary_wwn_address = wwn
+        interface.description = 'updated'
+        interface.save()
+
+        wwn.refresh_from_db()
+        # Updating an existing interface should not re-assign the WWN.
+        self.assertIsNone(wwn.assigned_object)
 
 
 class SyncCachedScopeFieldsSignalTestCase(TestCase):

--- a/netbox/dcim/tests/test_tables.py
+++ b/netbox/dcim/tests/test_tables.py
@@ -213,3 +213,11 @@ class VirtualDeviceContextTableTestCase(TableTestCases.StandardTableTestCase):
 
 class MACAddressTableTestCase(TableTestCases.StandardTableTestCase):
     table = MACAddressTable
+
+
+#
+# WWN addresses
+#
+
+class WWNAddressTableTestCase(TableTestCases.StandardTableTestCase):
+    table = WWNAddressTable

--- a/netbox/dcim/tests/test_views.py
+++ b/netbox/dcim/tests/test_views.py
@@ -3300,7 +3300,6 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
             'enabled': False,
             'bridge': interfaces[4].pk,
             'lag': interfaces[3].pk,
-            'wwn': EUI('01:02:03:04:05:06:07:08', version=64),
             'mtu': 65000,
             'speed': 16_000_000_000,
             'duplex': 'full',
@@ -3324,7 +3323,6 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
             'enabled': False,
             'bridge': interfaces[4].pk,
             'lag': interfaces[3].pk,
-            'wwn': EUI('01:02:03:04:05:06:07:08', version=64),
             'mtu': 2000,
             'speed': 16_000_000_000,
             'duplex': 'half',
@@ -3344,7 +3342,6 @@ class InterfaceTestCase(ViewTestCases.DeviceComponentViewTestCase):
             'type': InterfaceTypeChoices.TYPE_1GE_FIXED,
             'enabled': True,
             'lag': interfaces[3].pk,
-            'wwn': EUI('01:02:03:04:05:06:07:08', version=64),
             'mtu': 2000,
             'speed': 1000000,
             'duplex': 'full',
@@ -4651,6 +4648,83 @@ class MACAddressTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         response = self.client.post(url, data=quickadd_data)
 
         # Should successfully create the MAC address and return the quick_add_created template
+        self.assertHttpStatus(response, 200)
+        self.assertIn(b'quick-add-object', response.content)
+        self.assertEqual(initial_count + 1, self._get_queryset().count())
+
+
+class WWNAddressTestCase(ViewTestCases.PrimaryObjectViewTestCase):
+    model = WWNAddress
+
+    @classmethod
+    def setUpTestData(cls):
+        device = create_test_device(name='Device 1')
+        interfaces = (
+            Interface(device=device, name='Interface 1', type='32gfc-sfp28'),
+            Interface(device=device, name='Interface 2', type='32gfc-sfp28'),
+            Interface(device=device, name='Interface 3', type='32gfc-sfp28'),
+            Interface(device=device, name='Interface 4', type='32gfc-sfp28'),
+            Interface(device=device, name='Interface 5', type='32gfc-sfp28'),
+            Interface(device=device, name='Interface 6', type='32gfc-sfp28'),
+        )
+        Interface.objects.bulk_create(interfaces)
+
+        wwn_addresses = (
+            WWNAddress(wwn_address='00:00:00:00:00:00:00:01', assigned_object=interfaces[0]),
+            WWNAddress(wwn_address='00:00:00:00:00:00:00:02', assigned_object=interfaces[1]),
+            WWNAddress(wwn_address='00:00:00:00:00:00:00:03', assigned_object=interfaces[2]),
+        )
+        WWNAddress.objects.bulk_create(wwn_addresses)
+
+        tags = create_tags('Alpha', 'Bravo', 'Charlie')
+
+        cls.form_data = {
+            'wwn_address': EUI('00:00:00:00:00:00:00:04', version=64),
+            'description': 'New WWN address',
+            'interface_id': interfaces[3].pk,
+            'tags': [t.pk for t in tags],
+        }
+
+        cls.csv_data = (
+            "wwn_address,device,interface",
+            "00:00:00:00:00:00:00:04,Device 1,Interface 4",
+            "00:00:00:00:00:00:00:05,Device 1,Interface 5",
+            "00:00:00:00:00:00:00:06,Device 1,Interface 6",
+        )
+
+        cls.csv_update_data = (
+            "id,wwn_address",
+            f"{wwn_addresses[0].pk},00:00:00:00:00:00:00:0a",
+            f"{wwn_addresses[1].pk},00:00:00:00:00:00:00:0b",
+            f"{wwn_addresses[2].pk},00:00:00:00:00:00:00:0c",
+        )
+
+        cls.bulk_edit_data = {
+            'description': 'New description',
+        }
+
+    @tag('regression')  # Issue #20542
+    def test_create_wwnaddress_via_quickadd(self):
+        """
+        Test creating a WWN address via quick-add modal (e.g., from Interface form).
+        Regression test for issue #20542 where form prefix was missing in POST handler.
+        """
+        self.add_permissions('dcim.view_wwnaddress', 'dcim.view_interface', 'extras.view_tag')
+        obj_perm = ObjectPermission(name='Test permission', actions=['add'])
+        obj_perm.save()
+        obj_perm.users.add(self.user)
+        obj_perm.object_types.add(ObjectType.objects.get_for_model(self.model))
+
+        # Simulate quick-add form submission with 'quickadd-' prefix
+        formatted_data = post_data(self.form_data)
+        quickadd_data = {f'quickadd-{k}': v for k, v in formatted_data.items()}
+        quickadd_data['_quickadd'] = 'True'
+
+        initial_count = self._get_queryset().count()
+        url = f"{self._get_url('add')}?_quickadd=True&target=id_primary_wwn_address"
+        response = self.client.post(url, data=quickadd_data)
+
+        # Should successfully create the WWN address and return the quick_add_created template
         self.assertHttpStatus(response, 200)
         self.assertIn(b'quick-add-object', response.content)
         self.assertEqual(initial_count + 1, self._get_queryset().count())

--- a/netbox/dcim/ui/panels.py
+++ b/netbox/dcim/ui/panels.py
@@ -386,6 +386,13 @@ class MACAddressPanel(panels.ObjectAttributesPanel):
     is_primary = attrs.BooleanAttr('is_primary', label=_('Primary for interface'))
 
 
+class WWNAddressPanel(panels.ObjectAttributesPanel):
+    wwn_address = attrs.TextAttr('wwn_address', label=_('WWN address'), style='font-monospace', copy_button=True)
+    description = attrs.TextAttr('description')
+    assignment = attrs.RelatedObjectAttr('assigned_object', linkify=True, grouped_by='parent_object')
+    is_primary = attrs.BooleanAttr('is_primary', label=_('Primary for interface'))
+
+
 class ConnectionPanel(panels.ObjectPanel):
     """
     A panel which displays connection information for a cabled object.
@@ -517,7 +524,11 @@ class InterfaceAddressingPanel(panels.ObjectAttributesPanel):
         template_name='dcim/interface/attrs/mac_address.html',
         label=_('MAC address'),
     )
-    wwn = attrs.TextAttr('wwn', style='font-monospace', label=_('WWN'))
+    wwn_address = attrs.TemplatedAttr(
+        'primary_wwn_address',
+        template_name='dcim/interface/attrs/wwn_address.html',
+        label=_('WWN address'),
+    )
     vrf = attrs.RelatedObjectAttr('vrf', linkify=True, label=_('VRF'))
     vlan_translation = attrs.RelatedObjectAttr('vlan_translation_policy', linkify=True, label=_('VLAN translation'))
 

--- a/netbox/dcim/urls.py
+++ b/netbox/dcim/urls.py
@@ -178,4 +178,7 @@ urlpatterns = [
     path('mac-addresses/', include(get_model_urls('dcim', 'macaddress', detail=False))),
     path('mac-addresses/<int:pk>/', include(get_model_urls('dcim', 'macaddress'))),
 
+    path('wwn-addresses/', include(get_model_urls('dcim', 'wwnaddress', detail=False))),
+    path('wwn-addresses/<int:pk>/', include(get_model_urls('dcim', 'wwnaddress'))),
+
 ]

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -5043,6 +5043,7 @@ class MACAddressBulkDeleteView(generic.BulkDeleteView):
     filterset = filtersets.MACAddressFilterSet
     table = tables.MACAddressTable
 
+
 #
 # WWN addresses
 #

--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -3409,6 +3409,12 @@ class InterfaceView(generic.ObjectView):
                 exclude_columns=['assigned_object', 'assigned_object_parent'],
             ),
             ObjectsTablePanel(
+                model='dcim.WWNAddress',
+                filters={'interface_id': lambda ctx: ctx['object'].pk},
+                title=_('WWN Addresses'),
+                exclude_columns=['assigned_object', 'assigned_object_parent'],
+            ),
+            ObjectsTablePanel(
                 model='ipam.VLAN',
                 filters={'interface_id': lambda ctx: ctx['object'].pk},
                 title=_('VLANs'),
@@ -5036,3 +5042,64 @@ class MACAddressBulkDeleteView(generic.BulkDeleteView):
     queryset = MACAddress.objects.all()
     filterset = filtersets.MACAddressFilterSet
     table = tables.MACAddressTable
+
+#
+# WWN addresses
+#
+
+@register_model_view(WWNAddress, 'list', path='', detail=False)
+class WWNAddressListView(generic.ObjectListView):
+    queryset = WWNAddress.objects.all()
+    filterset = filtersets.WWNAddressFilterSet
+    filterset_form = forms.WWNAddressFilterForm
+    table = tables.WWNAddressTable
+    actions = (AddObject, BulkImport, BulkExport, BulkEdit, BulkDelete)
+
+
+@register_model_view(WWNAddress)
+class WWNAddressView(generic.ObjectView):
+    queryset = WWNAddress.objects.all()
+    template_name = 'generic/object.html'
+    layout = layout.SimpleLayout(
+        left_panels=[
+            panels.WWNAddressPanel(),
+            TagsPanel(),
+            CustomFieldsPanel(),
+        ],
+        right_panels=[
+            CommentsPanel(),
+        ],
+    )
+
+
+@register_model_view(WWNAddress, 'add', detail=False)
+@register_model_view(WWNAddress, 'edit')
+class WWNAddressEditView(generic.ObjectEditView):
+    queryset = WWNAddress.objects.all()
+    form = forms.WWNAddressForm
+
+
+@register_model_view(WWNAddress, 'delete')
+class WWNAddressDeleteView(generic.ObjectDeleteView):
+    queryset = WWNAddress.objects.all()
+
+
+@register_model_view(WWNAddress, 'bulk_import', path='import', detail=False)
+class WWNAddressBulkImportView(generic.BulkImportView):
+    queryset = WWNAddress.objects.all()
+    model_form = forms.WWNAddressImportForm
+
+
+@register_model_view(WWNAddress, 'bulk_edit', path='edit', detail=False)
+class WWNAddressBulkEditView(generic.BulkEditView):
+    queryset = WWNAddress.objects.all()
+    filterset = filtersets.WWNAddressFilterSet
+    table = tables.WWNAddressTable
+    form = forms.WWNAddressBulkEditForm
+
+
+@register_model_view(WWNAddress, 'bulk_delete', path='delete', detail=False)
+class WWNAddressBulkDeleteView(generic.BulkDeleteView):
+    queryset = WWNAddress.objects.all()
+    filterset = filtersets.WWNAddressFilterSet
+    table = tables.WWNAddressTable

--- a/netbox/extras/tests/test_filtersets.py
+++ b/netbox/extras/tests/test_filtersets.py
@@ -1410,6 +1410,7 @@ class TagTestCase(TestCase, ChangeLoggedFilterSetTests):
         'wirelesslan',
         'wirelesslangroup',
         'wirelesslink',
+        'wwnaddress',
     )
 
     @classmethod

--- a/netbox/netbox/filtersets.py
+++ b/netbox/netbox/filtersets.py
@@ -24,7 +24,7 @@ from utilities.constants import (
     FILTER_TAG_LOOKUP_MAP,
     FILTER_TREENODE_NEGATION_LOOKUP_MAP,
 )
-from utilities.forms.fields import MACAddressField
+from utilities.forms.fields import MACAddressField, WWNAddressField
 
 __all__ = (
     'AttributeFiltersMixin',
@@ -98,6 +98,9 @@ class BaseFilterSet(django_filters.FilterSet):
         },
         MACAddressField: {
             'filter_class': filters.MultiValueMACAddressFilter
+        },
+        WWNAddressField: {
+            'filter_class': filters.MultiValueWWNAddressFilter
         },
     })
 
@@ -175,7 +178,8 @@ class BaseFilterSet(django_filters.FilterSet):
             django_filters.ChoiceFilter,
             django_filters.MultipleChoiceFilter,
             filters.MultiValueCharFilter,
-            filters.MultiValueMACAddressFilter
+            filters.MultiValueMACAddressFilter,
+            filters.MultiValueWWNAddressFilter,
         )):
             return FILTER_CHAR_BASED_LOOKUP_MAP
 

--- a/netbox/netbox/navigation/menu.py
+++ b/netbox/netbox/navigation/menu.py
@@ -118,6 +118,7 @@ DEVICES_MENU = Menu(
             label=_('Addressing'),
             items=(
                 get_model_item('dcim', 'macaddress', _('MAC Addresses')),
+                get_model_item('dcim', 'wwnaddress', _('WWN Addresses')),
             ),
         ),
     ),

--- a/netbox/netbox/tests/test_forms.py
+++ b/netbox/netbox/tests/test_forms.py
@@ -288,16 +288,3 @@ class NetBoxModelImportFormCleanTestCase(TestCase):
         self.assertTrue(form.is_valid(), f'Form errors: {form.errors}')
         self.assertIsNone(form.cleaned_data['poe_mode'])
         self.assertIsNone(form.cleaned_data['poe_type'])
-
-    def test_wwn_field_nullable(self):
-        """WWN field (special field type) should convert empty string to None"""
-        form = InterfaceImportForm(
-            data={
-                'device': self.device,
-                'name': 'Interface 16',
-                'type': InterfaceTypeChoices.TYPE_1GE_GBIC,
-                'wwn': '',  # nullable WWNField
-            }
-        )
-        self.assertTrue(form.is_valid(), f'Form errors: {form.errors}')
-        self.assertIsNone(form.cleaned_data['wwn'])

--- a/netbox/templates/dcim/interface/attrs/wwn_address.html
+++ b/netbox/templates/dcim/interface/attrs/wwn_address.html
@@ -1,0 +1,3 @@
+{% load helpers i18n %}
+<span class="font-monospace">{{ value|linkify }}</span>
+<span class="badge text-bg-primary">{% trans "Primary" %}</span>

--- a/netbox/utilities/filters.py
+++ b/netbox/utilities/filters.py
@@ -21,7 +21,7 @@ __all__ = (
     'MultiValueMACAddressFilter',
     'MultiValueNumberFilter',
     'MultiValueTimeFilter',
-    'MultiValueWWNFilter',
+    'MultiValueWWNAddressFilter',
     'NullableCharFieldFilter',
     'NumericArrayFilter',
     'TreeNodeMultipleChoiceFilter',
@@ -122,8 +122,14 @@ class MultiValueMACAddressFilter(django_filters.MultipleChoiceFilter):
 
 
 @extend_schema_field(OpenApiTypes.STR)
-class MultiValueWWNFilter(django_filters.MultipleChoiceFilter):
+class MultiValueWWNAddressFilter(django_filters.MultipleChoiceFilter):
     field_class = multivalue_field_factory(forms.CharField)
+
+    def filter(self, qs, value):
+        try:
+            return super().filter(qs, value)
+        except ValidationError:
+            return qs.none()
 
 
 @extend_schema_field(OpenApiTypes.STR)

--- a/netbox/utilities/forms/fields/fields.py
+++ b/netbox/utilities/forms/fields/fields.py
@@ -24,6 +24,7 @@ __all__ = (
     'QueryField',
     'SlugField',
     'TagFilterField',
+    'WWNAddressField',
 )
 
 
@@ -174,6 +175,27 @@ class MACAddressField(forms.Field):
         # Validate MAC address format
         try:
             value = EUI(value.strip())
+        except AddrFormatError:
+            raise forms.ValidationError(self.error_messages['invalid'], code='invalid')
+
+        return value
+
+
+class WWNAddressField(forms.Field):
+    """
+    Validates a 64-bit WWN address.
+    """
+    widget = forms.CharField
+    default_error_messages = {
+        'invalid': _('WWN address must be in EUI-64 format'),
+    }
+
+    def to_python(self, value):
+        value = super().to_python(value)
+
+        # Validate WWN address format
+        try:
+            value = EUI(value.strip(), version=64)
         except AddrFormatError:
             raise forms.ValidationError(self.error_messages['invalid'], code='invalid')
 

--- a/netbox/utilities/tests/test_filters.py
+++ b/netbox/utilities/tests/test_filters.py
@@ -9,7 +9,7 @@ from taggit.managers import TaggableManager
 
 from core.models import ObjectType
 from dcim.choices import *
-from dcim.fields import MACAddressField
+from dcim.fields import MACAddressField, WWNAddressField
 from dcim.filtersets import DeviceFilterSet, InterfaceFilterSet, SiteFilterSet
 from dcim.models import (
     Device,
@@ -22,6 +22,7 @@ from dcim.models import (
     Rack,
     Region,
     Site,
+    WWNAddress,
 )
 from extras.filters import TagFilter
 from extras.models import SavedFilter, Tag, TaggedItem
@@ -35,6 +36,7 @@ from utilities.filters import (
     MultiValueMACAddressFilter,
     MultiValueNumberFilter,
     MultiValueTimeFilter,
+    MultiValueWWNAddressFilter,
     TreeNodeMultipleChoiceFilter,
 )
 from wireless.choices import WirelessRoleChoices
@@ -185,6 +187,7 @@ class DummyModel(models.Model):
         to='self',
         on_delete=models.CASCADE
     )
+    wwnaddressfield = WWNAddressField()
 
     tags = TaggableManager(through=TaggedItem)
 
@@ -215,6 +218,7 @@ class BaseFilterSetTestCase(TestCase):
         treeforeignkeyfield = TreeNodeMultipleChoiceFilter(
             queryset=DummyModel.objects.all()
         )
+        wwnaddressfield = MultiValueWWNAddressFilter()
 
         class Meta:
             model = DummyModel
@@ -232,6 +236,7 @@ class BaseFilterSetTestCase(TestCase):
                 'tagfield',
                 'timefield',
                 'treeforeignkeyfield',
+                'wwnaddressfield',
             )
 
     @classmethod
@@ -459,6 +464,33 @@ class BaseFilterSetTestCase(TestCase):
         self.assertEqual(self.filters['treeforeignkeyfield__n'].lookup_expr, 'in')
         self.assertEqual(self.filters['treeforeignkeyfield__n'].exclude, True)
 
+    def test_wwn_address_filter(self):
+        self.assertIsInstance(self.filters['wwnaddressfield'], MultiValueWWNAddressFilter)
+        self.assertEqual(self.filters['wwnaddressfield'].lookup_expr, 'exact')
+        self.assertEqual(self.filters['wwnaddressfield'].exclude, False)
+        self.assertEqual(self.filters['wwnaddressfield__n'].lookup_expr, 'exact')
+        self.assertEqual(self.filters['wwnaddressfield__n'].exclude, True)
+        self.assertEqual(self.filters['wwnaddressfield__ie'].lookup_expr, 'iexact')
+        self.assertEqual(self.filters['wwnaddressfield__ie'].exclude, False)
+        self.assertEqual(self.filters['wwnaddressfield__nie'].lookup_expr, 'iexact')
+        self.assertEqual(self.filters['wwnaddressfield__nie'].exclude, True)
+        self.assertEqual(self.filters['wwnaddressfield__ic'].lookup_expr, 'icontains')
+        self.assertEqual(self.filters['wwnaddressfield__ic'].exclude, False)
+        self.assertEqual(self.filters['wwnaddressfield__nic'].lookup_expr, 'icontains')
+        self.assertEqual(self.filters['wwnaddressfield__nic'].exclude, True)
+        self.assertEqual(self.filters['wwnaddressfield__isw'].lookup_expr, 'istartswith')
+        self.assertEqual(self.filters['wwnaddressfield__isw'].exclude, False)
+        self.assertEqual(self.filters['wwnaddressfield__nisw'].lookup_expr, 'istartswith')
+        self.assertEqual(self.filters['wwnaddressfield__nisw'].exclude, True)
+        self.assertEqual(self.filters['wwnaddressfield__iew'].lookup_expr, 'iendswith')
+        self.assertEqual(self.filters['wwnaddressfield__iew'].exclude, False)
+        self.assertEqual(self.filters['wwnaddressfield__niew'].lookup_expr, 'iendswith')
+        self.assertEqual(self.filters['wwnaddressfield__niew'].exclude, True)
+        self.assertEqual(self.filters['wwnaddressfield__regex'].lookup_expr, 'regex')
+        self.assertEqual(self.filters['wwnaddressfield__regex'].exclude, False)
+        self.assertEqual(self.filters['wwnaddressfield__iregex'].lookup_expr, 'iregex')
+        self.assertEqual(self.filters['wwnaddressfield__iregex'].exclude, False)
+
 
 class DynamicFilterLookupExpressionTestCase(TestCase):
     """
@@ -585,6 +617,16 @@ class DynamicFilterLookupExpressionTestCase(TestCase):
         )
         MACAddress.objects.bulk_create(mac_addresses)
 
+        wwn_addresses = (
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-01'),
+            WWNAddress(wwn_address='aa-00-00-00-00-00-00-01'),
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-02'),
+            WWNAddress(wwn_address='bb-00-00-00-00-00-00-02'),
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-03'),
+            WWNAddress(wwn_address='cc-00-00-00-00-00-00-03'),
+        )
+        WWNAddress.objects.bulk_create(wwn_addresses)
+
         interfaces = (
             Interface(device=devices[0], name='Interface 1'),
             Interface(device=devices[0], name='Interface 2'),
@@ -601,6 +643,13 @@ class DynamicFilterLookupExpressionTestCase(TestCase):
         interfaces[3].mac_addresses.set([mac_addresses[3]])
         interfaces[4].mac_addresses.set([mac_addresses[4]])
         interfaces[5].mac_addresses.set([mac_addresses[5]])
+
+        interfaces[0].wwn_addresses.set([wwn_addresses[0]])
+        interfaces[1].wwn_addresses.set([wwn_addresses[1]])
+        interfaces[2].wwn_addresses.set([wwn_addresses[2]])
+        interfaces[3].wwn_addresses.set([wwn_addresses[3]])
+        interfaces[4].wwn_addresses.set([wwn_addresses[4]])
+        interfaces[5].wwn_addresses.set([wwn_addresses[5]])
 
     def test_site_name_negation(self):
         params = {'name__n': ['Site 1']}

--- a/netbox/virtualization/api/serializers_/virtualmachines.py
+++ b/netbox/virtualization/api/serializers_/virtualmachines.py
@@ -1,7 +1,7 @@
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from dcim.api.serializers_.devices import DeviceSerializer, MACAddressSerializer
+from dcim.api.serializers_.devices import DeviceSerializer, MACAddressSerializer, WWNAddressSerializer
 from dcim.api.serializers_.platforms import PlatformSerializer
 from dcim.api.serializers_.roles import DeviceRoleSerializer
 from dcim.api.serializers_.sites import SiteSerializer
@@ -136,14 +136,20 @@ class VMInterfaceSerializer(OwnerMixin, NetBoxModelSerializer):
     mac_address = serializers.CharField(allow_null=True, read_only=True)
     primary_mac_address = MACAddressSerializer(nested=True, required=False, allow_null=True)
     mac_addresses = MACAddressSerializer(many=True, nested=True, read_only=True, allow_null=True)
+    # Maintains backward compatibility with NetBox <v4.7
+    wwn_address = serializers.CharField(allow_null=True, read_only=True)
+    primary_wwn_address = WWNAddressSerializer(nested=True, required=False, allow_null=True)
+    wwn_addresses = WWNAddressSerializer(many=True, nested=True, read_only=True, allow_null=True)
+
 
     class Meta:
         model = VMInterface
         fields = [
             'id', 'url', 'display_url', 'display', 'virtual_machine', 'name', 'enabled', 'parent', 'bridge', 'mtu',
-            'mac_address', 'primary_mac_address', 'mac_addresses', 'description', 'mode', 'untagged_vlan',
-            'tagged_vlans', 'qinq_svlan', 'vlan_translation_policy', 'vrf', 'l2vpn_termination', 'owner', 'tags',
-            'custom_fields', 'created', 'last_updated', 'count_ipaddresses', 'count_fhrp_groups',
+            'mac_address', 'primary_mac_address', 'mac_addresses', 'wwn_address', 'primary_wwn_address',
+            'wwn_addresses', 'description', 'mode', 'untagged_vlan', 'tagged_vlans', 'qinq_svlan',
+            'vlan_translation_policy', 'vrf', 'l2vpn_termination', 'owner', 'tags', 'custom_fields', 'created',
+            'last_updated', 'count_ipaddresses', 'count_fhrp_groups',
         ]
         brief_fields = ('id', 'url', 'display', 'virtual_machine', 'name', 'description')
 

--- a/netbox/virtualization/api/serializers_/virtualmachines.py
+++ b/netbox/virtualization/api/serializers_/virtualmachines.py
@@ -141,7 +141,6 @@ class VMInterfaceSerializer(OwnerMixin, NetBoxModelSerializer):
     primary_wwn_address = WWNAddressSerializer(nested=True, required=False, allow_null=True)
     wwn_addresses = WWNAddressSerializer(many=True, nested=True, read_only=True, allow_null=True)
 
-
     class Meta:
         model = VMInterface
         fields = [

--- a/netbox/virtualization/filtersets.py
+++ b/netbox/virtualization/filtersets.py
@@ -6,14 +6,14 @@ from netaddr.core import AddrFormatError
 
 from dcim.base_filtersets import ScopedFilterSet
 from dcim.filtersets import CommonInterfaceFilterSet
-from dcim.models import Device, DeviceRole, MACAddress, Platform, Region, Site, SiteGroup
+from dcim.models import Device, DeviceRole, MACAddress, Platform, Region, Site, SiteGroup, WWNAddress
 from extras.filtersets import LocalConfigContextFilterSet
 from extras.models import ConfigTemplate
 from ipam.filtersets import PrimaryIPFilterSet
 from netbox.filtersets import NetBoxModelFilterSet, OrganizationalModelFilterSet, PrimaryModelFilterSet
 from tenancy.filtersets import ContactModelFilterSet, TenancyFilterSet
 from users.filterset_mixins import OwnerFilterMixin
-from utilities.filters import MultiValueCharFilter, MultiValueMACAddressFilter, TreeNodeMultipleChoiceFilter
+from utilities.filters import MultiValueCharFilter, MultiValueMACAddressFilter, MultiValueWWNAddressFilter, TreeNodeMultipleChoiceFilter
 from utilities.filtersets import register_filterset
 
 from .choices import *
@@ -281,6 +281,10 @@ class VirtualMachineFilterSet(
         field_name='interfaces__mac_addresses__mac_address',
         label=_('MAC address'),
     )
+    wwn_address = MultiValueWWNAddressFilter(
+        field_name='interfaces__wwn_addresses__wwn_address',
+        label=_('WWN address'),
+    )
     has_primary_ip = django_filters.BooleanFilter(
         method='_has_primary_ip',
         label=_('Has a primary IP'),
@@ -381,6 +385,23 @@ class VMInterfaceFilterSet(CommonInterfaceFilterSet, OwnerFilterMixin, NetBoxMod
         distinct=False,
         to_field_name='mac_address',
         label=_('Primary MAC address'),
+    )
+    wwn_address = MultiValueWWNAddressFilter(
+        field_name='wwn_addresses__wwn_address',
+        label=_('WWN address'),
+    )
+    primary_wwn_address_id = django_filters.ModelMultipleChoiceFilter(
+        field_name='primary_wwn_address',
+        queryset=WWNAddress.objects.all(),
+        distinct=False,
+        label=_('Primary WWN address (ID)'),
+    )
+    primary_wwn_address = django_filters.ModelMultipleChoiceFilter(
+        field_name='primary_wwn_address__wwn_address',
+        queryset=WWNAddress.objects.all(),
+        distinct=False,
+        to_field_name='wwn_address',
+        label=_('Primary WWN address'),
     )
 
     class Meta:

--- a/netbox/virtualization/filtersets.py
+++ b/netbox/virtualization/filtersets.py
@@ -10,10 +10,19 @@ from dcim.models import Device, DeviceRole, MACAddress, Platform, Region, Site, 
 from extras.filtersets import LocalConfigContextFilterSet
 from extras.models import ConfigTemplate
 from ipam.filtersets import PrimaryIPFilterSet
-from netbox.filtersets import NetBoxModelFilterSet, OrganizationalModelFilterSet, PrimaryModelFilterSet
+from netbox.filtersets import (
+    NetBoxModelFilterSet,
+    OrganizationalModelFilterSet,
+    PrimaryModelFilterSet,
+)
 from tenancy.filtersets import ContactModelFilterSet, TenancyFilterSet
 from users.filterset_mixins import OwnerFilterMixin
-from utilities.filters import MultiValueCharFilter, MultiValueMACAddressFilter, MultiValueWWNAddressFilter, TreeNodeMultipleChoiceFilter
+from utilities.filters import (
+    MultiValueCharFilter,
+    MultiValueMACAddressFilter,
+    MultiValueWWNAddressFilter,
+    TreeNodeMultipleChoiceFilter,
+)
 from utilities.filtersets import register_filterset
 
 from .choices import *

--- a/netbox/virtualization/forms/filtersets.py
+++ b/netbox/virtualization/forms/filtersets.py
@@ -162,7 +162,7 @@ class VirtualMachineFilterForm(
         FieldSet('region_id', 'site_group_id', 'site_id', name=_('Location')),
         FieldSet(
             'virtual_machine_type_id', 'status', 'start_on_boot', 'role_id', 'platform_id', 'mac_address',
-            'has_primary_ip', 'config_template_id', 'local_context_data', 'serial',
+            'wwn_address', 'has_primary_ip', 'config_template_id', 'local_context_data', 'serial',
             name=_('Attributes')
         ),
         FieldSet('tenant_group_id', 'tenant_id', name=_('Tenant')),
@@ -246,6 +246,10 @@ class VirtualMachineFilterForm(
         required=False,
         label=_('MAC address')
     )
+    wwn_address = forms.CharField(
+        required=False,
+        label=_('WWN address')
+    )
     has_primary_ip = forms.NullBooleanField(
         required=False,
         label=_('Has a primary IP'),
@@ -271,7 +275,7 @@ class VMInterfaceFilterForm(OwnerFilterMixin, NetBoxModelFilterSetForm):
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet('cluster_id', 'virtual_machine_id', name=_('Virtual Machine')),
         FieldSet('enabled', name=_('Attributes')),
-        FieldSet('vrf_id', 'l2vpn_id', 'mac_address', name=_('Addressing')),
+        FieldSet('vrf_id', 'l2vpn_id', 'mac_address', 'wwn_address', name=_('Addressing')),
         FieldSet('mode', 'vlan_translation_policy_id', name=_('802.1Q Switching')),
         FieldSet('owner_group_id', 'owner_id', name=_('Ownership')),
     )
@@ -299,6 +303,10 @@ class VMInterfaceFilterForm(OwnerFilterMixin, NetBoxModelFilterSetForm):
     mac_address = forms.CharField(
         required=False,
         label=_('MAC address')
+    )
+    wwn_address = forms.CharField(
+        required=False,
+        label=_('WWN address')
     )
     vrf_id = DynamicModelMultipleChoiceField(
         queryset=VRF.objects.all(),

--- a/netbox/virtualization/forms/model_forms.py
+++ b/netbox/virtualization/forms/model_forms.py
@@ -7,7 +7,7 @@ from django.utils.translation import gettext_lazy as _
 
 from dcim.forms.common import InterfaceCommonForm
 from dcim.forms.mixins import ScopedForm
-from dcim.models import Device, DeviceRole, MACAddress, Platform, Rack, Region, Site, SiteGroup
+from dcim.models import Device, DeviceRole, MACAddress, Platform, Rack, Region, Site, SiteGroup, WWNAddress
 from extras.models import ConfigTemplate
 from ipam.choices import VLANQinQRoleChoices
 from ipam.models import VLAN, VRF, IPAddress, VLANGroup, VLANTranslationPolicy
@@ -394,6 +394,13 @@ class VMInterfaceForm(InterfaceCommonForm, VMComponentForm):
         quick_add=True,
         quick_add_params={'vminterface': '$pk'}
     )
+    primary_wwn_address = DynamicModelChoiceField(
+        queryset=WWNAddress.objects.all(),
+        label=_('Primary WWN address'),
+        required=False,
+        quick_add=True,
+        quick_add_params={'vminterface': '$pk'}
+    )
     parent = DynamicModelChoiceField(
         queryset=VMInterface.objects.all(),
         required=False,
@@ -456,7 +463,7 @@ class VMInterfaceForm(InterfaceCommonForm, VMComponentForm):
 
     fieldsets = (
         FieldSet('virtual_machine', 'name', 'description', 'tags', name=_('Interface')),
-        FieldSet('vrf', 'primary_mac_address', name=_('Addressing')),
+        FieldSet('vrf', 'primary_mac_address', 'primary_wwn_address', name=_('Addressing')),
         FieldSet('mtu', 'enabled', name=_('Operation')),
         FieldSet('parent', 'bridge', name=_('Related Interfaces')),
         FieldSet(
@@ -470,7 +477,7 @@ class VMInterfaceForm(InterfaceCommonForm, VMComponentForm):
         fields = [
             'virtual_machine', 'name', 'parent', 'bridge', 'enabled', 'mtu', 'description', 'mode', 'vlan_group',
             'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'vlan_translation_policy', 'vrf', 'primary_mac_address',
-            'owner', 'tags',
+            'primary_wwn_address', 'owner', 'tags',
         ]
         labels = {
             'mode': _('802.1Q Mode'),

--- a/netbox/virtualization/graphql/filters.py
+++ b/netbox/virtualization/graphql/filters.py
@@ -14,7 +14,14 @@ from virtualization import models
 from virtualization.graphql.filter_mixins import VMComponentFilterMixin
 
 if TYPE_CHECKING:
-    from dcim.graphql.filters import DeviceFilter, DeviceRoleFilter, MACAddressFilter, PlatformFilter, SiteFilter, WWNAddressFilter
+    from dcim.graphql.filters import (
+        DeviceFilter,
+        DeviceRoleFilter,
+        MACAddressFilter,
+        PlatformFilter,
+        SiteFilter,
+        WWNAddressFilter,
+    )
     from ipam.graphql.filters import (
         FHRPGroupAssignmentFilter,
         IPAddressFilter,

--- a/netbox/virtualization/graphql/filters.py
+++ b/netbox/virtualization/graphql/filters.py
@@ -14,7 +14,7 @@ from virtualization import models
 from virtualization.graphql.filter_mixins import VMComponentFilterMixin
 
 if TYPE_CHECKING:
-    from dcim.graphql.filters import DeviceFilter, DeviceRoleFilter, MACAddressFilter, PlatformFilter, SiteFilter
+    from dcim.graphql.filters import DeviceFilter, DeviceRoleFilter, MACAddressFilter, PlatformFilter, SiteFilter, WWNAddressFilter
     from ipam.graphql.filters import (
         FHRPGroupAssignmentFilter,
         IPAddressFilter,
@@ -178,6 +178,9 @@ class VMInterfaceFilter(InterfaceBaseFilterMixin, VMComponentFilterMixin, NetBox
         strawberry_django.filter_field()
     )
     mac_addresses: Annotated['MACAddressFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
+        strawberry_django.filter_field()
+    )
+    wwn_addresses: Annotated['WWNAddressFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
         strawberry_django.filter_field()
     )
 

--- a/netbox/virtualization/graphql/types.py
+++ b/netbox/virtualization/graphql/types.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
         RegionType,
         SiteGroupType,
         SiteType,
+        WWNAddressType,
     )
     from extras.graphql.types import ConfigTemplateType
     from ipam.graphql.types import IPAddressType, ServiceType, VLANTranslationPolicyType, VLANType, VRFType
@@ -140,11 +141,13 @@ class VirtualMachineType(ConfigContextMixin, ContactsMixin, PrimaryObjectType):
 class VMInterfaceType(IPAddressesMixin, ComponentType):
     _name: str
     mac_address: str | None
+    wwn_address: str | None
     parent: Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')] | None
     bridge: Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')] | None
     untagged_vlan: Annotated["VLANType", strawberry.lazy('ipam.graphql.types')] | None
     vrf: Annotated["VRFType", strawberry.lazy('ipam.graphql.types')] | None
     primary_mac_address: Annotated["MACAddressType", strawberry.lazy('dcim.graphql.types')] | None
+    primary_wwn_address: Annotated["WWNAddressType", strawberry.lazy('dcim.graphql.types')] | None
     qinq_svlan: Annotated["VLANType", strawberry.lazy('ipam.graphql.types')] | None
     vlan_translation_policy: Annotated["VLANTranslationPolicyType", strawberry.lazy('ipam.graphql.types')] | None
 
@@ -152,6 +155,7 @@ class VMInterfaceType(IPAddressesMixin, ComponentType):
     bridge_interfaces: list[Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')]]
     child_interfaces: list[Annotated["VMInterfaceType", strawberry.lazy('virtualization.graphql.types')]]
     mac_addresses: list[Annotated["MACAddressType", strawberry.lazy('dcim.graphql.types')]]
+    wwn_addresses: list[Annotated["WWNAddressType", strawberry.lazy('dcim.graphql.types')]]
 
 
 @strawberry_django.type(

--- a/netbox/virtualization/migrations/0001_squashed_0022.py
+++ b/netbox/virtualization/migrations/0001_squashed_0022.py
@@ -232,6 +232,7 @@ class Migration(migrations.Migration):
                 ('id', models.BigAutoField(primary_key=True, serialize=False)),
                 ('enabled', models.BooleanField(default=True)),
                 ('mac_address', dcim.fields.MACAddressField(blank=True, null=True)),
+                ('wwn', dcim.fields.WWNAddressField(blank=True, null=True)),
                 (
                     'mtu',
                     models.PositiveIntegerField(

--- a/netbox/virtualization/migrations/0058_populate_wwn_addresses.py
+++ b/netbox/virtualization/migrations/0058_populate_wwn_addresses.py
@@ -1,0 +1,94 @@
+import django.db.models.deletion
+from django.apps import apps
+from django.contrib.contenttypes.models import ContentType
+from django.db import migrations, models
+
+
+def populate_wwn_addresses(apps, schema_editor):
+    ContentType = apps.get_model('contenttypes', 'ContentType')
+    VMInterface = apps.get_model('virtualization', 'VMInterface')
+    WWNAddress = apps.get_model('dcim', 'WWNAddress')
+    db_alias = schema_editor.connection.alias
+    vminterface_ct = ContentType.objects.get_for_model(VMInterface)
+
+    wwn_addresses = [
+        WWNAddress(
+            wwn_address=vminterface.wwn,
+            assigned_object_type=vminterface_ct,
+            assigned_object_id=vminterface.pk
+        )
+        for vminterface in VMInterface.objects.using(db_alias).filter(wwn__isnull=False)
+    ]
+    WWNAddress.objects.using(db_alias).bulk_create(wwn_addresses, batch_size=100)
+
+    # TODO: Optimize interface updates
+    for wwn_address in wwn_addresses:
+        VMInterface.objects.using(db_alias).filter(pk=wwn_address.assigned_object_id).update(
+            primary_wwn_address=wwn_address
+        )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('dcim', '0243_populate_wwn_addresses'),
+        ('virtualization', '0057_alter_cluster__region_alter_cluster__site_group'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='vminterface',
+            name='primary_wwn_address',
+            field=models.OneToOneField(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.SET_NULL,
+                related_name='+',
+                to='dcim.wwnaddress',
+            ),
+        ),
+        migrations.RunPython(code=populate_wwn_addresses, reverse_code=migrations.RunPython.noop),
+        migrations.RemoveField(
+            model_name='vminterface',
+            name='wwn',
+        ),
+    ]
+
+
+# See peer migrator in dcim.0243_populate_wwn_addresses before making changes
+def oc_vminterface_primary_wwn_address(objectchange, reverting):
+    WWNAddress = apps.get_model('dcim', 'WWNAddress')
+    vminterface_ct = ContentType.objects.get_by_natural_key('virtualization', 'vminterface')
+
+    # Swap data order if the change is being reverted
+    if not reverting:
+        before, after = objectchange.prechange_data, objectchange.postchange_data
+    else:
+        before, after = objectchange.postchange_data, objectchange.prechange_data
+
+    if after.get('wwn') != before.get('wwn'):
+        # Create & assign the new WWNAddress (if any)
+        if after.get('wwn'):
+            wwn = WWNAddress.objects.create(
+                wwn_address=after['wwn'],
+                assigned_object_type=vminterface_ct,
+                assigned_object_id=objectchange.changed_object_id,
+            )
+            after['primary_wwn_address'] = wwn.pk
+        else:
+            after['primary_wwn_address'] = None
+        # Delete the old WWNAddress (if any)
+        if before.get('wwn'):
+            WWNAddress.objects.filter(
+                wwn_address=before['wwn'],
+                assigned_object_type=vminterface_ct,
+                assigned_object_id=objectchange.changed_object_id,
+            ).delete()
+        before['primary_wwn_address'] = None
+
+    before.pop('wwn', None)
+    after.pop('wwn', None)
+
+
+objectchange_migrators = {
+    'virtualization.vminterface': oc_vminterface_primary_wwn_address,
+}

--- a/netbox/virtualization/models/virtualmachines.py
+++ b/netbox/virtualization/models/virtualmachines.py
@@ -510,6 +510,12 @@ class VMInterface(ComponentModel, BaseInterface, TrackingModelMixin):
         object_id_field='assigned_object_id',
         related_query_name='vminterface'
     )
+    wwn_addresses = GenericRelation(
+        to='dcim.WWNAddress',
+        content_type_field='assigned_object_type',
+        object_id_field='assigned_object_id',
+        related_query_name='vminterface'
+    )
 
     class Meta(ComponentModel.Meta):
         verbose_name = _('interface')

--- a/netbox/virtualization/tables/template_code.py
+++ b/netbox/virtualization/tables/template_code.py
@@ -11,6 +11,9 @@ VMINTERFACE_BUTTONS = """
       {% if perms.dcim.add_macaddress %}
         <li><a class="dropdown-item" href="{% url 'dcim:macaddress_add' %}?vminterface={{ record.pk }}&return_url={% url 'virtualization:virtualmachine_interfaces' pk=object.pk %}">MAC Address</a></li>
       {% endif %}
+      {% if perms.dcim.add_wwnaddress %}
+        <li><a class="dropdown-item" href="{% url 'dcim:wwnaddress_add' %}?vminterface={{ record.pk }}&return_url={% url 'virtualization:virtualmachine_interfaces' pk=object.pk %}">WWN Address</a></li>
+      {% endif %}
       {% if perms.vpn.add_l2vpntermination %}
         <li><a class="dropdown-item" href="{% url 'vpn:l2vpntermination_add' %}?virtual_machine={{ object.pk }}&vminterface={{ record.pk }}&return_url={% url 'virtualization:virtualmachine_interfaces' pk=object.pk %}">L2VPN Termination</a></li>
       {% endif %}

--- a/netbox/virtualization/tables/virtualmachines.py
+++ b/netbox/virtualization/tables/virtualmachines.py
@@ -166,8 +166,8 @@ class VMInterfaceTable(BaseInterfaceTable):
         model = VMInterface
         fields = (
             'pk', 'id', 'name', 'virtual_machine', 'enabled', 'mtu', 'mode', 'description', 'tags', 'vrf',
-            'primary_mac_address', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans',
-            'qinq_svlan', 'created', 'last_updated', 'vlan_translation_policy',
+            'primary_mac_address', 'primary_wwn_address', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups',
+            'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'created', 'last_updated', 'vlan_translation_policy',
         )
         default_columns = ('pk', 'name', 'virtual_machine', 'enabled', 'description')
 
@@ -189,11 +189,14 @@ class VirtualMachineVMInterfaceTable(VMInterfaceTable):
     class Meta(NetBoxTable.Meta):
         model = VMInterface
         fields = (
-            'pk', 'id', 'name', 'enabled', 'parent', 'bridge', 'primary_mac_address', 'mtu', 'mode', 'description',
-            'tags', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan', 'tagged_vlans',
-            'qinq_svlan', 'actions',
+            'pk', 'id', 'name', 'enabled', 'parent', 'bridge', 'primary_mac_address', 'primary_wwn_address', 'mtu',
+            'mode', 'description', 'tags', 'vrf', 'l2vpn', 'tunnel', 'ip_addresses', 'fhrp_groups', 'untagged_vlan',
+            'tagged_vlans', 'qinq_svlan', 'actions',
         )
-        default_columns = ('pk', 'name', 'enabled', 'primary_mac_address', 'mtu', 'mode', 'description', 'ip_addresses')
+        default_columns = (
+            'pk', 'name', 'enabled', 'primary_mac_address', 'primary_wwn_address', 'mtu', 'mode',
+            'description', 'ip_addresses'
+        )
         row_attrs = {
             'data-name': lambda record: record.name,
             'data-virtual': lambda record: "true",

--- a/netbox/virtualization/tests/test_filtersets.py
+++ b/netbox/virtualization/tests/test_filtersets.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
 from dcim.choices import InterfaceModeChoices
-from dcim.models import Device, DeviceRole, MACAddress, Platform, Region, Site, SiteGroup
+from dcim.models import Device, DeviceRole, MACAddress, Platform, Region, Site, SiteGroup, WWNAddress
 from ipam.choices import VLANQinQRoleChoices
 from ipam.models import VLAN, VRF, IPAddress, VLANTranslationPolicy
 from tenancy.models import Tenant, TenantGroup
@@ -514,6 +514,13 @@ class VirtualMachineTestCase(TestCase, ChangeLoggedFilterSetTests):
         )
         MACAddress.objects.bulk_create(mac_addresses)
 
+        wwn_addresses = (
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-01'),
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-02'),
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-03'),
+        )
+        WWNAddress.objects.bulk_create(wwn_addresses)
+
         interfaces = (
             VMInterface(virtual_machine=vms[0], name='Interface 1'),
             VMInterface(virtual_machine=vms[1], name='Interface 2'),
@@ -524,6 +531,10 @@ class VirtualMachineTestCase(TestCase, ChangeLoggedFilterSetTests):
         interfaces[0].mac_addresses.set([mac_addresses[0]])
         interfaces[1].mac_addresses.set([mac_addresses[1]])
         interfaces[2].mac_addresses.set([mac_addresses[2]])
+
+        interfaces[0].wwn_addresses.set([wwn_addresses[0]])
+        interfaces[1].wwn_addresses.set([wwn_addresses[1]])
+        interfaces[2].wwn_addresses.set([wwn_addresses[2]])
 
         # Assign primary IPs for filtering
         ipaddresses = (
@@ -647,6 +658,10 @@ class VirtualMachineTestCase(TestCase, ChangeLoggedFilterSetTests):
         params = {'mac_address': ['00-00-00-00-00-01', '00-00-00-00-00-02']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
+    def test_wwn_address(self):
+        params = {'wwn_address': ['00-00-00-00-00-00-00-01', '00-00-00-00-00-00-00-02']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
     def test_has_primary_ip(self):
         params = {'has_primary_ip': 'true'}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
@@ -757,6 +772,13 @@ class VMInterfaceTestCase(TestCase, ChangeLoggedFilterSetTests):
         )
         MACAddress.objects.bulk_create(mac_addresses)
 
+        wwn_addresses = (
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-01'),
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-02'),
+            WWNAddress(wwn_address='00-00-00-00-00-00-00-03'),
+        )
+        WWNAddress.objects.bulk_create(wwn_addresses)
+
         interfaces = (
             VMInterface(
                 virtual_machine=vms[0],
@@ -794,6 +816,10 @@ class VMInterfaceTestCase(TestCase, ChangeLoggedFilterSetTests):
         interfaces[0].mac_addresses.set([mac_addresses[0]])
         interfaces[1].mac_addresses.set([mac_addresses[1]])
         interfaces[2].mac_addresses.set([mac_addresses[2]])
+
+        interfaces[0].wwn_addresses.set([wwn_addresses[0]])
+        interfaces[1].wwn_addresses.set([wwn_addresses[1]])
+        interfaces[2].wwn_addresses.set([wwn_addresses[2]])
 
     def test_q(self):
         params = {'q': 'foobar1'}
@@ -848,6 +874,10 @@ class VMInterfaceTestCase(TestCase, ChangeLoggedFilterSetTests):
 
     def test_mac_address(self):
         params = {'mac_address': ['00-00-00-00-00-01', '00-00-00-00-00-02']}
+        self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
+
+    def test_wwn_address(self):
+        params = {'wwn_address': ['00-00-00-00-00-00-00-01', '00-00-00-00-00-00-00-02']}
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
     def test_vrf(self):

--- a/netbox/virtualization/ui/panels.py
+++ b/netbox/virtualization/ui/panels.py
@@ -107,6 +107,9 @@ class VMInterfaceAddressingPanel(panels.ObjectAttributesPanel):
     primary_mac_address = attrs.TextAttr(
         'primary_mac_address', label=_('MAC Address'), style='font-monospace', copy_button=True
     )
+    primary_wwn_address = attrs.TextAttr(
+        'primary_wwn_address', label=_('WWN Address'), style='font-monospace', copy_button=True
+    )
     vrf = attrs.RelatedObjectAttr('vrf', linkify=True, label=_('VRF'))
     vlan_translation_policy = attrs.RelatedObjectAttr(
         'vlan_translation_policy', linkify=True, label=_('VLAN Translation')

--- a/netbox/virtualization/views.py
+++ b/netbox/virtualization/views.py
@@ -673,6 +673,16 @@ class VMInterfaceView(generic.ObjectView):
                 ],
             ),
             ObjectsTablePanel(
+                model='dcim.WWNAddress',
+                filters={'vminterface_id': lambda ctx: ctx['object'].pk},
+                exclude_columns=['assigned_object', 'assigned_object_parent'],
+                actions=[
+                    actions.AddObject(
+                        'dcim.WWNAddress', url_params={'vminterface': lambda ctx: ctx['object'].pk}
+                    ),
+                ],
+            ),
+            ObjectsTablePanel(
                 model='ipam.VLAN',
                 title=_('Assigned VLANs'),
                 filters={'vminterface_id': lambda ctx: ctx['object'].pk},


### PR DESCRIPTION
### Closes: #22727

## Summary
This change introduces support for managing World Wide Name (WWN) addresses as first-class objects, replacing the previous single-string `wwn` field on interfaces.

The implementation mirrors the existing `MACAddress` model and enables an interface to own multiple WWN addresses while designating one as the primary WWN address for compatibility with existing workflows.

## Changes
- Added a new `WWNAddress` model.
- Added a `primary_wwn_address` relationship to both physical and virtual interfaces.
- Implemented data migrations to migrate existing interface WWN values into `WWNAddress` objects.
- Removed the legacy `wwn` field from interfaces after migration.

## Notes for Reviewers
- The implementation intentionally follows the existing `MACAddress` architecture wherever possible to minimize behavioral differences.
- The data migration creates one `WWNAddress` object for each existing interface WWN and assigns it as the interface's primary WWN address.
- The documentation has been updated to reflect these changes. I assumed this feature would be introduced in **v4.7** and updated the documentation accordingly. If another release version is more appropriate, I'm happy to change it.

## Screenshots
<img width="2541" height="985" alt="image" src="https://github.com/user-attachments/assets/487951fa-b784-4424-be51-b05a6b047e7e" />
<img width="1611" height="850" alt="image" src="https://github.com/user-attachments/assets/0f67bbd0-0b13-41fe-a616-acd558efdebd" />
<img width="796" height="767" alt="image" src="https://github.com/user-attachments/assets/cbd70ace-6156-4ff7-a202-a3a4a1344355" />

This is my first community contribution to the NetBox project, so I hope I've followed the project's conventions correctly.