### PR TITLE
Closes #21387: Add InfiniBand 4X interface types

### DIFF
--- a/netbox/dcim/choices.py
+++ b/netbox/dcim/choices.py
@@ -1103,7 +1103,7 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_64GFC_SFP_PLUS = '64gfc-sfpp'
     TYPE_128GFC_QSFP28 = '128gfc-qsfp28'
 
-    # InfiniBand
+    # InfiniBand 1X
     TYPE_INFINIBAND_SDR = 'infiniband-sdr'
     TYPE_INFINIBAND_DDR = 'infiniband-ddr'
     TYPE_INFINIBAND_QDR = 'infiniband-qdr'
@@ -1113,6 +1113,17 @@ class InterfaceTypeChoices(ChoiceSet):
     TYPE_INFINIBAND_HDR = 'infiniband-hdr'
     TYPE_INFINIBAND_NDR = 'infiniband-ndr'
     TYPE_INFINIBAND_XDR = 'infiniband-xdr'
+
+    # InfiniBand 4X
+    TYPE_INFINIBAND_SDR_4X = 'infiniband-sdr-4x'
+    TYPE_INFINIBAND_DDR_4X = 'infiniband-ddr-4x'
+    TYPE_INFINIBAND_QDR_4X = 'infiniband-qdr-4x'
+    TYPE_INFINIBAND_FDR10_4X = 'infiniband-fdr10-4x'
+    TYPE_INFINIBAND_FDR_4X = 'infiniband-fdr-4x'
+    TYPE_INFINIBAND_EDR_4X = 'infiniband-edr-4x'
+    TYPE_INFINIBAND_HDR_4X = 'infiniband-hdr-4x'
+    TYPE_INFINIBAND_NDR_4X = 'infiniband-ndr-4x'
+    TYPE_INFINIBAND_XDR_4X = 'infiniband-xdr-4x'
 
     # Serial
     TYPE_T1 = 't1'
@@ -1431,7 +1442,7 @@ class InterfaceTypeChoices(ChoiceSet):
             )
         ),
         (
-            'InfiniBand',
+            'InfiniBand 1X',
             (
                 (TYPE_INFINIBAND_SDR, 'SDR (2 Gbps)'),
                 (TYPE_INFINIBAND_DDR, 'DDR (4 Gbps)'),
@@ -1441,7 +1452,21 @@ class InterfaceTypeChoices(ChoiceSet):
                 (TYPE_INFINIBAND_EDR, 'EDR (25 Gbps)'),
                 (TYPE_INFINIBAND_HDR, 'HDR (50 Gbps)'),
                 (TYPE_INFINIBAND_NDR, 'NDR (100 Gbps)'),
-                (TYPE_INFINIBAND_XDR, 'XDR (250 Gbps)'),
+                (TYPE_INFINIBAND_XDR, 'XDR (200 Gbps)'),
+            )
+        ),
+        (
+            'InfiniBand 4X',
+            (
+                (TYPE_INFINIBAND_SDR_4X, 'SDR 4X (8 Gbps)'),
+                (TYPE_INFINIBAND_DDR_4X, 'DDR 4X (16 Gbps)'),
+                (TYPE_INFINIBAND_QDR_4X, 'QDR 4X (32 Gbps)'),
+                (TYPE_INFINIBAND_FDR10_4X, 'FDR10 4X (40 Gbps)'),
+                (TYPE_INFINIBAND_FDR_4X, 'FDR 4X (56 Gbps)'),
+                (TYPE_INFINIBAND_EDR_4X, 'EDR 4X (100 Gbps)'),
+                (TYPE_INFINIBAND_HDR_4X, 'HDR 4X (200 Gbps)'),
+                (TYPE_INFINIBAND_NDR_4X, 'NDR 4X (400 Gbps)'),
+                (TYPE_INFINIBAND_XDR_4X, 'XDR 4X (800 Gbps)'),
             )
         ),
         (


### PR DESCRIPTION
Most Infiniband interfaces combine 4 channels to quadruple the connection speed. Add 4X choices for all InfiniBand speeds.

Fixes #21387

<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #21387

<!--
    Please include a summary of the proposed changes below.
-->
