### PR TITLE
Closes #22851: Unpin `social-auth-core`

### DIFF
--- a/base_requirements.txt
+++ b/base_requirements.txt
@@ -160,8 +160,7 @@ social-auth-app-django
 
 # Social authentication framework
 # https://github.com/python-social-auth/social-core/blob/master/CHANGELOG.md
-# Need to verify that v4.9.0 does not introduce breaking changes (see #22095)
-social-auth-core==4.8.*
+social-auth-core
 
 # Image thumbnail generation
 # https://github.com/jazzband/sorl-thumbnail/blob/master/CHANGES.rst

--- a/requirements.txt
+++ b/requirements.txt
@@ -35,8 +35,8 @@ PyYAML==6.0.3
 redis==7.4.1
 requests==2.34.2
 rq==2.10.0
-social-auth-app-django==5.9.0
-social-auth-core==4.8.7
+social-auth-app-django==6.0.1
+social-auth-core==5.1.0
 sorl-thumbnail==13.0.0
 strawberry-graphql==0.323.2
 strawberry-graphql-django==0.86.5


### PR DESCRIPTION
### Closes: #22851

- Remove the pinning of `social-auth-core` to v4.8.x
- Upgrade `social-auth-core` & `social-auth-app-django` to their latest releases

Per #22095, this does introduce some potential breaking changes that need to be called out in the v4.7 release notes.