### PR TITLE
Closes #23049: Update development database scripts for PostgreSQL 15 and later

### DIFF
--- a/scripts/drop_database.sh
+++ b/scripts/drop_database.sh
@@ -1,7 +1,14 @@
 #!/bin/sh
+# Drop and re-create a local NetBox database, granting the role named after
+# it create on the database and on schema public. The schema grant is
+# required since PostgreSQL 15. Runs psql as the postgres superuser via sudo.
+#
+# Usage:   scripts/drop_database.sh [database=netbox]
+# Example: scripts/drop_database.sh
 
 DB=${1:-netbox}
 
-# Drop and re-create the database locally
 sudo -u postgres psql -c "drop database $DB"
 sudo -u postgres psql -c "create database $DB"
+sudo -u postgres psql -c "grant create on database $DB to $DB"
+sudo -u postgres psql -d $DB -c "grant create on schema public to $DB"

--- a/scripts/load_database.sh
+++ b/scripts/load_database.sh
@@ -1,11 +1,20 @@
 #!/bin/sh
+# Drop, re-create and load a local NetBox database from a SQL dump, granting
+# the role named after the database create on it and on schema public. The
+# schema grant is required since PostgreSQL 15. Runs psql as the postgres
+# superuser via sudo.
+#
+# Usage:   scripts/load_database.sh <dump.sql> [database=netbox]
+# Example: scripts/load_database.sh netbox.sql
 
 DB=${2:-netbox}
 
-# Drop and re-create the database locally
 sudo -u postgres psql -c "DROP DATABASE $DB"
 sudo -u postgres psql -c "CREATE DATABASE $DB"
 sudo -u postgres psql -c "GRANT CREATE ON DATABASE $DB TO $DB"
 
 # Load tables from the production dump
 sudo -u postgres psql $DB < $1
+
+# Grant after the load so a dump that re-creates schema public cannot undo it
+sudo -u postgres psql -d $DB -c "GRANT CREATE ON SCHEMA public TO $DB"

--- a/scripts/save_database.sh
+++ b/scripts/save_database.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
+# Dump a local NetBox database to a SQL file that load_database.sh can
+# restore. Runs pg_dump as the postgres superuser via sudo, but the dump
+# file is written by the invoking user.
+#
+# Usage:   scripts/save_database.sh <dump.sql> [database=netbox]
+# Example: scripts/save_database.sh netbox.sql
 
 DB=${2:-netbox}
 
-# Dump the database to a file
 sudo -u postgres pg_dump $DB > $1
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #23049

<!--
    Please include a summary of the proposed changes below.
-->
Grant the database role matching the database name `CREATE` permission on the `public` schema when recreating or restoring a local development database. When loading a dump, apply the schema grant after the restore so permissions recreated by the dump cannot override it on PostgreSQL 15 and later.

Also add concise descriptions, usage instructions, and examples to the database utility scripts.