### PR TITLE
Closes #22991: Omit manufacturer from ModuleBayType representation

### DIFF
--- a/netbox/dcim/models/modules.py
+++ b/netbox/dcim/models/modules.py
@@ -78,6 +78,10 @@ class ModuleBayType(PrimaryModel):
         verbose_name_plural = _('module bay types')
 
     def __str__(self):
+        return self.name
+
+    @property
+    def full_name(self):
         if self.manufacturer:
             return f'{self.manufacturer} {self.name}'
         return self.name


### PR DESCRIPTION
### Closes: #22991

Side-steps the prefetching issue by omitting the manufacturer from the ModuleBayType representation entirely, inline with what we do for DeviceType and similar models. Provides a `full_name` attribute as well for each reference should it be needed (also like DeviceType).