### PR TITLE
Fixes #22957: Fix missing hierarchy in Device Role, Platform, and Power Panel breadcrumbs

### DIFF
--- a/netbox/dcim/views.py
+++ b/netbox/dcim/views.py
@@ -2869,6 +2869,10 @@ class PlatformView(GetRelatedModelsMixin, generic.ObjectView):
     layout = layout.SimpleLayout(
         breadcrumbs=[
             Breadcrumb('manufacturer', url=filtered_list_url('dcim:platform_list', 'manufacturer_id')),
+            Breadcrumb(
+                lambda o: o.get_ancestors(),
+                url=filtered_list_url('dcim:platform_list', 'parent_id'),
+            ),
         ],
         left_panels=[
             panels.PlatformPanel(),
@@ -5404,7 +5408,11 @@ class PowerPanelView(GetRelatedModelsMixin, generic.ObjectView):
     layout = layout.SimpleLayout(
         breadcrumbs=[
             Breadcrumb('site', url=filtered_list_url('dcim:powerpanel_list', 'site_id')),
-            Breadcrumb('location'),
+            Breadcrumb(
+                lambda o: o.location.get_ancestors() if o.location else [],
+                url=filtered_list_url('dcim:powerpanel_list', 'location_id'),
+            ),
+            Breadcrumb('location', url=filtered_list_url('dcim:powerpanel_list', 'location_id')),
         ],
         left_panels=[
             panels.PowerPanelPanel(),
@@ -5583,7 +5591,11 @@ class CoolingSourceView(GetRelatedModelsMixin, generic.ObjectView):
     layout = layout.SimpleLayout(
         breadcrumbs=[
             Breadcrumb('site', url=filtered_list_url('dcim:coolingsource_list', 'site_id')),
-            Breadcrumb('location'),
+            Breadcrumb(
+                lambda o: o.location.get_ancestors() if o.location else [],
+                url=filtered_list_url('dcim:coolingsource_list', 'location_id'),
+            ),
+            Breadcrumb('location', url=filtered_list_url('dcim:coolingsource_list', 'location_id')),
         ],
         left_panels=[
             panels.CoolingSourcePanel(),


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22957

<!--
    Please include a summary of the proposed changes below.
-->
Displays the full ancestor chain in Device Role and Platform breadcrumbs, and the full location hierarchy in Power Panel breadcrumbs. Each hierarchy entry links to the corresponding filtered object list, keeping navigation consistent with other nested DCIM objects.