### PR TITLE
Closes #22660: Add support for HPE Synergy's proprietary 300Gb QSFP-DD interface type

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1033,7 +1033,6 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_200GE_CFP2 = '200gbase-x-cfp2'
     TYPE_200GE_QSFP56 = '200gbase-x-qsfp56'
     TYPE_200GE_QSFP_DD = '200gbase-x-qsfpdd'
-    TYPE_300GE_QSFP_DD = '300gbase-x-qsfpdd'
     TYPE_400GE_CFP2 = '400gbase-x-cfp2'
     TYPE_400GE_QSFP112 = '400gbase-x-qsfp112'
     TYPE_400GE_QSFP_DD = '400gbase-x-qsfpdd'
@@ -1153,6 +1152,7 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_SUMMITSTACK128 = 'extreme-summitstack-128'
     TYPE_SUMMITSTACK256 = 'extreme-summitstack-256'
     TYPE_SUMMITSTACK512 = 'extreme-summitstack-512'
+    TYPE_HPE_SYNERGY_INTERCONNECT = 'hpe-synergy-interconnect-link'
 
     # Other
     TYPE_OTHER = 'other'
@@ -1344,7 +1344,6 @@ class InterfaceTypeChoices(ChoiceSet):
                 (TYPE_200GE_CFP2, 'CFP2 (200GE)'),
                 (TYPE_200GE_QSFP56, 'QSFP56 (200GE)'),
                 (TYPE_200GE_QSFP_DD, 'QSFP-DD (200GE)'),
-                (TYPE_300GE_QSFP_DD, 'QSFP-DD (300GE)'),
                 (TYPE_400GE_QSFP112, 'QSFP112 (400GE)'),
                 (TYPE_400GE_QSFP_DD, 'QSFP-DD (400GE)'),
                 (TYPE_400GE_CDFP, 'CDFP (400GE)'),
@@ -1497,6 +1496,7 @@ class InterfaceTypeChoices(ChoiceSet):
                 (TYPE_SUMMITSTACK128, 'Extreme SummitStack-128'),
                 (TYPE_SUMMITSTACK256, 'Extreme SummitStack-256'),
                 (TYPE_SUMMITSTACK512, 'Extreme SummitStack-512'),
+                (TYPE_HPE_SYNERGY_INTERCONNECT, 'HPE Synergy Interconnect Link'),
             )
         ),
         (

--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1033,6 +1033,7 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_200GE_CFP2 = '200gbase-x-cfp2'
     TYPE_200GE_QSFP56 = '200gbase-x-qsfp56'
     TYPE_200GE_QSFP_DD = '200gbase-x-qsfpdd'
+    TYPE_300GE_QSFP_DD = '300gbase-x-qsfpdd'
     TYPE_400GE_CFP2 = '400gbase-x-cfp2'
     TYPE_400GE_QSFP112 = '400gbase-x-qsfp112'
     TYPE_400GE_QSFP_DD = '400gbase-x-qsfpdd'
@@ -1343,6 +1344,7 @@ class InterfaceTypeChoices(ChoiceSet):
                 (TYPE_200GE_CFP2, 'CFP2 (200GE)'),
                 (TYPE_200GE_QSFP56, 'QSFP56 (200GE)'),
                 (TYPE_200GE_QSFP_DD, 'QSFP-DD (200GE)'),
+                (TYPE_300GE_QSFP_DD, 'QSFP-DD (300GE)'),
                 (TYPE_400GE_QSFP112, 'QSFP112 (400GE)'),
                 (TYPE_400GE_QSFP_DD, 'QSFP-DD (400GE)'),
                 (TYPE_400GE_CDFP, 'CDFP (400GE)'),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22660

<!--
    Please include a summary of the proposed changes below.
-->
Adds a new interface type choice for QSFP-DD (300GE) to support HPE Synergy 
composable infrastructure which uses a proprietary 300Gb Interconnect Link 
in QSFP-DD form factor.

The new type follows the existing naming convention:
- Constant: TYPE_300GE_QSFP_DD = '300gbase-x-qsfpdd'
- Display name: 'QSFP-DD (300GE)'

Added between the existing 200GE and 400GE QSFP-DD entries in 
netbox/dcim/choices.py.