### PR TITLE
Fixes #23052: Fix owner field handling for Power Outlets and Application Services

### DIFF
--- a/netbox/dcim/forms/model_forms.py
+++ b/netbox/dcim/forms/model_forms.py
@@ -1517,7 +1517,7 @@ class PowerOutletForm(ModularDeviceComponentForm):
     fieldsets = (
         FieldSet(
             'device', 'module', 'name', 'label', 'type', 'status', 'color', 'power_port', 'feed_leg', 'mark_connected',
-            'description', 'owner', 'tags',
+            'description', 'tags',
         ),
     )
 
@@ -1525,7 +1525,7 @@ class PowerOutletForm(ModularDeviceComponentForm):
         model = PowerOutlet
         fields = [
             'device', 'module', 'name', 'label', 'type', 'status', 'color', 'power_port', 'feed_leg', 'mark_connected',
-            'description', 'tags',
+            'description', 'owner', 'tags',
         ]
 
 

--- a/netbox/dcim/tests/test_views.py
+++ b/netbox/dcim/tests/test_views.py
@@ -20,7 +20,7 @@ from extras.models import ConfigContext, ConfigTemplate
 from ipam.models import ASN, RIR, VLAN, VRF
 from netbox.choices import CSVDelimiterChoices, ImportFormatChoices, WeightUnitChoices
 from tenancy.models import Tenant
-from users.models import ObjectPermission, User
+from users.models import ObjectPermission, Owner, User
 from utilities.testing import ViewTestCases, create_tags, create_test_device, post_data
 from wireless.models import WirelessLAN
 
@@ -3240,6 +3240,8 @@ class PowerOutletTestCase(ViewTestCases.DeviceComponentViewTestCase):
         )
         PowerOutlet.objects.bulk_create(power_outlets)
 
+        owner = Owner.objects.create(name='Owner 1')
+
         tags = create_tags('Alpha', 'Bravo', 'Charlie')
 
         cls.form_data = {
@@ -3250,6 +3252,7 @@ class PowerOutletTestCase(ViewTestCases.DeviceComponentViewTestCase):
             'power_port': powerports[1].pk,
             'feed_leg': PowerOutletFeedLegChoices.FEED_LEG_B,
             'description': 'A power outlet',
+            'owner': owner.pk,
             'tags': [t.pk for t in tags],
         }
 
@@ -3261,6 +3264,7 @@ class PowerOutletTestCase(ViewTestCases.DeviceComponentViewTestCase):
             'power_port': powerports[1].pk,
             'feed_leg': PowerOutletFeedLegChoices.FEED_LEG_B,
             'description': 'A power outlet',
+            'owner': owner.pk,
             'tags': [t.pk for t in tags],
         }
 

--- a/netbox/ipam/forms/model_forms.py
+++ b/netbox/ipam/forms/model_forms.py
@@ -910,7 +910,7 @@ class ServiceCreateForm(ServiceForm):
 
     class Meta(ServiceForm.Meta):
         fields = [
-            'service_template', 'name', 'protocol', 'ports', 'ipaddresses', 'description',
+            'service_template', 'name', 'protocol', 'ports', 'ipaddresses', 'description', 'owner',
             'comments', 'tags', 'parent_object_type',
         ]
 

--- a/netbox/ipam/tests/test_views.py
+++ b/netbox/ipam/tests/test_views.py
@@ -20,7 +20,7 @@ from ipam.utils import AvailableIPSpace
 from ipam.views import AggregatePrefixesView, PrefixPrefixesView
 from netbox.choices import CSVDelimiterChoices, ImportFormatChoices
 from tenancy.models import Tenant
-from users.models import Group, ObjectPermission
+from users.models import Group, ObjectPermission, Owner
 from utilities.testing import ViewTestCases, create_tags
 
 
@@ -2561,6 +2561,8 @@ class ServiceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
         )
         IPAddress.objects.bulk_create(ip_addresses)
 
+        owner = Owner.objects.create(name='Owner 1')
+
         tags = create_tags('Alpha', 'Bravo', 'Charlie')
 
         cls.form_data = {
@@ -2571,6 +2573,7 @@ class ServiceTestCase(ViewTestCases.PrimaryObjectViewTestCase):
             'ports': '104,105',
             'ipaddresses': [],
             'description': 'A new service',
+            'owner': owner.pk,
             'tags': [t.pk for t in tags],
         }
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #23052

<!--
    Please include a summary of the proposed changes below.
-->
Correct the owner field configuration for power outlets by moving `owner` out of the explicit fieldset and into `PowerOutletForm.Meta.fields`. This prevents the field from being rendered twice and ensures that the selected owner is saved.

Add `owner` to `ServiceCreateForm.Meta.fields` to resolve the same persistence issue when creating application services, and extend the existing view tests to cover owner assignment for both forms.
