### PR TITLE
#22447: Pre-release QA

### DIFF
--- a/netbox/dcim/forms/filtersets.py
+++ b/netbox/dcim/forms/filtersets.py
@@ -1940,7 +1940,7 @@ class CoolingOutflowFilterForm(DeviceComponentFilterForm):
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
         FieldSet(
-            'name', 'label', 'type', 'diameter', 'diameter_unit', name=_('Attributes')
+            'name', 'label', 'type', 'diameter', 'diameter_unit', 'cooling_intake_id', name=_('Attributes')
         ),
         FieldSet('region_id', 'site_group_id', 'site_id', 'location_id', 'rack_id', name=_('Location')),
         FieldSet(
@@ -1963,6 +1963,11 @@ class CoolingOutflowFilterForm(DeviceComponentFilterForm):
         choices=DiameterUnitChoices,
         required=False
     )
+    cooling_intake_id = DynamicModelMultipleChoiceField(
+        label=_('Cooling intake'),
+        queryset=CoolingIntake.objects.all(),
+        required=False
+    )
     tag = TagFilterField(model)
 
 
@@ -1970,7 +1975,7 @@ class CoolingOutflowTemplateFilterForm(ModularDeviceComponentTemplateFilterForm)
     model = CoolingOutflowTemplate
     fieldsets = (
         FieldSet('q', 'filter_id', 'tag'),
-        FieldSet('name', 'label', 'type', 'diameter', 'diameter_unit', name=_('Attributes')),
+        FieldSet('name', 'label', 'type', 'diameter', 'diameter_unit', 'cooling_intake_id', name=_('Attributes')),
         FieldSet('device_type_id', 'module_type_id', name=_('Device')),
     )
     type = forms.MultipleChoiceField(
@@ -1985,6 +1990,11 @@ class CoolingOutflowTemplateFilterForm(ModularDeviceComponentTemplateFilterForm)
     diameter_unit = forms.MultipleChoiceField(
         label=_('Diameter unit'),
         choices=DiameterUnitChoices,
+        required=False
+    )
+    cooling_intake_id = DynamicModelMultipleChoiceField(
+        label=_('Cooling intake'),
+        queryset=CoolingIntakeTemplate.objects.all(),
         required=False
     )
 

--- a/netbox/dcim/graphql/filters.py
+++ b/netbox/dcim/graphql/filters.py
@@ -1068,6 +1068,10 @@ class CoolingIntakeFilter(ModularComponentFilterMixin, NetBoxModelFilter):
     max_flow_unit: BaseFilterLookup[
         Annotated['FlowRateUnitEnum', strawberry.lazy('dcim.graphql.enums')]
     ] | None = strawberry_django.filter_field()
+    cooling_outflow: Annotated['CoolingOutflowFilter', strawberry.lazy('dcim.graphql.filters')] | None = (
+        strawberry_django.filter_field()
+    )
+    cooling_outflow_id: ID | None = strawberry_django.filter_field()
 
 
 @register_filter(models.CoolingIntakeTemplate, lookups=True)

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -700,7 +700,8 @@ class CoolingIntake(
 ):
     """
     A coolant intake port within a Device (e.g. a server cold-plate inlet or CDU intake). A
-    CoolingIntake is supplied by an upstream CoolingOutflow or CoolingFeed.
+    CoolingIntake is supplied by an upstream CoolingOutflow. The serving CoolingFeed is
+    derived from the Device's Rack rather than referenced directly.
     """
     type = models.CharField(
         verbose_name=_('type'),

--- a/netbox/dcim/models/device_components.py
+++ b/netbox/dcim/models/device_components.py
@@ -702,6 +702,10 @@ class CoolingIntake(
     A coolant intake port within a Device (e.g. a server cold-plate inlet or CDU intake). A
     CoolingIntake is supplied by an upstream CoolingOutflow. The serving CoolingFeed is
     derived from the Device's Rack rather than referenced directly.
+
+    Unlike CoolingOutflow (whose parent intake is on the same Device and can therefore be
+    templated), an intake's upstream outflow typically lives on a different Device (e.g. a
+    CDU), so there is deliberately no upstream-outflow field on CoolingIntakeTemplate.
     """
     type = models.CharField(
         verbose_name=_('type'),

--- a/netbox/dcim/tables/cooling.py
+++ b/netbox/dcim/tables/cooling.py
@@ -166,7 +166,7 @@ class CoolingIntakeTable(ModularDeviceComponentTable):
         )
         default_columns = (
             'pk', 'name', 'device', 'label', 'type', 'diameter', 'max_flow',
-            'description',
+            'cooling_outflow', 'description',
         )
 
 
@@ -281,7 +281,7 @@ class DeviceCoolingIntakeTable(CoolingIntakeTable):
         )
         default_columns = (
             'pk', 'name', 'label', 'type', 'diameter', 'max_flow',
-            'description',
+            'cooling_outflow', 'description',
         )
 
 


### PR DESCRIPTION
### Closes: #22447

Follow-up QA for the cooling infrastructure feature added in #22517.

Two small fixes found while QA'ing the feature:

**Add the missing `cooling_outflow` GraphQL filter on CoolingIntake**

`CoolingIntakeFilter` did not expose `cooling_outflow` / `cooling_outflow_id`, so an intake could not be filtered by its upstream outflow in GraphQL. The reverse direction (`CoolingOutflowFilter.cooling_intake`) and the REST filterset (`cooling_outflow_id`) already supported this; the GraphQL intake filter was the only side missing it.

**Correct the CoolingIntake docstring**

The docstring stated a CoolingIntake is supplied by an upstream `CoolingOutflow` or `CoolingFeed`. There is no direct feed relationship: the serving feed is derived from the device's rack, not stored on the intake.

### Testing

Covered by the existing `CoolingIntakeTestCase` (API + auto-generated GraphQL filter tests), which passes with the new filter. Verified live via schema introspection that the two filter fields now appear on `CoolingIntakeFilter`.
