### PR TITLE
Add the Redis username to the Django default cache settings

### DIFF
--- a/netbox/netbox/settings.py
+++ b/netbox/netbox/settings.py
@@ -413,6 +413,7 @@ CACHES = {
         'LOCATION': CACHING_REDIS_URL,
         'OPTIONS': {
             'CLIENT_CLASS': 'django_redis.client.DefaultClient',
+            'USERNAME': CACHING_REDIS_USERNAME,
             'PASSWORD': CACHING_REDIS_PASSWORD,
         }
     }


### PR DESCRIPTION
Closes: #23066 

As it turned out, the Redis username was missing from the Django default cache settings. This is fine as long as one only uses the `default` user, but it fails in the way shown in #23066 if a custom user is used. 

Fortunately, the fix is **extremely** simple.