### PR TITLE
Closes #23145: Prevent advisory lock cleanup races in Custom Field tests

### DIFF
--- a/netbox/extras/tests/test_customfields.py
+++ b/netbox/extras/tests/test_customfields.py
@@ -2876,9 +2876,18 @@ def hold_data_lock(custom_field):
             cursor.execute('SELECT pg_try_advisory_lock(%s, %s)', lock_key)
             if not cursor.fetchone()[0]:
                 raise RuntimeError(f"Failed to acquire the data lock for {custom_field}")
-        yield
+        released = False
+        try:
+            yield
+        finally:
+            # Closing the connection releases the lock asynchronously, so the next deletion can race it
+            with connection.cursor() as cursor:
+                cursor.execute('SELECT pg_advisory_unlock(%s, %s)', lock_key)
+                released = cursor.fetchone()[0]
+        # Outside the finally, so a failing body is reported as itself
+        if not released:
+            raise RuntimeError(f"Failed to release the data lock for {custom_field}")
     finally:
-        # Closing the session releases any advisory lock held on it
         connection.close()
 
 
@@ -3739,7 +3748,7 @@ class DeferredCustomFieldDataTestCase(TestCase):
 
         # delete() has returned and its own atomic block has exited, but the enclosing transaction
         # has yet to commit, so the lock must still be held
-        with self.assertRaises(RuntimeError):
+        with self.assertRaisesMessage(RuntimeError, "Failed to acquire the data lock"):
             with hold_data_lock(cf):
                 pass
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to NetBox! Before submitting a
    PR, please verify the following:

      1. An issue has been opened to capture these changes
      2. The issue has been accepted and assigned to you for work

    Pull requests which do not reference an assigned issue will be closed
    automatically. Please specify your assigned issue number on the line below.
-->
### Closes: #23145

<!--
    Please include a summary of the proposed changes below.
-->
This fixes an occasional custom field test failure where a deletion runs before PostgreSQL has finished releasing the advisory lock from the previous connection.

`hold_data_lock()` now calls `pg_advisory_unlock()` before closing the connection and checks that the release succeeded. Cleanup still runs when a test raises an exception. The transaction test also checks for the expected lock acquisition error.

This only changes tests.