### PR TITLE
Closes #22714: Recover system jobs stranded by a killed worker

### DIFF
--- a/netbox/core/management/commands/rqworker.py
+++ b/netbox/core/management/commands/rqworker.py
@@ -2,6 +2,7 @@ import logging
 
 from django_rq.management.commands.rqworker import Command as _Command
 
+from netbox.jobs import reconcile_stale_system_jobs
 from netbox.registry import registry
 
 DEFAULT_QUEUES = ('high', 'default', 'low')
@@ -21,6 +22,9 @@ class Command(_Command):
                 interval = kwargs['interval']
             except KeyError:
                 raise TypeError("System job must specify an interval (in minutes).")
+            # Recover jobs stranded by a killed worker before scheduling, so a stale row
+            # isn't mistaken for a live schedule (see #22714).
+            reconcile_stale_system_jobs(job, interval)
             logger.debug(f"Scheduling system job {job.name} (interval={interval})")
             job.enqueue_once(**kwargs)
 

--- a/netbox/core/tests/test_management_commands.py
+++ b/netbox/core/tests/test_management_commands.py
@@ -209,6 +209,28 @@ class RQWorkerTestCase(TestCase):
             with self.assertRaisesMessage(TypeError, 'System job must specify an interval'):
                 call_command('rqworker', stdout=StringIO(), stderr=StringIO())
 
+    def test_reconciles_stale_jobs_before_scheduling(self):
+        # Recovery of jobs stranded by a killed worker (#22714) must run before enqueue_once(),
+        # so a stale row can't be mistaken for a live schedule and block re-arming.
+        job = MagicMock()
+        job.name = 'TestJob'
+        manager = MagicMock()
+
+        with (
+            patch('core.management.commands.rqworker.registry', {'system_jobs': {job: {'interval': 5}}}),
+            patch('core.management.commands.rqworker.reconcile_stale_system_jobs') as reconcile,
+            patch('core.management.commands.rqworker._Command.handle'),
+        ):
+            manager.attach_mock(reconcile, 'reconcile')
+            manager.attach_mock(job.enqueue_once, 'enqueue_once')
+            call_command('rqworker', stdout=StringIO(), stderr=StringIO())
+
+        reconcile.assert_called_once_with(job, 5)
+        self.assertEqual(
+            [name for name, _, _ in manager.mock_calls],
+            ['reconcile', 'enqueue_once'],
+        )
+
 
 class SyncDataSourceTestCase(TestCase):
     class FakeDataSource:

--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -97,7 +97,10 @@ def reconcile_stale_system_jobs(job_class, interval):
     if not running:
         return
 
-    # The timeout is a property of the runner, not the individual job, so resolve it once.
+    # The timeout is a property of the runner, not the individual job, so resolve it once. Because
+    # the window sits past the job's own RQ timeout (the deadline at which RQ itself would kill a
+    # live run), a job still inside it is effectively never a live one, so this can't race a running
+    # worker's own terminate() under normal operation.
     grace = resolve_job_timeout(job_class, running[0]) + STALE_RUNNING_JOB_GRACE_SECONDS
     cutoff = timezone.now() - timedelta(seconds=grace)
 

--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -21,6 +21,7 @@ from utilities.request import apply_request_processors
 __all__ = (
     'AsyncViewJob',
     'JobRunner',
+    'reconcile_stale_system_jobs',
     'system_job',
 )
 
@@ -28,6 +29,11 @@ __all__ = (
 # prefixes from traceback file paths before recording them in the job log.
 # jobs.py lives at <root>/netbox/netbox/jobs.py, so parents[2] is the root.
 _INSTALL_ROOT = str(Path(__file__).resolve().parents[2]) + os.sep
+
+# Floor for the grace period before a "running" system job is treated as stranded. The window
+# is max(interval, this floor), so a short-interval job still gets time to finish a legitimate
+# run. See reconcile_stale_system_jobs() and issue #22714.
+STALE_RUNNING_JOB_GRACE_MINUTES = 30
 
 
 def system_job(interval):
@@ -44,6 +50,37 @@ def system_job(interval):
         return cls
 
     return _wrapper
+
+
+@advisory_lock(ADVISORY_LOCK_KEYS['job-schedules'])
+def reconcile_stale_system_jobs(job_class, interval):
+    """
+    Fail any object-less system job of this class left stranded in "running" status by a worker
+    that was killed mid-run (issue #22714). Such a row is never reset, and because "running" is
+    an enqueued state, `enqueue_once()` mistakes it for a live schedule and never re-arms it.
+
+    A running job is treated as stranded once its `started` timestamp is older than
+    `max(interval, STALE_RUNNING_JOB_GRACE_MINUTES)`. RQ is not consulted: a killed job's RQ
+    entry can outlive the worker, and the schedule may be recovered with RQ state wiped.
+    """
+    grace = max(interval, STALE_RUNNING_JOB_GRACE_MINUTES)
+    cutoff = timezone.now() - timedelta(minutes=grace)
+
+    orphaned = Job.objects.filter(
+        name=job_class.name,
+        object_id__isnull=True,
+        interval=interval,
+        status=JobStatusChoices.STATUS_RUNNING,
+        started__lte=cutoff,
+    )
+    for job in orphaned:
+        # STATUS_ERRORED (not FAILED) records an unexpected fault rather than a self-declared
+        # failure, as handle() does for an unhandled exception. For an object-less, userless
+        # system job, terminate() sends no notification and triggers no event rule.
+        job.terminate(
+            status=JobStatusChoices.STATUS_ERRORED,
+            error="Worker terminated before job completed",
+        )
 
 
 class JobLogHandler(logging.Handler):
@@ -223,7 +260,11 @@ class JobRunner(ABC):
             # Redis restart) and must be replaced rather than reused, even though its parameters match.
             # Running/pending jobs are exempt from this check: their `scheduled` timestamp is expected to be
             # in the past (or unset) once they've started, and that must not be mistaken for staleness.
-            is_stale = job.status == JobStatusChoices.STATUS_SCHEDULED and job.scheduled <= timezone.now()
+            is_stale = (
+                job.status == JobStatusChoices.STATUS_SCHEDULED and
+                job.scheduled and
+                job.scheduled <= timezone.now()
+            )
             if not is_stale and (not schedule_at or job.scheduled == schedule_at) and (job.interval == interval):
                 return job
             job.delete()

--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -217,9 +217,14 @@ class JobRunner(ABC):
         """
         job = cls.get_jobs(instance).filter(status__in=JobStatusChoices.ENQUEUED_STATE_CHOICES).first()
         if job:
-            # If the job parameters haven't changed, don't schedule a new job and keep the current schedule. Otherwise,
-            # delete the existing job and schedule a new job instead.
-            if (not schedule_at or job.scheduled == schedule_at) and (job.interval == interval):
+            # If the job parameters haven't changed, don't schedule a new job and keep the current schedule.
+            # Otherwise, delete the existing job and schedule a new job instead. A job still in "scheduled"
+            # status whose time has already passed is stale (its RQ-side scheduler entry was lost, e.g. by a
+            # Redis restart) and must be replaced rather than reused, even though its parameters match.
+            # Running/pending jobs are exempt from this check: their `scheduled` timestamp is expected to be
+            # in the past (or unset) once they've started, and that must not be mistaken for staleness.
+            is_stale = job.status == JobStatusChoices.STATUS_SCHEDULED and job.scheduled <= timezone.now()
+            if not is_stale and (not schedule_at or job.scheduled == schedule_at) and (job.interval == interval):
                 return job
             job.delete()
 

--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -38,6 +38,12 @@ _INSTALL_ROOT = str(Path(__file__).resolve().parents[2]) + os.sep
 # See reconcile_stale_system_jobs() and issue #22714.
 STALE_RUNNING_JOB_GRACE_SECONDS = 600
 
+# How long past its scheduled time a job in "scheduled" status must be before enqueue_once() treats
+# it as stranded (its RQ-side scheduler entry was lost) rather than merely waiting its turn in the
+# queue. This is queue latency, not run duration, so it's a separate margin from the running-job
+# grace above. See enqueue_once() and issue #22714.
+STALE_SCHEDULED_JOB_GRACE_SECONDS = 600
+
 
 def system_job(interval):
     """
@@ -280,14 +286,16 @@ class JobRunner(ABC):
         if job:
             # If the job parameters haven't changed, don't schedule a new job and keep the current schedule.
             # Otherwise, delete the existing job and schedule a new job instead. A job still in "scheduled"
-            # status whose time has already passed is stale (its RQ-side scheduler entry was lost, e.g. by a
-            # Redis restart) and must be replaced rather than reused, even though its parameters match.
-            # Running/pending jobs are exempt from this check: their `scheduled` timestamp is expected to be
-            # in the past (or unset) once they've started, and that must not be mistaken for staleness.
+            # status well past its scheduled time is stale (its RQ-side scheduler entry was lost, e.g. by a
+            # Redis restart) and must be replaced rather than reused, even though its parameters match. The
+            # grace margin avoids mistaking a job that is merely waiting its turn in the queue (still
+            # "scheduled" with a just-passed timestamp) for a stranded one. Running/pending jobs are exempt:
+            # their `scheduled` timestamp is expected to be in the past (or unset) once they've started.
+            stale_before = timezone.now() - timedelta(seconds=STALE_SCHEDULED_JOB_GRACE_SECONDS)
             is_stale = (
                 job.status == JobStatusChoices.STATUS_SCHEDULED and
                 job.scheduled and
-                job.scheduled <= timezone.now()
+                job.scheduled <= stale_before
             )
             if not is_stale and (not schedule_at or job.scheduled == schedule_at) and (job.interval == interval):
                 return job

--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -5,6 +5,7 @@ from abc import ABC, abstractmethod
 from datetime import timedelta
 from pathlib import Path
 
+from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import timezone
 from django.utils.functional import classproperty
@@ -22,6 +23,7 @@ __all__ = (
     'AsyncViewJob',
     'JobRunner',
     'reconcile_stale_system_jobs',
+    'resolve_job_timeout',
     'system_job',
 )
 
@@ -30,10 +32,11 @@ __all__ = (
 # jobs.py lives at <root>/netbox/netbox/jobs.py, so parents[2] is the root.
 _INSTALL_ROOT = str(Path(__file__).resolve().parents[2]) + os.sep
 
-# Floor for the grace period before a "running" system job is treated as stranded. The window
-# is max(interval, this floor), so a short-interval job still gets time to finish a legitimate
-# run. See reconcile_stale_system_jobs() and issue #22714.
-STALE_RUNNING_JOB_GRACE_MINUTES = 30
+# Margin added to a job's run timeout before a "running" system job is treated as stranded. A
+# job still running this long past its RQ timeout can no longer be executing legitimately (its
+# worker was killed), so the window is keyed on run duration rather than the recurrence interval.
+# See reconcile_stale_system_jobs() and issue #22714.
+STALE_RUNNING_JOB_GRACE_SECONDS = 600
 
 
 def system_job(interval):
@@ -52,6 +55,17 @@ def system_job(interval):
     return _wrapper
 
 
+def resolve_job_timeout(job_class, job):
+    """
+    Return the RQ run timeout (in seconds) a `JobRunner` runs under, falling back to
+    `RQ_DEFAULT_TIMEOUT` when it declares none. There is no single timeout contract across job
+    types: scripts expose `Meta.job_timeout` (class-level), some plugin runners expose an instance
+    `@property`, and the base class declares nothing. Instantiate the runner so an instance property
+    resolves correctly regardless of what it reads.
+    """
+    return getattr(job_class(job), 'job_timeout', None) or settings.RQ_DEFAULT_TIMEOUT
+
+
 @advisory_lock(ADVISORY_LOCK_KEYS['job-schedules'])
 def reconcile_stale_system_jobs(job_class, interval):
     """
@@ -59,21 +73,31 @@ def reconcile_stale_system_jobs(job_class, interval):
     that was killed mid-run (issue #22714). Such a row is never reset, and because "running" is
     an enqueued state, `enqueue_once()` mistakes it for a live schedule and never re-arms it.
 
-    A running job is treated as stranded once its `started` timestamp is older than
-    `max(interval, STALE_RUNNING_JOB_GRACE_MINUTES)`. RQ is not consulted: a killed job's RQ
-    entry can outlive the worker, and the schedule may be recovered with RQ state wiped.
+    A running job is treated as stranded once its `started` timestamp is older than the job's own
+    RQ run timeout plus a margin: past that point the run can no longer be executing legitimately.
+    Keying on run duration rather than the recurrence `interval` lets recovery fire on the common
+    case (a worker killed and restarted moments later) while still tolerating a legitimately long
+    run that declares a large timeout. RQ is not consulted: a killed job's RQ entry can outlive the
+    worker, and the schedule may be recovered with RQ state wiped.
     """
-    grace = max(interval, STALE_RUNNING_JOB_GRACE_MINUTES)
-    cutoff = timezone.now() - timedelta(minutes=grace)
-
-    orphaned = Job.objects.filter(
-        name=job_class.name,
-        object_id__isnull=True,
-        interval=interval,
-        status=JobStatusChoices.STATUS_RUNNING,
-        started__lte=cutoff,
+    running = list(
+        Job.objects.filter(
+            name=job_class.name,
+            object_id__isnull=True,
+            interval=interval,
+            status=JobStatusChoices.STATUS_RUNNING,
+        )
     )
-    for job in orphaned:
+    if not running:
+        return
+
+    # The timeout is a property of the runner, not the individual job, so resolve it once.
+    grace = resolve_job_timeout(job_class, running[0]) + STALE_RUNNING_JOB_GRACE_SECONDS
+    cutoff = timezone.now() - timedelta(seconds=grace)
+
+    for job in running:
+        if not job.started or job.started > cutoff:
+            continue
         # STATUS_ERRORED (not FAILED) records an unexpected fault rather than a self-declared
         # failure, as handle() does for an unhandled exception. For an object-less, userless
         # system job, terminate() sends no notification and triggers no event rule.

--- a/netbox/netbox/jobs.py
+++ b/netbox/netbox/jobs.py
@@ -9,6 +9,7 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.utils import timezone
 from django.utils.functional import classproperty
+from django.utils.translation import gettext_lazy as _
 from django_pglocks import advisory_lock
 from rq.timeouts import JobTimeoutException
 
@@ -22,8 +23,6 @@ from utilities.request import apply_request_processors
 __all__ = (
     'AsyncViewJob',
     'JobRunner',
-    'reconcile_stale_system_jobs',
-    'resolve_job_timeout',
     'system_job',
 )
 
@@ -112,7 +111,7 @@ def reconcile_stale_system_jobs(job_class, interval):
         # system job, terminate() sends no notification and triggers no event rule.
         job.terminate(
             status=JobStatusChoices.STATUS_ERRORED,
-            error="Worker terminated before job completed",
+            error=_("Worker terminated before job completed"),
         )
 
 

--- a/netbox/netbox/tests/test_jobs.py
+++ b/netbox/netbox/tests/test_jobs.py
@@ -501,6 +501,23 @@ class ReconcileStaleJobsTestCase(BaseJobRunnerTestCase):
         live.refresh_from_db()
         self.assertEqual(live.status, JobStatusChoices.STATUS_RUNNING)
 
+    def test_reconcile_ignores_running_job_without_started(self):
+        """A running row with no `started` timestamp can't be aged against the window. It must
+        be left untouched rather than raising when compared against the cutoff."""
+        no_started = Job.objects.create(
+            name=TestSystemJobRunner.name,
+            status=JobStatusChoices.STATUS_RUNNING,
+            interval=60,
+            scheduled=timezone.now() - timedelta(hours=2),
+            started=None,
+            job_id=uuid.uuid4(),
+        )
+
+        reconcile_stale_system_jobs(TestSystemJobRunner, 60)
+
+        no_started.refresh_from_db()
+        self.assertEqual(no_started.status, JobStatusChoices.STATUS_RUNNING)
+
     def test_reconcile_ignores_instance_bound_job(self):
         """The sweep targets object-less system jobs only. An instance-bound job of the
         same runner class must be left alone even if it looks stale."""

--- a/netbox/netbox/tests/test_jobs.py
+++ b/netbox/netbox/tests/test_jobs.py
@@ -192,6 +192,25 @@ class EnqueueTestCase(BaseJobRunnerTestCase):
         self.assertRaises(Job.DoesNotExist, stale.refresh_from_db)
         self.assertEqual(TestJobRunner.get_jobs().count(), 1)
 
+    def test_enqueue_once_reuses_recently_scheduled_job(self):
+        """
+        A job whose scheduled time has only just passed is waiting its turn in the queue, not
+        stranded. Within the grace margin it must be reused, not deleted and re-enqueued — a
+        concurrent enqueue_once() (e.g. a DataSource save) must not disrupt a due-but-queued job.
+        """
+        queued = Job.objects.create(
+            name=TestJobRunner.name,
+            status=JobStatusChoices.STATUS_SCHEDULED,
+            interval=60,
+            scheduled=timezone.now() - timedelta(seconds=30),
+            job_id=uuid.uuid4(),
+        )
+
+        job = TestJobRunner.enqueue_once(interval=60)
+
+        self.assertEqual(job, queued)
+        self.assertEqual(TestJobRunner.get_jobs().count(), 1)
+
     def test_enqueue_once_reuses_pending_job_with_no_schedule(self):
         """
         A pending job (not yet picked up by a worker) has no `scheduled` timestamp at all.

--- a/netbox/netbox/tests/test_jobs.py
+++ b/netbox/netbox/tests/test_jobs.py
@@ -2,17 +2,18 @@ import uuid
 from datetime import timedelta
 from unittest.mock import patch
 
+from django.conf import settings
 from django.test import TestCase
 from django.utils import timezone
 
-from core.choices import JobStatusChoices
+from core.choices import JobIntervalChoices, JobStatusChoices
 from core.exceptions import JobFailed
 from core.models import DataSource, Job
 from utilities.testing import disable_warnings
 from utilities.testing.mixins import RQQueueTestMixin
 
 from ..jobs import *
-from ..jobs import _INSTALL_ROOT
+from ..jobs import _INSTALL_ROOT, STALE_RUNNING_JOB_GRACE_SECONDS
 
 
 class TestJobRunner(JobRunner):
@@ -33,8 +34,18 @@ class TestSystemJobRunner(JobRunner):
         pass
 
 
-@system_job(interval=1)
-class TestShortIntervalSystemJobRunner(JobRunner):
+class TestClassTimeoutJobRunner(JobRunner):
+    job_timeout = 3600
+
+    def run(self, *args, **kwargs):
+        pass
+
+
+class TestPropertyTimeoutJobRunner(JobRunner):
+    # Mirrors plugins (e.g. netbox-branching) that expose job_timeout as an instance property.
+    @property
+    def job_timeout(self):
+        return 7200
 
     def run(self, *args, **kwargs):
         pass
@@ -394,7 +405,7 @@ class ReconcileStaleJobsTestCase(BaseJobRunnerTestCase):
     """
 
     def test_reconcile_terminates_orphaned_running_job(self):
-        """A running system job whose `started` is older than the grace window is an
+        """A running system job whose `started` predates the run timeout window is an
         orphan (its worker died) and must be moved to `errored`."""
         orphan = Job.objects.create(
             name=TestSystemJobRunner.name,
@@ -413,8 +424,8 @@ class ReconcileStaleJobsTestCase(BaseJobRunnerTestCase):
         self.assertEqual(orphan.error, "Worker terminated before job completed")
 
     def test_reconcile_preserves_recently_started_running_job(self):
-        """A running system job that started recently (within the grace window) is a
-        legitimately in-flight job and must NOT be reaped."""
+        """A running system job that started recently (within the run timeout window) is a
+        legitimately in-flight job and must NOT be reaped, regardless of its interval."""
         live = Job.objects.create(
             name=TestSystemJobRunner.name,
             status=JobStatusChoices.STATUS_RUNNING,
@@ -429,58 +440,42 @@ class ReconcileStaleJobsTestCase(BaseJobRunnerTestCase):
         live.refresh_from_db()
         self.assertEqual(live.status, JobStatusChoices.STATUS_RUNNING)
 
-    def test_reconcile_grace_window_scales_with_interval(self):
-        """The grace window is max(interval, floor). A job whose interval exceeds the floor
-        gets the longer window: a 60-minute-interval job started 45 minutes ago is past the
-        30-minute floor but still within its own interval, so it must be preserved."""
-        within_interval = Job.objects.create(
+    def test_reconcile_window_is_run_timeout_not_interval(self):
+        """The window is keyed on the RQ run timeout, not the recurrence interval, so a
+        long-interval job whose worker was just killed is recovered promptly. A daily job
+        started well past its run timeout (but far short of a day) must be reaped."""
+        grace = settings.RQ_DEFAULT_TIMEOUT + STALE_RUNNING_JOB_GRACE_SECONDS
+        orphan = Job.objects.create(
             name=TestSystemJobRunner.name,
             status=JobStatusChoices.STATUS_RUNNING,
-            interval=60,
-            scheduled=timezone.now() - timedelta(minutes=45),
-            started=timezone.now() - timedelta(minutes=45),
+            interval=JobIntervalChoices.INTERVAL_DAILY,
+            scheduled=timezone.now() - timedelta(seconds=grace + 60),
+            started=timezone.now() - timedelta(seconds=grace + 60),
             job_id=uuid.uuid4(),
         )
 
-        reconcile_stale_system_jobs(TestSystemJobRunner, 60)
-
-        within_interval.refresh_from_db()
-        self.assertEqual(within_interval.status, JobStatusChoices.STATUS_RUNNING)
-
-    def test_reconcile_grace_floor_protects_short_interval_job(self):
-        """For a job whose interval is shorter than the floor, the floor governs the window.
-        A 1-minute-interval job started 20 minutes ago is well past its interval but within
-        the 30-minute floor, so it must NOT be reaped."""
-        within_floor = Job.objects.create(
-            name=TestShortIntervalSystemJobRunner.name,
-            status=JobStatusChoices.STATUS_RUNNING,
-            interval=1,
-            scheduled=timezone.now() - timedelta(minutes=20),
-            started=timezone.now() - timedelta(minutes=20),
-            job_id=uuid.uuid4(),
-        )
-
-        reconcile_stale_system_jobs(TestShortIntervalSystemJobRunner, 1)
-
-        within_floor.refresh_from_db()
-        self.assertEqual(within_floor.status, JobStatusChoices.STATUS_RUNNING)
-
-    def test_reconcile_grace_floor_reaps_short_interval_orphan(self):
-        """A 1-minute-interval job started 40 minutes ago is past the 30-minute floor and is
-        an orphan, so it must be reaped despite its short interval."""
-        orphan = Job.objects.create(
-            name=TestShortIntervalSystemJobRunner.name,
-            status=JobStatusChoices.STATUS_RUNNING,
-            interval=1,
-            scheduled=timezone.now() - timedelta(minutes=40),
-            started=timezone.now() - timedelta(minutes=40),
-            job_id=uuid.uuid4(),
-        )
-
-        reconcile_stale_system_jobs(TestShortIntervalSystemJobRunner, 1)
+        reconcile_stale_system_jobs(TestSystemJobRunner, JobIntervalChoices.INTERVAL_DAILY)
 
         orphan.refresh_from_db()
         self.assertEqual(orphan.status, JobStatusChoices.STATUS_ERRORED)
+
+    def test_reconcile_preserves_job_within_run_timeout(self):
+        """A job started just inside the run timeout window is still legitimately running
+        and must be preserved."""
+        grace = settings.RQ_DEFAULT_TIMEOUT + STALE_RUNNING_JOB_GRACE_SECONDS
+        live = Job.objects.create(
+            name=TestSystemJobRunner.name,
+            status=JobStatusChoices.STATUS_RUNNING,
+            interval=JobIntervalChoices.INTERVAL_DAILY,
+            scheduled=timezone.now() - timedelta(seconds=grace - 60),
+            started=timezone.now() - timedelta(seconds=grace - 60),
+            job_id=uuid.uuid4(),
+        )
+
+        reconcile_stale_system_jobs(TestSystemJobRunner, JobIntervalChoices.INTERVAL_DAILY)
+
+        live.refresh_from_db()
+        self.assertEqual(live.status, JobStatusChoices.STATUS_RUNNING)
 
     def test_reconcile_ignores_instance_bound_job(self):
         """The sweep targets object-less system jobs only. An instance-bound job of the
@@ -529,3 +524,43 @@ class ReconcileStaleJobsTestCase(BaseJobRunnerTestCase):
             status__in=JobStatusChoices.ENQUEUED_STATE_CHOICES,
         )
         self.assertEqual(enqueued.count(), 1)
+
+    def test_reconcile_honors_longer_per_job_timeout(self):
+        """A runner that declares a large `job_timeout` gets a proportionally longer window. A
+        job started past the default window but within its own declared timeout must be preserved,
+        so a legitimately long run (e.g. a bulk branch archival) is not reaped."""
+        interval = JobIntervalChoices.INTERVAL_DAILY
+        default_window = settings.RQ_DEFAULT_TIMEOUT + STALE_RUNNING_JOB_GRACE_SECONDS
+        # Older than the default window, but well within this runner's 3600s job_timeout.
+        started = timezone.now() - timedelta(seconds=default_window + 120)
+        live = Job.objects.create(
+            name=TestClassTimeoutJobRunner.name,
+            status=JobStatusChoices.STATUS_RUNNING,
+            interval=interval,
+            scheduled=started,
+            started=started,
+            job_id=uuid.uuid4(),
+        )
+
+        reconcile_stale_system_jobs(TestClassTimeoutJobRunner, interval)
+
+        live.refresh_from_db()
+        self.assertEqual(live.status, JobStatusChoices.STATUS_RUNNING)
+
+
+class ResolveJobTimeoutTestCase(BaseJobRunnerTestCase):
+    """
+    Test resolution of a runner's RQ run timeout across the ad-hoc conventions (#22714).
+    """
+
+    def test_falls_back_to_rq_default(self):
+        job = Job(name=TestSystemJobRunner.name)
+        self.assertEqual(resolve_job_timeout(TestSystemJobRunner, job), settings.RQ_DEFAULT_TIMEOUT)
+
+    def test_reads_class_attribute(self):
+        job = Job(name=TestClassTimeoutJobRunner.name)
+        self.assertEqual(resolve_job_timeout(TestClassTimeoutJobRunner, job), 3600)
+
+    def test_reads_instance_property(self):
+        job = Job(name=TestPropertyTimeoutJobRunner.name)
+        self.assertEqual(resolve_job_timeout(TestPropertyTimeoutJobRunner, job), 7200)

--- a/netbox/netbox/tests/test_jobs.py
+++ b/netbox/netbox/tests/test_jobs.py
@@ -152,6 +152,68 @@ class EnqueueTestCase(BaseJobRunnerTestCase):
         self.assertRaises(Job.DoesNotExist, job1.refresh_from_db)
         self.assertEqual(TestJobRunner.get_jobs(instance).count(), 1)
 
+    def test_enqueue_once_replaces_stale_scheduled_job(self):
+        """
+        A job still in "scheduled" status whose time has already passed is stale (its RQ-side
+        scheduler entry was lost, e.g. by a Redis restart between backup and restore — see
+        #22714) and must be replaced, even though its recorded interval matches.
+        """
+        stale = Job.objects.create(
+            name=TestJobRunner.name,
+            status=JobStatusChoices.STATUS_SCHEDULED,
+            interval=60,
+            scheduled=timezone.now() - timedelta(days=1),
+            job_id=uuid.uuid4(),
+        )
+
+        # Mirrors how rqworker.py calls enqueue_once() for system jobs at startup: no
+        # schedule_at, only the registered interval.
+        job = TestJobRunner.enqueue_once(interval=60)
+
+        self.assertNotEqual(job, stale)
+        self.assertRaises(Job.DoesNotExist, stale.refresh_from_db)
+        self.assertEqual(TestJobRunner.get_jobs().count(), 1)
+
+    def test_enqueue_once_reuses_pending_job_with_no_schedule(self):
+        """
+        A pending job (not yet picked up by a worker) has no `scheduled` timestamp at all.
+        That must not be mistaken for a stale schedule and must not raise when compared
+        against the current time.
+        """
+        pending = Job.objects.create(
+            name=TestJobRunner.name,
+            status=JobStatusChoices.STATUS_PENDING,
+            interval=60,
+            scheduled=None,
+            job_id=uuid.uuid4(),
+        )
+
+        job = TestJobRunner.enqueue_once(interval=60)
+
+        self.assertEqual(job, pending)
+        self.assertEqual(TestJobRunner.get_jobs().count(), 1)
+
+    def test_enqueue_once_reuses_running_job_with_past_schedule(self):
+        """
+        Once a job starts, its `scheduled` timestamp is left in the past (that's normal —
+        `start()` doesn't clear it) while status moves to "running". A concurrent
+        enqueue_once() call (e.g. a second worker starting up mid-run) must not mistake
+        that for staleness and delete an in-flight job out from under itself.
+        """
+        running = Job.objects.create(
+            name=TestJobRunner.name,
+            status=JobStatusChoices.STATUS_RUNNING,
+            interval=60,
+            scheduled=timezone.now() - timedelta(minutes=5),
+            started=timezone.now(),
+            job_id=uuid.uuid4(),
+        )
+
+        job = TestJobRunner.enqueue_once(interval=60)
+
+        self.assertEqual(job, running)
+        self.assertEqual(TestJobRunner.get_jobs().count(), 1)
+
     def test_enqueue_once_with_enqueue(self):
         instance = DataSource()
         job1 = TestJobRunner.enqueue_once(instance, schedule_at=self.get_schedule_at(2))

--- a/netbox/netbox/tests/test_jobs.py
+++ b/netbox/netbox/tests/test_jobs.py
@@ -33,6 +33,13 @@ class TestSystemJobRunner(JobRunner):
         pass
 
 
+@system_job(interval=1)
+class TestShortIntervalSystemJobRunner(JobRunner):
+
+    def run(self, *args, **kwargs):
+        pass
+
+
 class BaseJobRunnerTestCase(RQQueueTestMixin, TestCase):
 
     @staticmethod
@@ -379,3 +386,146 @@ class SystemJobTestCase(BaseJobRunnerTestCase):
             interval=interval,
         )
         self.assertEqual(enqueued.count(), 2)
+
+
+class ReconcileStaleJobsTestCase(BaseJobRunnerTestCase):
+    """
+    Test recovery of system jobs stranded in "running" status by a killed worker (#22714).
+    """
+
+    def test_reconcile_terminates_orphaned_running_job(self):
+        """A running system job whose `started` is older than the grace window is an
+        orphan (its worker died) and must be moved to `errored`."""
+        orphan = Job.objects.create(
+            name=TestSystemJobRunner.name,
+            status=JobStatusChoices.STATUS_RUNNING,
+            interval=60,
+            scheduled=timezone.now() - timedelta(hours=2),
+            started=timezone.now() - timedelta(hours=2),
+            job_id=uuid.uuid4(),
+        )
+
+        reconcile_stale_system_jobs(TestSystemJobRunner, 60)
+
+        orphan.refresh_from_db()
+        self.assertEqual(orphan.status, JobStatusChoices.STATUS_ERRORED)
+        self.assertIsNotNone(orphan.completed)
+        self.assertEqual(orphan.error, "Worker terminated before job completed")
+
+    def test_reconcile_preserves_recently_started_running_job(self):
+        """A running system job that started recently (within the grace window) is a
+        legitimately in-flight job and must NOT be reaped."""
+        live = Job.objects.create(
+            name=TestSystemJobRunner.name,
+            status=JobStatusChoices.STATUS_RUNNING,
+            interval=60,
+            scheduled=timezone.now() - timedelta(minutes=1),
+            started=timezone.now(),
+            job_id=uuid.uuid4(),
+        )
+
+        reconcile_stale_system_jobs(TestSystemJobRunner, 60)
+
+        live.refresh_from_db()
+        self.assertEqual(live.status, JobStatusChoices.STATUS_RUNNING)
+
+    def test_reconcile_grace_window_scales_with_interval(self):
+        """The grace window is max(interval, floor). A job whose interval exceeds the floor
+        gets the longer window: a 60-minute-interval job started 45 minutes ago is past the
+        30-minute floor but still within its own interval, so it must be preserved."""
+        within_interval = Job.objects.create(
+            name=TestSystemJobRunner.name,
+            status=JobStatusChoices.STATUS_RUNNING,
+            interval=60,
+            scheduled=timezone.now() - timedelta(minutes=45),
+            started=timezone.now() - timedelta(minutes=45),
+            job_id=uuid.uuid4(),
+        )
+
+        reconcile_stale_system_jobs(TestSystemJobRunner, 60)
+
+        within_interval.refresh_from_db()
+        self.assertEqual(within_interval.status, JobStatusChoices.STATUS_RUNNING)
+
+    def test_reconcile_grace_floor_protects_short_interval_job(self):
+        """For a job whose interval is shorter than the floor, the floor governs the window.
+        A 1-minute-interval job started 20 minutes ago is well past its interval but within
+        the 30-minute floor, so it must NOT be reaped."""
+        within_floor = Job.objects.create(
+            name=TestShortIntervalSystemJobRunner.name,
+            status=JobStatusChoices.STATUS_RUNNING,
+            interval=1,
+            scheduled=timezone.now() - timedelta(minutes=20),
+            started=timezone.now() - timedelta(minutes=20),
+            job_id=uuid.uuid4(),
+        )
+
+        reconcile_stale_system_jobs(TestShortIntervalSystemJobRunner, 1)
+
+        within_floor.refresh_from_db()
+        self.assertEqual(within_floor.status, JobStatusChoices.STATUS_RUNNING)
+
+    def test_reconcile_grace_floor_reaps_short_interval_orphan(self):
+        """A 1-minute-interval job started 40 minutes ago is past the 30-minute floor and is
+        an orphan, so it must be reaped despite its short interval."""
+        orphan = Job.objects.create(
+            name=TestShortIntervalSystemJobRunner.name,
+            status=JobStatusChoices.STATUS_RUNNING,
+            interval=1,
+            scheduled=timezone.now() - timedelta(minutes=40),
+            started=timezone.now() - timedelta(minutes=40),
+            job_id=uuid.uuid4(),
+        )
+
+        reconcile_stale_system_jobs(TestShortIntervalSystemJobRunner, 1)
+
+        orphan.refresh_from_db()
+        self.assertEqual(orphan.status, JobStatusChoices.STATUS_ERRORED)
+
+    def test_reconcile_ignores_instance_bound_job(self):
+        """The sweep targets object-less system jobs only. An instance-bound job of the
+        same runner class must be left alone even if it looks stale."""
+        instance = DataSource.objects.create(name='test-ds-reconcile', type='local')
+        bound = Job.objects.create(
+            name=TestSystemJobRunner.name,
+            object=instance,
+            status=JobStatusChoices.STATUS_RUNNING,
+            interval=60,
+            scheduled=timezone.now() - timedelta(hours=2),
+            started=timezone.now() - timedelta(hours=2),
+            job_id=uuid.uuid4(),
+        )
+
+        reconcile_stale_system_jobs(TestSystemJobRunner, 60)
+
+        bound.refresh_from_db()
+        self.assertEqual(bound.status, JobStatusChoices.STATUS_RUNNING)
+
+    def test_reconcile_then_enqueue_once_rearms(self):
+        """After a stranded job is reconciled to `errored`, the startup `enqueue_once()`
+        call must re-arm a fresh scheduled successor."""
+        orphan = Job.objects.create(
+            name=TestSystemJobRunner.name,
+            status=JobStatusChoices.STATUS_RUNNING,
+            interval=60,
+            scheduled=timezone.now() - timedelta(hours=2),
+            started=timezone.now() - timedelta(hours=2),
+            job_id=uuid.uuid4(),
+        )
+
+        # Mirror rqworker startup: reconcile stale jobs, then enqueue_once.
+        reconcile_stale_system_jobs(TestSystemJobRunner, 60)
+        successor = TestSystemJobRunner.enqueue_once(interval=60)
+
+        orphan.refresh_from_db()
+        self.assertEqual(orphan.status, JobStatusChoices.STATUS_ERRORED)
+        self.assertNotEqual(successor.pk, orphan.pk)
+        self.assertIn(successor.status, JobStatusChoices.ENQUEUED_STATE_CHOICES)
+
+        # Exactly one live (enqueued) successor should remain.
+        enqueued = Job.objects.filter(
+            name=TestSystemJobRunner.name,
+            object_id__isnull=True,
+            status__in=JobStatusChoices.ENQUEUED_STATE_CHOICES,
+        )
+        self.assertEqual(enqueued.count(), 1)

--- a/netbox/netbox/tests/test_jobs.py
+++ b/netbox/netbox/tests/test_jobs.py
@@ -13,7 +13,12 @@ from utilities.testing import disable_warnings
 from utilities.testing.mixins import RQQueueTestMixin
 
 from ..jobs import *
-from ..jobs import _INSTALL_ROOT, STALE_RUNNING_JOB_GRACE_SECONDS
+from ..jobs import (
+    _INSTALL_ROOT,
+    STALE_RUNNING_JOB_GRACE_SECONDS,
+    reconcile_stale_system_jobs,
+    resolve_job_timeout,
+)
 
 
 class TestJobRunner(JobRunner):


### PR DESCRIPTION
### Closes: #22714

A recurring system job can stop rescheduling itself and never recover. At worker startup `enqueue_once()` reuses any existing `Job` row in an enqueued state (`pending`/`scheduled`/`running`) as a live successor. When the row is actually dead, nothing re-arms the schedule until an operator deletes it and restarts the worker.

Two ways a row ends up dead but enqueued:

- **Stuck in `scheduled`** with a past scheduled time, left behind when the worker was down across its due time (the issue's repro). The fix treats a past-due `scheduled` job as stale and replaces it. This half is `mderekasir`'s work from #22952, preserved as his commit.
- **Stuck in `running`** after a worker was killed mid-run (`SIGKILL`, OOM, deploy restart): `start()` persists `running`, but the `finally` in `handle()` that reschedules never runs. `reconcile_stale_system_jobs()` runs at startup and moves an object-less system job stranded in `running` past `max(interval, 30 minutes)` to `errored`, so `enqueue_once()` re-arms. Detection is pure-DB on `started`, not RQ state, since a killed job's RQ entry can outlive the worker and the schedule may need recovering with Redis wiped.

Recovery runs at worker startup, so a worker that never restarts won't reconcile a mid-run orphan until it does. Bounding worker lifetime (max time or tasks) is the operator-level answer, left out of scope here.
