### PR TITLE
Fixes #22954: Display nested group and platform hierarchies in info panels

### DIFF
--- a/netbox/dcim/ui/panels.py
+++ b/netbox/dcim/ui/panels.py
@@ -150,7 +150,7 @@ class DeviceTypePanel(panels.ObjectAttributesPanel):
     manufacturer = attrs.RelatedObjectAttr('manufacturer', linkify=True)
     model = attrs.TextAttr('model')
     part_number = attrs.TextAttr('part_number')
-    default_platform = attrs.RelatedObjectAttr('default_platform', linkify=True)
+    default_platform = attrs.NestedObjectAttr('default_platform', linkify=True, max_depth=3)
     description = attrs.TextAttr('description')
     height = attrs.TemplatedAttr('u_height', template_name='dcim/devicetype/attrs/height.html')
     exclude_from_utilization = attrs.BooleanAttr('exclude_from_utilization')

--- a/netbox/tenancy/ui/panels.py
+++ b/netbox/tenancy/ui/panels.py
@@ -4,7 +4,7 @@ from netbox.ui import attrs, panels
 
 
 class TenantPanel(panels.ObjectAttributesPanel):
-    group = attrs.RelatedObjectAttr('group', linkify=True)
+    group = attrs.NestedObjectAttr('group', linkify=True)
     description = attrs.TextAttr('description')
 
 

--- a/netbox/virtualization/ui/panels.py
+++ b/netbox/virtualization/ui/panels.py
@@ -24,7 +24,7 @@ class ClusterPanel(panels.ObjectAttributesPanel):
 
 class VirtualMachineTypePanel(panels.ObjectAttributesPanel):
     name = attrs.TextAttr('name')
-    default_platform = attrs.RelatedObjectAttr('default_platform', linkify=True)
+    default_platform = attrs.NestedObjectAttr('default_platform', linkify=True, max_depth=3)
     default_vcpus = attrs.TextAttr('default_vcpus', label=_('Default vCPUs'))
     default_memory = attrs.TemplatedAttr(
         'default_memory',

--- a/netbox/wireless/ui/panels.py
+++ b/netbox/wireless/ui/panels.py
@@ -9,7 +9,7 @@ class WirelessLANGroupPanel(panels.NestedGroupObjectPanel):
 
 class WirelessLANPanel(panels.ObjectAttributesPanel):
     ssid = attrs.TextAttr('ssid', label=_('SSID'))
-    group = attrs.RelatedObjectAttr('group', linkify=True)
+    group = attrs.NestedObjectAttr('group', linkify=True)
     status = attrs.ChoiceAttr('status')
     scope = attrs.GenericForeignKeyAttr('scope', linkify=True, nested=True, max_depth=3)
     description = attrs.TextAttr('description')


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22954

<!--
    Please include a summary of the proposed changes below.
-->
Updates the Tenant, Wireless LAN, Device Type, and Virtual Machine Type info panels to display nested group and default platform hierarchies. Replaces `RelatedObjectAttr` with `NestedObjectAttr` for these fields and limits platform nesting to three levels for consistency with existing platform fields.
