### PR TITLE
Fixes #22854: Set `USE_SHADOW_DOM=False` to fix GraphiQL queries w/debug enabled

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -634,6 +634,10 @@ SERIALIZATION_MODULES = {
 
 DEBUG_TOOLBAR_CONFIG = {
     'SHOW_TOOLBAR_CALLBACK': 'utilities.debug.show_toolbar',
+    # The GraphiQL integration provided by strawberry-django locates the toolbar via
+    # document.getElementById('djDebug'), which fails when the toolbar is rendered inside a
+    # shadow root (the default as of django-debug-toolbar v7.0).
+    'USE_SHADOW_DOM': False,
 }
 
 


### PR DESCRIPTION
### Fixes: #22854

- Disable the use of a shadow DOM for Django Debug Toolbar to fix the GraphiQL integration