### PR TITLE
Fixes #22953: Restore Custom Script log messages in `runscript` output

### DIFF
--- a/netbox/extras/scripts.py
+++ b/netbox/extras/scripts.py
@@ -326,7 +326,7 @@ class BaseScript:
         self._current_test = None  # Tracks the current test method being run (if any)
 
         # Initiate the log
-        self.logger = logging.getLogger(f"netbox.scripts.{self.__module__}.{self.__class__.__name__}")
+        self.logger = logging.getLogger(f"netbox.scripts.{self.full_name}")
 
         # Declare the placeholder for the current request
         self.request = None

--- a/netbox/extras/tests/test_scripts.py
+++ b/netbox/extras/tests/test_scripts.py
@@ -439,3 +439,33 @@ class ScriptModuleLoadingTestCase(TestCase):
         # The real circuits app must be untouched and remain an importable package
         self.assertIs(sys.modules['circuits'], circuits)
         self.assertTrue(hasattr(circuits, '__path__'))
+
+    def test_script_logger_uses_public_module_name(self):
+        """
+        A dynamically loaded script logs to the public netbox.scripts.<module>.<class> namespace.
+        """
+        script_content = (
+            b"from extras.scripts import Script\n\n\n"
+            b"class TestScript(Script):\n    pass\n"
+        )
+
+        class _Storage:
+            def open(self, name, mode='rb'):
+                return io.BytesIO(script_content)
+
+        module = ScriptModule(file_root='scripts', file_path='example.py')
+        namespaced_key = f'{SCRIPT_MODULE_NAME_PREFIX}example'
+        self.addCleanup(lambda: sys.modules.pop(namespaced_key, None))
+
+        with patch('extras.models.mixins.storages') as mock_storages:
+            mock_storages.__getitem__.return_value = _Storage()
+            script_class = module.get_module().TestScript
+
+        # This is the name runscript and ScriptJob attach their handlers to
+        logger_name = f'netbox.scripts.{script_class.full_name}'
+        script = script_class()
+        self.assertEqual(script.logger.name, logger_name)
+
+        with self.assertLogs(logger_name, 'INFO') as captured:
+            script.log_success('Start')
+        self.assertIn('Start', captured.output[0])


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22953

<!--
    Please include a summary of the proposed changes below.
-->
Updates `BaseScript` to initialize its logger from the canonical `full_name` property rather than reconstructing the namespace from `__module__` and `__class__.__name__`.

This restores `self.log_*()` output for custom scripts executed with `runscript` while preserving the private module namespace used to prevent import collisions. Adds regression coverage to ensure dynamically loaded scripts log through their public `netbox.scripts.<module>.<class>` namespace.

