### PR TITLE
Closes #22502: Add direct unit tests for is_api_request() and is_graphql_request()

### DIFF
--- a/netbox/utilities/tests/test_api.py
+++ b/netbox/utilities/tests/test_api.py
@@ -1,4 +1,4 @@
-from django.test import Client, TestCase, override_settings, tag
+from django.test import Client, RequestFactory, TestCase, override_settings, tag
 from django.urls import reverse
 from drf_spectacular.drainage import GENERATOR_STATS
 from rest_framework import status
@@ -16,7 +16,13 @@ from netbox.config import get_config
 from netbox.plugins import register_serializer_resolver
 from netbox.registry import registry
 from users.models import ObjectPermission
-from utilities.api import get_prefetches_for_serializer, get_serializer_for_model, get_view_name
+from utilities.api import (
+    get_prefetches_for_serializer,
+    get_serializer_for_model,
+    get_view_name,
+    is_api_request,
+    is_graphql_request,
+)
 from utilities.testing import APITestCase, disable_warnings
 
 
@@ -715,3 +721,49 @@ class APITrailingSlashTestCase(APITestCase):
             response = self.client.delete(url, **self.header)
         self.assertHttpStatus(response, status.HTTP_404_NOT_FOUND)
         self.assertTrue(Site.objects.filter(pk=self.site.pk).exists())
+
+
+class IsApiRequestTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_returns_true_for_api_path(self):
+        request = self.factory.get(reverse('api-root'))
+        self.assertTrue(is_api_request(request))
+
+    def test_returns_false_for_non_api_path(self):
+        request = self.factory.get('/dcim/interfaces/')
+        self.assertFalse(is_api_request(request))
+
+    def test_returns_false_for_path_merely_containing_api(self):
+        """
+        A path that contains 'api' as a substring, but does not start with the
+        API root, must not be classified as an API request.
+        """
+        request = self.factory.get('/dcim/api-widget/')
+        self.assertFalse(is_api_request(request))
+
+
+class IsGraphqlRequestTestCase(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
+    def test_returns_true_for_graphql_json_request(self):
+        request = self.factory.post(
+            reverse('graphql'),
+            data='{"query": "{ __typename }"}',
+            content_type='application/json',
+        )
+        self.assertTrue(is_graphql_request(request))
+
+    def test_returns_false_for_graphql_non_json_request(self):
+        """
+        The GraphiQL browser UI hits the same path with a non-JSON content
+        type; it must not be classified as a GraphQL API request.
+        """
+        request = self.factory.get(reverse('graphql'))
+        self.assertFalse(is_graphql_request(request))
+
+    def test_returns_false_for_non_graphql_path(self):
+        request = self.factory.get(reverse('api-root'))
+        self.assertFalse(is_graphql_request(request))


### PR DESCRIPTION
Closes #22502

`handle_rest_api_exception()` already has response shape/status code
coverage (#22562, fixing #22500) and both middleware paths already have
DEBUG-gated and API-vs-non-API routing coverage (#22552, fixing #22501).
That coverage only exercises `is_api_request()`/`is_graphql_request()`
indirectly, through the middleware.

This adds direct unit tests for both functions, in isolation:

- `IsApiRequestTestCase` — true for an API path, false for a non-API path,
  false for a path that merely contains "api" without starting with it
- `IsGraphqlRequestTestCase` — true for a GraphQL request with JSON
  content type, false for the same path without JSON content type
  (e.g. GraphiQL), false for a non-GraphQL path

All existing tests in `utilities/tests/test_api.py` still pass (51/51).