### PR TITLE
#15165: Pre-release QA

### DIFF
--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -2043,6 +2043,7 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
         choices=add_blank_choice(InterfaceModeChoices),
         required=False,
         help_text=_('IEEE 802.1Q tagging strategy'),
+        widget=HTMXSelect(hx_target_id='dot1q-switching'),
     )
     rf_role = TypedChoiceField(
         label=_('Wireless role'),
@@ -2186,7 +2187,8 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
             'speed': NumberWithOptions(
                 options=InterfaceSpeedChoices
             ),
-            'mode': HTMXSelect(hx_target_id='dot1q-switching'),
+            # Note: the HTMXSelect widget for `mode` is set on the explicitly declared field above,
+            # not here. Meta.widgets is ignored for explicitly declared fields.
         }
         labels = {
             'mode': '802.1Q Mode',

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -2187,11 +2187,8 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
             'speed': NumberWithOptions(
                 options=InterfaceSpeedChoices
             ),
-            # Note: the HTMXSelect widget for `mode` is set on the explicitly declared field above,
-            # not here. Meta.widgets is ignored for explicitly declared fields.
-        }
-        labels = {
-            'mode': '802.1Q Mode',
+            # Note: `mode` is configured on the explicitly declared field above (widget and label),
+            # not here. Meta.widgets and Meta.labels are both ignored for explicitly declared fields.
         }
 
 

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -2187,9 +2187,9 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
             'speed': NumberWithOptions(
                 options=InterfaceSpeedChoices
             ),
-            # Note: `mode` is configured on the explicitly declared field above (widget and label),
-            # not here. Meta.widgets and Meta.labels are both ignored for explicitly declared fields.
         }
+        # Note: `mode` is configured on the explicitly declared field above (widget and label),
+        # not here. Meta.widgets and Meta.labels are both ignored for explicitly declared fields.
 
 
 class FrontPortForm(FrontPortFormMixin, ModularDeviceComponentForm):

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -2186,8 +2186,6 @@ class InterfaceForm(InterfaceCommonForm, ModularDeviceComponentForm):
                 options=InterfaceSpeedChoices
             ),
         }
-        # Note: `mode` is configured on the explicitly declared field above (widget and label),
-        # not here. Meta.widgets and Meta.labels are both ignored for explicitly declared fields.
 
 
 class FrontPortForm(FrontPortFormMixin, ModularDeviceComponentForm):

--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -1242,6 +1242,7 @@ class VirtualChassisForm(PrimaryModelForm):
         label=_('Master'),
         queryset=Device.objects.all(),
         required=False,
+        widget=SelectWithPK(),
     )
 
     class Meta:
@@ -1249,9 +1250,6 @@ class VirtualChassisForm(PrimaryModelForm):
         fields = [
             'name', 'domain', 'master', 'description', 'owner', 'comments', 'tags',
         ]
-        widgets = {
-            'master': SelectWithPK(),
-        }
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -129,8 +129,6 @@ class CustomFieldForm(ChangelogMessageMixin, OwnerMixin, forms.ModelForm):
         model = CustomField
         fields = '__all__'
         help_texts = {
-            # Note: `type` is explicitly declared above with the same help_text; a Meta.help_texts
-            # entry for it would be silently discarded, so it must not be set here.
             'description': _("This will be displayed as help text for the form field. Markdown is supported.")
         }
 
@@ -639,8 +637,6 @@ class EventRuleForm(OwnerMixin, NetBoxModelForm):
             'action_object_type', 'action_object_id', 'action_data', 'owner', 'comments', 'tags'
         )
         widgets = {
-            # Note: `conditions` is explicitly declared above (a JSONField that already renders a
-            # monospace Textarea); a Meta.widgets entry for it would be silently discarded.
             'action_object_type': forms.HiddenInput,
             'action_object_id': forms.HiddenInput,
         }

--- a/netbox/extras/forms/model_forms.py
+++ b/netbox/extras/forms/model_forms.py
@@ -129,10 +129,8 @@ class CustomFieldForm(ChangelogMessageMixin, OwnerMixin, forms.ModelForm):
         model = CustomField
         fields = '__all__'
         help_texts = {
-            'type': _(
-                "The type of data stored in this field. For object/multi-object fields, select the related object "
-                "type below."
-            ),
+            # Note: `type` is explicitly declared above with the same help_text; a Meta.help_texts
+            # entry for it would be silently discarded, so it must not be set here.
             'description': _("This will be displayed as help text for the form field. Markdown is supported.")
         }
 
@@ -641,7 +639,8 @@ class EventRuleForm(OwnerMixin, NetBoxModelForm):
             'action_object_type', 'action_object_id', 'action_data', 'owner', 'comments', 'tags'
         )
         widgets = {
-            'conditions': forms.Textarea(attrs={'class': 'font-monospace'}),
+            # Note: `conditions` is explicitly declared above (a JSONField that already renders a
+            # monospace Textarea); a Meta.widgets entry for it would be silently discarded.
             'action_object_type': forms.HiddenInput,
             'action_object_id': forms.HiddenInput,
         }

--- a/netbox/netbox/tests/test_forms.py
+++ b/netbox/netbox/tests/test_forms.py
@@ -4,7 +4,14 @@ from django.test import TestCase
 from circuits.forms import CircuitGroupAssignmentForm, CircuitTerminationForm
 from core.forms import DataSourceForm
 from dcim.choices import InterfaceTypeChoices
-from dcim.forms import CableForm, InterfaceForm, InterfaceImportForm, ModuleTypeForm
+from dcim.forms import (
+    CableForm,
+    FrontPortCreateForm,
+    InterfaceForm,
+    InterfaceImportForm,
+    ModuleTypeForm,
+    RackForm,
+)
 from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
 from extras.forms import CustomFieldForm, EventRuleForm
 from ipam.forms import PrefixForm, ServiceForm, VLANGroupForm
@@ -349,6 +356,8 @@ class HTMXPartialSwapRenderingTestCase(TestCase):
         (CustomFieldForm, 'type'),
         (DataSourceForm, 'type'),
         (VirtualMachineForm, 'virtual_machine_type'),
+        (RackForm, 'rack_type'),
+        (FrontPortCreateForm, 'device'),
     )
 
     @staticmethod
@@ -361,7 +370,9 @@ class HTMXPartialSwapRenderingTestCase(TestCase):
         """
         widget = field.widget
         if isinstance(widget, forms.MultiWidget):
-            return next(w for w in widget.widgets if isinstance(w, HTMXSelect))
+            hx = next((w for w in widget.widgets if isinstance(w, HTMXSelect)), None)
+            assert hx is not None, f'{type(widget).__name__} has no HTMXSelect subwidget'
+            return hx
         return widget
 
     def test_partial_swap_fields_target_their_fieldset(self):
@@ -375,6 +386,14 @@ class HTMXPartialSwapRenderingTestCase(TestCase):
                 self.assertIn('hx-get', attrs)
                 self.assertEqual(attrs.get('hx-select'), f'#{target_id}')
                 self.assertEqual(attrs.get('hx-target'), f'#{target_id}')
+                # The target must name a real swap container, or the swap fails silently in the
+                # browser. A typo'd id passes the assertions above (both read the same source), so
+                # check it against the form's declared FieldSet html_ids. CableForm is exempt: its
+                # targets are <div id="..."> in a hand-rolled template (cable_edit.html), not
+                # FieldSets, so it has no `fieldsets` to check against.
+                if getattr(form, 'fieldsets', None):
+                    fieldset_ids = {getattr(fs, 'html_id', None) for fs in form.fieldsets}
+                    self.assertIn(target_id, fieldset_ids)
 
     def test_interface_mode_retains_option_descriptions(self):
         # The mode field must keep its 802.1Q Mode option descriptions (a description-aware widget

--- a/netbox/netbox/tests/test_forms.py
+++ b/netbox/netbox/tests/test_forms.py
@@ -452,7 +452,10 @@ class MetaShadowingTestCase(TestCase):
             declared = set(getattr(form_class, 'declared_fields', {}))
             if meta is None or not declared:
                 continue
-            for attr in ('widgets', 'labels', 'help_texts'):
+            # All Meta options Django keys by field name and discards for explicitly declared
+            # fields. localized_fields is a list of names rather than a dict, but set() of either a
+            # dict or a list yields the field names, so one comparison covers all six.
+            for attr in ('widgets', 'labels', 'help_texts', 'error_messages', 'field_classes', 'localized_fields'):
                 overlap = declared & set(getattr(meta, attr, None) or {})
                 overlap -= {f for f in overlap if (form_class.__name__, attr, f) in self.ALLOWED}
                 with self.subTest(form=form_class.__name__, meta=attr):

--- a/netbox/netbox/tests/test_forms.py
+++ b/netbox/netbox/tests/test_forms.py
@@ -420,15 +420,23 @@ class MetaShadowingTestCase(TestCase):
             'circuits', 'core', 'dcim', 'extras', 'ipam', 'tenancy', 'users', 'utilities',
             'virtualization', 'vpn', 'wireless', 'netbox',
         ):
+            # Only tolerate an app that has no forms package; a broken import inside a package that
+            # does exist must surface, or the invariant could pass having skipped part of the tree.
+            pkg_name = f'{app}.forms'
             try:
-                pkg = importlib.import_module(f'{app}.forms')
-            except ImportError:
-                continue
+                pkg = importlib.import_module(pkg_name)
+            except ModuleNotFoundError as e:
+                if e.name == pkg_name:
+                    continue
+                raise
             for module in getattr(pkg, '__path__', []) and pkgutil.iter_modules(pkg.__path__) or []:
+                submodule = f'{app}.forms.{module.name}'
                 try:
-                    importlib.import_module(f'{app}.forms.{module.name}')
-                except ImportError:
-                    pass
+                    importlib.import_module(submodule)
+                except ModuleNotFoundError as e:
+                    if e.name == submodule:
+                        continue
+                    raise
 
         seen, stack = set(), [forms.ModelForm]
         while stack:

--- a/netbox/netbox/tests/test_forms.py
+++ b/netbox/netbox/tests/test_forms.py
@@ -401,7 +401,7 @@ class MetaShadowingTestCase(TestCase):
     """Ensure declared fields do not shadow supported `ModelForm.Meta` configuration."""
     # Known overlaps whose cleanup is deferred, as specific (form, Meta attribute, field) triples so
     # that any new overlap on the same form is still caught. ConfigRevisionForm builds these fields
-    # via ConfigFormMetaclass; restoring their monospace widget is tracked separately (see #8974).
+    # via ConfigFormMetaclass; restoring their monospace widget is tracked separately (see #22889).
     ALLOWED = {
         ('ConfigRevisionForm', 'widgets', 'BANNER_LOGIN'),
         ('ConfigRevisionForm', 'widgets', 'BANNER_MAINTENANCE'),

--- a/netbox/netbox/tests/test_forms.py
+++ b/netbox/netbox/tests/test_forms.py
@@ -320,15 +320,9 @@ class NetBoxModelImportFormCleanTestCase(TestCase):
 
 
 class HTMXPartialSwapRenderingTestCase(TestCase):
-    """
-    Verify that each form field's HTMX swap wiring resolves to the widget actually bound to the
-    field. An explicitly declared form field silently overrides a widget set via Meta.widgets, so
-    a field can have HTMXSelect assigned in Meta yet end up with a plain widget carrying no HTMX
-    wiring. Unit-testing the widget in isolation cannot see that, which is how the interface 802.1Q
-    mode swap regressed unnoticed. These tests read the bound field's widget attrs directly so a
-    shadowed field is caught.
-    """
-    # (form, bound field name, target fieldset id) — the field's change must swap only that fieldset.
+    """Ensure each form field's HTMX swap wiring is present on the widget bound to the field."""
+
+    # (form, bound field name, target fieldset id)
     PARTIAL_SWAP_FIELDS = (
         (InterfaceForm, 'mode', 'dot1q-switching'),
         (VMInterfaceForm, 'mode', 'dot1q-switching'),
@@ -348,10 +342,7 @@ class HTMXPartialSwapRenderingTestCase(TestCase):
         (PrefixForm, 'scope', 'scope'),
     )
 
-    # These fields intentionally re-render the whole form rather than a single fieldset, because
-    # changing them adds or removes entire fieldsets that a targeted swap would miss. The guard
-    # ensures they keep targeting #form_fields and are not "optimized" into a partial swap that
-    # would silently drop the added/removed fieldsets.
+    # Fields that intentionally re-render the whole form (#form_fields) rather than a single fieldset.
     FULL_FORM_FIELDS = (
         (CustomFieldForm, 'type'),
         (DataSourceForm, 'type'),
@@ -360,18 +351,13 @@ class HTMXPartialSwapRenderingTestCase(TestCase):
         (FrontPortCreateForm, 'device'),
     )
 
-    # Forms whose swap target is not a FieldSet(html_id=...) and so cannot be checked against
-    # `form.fieldsets`. CableForm targets <div id="..."> in a hand-rolled template (cable_edit.html).
+    # CableForm targets template <div>s, not FieldSet(html_id=...), so its target can't be checked
+    # against form.fieldsets.
     FIELDSET_ID_EXEMPT = {CableForm}
 
     @staticmethod
     def _hx_widget(field):
-        """
-        Return the HTMXSelect carrying the field's HTMX attrs. For a plain HTMXSelect field that is
-        the field's own widget; for a generic-object selector (a MultiWidget) it is the HTMXSelect
-        subwidget, located by type rather than position so a change in subwidget ordering can't
-        silently select the wrong one.
-        """
+        """Return the HTMXSelect carrying the field's HTMX attrs, unwrapping a MultiWidget by type."""
         widget = field.widget
         if isinstance(widget, forms.MultiWidget):
             hx = next((w for w in widget.widgets if isinstance(w, HTMXSelect)), None)
@@ -385,23 +371,17 @@ class HTMXPartialSwapRenderingTestCase(TestCase):
                 form = form_class()
                 self.assertIn(field_name, form.fields)
                 attrs = self._hx_widget(form.fields[field_name]).attrs
-                # A verb (hx-get) is what actually issues the request; hx-target/hx-select alone
-                # are inert. Its absence was the reported symptom ("changing mode fires no request").
+                # hx-get issues the request; hx-target/hx-select alone are inert.
                 self.assertIn('hx-get', attrs)
                 self.assertEqual(attrs.get('hx-select'), f'#{target_id}')
                 self.assertEqual(attrs.get('hx-target'), f'#{target_id}')
-                # The target must name a real swap container, or the swap fails silently in the
-                # browser. A typo'd id passes the assertions above (both read the same source), so
-                # check it against the form's declared FieldSet html_ids. Exempt forms (CableForm)
-                # target template <div>s instead and are checked explicitly, not by absence of
-                # fieldsets, so a non-exempt form that forgets its fieldsets still fails here.
+                # The target must name a declared FieldSet html_id, else the swap fails silently.
                 if form_class not in self.FIELDSET_ID_EXEMPT:
                     fieldset_ids = {getattr(fs, 'html_id', None) for fs in getattr(form, 'fieldsets', ())}
                     self.assertIn(target_id, fieldset_ids)
 
     def test_interface_mode_retains_option_descriptions(self):
-        # The mode field must keep its 802.1Q Mode option descriptions (a description-aware widget
-        # feature) alongside the restored partial swap; the two must coexist on the same field.
+        # Partial swap and option descriptions must coexist on the mode field.
         for form_class in (InterfaceForm, VMInterfaceForm):
             with self.subTest(form=form_class.__name__):
                 self.assertTrue(form_class().fields['mode'].widget.descriptions)
@@ -418,14 +398,7 @@ class HTMXPartialSwapRenderingTestCase(TestCase):
 
 
 class MetaShadowingTestCase(TestCase):
-    """
-    Guard the whole bug class behind #15165, not just the HTMX fields. Django's ModelFormMetaclass
-    applies Meta.widgets/labels/help_texts only to fields it generates from the model; for a field
-    the form declares explicitly, the declared field wins and the Meta entry is silently discarded.
-    A key appearing in both is therefore dead config at best and a dropped widget/label/help_text at
-    worst (the #15165 regression, and the VirtualChassis master SelectWithPK before this PR). This
-    walks every ModelForm and asserts the two never overlap, so the next occurrence fails here.
-    """
+    """Ensure declared fields do not shadow supported `ModelForm.Meta` configuration."""
     # ConfigRevisionForm builds its parameter fields via a custom metaclass (ConfigFormMetaclass)
     # that turns them into declared_fields while still sourcing widgets from Meta.widgets. Its
     # overlap is a known consequence of that design, not the shadowing bug this guards; excluded

--- a/netbox/netbox/tests/test_forms.py
+++ b/netbox/netbox/tests/test_forms.py
@@ -360,6 +360,10 @@ class HTMXPartialSwapRenderingTestCase(TestCase):
         (FrontPortCreateForm, 'device'),
     )
 
+    # Forms whose swap target is not a FieldSet(html_id=...) and so cannot be checked against
+    # `form.fieldsets`. CableForm targets <div id="..."> in a hand-rolled template (cable_edit.html).
+    FIELDSET_ID_EXEMPT = {CableForm}
+
     @staticmethod
     def _hx_widget(field):
         """
@@ -388,11 +392,11 @@ class HTMXPartialSwapRenderingTestCase(TestCase):
                 self.assertEqual(attrs.get('hx-target'), f'#{target_id}')
                 # The target must name a real swap container, or the swap fails silently in the
                 # browser. A typo'd id passes the assertions above (both read the same source), so
-                # check it against the form's declared FieldSet html_ids. CableForm is exempt: its
-                # targets are <div id="..."> in a hand-rolled template (cable_edit.html), not
-                # FieldSets, so it has no `fieldsets` to check against.
-                if getattr(form, 'fieldsets', None):
-                    fieldset_ids = {getattr(fs, 'html_id', None) for fs in form.fieldsets}
+                # check it against the form's declared FieldSet html_ids. Exempt forms (CableForm)
+                # target template <div>s instead and are checked explicitly, not by absence of
+                # fieldsets, so a non-exempt form that forgets its fieldsets still fails here.
+                if form_class not in self.FIELDSET_ID_EXEMPT:
+                    fieldset_ids = {getattr(fs, 'html_id', None) for fs in getattr(form, 'fieldsets', ())}
                     self.assertIn(target_id, fieldset_ids)
 
     def test_interface_mode_retains_option_descriptions(self):
@@ -411,3 +415,64 @@ class HTMXPartialSwapRenderingTestCase(TestCase):
                 self.assertIn('hx-get', attrs)
                 self.assertEqual(attrs.get('hx-target'), '#form_fields')
                 self.assertNotIn('hx-select', attrs)
+
+
+class MetaShadowingTestCase(TestCase):
+    """
+    Guard the whole bug class behind #15165, not just the HTMX fields. Django's ModelFormMetaclass
+    applies Meta.widgets/labels/help_texts only to fields it generates from the model; for a field
+    the form declares explicitly, the declared field wins and the Meta entry is silently discarded.
+    A key appearing in both is therefore dead config at best and a dropped widget/label/help_text at
+    worst (the #15165 regression, and the VirtualChassis master SelectWithPK before this PR). This
+    walks every ModelForm and asserts the two never overlap, so the next occurrence fails here.
+    """
+    # ConfigRevisionForm builds its parameter fields via a custom metaclass (ConfigFormMetaclass)
+    # that turns them into declared_fields while still sourcing widgets from Meta.widgets. Its
+    # overlap is a known consequence of that design, not the shadowing bug this guards; excluded
+    # here and left for a separate cleanup.
+    ALLOWED = {'ConfigRevisionForm'}
+
+    @staticmethod
+    def _all_model_forms():
+        # Import every app's forms package so all ModelForm subclasses are registered before walking.
+        import importlib
+        import pkgutil
+        for app in (
+            'circuits', 'core', 'dcim', 'extras', 'ipam', 'tenancy', 'users', 'utilities',
+            'virtualization', 'vpn', 'wireless', 'netbox',
+        ):
+            try:
+                pkg = importlib.import_module(f'{app}.forms')
+            except ImportError:
+                continue
+            for module in getattr(pkg, '__path__', []) and pkgutil.iter_modules(pkg.__path__) or []:
+                try:
+                    importlib.import_module(f'{app}.forms.{module.name}')
+                except ImportError:
+                    pass
+
+        seen, stack = set(), [forms.ModelForm]
+        while stack:
+            for sub in stack.pop().__subclasses__():
+                if sub not in seen:
+                    seen.add(sub)
+                    stack.append(sub)
+        return seen
+
+    def test_meta_config_does_not_shadow_declared_fields(self):
+        for form_class in self._all_model_forms():
+            if form_class.__name__ in self.ALLOWED:
+                continue
+            meta = getattr(form_class, 'Meta', None)
+            declared = set(getattr(form_class, 'declared_fields', {}))
+            if meta is None or not declared:
+                continue
+            for attr in ('widgets', 'labels', 'help_texts'):
+                overlap = declared & set(getattr(meta, attr, None) or {})
+                with self.subTest(form=form_class.__name__, meta=attr):
+                    self.assertEqual(
+                        overlap, set(),
+                        f"{form_class.__module__}.{form_class.__name__} sets Meta.{attr} for "
+                        f"explicitly declared field(s) {sorted(overlap)}; Django discards these. "
+                        f"Move the config onto the declared field or drop the Meta entry."
+                    )

--- a/netbox/netbox/tests/test_forms.py
+++ b/netbox/netbox/tests/test_forms.py
@@ -1,4 +1,5 @@
 from django import forms
+from django.forms.models import ALL_FIELDS
 from django.test import TestCase
 
 from circuits.forms import CircuitGroupAssignmentForm, CircuitTerminationForm
@@ -446,17 +447,24 @@ class MetaShadowingTestCase(TestCase):
                     stack.append(sub)
         return seen
 
+    @staticmethod
+    def _configured_field_names(configured, declared):
+        # Field names a Meta option targets. localized_fields may be the ALL_FIELDS sentinel
+        # ('__all__') meaning every field; set() of that string would yield its characters, so map
+        # the sentinel to the full declared set instead.
+        if configured == ALL_FIELDS:
+            return set(declared)
+        return set(configured or ())
+
     def test_meta_config_does_not_shadow_declared_fields(self):
         for form_class in self._all_model_forms():
             meta = getattr(form_class, 'Meta', None)
             declared = set(getattr(form_class, 'declared_fields', {}))
             if meta is None or not declared:
                 continue
-            # All Meta options Django keys by field name and discards for explicitly declared
-            # fields. localized_fields is a list of names rather than a dict, but set() of either a
-            # dict or a list yields the field names, so one comparison covers all six.
             for attr in ('widgets', 'labels', 'help_texts', 'error_messages', 'field_classes', 'localized_fields'):
-                overlap = declared & set(getattr(meta, attr, None) or {})
+                configured = self._configured_field_names(getattr(meta, attr, None), declared)
+                overlap = declared & configured
                 overlap -= {f for f in overlap if (form_class.__name__, attr, f) in self.ALLOWED}
                 with self.subTest(form=form_class.__name__, meta=attr):
                     self.assertEqual(
@@ -465,3 +473,7 @@ class MetaShadowingTestCase(TestCase):
                         f"explicitly declared field(s) {sorted(overlap)}; Django discards these. "
                         f"Move the config onto the declared field or drop the Meta entry."
                     )
+
+    def test_localized_fields_all_sentinel_expands_to_declared(self):
+        # The ALL_FIELDS sentinel must expand to the declared fields, not char-split into letters.
+        self.assertEqual(self._configured_field_names(ALL_FIELDS, {'name', 'status'}), {'name', 'status'})

--- a/netbox/netbox/tests/test_forms.py
+++ b/netbox/netbox/tests/test_forms.py
@@ -1,8 +1,17 @@
+from django import forms
 from django.test import TestCase
 
+from circuits.forms import CircuitGroupAssignmentForm, CircuitTerminationForm
+from core.forms import DataSourceForm
 from dcim.choices import InterfaceTypeChoices
-from dcim.forms import InterfaceImportForm
+from dcim.forms import CableForm, InterfaceForm, InterfaceImportForm, ModuleTypeForm
 from dcim.models import Device, DeviceRole, DeviceType, Interface, Manufacturer, Site
+from extras.forms import CustomFieldForm, EventRuleForm
+from ipam.forms import PrefixForm, ServiceForm, VLANGroupForm
+from utilities.forms.widgets import HTMXSelect
+from virtualization.forms import ClusterForm, VirtualMachineForm, VMInterfaceForm
+from vpn.forms import TunnelCreateForm, TunnelTerminationForm
+from wireless.forms import WirelessLANForm
 
 
 class NetBoxModelImportFormCleanTestCase(TestCase):
@@ -301,3 +310,85 @@ class NetBoxModelImportFormCleanTestCase(TestCase):
         )
         self.assertTrue(form.is_valid(), f'Form errors: {form.errors}')
         self.assertIsNone(form.cleaned_data['wwn'])
+
+
+class HTMXPartialSwapRenderingTestCase(TestCase):
+    """
+    Verify that each form field's HTMX swap wiring resolves to the widget actually bound to the
+    field. An explicitly declared form field silently overrides a widget set via Meta.widgets, so
+    a field can have HTMXSelect assigned in Meta yet end up with a plain widget carrying no HTMX
+    wiring. Unit-testing the widget in isolation cannot see that, which is how the interface 802.1Q
+    mode swap regressed unnoticed. These tests read the bound field's widget attrs directly so a
+    shadowed field is caught.
+    """
+    # (form, bound field name, target fieldset id) — the field's change must swap only that fieldset.
+    PARTIAL_SWAP_FIELDS = (
+        (InterfaceForm, 'mode', 'dot1q-switching'),
+        (VMInterfaceForm, 'mode', 'dot1q-switching'),
+        (ModuleTypeForm, 'profile', 'profile-attributes'),
+        (CableForm, 'a_terminations_type', 'cable-side-a'),
+        (CableForm, 'b_terminations_type', 'cable-side-b'),
+        (VLANGroupForm, 'scope', 'scope'),
+        (ServiceForm, 'parent', 'service'),
+        (CircuitTerminationForm, 'termination', 'circuit-termination'),
+        (CircuitGroupAssignmentForm, 'member', 'circuit-group-assignment'),
+        (TunnelCreateForm, 'termination1_type', 'tunnel-termination1'),
+        (TunnelCreateForm, 'termination2_type', 'tunnel-termination2'),
+        (TunnelTerminationForm, 'type', 'tunnel-termination'),
+        (EventRuleForm, 'action_type', 'event-rule-action'),
+        (ClusterForm, 'scope', 'scope'),
+        (WirelessLANForm, 'scope', 'scope'),
+        (PrefixForm, 'scope', 'scope'),
+    )
+
+    # These fields intentionally re-render the whole form rather than a single fieldset, because
+    # changing them adds or removes entire fieldsets that a targeted swap would miss. The guard
+    # ensures they keep targeting #form_fields and are not "optimized" into a partial swap that
+    # would silently drop the added/removed fieldsets.
+    FULL_FORM_FIELDS = (
+        (CustomFieldForm, 'type'),
+        (DataSourceForm, 'type'),
+        (VirtualMachineForm, 'virtual_machine_type'),
+    )
+
+    @staticmethod
+    def _hx_widget(field):
+        """
+        Return the HTMXSelect carrying the field's HTMX attrs. For a plain HTMXSelect field that is
+        the field's own widget; for a generic-object selector (a MultiWidget) it is the HTMXSelect
+        subwidget, located by type rather than position so a change in subwidget ordering can't
+        silently select the wrong one.
+        """
+        widget = field.widget
+        if isinstance(widget, forms.MultiWidget):
+            return next(w for w in widget.widgets if isinstance(w, HTMXSelect))
+        return widget
+
+    def test_partial_swap_fields_target_their_fieldset(self):
+        for form_class, field_name, target_id in self.PARTIAL_SWAP_FIELDS:
+            with self.subTest(form=form_class.__name__, field=field_name):
+                form = form_class()
+                self.assertIn(field_name, form.fields)
+                attrs = self._hx_widget(form.fields[field_name]).attrs
+                # A verb (hx-get) is what actually issues the request; hx-target/hx-select alone
+                # are inert. Its absence was the reported symptom ("changing mode fires no request").
+                self.assertIn('hx-get', attrs)
+                self.assertEqual(attrs.get('hx-select'), f'#{target_id}')
+                self.assertEqual(attrs.get('hx-target'), f'#{target_id}')
+
+    def test_interface_mode_retains_option_descriptions(self):
+        # The mode field must keep its 802.1Q Mode option descriptions (a description-aware widget
+        # feature) alongside the restored partial swap; the two must coexist on the same field.
+        for form_class in (InterfaceForm, VMInterfaceForm):
+            with self.subTest(form=form_class.__name__):
+                self.assertTrue(form_class().fields['mode'].widget.descriptions)
+
+    def test_full_form_fields_do_not_partial_swap(self):
+        for form_class, field_name in self.FULL_FORM_FIELDS:
+            with self.subTest(form=form_class.__name__, field=field_name):
+                form = form_class()
+                self.assertIn(field_name, form.fields)
+                attrs = self._hx_widget(form.fields[field_name]).attrs
+                self.assertIn('hx-get', attrs)
+                self.assertEqual(attrs.get('hx-target'), '#form_fields')
+                self.assertNotIn('hx-select', attrs)

--- a/netbox/netbox/tests/test_forms.py
+++ b/netbox/netbox/tests/test_forms.py
@@ -399,11 +399,17 @@ class HTMXPartialSwapRenderingTestCase(TestCase):
 
 class MetaShadowingTestCase(TestCase):
     """Ensure declared fields do not shadow supported `ModelForm.Meta` configuration."""
-    # ConfigRevisionForm builds its parameter fields via a custom metaclass (ConfigFormMetaclass)
-    # that turns them into declared_fields while still sourcing widgets from Meta.widgets. Its
-    # overlap is a known consequence of that design, not the shadowing bug this guards; excluded
-    # here and left for a separate cleanup.
-    ALLOWED = {'ConfigRevisionForm'}
+    # Known overlaps whose cleanup is deferred, as specific (form, Meta attribute, field) triples so
+    # that any new overlap on the same form is still caught. ConfigRevisionForm builds these fields
+    # via ConfigFormMetaclass; restoring their monospace widget is tracked separately (see #8974).
+    ALLOWED = {
+        ('ConfigRevisionForm', 'widgets', 'BANNER_LOGIN'),
+        ('ConfigRevisionForm', 'widgets', 'BANNER_MAINTENANCE'),
+        ('ConfigRevisionForm', 'widgets', 'BANNER_TOP'),
+        ('ConfigRevisionForm', 'widgets', 'BANNER_BOTTOM'),
+        ('ConfigRevisionForm', 'widgets', 'CUSTOM_VALIDATORS'),
+        ('ConfigRevisionForm', 'widgets', 'PROTECTION_RULES'),
+    }
 
     @staticmethod
     def _all_model_forms():
@@ -434,14 +440,13 @@ class MetaShadowingTestCase(TestCase):
 
     def test_meta_config_does_not_shadow_declared_fields(self):
         for form_class in self._all_model_forms():
-            if form_class.__name__ in self.ALLOWED:
-                continue
             meta = getattr(form_class, 'Meta', None)
             declared = set(getattr(form_class, 'declared_fields', {}))
             if meta is None or not declared:
                 continue
             for attr in ('widgets', 'labels', 'help_texts'):
                 overlap = declared & set(getattr(meta, attr, None) or {})
+                overlap -= {f for f in overlap if (form_class.__name__, attr, f) in self.ALLOWED}
                 with self.subTest(form=form_class.__name__, meta=attr):
                     self.assertEqual(
                         overlap, set(),

--- a/netbox/utilities/forms/widgets/select.py
+++ b/netbox/utilities/forms/widgets/select.py
@@ -90,9 +90,13 @@ class ColorSelect(forms.Select):
         self.attrs['class'] = 'color-select'
 
 
-class HTMXSelect(forms.Select):
+class HTMXSelect(AttrSelectMixin, forms.Select):
     """
     Selection widget that will re-generate the HTML form upon the selection of a new option.
+
+    Includes AttrSelectMixin so that a field using this widget can still render per-option
+    descriptions (see ChoiceField/TypedChoiceField), rather than having to choose between HTMX
+    re-rendering and description subtitles.
     """
     def __init__(self, method='get', hx_url='.', hx_include_id='form_fields', hx_target_id=None, attrs=None, **kwargs):
         method = method.lower()

--- a/netbox/utilities/forms/widgets/select.py
+++ b/netbox/utilities/forms/widgets/select.py
@@ -26,6 +26,13 @@ class AttrSelectMixin:
         super().__init__(*args, **kwargs)
         self.descriptions = descriptions or {}
 
+    def __deepcopy__(self, memo):
+        # Django's ChoiceWidget.__deepcopy__ copies attrs and choices but not descriptions, so
+        # every per-instance widget copy would otherwise share one dict with the class-level widget.
+        obj = super().__deepcopy__(memo)
+        obj.descriptions = self.descriptions.copy()
+        return obj
+
     def create_option(self, name, value, label, selected, index, subindex=None, attrs=None):
         option = super().create_option(name, value, label, selected, index, subindex, attrs)
 

--- a/netbox/utilities/forms/widgets/select.py
+++ b/netbox/utilities/forms/widgets/select.py
@@ -97,13 +97,13 @@ class ColorSelect(forms.Select):
         self.attrs['class'] = 'color-select'
 
 
-class HTMXSelect(AttrSelectMixin, forms.Select):
+class HTMXSelect(Select):
     """
     Selection widget that will re-generate the HTML form upon the selection of a new option.
 
-    Includes AttrSelectMixin so that a field using this widget can still render per-option
-    descriptions (see ChoiceField/TypedChoiceField), rather than having to choose between HTMX
-    re-rendering and description subtitles.
+    Subclasses the local description-aware `Select` (not `forms.Select`) so that a field using this
+    widget can still render per-option descriptions (see ChoiceField/TypedChoiceField), rather than
+    having to choose between HTMX re-rendering and description subtitles.
     """
     def __init__(self, method='get', hx_url='.', hx_include_id='form_fields', hx_target_id=None, attrs=None, **kwargs):
         method = method.lower()

--- a/netbox/utilities/forms/widgets/select.py
+++ b/netbox/utilities/forms/widgets/select.py
@@ -27,8 +27,6 @@ class AttrSelectMixin:
         self.descriptions = descriptions or {}
 
     def __deepcopy__(self, memo):
-        # Django's ChoiceWidget.__deepcopy__ copies attrs and choices but not descriptions, so
-        # every per-instance widget copy would otherwise share one dict with the class-level widget.
         obj = super().__deepcopy__(memo)
         obj.descriptions = self.descriptions.copy()
         return obj
@@ -99,11 +97,8 @@ class ColorSelect(forms.Select):
 
 class HTMXSelect(Select):
     """
-    Selection widget that will re-generate the HTML form upon the selection of a new option.
-
-    Subclasses the local description-aware `Select` (not `forms.Select`) so that a field using this
-    widget can still render per-option descriptions (see ChoiceField/TypedChoiceField), rather than
-    having to choose between HTMX re-rendering and description subtitles.
+    Selection widget that re-generates the HTML form upon selection of a new option, and supports
+    per-option descriptions alongside its HTMX behavior.
     """
     def __init__(self, method='get', hx_url='.', hx_include_id='form_fields', hx_target_id=None, attrs=None, **kwargs):
         method = method.lower()

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -5,7 +5,12 @@ from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, override_settings
 
+from circuits.forms import CircuitGroupAssignmentForm, CircuitTerminationForm
+from core.forms import DataSourceForm
+from dcim.forms import CableForm, InterfaceForm, ModuleTypeForm
 from dcim.models import Site
+from extras.forms import CustomFieldForm, EventRuleForm
+from ipam.forms import PrefixForm, ServiceForm, VLANGroupForm
 from netbox.choices import ImportFormatChoices
 from utilities.choices import Choice, ChoiceSet
 from utilities.forms.bulk_import import BulkImportForm
@@ -25,6 +30,9 @@ from utilities.forms.utils import (
     parse_numeric_range,
 )
 from utilities.forms.widgets.select import AvailableOptions, HTMXSelect, Select, SelectedOptions
+from virtualization.forms import ClusterForm, VirtualMachineForm, VMInterfaceForm
+from vpn.forms import TunnelCreateForm, TunnelTerminationForm
+from wireless.forms import WirelessLANForm
 
 
 class ExpandIPNetworkTestCase(TestCase):
@@ -1068,3 +1076,80 @@ class DescriptionSelectTestCase(TestCase):
         self.assertTrue(calls)
         # And descriptions are still collected as normal
         self.assertEqual(field.widget.descriptions, {self.ExampleChoices.FOO: 'Description of foo'})
+
+
+class HTMXPartialSwapRenderingTestCase(TestCase):
+    """
+    Verify that each form field's HTMX swap wiring resolves to the widget actually bound to the
+    field. An explicitly declared form field silently overrides a widget set via Meta.widgets, so
+    a field can have HTMXSelect assigned in Meta yet end up with a plain widget carrying no HTMX
+    wiring. The unit-level widget tests above cannot see that, which is how the interface 802.1Q
+    mode swap regressed unnoticed. These tests read the bound field's widget attrs directly so a
+    shadowed field is caught.
+    """
+    # (form, bound field name, target fieldset id) — the field's change must swap only that fieldset.
+    PARTIAL_SWAP_FIELDS = (
+        (InterfaceForm, 'mode', 'dot1q-switching'),
+        (VMInterfaceForm, 'mode', 'dot1q-switching'),
+        (ModuleTypeForm, 'profile', 'profile-attributes'),
+        (CableForm, 'a_terminations_type', 'cable-side-a'),
+        (CableForm, 'b_terminations_type', 'cable-side-b'),
+        (VLANGroupForm, 'scope', 'scope'),
+        (ServiceForm, 'parent', 'service'),
+        (CircuitTerminationForm, 'termination', 'circuit-termination'),
+        (CircuitGroupAssignmentForm, 'member', 'circuit-group-assignment'),
+        (TunnelCreateForm, 'termination1_type', 'tunnel-termination1'),
+        (TunnelCreateForm, 'termination2_type', 'tunnel-termination2'),
+        (TunnelTerminationForm, 'type', 'tunnel-termination'),
+        (EventRuleForm, 'action_type', 'event-rule-action'),
+        (ClusterForm, 'scope', 'scope'),
+        (WirelessLANForm, 'scope', 'scope'),
+        (PrefixForm, 'scope', 'scope'),
+    )
+
+    @staticmethod
+    def _hx_widget(field):
+        """
+        Return the widget carrying the HTMX attrs for a bound field. For plain HTMXSelect fields
+        that is the field's own widget; for a generic-object selector (a MultiWidget), the HTMX
+        content-type selector is its first subwidget.
+        """
+        widget = field.widget
+        if hasattr(widget, 'widgets'):
+            return widget.widgets[0]
+        return widget
+
+    def test_partial_swap_fields_target_their_fieldset(self):
+        for form_class, field_name, target_id in self.PARTIAL_SWAP_FIELDS:
+            with self.subTest(form=form_class.__name__, field=field_name):
+                form = form_class()
+                self.assertIn(field_name, form.fields)
+                attrs = self._hx_widget(form.fields[field_name]).attrs
+                self.assertEqual(attrs.get('hx-select'), f'#{target_id}')
+                self.assertEqual(attrs.get('hx-target'), f'#{target_id}')
+
+    def test_interface_mode_retains_option_descriptions(self):
+        # The mode field must keep its 802.1Q Mode option descriptions (a description-aware widget
+        # feature) alongside the restored partial swap; the two must coexist on the same field.
+        for form_class in (InterfaceForm, VMInterfaceForm):
+            with self.subTest(form=form_class.__name__):
+                self.assertTrue(form_class().fields['mode'].widget.descriptions)
+
+    # These fields intentionally re-render the whole form rather than a single fieldset, because
+    # changing them adds or removes entire fieldsets that a targeted swap would miss. The guard
+    # ensures they keep targeting #form_fields and are not "optimized" into a partial swap that
+    # would silently drop the added/removed fieldsets.
+    FULL_FORM_FIELDS = (
+        (CustomFieldForm, 'type'),
+        (DataSourceForm, 'type'),
+        (VirtualMachineForm, 'virtual_machine_type'),
+    )
+
+    def test_full_form_fields_do_not_partial_swap(self):
+        for form_class, field_name in self.FULL_FORM_FIELDS:
+            with self.subTest(form=form_class.__name__, field=field_name):
+                form = form_class()
+                self.assertIn(field_name, form.fields)
+                attrs = self._hx_widget(form.fields[field_name]).attrs
+                self.assertEqual(attrs.get('hx-target'), '#form_fields')
+                self.assertNotIn('hx-select', attrs)

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -1,3 +1,4 @@
+import copy
 import warnings
 from types import SimpleNamespace
 
@@ -5,12 +6,7 @@ from django import forms
 from django.contrib.contenttypes.models import ContentType
 from django.test import TestCase, override_settings
 
-from circuits.forms import CircuitGroupAssignmentForm, CircuitTerminationForm
-from core.forms import DataSourceForm
-from dcim.forms import CableForm, InterfaceForm, ModuleTypeForm
 from dcim.models import Site
-from extras.forms import CustomFieldForm, EventRuleForm
-from ipam.forms import PrefixForm, ServiceForm, VLANGroupForm
 from netbox.choices import ImportFormatChoices
 from utilities.choices import Choice, ChoiceSet
 from utilities.forms.bulk_import import BulkImportForm
@@ -30,9 +26,6 @@ from utilities.forms.utils import (
     parse_numeric_range,
 )
 from utilities.forms.widgets.select import AvailableOptions, HTMXSelect, Select, SelectedOptions
-from virtualization.forms import ClusterForm, VirtualMachineForm, VMInterfaceForm
-from vpn.forms import TunnelCreateForm, TunnelTerminationForm
-from wireless.forms import WirelessLANForm
 
 
 class ExpandIPNetworkTestCase(TestCase):
@@ -1050,6 +1043,15 @@ class DescriptionSelectTestCase(TestCase):
         self.assertInHTML('<option value="x" data-description="Description X">X</option>', html)
         self.assertInHTML('<option value="y">Y</option>', html)
 
+    def test_deepcopy_does_not_share_descriptions(self):
+        """Each deep-copied widget (one per form instance) must own its descriptions dict, so a
+        mutation on one instance cannot leak across requests."""
+        widget = Select(choices=[('x', 'X')], descriptions={'x': 'Description X'})
+        clone = copy.deepcopy(widget)
+        self.assertIsNot(widget.descriptions, clone.descriptions)
+        widget.descriptions['y'] = 'leaked'
+        self.assertNotIn('y', clone.descriptions)
+
     def test_choices_setter_delegates_through_mro(self):
         """
         AttrChoiceMixin must delegate to the parent field's choices setter via the MRO, not a hardcoded base,
@@ -1076,80 +1078,3 @@ class DescriptionSelectTestCase(TestCase):
         self.assertTrue(calls)
         # And descriptions are still collected as normal
         self.assertEqual(field.widget.descriptions, {self.ExampleChoices.FOO: 'Description of foo'})
-
-
-class HTMXPartialSwapRenderingTestCase(TestCase):
-    """
-    Verify that each form field's HTMX swap wiring resolves to the widget actually bound to the
-    field. An explicitly declared form field silently overrides a widget set via Meta.widgets, so
-    a field can have HTMXSelect assigned in Meta yet end up with a plain widget carrying no HTMX
-    wiring. The unit-level widget tests above cannot see that, which is how the interface 802.1Q
-    mode swap regressed unnoticed. These tests read the bound field's widget attrs directly so a
-    shadowed field is caught.
-    """
-    # (form, bound field name, target fieldset id) — the field's change must swap only that fieldset.
-    PARTIAL_SWAP_FIELDS = (
-        (InterfaceForm, 'mode', 'dot1q-switching'),
-        (VMInterfaceForm, 'mode', 'dot1q-switching'),
-        (ModuleTypeForm, 'profile', 'profile-attributes'),
-        (CableForm, 'a_terminations_type', 'cable-side-a'),
-        (CableForm, 'b_terminations_type', 'cable-side-b'),
-        (VLANGroupForm, 'scope', 'scope'),
-        (ServiceForm, 'parent', 'service'),
-        (CircuitTerminationForm, 'termination', 'circuit-termination'),
-        (CircuitGroupAssignmentForm, 'member', 'circuit-group-assignment'),
-        (TunnelCreateForm, 'termination1_type', 'tunnel-termination1'),
-        (TunnelCreateForm, 'termination2_type', 'tunnel-termination2'),
-        (TunnelTerminationForm, 'type', 'tunnel-termination'),
-        (EventRuleForm, 'action_type', 'event-rule-action'),
-        (ClusterForm, 'scope', 'scope'),
-        (WirelessLANForm, 'scope', 'scope'),
-        (PrefixForm, 'scope', 'scope'),
-    )
-
-    @staticmethod
-    def _hx_widget(field):
-        """
-        Return the widget carrying the HTMX attrs for a bound field. For plain HTMXSelect fields
-        that is the field's own widget; for a generic-object selector (a MultiWidget), the HTMX
-        content-type selector is its first subwidget.
-        """
-        widget = field.widget
-        if hasattr(widget, 'widgets'):
-            return widget.widgets[0]
-        return widget
-
-    def test_partial_swap_fields_target_their_fieldset(self):
-        for form_class, field_name, target_id in self.PARTIAL_SWAP_FIELDS:
-            with self.subTest(form=form_class.__name__, field=field_name):
-                form = form_class()
-                self.assertIn(field_name, form.fields)
-                attrs = self._hx_widget(form.fields[field_name]).attrs
-                self.assertEqual(attrs.get('hx-select'), f'#{target_id}')
-                self.assertEqual(attrs.get('hx-target'), f'#{target_id}')
-
-    def test_interface_mode_retains_option_descriptions(self):
-        # The mode field must keep its 802.1Q Mode option descriptions (a description-aware widget
-        # feature) alongside the restored partial swap; the two must coexist on the same field.
-        for form_class in (InterfaceForm, VMInterfaceForm):
-            with self.subTest(form=form_class.__name__):
-                self.assertTrue(form_class().fields['mode'].widget.descriptions)
-
-    # These fields intentionally re-render the whole form rather than a single fieldset, because
-    # changing them adds or removes entire fieldsets that a targeted swap would miss. The guard
-    # ensures they keep targeting #form_fields and are not "optimized" into a partial swap that
-    # would silently drop the added/removed fieldsets.
-    FULL_FORM_FIELDS = (
-        (CustomFieldForm, 'type'),
-        (DataSourceForm, 'type'),
-        (VirtualMachineForm, 'virtual_machine_type'),
-    )
-
-    def test_full_form_fields_do_not_partial_swap(self):
-        for form_class, field_name in self.FULL_FORM_FIELDS:
-            with self.subTest(form=form_class.__name__, field=field_name):
-                form = form_class()
-                self.assertIn(field_name, form.fields)
-                attrs = self._hx_widget(form.fields[field_name]).attrs
-                self.assertEqual(attrs.get('hx-target'), '#form_fields')
-                self.assertNotIn('hx-select', attrs)

--- a/netbox/utilities/tests/test_forms.py
+++ b/netbox/utilities/tests/test_forms.py
@@ -1044,8 +1044,6 @@ class DescriptionSelectTestCase(TestCase):
         self.assertInHTML('<option value="y">Y</option>', html)
 
     def test_deepcopy_does_not_share_descriptions(self):
-        """Each deep-copied widget (one per form instance) must own its descriptions dict, so a
-        mutation on one instance cannot leak across requests."""
         widget = Select(choices=[('x', 'X')], descriptions={'x': 'Description X'})
         clone = copy.deepcopy(widget)
         self.assertIsNot(widget.descriptions, clone.descriptions)

--- a/netbox/virtualization/forms/model_forms.py
+++ b/netbox/virtualization/forms/model_forms.py
@@ -422,6 +422,7 @@ class VMInterfaceForm(InterfaceCommonForm, VMComponentForm):
         choices=add_blank_choice(InterfaceModeChoices),
         required=False,
         help_text=_('IEEE 802.1Q tagging strategy'),
+        widget=HTMXSelect(hx_target_id='dot1q-switching'),
     )
     primary_mac_address = DynamicModelChoiceField(
         queryset=MACAddress.objects.all(),
@@ -512,9 +513,8 @@ class VMInterfaceForm(InterfaceCommonForm, VMComponentForm):
         labels = {
             'mode': _('802.1Q Mode'),
         }
-        widgets = {
-            'mode': HTMXSelect(hx_target_id='dot1q-switching'),
-        }
+        # Note: the HTMXSelect widget for `mode` is set on the explicitly declared field above.
+        # Meta.widgets is ignored for explicitly declared fields, so it must not be set here.
 
 
 class VirtualDiskForm(VMComponentForm):

--- a/netbox/virtualization/forms/model_forms.py
+++ b/netbox/virtualization/forms/model_forms.py
@@ -510,11 +510,8 @@ class VMInterfaceForm(InterfaceCommonForm, VMComponentForm):
             'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'vlan_translation_policy', 'vrf',
             'owner', 'tags',
         ]
-        labels = {
-            'mode': _('802.1Q Mode'),
-        }
-        # Note: the HTMXSelect widget for `mode` is set on the explicitly declared field above.
-        # Meta.widgets is ignored for explicitly declared fields, so it must not be set here.
+        # Note: `mode` is configured on the explicitly declared field above (widget and label),
+        # not here. Meta.widgets and Meta.labels are both ignored for explicitly declared fields.
 
 
 class VirtualDiskForm(VMComponentForm):

--- a/netbox/virtualization/forms/model_forms.py
+++ b/netbox/virtualization/forms/model_forms.py
@@ -510,8 +510,6 @@ class VMInterfaceForm(InterfaceCommonForm, VMComponentForm):
             'untagged_vlan', 'tagged_vlans', 'qinq_svlan', 'vlan_translation_policy', 'vrf',
             'owner', 'tags',
         ]
-        # Note: `mode` is configured on the explicitly declared field above (widget and label),
-        # not here. Meta.widgets and Meta.labels are both ignored for explicitly declared fields.
 
 
 class VirtualDiskForm(VMComponentForm):

--- a/netbox/wireless/forms/model_forms.py
+++ b/netbox/wireless/forms/model_forms.py
@@ -228,5 +228,3 @@ class WirelessLinkForm(DistanceValidationMixin, TenancyForm, PrimaryModelForm):
                 attrs={'data-toggle': 'password'}
             ),
         }
-        # Note: `auth_type` and `auth_cipher` are explicitly declared with these same labels;
-        # Meta.labels entries for them would be silently discarded, so they are not set here.

--- a/netbox/wireless/forms/model_forms.py
+++ b/netbox/wireless/forms/model_forms.py
@@ -228,7 +228,5 @@ class WirelessLinkForm(DistanceValidationMixin, TenancyForm, PrimaryModelForm):
                 attrs={'data-toggle': 'password'}
             ),
         }
-        labels = {
-            'auth_type': 'Type',
-            'auth_cipher': 'Cipher',
-        }
+        # Note: `auth_type` and `auth_cipher` are explicitly declared with these same labels;
+        # Meta.labels entries for them would be silently discarded, so they are not set here.


### PR DESCRIPTION
### Closes: #15165

Pre-release QA found the 802.1Q Mode field on `InterfaceForm` and `VMInterfaceForm` no longer triggers a partial swap: changing mode fires no HTMX request, so dependent VLAN fields never update. This is the exact case #15165 delivered; it regressed on `feature`. The root cause turned out to be a general trap, so the PR also guards the whole class.

- Cause: #21712 declared `mode` as an explicit field, which shadows `Meta.widgets` (Django discards `Meta.widgets`/`labels`/`help_texts` for explicitly declared fields), so the `HTMXSelect` set there was dropped and `mode` rendered as a plain `Select`.
- Set `HTMXSelect` on the explicit field; removed the dead `Meta` entries. `HTMXSelect` now includes `AttrSelectMixin` so `mode` keeps both the partial swap and its option descriptions, and `AttrSelectMixin.__deepcopy__` stops per-instance widget copies sharing one `descriptions` dict.
- Fixed the same shadow on `VirtualChassisForm.master` (`SelectWithPK` was dropped, rendering a plain `Select` with no PK in the label) and removed three dead shadowed `Meta` entries elsewhere.
- `HTMXPartialSwapRenderingTestCase` pins every partial-swap field plus the intentional full-form fields, asserting on the widget bound to each field. `MetaShadowingTestCase` walks every `ModelForm` and fails on any `Meta` key that collides with a declared field, so this class can't recur unnoticed. `ConfigRevisionForm` is allowlisted (its metaclass sources widgets from `Meta` by design); its monospace-class drop is a follow-up.
