### PR TITLE
Closes #22987: Remove unused `clone_fields` declarations from non-cloneable models

### DIFF
--- a/netbox/extras/models/models.py
+++ b/netbox/extras/models/models.py
@@ -770,8 +770,6 @@ class ImageAttachment(ChangeLoggedModel):
 
     objects = RestrictedQuerySet.as_manager()
 
-    clone_fields = ('object_type', 'object_id')
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 

--- a/netbox/ipam/models/fhrp.py
+++ b/netbox/ipam/models/fhrp.py
@@ -103,8 +103,6 @@ class FHRPGroupAssignment(ChangeLoggedModel):
         )
     )
 
-    clone_fields = ('interface_type', 'interface_id')
-
     class Meta:
         ordering = ('-priority', 'pk')
         indexes = (

--- a/netbox/netbox/tests/test_model_features.py
+++ b/netbox/netbox/tests/test_model_features.py
@@ -1,5 +1,6 @@
 from unittest import skipIf
 
+from django.apps import apps
 from django.conf import settings
 from django.test import TestCase
 from taggit.models import Tag
@@ -8,7 +9,8 @@ from core.models import AutoSyncRecord, DataSource
 from dcim.models import Site
 from extras.models import CustomLink
 from ipam.models import Prefix
-from netbox.models.features import get_model_features, has_feature, model_is_public
+from netbox.constants import CORE_APPS
+from netbox.models.features import CloningMixin, get_model_features, has_feature, model_is_public
 
 
 class ModelFeaturesTestCase(TestCase):
@@ -61,6 +63,23 @@ class ModelFeaturesTestCase(TestCase):
         features = get_model_features(CustomLink)
         self.assertIn('cloning', features)
         self.assertNotIn('bookmarks', features)
+
+    def test_clone_fields_requires_cloning_support(self):
+        """
+        Check that only models which support the cloning feature declare clone_fields.
+        """
+        declaring = [
+            model for model in apps.get_models()
+            if model._meta.app_label in CORE_APPS and hasattr(model, 'clone_fields')
+        ]
+
+        # Sanity checking
+        self.assertIn(Prefix, declaring, "Invalid test?")
+
+        offenders = sorted(
+            model._meta.label for model in declaring if not issubclass(model, CloningMixin)
+        )
+        self.assertEqual(offenders, [], "clone_fields is inert on models which do not inherit CloningMixin")
 
     def test_cloningmixin_injects_gfk_attribute(self):
         """

--- a/netbox/tenancy/models/contacts.py
+++ b/netbox/tenancy/models/contacts.py
@@ -154,8 +154,6 @@ class ContactAssignment(CustomFieldsMixin, ExportTemplatesMixin, TagsMixin, Chan
         null=True
     )
 
-    clone_fields = ('object_type', 'object_id', 'role', 'priority')
-
     class Meta:
         ordering = ('contact', 'priority', 'role', 'pk')
         indexes = (


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #22987

<!--
    Please include a summary of the proposed changes below.
-->
Removes unused `clone_fields` declarations from `tenancy.ContactAssignment`, `ipam.FHRPGroupAssignment`, and `extras.ImageAttachment`, which do not inherit `CloningMixin` and therefore do not support cloning.

Also adds regression coverage to ensure that core models declare `clone_fields` only when they inherit `CloningMixin`.
