### PR TITLE
Closes #22161: Rename filterset test mixin base classes to *TestMixin

### DIFF
--- a/.claude/skills/add-model/SKILL.md
+++ b/.claude/skills/add-model/SKILL.md
@@ -478,9 +478,9 @@ class MyModelTestCase(ViewTestCases.PrimaryObjectViewTestCase):
 **File:** `netbox/<app>/tests/test_filtersets.py`
 
 ```python
-from utilities.testing import ChangeLoggedFilterSetTests
+from utilities.testing import ChangeLoggedFilterSetTestMixin
 
-class MyModelFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
+class MyModelFilterSetTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = MyModel.objects.all()
     filterset = MyModelFilterSet
 
@@ -496,7 +496,7 @@ class MyModelFilterSetTestCase(TestCase, ChangeLoggedFilterSetTests):
         # Test FK and FK_id filters
 ```
 
-`ChangeLoggedFilterSetTests` provides standard tests for `id`, `created`, `last_updated`, `q` search, etc. Always mix it in.
+`ChangeLoggedFilterSetTestMixin` provides standard tests for `id`, `created`, `last_updated`, `q` search, etc. Always mix it in.
 
 ## Common Gotchas
 

--- a/netbox/circuits/tests/test_filtersets.py
+++ b/netbox/circuits/tests/test_filtersets.py
@@ -19,10 +19,10 @@ from dcim.models import (
 from ipam.models import ASN, RIR
 from netbox.choices import DistanceUnitChoices
 from tenancy.models import Tenant, TenantGroup
-from utilities.testing import ChangeLoggedFilterSetTests
+from utilities.testing import ChangeLoggedFilterSetTestMixin
 
 
-class ProviderTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ProviderTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Provider.objects.all()
     filterset = ProviderFilterSet
 
@@ -134,7 +134,7 @@ class ProviderTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class CircuitTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
+class CircuitTypeTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = CircuitType.objects.all()
     filterset = CircuitTypeFilterSet
 
@@ -164,7 +164,7 @@ class CircuitTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class CircuitTestCase(TestCase, ChangeLoggedFilterSetTests):
+class CircuitTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Circuit.objects.all()
     filterset = CircuitFilterSet
 
@@ -439,7 +439,7 @@ class CircuitTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
-class CircuitTerminationTestCase(TestCase, ChangeLoggedFilterSetTests):
+class CircuitTerminationTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = CircuitTermination.objects.all()
     filterset = CircuitTerminationFilterSet
     ignore_fields = ('cable', 'cable_positions')
@@ -608,7 +608,7 @@ class CircuitTerminationTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 7)
 
 
-class CircuitGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
+class CircuitGroupTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = CircuitGroup.objects.all()
     filterset = CircuitGroupFilterSet
 
@@ -666,7 +666,7 @@ class CircuitGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
 
-class CircuitGroupAssignmentTestCase(TestCase, ChangeLoggedFilterSetTests):
+class CircuitGroupAssignmentTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = CircuitGroupAssignment.objects.all()
     filterset = CircuitGroupAssignmentFilterSet
 
@@ -787,7 +787,7 @@ class CircuitGroupAssignmentTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
-class ProviderNetworkTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ProviderNetworkTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ProviderNetwork.objects.all()
     filterset = ProviderNetworkFilterSet
 
@@ -828,7 +828,7 @@ class ProviderNetworkTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ProviderAccountTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ProviderAccountTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ProviderAccount.objects.all()
     filterset = ProviderAccountFilterSet
 
@@ -873,7 +873,7 @@ class ProviderAccountTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class VirtualCircuitTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VirtualCircuitTypeTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VirtualCircuitType.objects.all()
     filterset = VirtualCircuitTypeFilterSet
 
@@ -903,7 +903,7 @@ class VirtualCircuitTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class VirtualCircuitTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VirtualCircuitTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VirtualCircuit.objects.all()
     filterset = VirtualCircuitFilterSet
 
@@ -1039,7 +1039,7 @@ class VirtualCircuitTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class VirtualCircuitTerminationTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VirtualCircuitTerminationTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VirtualCircuitTermination.objects.all()
     filterset = VirtualCircuitTerminationFilterSet
 

--- a/netbox/core/tests/test_filtersets.py
+++ b/netbox/core/tests/test_filtersets.py
@@ -7,14 +7,14 @@ from django.test import TestCase
 from dcim.models import Site
 from ipam.models import IPAddress
 from users.models import User
-from utilities.testing import BaseFilterSetTests, ChangeLoggedFilterSetTests
+from utilities.testing import BaseFilterSetTestMixin, ChangeLoggedFilterSetTestMixin
 
 from ..choices import *
 from ..filtersets import *
 from ..models import *
 
 
-class DataSourceTestCase(TestCase, ChangeLoggedFilterSetTests):
+class DataSourceTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = DataSource.objects.all()
     filterset = DataSourceFilterSet
     ignore_fields = ('ignore_rules', 'parameters')
@@ -82,7 +82,7 @@ class DataSourceTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class DataFileTestCase(TestCase, ChangeLoggedFilterSetTests):
+class DataFileTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = DataFile.objects.all()
     filterset = DataFileFilterSet
     ignore_fields = ('data',)
@@ -148,7 +148,7 @@ class DataFileTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ObjectChangeTestCase(TestCase, BaseFilterSetTests):
+class ObjectChangeTestCase(TestCase, BaseFilterSetTestMixin):
     queryset = ObjectChange.objects.all()
     filterset = ObjectChangeFilterSet
     ignore_fields = ('message', 'prechange_data', 'postchange_data')
@@ -244,7 +244,7 @@ class ObjectChangeTestCase(TestCase, BaseFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
 
-class JobTestCase(TestCase, BaseFilterSetTests):
+class JobTestCase(TestCase, BaseFilterSetTestMixin):
     queryset = Job.objects.all()
     filterset = JobFilterSet
     ignore_fields = ('data', 'error', 'log_entries')
@@ -306,7 +306,7 @@ class JobTestCase(TestCase, BaseFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ObjectTypeTestCase(TestCase, BaseFilterSetTests):
+class ObjectTypeTestCase(TestCase, BaseFilterSetTestMixin):
     queryset = ObjectType.objects.all()
     filterset = ObjectTypeFilterSet
     ignore_fields = (

--- a/netbox/dcim/tests/test_filtersets.py
+++ b/netbox/dcim/tests/test_filtersets.py
@@ -11,13 +11,13 @@ from ipam.models import ASN, RIR, VLAN, VRF, IPAddress, VLANTranslationPolicy
 from netbox.choices import ColorChoices, WeightUnitChoices
 from tenancy.models import Tenant, TenantGroup
 from users.models import User
-from utilities.testing import ChangeLoggedFilterSetTests, create_test_device, create_test_virtualmachine
+from utilities.testing import ChangeLoggedFilterSetTestMixin, create_test_device, create_test_virtualmachine
 from virtualization.models import Cluster, ClusterGroup, ClusterType, VirtualMachine, VMInterface
 from wireless.choices import WirelessChannelChoices, WirelessRoleChoices
 from wireless.models import WirelessLink
 
 
-class DeviceComponentFilterSetTests:
+class DeviceComponentFilterSetTestMixin:
 
     def test_q(self):
         params = {'q': 'First'}
@@ -53,7 +53,7 @@ class DeviceComponentFilterSetTests:
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class DeviceComponentTemplateFilterSetTests:
+class DeviceComponentTemplateFilterSetTestMixin:
 
     def test_q(self):
         params = {'q': 'foobar1'}
@@ -69,7 +69,7 @@ class DeviceComponentTemplateFilterSetTests:
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class RegionTestCase(TestCase, ChangeLoggedFilterSetTests):
+class RegionTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Region.objects.all()
     filterset = RegionFilterSet
 
@@ -150,7 +150,7 @@ class RegionTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
 
 
-class SiteGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
+class SiteGroupTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = SiteGroup.objects.all()
     filterset = SiteGroupFilterSet
 
@@ -229,7 +229,7 @@ class SiteGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
 
 
-class SiteTestCase(TestCase, ChangeLoggedFilterSetTests):
+class SiteTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Site.objects.all()
     filterset = SiteFilterSet
     ignore_fields = ('physical_address', 'shipping_address')
@@ -388,7 +388,7 @@ class SiteTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class LocationTestCase(TestCase, ChangeLoggedFilterSetTests):
+class LocationTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Location.objects.all()
     filterset = LocationFilterSet
 
@@ -536,7 +536,7 @@ class LocationTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
-class RackGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
+class RackGroupTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = RackGroup.objects.all()
     filterset = RackGroupFilterSet
 
@@ -567,7 +567,7 @@ class RackGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class RackRoleTestCase(TestCase, ChangeLoggedFilterSetTests):
+class RackRoleTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = RackRole.objects.all()
     filterset = RackRoleFilterSet
 
@@ -602,7 +602,7 @@ class RackRoleTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class RackTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
+class RackTypeTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = RackType.objects.all()
     filterset = RackTypeFilterSet
 
@@ -755,7 +755,7 @@ class RackTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class RackTestCase(TestCase, ChangeLoggedFilterSetTests):
+class RackTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Rack.objects.all()
     filterset = RackFilterSet
     ignore_fields = ('units',)
@@ -1129,7 +1129,7 @@ class RackTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
-class RackReservationTestCase(TestCase, ChangeLoggedFilterSetTests):
+class RackReservationTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = RackReservation.objects.all()
     filterset = RackReservationFilterSet
     ignore_fields = ('units',)
@@ -1309,7 +1309,7 @@ class RackReservationTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ManufacturerTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ManufacturerTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Manufacturer.objects.all()
     filterset = ManufacturerFilterSet
 
@@ -1340,7 +1340,7 @@ class ManufacturerTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class DeviceTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
+class DeviceTypeTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = DeviceType.objects.all()
     filterset = DeviceTypeFilterSet
     ignore_fields = ('front_image', 'rear_image')
@@ -1592,7 +1592,7 @@ class DeviceTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ModuleTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ModuleTypeTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ModuleType.objects.all()
     filterset = ModuleTypeFilterSet
     ignore_fields = ['attribute_data']
@@ -1827,7 +1827,7 @@ class ModuleTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
-class ModuleTypeProfileTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ModuleTypeProfileTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ModuleTypeProfile.objects.all()
     filterset = ModuleTypeProfileFilterSet
     ignore_fields = ['schema']
@@ -1886,7 +1886,7 @@ class ModuleTypeProfileTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ModuleBayTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ModuleBayTypeTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ModuleBayType.objects.all()
     filterset = ModuleBayTypeFilterSet
 
@@ -1929,7 +1929,7 @@ class ModuleBayTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ConsolePortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
+class ConsolePortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = ConsolePortTemplate.objects.all()
     filterset = ConsolePortTemplateFilterSet
 
@@ -1956,7 +1956,9 @@ class ConsolePortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTest
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ConsoleServerPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
+class ConsoleServerPortTemplateTestCase(
+    TestCase, DeviceComponentTemplateFilterSetTestMixin, ChangeLoggedFilterSetTestMixin
+):
     queryset = ConsoleServerPortTemplate.objects.all()
     filterset = ConsoleServerPortTemplateFilterSet
 
@@ -1983,7 +1985,7 @@ class ConsoleServerPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterS
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class PowerPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
+class PowerPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = PowerPortTemplate.objects.all()
     filterset = PowerPortTemplateFilterSet
 
@@ -2036,7 +2038,7 @@ class PowerPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests,
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class PowerOutletTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
+class PowerOutletTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = PowerOutletTemplate.objects.all()
     filterset = PowerOutletTemplateFilterSet
 
@@ -2089,7 +2091,7 @@ class PowerOutletTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTest
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class InterfaceTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
+class InterfaceTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = InterfaceTemplate.objects.all()
     filterset = InterfaceTemplateFilterSet
 
@@ -2172,7 +2174,7 @@ class InterfaceTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests,
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class FrontPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
+class FrontPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = FrontPortTemplate.objects.all()
     filterset = FrontPortTemplateFilterSet
 
@@ -2245,7 +2247,7 @@ class FrontPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests,
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class RearPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
+class RearPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = RearPortTemplate.objects.all()
     filterset = RearPortTemplateFilterSet
 
@@ -2305,7 +2307,7 @@ class RearPortTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, 
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ModuleBayTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
+class ModuleBayTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = ModuleBayTemplate.objects.all()
     filterset = ModuleBayTemplateFilterSet
 
@@ -2365,7 +2367,7 @@ class ModuleBayTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests,
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class DeviceBayTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
+class DeviceBayTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = DeviceBayTemplate.objects.all()
     filterset = DeviceBayTemplateFilterSet
 
@@ -2406,7 +2408,9 @@ class DeviceBayTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests,
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
-class InventoryItemTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTests, ChangeLoggedFilterSetTests):
+class InventoryItemTemplateTestCase(
+    TestCase, DeviceComponentTemplateFilterSetTestMixin, ChangeLoggedFilterSetTestMixin
+):
     queryset = InventoryItemTemplate.objects.all()
     filterset = InventoryItemTemplateFilterSet
 
@@ -2516,7 +2520,7 @@ class InventoryItemTemplateTestCase(TestCase, DeviceComponentTemplateFilterSetTe
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class DeviceRoleTestCase(TestCase, ChangeLoggedFilterSetTests):
+class DeviceRoleTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = DeviceRole.objects.all()
     filterset = DeviceRoleFilterSet
 
@@ -2624,7 +2628,7 @@ class DeviceRoleTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
-class PlatformTestCase(TestCase, ChangeLoggedFilterSetTests):
+class PlatformTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Platform.objects.all()
     filterset = PlatformFilterSet
 
@@ -2725,7 +2729,7 @@ class PlatformTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
-class DeviceTestCase(TestCase, ChangeLoggedFilterSetTests):
+class DeviceTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Device.objects.all()
     filterset = DeviceFilterSet
     ignore_fields = ('local_context_data', 'oob_ip', 'primary_ip4', 'primary_ip6', 'vc_master_for')
@@ -3222,7 +3226,7 @@ class DeviceTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ModuleTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ModuleTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Module.objects.all()
     filterset = ModuleFilterSet
     ignore_fields = ('local_context_data',)
@@ -3520,7 +3524,7 @@ class ModuleTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 6)
 
 
-class ConsolePortTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFilterSetTests):
+class ConsolePortTestCase(TestCase, DeviceComponentFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = ConsolePort.objects.all()
     filterset = ConsolePortFilterSet
     ignore_fields = ('cable_positions',)
@@ -3771,7 +3775,7 @@ class ConsolePortTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedF
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
-class ConsoleServerPortTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFilterSetTests):
+class ConsoleServerPortTestCase(TestCase, DeviceComponentFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = ConsoleServerPort.objects.all()
     filterset = ConsoleServerPortFilterSet
     ignore_fields = ('cable_positions',)
@@ -4022,7 +4026,7 @@ class ConsoleServerPortTestCase(TestCase, DeviceComponentFilterSetTests, ChangeL
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
-class PowerPortTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFilterSetTests):
+class PowerPortTestCase(TestCase, DeviceComponentFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = PowerPort.objects.all()
     filterset = PowerPortFilterSet
     ignore_fields = ('cable_positions',)
@@ -4287,7 +4291,7 @@ class PowerPortTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFil
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
-class PowerOutletTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFilterSetTests):
+class PowerOutletTestCase(TestCase, DeviceComponentFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = PowerOutlet.objects.all()
     filterset = PowerOutletFilterSet
     ignore_fields = ('cable_positions',)
@@ -4572,7 +4576,7 @@ class PowerOutletTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedF
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
 
-class InterfaceTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFilterSetTests):
+class InterfaceTestCase(TestCase, DeviceComponentFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = Interface.objects.all()
     filterset = InterfaceFilterSet
     ignore_fields = ('tagged_vlans', 'untagged_vlan', 'qinq_svlan', 'vdcs', 'cable_positions')
@@ -5325,7 +5329,7 @@ class InterfaceTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFil
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
-class FrontPortTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFilterSetTests):
+class FrontPortTestCase(TestCase, DeviceComponentFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = FrontPort.objects.all()
     filterset = FrontPortFilterSet
     ignore_fields = ('cable_positions',)
@@ -5630,7 +5634,7 @@ class FrontPortTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFil
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class RearPortTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFilterSetTests):
+class RearPortTestCase(TestCase, DeviceComponentFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = RearPort.objects.all()
     filterset = RearPortFilterSet
     ignore_fields = ('cable_positions',)
@@ -5920,7 +5924,7 @@ class RearPortTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFilt
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ModuleBayTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFilterSetTests):
+class ModuleBayTestCase(TestCase, DeviceComponentFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = ModuleBay.objects.all()
     filterset = ModuleBayFilterSet
 
@@ -6109,7 +6113,7 @@ class ModuleBayTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFil
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class DeviceBayTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFilterSetTests):
+class DeviceBayTestCase(TestCase, DeviceComponentFilterSetTestMixin, ChangeLoggedFilterSetTestMixin):
     queryset = DeviceBay.objects.all()
     filterset = DeviceBayFilterSet
 
@@ -6306,7 +6310,7 @@ class DeviceBayTestCase(TestCase, DeviceComponentFilterSetTests, ChangeLoggedFil
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class InventoryItemTestCase(TestCase, ChangeLoggedFilterSetTests):
+class InventoryItemTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = InventoryItem.objects.all()
     filterset = InventoryItemFilterSet
 
@@ -6581,7 +6585,7 @@ class InventoryItemTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class InventoryItemRoleTestCase(TestCase, ChangeLoggedFilterSetTests):
+class InventoryItemRoleTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = InventoryItemRole.objects.all()
     filterset = InventoryItemRoleFilterSet
 
@@ -6631,7 +6635,7 @@ class InventoryItemRoleTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class VirtualChassisTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VirtualChassisTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VirtualChassis.objects.all()
     filterset = VirtualChassisFilterSet
 
@@ -6731,7 +6735,7 @@ class VirtualChassisTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class CableBundleTestCase(TestCase, ChangeLoggedFilterSetTests):
+class CableBundleTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = CableBundle.objects.all()
     filterset = CableBundleFilterSet
 
@@ -6757,7 +6761,7 @@ class CableBundleTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
+class CableTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Cable.objects.all()
     filterset = CableFilterSet
 
@@ -7136,7 +7140,7 @@ class CableTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
-class CableTerminationTestCase(TestCase, ChangeLoggedFilterSetTests):
+class CableTerminationTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = CableTermination.objects.all()
     filterset = CableTerminationFilterSet
     ignore_fields = ('connector', 'positions')
@@ -7226,7 +7230,7 @@ class CableTerminationTestCase(TestCase, ChangeLoggedFilterSetTests):
                 self.assertEqual(results.first().termination_id, obj.pk)
 
 
-class PowerPanelTestCase(TestCase, ChangeLoggedFilterSetTests):
+class PowerPanelTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = PowerPanel.objects.all()
     filterset = PowerPanelFilterSet
 
@@ -7310,7 +7314,7 @@ class PowerPanelTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class PowerFeedTestCase(TestCase, ChangeLoggedFilterSetTests):
+class PowerFeedTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = PowerFeed.objects.all()
     filterset = PowerFeedFilterSet
     ignore_fields = ('cable_positions',)
@@ -7526,7 +7530,7 @@ class PowerFeedTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class VirtualDeviceContextTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VirtualDeviceContextTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VirtualDeviceContext.objects.all()
     filterset = VirtualDeviceContextFilterSet
     ignore_fields = ('primary_ip4', 'primary_ip6')
@@ -7683,7 +7687,7 @@ class VirtualDeviceContextTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 0)
 
 
-class MACAddressTestCase(TestCase, ChangeLoggedFilterSetTests):
+class MACAddressTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = MACAddress.objects.all()
     filterset = MACAddressFilterSet
 

--- a/netbox/extras/tests/test_filtersets.py
+++ b/netbox/extras/tests/test_filtersets.py
@@ -15,11 +15,11 @@ from extras.filtersets import *
 from extras.models import *
 from tenancy.models import Tenant, TenantGroup
 from users.models import Group, User
-from utilities.testing import BaseFilterSetTests, ChangeLoggedFilterSetTests, create_tags
+from utilities.testing import BaseFilterSetTestMixin, ChangeLoggedFilterSetTestMixin, create_tags
 from virtualization.models import Cluster, ClusterGroup, ClusterType
 
 
-class CustomFieldTestCase(TestCase, ChangeLoggedFilterSetTests):
+class CustomFieldTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = CustomField.objects.all()
     filterset = CustomFieldFilterSet
     ignore_fields = ('default', 'related_object_filter', 'validation_schema')
@@ -160,7 +160,7 @@ class CustomFieldTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class CustomFieldChoiceSetTestCase(TestCase, ChangeLoggedFilterSetTests):
+class CustomFieldChoiceSetTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = CustomFieldChoiceSet.objects.all()
     filterset = CustomFieldChoiceSetFilterSet
     ignore_fields = ('extra_choices',)
@@ -214,7 +214,7 @@ class CustomFieldChoiceSetTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class WebhookTestCase(TestCase, BaseFilterSetTests):
+class WebhookTestCase(TestCase, BaseFilterSetTestMixin):
     queryset = Webhook.objects.all()
     filterset = WebhookFilterSet
     ignore_fields = ('additional_headers', 'body_template')
@@ -286,7 +286,7 @@ class WebhookTestCase(TestCase, BaseFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class EventRuleTestCase(TestCase, BaseFilterSetTests):
+class EventRuleTestCase(TestCase, BaseFilterSetTestMixin):
     queryset = EventRule.objects.all()
     filterset = EventRuleFilterSet
     ignore_fields = ('action_data', 'conditions', 'event_types')
@@ -407,7 +407,7 @@ class EventRuleTestCase(TestCase, BaseFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class CustomLinkTestCase(TestCase, ChangeLoggedFilterSetTests):
+class CustomLinkTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = CustomLink.objects.all()
     filterset = CustomLinkFilterSet
 
@@ -476,7 +476,7 @@ class CustomLinkTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
-class SavedFilterTestCase(TestCase, ChangeLoggedFilterSetTests):
+class SavedFilterTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = SavedFilter.objects.all()
     filterset = SavedFilterFilterSet
     ignore_fields = ('parameters',)
@@ -581,7 +581,7 @@ class SavedFilterTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 1)
 
 
-class BookmarkTestCase(TestCase, BaseFilterSetTests):
+class BookmarkTestCase(TestCase, BaseFilterSetTestMixin):
     queryset = Bookmark.objects.all()
     filterset = BookmarkFilterSet
 
@@ -650,7 +650,7 @@ class BookmarkTestCase(TestCase, BaseFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
-class ExportTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ExportTemplateTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ExportTemplate.objects.all()
     filterset = ExportTemplateFilterSet
     ignore_fields = ('template_code', 'environment_params', 'data_path')
@@ -726,7 +726,7 @@ class ExportTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ImageAttachmentTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ImageAttachmentTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ImageAttachment.objects.all()
     filterset = ImageAttachmentFilterSet
     ignore_fields = ('image',)
@@ -820,7 +820,7 @@ class ImageAttachmentTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class TableConfigTestCase(TestCase, ChangeLoggedFilterSetTests):
+class TableConfigTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = TableConfig.objects.all()
     filterset = TableConfigFilterSet
     ignore_fields = ('columns', 'ordering')
@@ -876,7 +876,7 @@ class TableConfigTestCase(TestCase, ChangeLoggedFilterSetTests):
         )
 
 
-class JournalEntryTestCase(TestCase, ChangeLoggedFilterSetTests):
+class JournalEntryTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = JournalEntry.objects.all()
     filterset = JournalEntryFilterSet
 
@@ -979,7 +979,7 @@ class JournalEntryTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ConfigContextProfileTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ConfigContextProfileTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ConfigContextProfile.objects.all()
     filterset = ConfigContextProfileFilterSet
     ignore_fields = ('schema', 'data_path')
@@ -1012,7 +1012,7 @@ class ConfigContextProfileTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ConfigContextTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ConfigContextTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ConfigContext.objects.all()
     filterset = ConfigContextFilterSet
     ignore_fields = ('data', 'data_path')
@@ -1255,7 +1255,7 @@ class ConfigContextTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ConfigTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ConfigTemplateTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ConfigTemplate.objects.all()
     filterset = ConfigTemplateFilterSet
     ignore_fields = ('template_code', 'environment_params', 'data_path')
@@ -1321,7 +1321,7 @@ class ConfigTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class TagTestCase(TestCase, ChangeLoggedFilterSetTests):
+class TagTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Tag.objects.all()
     filterset = TagFilterSet
     ignore_fields = (
@@ -1644,7 +1644,7 @@ class ChangeLoggedFilterSetTestCase(TestCase):
         self.assertEqual(self.queryset.count(), 4)
 
 
-class NotificationGroupTestCase(TestCase, BaseFilterSetTests):
+class NotificationGroupTestCase(TestCase, BaseFilterSetTestMixin):
     queryset = NotificationGroup.objects.all()
     filterset = NotificationGroupFilterSet
 

--- a/netbox/ipam/tests/test_filtersets.py
+++ b/netbox/ipam/tests/test_filtersets.py
@@ -10,13 +10,13 @@ from ipam.choices import *
 from ipam.filtersets import *
 from ipam.models import *
 from tenancy.models import Tenant, TenantGroup
-from utilities.testing import ChangeLoggedFilterSetTests, create_test_device, create_test_virtualmachine
+from utilities.testing import ChangeLoggedFilterSetTestMixin, create_test_device, create_test_virtualmachine
 from virtualization.models import Cluster, ClusterGroup, ClusterType, VirtualMachine, VMInterface
 from vpn.choices import L2VPNTypeChoices
 from vpn.models import L2VPN
 
 
-class ASNRangeTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ASNRangeTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ASNRange.objects.all()
     filterset = ASNRangeFilterSet
 
@@ -101,7 +101,7 @@ class ASNRangeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ASNTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ASNTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ASN.objects.all()
     filterset = ASNFilterSet
 
@@ -224,7 +224,7 @@ class ASNTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class VRFTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VRFTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VRF.objects.all()
     filterset = VRFFilterSet
 
@@ -234,7 +234,7 @@ class VRFTestCase(TestCase, ChangeLoggedFilterSetTests):
             return 'import_target'
         if field.name == 'export_targets':
             return 'export_target'
-        return ChangeLoggedFilterSetTests.get_m2m_filter_name(field)
+        return ChangeLoggedFilterSetTestMixin.get_m2m_filter_name(field)
 
     @classmethod
     def setUpTestData(cls):
@@ -328,7 +328,7 @@ class VRFTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class RouteTargetTestCase(TestCase, ChangeLoggedFilterSetTests):
+class RouteTargetTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = RouteTarget.objects.all()
     filterset = RouteTargetFilterSet
 
@@ -342,7 +342,7 @@ class RouteTargetTestCase(TestCase, ChangeLoggedFilterSetTests):
             return 'importing_l2vpn'
         if field.name == 'exporting_l2vpns':
             return 'exporting_l2vpn'
-        return ChangeLoggedFilterSetTests.get_m2m_filter_name(field)
+        return ChangeLoggedFilterSetTestMixin.get_m2m_filter_name(field)
 
     @classmethod
     def setUpTestData(cls):
@@ -455,7 +455,7 @@ class RouteTargetTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class RIRTestCase(TestCase, ChangeLoggedFilterSetTests):
+class RIRTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = RIR.objects.all()
     filterset = RIRFilterSet
 
@@ -495,7 +495,7 @@ class RIRTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
 
-class AggregateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class AggregateTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Aggregate.objects.all()
     filterset = AggregateFilterSet
 
@@ -581,7 +581,7 @@ class AggregateTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
-class RoleTestCase(TestCase, ChangeLoggedFilterSetTests):
+class RoleTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Role.objects.all()
     filterset = RoleFilterSet
 
@@ -612,7 +612,7 @@ class RoleTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class PrefixTestCase(TestCase, ChangeLoggedFilterSetTests):
+class PrefixTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Prefix.objects.all()
     filterset = PrefixFilterSet
 
@@ -916,7 +916,7 @@ class PrefixTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class IPRangeTestCase(TestCase, ChangeLoggedFilterSetTests):
+class IPRangeTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = IPRange.objects.all()
     filterset = IPRangeFilterSet
 
@@ -1130,7 +1130,7 @@ class IPRangeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertIn(iprange, self.filterset(params, self.queryset).qs)
 
 
-class IPAddressTestCase(TestCase, ChangeLoggedFilterSetTests):
+class IPAddressTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = IPAddress.objects.all()
     filterset = IPAddressFilterSet
     ignore_fields = ('fhrpgroup',)
@@ -1486,7 +1486,7 @@ class IPAddressTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class FHRPGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
+class FHRPGroupTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = FHRPGroup.objects.all()
     filterset = FHRPGroupFilterSet
 
@@ -1568,7 +1568,7 @@ class FHRPGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class FHRPGroupAssignmentTestCase(TestCase, ChangeLoggedFilterSetTests):
+class FHRPGroupAssignmentTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = FHRPGroupAssignment.objects.all()
     filterset = FHRPGroupAssignmentFilterSet
 
@@ -1641,7 +1641,7 @@ class FHRPGroupAssignmentTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
 
-class VLANGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VLANGroupTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VLANGroup.objects.all()
     filterset = VLANGroupFilterSet
     ignore_fields = ('vid_ranges',)
@@ -1821,7 +1821,7 @@ class VLANGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 3)
 
 
-class VLANTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VLANTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VLAN.objects.all()
     filterset = VLANFilterSet
     ignore_fields = ('interfaces_as_tagged', 'vminterfaces_as_tagged')
@@ -2287,7 +2287,7 @@ class VLANTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class VLANTranslationPolicyTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VLANTranslationPolicyTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VLANTranslationPolicy.objects.all()
     filterset = VLANTranslationPolicyFilterSet
 
@@ -2319,7 +2319,7 @@ class VLANTranslationPolicyTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class VLANTranslationRuleTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VLANTranslationRuleTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VLANTranslationRule.objects.all()
     filterset = VLANTranslationRuleFilterSet
 
@@ -2380,7 +2380,7 @@ class VLANTranslationRuleTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ServiceTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ServiceTemplateTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ServiceTemplate.objects.all()
     filterset = ServiceTemplateFilterSet
     ignore_fields = ('ports',)
@@ -2445,7 +2445,7 @@ class ServiceTemplateTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ServiceTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ServiceTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Service.objects.all()
     filterset = ServiceFilterSet
     ignore_fields = ('ports',)

--- a/netbox/netbox/tests/test_model_test_coverage.py
+++ b/netbox/netbox/tests/test_model_test_coverage.py
@@ -9,7 +9,7 @@ from django.urls import NoReverseMatch
 from core.filtersets import ObjectTypeFilterSet
 from core.models import ObjectType
 from netbox.registry import registry
-from utilities.testing import APITestCase, BaseFilterSetTests, ModelViewTestCase
+from utilities.testing import APITestCase, BaseFilterSetTestMixin, ModelViewTestCase
 from utilities.views import get_action_url
 
 
@@ -209,7 +209,7 @@ class ModelTestCoverageTestCase(TestCase):
         covered = self.collect_covered_models(
             app_labels,
             'test_filtersets',
-            BaseFilterSetTests,
+            BaseFilterSetTestMixin,
             get_queryset_model,
         )
 

--- a/netbox/tenancy/tests/test_filtersets.py
+++ b/netbox/tenancy/tests/test_filtersets.py
@@ -4,10 +4,10 @@ from core.models import ObjectType
 from dcim.models import Manufacturer, Site
 from tenancy.filtersets import *
 from tenancy.models import *
-from utilities.testing import ChangeLoggedFilterSetTests
+from utilities.testing import ChangeLoggedFilterSetTestMixin
 
 
-class TenantGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
+class TenantGroupTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = TenantGroup.objects.all()
     filterset = TenantGroupFilterSet
 
@@ -95,7 +95,7 @@ class TenantGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
-class TenantTestCase(TestCase, ChangeLoggedFilterSetTests):
+class TenantTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Tenant.objects.all()
     filterset = TenantFilterSet
 
@@ -141,7 +141,7 @@ class TenantTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ContactGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ContactGroupTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ContactGroup.objects.all()
     filterset = ContactGroupFilterSet
 
@@ -229,7 +229,7 @@ class ContactGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
-class ContactRoleTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ContactRoleTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ContactRole.objects.all()
     filterset = ContactRoleFilterSet
 
@@ -260,7 +260,7 @@ class ContactRoleTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ContactTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ContactTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Contact.objects.all()
     filterset = ContactFilterSet
     ignore_fields = ('groups',)
@@ -306,7 +306,7 @@ class ContactTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ContactAssignmentTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ContactAssignmentTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ContactAssignment.objects.all()
     filterset = ContactAssignmentFilterSet
 

--- a/netbox/users/tests/test_filtersets.py
+++ b/netbox/users/tests/test_filtersets.py
@@ -6,10 +6,10 @@ from django.utils.timezone import make_aware
 from core.models import ObjectType
 from users import filtersets
 from users.models import Group, ObjectPermission, Owner, OwnerGroup, Token, User
-from utilities.testing import BaseFilterSetTests
+from utilities.testing import BaseFilterSetTestMixin
 
 
-class UserTestCase(TestCase, BaseFilterSetTests):
+class UserTestCase(TestCase, BaseFilterSetTestMixin):
     queryset = User.objects.all()
     filterset = filtersets.UserFilterSet
     ignore_fields = ('config', 'dashboard', 'password', 'user_permissions')
@@ -114,7 +114,7 @@ class UserTestCase(TestCase, BaseFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class GroupTestCase(TestCase, BaseFilterSetTests):
+class GroupTestCase(TestCase, BaseFilterSetTestMixin):
     queryset = Group.objects.all()
     filterset = filtersets.GroupFilterSet
     ignore_fields = ('permissions',)
@@ -168,7 +168,7 @@ class GroupTestCase(TestCase, BaseFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ObjectPermissionTestCase(TestCase, BaseFilterSetTests):
+class ObjectPermissionTestCase(TestCase, BaseFilterSetTestMixin):
     queryset = ObjectPermission.objects.all()
     filterset = filtersets.ObjectPermissionFilterSet
     ignore_fields = ('actions', 'constraints')
@@ -263,7 +263,7 @@ class ObjectPermissionTestCase(TestCase, BaseFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 4)
 
 
-class TokenTestCase(TestCase, BaseFilterSetTests):
+class TokenTestCase(TestCase, BaseFilterSetTestMixin):
     queryset = Token.objects.all()
     filterset = filtersets.TokenFilterSet
     ignore_fields = ('plaintext', 'hmac_digest', 'allowed_ips')
@@ -359,7 +359,7 @@ class TokenTestCase(TestCase, BaseFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class OwnerGroupTestCase(TestCase, BaseFilterSetTests):
+class OwnerGroupTestCase(TestCase, BaseFilterSetTestMixin):
     queryset = OwnerGroup.objects.all()
     filterset = filtersets.OwnerGroupFilterSet
 
@@ -386,7 +386,7 @@ class OwnerGroupTestCase(TestCase, BaseFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class OwnerTestCase(TestCase, BaseFilterSetTests):
+class OwnerTestCase(TestCase, BaseFilterSetTestMixin):
     queryset = Owner.objects.all()
     filterset = filtersets.OwnerFilterSet
 

--- a/netbox/utilities/testing/filtersets.py
+++ b/netbox/utilities/testing/filtersets.py
@@ -13,8 +13,8 @@ from netbox.models.ltree import LtreeModel
 from utilities.filters import MultiValueContentTypeFilter, TreeNodeMultipleChoiceFilter
 
 __all__ = (
-    'BaseFilterSetTests',
-    'ChangeLoggedFilterSetTests',
+    'BaseFilterSetTestMixin',
+    'ChangeLoggedFilterSetTestMixin',
 )
 
 EXEMPT_MODEL_FIELDS = (
@@ -25,7 +25,7 @@ EXEMPT_MODEL_FIELDS = (
 )
 
 
-class BaseFilterSetTests:
+class BaseFilterSetTestMixin:
     queryset = None
     filterset = None
     ignore_fields = tuple()
@@ -150,7 +150,7 @@ class BaseFilterSetTests:
                     )
 
 
-class ChangeLoggedFilterSetTests(BaseFilterSetTests):
+class ChangeLoggedFilterSetTestMixin(BaseFilterSetTestMixin):
 
     def test_created(self):
         pk_list = self.queryset.values_list('pk', flat=True)[:2]

--- a/netbox/virtualization/tests/test_filtersets.py
+++ b/netbox/virtualization/tests/test_filtersets.py
@@ -5,13 +5,13 @@ from dcim.models import Device, DeviceRole, MACAddress, Platform, Region, Site, 
 from ipam.choices import VLANQinQRoleChoices
 from ipam.models import VLAN, VRF, IPAddress, VLANTranslationPolicy
 from tenancy.models import Tenant, TenantGroup
-from utilities.testing import ChangeLoggedFilterSetTests, create_test_device
+from utilities.testing import ChangeLoggedFilterSetTestMixin, create_test_device
 from virtualization.choices import *
 from virtualization.filtersets import *
 from virtualization.models import *
 
 
-class ClusterTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ClusterTypeTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ClusterType.objects.all()
     filterset = ClusterTypeFilterSet
 
@@ -42,7 +42,7 @@ class ClusterTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ClusterGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ClusterGroupTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = ClusterGroup.objects.all()
     filterset = ClusterGroupFilterSet
 
@@ -73,7 +73,7 @@ class ClusterGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class ClusterTestCase(TestCase, ChangeLoggedFilterSetTests):
+class ClusterTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Cluster.objects.all()
     filterset = ClusterFilterSet
 
@@ -230,7 +230,7 @@ class ClusterTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class VirtualMachineTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VirtualMachineTypeTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VirtualMachineType.objects.all()
     filterset = VirtualMachineTypeFilterSet
 
@@ -340,7 +340,7 @@ class VirtualMachineTypeTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class VirtualMachineTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VirtualMachineTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VirtualMachine.objects.all()
     filterset = VirtualMachineFilterSet
 
@@ -700,7 +700,7 @@ class VirtualMachineTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class VMInterfaceTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VMInterfaceTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VMInterface.objects.all()
     filterset = VMInterfaceFilterSet
     ignore_fields = ('tagged_vlans', 'untagged_vlan', 'qinq_svlan')
@@ -880,7 +880,7 @@ class VMInterfaceTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class VirtualDiskTestCase(TestCase, ChangeLoggedFilterSetTests):
+class VirtualDiskTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = VirtualDisk.objects.all()
     filterset = VirtualDiskFilterSet
 

--- a/netbox/vpn/tests/test_filtersets.py
+++ b/netbox/vpn/tests/test_filtersets.py
@@ -3,14 +3,14 @@ from django.test import TestCase
 from dcim.choices import InterfaceTypeChoices
 from dcim.models import Device, Interface, Site
 from ipam.models import VLAN, IPAddress, RouteTarget
-from utilities.testing import ChangeLoggedFilterSetTests, create_test_device, create_test_virtualmachine
+from utilities.testing import ChangeLoggedFilterSetTestMixin, create_test_device, create_test_virtualmachine
 from virtualization.models import VirtualMachine, VMInterface
 from vpn.choices import *
 from vpn.filtersets import *
 from vpn.models import *
 
 
-class TunnelGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
+class TunnelGroupTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = TunnelGroup.objects.all()
     filterset = TunnelGroupFilterSet
 
@@ -40,7 +40,7 @@ class TunnelGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class TunnelTestCase(TestCase, ChangeLoggedFilterSetTests):
+class TunnelTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = Tunnel.objects.all()
     filterset = TunnelFilterSet
 
@@ -162,7 +162,7 @@ class TunnelTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class TunnelTerminationTestCase(TestCase, ChangeLoggedFilterSetTests):
+class TunnelTerminationTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = TunnelTermination.objects.all()
     filterset = TunnelTerminationFilterSet
 
@@ -293,7 +293,7 @@ class TunnelTerminationTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class IKEProposalTestCase(TestCase, ChangeLoggedFilterSetTests):
+class IKEProposalTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = IKEProposal.objects.all()
     filterset = IKEProposalFilterSet
 
@@ -386,7 +386,7 @@ class IKEProposalTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class IKEPolicyTestCase(TestCase, ChangeLoggedFilterSetTests):
+class IKEPolicyTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = IKEPolicy.objects.all()
     filterset = IKEPolicyFilterSet
 
@@ -470,7 +470,7 @@ class IKEPolicyTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class IPSecProposalTestCase(TestCase, ChangeLoggedFilterSetTests):
+class IPSecProposalTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = IPSecProposal.objects.all()
     filterset = IPSecProposalFilterSet
 
@@ -554,7 +554,7 @@ class IPSecProposalTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class IPSecPolicyTestCase(TestCase, ChangeLoggedFilterSetTests):
+class IPSecPolicyTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = IPSecPolicy.objects.all()
     filterset = IPSecPolicyFilterSet
 
@@ -625,7 +625,7 @@ class IPSecPolicyTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class IPSecProfileTestCase(TestCase, ChangeLoggedFilterSetTests):
+class IPSecProfileTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = IPSecProfile.objects.all()
     filterset = IPSecProfileFilterSet
 
@@ -739,7 +739,7 @@ class IPSecProfileTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class L2VPNTestCase(TestCase, ChangeLoggedFilterSetTests):
+class L2VPNTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = L2VPN.objects.all()
     filterset = L2VPNFilterSet
 
@@ -749,7 +749,7 @@ class L2VPNTestCase(TestCase, ChangeLoggedFilterSetTests):
             return 'import_target'
         if field.name == 'export_targets':
             return 'export_target'
-        return ChangeLoggedFilterSetTests.get_m2m_filter_name(field)
+        return ChangeLoggedFilterSetTestMixin.get_m2m_filter_name(field)
 
     @classmethod
     def setUpTestData(cls):
@@ -845,7 +845,7 @@ class L2VPNTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class L2VPNTerminationTestCase(TestCase, ChangeLoggedFilterSetTests):
+class L2VPNTerminationTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = L2VPNTermination.objects.all()
     filterset = L2VPNTerminationFilterSet
 

--- a/netbox/wireless/tests/test_filtersets.py
+++ b/netbox/wireless/tests/test_filtersets.py
@@ -5,13 +5,13 @@ from dcim.models import Interface, Location, Region, Site, SiteGroup
 from ipam.models import VLAN
 from netbox.choices import DistanceUnitChoices
 from tenancy.models import Tenant
-from utilities.testing import ChangeLoggedFilterSetTests, create_test_device
+from utilities.testing import ChangeLoggedFilterSetTestMixin, create_test_device
 from wireless.choices import *
 from wireless.filtersets import *
 from wireless.models import *
 
 
-class WirelessLANGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
+class WirelessLANGroupTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = WirelessLANGroup.objects.all()
     filterset = WirelessLANGroupFilterSet
 
@@ -104,7 +104,7 @@ class WirelessLANGroupTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 8)
 
 
-class WirelessLANTestCase(TestCase, ChangeLoggedFilterSetTests):
+class WirelessLANTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = WirelessLAN.objects.all()
     filterset = WirelessLANFilterSet
 
@@ -309,7 +309,7 @@ class WirelessLANTestCase(TestCase, ChangeLoggedFilterSetTests):
         self.assertEqual(self.filterset(params, self.queryset).qs.count(), 2)
 
 
-class WirelessLinkTestCase(TestCase, ChangeLoggedFilterSetTests):
+class WirelessLinkTestCase(TestCase, ChangeLoggedFilterSetTestMixin):
     queryset = WirelessLink.objects.all()
     filterset = WirelessLinkFilterSet
 


### PR DESCRIPTION
### Closes: #22161

Completes the test-class naming standardization from #22097, which renamed concrete test classes to the `*TestCase` suffix but left four filterset test mixin base classes alone because renaming them breaks plugins that inherit from them.

These are renamed to `*TestMixin`, not the `*Tests` -> `*TestCase` the issue proposed:

- `BaseFilterSetTests` -> `BaseFilterSetTestMixin`
- `ChangeLoggedFilterSetTests` -> `ChangeLoggedFilterSetTestMixin`
- `DeviceComponentFilterSetTests` -> `DeviceComponentFilterSetTestMixin`
- `DeviceComponentTemplateFilterSetTests` -> `DeviceComponentTemplateFilterSetTestMixin`

I went with `*TestMixin` over the issue's proposed `*TestCase` for two reasons. 

1. These are pure mixins, not concrete test cases, so they follow NetBox's existing mixin convention (`RQQueueTestMixin`, `ComponentTraceMixin`) rather than `*TestCase`. 
3. The literal `*TestCase` names collide with two existing concrete classes: `BaseFilterSetTestCase` in `utilities/tests/test_filters.py` and `ChangeLoggedFilterSetTestCase` in `extras/tests/test_filtersets.py`. Renaming the mixin to the latter's name would shadow it within that module.

This diverges from the naming in the accepted issue, so I'm flagging it for reviewr input. Happy to switch to a different suffix if you'd prefer.

Breaking change: plugins whose test suites import the two exported mixins (`BaseFilterSetTests`, `ChangeLoggedFilterSetTests`) from `utilities.testing` must update their imports.
