### PR TITLE
Closes #22889: Render config revision banner fields in monospace

### DIFF
--- a/.claude/skills/add-config-param/SKILL.md
+++ b/.claude/skills/add-config-param/SKILL.md
@@ -43,7 +43,7 @@ ConfigParam(
     field=forms.BooleanField,   # or IntegerField, CharField, JSONField, SimpleArrayField
     # field_kwargs only when extra widget/validation config is needed:
     field_kwargs={
-        'widget': forms.Textarea(attrs={'class': 'vLargeTextField'}),
+        'widget': forms.Textarea(attrs={'class': 'font-monospace'}),
     },
 ),
 ```

--- a/netbox/core/forms/model_forms.py
+++ b/netbox/core/forms/model_forms.py
@@ -168,12 +168,6 @@ class ConfigRevisionForm(forms.ModelForm, metaclass=ConfigFormMetaclass):
         model = ConfigRevision
         fields = '__all__'
         widgets = {
-            'BANNER_LOGIN': forms.Textarea(attrs={'class': 'font-monospace'}),
-            'BANNER_MAINTENANCE': forms.Textarea(attrs={'class': 'font-monospace'}),
-            'BANNER_TOP': forms.Textarea(attrs={'class': 'font-monospace'}),
-            'BANNER_BOTTOM': forms.Textarea(attrs={'class': 'font-monospace'}),
-            'CUSTOM_VALIDATORS': forms.Textarea(attrs={'class': 'font-monospace'}),
-            'PROTECTION_RULES': forms.Textarea(attrs={'class': 'font-monospace'}),
             'comment': forms.Textarea(),
         }
 

--- a/netbox/core/tests/test_forms.py
+++ b/netbox/core/tests/test_forms.py
@@ -1,0 +1,25 @@
+from django.test import TestCase
+
+from core.forms import ConfigRevisionForm
+
+
+class ConfigRevisionFormTestCase(TestCase):
+
+    def test_code_fields_render_monospace(self):
+        """
+        Config parameters that hold markup or code (banners, JSON) must render their
+        textareas in a monospace font. See #8974 and #22889.
+        """
+        form = ConfigRevisionForm()
+        monospace_fields = (
+            'BANNER_LOGIN',
+            'BANNER_MAINTENANCE',
+            'BANNER_TOP',
+            'BANNER_BOTTOM',
+            'CUSTOM_VALIDATORS',
+            'PROTECTION_RULES',
+        )
+        for name in monospace_fields:
+            with self.subTest(field=name):
+                css_classes = form[name].field.widget.attrs.get('class', '').split()
+                self.assertIn('font-monospace', css_classes)

--- a/netbox/netbox/config/parameters.py
+++ b/netbox/netbox/config/parameters.py
@@ -24,7 +24,7 @@ PARAMS = (
         description=_("Additional content to display on the login page"),
         field_kwargs={
             'widget': forms.Textarea(
-                attrs={'class': 'vLargeTextField'}
+                attrs={'class': 'font-monospace'}
             ),
         },
     ),
@@ -35,7 +35,7 @@ PARAMS = (
         description=_('Additional content to display when in maintenance mode'),
         field_kwargs={
             'widget': forms.Textarea(
-                attrs={'class': 'vLargeTextField'}
+                attrs={'class': 'font-monospace'}
             ),
         },
     ),
@@ -46,7 +46,7 @@ PARAMS = (
         description=_("Additional content to display at the top of every page"),
         field_kwargs={
             'widget': forms.Textarea(
-                attrs={'class': 'vLargeTextField'}
+                attrs={'class': 'font-monospace'}
             ),
         },
     ),
@@ -57,7 +57,7 @@ PARAMS = (
         description=_("Additional content to display at the bottom of every page"),
         field_kwargs={
             'widget': forms.Textarea(
-                attrs={'class': 'vLargeTextField'}
+                attrs={'class': 'font-monospace'}
             ),
         },
     ),


### PR DESCRIPTION
### Closes: #22889

- The banner config parameters (`BANNER_LOGIN`, `BANNER_MAINTENANCE`, `BANNER_TOP`, `BANNER_BOTTOM`) carried the CSS class `vLargeTextField`, which only rendered monospace while the config revision form lived in Django admin. After the form moved to NetBox's own UI in #14312, admin's stylesheet stopped loading, so the class matches nothing and the fields fell back to the proportional font.
- Swapped `vLargeTextField` for `font-monospace` (the Tabler utility class the current UI loads) on the four banner widgets in `parameters.py`, which is the live source for these fields.
- Removed the `font-monospace` entries from `ConfigRevisionForm.Meta.widgets`: `ConfigFormMetaclass` emulates each config parameter as a declared field, and declared fields override `Meta.widgets`, so those entries never applied.
- `CUSTOM_VALIDATORS` and `PROTECTION_RULES` were listed on the issue but were not broken on `main` (they get `font-monospace` from NetBox's `JSONField`). Only the four banners regressed.
- Added a regression test covering all six code fields.
