### PR TITLE
Fixes #22957: Fix missing hierarchy in Device Role, Platform, and Power Panel breadcrumbs

### DIFF
--- a/netbox/templates/dcim/devicerole.html
+++ b/netbox/templates/dcim/devicerole.html
@@ -5,7 +5,10 @@
 {% load i18n %}
 
 {% block breadcrumbs %}
-  <li class="breadcrumb-item"><a href="{% url 'dcim:devicerole_list' %}">{% trans "Device Roles" %}</a></li>
+  {{ block.super }}
+  {% for devicerole in object.get_ancestors %}
+    <li class="breadcrumb-item"><a href="{% url 'dcim:devicerole_list' %}?parent_id={{ devicerole.pk }}">{{ devicerole }}</a></li>
+  {% endfor %}
 {% endblock %}
 
 {% block extra_controls %}

--- a/netbox/templates/dcim/platform.html
+++ b/netbox/templates/dcim/platform.html
@@ -9,6 +9,9 @@
   {% if object.manufacturer %}
     <li class="breadcrumb-item"><a href="{% url 'dcim:platform_list' %}?manufacturer_id={{ object.manufacturer.pk }}">{{ object.manufacturer }}</a></li>
   {% endif %}
+  {% for platform in object.get_ancestors %}
+    <li class="breadcrumb-item"><a href="{% url 'dcim:platform_list' %}?parent_id={{ platform.pk }}">{{ platform }}</a></li>
+  {% endfor %}
 {% endblock %}
 
 {% block extra_controls %}

--- a/netbox/templates/dcim/powerpanel.html
+++ b/netbox/templates/dcim/powerpanel.html
@@ -4,6 +4,9 @@
   {{ block.super }}
   <li class="breadcrumb-item"><a href="{% url 'dcim:powerpanel_list' %}?site_id={{ object.site.pk }}">{{ object.site }}</a></li>
   {% if object.location %}
-    <li class="breadcrumb-item">{{ object.location|linkify }}</li>
+    {% for location in object.location.get_ancestors %}
+      <li class="breadcrumb-item"><a href="{% url 'dcim:powerpanel_list' %}?location_id={{ location.pk }}">{{ location }}</a></li>
+    {% endfor %}
+    <li class="breadcrumb-item"><a href="{% url 'dcim:powerpanel_list' %}?location_id={{ object.location.pk }}">{{ object.location }}</a></li>
   {% endif %}
 {% endblock %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22957

<!--
    Please include a summary of the proposed changes below.
-->
Displays the full ancestor chain in Device Role and Platform breadcrumbs, and the full location hierarchy in Power Panel breadcrumbs. Each hierarchy entry links to the corresponding filtered object list, keeping navigation consistent with other nested DCIM objects.