### PR TITLE
Add optional suspected cause & suggested fix fields to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02-bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/02-bug_report.yaml
@@ -70,3 +70,15 @@ body:
       placeholder: A TypeError exception was raised
     validations:
       required: true
+  - type: textarea
+    attributes:
+      label: Suspected Cause
+      description: >
+        If you have identified the likely root cause(s), please detail your findings
+        here (optional).
+  - type: textarea
+    attributes:
+      label: Proposed Fix
+      description: >
+        If you would like to propose a specific fix likely to resolve this issue, please
+        describe it here (optional).


### PR DESCRIPTION
Adds two optional fields to the bug report template:

* Suspected Cause
* Proposed Fix

These would be helpful to incorporate as many of our AI-originated findings include root cause analysis and suggested fixes along with the other bug attributes.