### PR TITLE
Closes #22935: Deprecate custom scripts

### DIFF
--- a/docs/administration/management-commands.md
+++ b/docs/administration/management-commands.md
@@ -62,6 +62,9 @@ python3 netbox/manage.py renaturalize [app_label.ModelName ...]
 
 ## runscript
 
+!!! warning "Deprecation Warning"
+    The custom scripts functionality has been deprecated beginning in NetBox v4.7, and is scheduled for removal in NetBox v5.0. This command will be removed along with it.
+
 Run a [custom script](../customization/custom-scripts.md) from the command line, outside the web UI or API.
 
 ```

--- a/docs/configuration/system.md
+++ b/docs/configuration/system.md
@@ -282,6 +282,9 @@ The file path to the location where [custom reports](../customization/reports.md
 
 ## SCRIPTS_ROOT
 
+!!! warning "Deprecation Warning"
+    The custom scripts functionality has been deprecated beginning in NetBox v4.7, and is scheduled for removal in NetBox v5.0. This parameter will be removed along with it.
+
 Default: `$INSTALL_ROOT/netbox/scripts/`
 
 The file path to the location where [custom scripts](../customization/custom-scripts.md) will be kept. By default, this is the `netbox/scripts/` directory within the base NetBox installation path.

--- a/docs/customization/custom-scripts.md
+++ b/docs/customization/custom-scripts.md
@@ -1,5 +1,10 @@
 # Custom Scripts
 
+!!! warning "Deprecation Warning"
+    Beginning in NetBox v4.7, the custom scripts functionality built into core NetBox has been deprecated. It is being replaced by a dedicated open source plugin, which offers an expanded feature set including the organization of scripts into projects, the sharing of Python resources among scripts, and version control for individual scripts.
+
+    The core implementation will remain available and supported throughout the v4.7 and v4.8 release cycles, and is scheduled for removal in NetBox v5.0. No immediate action is required: Existing scripts will continue to work as they do today, and users may migrate to the plugin at any point during the migration period. Migration is intended to be a largely automated process which should not require rewriting scripts.
+
 Custom scripting was introduced to provide a way for users to execute custom logic from within the NetBox UI. Custom scripts enable the user to directly and conveniently manipulate NetBox data in a prescribed fashion. They can be used to accomplish myriad tasks, such as:
 
 * Automatically populate new devices and cables in preparation for a new site deployment

--- a/docs/customization/reports.md
+++ b/docs/customization/reports.md
@@ -3,6 +3,8 @@
 !!! warning
     Reports are deprecated beginning with NetBox v4.0, and their functionality has been merged with [custom scripts](./custom-scripts.md). While backward compatibility has been maintained, users are advised to convert legacy reports into custom scripts soon, as support for legacy reports will be removed in a future release.
 
+    Beginning with NetBox v4.7, NetBox's built-in custom scripts implementation is deprecated and is being replaced by a dedicated plugin. Converting a legacy report to a custom script remains the recommended first step. See the [custom scripts documentation](./custom-scripts.md) for details.
+
 ## Converting Reports to Scripts
 
 ### Step 1: Update Class Definition

--- a/docs/features/customization.md
+++ b/docs/features/customization.md
@@ -79,6 +79,9 @@ To learn more about this feature, check out the [documentation for reports](../c
 
 ## Custom Scripts
 
+!!! warning "Deprecation Warning"
+    Beginning in NetBox v4.7, the custom scripts functionality built into core NetBox has been deprecated in favor of a dedicated plugin, and is scheduled for removal in NetBox v5.0. See the [custom scripts documentation](../customization/custom-scripts.md) for details.
+
 Custom scripts are similar to reports, but more powerful. A custom script can prompt the user for input via a form (or API data), and is built to do much more than just reporting. Custom scripts are generally used to automate tasks, such as the population of new objects in NetBox, or exchanging data with external systems. As with reports, they can be run via the UI, REST API, or CLI, and be scheduled to execute at a future time.
 
 The complete Python environment is available to a custom script, including all of NetBox's internal mechanisms: There are no artificial restrictions on what a script can do. As such, custom scripting is considered an advanced feature and requires sufficient familiarity with Python and NetBox's data model.


### PR DESCRIPTION
### Closes: #22935

Adds deprecation warnings several places within the documentation, but does not embed any warnings in the UI itself. This can be done once the new plugin has been released.