### PR TITLE
Closes #23044: Enforce milestone assignment when closing issues as completed

### DIFF
--- a/.github/workflows/enforce-milestone.yml
+++ b/.github/workflows/enforce-milestone.yml
@@ -1,0 +1,37 @@
+name: Enforce milestone on close
+
+on:
+  issues:
+    types:
+      - closed
+
+permissions:
+  issues: write
+
+jobs:
+  check-milestone:
+    name: Check Milestone
+    if: github.repository == 'netbox-community/netbox' && github.event.issue.state_reason == 'completed'
+    runs-on: ubuntu-slim
+
+    steps:
+      - name: Reopen issues completed without a milestone
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE: ${{ github.event.issue.number }}
+        run: |
+          # Grace period, in case the milestone is assigned immediately after closure
+          sleep 90
+
+          # Re-check the issue: bail out if it has been reopened or a milestone has since been set
+          DATA=$(gh issue view "$ISSUE" --json state,milestone)
+          STATE=$(jq -r '.state' <<< "$DATA")
+          MILESTONE=$(jq -r '.milestone.title // ""' <<< "$DATA")
+          if [ "$STATE" != "CLOSED" ] || [ -n "$MILESTONE" ]; then
+            echo "Nothing to do (state=$STATE, milestone=${MILESTONE:-none})"
+            exit 0
+          fi
+
+          gh issue reopen "$ISSUE" --comment \
+            "This issue was closed as completed without a milestone assigned, and has been reopened automatically. Please assign the milestone for the upcoming release, then close the issue again."


### PR DESCRIPTION
### Closes: #23044

#### Summary

Adds a `Enforce milestone on close` workflow which reopens any issue that is closed as completed without a milestone assigned. This guards against the manual step of assigning the upcoming release's milestone being forgotten, which we rely on when compiling release notes.

#### Behavior

* Triggers only on the `issues: closed` event where `state_reason` is `completed`. Issues closed as not planned or as duplicates are ignored, as are pull requests (the `issues` event does not fire for PRs).
* Waits 90 seconds, then re-checks the issue before acting, so that assigning the milestone immediately after closing does not produce a spurious reopen.
* Reopens the issue with an explanatory comment. Because the reopen is performed using `GITHUB_TOKEN`, it does not trigger further workflow runs.

Note that this enforces only the *presence* of a milestone, not its correctness — the workflow has no way to determine which milestone is appropriate for a given issue.
