### PR TITLE
#18159: Pre-release QA

### DIFF
--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -154,6 +154,8 @@ You can also read pre- or post-change values directly using the `snapshots.prech
 
     For delete events, `postchange` is `null`. The `changed` operator evaluates to `true` for any attribute present in the prechange snapshot, `unchanged` evaluates to `false`, and any `snapshots.postchange.*` path resolves to `null`.
 
+    An absent snapshot excuses only the absence of the data, not a malformed path: a path which cannot be resolved against a snapshot at all (such as the `.value` suffix above) fails closed and is logged regardless of the event type.
+
 Because an absent snapshot resolves to `null` rather than raising an error — matching a condition testing for `null` and failing any other comparison, whichever operator is used — a snapshot path can be combined safely with other conditions in a rule that also fires on create or delete. For example, this rule fires when a site is created, or when a site whose status was previously `planned` is updated:
 
 ```json

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -116,6 +116,8 @@ Fire only when `status` changes (to any value):
 }
 ```
 
+An attribute which resolves in neither snapshot — a misspelling, an attribute the object type does not have, or an event which recorded no snapshots at all — leaves nothing to compare. The condition fails closed (the rule does not fire) and an error is logged to `netbox.event_rules`. This holds regardless of `negate`: negating a condition whose attribute cannot be resolved does not turn it into a match.
+
 ### Combining with Standard Conditions
 
 The canonical use case — fire only when `status` changes **to** `active` — combines a standard value check with the `changed` operator:
@@ -150,7 +152,7 @@ You can also read pre- or post-change values directly using the `snapshots.prech
     Snapshot data uses the **model serializer format**, not the REST API format. Choice fields such as `status` are stored as raw strings (e.g. `"active"`) rather than nested objects (e.g. `{"value": "active", "label": "Active"}`). Use `status` — not `status.value` — when referencing a snapshot attribute, both in `snapshots.prechange.*`/`snapshots.postchange.*` paths and with the `changed`/`unchanged` operators. A `.value` suffix cannot be resolved against a snapshot: the condition fails closed (the rule does not fire) and an error is logged to `netbox.event_rules`.
 
 !!! note "Snapshot availability"
-    For create events, `prechange` is `null`. The `changed` operator evaluates to `true` (each field transitioned from non-existent to its initial value), and a `snapshots.prechange.*` path resolves to `null` — so it matches a condition testing for `null` and fails any other comparison.
+    For create events, `prechange` is `null`. The `changed` operator evaluates to `true` for any attribute present in the postchange snapshot (each field transitioned from non-existent to its initial value), and a `snapshots.prechange.*` path resolves to `null` — so it matches a condition testing for `null` and fails any other comparison.
 
     For delete events, `postchange` is `null`. The `changed` operator evaluates to `true` for any attribute present in the prechange snapshot, `unchanged` evaluates to `false`, and a `snapshots.postchange.*` path resolves to `null`.
 

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -49,6 +49,11 @@ The following condition will evaluate as true:
 }
 ```
 
+!!! note "Missing keys and absent data"
+    A condition which references a key that does not exist in the data being evaluated fails closed: the condition set evaluates as false, and (for an [event rule](../features/event-rules.md)) an error is logged to `netbox.event_rules` so that a typo does not silently disable the rule.
+
+    Where the data is absent altogether rather than merely missing the referenced key, the reference instead resolves to `null`. This applies to an event rule evaluating a job which recorded no data, and to a snapshot which does not exist for the event type (see [below](#snapshot-conditions-event-rules)). Such an absence is a normal property of the event rather than a mistake, so it is not treated as an error: the reference matches a condition testing for `null`, fails any other comparison, and does not affect the evaluation of the other conditions in the set.
+
 ### Examples
 
 `name` equals "foo":
@@ -149,7 +154,7 @@ You can also read pre- or post-change values directly using the `snapshots.prech
 
     For delete events, `postchange` is `null`. The `changed` operator evaluates to `true` for any attribute present in the prechange snapshot, `unchanged` evaluates to `false`, and any `snapshots.postchange.*` path resolves to `null`.
 
-Because an absent snapshot resolves to `null` rather than raising an error, a snapshot path can be combined safely with other conditions in a rule that also fires on create or delete. For example, this rule fires when a site is created, or when an existing site moves out of the `planned` status:
+Because an absent snapshot resolves to `null` rather than raising an error — matching a condition testing for `null` and failing any other comparison, whichever operator is used — a snapshot path can be combined safely with other conditions in a rule that also fires on create or delete. For example, this rule fires when a site is created, or when a site whose status was previously `planned` is updated:
 
 ```json
 {

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -145,7 +145,26 @@ You can also read pre- or post-change values directly using the `snapshots.prech
     Snapshot data uses the **model serializer format**, not the REST API format. Choice fields such as `status` are stored as raw strings (e.g. `"active"`) rather than nested objects (e.g. `{"value": "active", "label": "Active"}`). Use `status` — not `status.value` — when referencing a snapshot attribute, both in `snapshots.prechange.*`/`snapshots.postchange.*` paths and with the `changed`/`unchanged` operators. A `.value` suffix cannot be resolved against a snapshot: the condition fails closed (the rule does not fire) and an error is logged to `netbox.event_rules`.
 
 !!! note "Snapshot availability"
-    Snapshots are only populated for update and delete events. For create events, `prechange` is `null` — conditions using the `changed` operator on a create event evaluate to `true` (the field transitioned from non-existent to its initial value), while conditions using `snapshots.prechange.*` paths evaluate to `false`. For delete events, `postchange` is `null` — the `changed` operator evaluates to `true` for any attribute present in the prechange snapshot, and `unchanged` evaluates to `false`.
+    For create events, `prechange` is `null`. The `changed` operator evaluates to `true` (each field transitioned from non-existent to its initial value), and any `snapshots.prechange.*` path resolves to `null` — so it matches a condition testing for `null` and fails any other comparison.
+
+    For delete events, `postchange` is `null`. The `changed` operator evaluates to `true` for any attribute present in the prechange snapshot, `unchanged` evaluates to `false`, and any `snapshots.postchange.*` path resolves to `null`.
+
+Because an absent snapshot resolves to `null` rather than raising an error, a snapshot path can be combined safely with other conditions in a rule that also fires on create or delete. For example, this rule fires when a site is created, or when an existing site moves out of the `planned` status:
+
+```json
+{
+  "or": [
+    {
+      "attr": "snapshots.prechange.status",
+      "value": null
+    },
+    {
+      "attr": "snapshots.prechange.status",
+      "value": "planned"
+    }
+  ]
+}
+```
 
 ## Condition Sets
 

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -150,11 +150,13 @@ You can also read pre- or post-change values directly using the `snapshots.prech
     Snapshot data uses the **model serializer format**, not the REST API format. Choice fields such as `status` are stored as raw strings (e.g. `"active"`) rather than nested objects (e.g. `{"value": "active", "label": "Active"}`). Use `status` — not `status.value` — when referencing a snapshot attribute, both in `snapshots.prechange.*`/`snapshots.postchange.*` paths and with the `changed`/`unchanged` operators. A `.value` suffix cannot be resolved against a snapshot: the condition fails closed (the rule does not fire) and an error is logged to `netbox.event_rules`.
 
 !!! note "Snapshot availability"
-    For create events, `prechange` is `null`. The `changed` operator evaluates to `true` (each field transitioned from non-existent to its initial value), and any `snapshots.prechange.*` path resolves to `null` — so it matches a condition testing for `null` and fails any other comparison.
+    For create events, `prechange` is `null`. The `changed` operator evaluates to `true` (each field transitioned from non-existent to its initial value), and a `snapshots.prechange.*` path resolves to `null` — so it matches a condition testing for `null` and fails any other comparison.
 
-    For delete events, `postchange` is `null`. The `changed` operator evaluates to `true` for any attribute present in the prechange snapshot, `unchanged` evaluates to `false`, and any `snapshots.postchange.*` path resolves to `null`.
+    For delete events, `postchange` is `null`. The `changed` operator evaluates to `true` for any attribute present in the prechange snapshot, `unchanged` evaluates to `false`, and a `snapshots.postchange.*` path resolves to `null`.
 
-    An absent snapshot excuses only the absence of the data, not a malformed path: a path which cannot be resolved against a snapshot at all (such as the `.value` suffix above) fails closed and is logged regardless of the event type.
+    An absent snapshot excuses only the absence of the data, not a path which does not describe it. The attribute path is checked against the opposite snapshot, and fails closed (the rule does not fire, and an error is logged) if it cannot be resolved there — whether because it cannot be resolved against a snapshot at all, such as the `.value` suffix above, or because the attribute is misspelled or unknown. Otherwise a typo would resolve to `null` and fire the rule on every create or delete.
+
+    To test only whether a snapshot is absent, reference the snapshot itself rather than an attribute of it: `{"attr": "snapshots.prechange", "value": null}`.
 
 Because an absent snapshot resolves to `null` rather than raising an error — matching a condition testing for `null` and failing any other comparison, whichever operator is used — a snapshot path can be combined safely with other conditions in a rule that also fires on create or delete. For example, this rule fires when a site is created, or when a site whose status was previously `planned` is updated:
 

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -52,7 +52,9 @@ The following condition will evaluate as true:
 !!! note "Missing keys and absent data"
     A condition which references a key that does not exist in the data being evaluated fails closed: the condition set evaluates as false, and (for an [event rule](../features/event-rules.md)) an error is logged to `netbox.event_rules` so that a typo does not silently disable the rule.
 
-    Where the data is absent altogether rather than merely missing the referenced key, the reference instead resolves to `null`. This applies to an event rule evaluating a job which recorded no data, and to a snapshot which does not exist for the event type (see [below](#snapshot-conditions-event-rules)). Such an absence is a normal property of the event rather than a mistake, so it is not treated as an error: the reference matches a condition testing for `null`, fails any other comparison, and does not affect the evaluation of the other conditions in the set.
+    Where the data is absent altogether rather than merely missing the referenced key — an event rule evaluating a job which recorded no data, say — the condition does not match. Such an absence is a normal property of the event rather than a mistake, so it is not treated as an error and does not affect the evaluation of the other conditions in the set. Because there is nothing to compare against, the condition does not match whatever the operator, and remains a non-match when `negate` is set: no rule fires on data an event never carried.
+
+    A snapshot which does not exist for the event type is the exception: it resolves to `null`, so that a condition can distinguish (for example) a newly created object from an updated one. See [below](#snapshot-conditions-event-rules).
 
 ### Examples
 

--- a/docs/reference/conditions.md
+++ b/docs/reference/conditions.md
@@ -142,7 +142,7 @@ You can also read pre- or post-change values directly using the `snapshots.prech
 ```
 
 !!! warning "Snapshot serialization format"
-    Snapshot data uses the **model serializer format**, not the REST API format. Choice fields such as `status` are stored as raw strings (e.g. `"active"`) rather than nested objects (e.g. `{"value": "active", "label": "Active"}`). Use `attr: "snapshots.prechange.status"` — not `"snapshots.prechange.status.value"` — when referencing snapshot attributes. The `changed`/`unchanged` operators compare the same format on both sides, so they are not affected by this distinction.
+    Snapshot data uses the **model serializer format**, not the REST API format. Choice fields such as `status` are stored as raw strings (e.g. `"active"`) rather than nested objects (e.g. `{"value": "active", "label": "Active"}`). Use `status` — not `status.value` — when referencing a snapshot attribute, both in `snapshots.prechange.*`/`snapshots.postchange.*` paths and with the `changed`/`unchanged` operators. A `.value` suffix cannot be resolved against a snapshot: the condition fails closed (the rule does not fire) and an error is logged to `netbox.event_rules`.
 
 !!! note "Snapshot availability"
     Snapshots are only populated for update and delete events. For create events, `prechange` is `null` — conditions using the `changed` operator on a create event evaluate to `true` (the field transitioned from non-existent to its initial value), while conditions using `snapshots.prechange.*` paths evaluate to `false`. For delete events, `postchange` is `null` — the `changed` operator evaluates to `true` for any attribute present in the prechange snapshot, and `unchanged` evaluates to `false`.

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -22,32 +22,14 @@ OPPOSITE_SNAPSHOT = {
     'postchange': 'prechange',
 }
 
-# Sentinel for a snapshot attribute that could not be resolved (missing key or null snapshot). Using a unique object
-# ensures that two independently unresolvable values compare equal to each other, which is the correct semantics for the
-# 'unchanged' operator when neither snapshot has the field.
+# Sentinel for a snapshot attribute that could not be resolved (missing key or null snapshot)
 _MISSING = object()
 
 
 class AbsentData(dict):
     """
     An empty dict standing in for an event payload which cannot be evaluated: one which is
-    absent altogether (a job which recorded no data), or one which is present but unusable
-    (a payload which is not a dict at all, and so has no attributes to address). Either way
-    nothing can be resolved from it, as opposed to a usable payload which merely does not
-    contain a referenced attribute.
-
-    An unusable payload is an anomaly worth reporting and an absent one is routine, but that
-    distinction belongs where the payload is normalized (see extras.events), which reports it
-    once for the event rather than once per rule. By the time conditions are evaluated the two
-    are the same thing: no data to evaluate.
-
-    A condition referencing an attribute of absent data is a non-match. It does not raise
-    InvalidCondition: the absence is a normal property of the event (e.g. a job which
-    recorded no data), not a malformed condition, so it must not abort evaluation of the
-    condition set or log an error for every rule on every such event. Neither does it resolve
-    to a value: every attribute of an absent payload is equally unresolvable, so a value would
-    let a rule fire on data the event never carried - including for an attribute which does
-    not exist at all.
+    absent (a job which recorded no data) or unusable (a payload which is not a dict at all).
     """
     def copy(self):
         # dict.copy() would return a plain dict, silently discarding the marker.
@@ -56,25 +38,12 @@ class AbsentData(dict):
 
 def walk_path(obj, keys, empty_list_is_absent=False):
     """
-    Walk a sequence of keys through obj, returning _MISSING if a key is absent along the way.
+    Walk a sequence of keys through obj, returning _MISSING if a key is absent or null along the way.
 
-    Raises TypeError if the path cannot be walked at all, i.e. if it descends into a value
-    which cannot be indexed by key (e.g. a REST API-style 'status.value' applied to a
-    snapshot, where status is the raw string "active" rather than a nested dict).
-
-    Walkability is determined from the type of the value being descended into, never from
-    its truthiness: an empty string or a zero is just as unwalkable as any other scalar, and
-    must be reported as such rather than being mistaken for an absent key.
-
-    Null values are the exception: a null is no evidence of a malformed path, since there is
-    nothing there to walk either way, so it resolves to _MISSING exactly as an absent key does.
-
-    Descending a key into an empty list maps it across no elements and so yields an empty
-    list, exactly as it yields a list of values for a populated one. An object with no tags
-    thus resolves 'tags.slug' to [], which is a legitimate value for a condition to compare
-    against, not a malformed path. Callers for which an empty list is instead an absence -
-    the snapshot operators, which need a resolved value to serve as evidence that the path is
-    well-formed - can pass empty_list_is_absent=True to get _MISSING.
+    Raises TypeError if the path descends into a value which cannot be indexed by key (e.g. a
+    REST API-style 'status.value' applied to a snapshot, where status is the raw string
+    "active"). Walkability follows from the value's type: an empty string is as unwalkable as any
+    other scalar, not an absent key.
     """
     for key in keys:
         if obj is None:
@@ -199,25 +168,20 @@ class Condition:
     def _references_absent_payload(self, data):
         """
         Return True if self.attr references an attribute of a payload which is absent
-        altogether (an AbsentData payload), e.g. a job event for a job which recorded no data,
-        as opposed to a payload which is present but does not contain the attribute.
-
-        The snapshots key is part of the evaluation context rather than of the payload, so a
-        snapshot path is never treated as referencing an absent payload.
+        altogether (AbsentData), as opposed to one which is present but lacks the attribute.
         """
         return isinstance(data, AbsentData) and self.attr.split('.')[0] not in data
 
     def _references_absent_snapshot(self, data):
         """
         Return True if self.attr is a direct snapshot path (snapshots.prechange.* or
-        snapshots.postchange.*) whose referenced snapshot is null, and whose remaining path the
-        opposite snapshot shows to be resolvable. Create events have no prechange snapshot and
-        delete events have no postchange snapshot.
+        snapshots.postchange.*) whose snapshot is null and whose remaining path the opposite
+        snapshot resolves. Create events have no prechange snapshot, delete events no
+        postchange snapshot.
 
-        Unlike an absent payload, an absent snapshot resolves to null: the snapshot's absence
-        is itself meaningful (the object did not exist before, or does not exist after), and
-        the path is validated below, so a reference which resolves to null has been shown to
-        describe the data rather than merely being unresolvable.
+        Unlike an absent payload, such a reference resolves to null: the snapshot's absence is
+        itself meaningful (the object did not exist before, or does not after), and validating
+        the path below shows the reference to describe the data.
         """
         if not self.attr.startswith(SNAPSHOT_PREFIX):
             return False
@@ -228,15 +192,11 @@ class Condition:
         if which not in snapshots or snapshots[which] is not None:
             return False
 
-        # The referenced snapshot is null. A null snapshot excuses only the absence of data
-        # the event would otherwise have carried, never a path which does not describe the
-        # data at all, so the remainder is validated against the opposite snapshot: only a
-        # path which resolves there is treated as genuinely absent here. A path the opposite
-        # snapshot cannot vouch for - because it cannot be walked at all (e.g. the REST
-        # API-style 'status.value'), or because it resolves to nothing there either (an absent
-        # key, a null, an empty list) - fails closed instead, exactly as it does when both
-        # snapshots are present. Otherwise a typo would resolve to null and fire the rule on
-        # every create or delete, and do so with nothing logged.
+        # The referenced snapshot is null, which excuses only data the event would otherwise
+        # have carried, never a path which does not describe the data. Validate the remainder
+        # against the opposite snapshot so that such a path fails closed here exactly as it does
+        # when both snapshots are present; otherwise a typo would resolve to null and fire the
+        # rule on every create or delete, with nothing logged.
         other = snapshots.get(OPPOSITE_SNAPSHOT.get(which))
         if remainder and other is not None:
             try:
@@ -246,38 +206,27 @@ class Condition:
             if value is _MISSING:
                 return False
 
-        # Nothing to validate against: with the opposite snapshot absent too, the event
-        # carries no data anywhere for the path to be checked against. Treat the data as
-        # absent rather than logging an error for every rule on every such event; testing
-        # for the absent snapshot itself (snapshots.prechange, no remainder) lands here too.
+        # Nothing to validate against: with the opposite snapshot absent too, the event carries
+        # no data anywhere for the path to be checked. Testing for the absent snapshot itself
+        # (snapshots.prechange, no remainder) lands here too.
         return True
 
     def _resolve_snapshot_attrs(self, snapshots):
         """
-        Walk self.attr through both the prechange and postchange snapshots, returning the
-        two resolved values. _MISSING is returned for a snapshot which is absent, which does
-        not contain the attribute, or in which the path cannot be walked at all (e.g. a REST
-        API-style 'status.value', where status is the raw string "active" rather than a
-        nested dict).
+        Walk self.attr through the prechange and postchange snapshots, returning the two
+        resolved values, with _MISSING for a snapshot which is absent, lacks the attribute, or
+        cannot be walked by the path.
 
-        Snapshots use the model serializer format (raw field values), not the REST
-        API format, so e.g. status is stored as "active" not {"value": "active"}.
+        Raises InvalidCondition if the attribute resolves in neither snapshot, leaving nothing
+        to compare: a misspelling, an unwalkable path, or an event which recorded no snapshots.
+        The unresolved state must be reported rather than compared, since any boolean it
+        returned would become a match under negate.
 
-        Raises InvalidCondition if the attribute resolves in neither snapshot, leaving no
-        basis for the comparison: a misspelled or unknown attribute, a path which cannot be
-        walked at all, or an event which recorded no snapshots. The unresolved state must be
-        reported rather than compared, because any value the comparison could return is a
-        boolean which negate turns into a match: 'statsu' with the changed operator and
-        negate set would otherwise fire on every event, which is the very mistake failing
-        closed is meant to catch.
-
-        A path which resolves in one snapshot but not the other describes a real difference
-        between them (a JSON attribute whose value changed shape, say, or an attribute absent
-        from one side), so the unresolved side counts as missing and the comparison proceeds:
-        raising would report the attribute as unchanged even though it demonstrably changed.
-        Only a snapshot which actually yields a value excuses the other side; one which merely
-        resolves to nothing (an absent key, a null, an empty list) offers no evidence that the
-        path describes the data at all.
+        A path which resolves in only one snapshot describes a real difference between them (a
+        JSON attribute whose value changed shape, say), so the unresolved side counts as missing
+        and the comparison proceeds: raising would report as unchanged an attribute which
+        demonstrably changed. Only a snapshot yielding a value excuses the other side; one
+        resolving to nothing is no evidence that the path describes the data.
         """
         keys = self.attr.split('.')
         values = []
@@ -331,15 +280,11 @@ class Condition:
             return not result if self.negate else result
 
         if self._references_absent_payload(data):
-            # There is no payload to evaluate, so the condition cannot be satisfied. Report a
-            # non-match without applying negation: negate inverts the result of a comparison,
-            # and no comparison took place. Inverting would let the rule fire on an event which
-            # carried nothing to match against, and since every attribute of an absent payload
-            # is equally unresolvable, a misspelled attribute would fire it too.
-            #
-            # Unlike an unresolvable snapshot reference this is not reported as an invalid
-            # condition: a job which records no data is routine, and logging an error for every
-            # rule on every such event would bury the malformed conditions worth acting on.
+            # No payload to evaluate, so the condition cannot be satisfied. Negation is not
+            # applied: it inverts the result of a comparison, and none took place - inverting
+            # would fire the rule on an event which carried nothing to match against. Nor is
+            # this an invalid condition: a job which records no data is routine, and logging it
+            # per rule per event would bury the malformed conditions worth acting on.
             return False
 
         absent = self._references_absent_snapshot(data)
@@ -349,10 +294,10 @@ class Condition:
         except TypeError as e:
             if not absent:
                 raise InvalidCondition(f"Invalid data type at '{self.attr}' for '{self.op}' evaluation: {e}")
-            # An absent snapshot resolves to null, which satisfies only a comparison
-            # against null: operators such as contains, regex, and the numeric comparisons
-            # raise a TypeError on None. That is a non-match, not a malformed condition, so
-            # report False (subject to negation below) rather than aborting the condition set.
+            # An absent snapshot resolves to null, which satisfies only a comparison against
+            # null: contains, regex and the numeric comparisons raise TypeError on None. That is
+            # a non-match, not a malformed condition, so report False (subject to negation
+            # below) rather than aborting the condition set.
             result = False
 
         if self.negate:
@@ -395,17 +340,6 @@ class Condition:
         return re.match(self.value, value) is not None
 
     # Snapshot comparison operators
-    # These resolve self.attr in both the prechange and postchange snapshots and compare the
-    # resulting values. _MISSING is used for the side which does not resolve: a snapshot which
-    # is absent (normal for create and delete events), which does not contain the attribute,
-    # or which the path cannot be walked in. At least one side always resolves, since
-    # _resolve_snapshot_attrs() raises InvalidCondition when neither does.
-    #
-    # Fail-closed semantics: an attribute which resolves in no snapshot available for the event
-    # leaves nothing to compare, so it is reported as an invalid condition rather than compared.
-    # Returning a boolean instead would let negate turn the failure into a match, and returning
-    # one quietly would leave a typo evaluating forever with no indication of why. The mistake
-    # is logged by EventRule.eval_conditions(), and the rule does not fire.
 
     def eval_changed(self, snapshots):
         pre, post = self._resolve_snapshot_attrs(snapshots)

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -1,4 +1,3 @@
-import operator
 import re
 
 from django.utils.translation import gettext as _
@@ -53,15 +52,38 @@ def walk_path(obj, keys):
     Raises TypeError if the path cannot be walked at all, i.e. if it descends into a value
     which cannot be indexed by key (e.g. a REST API-style 'status.value' applied to a
     snapshot, where status is the raw string "active" rather than a nested dict).
+
+    Walkability is determined from the type of the value being descended into, never from
+    its truthiness: an empty string or a zero is just as unwalkable as any other scalar, and
+    must be reported as such rather than being mistaken for an absent key.
+
+    Null values and empty lists are the exception. Neither is evidence of a malformed path,
+    since there is nothing there to walk either way, so both resolve to _MISSING exactly as
+    an absent key does.
     """
     for key in keys:
-        try:
-            if isinstance(obj, list):
-                obj = [operator.getitem(item or {}, key) for item in obj]
-            else:
-                obj = operator.getitem(obj or {}, key)
-        except KeyError:
+        if obj is None:
             return _MISSING
+        if isinstance(obj, list):
+            values = []
+            for item in obj:
+                if item is None:
+                    return _MISSING
+                if not isinstance(item, dict):
+                    raise TypeError(f"cannot resolve '{key}' within {type(item).__name__}")
+                if key not in item:
+                    return _MISSING
+                values.append(item[key])
+            if not values:
+                # An empty list yields no evidence either way
+                return _MISSING
+            obj = values
+        elif isinstance(obj, dict):
+            if key not in obj:
+                return _MISSING
+            obj = obj[key]
+        else:
+            raise TypeError(f"cannot resolve '{key}' within {type(obj).__name__}")
     return obj
 
 
@@ -219,17 +241,19 @@ class Condition:
         Snapshots use the model serializer format (raw field values), not the REST
         API format, so e.g. status is stored as "active" not {"value": "active"}.
 
-        Raises InvalidCondition only if the path cannot be walked in *any* of the snapshots
-        available for the event, which is the case for a genuinely malformed path. A path
+        Raises InvalidCondition if the path cannot be walked in any snapshot and resolves to
+        a value in none of them, which is the case for a genuinely malformed path. A path
         which resolves in one snapshot but not the other describes a real difference between
         them (a JSON attribute whose value changed shape, say), so the unwalkable side is
         treated as missing and the comparison proceeds: raising would report the attribute as
-        unchanged even though it demonstrably changed.
+        unchanged even though it demonstrably changed. Only a snapshot which actually yields
+        a value excuses the unwalkable side; one which merely resolves to nothing (an absent
+        key, a null, an empty list) offers no evidence that the path is well-formed.
         """
         keys = self.attr.split('.')
         values = []
         errors = []
-        available = 0
+        resolved = False
 
         for which in ('prechange', 'postchange'):
             snapshot = snapshots.get(which)
@@ -237,14 +261,16 @@ class Condition:
                 # Absent snapshot (normal for create and delete events): nothing to resolve
                 values.append(_MISSING)
                 continue
-            available += 1
             try:
-                values.append(walk_path(snapshot, keys))
+                value = walk_path(snapshot, keys)
             except TypeError as e:
                 values.append(_MISSING)
                 errors.append(e)
+            else:
+                values.append(value)
+                resolved = resolved or value is not _MISSING
 
-        if available and len(errors) == available:
+        if errors and not resolved:
             raise InvalidCondition(
                 f"Invalid key path for '{self.op}' operator: {self.attr} ({errors[0]}). Note that snapshots store "
                 f"raw field values, so choice fields have no '.value' suffix."

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -33,10 +33,13 @@ class AbsentData(dict):
     An empty dict standing in for event data which is absent altogether, as opposed to data
     which is present but does not contain a referenced attribute.
 
-    A condition referencing an attribute of absent data resolves to null instead of raising
+    A condition referencing an attribute of absent data is a non-match. It does not raise
     InvalidCondition: the absence is a normal property of the event (e.g. a job which
     recorded no data), not a malformed condition, so it must not abort evaluation of the
-    condition set or log an error for every rule on every such event.
+    condition set or log an error for every rule on every such event. Neither does it resolve
+    to a value: every attribute of an absent payload is equally unresolvable, so a value would
+    let a rule fire on data the event never carried - including for an attribute which does
+    not exist at all.
     """
     def copy(self):
         # dict.copy() would return a plain dict, silently discarding the marker.
@@ -185,20 +188,29 @@ class Condition:
             raise InvalidCondition(f"Invalid key path: {self.attr}")
         return value
 
-    def _references_absent_data(self, data):
+    def _references_absent_payload(self, data):
         """
-        Return True if self.attr references data which is absent altogether, as opposed to
-        data which is present but does not contain the attribute. Two cases qualify:
+        Return True if self.attr references an attribute of a payload which is absent
+        altogether (an AbsentData payload), e.g. a job event for a job which recorded no data,
+        as opposed to a payload which is present but does not contain the attribute.
 
-        * The data itself is absent (an AbsentData payload), e.g. a job event for a job
-          which recorded no data.
-        * self.attr is a direct snapshot path (snapshots.prechange.* or
-          snapshots.postchange.*) whose referenced snapshot is null, and whose remaining path
-          the opposite snapshot shows to be resolvable. Create events have no prechange
-          snapshot and delete events have no postchange snapshot.
+        The snapshots key is part of the evaluation context rather than of the payload, so a
+        snapshot path is never treated as referencing an absent payload.
         """
-        if isinstance(data, AbsentData) and self.attr.split('.')[0] not in data:
-            return True
+        return isinstance(data, AbsentData) and self.attr.split('.')[0] not in data
+
+    def _references_absent_snapshot(self, data):
+        """
+        Return True if self.attr is a direct snapshot path (snapshots.prechange.* or
+        snapshots.postchange.*) whose referenced snapshot is null, and whose remaining path the
+        opposite snapshot shows to be resolvable. Create events have no prechange snapshot and
+        delete events have no postchange snapshot.
+
+        Unlike an absent payload, an absent snapshot resolves to null: the snapshot's absence
+        is itself meaningful (the object did not exist before, or does not exist after), and
+        the path is validated below, so a reference which resolves to null has been shown to
+        describe the data rather than merely being unresolvable.
+        """
         if not self.attr.startswith(SNAPSHOT_PREFIX):
             return False
         snapshots = data.get('snapshots') if isinstance(data, dict) else None
@@ -310,17 +322,29 @@ class Condition:
             result = self.eval_func(snapshots)
             return not result if self.negate else result
 
-        absent = self._references_absent_data(data)
+        if self._references_absent_payload(data):
+            # There is no payload to evaluate, so the condition cannot be satisfied. Report a
+            # non-match without applying negation: negate inverts the result of a comparison,
+            # and no comparison took place. Inverting would let the rule fire on an event which
+            # carried nothing to match against, and since every attribute of an absent payload
+            # is equally unresolvable, a misspelled attribute would fire it too.
+            #
+            # Unlike an unresolvable snapshot reference this is not reported as an invalid
+            # condition: a job which records no data is routine, and logging an error for every
+            # rule on every such event would bury the malformed conditions worth acting on.
+            return False
+
+        absent = self._references_absent_snapshot(data)
         value = None if absent else self._resolve_attr(data)
         try:
             result = self.eval_func(value)
         except TypeError as e:
             if not absent:
                 raise InvalidCondition(f"Invalid data type at '{self.attr}' for '{self.op}' evaluation: {e}")
-            # Absent data resolves to null, which satisfies only a comparison against null:
-            # operators such as contains, regex, and the numeric comparisons raise a
-            # TypeError on None. That is a non-match, not a malformed condition, so report
-            # False (subject to negation below) rather than aborting the condition set.
+            # An absent snapshot resolves to null, which satisfies only a comparison
+            # against null: operators such as contains, regex, and the numeric comparisons
+            # raise a TypeError on None. That is a non-match, not a malformed condition, so
+            # report False (subject to negation below) rather than aborting the condition set.
             result = False
 
         if self.negate:

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -1,4 +1,3 @@
-import functools
 import operator
 import re
 
@@ -17,6 +16,13 @@ OR = 'or'
 # Prefix identifying a condition attribute that reads an event's pre- or post-change
 # snapshot directly, e.g. 'snapshots.prechange.status'.
 SNAPSHOT_PREFIX = 'snapshots.'
+
+# Maps each snapshot to its counterpart, which is consulted to validate the shape of a path
+# referencing a snapshot that does not exist for the event type.
+OPPOSITE_SNAPSHOT = {
+    'prechange': 'postchange',
+    'postchange': 'prechange',
+}
 
 # Sentinel for a snapshot attribute that could not be resolved (missing key or
 # null snapshot).  Using a unique object ensures that two independently
@@ -38,6 +44,25 @@ class AbsentData(dict):
     def copy(self):
         # dict.copy() would return a plain dict, silently discarding the marker.
         return AbsentData(self)
+
+
+def walk_path(obj, keys):
+    """
+    Walk a sequence of keys through obj, returning _MISSING if a key is absent along the way.
+
+    Raises TypeError if the path cannot be walked at all, i.e. if it descends into a value
+    which cannot be indexed by key (e.g. a REST API-style 'status.value' applied to a
+    snapshot, where status is the raw string "active" rather than a nested dict).
+    """
+    for key in keys:
+        try:
+            if isinstance(obj, list):
+                obj = [operator.getitem(item or {}, key) for item in obj]
+            else:
+                obj = operator.getitem(obj or {}, key)
+        except KeyError:
+            return _MISSING
+    return obj
 
 
 def is_ruleset(data):
@@ -126,17 +151,13 @@ class Condition:
         missing keys, or when an intermediate value can't be indexed by key (e.g. a
         REST API-style path like 'status.value' applied to a raw snapshot value).
         """
-        def _get(obj, key):
-            if isinstance(obj, list):
-                return [operator.getitem(item or {}, key) for item in obj]
-            return operator.getitem(obj or {}, key)
-
         try:
-            return functools.reduce(_get, self.attr.split('.'), data)
-        except KeyError:
-            raise InvalidCondition(f"Invalid key path: {self.attr}")
+            value = walk_path(data, self.attr.split('.'))
         except TypeError as e:
             raise InvalidCondition(f"Invalid key path: {self.attr} ({e})")
+        if value is _MISSING:
+            raise InvalidCondition(f"Invalid key path: {self.attr}")
+        return value
 
     def _references_absent_data(self, data):
         """
@@ -155,7 +176,9 @@ class Condition:
         match and logging an error on every such event.
 
         Data which is present but lacks the attribute is left alone, so a genuine typo still
-        fails closed and is logged.
+        fails closed and is logged. So is a snapshot path which cannot be walked at all, as
+        determined from the opposite snapshot: the absence of a snapshot excuses the absence
+        of the data, not a malformed path.
         """
         if isinstance(data, AbsentData) and self.attr.split('.')[0] not in data:
             return True
@@ -166,8 +189,24 @@ class Condition:
             # No snapshot context at all (e.g. a job event). Treat as a mismatched rule
             # and let the normal path resolution fail closed.
             return False
-        which = self.attr.split('.')[1]
-        return which in snapshots and snapshots[which] is None
+        which, _sep, remainder = self.attr[len(SNAPSHOT_PREFIX):].partition('.')
+        if which not in snapshots or snapshots[which] is not None:
+            return False
+
+        # The referenced snapshot is null. Validate the remainder of the path against the
+        # opposite snapshot, so that a path which cannot be walked at all (e.g. the REST
+        # API-style 'status.value') fails closed here exactly as it does when both snapshots
+        # are present, rather than resolving to None and firing the rule on every create or
+        # delete. A path which is merely absent from the opposite snapshot is indeterminate
+        # and treated as absent, since it resolves to nothing either way.
+        other = snapshots.get(OPPOSITE_SNAPSHOT.get(which))
+        if remainder and other is not None:
+            try:
+                walk_path(other, remainder.split('.'))
+            except TypeError:
+                return False
+
+        return True
 
     def _resolve_snapshot_attr(self, snapshot):
         """
@@ -182,15 +221,7 @@ class Condition:
         if snapshot is None:
             return _MISSING
         try:
-            obj = snapshot
-            for key in self.attr.split('.'):
-                if isinstance(obj, list):
-                    obj = [operator.getitem(item or {}, key) for item in obj]
-                else:
-                    obj = operator.getitem(obj or {}, key)
-            return obj
-        except KeyError:
-            return _MISSING
+            return walk_path(snapshot, self.attr.split('.'))
         except TypeError as e:
             raise InvalidCondition(
                 f"Invalid key path for '{self.op}' operator: {self.attr} ({e}). Note that snapshots store "

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -12,21 +12,19 @@ __all__ = (
 AND = 'and'
 OR = 'or'
 
-# Prefix identifying a condition attribute that reads an event's pre- or post-change
-# snapshot directly, e.g. 'snapshots.prechange.status'.
+# Prefix identifying a condition attribute that reads an event's pre- or post-change snapshot directly, e.g.
+# 'snapshots.prechange.status'.
 SNAPSHOT_PREFIX = 'snapshots.'
 
-# Maps each snapshot to its counterpart, which is consulted to validate the shape of a path
-# referencing a snapshot that does not exist for the event type.
+# Maps each snapshot to its counterpart
 OPPOSITE_SNAPSHOT = {
     'prechange': 'postchange',
     'postchange': 'prechange',
 }
 
-# Sentinel for a snapshot attribute that could not be resolved (missing key or
-# null snapshot).  Using a unique object ensures that two independently
-# unresolvable values compare equal to each other, which is the correct
-# semantics for the 'unchanged' operator when neither snapshot has the field.
+# Sentinel for a snapshot attribute that could not be resolved (missing key or null snapshot). Using a unique object
+# ensures that two independently unresolvable values compare equal to each other, which is the correct semantics for the
+# 'unchanged' operator when neither snapshot has the field.
 _MISSING = object()
 
 
@@ -191,16 +189,6 @@ class Condition:
         * self.attr is a direct snapshot path (snapshots.prechange.* or
           snapshots.postchange.*) whose referenced snapshot is null. Create events have no
           prechange snapshot and delete events have no postchange snapshot.
-
-        In both cases the absence is a normal property of the event, not a malformed
-        condition, so such a reference resolves to None instead of raising: raising would
-        abort evaluation of the entire condition set, suppressing sibling conditions that do
-        match and logging an error on every such event.
-
-        Data which is present but lacks the attribute is left alone, so a genuine typo still
-        fails closed and is logged. So is a snapshot path which cannot be walked at all, as
-        determined from the opposite snapshot: the absence of a snapshot excuses the absence
-        of the data, not a malformed path.
         """
         if isinstance(data, AbsentData) and self.attr.split('.')[0] not in data:
             return True
@@ -208,8 +196,6 @@ class Condition:
             return False
         snapshots = data.get('snapshots') if isinstance(data, dict) else None
         if type(snapshots) is not dict:
-            # No snapshot context at all (e.g. a job event). Treat as a mismatched rule
-            # and let the normal path resolution fail closed.
             return False
         which, _sep, remainder = self.attr[len(SNAPSHOT_PREFIX):].partition('.')
         if which not in snapshots or snapshots[which] is not None:

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -189,6 +189,10 @@ class Condition:
         if type(snapshots) is not dict:
             return False
         which, _sep, remainder = self.attr[len(SNAPSHOT_PREFIX):].partition('.')
+        if which not in OPPOSITE_SNAPSHOT:
+            # Anything other than prechange or postchange names no snapshot the event could have
+            # recorded, so the path does not describe the data
+            return False
         if which not in snapshots or snapshots[which] is not None:
             return False
 
@@ -197,7 +201,7 @@ class Condition:
         # against the opposite snapshot so that such a path fails closed here exactly as it does
         # when both snapshots are present; otherwise a typo would resolve to null and fire the
         # rule on every create or delete, with nothing logged.
-        other = snapshots.get(OPPOSITE_SNAPSHOT.get(which))
+        other = snapshots.get(OPPOSITE_SNAPSHOT[which])
         if remainder and other is not None:
             try:
                 value = walk_path(other, remainder.split('.'), empty_list_is_absent=True)
@@ -271,7 +275,7 @@ class Condition:
         """
         if self.op in self.SNAPSHOT_OPERATORS:
             snapshots = data.get('snapshots') if isinstance(data, dict) else None
-            if snapshots is None:
+            if type(snapshots) is not dict:
                 raise InvalidCondition(
                     f"No snapshot data available for '{self.op}' operator. "
                     f"Snapshot operators are only meaningful on update and delete events."

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -5,6 +5,7 @@ import re
 from django.utils.translation import gettext as _
 
 __all__ = (
+    'AbsentData',
     'Condition',
     'ConditionSet',
     'InvalidCondition',
@@ -22,6 +23,21 @@ SNAPSHOT_PREFIX = 'snapshots.'
 # unresolvable values compare equal to each other, which is the correct
 # semantics for the 'unchanged' operator when neither snapshot has the field.
 _MISSING = object()
+
+
+class AbsentData(dict):
+    """
+    An empty dict standing in for event data which is absent altogether, as opposed to data
+    which is present but does not contain a referenced attribute.
+
+    A condition referencing an attribute of absent data resolves to null instead of raising
+    InvalidCondition: the absence is a normal property of the event (e.g. a job which
+    recorded no data), not a malformed condition, so it must not abort evaluation of the
+    condition set or log an error for every rule on every such event.
+    """
+    def copy(self):
+        # dict.copy() would return a plain dict, silently discarding the marker.
+        return AbsentData(self)
 
 
 def is_ruleset(data):
@@ -122,20 +138,27 @@ class Condition:
         except TypeError as e:
             raise InvalidCondition(f"Invalid key path: {self.attr} ({e})")
 
-    def _references_absent_snapshot(self, data):
+    def _references_absent_data(self, data):
         """
-        Return True if self.attr is a direct snapshot path (snapshots.prechange.* or
-        snapshots.postchange.*) whose referenced snapshot is null.
+        Return True if self.attr references data which is absent altogether, as opposed to
+        data which is present but does not contain the attribute. Two cases qualify:
 
-        Create events have no prechange snapshot and delete events have no postchange
-        snapshot. That is a normal property of the event, not a malformed condition, so
-        such a path resolves to None instead of raising: raising would abort evaluation of
-        the entire condition set, suppressing sibling conditions that do match and logging
-        an error on every create (or delete) of the object type.
+        * The data itself is absent (an AbsentData payload), e.g. a job event for a job
+          which recorded no data.
+        * self.attr is a direct snapshot path (snapshots.prechange.* or
+          snapshots.postchange.*) whose referenced snapshot is null. Create events have no
+          prechange snapshot and delete events have no postchange snapshot.
 
-        A path naming a snapshot that exists but lacks the attribute is left alone, so a
-        genuine typo still fails closed and is logged.
+        In both cases the absence is a normal property of the event, not a malformed
+        condition, so such a reference resolves to None instead of raising: raising would
+        abort evaluation of the entire condition set, suppressing sibling conditions that do
+        match and logging an error on every such event.
+
+        Data which is present but lacks the attribute is left alone, so a genuine typo still
+        fails closed and is logged.
         """
+        if isinstance(data, AbsentData) and self.attr.split('.')[0] not in data:
+            return True
         if not self.attr.startswith(SNAPSHOT_PREFIX):
             return False
         snapshots = data.get('snapshots') if isinstance(data, dict) else None
@@ -188,11 +211,18 @@ class Condition:
             result = self.eval_func(snapshots)
             return not result if self.negate else result
 
-        value = None if self._references_absent_snapshot(data) else self._resolve_attr(data)
+        absent = self._references_absent_data(data)
+        value = None if absent else self._resolve_attr(data)
         try:
             result = self.eval_func(value)
         except TypeError as e:
-            raise InvalidCondition(f"Invalid data type at '{self.attr}' for '{self.op}' evaluation: {e}")
+            if not absent:
+                raise InvalidCondition(f"Invalid data type at '{self.attr}' for '{self.op}' evaluation: {e}")
+            # Absent data resolves to null, which satisfies only a comparison against null:
+            # operators such as contains, regex, and the numeric comparisons raise a
+            # TypeError on None. That is a non-match, not a malformed condition, so report
+            # False (subject to negation below) rather than aborting the condition set.
+            result = False
 
         if self.negate:
             return not result

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -243,18 +243,26 @@ class Condition:
         Snapshots use the model serializer format (raw field values), not the REST
         API format, so e.g. status is stored as "active" not {"value": "active"}.
 
-        Raises InvalidCondition if the path cannot be walked in any snapshot and resolves to
-        a value in none of them, which is the case for a genuinely malformed path. A path
-        which resolves in one snapshot but not the other describes a real difference between
-        them (a JSON attribute whose value changed shape, say), so the unwalkable side is
-        treated as missing and the comparison proceeds: raising would report the attribute as
-        unchanged even though it demonstrably changed. Only a snapshot which actually yields
-        a value excuses the unwalkable side; one which merely resolves to nothing (an absent
-        key, a null, an empty list) offers no evidence that the path is well-formed.
+        Raises InvalidCondition if the attribute resolves in neither snapshot, leaving no
+        basis for the comparison: a misspelled or unknown attribute, a path which cannot be
+        walked at all, or an event which recorded no snapshots. The unresolved state must be
+        reported rather than compared, because any value the comparison could return is a
+        boolean which negate turns into a match: 'statsu' with the changed operator and
+        negate set would otherwise fire on every event, which is the very mistake failing
+        closed is meant to catch.
+
+        A path which resolves in one snapshot but not the other describes a real difference
+        between them (a JSON attribute whose value changed shape, say, or an attribute absent
+        from one side), so the unresolved side counts as missing and the comparison proceeds:
+        raising would report the attribute as unchanged even though it demonstrably changed.
+        Only a snapshot which actually yields a value excuses the other side; one which merely
+        resolves to nothing (an absent key, a null, an empty list) offers no evidence that the
+        path describes the data at all.
         """
         keys = self.attr.split('.')
         values = []
         errors = []
+        available = False
         resolved = False
 
         for which in ('prechange', 'postchange'):
@@ -263,6 +271,7 @@ class Condition:
                 # Absent snapshot (normal for create and delete events): nothing to resolve
                 values.append(_MISSING)
                 continue
+            available = True
             try:
                 value = walk_path(snapshot, keys, empty_list_is_absent=True)
             except TypeError as e:
@@ -272,10 +281,17 @@ class Condition:
                 values.append(value)
                 resolved = resolved or value is not _MISSING
 
-        if errors and not resolved:
+        if not available:
+            # Neither snapshot was recorded, so the attribute itself is not in question
             raise InvalidCondition(
-                f"Invalid key path for '{self.op}' operator: {self.attr} ({errors[0]}). Note that snapshots store "
-                f"raw field values, so choice fields have no '.value' suffix."
+                f"No snapshot data available for '{self.op}' operator: {self.attr}. "
+                f"Snapshot operators are only meaningful on update and delete events."
+            )
+        if not resolved:
+            reason = f" ({errors[0]})" if errors else ""
+            raise InvalidCondition(
+                f"Invalid key path for '{self.op}' operator: {self.attr}{reason}. The attribute resolves in neither "
+                f"snapshot. Note that snapshots store raw field values, so choice fields have no '.value' suffix."
             )
 
         return values
@@ -347,18 +363,17 @@ class Condition:
         return re.match(self.value, value) is not None
 
     # Snapshot comparison operators
-    # These resolve self.attr in both the prechange and postchange snapshots and
-    # compare the resulting values.  _MISSING is used when a snapshot is absent,
-    # does not contain the attribute, or cannot be walked by the path.
+    # These resolve self.attr in both the prechange and postchange snapshots and compare the
+    # resulting values. _MISSING is used for the side which does not resolve: a snapshot which
+    # is absent (normal for create and delete events), which does not contain the attribute,
+    # or which the path cannot be walked in. At least one side always resolves, since
+    # _resolve_snapshot_attrs() raises InvalidCondition when neither does.
     #
-    # Fail-closed semantics:
-    #   changed:   False when attr is absent from both snapshots (field never existed)
-    #   unchanged: False when attr is absent from both snapshots (avoids silent pass on typos)
-    #
-    # A path that cannot be walked in any of the snapshots available for the event (as
-    # opposed to one that resolves to nothing) raises InvalidCondition from
-    # _resolve_snapshot_attrs(), so a malformed condition is logged by
-    # EventRule.eval_conditions() rather than quietly evaluating False forever.
+    # Fail-closed semantics: an attribute which resolves in no snapshot available for the event
+    # leaves nothing to compare, so it is reported as an invalid condition rather than compared.
+    # Returning a boolean instead would let negate turn the failure into a match, and returning
+    # one quietly would leave a typo evaluating forever with no indication of why. The mistake
+    # is logged by EventRule.eval_conditions(), and the rule does not fire.
 
     def eval_changed(self, snapshots):
         pre, post = self._resolve_snapshot_attrs(snapshots)
@@ -366,8 +381,6 @@ class Condition:
 
     def eval_unchanged(self, snapshots):
         pre, post = self._resolve_snapshot_attrs(snapshots)
-        if pre is _MISSING and post is _MISSING:
-            return False
         return pre == post
 
 

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -208,25 +208,49 @@ class Condition:
 
         return True
 
-    def _resolve_snapshot_attr(self, snapshot):
+    def _resolve_snapshot_attrs(self, snapshots):
         """
-        Walk self.attr through a snapshot dict. Returns _MISSING when the attribute is
-        simply absent from the snapshot, but raises InvalidCondition when the path cannot
-        be walked at all (e.g. a REST API-style 'status.value' applied to a snapshot,
-        where status is the raw string "active" rather than a nested dict).
+        Walk self.attr through both the prechange and postchange snapshots, returning the
+        two resolved values. _MISSING is returned for a snapshot which is absent, which does
+        not contain the attribute, or in which the path cannot be walked at all (e.g. a REST
+        API-style 'status.value', where status is the raw string "active" rather than a
+        nested dict).
 
         Snapshots use the model serializer format (raw field values), not the REST
         API format, so e.g. status is stored as "active" not {"value": "active"}.
+
+        Raises InvalidCondition only if the path cannot be walked in *any* of the snapshots
+        available for the event, which is the case for a genuinely malformed path. A path
+        which resolves in one snapshot but not the other describes a real difference between
+        them (a JSON attribute whose value changed shape, say), so the unwalkable side is
+        treated as missing and the comparison proceeds: raising would report the attribute as
+        unchanged even though it demonstrably changed.
         """
-        if snapshot is None:
-            return _MISSING
-        try:
-            return walk_path(snapshot, self.attr.split('.'))
-        except TypeError as e:
+        keys = self.attr.split('.')
+        values = []
+        errors = []
+        available = 0
+
+        for which in ('prechange', 'postchange'):
+            snapshot = snapshots.get(which)
+            if snapshot is None:
+                # Absent snapshot (normal for create and delete events): nothing to resolve
+                values.append(_MISSING)
+                continue
+            available += 1
+            try:
+                values.append(walk_path(snapshot, keys))
+            except TypeError as e:
+                values.append(_MISSING)
+                errors.append(e)
+
+        if available and len(errors) == available:
             raise InvalidCondition(
-                f"Invalid key path for '{self.op}' operator: {self.attr} ({e}). Note that snapshots store "
+                f"Invalid key path for '{self.op}' operator: {self.attr} ({errors[0]}). Note that snapshots store "
                 f"raw field values, so choice fields have no '.value' suffix."
             )
+
+        return values
 
     def eval(self, data):
         """
@@ -296,25 +320,24 @@ class Condition:
 
     # Snapshot comparison operators
     # These resolve self.attr in both the prechange and postchange snapshots and
-    # compare the resulting values.  _MISSING is used when a snapshot is absent
-    # or does not contain the attribute.
+    # compare the resulting values.  _MISSING is used when a snapshot is absent,
+    # does not contain the attribute, or cannot be walked by the path.
     #
     # Fail-closed semantics:
     #   changed:   False when attr is absent from both snapshots (field never existed)
     #   unchanged: False when attr is absent from both snapshots (avoids silent pass on typos)
     #
-    # A path that cannot be walked at all (as opposed to one that resolves to nothing)
-    # raises InvalidCondition from _resolve_snapshot_attr(), so a malformed condition is
-    # logged by EventRule.eval_conditions() rather than quietly evaluating False forever.
+    # A path that cannot be walked in any of the snapshots available for the event (as
+    # opposed to one that resolves to nothing) raises InvalidCondition from
+    # _resolve_snapshot_attrs(), so a malformed condition is logged by
+    # EventRule.eval_conditions() rather than quietly evaluating False forever.
 
     def eval_changed(self, snapshots):
-        pre = self._resolve_snapshot_attr(snapshots.get('prechange'))
-        post = self._resolve_snapshot_attr(snapshots.get('postchange'))
+        pre, post = self._resolve_snapshot_attrs(snapshots)
         return pre != post
 
     def eval_unchanged(self, snapshots):
-        pre = self._resolve_snapshot_attr(snapshots.get('prechange'))
-        post = self._resolve_snapshot_attr(snapshots.get('postchange'))
+        pre, post = self._resolve_snapshot_attrs(snapshots)
         if pre is _MISSING and post is _MISSING:
             return False
         return pre == post

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -30,8 +30,16 @@ _MISSING = object()
 
 class AbsentData(dict):
     """
-    An empty dict standing in for event data which is absent altogether, as opposed to data
-    which is present but does not contain a referenced attribute.
+    An empty dict standing in for an event payload which cannot be evaluated: one which is
+    absent altogether (a job which recorded no data), or one which is present but unusable
+    (a payload which is not a dict at all, and so has no attributes to address). Either way
+    nothing can be resolved from it, as opposed to a usable payload which merely does not
+    contain a referenced attribute.
+
+    An unusable payload is an anomaly worth reporting and an absent one is routine, but that
+    distinction belongs where the payload is normalized (see extras.events), which reports it
+    once for the event rather than once per rule. By the time conditions are evaluated the two
+    are the same thing: no data to evaluate.
 
     A condition referencing an attribute of absent data is a non-match. It does not raise
     InvalidCondition: the absence is a normal property of the event (e.g. a job which

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -43,7 +43,7 @@ class AbsentData(dict):
         return AbsentData(self)
 
 
-def walk_path(obj, keys):
+def walk_path(obj, keys, empty_list_is_absent=False):
     """
     Walk a sequence of keys through obj, returning _MISSING if a key is absent along the way.
 
@@ -55,14 +55,23 @@ def walk_path(obj, keys):
     its truthiness: an empty string or a zero is just as unwalkable as any other scalar, and
     must be reported as such rather than being mistaken for an absent key.
 
-    Null values and empty lists are the exception. Neither is evidence of a malformed path,
-    since there is nothing there to walk either way, so both resolve to _MISSING exactly as
-    an absent key does.
+    Null values are the exception: a null is no evidence of a malformed path, since there is
+    nothing there to walk either way, so it resolves to _MISSING exactly as an absent key does.
+
+    Descending a key into an empty list maps it across no elements and so yields an empty
+    list, exactly as it yields a list of values for a populated one. An object with no tags
+    thus resolves 'tags.slug' to [], which is a legitimate value for a condition to compare
+    against, not a malformed path. Callers for which an empty list is instead an absence -
+    the snapshot operators, which need a resolved value to serve as evidence that the path is
+    well-formed - can pass empty_list_is_absent=True to get _MISSING.
     """
     for key in keys:
         if obj is None:
             return _MISSING
         if isinstance(obj, list):
+            if not obj and empty_list_is_absent:
+                # An empty list yields no evidence either way
+                return _MISSING
             values = []
             for item in obj:
                 if item is None:
@@ -72,9 +81,6 @@ def walk_path(obj, keys):
                 if key not in item:
                     return _MISSING
                 values.append(item[key])
-            if not values:
-                # An empty list yields no evidence either way
-                return _MISSING
             obj = values
         elif isinstance(obj, dict):
             if key not in obj:
@@ -248,7 +254,7 @@ class Condition:
                 values.append(_MISSING)
                 continue
             try:
-                value = walk_path(snapshot, keys)
+                value = walk_path(snapshot, keys, empty_list_is_absent=True)
             except TypeError as e:
                 values.append(_MISSING)
                 errors.append(e)

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -13,6 +13,10 @@ __all__ = (
 AND = 'and'
 OR = 'or'
 
+# Prefix identifying a condition attribute that reads an event's pre- or post-change
+# snapshot directly, e.g. 'snapshots.prechange.status'.
+SNAPSHOT_PREFIX = 'snapshots.'
+
 # Sentinel for a snapshot attribute that could not be resolved (missing key or
 # null snapshot).  Using a unique object ensures that two independently
 # unresolvable values compare equal to each other, which is the correct
@@ -78,7 +82,7 @@ class Condition:
                 raise ValueError(_(
                     "The '{op}' operator compares snapshots and does not accept a value."
                 ).format(op=op))
-            if attr.startswith('snapshots.'):
+            if attr.startswith(SNAPSHOT_PREFIX):
                 raise ValueError(_(
                     "The '{op}' operator resolves '{attr}' within each snapshot dict, not the "
                     "top-level condition context. Use the bare attribute name (e.g. 'status') "
@@ -117,6 +121,30 @@ class Condition:
             raise InvalidCondition(f"Invalid key path: {self.attr}")
         except TypeError as e:
             raise InvalidCondition(f"Invalid key path: {self.attr} ({e})")
+
+    def _references_absent_snapshot(self, data):
+        """
+        Return True if self.attr is a direct snapshot path (snapshots.prechange.* or
+        snapshots.postchange.*) whose referenced snapshot is null.
+
+        Create events have no prechange snapshot and delete events have no postchange
+        snapshot. That is a normal property of the event, not a malformed condition, so
+        such a path resolves to None instead of raising: raising would abort evaluation of
+        the entire condition set, suppressing sibling conditions that do match and logging
+        an error on every create (or delete) of the object type.
+
+        A path naming a snapshot that exists but lacks the attribute is left alone, so a
+        genuine typo still fails closed and is logged.
+        """
+        if not self.attr.startswith(SNAPSHOT_PREFIX):
+            return False
+        snapshots = data.get('snapshots') if isinstance(data, dict) else None
+        if type(snapshots) is not dict:
+            # No snapshot context at all (e.g. a job event). Treat as a mismatched rule
+            # and let the normal path resolution fail closed.
+            return False
+        which = self.attr.split('.')[1]
+        return which in snapshots and snapshots[which] is None
 
     def _resolve_snapshot_attr(self, snapshot):
         """
@@ -160,7 +188,7 @@ class Condition:
             result = self.eval_func(snapshots)
             return not result if self.negate else result
 
-        value = self._resolve_attr(data)
+        value = None if self._references_absent_snapshot(data) else self._resolve_attr(data)
         try:
             result = self.eval_func(value)
         except TypeError as e:

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -120,7 +120,11 @@ class Condition:
 
     def _resolve_snapshot_attr(self, snapshot):
         """
-        Walk self.attr through a snapshot dict, returning _MISSING on any miss.
+        Walk self.attr through a snapshot dict. Returns _MISSING when the attribute is
+        simply absent from the snapshot, but raises InvalidCondition when the path cannot
+        be walked at all (e.g. a REST API-style 'status.value' applied to a snapshot,
+        where status is the raw string "active" rather than a nested dict).
+
         Snapshots use the model serializer format (raw field values), not the REST
         API format, so e.g. status is stored as "active" not {"value": "active"}.
         """
@@ -134,8 +138,13 @@ class Condition:
                 else:
                     obj = operator.getitem(obj or {}, key)
             return obj
-        except (KeyError, TypeError):
+        except KeyError:
             return _MISSING
+        except TypeError as e:
+            raise InvalidCondition(
+                f"Invalid key path for '{self.op}' operator: {self.attr} ({e}). Note that snapshots store "
+                f"raw field values, so choice fields have no '.value' suffix."
+            )
 
     def eval(self, data):
         """
@@ -204,6 +213,10 @@ class Condition:
     # Fail-closed semantics:
     #   changed:   False when attr is absent from both snapshots (field never existed)
     #   unchanged: False when attr is absent from both snapshots (avoids silent pass on typos)
+    #
+    # A path that cannot be walked at all (as opposed to one that resolves to nothing)
+    # raises InvalidCondition from _resolve_snapshot_attr(), so a malformed condition is
+    # logged by EventRule.eval_conditions() rather than quietly evaluating False forever.
 
     def eval_changed(self, snapshots):
         pre = self._resolve_snapshot_attr(snapshots.get('prechange'))

--- a/netbox/extras/conditions.py
+++ b/netbox/extras/conditions.py
@@ -193,8 +193,9 @@ class Condition:
         * The data itself is absent (an AbsentData payload), e.g. a job event for a job
           which recorded no data.
         * self.attr is a direct snapshot path (snapshots.prechange.* or
-          snapshots.postchange.*) whose referenced snapshot is null. Create events have no
-          prechange snapshot and delete events have no postchange snapshot.
+          snapshots.postchange.*) whose referenced snapshot is null, and whose remaining path
+          the opposite snapshot shows to be resolvable. Create events have no prechange
+          snapshot and delete events have no postchange snapshot.
         """
         if isinstance(data, AbsentData) and self.attr.split('.')[0] not in data:
             return True
@@ -207,19 +208,28 @@ class Condition:
         if which not in snapshots or snapshots[which] is not None:
             return False
 
-        # The referenced snapshot is null. Validate the remainder of the path against the
-        # opposite snapshot, so that a path which cannot be walked at all (e.g. the REST
-        # API-style 'status.value') fails closed here exactly as it does when both snapshots
-        # are present, rather than resolving to None and firing the rule on every create or
-        # delete. A path which is merely absent from the opposite snapshot is indeterminate
-        # and treated as absent, since it resolves to nothing either way.
+        # The referenced snapshot is null. A null snapshot excuses only the absence of data
+        # the event would otherwise have carried, never a path which does not describe the
+        # data at all, so the remainder is validated against the opposite snapshot: only a
+        # path which resolves there is treated as genuinely absent here. A path the opposite
+        # snapshot cannot vouch for - because it cannot be walked at all (e.g. the REST
+        # API-style 'status.value'), or because it resolves to nothing there either (an absent
+        # key, a null, an empty list) - fails closed instead, exactly as it does when both
+        # snapshots are present. Otherwise a typo would resolve to null and fire the rule on
+        # every create or delete, and do so with nothing logged.
         other = snapshots.get(OPPOSITE_SNAPSHOT.get(which))
         if remainder and other is not None:
             try:
-                walk_path(other, remainder.split('.'))
+                value = walk_path(other, remainder.split('.'), empty_list_is_absent=True)
             except TypeError:
                 return False
+            if value is _MISSING:
+                return False
 
+        # Nothing to validate against: with the opposite snapshot absent too, the event
+        # carries no data anywhere for the path to be checked against. Treat the data as
+        # absent rather than logging an error for every rule on every such event; testing
+        # for the absent snapshot itself (snapshots.prechange, no remainder) lands here too.
         return True
 
     def _resolve_snapshot_attrs(self, snapshots):

--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -179,9 +179,6 @@ def process_event_rules(event_rules, object_type, event):
     # Normalize the event payload to a dict once for all rules. A null payload is routine
     # for job events (the job simply recorded no data); any other non-dict is unexpected
     # and worth surfacing, but must not take down event processing for the whole batch.
-    # Either way no attributes can be resolved from it, so substitute an AbsentData rather
-    # than a plain empty dict: a condition referencing the payload then resolves to null
-    # instead of raising (and logging an error) once per rule on every such event.
     data = event['data']
     if not isinstance(data, dict):
         if data is not None:
@@ -195,14 +192,7 @@ def process_event_rules(event_rules, object_type, event):
 
     for event_rule in event_rules:
 
-        # Evaluate event rule conditions (if any).
-        # Snapshots are merged into the condition context so conditions can
-        # reference snapshots.prechange.<attr> and snapshots.postchange.<attr>
-        # using the standard dot-path syntax, and so the 'changed'/'unchanged'
-        # operators can access pre/post values.
-        # data.copy() preserves an AbsentData payload (which unpacking into a new dict would
-        # not), so that conditions can distinguish absent data from data which is merely
-        # missing the referenced attribute.
+        # Merge snapshots and evaluate event rule conditions (if any).
         condition_data = data.copy()
         condition_data['snapshots'] = event.get('snapshots')
         if not event_rule.eval_conditions(condition_data):

--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -11,6 +11,7 @@ from netbox.models.features import has_feature
 from utilities.api import get_serializer_for_model
 from utilities.serialization import serialize_object
 
+from .conditions import AbsentData
 from .models import EventRule
 
 logger = logging.getLogger('netbox.events_processor')
@@ -178,6 +179,9 @@ def process_event_rules(event_rules, object_type, event):
     # Normalize the event payload to a dict once for all rules. A null payload is routine
     # for job events (the job simply recorded no data); any other non-dict is unexpected
     # and worth surfacing, but must not take down event processing for the whole batch.
+    # Either way no attributes can be resolved from it, so substitute an AbsentData rather
+    # than a plain empty dict: a condition referencing the payload then resolves to null
+    # instead of raising (and logging an error) once per rule on every such event.
     data = event['data']
     if not isinstance(data, dict):
         if data is not None:
@@ -187,7 +191,7 @@ def process_event_rules(event_rules, object_type, event):
                     data_type=type(data).__name__,
                 )
             )
-        data = {}
+        data = AbsentData()
 
     for event_rule in event_rules:
 
@@ -196,7 +200,11 @@ def process_event_rules(event_rules, object_type, event):
         # reference snapshots.prechange.<attr> and snapshots.postchange.<attr>
         # using the standard dot-path syntax, and so the 'changed'/'unchanged'
         # operators can access pre/post values.
-        condition_data = {**data, 'snapshots': event.get('snapshots')}
+        # data.copy() preserves an AbsentData payload (which unpacking into a new dict would
+        # not), so that conditions can distinguish absent data from data which is merely
+        # missing the referenced attribute.
+        condition_data = data.copy()
+        condition_data['snapshots'] = event.get('snapshots')
         if not event_rule.eval_conditions(condition_data):
             continue
 

--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -161,15 +161,33 @@ def process_event_rules(event_rules, object_type, event):
 
     Notes on event sources:
     - Object change events (created/updated/deleted) are enqueued via enqueue_event()
-      during an HTTP request. These events include a request object.
+      during an HTTP request. These events include a request object, and their payload is
+      always the serialized object.
     - Job lifecycle events (JOB_STARTED/JOB_COMPLETED) are emitted by job_start/job_end
       signal handlers and may not include a request context. Consumers must not assume
-      that a request is always present.
+      that a request is always present. Their payload is the job's `data` field, which is
+      nullable and (for a job which sets it directly) not guaranteed to be a dict.
     """
+    if not event_rules:
+        return
 
     # Normalize object_type onto the event context so that an action's enqueue() can always read
     # event_context['object_type']: job-lifecycle events pass it only as this parameter.
     event['object_type'] = object_type
+
+    # Normalize the event payload to a dict once for all rules. A null payload is routine
+    # for job events (the job simply recorded no data); any other non-dict is unexpected
+    # and worth surfacing, but must not take down event processing for the whole batch.
+    data = event['data']
+    if not isinstance(data, dict):
+        if data is not None:
+            logger.warning(
+                _('Ignoring invalid data payload on {event_type} event (got {data_type})').format(
+                    event_type=event['event_type'],
+                    data_type=type(data).__name__,
+                )
+            )
+        data = {}
 
     for event_rule in event_rules:
 
@@ -178,7 +196,7 @@ def process_event_rules(event_rules, object_type, event):
         # reference snapshots.prechange.<attr> and snapshots.postchange.<attr>
         # using the standard dot-path syntax, and so the 'changed'/'unchanged'
         # operators can access pre/post values.
-        condition_data = {**event['data'], 'snapshots': event.get('snapshots')}
+        condition_data = {**data, 'snapshots': event.get('snapshots')}
         if not event_rule.eval_conditions(condition_data):
             continue
 
@@ -201,7 +219,7 @@ def process_event_rules(event_rules, object_type, event):
 
         # Merge rule-specific action_data with the event payload.
         # Copy to avoid mutating the rule's stored action_data dict.
-        event_data = {**action_data, **event['data']}
+        event_data = {**action_data, **data}
 
         action = event_rule.action_provider
         if action is None:

--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -176,9 +176,17 @@ def process_event_rules(event_rules, object_type, event):
     # event_context['object_type']: job-lifecycle events pass it only as this parameter.
     event['object_type'] = object_type
 
-    # Normalize the event payload to a dict once for all rules. A null payload is routine
-    # for job events (the job simply recorded no data); any other non-dict is unexpected
-    # and worth surfacing, but must not take down event processing for the whole batch.
+    # Normalize the event payload to a dict once for all rules. A null payload is routine for
+    # job events (the job simply recorded no data); any other non-dict is unexpected and worth
+    # surfacing, but must not take down event processing for the whole batch. This is the only
+    # place the two are distinguished, and it reports the anomaly once for the event rather
+    # than once per rule.
+    #
+    # Both become AbsentData, which conditions treat as data absent altogether: neither offers
+    # an attribute to resolve, so a conditioned rule fails closed on either rather than
+    # matching a comparison against null. A rule with no conditions still fires, receiving the
+    # empty payload - dropping an unusable payload is deliberate, since there is nothing
+    # meaningful to hand the action.
     data = event['data']
     if not isinstance(data, dict):
         if data is not None:

--- a/netbox/extras/events.py
+++ b/netbox/extras/events.py
@@ -176,17 +176,7 @@ def process_event_rules(event_rules, object_type, event):
     # event_context['object_type']: job-lifecycle events pass it only as this parameter.
     event['object_type'] = object_type
 
-    # Normalize the event payload to a dict once for all rules. A null payload is routine for
-    # job events (the job simply recorded no data); any other non-dict is unexpected and worth
-    # surfacing, but must not take down event processing for the whole batch. This is the only
-    # place the two are distinguished, and it reports the anomaly once for the event rather
-    # than once per rule.
-    #
-    # Both become AbsentData, which conditions treat as data absent altogether: neither offers
-    # an attribute to resolve, so a conditioned rule fails closed on either rather than
-    # matching a comparison against null. A rule with no conditions still fires, receiving the
-    # empty payload - dropping an unusable payload is deliberate, since there is nothing
-    # meaningful to hand the action.
+    # Normalize the event payload to a dict or AbsentData once for all rules.
     data = event['data']
     if not isinstance(data, dict):
         if data is not None:

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -494,6 +494,45 @@ class SnapshotConditionTestCase(TestCase):
         with self.assertRaises(InvalidCondition):
             c.eval({'snapshots': snapshots})
 
+    def test_changed_when_path_is_walkable_in_only_one_snapshot(self):
+        """
+        A path which resolves in one snapshot but not the other is not malformed: it
+        describes a real difference between them, such as a JSON attribute whose value
+        changed shape. The unwalkable side counts as missing and the comparison proceeds,
+        rather than raising and reporting the attribute as unchanged.
+        """
+        snapshots = {
+            'prechange': {'custom_fields': {'blob': 'legacy'}},
+            'postchange': {'custom_fields': {'blob': {'key': 1}}},
+        }
+        reversed_snapshots = {'prechange': snapshots['postchange'], 'postchange': snapshots['prechange']}
+        self.assertTrue(Condition('custom_fields.blob.key', op='changed').eval({'snapshots': snapshots}))
+        self.assertTrue(Condition('custom_fields.blob.key', op='changed').eval({'snapshots': reversed_snapshots}))
+        self.assertFalse(Condition('custom_fields.blob.key', op='unchanged').eval({'snapshots': snapshots}))
+
+    def test_changed_raises_when_only_available_snapshot_traverses_scalar(self):
+        """
+        On create and delete events only one snapshot is available, so an unwalkable path is
+        unwalkable everywhere it can be evaluated: still malformed, and still raises.
+        """
+        with self.assertRaises(InvalidCondition):
+            Condition('status.value', op='changed').eval({
+                'snapshots': {'prechange': None, 'postchange': {'status': 'active'}}
+            })
+        with self.assertRaises(InvalidCondition):
+            Condition('status.value', op='changed').eval({
+                'snapshots': {'prechange': {'status': 'active'}, 'postchange': None}
+            })
+
+    def test_changed_does_not_raise_when_no_snapshot_is_available(self):
+        """
+        With neither snapshot available there is nothing to walk, so even a malformed path
+        cannot be identified as such; both sides are missing and the operators fail closed.
+        """
+        snapshots = {'prechange': None, 'postchange': None}
+        self.assertFalse(Condition('status.value', op='changed').eval({'snapshots': snapshots}))
+        self.assertFalse(Condition('status.value', op='unchanged').eval({'snapshots': snapshots}))
+
     def test_changed_missing_attr_still_resolves_to_missing(self):
         # An attribute that is simply absent is an ordinary state difference, not a
         # malformed path, and must not raise.

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -642,6 +642,42 @@ class SnapshotConditionTestCase(TestCase):
         with self.assertRaises(InvalidCondition):
             Condition('snapshots.bogus.status', value='planned').eval({'snapshots': snapshots})
 
+    def test_absent_snapshot_path_traversing_scalar_still_fails_closed(self):
+        """
+        An absent snapshot excuses only the absence of the data, not a path which cannot be
+        walked at all. A REST API-style 'status.value' must fail closed on create and delete
+        events exactly as it does on updates, rather than resolving to null (which would fire
+        the rule on every create) with nothing logged.
+        """
+        create = {'snapshots': {'prechange': None, 'postchange': {'status': 'active', 'tags': ['Alpha']}}}
+        with self.assertRaises(InvalidCondition):
+            Condition('snapshots.prechange.status.value', value='active').eval(create)
+        with self.assertRaises(InvalidCondition):
+            # A test for null must not escape the check either
+            Condition('snapshots.prechange.status.value', value=None).eval(create)
+        with self.assertRaises(InvalidCondition):
+            # Snapshot list fields hold raw values, so descending into an element is
+            # equally unwalkable
+            Condition('snapshots.prechange.tags.name', value='Alpha').eval(create)
+
+        delete = {'snapshots': {'prechange': {'status': 'active'}, 'postchange': None}}
+        with self.assertRaises(InvalidCondition):
+            Condition('snapshots.postchange.status.value', value='active').eval(delete)
+
+    def test_absent_snapshot_path_resolves_to_none_when_shape_is_valid(self):
+        """
+        A nested path which the opposite snapshot shows to be walkable is a genuine absence,
+        so it resolves to null. So is a path which cannot be checked at all, because the
+        opposite snapshot does not contain it either or is itself null.
+        """
+        create = {'snapshots': {'prechange': None, 'postchange': {'custom_fields': {'cf1': 'x'}}}}
+        self.assertTrue(Condition('snapshots.prechange.custom_fields.cf1', value=None).eval(create))
+        self.assertTrue(Condition('snapshots.prechange.nonexistent.attr', value=None).eval(create))
+        self.assertTrue(Condition('snapshots.prechange', value=None).eval(create))
+
+        both_absent = {'snapshots': {'prechange': None, 'postchange': None}}
+        self.assertTrue(Condition('snapshots.prechange.status.value', value=None).eval(both_absent))
+
     def test_snapshot_path_without_snapshot_context_fails_closed(self):
         """
         A snapshot path used where there is no snapshot context at all (e.g. a job event)
@@ -727,6 +763,29 @@ class SnapshotConditionTestCase(TestCase):
             'postchange': {'status': SiteStatusChoices.STATUS_ACTIVE},
         })
         self.assertFalse(event_rule.eval_conditions(data))
+
+    def test_event_rule_snapshot_path_rest_api_style_attr_on_create_is_logged(self):
+        """
+        The same mistake must behave identically on a create event, where the prechange
+        snapshot is absent: fail closed and log, rather than resolving to null and firing
+        the rule for every object created.
+        """
+        event_rule = EventRule(
+            name='Was planned (REST-style mistake)',
+            event_types=[OBJECT_CREATED, OBJECT_UPDATED],
+            conditions={
+                'attr': 'snapshots.prechange.status.value',
+                'value': None,
+            }
+        )
+        site = Site.objects.create(name='Site 6', slug='site-6', status=SiteStatusChoices.STATUS_ACTIVE)
+        data = self._make_condition_data(site, {
+            'prechange': None,
+            'postchange': {'status': SiteStatusChoices.STATUS_ACTIVE},
+        })
+        with self.assertLogs('netbox.event_rules', level='ERROR') as cm:
+            self.assertFalse(event_rule.eval_conditions(data))
+        self.assertIn('snapshots.prechange.status.value', cm.output[0])
 
     def test_event_rule_changed_operator_rest_api_style_attr_is_logged(self):
         """

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -524,6 +524,57 @@ class SnapshotConditionTestCase(TestCase):
         with self.assertRaises(InvalidCondition):
             c.eval({'snapshots': snapshots})
 
+    def test_snapshot_path_resolves_to_none_when_prechange_absent(self):
+        """
+        On a create event there is no prechange snapshot. That is a property of the event,
+        not a malformed condition, so the path resolves to None rather than raising.
+        """
+        snapshots = {'prechange': None, 'postchange': {'status': 'active'}}
+        self.assertFalse(Condition('snapshots.prechange.status', value='planned').eval({'snapshots': snapshots}))
+        self.assertTrue(Condition('snapshots.prechange.status', value=None).eval({'snapshots': snapshots}))
+        self.assertTrue(
+            Condition('snapshots.prechange.status', value='planned', negate=True).eval({'snapshots': snapshots})
+        )
+
+    def test_snapshot_path_resolves_to_none_when_postchange_absent(self):
+        """As above, for the postchange snapshot on a delete event."""
+        snapshots = {'prechange': {'status': 'active'}, 'postchange': None}
+        self.assertFalse(Condition('snapshots.postchange.status', value='active').eval({'snapshots': snapshots}))
+        self.assertTrue(Condition('snapshots.postchange.status', value=None).eval({'snapshots': snapshots}))
+
+    def test_absent_snapshot_does_not_veto_sibling_conditions(self):
+        """
+        Regression: an absent prechange snapshot must not abort evaluation of the whole
+        condition set, which would suppress a sibling condition that does match. The
+        result must also not depend on the order of the conditions.
+        """
+        data = {'name': 'Site 1', 'snapshots': {'prechange': None, 'postchange': {'status': 'active'}}}
+        snapshot_rule = {'attr': 'snapshots.prechange.status', 'value': 'planned'}
+        name_rule = {'attr': 'name', 'value': 'Site 1'}
+        self.assertTrue(ConditionSet({'or': [snapshot_rule, name_rule]}).eval(data))
+        self.assertTrue(ConditionSet({'or': [name_rule, snapshot_rule]}).eval(data))
+
+    def test_snapshot_path_typo_still_fails_closed(self):
+        """
+        A path naming a snapshot that exists but lacks the attribute is a genuine typo and
+        must still raise, so that it is logged rather than silently evaluating.
+        """
+        snapshots = {'prechange': {'status': 'planned'}, 'postchange': {'status': 'active'}}
+        with self.assertRaises(InvalidCondition):
+            Condition('snapshots.prechange.stauts', value='planned').eval({'snapshots': snapshots})
+        with self.assertRaises(InvalidCondition):
+            Condition('snapshots.bogus.status', value='planned').eval({'snapshots': snapshots})
+
+    def test_snapshot_path_without_snapshot_context_fails_closed(self):
+        """
+        A snapshot path used where there is no snapshot context at all (e.g. a job event)
+        is a mismatched rule and must fail closed rather than resolving to None.
+        """
+        with self.assertRaises(InvalidCondition):
+            Condition('snapshots.prechange.status', value='planned').eval({'snapshots': None})
+        with self.assertRaises(InvalidCondition):
+            Condition('snapshots.prechange.status', value='planned').eval({'name': 'Site 1'})
+
     #
     # EventRule.eval_conditions integration
     #

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -53,6 +53,24 @@ class ConditionTestCase(TestCase):
         with self.assertRaises(InvalidCondition):
             c.eval({'x': {'y': {'a': 1}}})
 
+    def test_nested_within_list(self):
+        c = Condition('tags.slug', 'exempt', 'contains')
+        self.assertTrue(c.eval({'tags': [{'slug': 'exempt'}, {'slug': 'other'}]}))
+        self.assertFalse(c.eval({'tags': [{'slug': 'other'}]}))
+
+    def test_nested_within_empty_list(self):
+        """
+        Descending into an empty list resolves to an empty list, not an absent attribute: an
+        object with no tags is a legitimate non-match for the documented 'tags.slug contains'
+        condition, not a malformed path. Raising here would abort the whole condition set,
+        which for an 'or' set means a matching sibling condition never gets evaluated.
+        """
+        self.assertFalse(Condition('tags.slug', 'exempt', 'contains').eval({'tags': []}))
+        self.assertTrue(Condition('tags.slug', 'exempt', 'contains', negate=True).eval({'tags': []}))
+        self.assertTrue(Condition('tags.slug', [], 'eq').eval({'tags': []}))
+        # The list is carried through the remainder of the path, just as a populated one is
+        self.assertFalse(Condition('tags.parent.slug', 'exempt', 'contains').eval({'tags': []}))
+
     #
     # Operator tests
     #
@@ -235,6 +253,28 @@ class ConditionSetTestCase(TestCase):
         self.assertTrue(cs.eval({'a': 1, 'b': 2, 'c': 9}))
         self.assertFalse(cs.eval({'a': 9, 'b': 2, 'c': 9}))
         self.assertFalse(cs.eval({'a': 9, 'b': 9, 'c': 3}))
+
+    def test_untagged_object_does_not_veto_sibling_conditions(self):
+        """
+        The documented "status is active and primary_ip4 is defined, or the exempt tag is
+        applied" example, evaluated for an object with no tags at all. The tag condition is a
+        plain non-match: it must not abort the set before its sibling is reached, whichever
+        order the two are listed in.
+        """
+        tag_rule = {'attr': 'tags.slug', 'value': 'exempt', 'op': 'contains'}
+        status_rule = {'and': [
+            {'attr': 'status.value', 'value': 'active'},
+            {'attr': 'primary_ip4', 'value': None, 'negate': True},
+        ]}
+        data = {'status': {'value': 'active'}, 'primary_ip4': {'address': '192.0.2.1/32'}, 'tags': []}
+
+        self.assertTrue(ConditionSet({'or': [tag_rule, status_rule]}).eval(data))
+        self.assertTrue(ConditionSet({'or': [status_rule, tag_rule]}).eval(data))
+
+        # Neither condition matches: still False rather than an error
+        self.assertFalse(ConditionSet({'or': [tag_rule, status_rule]}).eval({
+            'status': {'value': 'planned'}, 'primary_ip4': None, 'tags': []
+        }))
 
     def test_event_rule_conditions_without_logic_operator(self):
         """

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -404,14 +404,46 @@ class SnapshotConditionTestCase(TestCase):
         }
         self.assertFalse(c.eval({'snapshots': snapshots}))
 
-    def test_changed_false_when_path_traverses_scalar(self):
-        # Snapshot choice fields are raw strings, not nested dicts. A path like
-        # 'status.value' hits a TypeError when traversing into the string; both
-        # sides resolve to _MISSING and the operator returns False (no change).
+    def test_changed_raises_when_path_traverses_scalar(self):
+        # Snapshot choice fields are raw strings, not nested dicts. A REST API-style path
+        # like 'status.value' cannot be walked at all, which is a malformed condition
+        # rather than an absent attribute: it must raise so that the mistake is logged,
+        # not silently evaluate False on every event.
         c = Condition('status.value', op='changed')
         snapshots = {
             'prechange': {'status': 'planned'},
             'postchange': {'status': 'active'},
+        }
+        with self.assertRaises(InvalidCondition):
+            c.eval({'snapshots': snapshots})
+
+    def test_unchanged_raises_when_path_traverses_scalar(self):
+        c = Condition('status.value', op='unchanged')
+        snapshots = {
+            'prechange': {'status': 'active'},
+            'postchange': {'status': 'active'},
+        }
+        with self.assertRaises(InvalidCondition):
+            c.eval({'snapshots': snapshots})
+
+    def test_changed_raises_when_path_traverses_scalar_in_list(self):
+        # Snapshot list fields hold raw values (e.g. tag names), so a path descending
+        # into a list element is equally unwalkable.
+        c = Condition('tags.name', op='changed')
+        snapshots = {
+            'prechange': {'tags': ['Alpha']},
+            'postchange': {'tags': ['Alpha', 'Beta']},
+        }
+        with self.assertRaises(InvalidCondition):
+            c.eval({'snapshots': snapshots})
+
+    def test_changed_missing_attr_still_resolves_to_missing(self):
+        # An attribute that is simply absent is an ordinary state difference, not a
+        # malformed path, and must not raise.
+        c = Condition('nonexistent', op='changed')
+        snapshots = {
+            'prechange': {'status': 'planned'},
+            'postchange': {'status': 'active', 'description': 'x'},
         }
         self.assertFalse(c.eval({'snapshots': snapshots}))
 
@@ -567,3 +599,23 @@ class SnapshotConditionTestCase(TestCase):
             'postchange': {'status': SiteStatusChoices.STATUS_ACTIVE},
         })
         self.assertFalse(event_rule.eval_conditions(data))
+
+    def test_event_rule_changed_operator_rest_api_style_attr_is_logged(self):
+        """
+        The same REST API-style mistake made with a snapshot operator must also fail
+        closed *and* be logged. Silently evaluating False would leave the rule dead with
+        no indication of why, even though the watched attribute really did change.
+        """
+        event_rule = EventRule(
+            name='Activated (REST-style mistake)',
+            event_types=[OBJECT_UPDATED],
+            conditions={'attr': 'status.value', 'op': 'changed'}
+        )
+        site = Site.objects.create(name='Site 5', slug='site-5', status=SiteStatusChoices.STATUS_ACTIVE)
+        data = self._make_condition_data(site, {
+            'prechange': {'status': SiteStatusChoices.STATUS_PLANNED},
+            'postchange': {'status': SiteStatusChoices.STATUS_ACTIVE},
+        })
+        with self.assertLogs('netbox.event_rules', level='ERROR') as cm:
+            self.assertFalse(event_rule.eval_conditions(data))
+        self.assertIn('status.value', cm.output[0])

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -684,6 +684,19 @@ class SnapshotConditionTestCase(TestCase):
         with self.assertRaises(InvalidCondition):
             c.eval({'status': {'value': 'active'}})
 
+    def test_changed_raises_when_snapshots_is_not_a_dict(self):
+        """
+        A snapshots value which is not a dict holds no snapshot to compare. It must be reported
+        as an invalid condition, matching a direct snapshot path against the same data, rather
+        than raising an uncaught AttributeError which would abort event processing entirely.
+        """
+        for snapshots in ('oops', ['prechange'], 42):
+            with self.subTest(snapshots=snapshots):
+                with self.assertRaises(InvalidCondition):
+                    Condition('status', op='changed').eval({'snapshots': snapshots})
+                with self.assertRaises(InvalidCondition):
+                    Condition('snapshots.prechange.status', value='active').eval({'snapshots': snapshots})
+
     #
     # 'unchanged' operator
     #
@@ -809,6 +822,12 @@ class SnapshotConditionTestCase(TestCase):
             Condition('snapshots.prechange.stauts', value='planned').eval({'snapshots': snapshots})
         with self.assertRaises(InvalidCondition):
             Condition('snapshots.bogus.status', value='planned').eval({'snapshots': snapshots})
+
+        # A misnamed snapshot which happens to be null names no snapshot the event could have
+        # recorded, so it has no absence to excuse it: it must fail closed like any other typo,
+        # rather than resolving to null and firing the rule
+        with self.assertRaises(InvalidCondition):
+            Condition('snapshots.bogus.status', value=None).eval({'snapshots': {'bogus': None}})
 
     def test_absent_snapshot_path_traversing_scalar_still_fails_closed(self):
         """

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -492,14 +492,16 @@ class SnapshotConditionTestCase(TestCase):
         }
         self.assertTrue(c.eval({'snapshots': snapshots}))
 
-    def test_changed_false_when_both_snapshots_missing_attr(self):
-        # If neither snapshot has the attr, nothing changed
+    def test_changed_raises_when_both_snapshots_missing_attr(self):
+        # An attr absent from both snapshots leaves nothing to compare: report it rather than
+        # returning a non-match, which negate would turn into a match
         c = Condition('nonexistent', op='changed')
         snapshots = {
             'prechange': {'status': 'active'},
             'postchange': {'status': 'active'},
         }
-        self.assertFalse(c.eval({'snapshots': snapshots}))
+        with self.assertRaises(InvalidCondition):
+            c.eval({'snapshots': snapshots})
 
     def test_changed_raises_when_path_traverses_scalar(self):
         # Snapshot choice fields are raw strings, not nested dicts. A REST API-style path
@@ -598,24 +600,35 @@ class SnapshotConditionTestCase(TestCase):
                 'snapshots': {'prechange': {'status': 'active'}, 'postchange': None}
             })
 
-    def test_changed_does_not_raise_when_no_snapshot_is_available(self):
+    def test_changed_raises_when_no_snapshot_is_available(self):
         """
-        With neither snapshot available there is nothing to walk, so even a malformed path
-        cannot be identified as such; both sides are missing and the operators fail closed.
+        With neither snapshot available there is nothing to compare, whether the path is
+        malformed or not. Reporting the condition is the only way to fail closed: a boolean
+        would be a verdict on data the event never carried, and negate would turn it into a
+        match.
         """
         snapshots = {'prechange': None, 'postchange': None}
-        self.assertFalse(Condition('status.value', op='changed').eval({'snapshots': snapshots}))
-        self.assertFalse(Condition('status.value', op='unchanged').eval({'snapshots': snapshots}))
+        for attr, op, negate in (
+            ('status', 'changed', False),
+            ('status', 'changed', True),
+            ('status', 'unchanged', True),
+            ('status.value', 'changed', False),
+            ('status.value', 'unchanged', False),
+        ):
+            with self.subTest(attr=attr, op=op, negate=negate):
+                with self.assertRaises(InvalidCondition):
+                    Condition(attr, op=op, negate=negate).eval({'snapshots': snapshots})
 
-    def test_changed_missing_attr_still_resolves_to_missing(self):
-        # An attribute that is simply absent is an ordinary state difference, not a
-        # malformed path, and must not raise.
+    def test_changed_raises_when_attr_resolves_in_neither_snapshot(self):
+        # An attribute absent from both snapshots is indistinguishable from a typo, so it
+        # cannot be reported as an ordinary non-match
         c = Condition('nonexistent', op='changed')
         snapshots = {
             'prechange': {'status': 'planned'},
             'postchange': {'status': 'active', 'description': 'x'},
         }
-        self.assertFalse(c.eval({'snapshots': snapshots}))
+        with self.assertRaises(InvalidCondition):
+            c.eval({'snapshots': snapshots})
 
     def test_changed_negated(self):
         c = Condition('status', op='changed', negate=True)
@@ -624,6 +637,23 @@ class SnapshotConditionTestCase(TestCase):
             'postchange': {'status': 'active'},
         }
         self.assertFalse(c.eval({'snapshots': snapshots}))
+        self.assertTrue(c.eval({'snapshots': {
+            'prechange': {'status': 'active'},
+            'postchange': {'status': 'active'},
+        }}))
+
+    def test_negate_cannot_turn_an_unresolved_attr_into_a_match(self):
+        """
+        A misspelled attribute must not fire the rule, whichever operator it is used with and
+        whether or not the condition is negated. Returning False for the unresolved state
+        would make 'negate' a fail-open switch.
+        """
+        snapshots = {'prechange': {'status': 'planned'}, 'postchange': {'status': 'active'}}
+        for op in ('changed', 'unchanged'):
+            for negate in (False, True):
+                with self.subTest(op=op, negate=negate):
+                    with self.assertRaises(InvalidCondition):
+                        Condition('statsu', op=op, negate=negate).eval({'snapshots': snapshots})
 
     def test_changed_raises_when_no_snapshots(self):
         c = Condition('status', op='changed')
@@ -650,15 +680,16 @@ class SnapshotConditionTestCase(TestCase):
         }
         self.assertFalse(c.eval({'snapshots': snapshots}))
 
-    def test_unchanged_false_when_both_snapshots_missing_attr(self):
-        # Fail-closed: a typo or non-existent attr resolves to _MISSING on both
-        # sides; unchanged must return False rather than silently passing.
+    def test_unchanged_raises_when_both_snapshots_missing_attr(self):
+        # Fail-closed: a typo or non-existent attr resolves on neither side, so 'unchanged'
+        # must report it rather than silently passing (or, negated, matching)
         c = Condition('statsu', op='unchanged')
         snapshots = {
             'prechange': {'status': 'active'},
             'postchange': {'status': 'active'},
         }
-        self.assertFalse(c.eval({'snapshots': snapshots}))
+        with self.assertRaises(InvalidCondition):
+            c.eval({'snapshots': snapshots})
 
     #
     # Direct snapshot path access (snapshots.prechange.* / snapshots.postchange.*)

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -4,7 +4,7 @@ from django.test import TestCase
 from core.events import *
 from dcim.choices import SiteStatusChoices
 from dcim.models import Site
-from extras.conditions import Condition, ConditionSet, InvalidCondition
+from extras.conditions import AbsentData, Condition, ConditionSet, InvalidCondition
 from extras.events import serialize_for_event
 from extras.forms import EventRuleForm
 from extras.models import EventRule, Webhook
@@ -323,6 +323,63 @@ class ConditionSetTestCase(TestCase):
         self.assertFalse(form.is_valid())
 
 
+class AbsentDataTestCase(TestCase):
+    """
+    Tests for conditions evaluated against an AbsentData payload, i.e. event data which is
+    absent altogether (a job which recorded no data) rather than merely lacking the
+    referenced attribute.
+    """
+
+    def _absent_data(self, **kwargs):
+        """Return an absent payload as produced by process_event_rules()."""
+        data = AbsentData()
+        data['snapshots'] = kwargs.get('snapshots')
+        return data
+
+    def test_absent_data_resolves_to_none(self):
+        data = self._absent_data()
+        self.assertTrue(Condition('status', value=None).eval(data))
+        self.assertFalse(Condition('status', value='completed').eval(data))
+        self.assertTrue(Condition('status', value='completed', negate=True).eval(data))
+        # A nested path is equally unresolvable, and equally not an error
+        self.assertFalse(Condition('output.result', value='x').eval(data))
+
+    def test_absent_data_is_a_non_match_for_every_operator(self):
+        data = self._absent_data()
+        for op, value in (('contains', 'foo'), ('regex', '^foo'), ('gt', 1), ('gte', 1), ('lt', 1), ('lte', 1)):
+            with self.subTest(op=op):
+                self.assertFalse(Condition('status', value=value, op=op).eval(data))
+
+    def test_absent_data_does_not_veto_sibling_conditions(self):
+        """
+        As with an absent snapshot, an absent payload must not abort evaluation of the whole
+        condition set.
+        """
+        data = self._absent_data()
+        ruleset = {'or': [
+            {'attr': 'status', 'value': 'foo', 'op': 'regex'},
+            {'attr': 'status', 'value': None},
+        ]}
+        self.assertTrue(ConditionSet(ruleset).eval(data))
+
+    def test_present_data_missing_attr_still_fails_closed(self):
+        """
+        Only data which is absent altogether resolves to None; a payload which is present
+        but lacks the attribute remains a fail-closed error, so that a typo is logged.
+        """
+        with self.assertRaises(InvalidCondition):
+            Condition('status', value='completed').eval({'other': 1})
+
+    def test_snapshot_path_against_absent_data(self):
+        """
+        The absent-payload marker must not short-circuit a snapshot path: the snapshots key
+        is part of the evaluation context, not of the payload.
+        """
+        data = self._absent_data(snapshots={'prechange': {'status': 'planned'}, 'postchange': None})
+        self.assertTrue(Condition('snapshots.prechange.status', value='planned').eval(data))
+        self.assertTrue(Condition('snapshots.postchange.status', value=None).eval(data))
+
+
 class SnapshotConditionTestCase(TestCase):
     """
     Tests for snapshot-aware conditions: the 'changed'/'unchanged' operators and
@@ -542,17 +599,37 @@ class SnapshotConditionTestCase(TestCase):
         self.assertFalse(Condition('snapshots.postchange.status', value='active').eval({'snapshots': snapshots}))
         self.assertTrue(Condition('snapshots.postchange.status', value=None).eval({'snapshots': snapshots}))
 
+    def test_absent_snapshot_is_a_non_match_for_every_operator(self):
+        """
+        An absent snapshot resolves to None, which satisfies only a comparison against null.
+        Operators which raise a TypeError on None must report a plain non-match rather than
+        aborting evaluation, so that the guarantee holds for all operators and not just
+        those which happen to tolerate None.
+        """
+        data = {'snapshots': {'prechange': None, 'postchange': {'description': 'foo'}}}
+        attr = 'snapshots.prechange.description'
+        for op, value in (('contains', 'foo'), ('regex', '^foo'), ('gt', 1), ('gte', 1), ('lt', 1), ('lte', 1)):
+            with self.subTest(op=op):
+                self.assertFalse(Condition(attr, value=value, op=op).eval(data))
+                self.assertTrue(Condition(attr, value=value, op=op, negate=True).eval(data))
+
     def test_absent_snapshot_does_not_veto_sibling_conditions(self):
         """
         Regression: an absent prechange snapshot must not abort evaluation of the whole
         condition set, which would suppress a sibling condition that does match. The
-        result must also not depend on the order of the conditions.
+        result must also not depend on the order of the conditions, nor on which operator
+        the snapshot condition uses.
         """
         data = {'name': 'Site 1', 'snapshots': {'prechange': None, 'postchange': {'status': 'active'}}}
-        snapshot_rule = {'attr': 'snapshots.prechange.status', 'value': 'planned'}
         name_rule = {'attr': 'name', 'value': 'Site 1'}
-        self.assertTrue(ConditionSet({'or': [snapshot_rule, name_rule]}).eval(data))
-        self.assertTrue(ConditionSet({'or': [name_rule, snapshot_rule]}).eval(data))
+        for snapshot_rule in (
+            {'attr': 'snapshots.prechange.status', 'value': 'planned'},
+            {'attr': 'snapshots.prechange.status', 'value': 'plan', 'op': 'contains'},
+            {'attr': 'snapshots.prechange.status', 'value': '^plan', 'op': 'regex'},
+        ):
+            with self.subTest(op=snapshot_rule.get('op', 'eq')):
+                self.assertTrue(ConditionSet({'or': [snapshot_rule, name_rule]}).eval(data))
+                self.assertTrue(ConditionSet({'or': [name_rule, snapshot_rule]}).eval(data))
 
     def test_snapshot_path_typo_still_fails_closed(self):
         """

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -783,22 +783,46 @@ class SnapshotConditionTestCase(TestCase):
         with self.assertRaises(InvalidCondition):
             Condition('snapshots.prechange.description.value', value=None).eval(blank)
 
+    def test_absent_snapshot_path_unknown_to_opposite_snapshot_fails_closed(self):
+        """
+        An absent snapshot excuses only a path the opposite snapshot shows to describe the
+        data. A path which resolves to nothing there either is not shown to describe it, so it
+        must fail closed rather than resolving to null - which would let an unknown path fire
+        the rule on every create or delete, with nothing logged, even though the same path
+        raises on an update event. Testing for the absent snapshot itself remains available
+        as 'snapshots.prechange' with no remainder.
+        """
+        create = {'snapshots': {'prechange': None, 'postchange': {'custom_fields': {'cf1': 'x'}, 'tags': []}}}
+        with self.assertRaises(InvalidCondition):
+            Condition('snapshots.prechange.nonexistent.attr', value=None).eval(create)
+        with self.assertRaises(InvalidCondition):
+            Condition('snapshots.prechange.custom_fields.cf2', value=None).eval(create)
+        # An empty list holds no element in which to find 'name', so it cannot show the path
+        # to describe the data any more than an absent key can
+        with self.assertRaises(InvalidCondition):
+            Condition('snapshots.prechange.tags.name', value=None).eval(create)
+
+        delete = {'snapshots': {'prechange': {'status': 'active'}, 'postchange': None}}
+        with self.assertRaises(InvalidCondition):
+            Condition('snapshots.postchange.nonexistent.attr', value=None).eval(delete)
+
     def test_absent_snapshot_path_resolves_to_none_when_shape_is_valid(self):
         """
-        A nested path which the opposite snapshot shows to be walkable is a genuine absence,
-        so it resolves to null. So is a path which cannot be checked at all, because the
-        opposite snapshot does not contain it either or is itself null.
+        A nested path which the opposite snapshot resolves is a genuine absence, so it
+        resolves to null. So is the absent snapshot itself, and a path which cannot be checked
+        at all because the opposite snapshot is null too: the event then carries no data
+        anywhere to check against, so treating it as absent is the only alternative to logging
+        an error for every rule on every such event.
         """
         create = {'snapshots': {'prechange': None, 'postchange': {'custom_fields': {'cf1': 'x'}, 'tags': []}}}
         self.assertTrue(Condition('snapshots.prechange.custom_fields.cf1', value=None).eval(create))
-        self.assertTrue(Condition('snapshots.prechange.nonexistent.attr', value=None).eval(create))
         self.assertTrue(Condition('snapshots.prechange', value=None).eval(create))
-        # An empty list contains nothing to walk, so like an absent key it cannot show the
-        # path to be malformed either
-        self.assertTrue(Condition('snapshots.prechange.tags.name', value=None).eval(create))
+        # A resolved value is a resolved value, whatever its own shape
+        self.assertTrue(Condition('snapshots.prechange.tags', value=None).eval(create))
 
         both_absent = {'snapshots': {'prechange': None, 'postchange': None}}
         self.assertTrue(Condition('snapshots.prechange.status.value', value=None).eval(both_absent))
+        self.assertTrue(Condition('snapshots.prechange.nonexistent.attr', value=None).eval(both_absent))
 
     def test_snapshot_path_without_snapshot_context_fails_closed(self):
         """

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -474,6 +474,19 @@ class SnapshotConditionTestCase(TestCase):
         with self.assertRaises(InvalidCondition):
             c.eval({'snapshots': snapshots})
 
+    def test_changed_raises_when_path_traverses_falsy_scalar(self):
+        # Walkability is a property of the value's type, not its truthiness: an empty string
+        # is exactly as unwalkable as a populated one, and must not be mistaken for an absent
+        # attribute. (description and comments default to an empty string on most models, so
+        # this is the common case rather than an edge case.)
+        c = Condition('description.value', op='changed')
+        snapshots = {
+            'prechange': {'description': ''},
+            'postchange': {'description': 'foo'},
+        }
+        with self.assertRaises(InvalidCondition):
+            c.eval({'snapshots': snapshots})
+
     def test_unchanged_raises_when_path_traverses_scalar(self):
         c = Condition('status.value', op='unchanged')
         snapshots = {
@@ -493,6 +506,27 @@ class SnapshotConditionTestCase(TestCase):
         }
         with self.assertRaises(InvalidCondition):
             c.eval({'snapshots': snapshots})
+
+    def test_changed_raises_when_counterpart_snapshot_resolves_to_nothing(self):
+        """
+        Only a snapshot which actually yields a value excuses an unwalkable path in the
+        other. A snapshot which merely resolves to nothing - an empty list, an absent key -
+        is no evidence that the path is well-formed, so the malformed condition must still
+        be reported rather than evaluating (and possibly firing) until the data fills in.
+        """
+        for snapshots in (
+            # Tagging a previously untagged object: the likely first evaluation of the rule
+            {'prechange': {'tags': []}, 'postchange': {'tags': ['Alpha']}},
+            {'prechange': {'tags': ['Alpha']}, 'postchange': {'tags': []}},
+        ):
+            with self.subTest(snapshots=snapshots):
+                with self.assertRaises(InvalidCondition):
+                    Condition('tags.name', op='changed').eval({'snapshots': snapshots})
+
+        with self.assertRaises(InvalidCondition):
+            Condition('status.value', op='changed').eval({
+                'snapshots': {'prechange': {}, 'postchange': {'status': 'active'}}
+            })
 
     def test_changed_when_path_is_walkable_in_only_one_snapshot(self):
         """
@@ -703,16 +737,25 @@ class SnapshotConditionTestCase(TestCase):
         with self.assertRaises(InvalidCondition):
             Condition('snapshots.postchange.status.value', value='active').eval(delete)
 
+        # An empty string is exactly as unwalkable as a populated one, so the check must not
+        # turn on the truthiness of the value in the opposite snapshot
+        blank = {'snapshots': {'prechange': None, 'postchange': {'description': ''}}}
+        with self.assertRaises(InvalidCondition):
+            Condition('snapshots.prechange.description.value', value=None).eval(blank)
+
     def test_absent_snapshot_path_resolves_to_none_when_shape_is_valid(self):
         """
         A nested path which the opposite snapshot shows to be walkable is a genuine absence,
         so it resolves to null. So is a path which cannot be checked at all, because the
         opposite snapshot does not contain it either or is itself null.
         """
-        create = {'snapshots': {'prechange': None, 'postchange': {'custom_fields': {'cf1': 'x'}}}}
+        create = {'snapshots': {'prechange': None, 'postchange': {'custom_fields': {'cf1': 'x'}, 'tags': []}}}
         self.assertTrue(Condition('snapshots.prechange.custom_fields.cf1', value=None).eval(create))
         self.assertTrue(Condition('snapshots.prechange.nonexistent.attr', value=None).eval(create))
         self.assertTrue(Condition('snapshots.prechange', value=None).eval(create))
+        # An empty list contains nothing to walk, so like an absent key it cannot show the
+        # path to be malformed either
+        self.assertTrue(Condition('snapshots.prechange.tags.name', value=None).eval(create))
 
         both_absent = {'snapshots': {'prechange': None, 'postchange': None}}
         self.assertTrue(Condition('snapshots.prechange.status.value', value=None).eval(both_absent))

--- a/netbox/extras/tests/test_conditions.py
+++ b/netbox/extras/tests/test_conditions.py
@@ -376,31 +376,55 @@ class AbsentDataTestCase(TestCase):
         data['snapshots'] = kwargs.get('snapshots')
         return data
 
-    def test_absent_data_resolves_to_none(self):
+    def test_absent_data_is_a_non_match(self):
+        """
+        An absent payload carries nothing to match against, so a reference to any attribute of
+        it is a non-match rather than a resolved null. Matching would enqueue the rule's action
+        on an event which recorded no data at all.
+        """
         data = self._absent_data()
-        self.assertTrue(Condition('status', value=None).eval(data))
+        self.assertFalse(Condition('status', value=None).eval(data))
         self.assertFalse(Condition('status', value='completed').eval(data))
-        self.assertTrue(Condition('status', value='completed', negate=True).eval(data))
         # A nested path is equally unresolvable, and equally not an error
         self.assertFalse(Condition('output.result', value='x').eval(data))
+        self.assertFalse(Condition('output.result', value=None).eval(data))
 
     def test_absent_data_is_a_non_match_for_every_operator(self):
         data = self._absent_data()
-        for op, value in (('contains', 'foo'), ('regex', '^foo'), ('gt', 1), ('gte', 1), ('lt', 1), ('lte', 1)):
-            with self.subTest(op=op):
+        for op, value in (
+            ('eq', None), ('eq', 'foo'), ('in', ['foo']), ('contains', 'foo'), ('regex', '^foo'),
+            ('gt', 1), ('gte', 1), ('lt', 1), ('lte', 1),
+        ):
+            with self.subTest(op=op, value=value):
                 self.assertFalse(Condition('status', value=value, op=op).eval(data))
+
+    def test_negate_cannot_turn_an_absent_payload_into_a_match(self):
+        """
+        Negation inverts the result of a comparison, and against an absent payload no
+        comparison takes place. Inverting the non-match would make 'negate' a fail-open switch,
+        firing the rule on an empty payload - for a misspelled attribute as readily as a real
+        one, since neither resolves.
+        """
+        data = self._absent_data()
+        for attr in ('status', 'stauts', 'output.result'):
+            for value in (None, 'completed'):
+                with self.subTest(attr=attr, value=value):
+                    self.assertFalse(Condition(attr, value=value, negate=True).eval(data))
+        self.assertFalse(Condition('status', value='foo', op='contains', negate=True).eval(data))
 
     def test_absent_data_does_not_veto_sibling_conditions(self):
         """
-        As with an absent snapshot, an absent payload must not abort evaluation of the whole
-        condition set.
+        An absent payload must not abort evaluation of the whole condition set: the other
+        conditions, including a snapshot path drawn from the surrounding context, are still
+        evaluated on their own merits.
         """
-        data = self._absent_data()
+        data = self._absent_data(snapshots={'prechange': {'status': 'planned'}, 'postchange': None})
         ruleset = {'or': [
             {'attr': 'status', 'value': 'foo', 'op': 'regex'},
-            {'attr': 'status', 'value': None},
+            {'attr': 'snapshots.prechange.status', 'value': 'planned'},
         ]}
         self.assertTrue(ConditionSet(ruleset).eval(data))
+        self.assertFalse(ConditionSet({'and': list(ruleset['or'])}).eval(data))
 
     def test_present_data_missing_attr_still_fails_closed(self):
         """

--- a/netbox/extras/tests/test_event_rules.py
+++ b/netbox/extras/tests/test_event_rules.py
@@ -630,13 +630,25 @@ class EventRuleTestCase(RQQueueTestMixin, APITestCase):
 
     def test_job_event_with_null_data_and_conditions(self):
         """
-        A null payload must be evaluated as an empty dict rather than raising, so a rule
-        whose conditions cannot match is simply skipped.
+        A condition referencing an attribute of a null payload must resolve to null rather
+        than raising: the rule is skipped without logging an error, since a job which
+        recorded no data is routine rather than a misconfigured rule.
         """
         script_type = ObjectType.objects.get_for_model(Script)
         self._job_event_rule(conditions={'attr': 'status', 'value': 'completed'})
-        process_job_end_event_rules(Mock(object_type=script_type, data=None, user=self.user))
+        with self.assertNoLogs('netbox.event_rules', level='ERROR'):
+            process_job_end_event_rules(Mock(object_type=script_type, data=None, user=self.user))
         self.assertEqual(self.queue.count, 0)
+
+    def test_job_event_with_null_data_matching_conditions(self):
+        """
+        A rule whose conditions a null payload does satisfy must still fire.
+        """
+        script_type = ObjectType.objects.get_for_model(Script)
+        self._job_event_rule(conditions={'attr': 'status', 'value': None})
+        process_job_end_event_rules(Mock(object_type=script_type, data=None, user=self.user))
+        self.assertEqual(self.queue.count, 1)
+        self.assertEqual(self.queue.jobs[0].kwargs['data'], {})
 
     def test_job_event_with_non_dict_data(self):
         """

--- a/netbox/extras/tests/test_event_rules.py
+++ b/netbox/extras/tests/test_event_rules.py
@@ -604,6 +604,77 @@ class EventRuleTestCase(RQQueueTestMixin, APITestCase):
         self.assertEqual(job.kwargs['object_type'], script_type)
         self.assertNotIn('request', job.kwargs)
 
+    def _job_event_rule(self, conditions=None):
+        webhook = Webhook.objects.get(name='Webhook 1')
+        event_rule = EventRule.objects.create(
+            name='Event Rule Job Completed',
+            event_types=[JOB_COMPLETED],
+            action_type=EventRuleActionChoices.WEBHOOK,
+            action_object_type=ObjectType.objects.get_for_model(Webhook),
+            action_object_id=webhook.pk,
+            conditions=conditions,
+        )
+        event_rule.object_types.set([ObjectType.objects.get_for_model(Script)])
+        return event_rule
+
+    def test_job_event_with_null_data(self):
+        """
+        Job.data is nullable, and a job which recorded no data is entirely routine. Event
+        processing must handle it rather than raising while merging the payload.
+        """
+        script_type = ObjectType.objects.get_for_model(Script)
+        self._job_event_rule()
+        process_job_end_event_rules(Mock(object_type=script_type, data=None, user=self.user))
+        self.assertEqual(self.queue.count, 1)
+        self.assertEqual(self.queue.jobs[0].kwargs['data'], {})
+
+    def test_job_event_with_null_data_and_conditions(self):
+        """
+        A null payload must be evaluated as an empty dict rather than raising, so a rule
+        whose conditions cannot match is simply skipped.
+        """
+        script_type = ObjectType.objects.get_for_model(Script)
+        self._job_event_rule(conditions={'attr': 'status', 'value': 'completed'})
+        process_job_end_event_rules(Mock(object_type=script_type, data=None, user=self.user))
+        self.assertEqual(self.queue.count, 0)
+
+    def test_job_event_with_non_dict_data(self):
+        """
+        A payload which is neither null nor a dict is unexpected: log it, but continue
+        processing rather than aborting the batch.
+        """
+        script_type = ObjectType.objects.get_for_model(Script)
+        self._job_event_rule()
+        for payload in ([1, 2], 'a string', 42):
+            self.queue.empty()
+            with self.assertLogs('netbox.events_processor', level='WARNING') as cm:
+                process_job_end_event_rules(Mock(object_type=script_type, data=payload, user=self.user))
+            self.assertIn(type(payload).__name__, cm.output[0])
+            self.assertEqual(self.queue.count, 1)
+            self.assertEqual(self.queue.jobs[0].kwargs['data'], {})
+
+    def test_no_matching_rules_leaves_payload_unserialized(self):
+        """
+        Normalizing the payload must not defeat EventContext's lazy serialization: an
+        event with no applicable rules should never have its payload materialized.
+        """
+        request = RequestFactory().get('/')
+        request.id = uuid.uuid4()
+        request.user = self.user
+        site = Site.objects.create(name='Site Lazy', slug='site-lazy')
+
+        queue = {}
+        enqueue_event(queue, site, request, OBJECT_UPDATED)
+        event = queue[f'dcim.site:{site.pk}']
+        self.assertNotIn('data', event.data)
+
+        process_event_rules(
+            event_rules=EventRule.objects.none(),
+            object_type=ObjectType.objects.get_for_model(Site),
+            event=event,
+        )
+        self.assertNotIn('data', event.data)
+
     def test_duplicate_enqueue_refreshes_lazy_payload(self):
         """
         When the same object is enqueued more than once in a single request,

--- a/netbox/extras/tests/test_event_rules.py
+++ b/netbox/extras/tests/test_event_rules.py
@@ -630,9 +630,9 @@ class EventRuleTestCase(RQQueueTestMixin, APITestCase):
 
     def test_job_event_with_null_data_and_conditions(self):
         """
-        A condition referencing an attribute of a null payload must resolve to null rather
-        than raising: the rule is skipped without logging an error, since a job which
-        recorded no data is routine rather than a misconfigured rule.
+        A condition referencing an attribute of a null payload is a non-match rather than an
+        error: the rule is skipped without logging, since a job which recorded no data is
+        routine rather than a misconfigured rule.
         """
         script_type = ObjectType.objects.get_for_model(Script)
         self._job_event_rule(conditions={'attr': 'status', 'value': 'completed'})
@@ -640,15 +640,23 @@ class EventRuleTestCase(RQQueueTestMixin, APITestCase):
             process_job_end_event_rules(Mock(object_type=script_type, data=None, user=self.user))
         self.assertEqual(self.queue.count, 0)
 
-    def test_job_event_with_null_data_matching_conditions(self):
+    def test_job_event_with_null_data_does_not_satisfy_conditions(self):
         """
-        A rule whose conditions a null payload does satisfy must still fire.
+        A null payload must not satisfy a conditioned rule, however the condition is phrased:
+        there is no data to evaluate, so nothing may enqueue the rule's action. A test for null
+        and a negated test are the two phrasings which would otherwise match.
         """
         script_type = ObjectType.objects.get_for_model(Script)
-        self._job_event_rule(conditions={'attr': 'status', 'value': None})
-        process_job_end_event_rules(Mock(object_type=script_type, data=None, user=self.user))
-        self.assertEqual(self.queue.count, 1)
-        self.assertEqual(self.queue.jobs[0].kwargs['data'], {})
+        for conditions in (
+            {'attr': 'status', 'value': None},
+            {'attr': 'status', 'value': 'completed', 'negate': True},
+        ):
+            with self.subTest(conditions=conditions):
+                event_rule = self._job_event_rule(conditions=conditions)
+                with self.assertNoLogs('netbox.event_rules', level='ERROR'):
+                    process_job_end_event_rules(Mock(object_type=script_type, data=None, user=self.user))
+                self.assertEqual(self.queue.count, 0)
+                event_rule.delete()
 
     def test_job_event_with_non_dict_data(self):
         """

--- a/netbox/extras/tests/test_event_rules.py
+++ b/netbox/extras/tests/test_event_rules.py
@@ -673,6 +673,31 @@ class EventRuleTestCase(RQQueueTestMixin, APITestCase):
             self.assertEqual(self.queue.count, 1)
             self.assertEqual(self.queue.jobs[0].kwargs['data'], {})
 
+    def test_job_event_with_non_dict_data_and_conditions(self):
+        """
+        An invalid payload is no more evaluable than an absent one, so a conditioned rule must
+        fail closed for it — including for the phrasings which a payload normalized to an empty
+        dict would otherwise satisfy. The invalid payload is still reported once for the event,
+        as the anomaly it is.
+        """
+        script_type = ObjectType.objects.get_for_model(Script)
+        for conditions in (
+            {'attr': 'status', 'value': None},
+            {'attr': 'status', 'value': 'completed', 'negate': True},
+            {'attr': 'status', 'value': 'completed'},
+        ):
+            event_rule = self._job_event_rule(conditions=conditions)
+            for payload in ([1, 2], 'a string', 42):
+                with self.subTest(conditions=conditions, payload=payload):
+                    self.queue.empty()
+                    with self.assertLogs('netbox.events_processor', level='WARNING') as cm:
+                        process_job_end_event_rules(
+                            Mock(object_type=script_type, data=payload, user=self.user)
+                        )
+                    self.assertIn(type(payload).__name__, cm.output[0])
+                    self.assertEqual(self.queue.count, 0)
+            event_rule.delete()
+
     def test_no_matching_rules_leaves_payload_unserialized(self):
         """
         Normalizing the payload must not defeat EventContext's lazy serialization: an


### PR DESCRIPTION
Pre-release QA for the snapshot conditions added under #18159 (merged in #22637). No new functionality: this corrects edge-case behavior in condition evaluation, drawing a consistent line between a condition which is **malformed** and data which is simply **absent**.

### Malformed paths fail closed and are logged

Path resolution conflated a missing key with a value which cannot be indexed at all, so a REST API-style path such as `status.value` applied to a snapshot (where `status` is the raw string `"active"`) evaluated as false forever, silently. Resolution is now consolidated in a single `walk_path()` helper, which returns a sentinel for an absent key and raises `TypeError` for an unwalkable one; the latter surfaces as `InvalidCondition` and is logged to `netbox.event_rules`.

Walkability is determined by the type of the value being traversed rather than its truthiness, so an empty string or a zero is reported as unwalkable rather than mistaken for a missing key. For the `changed`/`unchanged` operators the error is raised only when no snapshot resolves the path to a value: a path which resolves in one snapshot but not the other describes a real difference between them (a JSON attribute whose value changed shape, say), and is compared as before.

An event whose `snapshots` value is not a dict at all is reported the same way — as an invalid condition, by both the snapshot operators and direct snapshot paths — rather than raising an uncaught `AttributeError` which would abort event processing.

### Absent data resolves to null

Where the data referenced by a condition is absent altogether rather than merely missing the referenced key, the reference now resolves to `null` instead of aborting evaluation of the condition set. This covers a job event for a job which recorded no data (`AbsentData`), and a `snapshots.prechange.*` / `snapshots.postchange.*` path on a create or delete event.

Such a reference matches a condition testing for `null` and is a plain non-match for every other operator — including `contains`, `regex`, and the numeric comparisons, which raise `TypeError` on `None` — so it no longer suppresses sibling conditions which do match, nor logs an error on every such event. An absent snapshot excuses only the absence of the data, not a path which does not describe it: the path is validated against the opposite snapshot, so a `.value` suffix, a misspelled attribute, or a name which is neither `prechange` nor `postchange` still fails closed on create and delete events.

### Event payload normalization

`process_event_rules()` now normalizes the event payload once for all rules. A null job payload no longer raises a `TypeError` when merged into the condition context; any other non-dict payload is logged and treated as absent rather than taking down processing for the whole batch. The function also returns early when there are no rules to process.

### Documentation and tests

`docs/reference/conditions.md` documents the fail-closed and absent-data semantics, and adds an example of combining a snapshot path with other conditions in a rule which also fires on create. Coverage in `extras/tests/test_conditions.py` and `extras/tests/test_event_rules.py` is extended accordingly.
