### PR TITLE
Closes #22959: Notify the reader to confirm database user permission before upgrading

### DIFF
--- a/docs/installation/1-postgresql.md
+++ b/docs/installation/1-postgresql.md
@@ -5,9 +5,6 @@ This section entails the installation and configuration of a local PostgreSQL da
 !!! warning "PostgreSQL 15 or later required"
     NetBox requires PostgreSQL 15 or later. Please note that MySQL and other relational databases are **not** supported.
 
-!!! warning "PostgreSQL 14 deprecation notice"
-    Support for PostgreSQL 14 is deprecated as of NetBox v4.6 and will be removed in NetBox v4.7. Please plan to upgrade to PostgreSQL 15 or later.
-
 ## Installation
 
 ```no-highlight

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -68,6 +68,22 @@ NetBox v4.7 and later require the PostgreSQL [`ltree` extension](https://www.pos
 
 If `ltree` is not already installed and the NetBox database user does not hold the `CREATE` privilege, grant it by invoking the PostgreSQL shell as the system Postgres user:
 
+```no-highlight
+sudo -u postgres psql
+```
+
+Then issue the following command, substituting the name of your database and user (role) where applicable:
+
+```postgresql
+GRANT CREATE ON DATABASE netbox TO netbox;
+```
+
+Alternatively, a database administrator can install the extension before upgrading:
+
+```postgresql
+CREATE EXTENSION IF NOT EXISTS ltree;
+```
+
 ## Upgrade a Release Archive or Git Installation
 
 The following procedure applies to NetBox installations created from a release archive or Git checkout. Complete the preparation steps above, then use the same installation method that was used for the existing deployment.

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -61,22 +61,12 @@ NetBox requires the following dependencies:
 
 ## Verify Database Permissions
 
-NetBox v4.7 and later require the PostgreSQL [`ltree` extension](https://www.postgresql.org/docs/current/ltree.html), which NetBox installs automatically when applying database migrations. Installing an extension requires that the NetBox database user hold the `CREATE` privilege on the database; without it, the upgrade will fail with a permission error while migrating.
-
-Before upgrading to NetBox v4.7 or later, grant the privilege by invoking the PostgreSQL shell as the system Postgres user:
-
-```no-highlight
-sudo -u postgres psql
-```
-
-Then issue the following command, substituting the name of your database and user (role) where applicable:
-
-```postgresql
-GRANT CREATE ON DATABASE netbox TO netbox;
-```
+NetBox v4.7 and later require the PostgreSQL [`ltree` extension](https://www.postgresql.org/docs/current/ltree.html). NetBox installs this extension automatically when applying database migrations if it is not already present. Installing it requires that the NetBox database user hold the `CREATE` privilege on the database.
 
 !!! note
-    The database owner already holds this privilege implicitly, so this step is unnecessary if your NetBox user owns the NetBox database. (`ltree` is a trusted module which ships with PostgreSQL; activating it does not require superuser permission.)
+    Installations created using NetBox's PostgreSQL setup instructions already satisfy this requirement because those instructions make the NetBox user the database owner. No additional grant is needed for these installations.
+
+If `ltree` is not already installed and the NetBox database user does not hold the `CREATE` privilege, grant it by invoking the PostgreSQL shell as the system Postgres user:
 
 ## Upgrade a Release Archive or Git Installation
 

--- a/docs/installation/upgrading.md
+++ b/docs/installation/upgrading.md
@@ -42,6 +42,7 @@ NetBox requires the following dependencies:
 
 | NetBox Version | Python min | Python max | PostgreSQL min | Redis min |                                       Documentation                                       |
 |:--------------:|:----------:|:----------:|:--------------:|:---------:|:-----------------------------------------------------------------------------------------:|
+|      4.7       |    3.12    |    3.14    |       15       |    6.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.7.0/docs/installation/index.md) |
 |      4.6       |    3.12    |    3.14    |       14       |    5.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.6.0/docs/installation/index.md) |
 |      4.5       |    3.12    |    3.14    |       14       |    5.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.5.0/docs/installation/index.md) |
 |      4.4       |    3.10    |    3.12    |       14       |    5.0    | [Link](https://github.com/netbox-community/netbox/blob/v4.4.0/docs/installation/index.md) |
@@ -57,6 +58,25 @@ NetBox requires the following dependencies:
 |      3.2       |    3.8     |    3.10    |       10       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v3.2.0/docs/installation/index.md) |
 |      3.1       |    3.7     |    3.9     |       10       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v3.1.0/docs/installation/index.md) |
 |      3.0       |    3.7     |    3.9     |      9.6       |    4.0    | [Link](https://github.com/netbox-community/netbox/blob/v3.0.0/docs/installation/index.md) |
+
+## Verify Database Permissions
+
+NetBox v4.7 and later require the PostgreSQL [`ltree` extension](https://www.postgresql.org/docs/current/ltree.html), which NetBox installs automatically when applying database migrations. Installing an extension requires that the NetBox database user hold the `CREATE` privilege on the database; without it, the upgrade will fail with a permission error while migrating.
+
+Before upgrading to NetBox v4.7 or later, grant the privilege by invoking the PostgreSQL shell as the system Postgres user:
+
+```no-highlight
+sudo -u postgres psql
+```
+
+Then issue the following command, substituting the name of your database and user (role) where applicable:
+
+```postgresql
+GRANT CREATE ON DATABASE netbox TO netbox;
+```
+
+!!! note
+    The database owner already holds this privilege implicitly, so this step is unnecessary if your NetBox user owns the NetBox database. (`ltree` is a trusted module which ships with PostgreSQL; activating it does not require superuser permission.)
 
 ## Upgrade a Release Archive or Git Installation
 

--- a/docs/release-notes/version-4.7.md
+++ b/docs/release-notes/version-4.7.md
@@ -9,7 +9,7 @@
     This release of NetBox drops support for PostgreSQL 14.
 
 !!! warning "PostgreSQL ltree Extension Required"
-    The PostgreSQL database must support the [ltree extension](https://www.postgresql.org/docs/current/ltree.html). This is a trusted module which ships with PostgreSQL and does not require superuser permission to activate. It will be installed automatically upon upgrade.
+    The PostgreSQL database must support the [ltree extension](https://www.postgresql.org/docs/current/ltree.html). This is a trusted module which ships with PostgreSQL and does not require superuser permission to activate. It will be installed automatically upon upgrade, however the NetBox database user must hold the `CREATE` privilege on the database (i.e. `GRANT CREATE ON DATABASE netbox TO netbox;`) in order for this to succeed. See [Verify Database Permissions](../installation/upgrading.md#verify-database-permissions) for details.
 
 !!! warning "Redis 6.0 or Later Required"
     This release of NetBox drops support for Redis 5.x.

--- a/docs/release-notes/version-4.7.md
+++ b/docs/release-notes/version-4.7.md
@@ -9,7 +9,7 @@
     This release of NetBox drops support for PostgreSQL 14.
 
 !!! warning "PostgreSQL ltree Extension Required"
-    The PostgreSQL database must support the [ltree extension](https://www.postgresql.org/docs/current/ltree.html). This is a trusted module which ships with PostgreSQL and does not require superuser permission to activate. It will be installed automatically upon upgrade, however the NetBox database user must hold the `CREATE` privilege on the database (i.e. `GRANT CREATE ON DATABASE netbox TO netbox;`) in order for this to succeed. See [Verify Database Permissions](../installation/upgrading.md#verify-database-permissions) for details.
+    The PostgreSQL database must support the [ltree extension](https://www.postgresql.org/docs/current/ltree.html). This trusted module ships with PostgreSQL and does not require superuser permission to activate. NetBox will install it automatically during the upgrade if it is not already present. This requires the NetBox database user to hold the `CREATE` privilege on the database. Installations created using NetBox's standard PostgreSQL setup instructions already satisfy this requirement because the NetBox user owns the database. See [Verify Database Permissions](../installation/upgrading.md#verify-database-permissions) for details.
 
 !!! warning "Redis 6.0 or Later Required"
     This release of NetBox drops support for Redis 5.x.


### PR DESCRIPTION
### Closes: #22959

- Add a section on validating database user permissions to the upgrade documentation
- Add a similar note to the v4.7 release notes
- Add v4.7 to the dependency matrix
- Remove an obsolete deprecation warning for PostgreSQL 14