### PR TITLE
Fixes #22569: Ensures that Script Run OpenAPI operation is present

### DIFF
--- a/netbox/core/tests/test_openapi_schema.py
+++ b/netbox/core/tests/test_openapi_schema.py
@@ -5,7 +5,7 @@ Refs: #20638
 """
 import json
 
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from core.api.schema import FixSerializedPKRelatedField
 from dcim.api.serializers import SiteSerializer
@@ -13,6 +13,11 @@ from dcim.models import Site
 from netbox.api.fields import SerializedPKRelatedField
 
 
+@override_settings(CACHES={
+    'default': {
+        'BACKEND': 'django.core.cache.backends.dummy.DummyCache'
+    }
+})
 class OpenAPISchemaTestCase(TestCase):
     """Tests for OpenAPI schema generation."""
 
@@ -199,6 +204,22 @@ class OpenAPISchemaTestCase(TestCase):
         ):
             with self.subTest(component=component, field=field):
                 self.assertEqual(components[component]['properties'][field]['items']['type'], 'integer')
+
+    def test_script_run_operation_exists(self):
+        """
+        Encodes presence of extras_scripts_run operation in schema as expected.
+
+        Refs: #22569
+        """
+        paths = self.schema['paths']
+        resource_path = paths['/api/extras/scripts/{id}/']
+        self.assertIn('post', resource_path)
+
+        run_operation = resource_path['post']
+
+        self.assertEqual(run_operation['operationId'], 'extras_scripts_run')
+        self.assertEqual(len(run_operation['responses']), 1)
+        self.assertIn('200', run_operation['responses'])
 
 
 class SerializedPKRelatedFieldSchemaTestCase(SimpleTestCase):


### PR DESCRIPTION
### Closes: #22569

Turns out, this bug was actually fixed incidentally in #22745, but the original issue was not recognized as completed.

This PR does two things:

1. Adds a regression test to ensure that the `extras_scripts_run` operation is always present in contrib/openapi.json. This has regressed at least once since original implementation, so I wanted to make sure we catch it quickly in the future.
2. Overrides the Django `CACHES` setting for the OpenAPISchemaTestCase, which contains the new test, so that caching of the schema is disabled. This caused problems by masking whether or not the regression test (and other existing tests) were failing/succeeding in response to changes or not.