### PR TITLE
Closes #23060: Optimize REST API prefetching for reverse many-to-many fields

### DIFF
--- a/netbox/ipam/tests/query_counts.json
+++ b/netbox/ipam/tests/query_counts.json
@@ -1,7 +1,7 @@
 {
   "aggregate:api_list_objects": 13,
   "aggregate:list_objects_with_permission": 21,
-  "asn:api_list_objects": 17,
+  "asn:api_list_objects": 16,
   "asn:list_objects_with_permission": 28,
   "asnrange:api_list_objects": 14,
   "asnrange:list_objects_with_permission": 19,

--- a/netbox/users/tests/query_counts.json
+++ b/netbox/users/tests/query_counts.json
@@ -1,7 +1,7 @@
 {
   "group:api_list_objects": 10,
   "group:list_objects_with_permission": 16,
-  "objectpermission:api_list_objects": 14,
+  "objectpermission:api_list_objects": 12,
   "objectpermission:list_objects_with_permission": 17,
   "owner:api_list_objects": 11,
   "owner:list_objects_with_permission": 18,

--- a/netbox/utilities/api.py
+++ b/netbox/utilities/api.py
@@ -8,7 +8,7 @@ from django.core.exceptions import (
     ObjectDoesNotExist,
     ValidationError,
 )
-from django.db.models.fields.related import ManyToOneRel, RelatedField
+from django.db.models.fields.related import ManyToManyRel, ManyToOneRel, RelatedField
 from django.urls import reverse
 from django.utils.module_loading import import_string
 from django.utils.translation import gettext_lazy as _
@@ -193,7 +193,7 @@ def get_prefetches_for_serializer(serializer_class, fields=None, omit=None, _ser
         # If the serializer field does not map to a discrete model field, skip it.
         try:
             field = model._meta.get_field(model_field_name)
-            if isinstance(field, (RelatedField, ManyToOneRel, GenericForeignKey)):
+            if isinstance(field, (RelatedField, ManyToOneRel, ManyToManyRel, GenericForeignKey)):
                 prefetch_fields.append(field.name)
         except FieldDoesNotExist:
             continue

--- a/netbox/utilities/tests/test_api.py
+++ b/netbox/utilities/tests/test_api.py
@@ -16,7 +16,7 @@ from netbox.api.serializers import BaseModelSerializer
 from netbox.config import get_config
 from netbox.plugins import register_serializer_resolver
 from netbox.registry import registry
-from users.models import ObjectPermission
+from users.models import Group, ObjectPermission
 from utilities.api import (
     get_prefetches_for_serializer,
     get_serializer_for_model,
@@ -752,6 +752,41 @@ class GetPrefetchesForSerializerTestCase(TestCase):
         self.assertListEqual(
             get_prefetches_for_serializer(RegionSerializer),
             ['parent', 'parent__sites', 'children', 'children__sites'],
+        )
+
+    def test_reverse_many_to_many_relation_is_prefetched(self):
+        class ObjectPermissionSerializer(BaseModelSerializer):
+            class Meta:
+                model = ObjectPermission
+                fields = ('groups',)
+
+        self.assertListEqual(
+            get_prefetches_for_serializer(ObjectPermissionSerializer),
+            ['groups'],
+        )
+
+    def test_reverse_many_to_many_serialized_related_field_is_prefetched(self):
+        class GroupSerializer(BaseModelSerializer):
+            class Meta:
+                model = Group
+                fields = ('id', 'name')
+
+        class ObjectPermissionSerializer(BaseModelSerializer):
+            groups = SerializedPKRelatedField(
+                queryset=Group.objects.all(),
+                serializer=GroupSerializer,
+                nested=True,
+                required=False,
+                many=True
+            )
+
+            class Meta:
+                model = ObjectPermission
+                fields = ('id', 'groups')
+
+        self.assertListEqual(
+            get_prefetches_for_serializer(ObjectPermissionSerializer),
+            ['groups'],
         )
 
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #23060

<!--
    Please include a summary of the proposed changes below.
-->
`get_prefetches_for_serializer()` did not recognize Django's `ManyToManyRel`, so reverse many-to-many fields were omitted from REST API prefetches. These relations were consequently fetched once per serialized object, causing query counts to grow linearly with the page size.

This change adds `ManyToManyRel` to the existing relation type check. Keeping the fix in the shared resolver preserves serializer-driven field selection: a relation is prefetched only when it is included in the requested representation.

The explicit `ManyToManyRel` check is intentionally narrower than using `ForeignObjectRel` or `field.is_relation`, either of which would also include relation types outside the scope of this issue, such as `GenericRel`.

The affected default serializer fields are:

| Serializer | Field | Relation |
|---|---|---|
| `ASNSerializer` | `sites` | Reverse of `Site.asns` |
| `ObjectPermissionSerializer` | `groups` | Reverse of `Group.object_permissions` |
| `ObjectPermissionSerializer` | `users` | Reverse of `User.object_permissions` |

Each field is declared as `SerializedPKRelatedField(..., many=True)`.

#### Measured impact

Measurements through the full HTTP stack against PostgreSQL confirm that the query count is now constant as the page size increases:

| Endpoint | Before, 5 objects | Before, 40 objects | After, 5–40 objects | `?fields=id` |
|---|---:|---:|---:|---:|
| `/api/ipam/asns/?fields=id,sites` | 15 | 50 | 11 | 10 |
| `/api/users/permissions/?fields=id,groups,users` | 18 | 88 | 10 | 8 |

Response bodies were unchanged between both variants. The `?fields=id` controls were also unchanged, confirming that no prefetch is added when the relation is omitted from the requested representation.

#### Testing

Added regression coverage to `GetPrefetchesForSerializerTestCase` for both an automatically generated reverse many-to-many serializer field and an explicitly declared `SerializedPKRelatedField(many=True)`.

Regenerated the affected API query-count baselines:

- `asn:api_list_objects`: 17 to 16
- `objectpermission:api_list_objects`: 14 to 12

The existing fixtures already populate all three relations, so no fixture changes were required. The corresponding UI query-count baselines remain unchanged because the table-based list views do not use this helper.

A sweep of all 135 model serializers found only the three expected new prefetch paths and no resolution failures. The full test suite passes.

This remains separate from #22988 and #23061, which address discovering nested prefetch paths after the base relation has already been identified. This change ensures that the base reverse many-to-many relation is recognized.