### PR TITLE
Fixes #22944: Display nested role hierarchy in Virtual Machine info panel

### DIFF
--- a/netbox/virtualization/ui/panels.py
+++ b/netbox/virtualization/ui/panels.py
@@ -44,7 +44,7 @@ class VirtualMachinePanel(panels.ObjectAttributesPanel):
     virtual_machine_type = attrs.RelatedObjectAttr('virtual_machine_type', linkify=True, label=_('Type'))
     status = attrs.ChoiceAttr('status')
     start_on_boot = attrs.ChoiceAttr('start_on_boot')
-    role = attrs.RelatedObjectAttr('role', linkify=True, colored=True)
+    role = attrs.NestedObjectAttr('role', linkify=True, max_depth=3, colored=True)
     platform = attrs.NestedObjectAttr('platform', linkify=True, max_depth=3)
     description = attrs.TextAttr('description')
     serial = attrs.TextAttr('serial', label=_('Serial number'), style='font-monospace', copy_button=True)


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22944

<!--
    Please include a summary of the proposed changes below.
-->
Updates the virtual machine info panel to display nested role hierarchies, such as `Parent / Child`. The role attribute now uses `NestedObjectAttr` with a maximum depth of three, matching the existing device management panel behavior while preserving linked and color-coded role display.
