### PR TITLE
Closes #23046: Address tests that are skipped by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
           pip install coverage tblib
+          # dulwich is the optional 'git' extra, so it is absent from requirements.txt.
+          # The Git data backend tests mock dulwich.porcelain.clone and only need the
+          # module to be importable; without it they skip silently.
+          pip install dulwich
 
       - name: Check for missing migrations
         run: python netbox/manage.py makemigrations --check

--- a/netbox/circuits/tests/test_api.py
+++ b/netbox/circuits/tests/test_api.py
@@ -23,6 +23,9 @@ class ProviderTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'comments': 'New comments',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -79,6 +82,9 @@ class CircuitTypeTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'color': 'not-a-color',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -96,6 +102,9 @@ class CircuitTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['cid', 'description', 'display', 'id', 'provider', 'url']
     bulk_update_data = {
         'status': 'planned',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
     user_permissions = ('circuits.view_provider', 'circuits.view_circuittype')
 
@@ -215,6 +224,9 @@ class CircuitTerminationTestCase(APIViewTestCases.APIViewTestCase):
         cls.bulk_update_data = {
             'port_speed': 123456
         }
+        cls.bulk_update_invalid_data = {
+            'term_side': 'not-a-valid-term-side',
+        }
 
 
 class CircuitGroupTestCase(APIViewTestCases.APIViewTestCase):
@@ -222,6 +234,9 @@ class CircuitGroupTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'tenant': 99999,
     }
 
     @classmethod
@@ -291,6 +306,9 @@ class ProviderAccountTestCase(APIViewTestCases.APIViewTestCase):
             'provider': providers[1].pk,
             'description': 'New description',
         }
+        cls.bulk_update_invalid_data = {
+            'provider': 99999,
+        }
 
 
 class CircuitGroupAssignmentTestCase(APIViewTestCases.APIViewTestCase):
@@ -298,6 +316,9 @@ class CircuitGroupAssignmentTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['display', 'group', 'id', 'member', 'member_id', 'member_type', 'priority', 'url']
     bulk_update_data = {
         'priority': CircuitPriorityChoices.PRIORITY_INACTIVE,
+    }
+    bulk_update_invalid_data = {
+        'priority': 'not-a-valid-priority',
     }
     user_permissions = ('circuits.view_circuit', 'circuits.view_circuitgroup')
 
@@ -407,6 +428,9 @@ class ProviderNetworkTestCase(APIViewTestCases.APIViewTestCase):
             'provider': providers[1].pk,
             'description': 'New description',
         }
+        cls.bulk_update_invalid_data = {
+            'provider': 99999,
+        }
 
 
 class VirtualCircuitTypeTestCase(APIViewTestCases.APIViewTestCase):
@@ -429,6 +453,9 @@ class VirtualCircuitTypeTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'color': 'not-a-color',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -446,6 +473,9 @@ class VirtualCircuitTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['cid', 'description', 'display', 'id', 'provider_network', 'url']
     bulk_update_data = {
         'status': 'planned',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
 
     @classmethod
@@ -510,6 +540,9 @@ class VirtualCircuitTerminationTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'interface', 'role', 'url', 'virtual_circuit']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'role': 'not-a-valid-role',
     }
 
     @classmethod

--- a/netbox/core/tests/test_api.py
+++ b/netbox/core/tests/test_api.py
@@ -35,6 +35,9 @@ class DataSourceTestCase(APIViewTestCases.APIViewTestCase):
         'enabled': False,
         'description': 'foo bar baz',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):

--- a/netbox/core/tests/test_data_backends.py
+++ b/netbox/core/tests/test_data_backends.py
@@ -62,8 +62,7 @@ class GitBackendCredentialIntegrationTestCase(TestCase):
     Integration tests that verify GitBackend correctly applies credential logic.
 
     These tests require dulwich to be installed and verify the full integration
-    of the credential handling in GitBackend.fetch(). dulwich is the optional
-    'git' extra, so CI installs it explicitly; see .github/workflows/ci.yml.
+    of the credential handling in GitBackend.fetch().
     """
 
     def _get_clone_kwargs(self, url, **params):

--- a/netbox/core/tests/test_data_backends.py
+++ b/netbox/core/tests/test_data_backends.py
@@ -62,7 +62,8 @@ class GitBackendCredentialIntegrationTestCase(TestCase):
     Integration tests that verify GitBackend correctly applies credential logic.
 
     These tests require dulwich to be installed and verify the full integration
-    of the credential handling in GitBackend.fetch().
+    of the credential handling in GitBackend.fetch(). dulwich is the optional
+    'git' extra, so CI installs it explicitly; see .github/workflows/ci.yml.
     """
 
     def _get_clone_kwargs(self, url, **params):

--- a/netbox/dcim/tests/test_api.py
+++ b/netbox/dcim/tests/test_api.py
@@ -106,6 +106,9 @@ class RegionTestCase(APIViewTestCases.APIViewTestCase):
         'description': 'New description',
         'comments': 'New comments',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -138,6 +141,9 @@ class SiteGroupTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
         'comments': 'I do exist!',
+    }
+    bulk_update_invalid_data = {
+        'owner': 99999,
     }
 
     @classmethod
@@ -973,6 +979,9 @@ class LocationTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
+    }
     user_permissions = ('dcim.view_site',)
     graphql_filter_tests = (
         GraphQLFilterTest(
@@ -1095,6 +1104,9 @@ class RackGroupTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -1130,6 +1142,9 @@ class RackRoleTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'color': 'not-a-color',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -1149,6 +1164,9 @@ class RackTypeTestCase(APIViewTestCases.APIViewTestCase):
         'description': 'new description',
         'cooling_capability': RackCoolingCapabilityChoices.CAPABILITY_HYBRID,
         'cooling_capacity': 50,
+    }
+    bulk_update_invalid_data = {
+        'form_factor': 'not-a-valid-form-factor',
     }
     user_permissions = ('dcim.view_manufacturer',)
 
@@ -1212,6 +1230,9 @@ class RackTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'device_count', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'planned',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
     user_permissions = ('dcim.view_site', )
 
@@ -1339,6 +1360,9 @@ class RackReservationTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
+    }
     user_permissions = ('dcim.view_rack', 'users.view_user')
 
     @classmethod
@@ -1428,6 +1452,9 @@ class ManufacturerTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -1446,6 +1473,9 @@ class DeviceTypeTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'part_number': 'ABC123',
         'end_of_life': '2030-01-01',
+    }
+    bulk_update_invalid_data = {
+        'airflow': 'not-a-valid-airflow',
     }
     user_permissions = ('dcim.view_manufacturer', )
 
@@ -1494,6 +1524,9 @@ class ModuleTypeTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'part_number': 'ABC123',
         'end_of_life': '2030-01-01',
+    }
+    bulk_update_invalid_data = {
+        'airflow': 'not-a-valid-airflow',
     }
     user_permissions = ('dcim.view_manufacturer', )
 
@@ -1584,6 +1617,9 @@ class ModuleTypeProfileTestCase(APIViewTestCases.APIViewTestCase):
         'description': 'New description',
         'comments': 'New comments',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -1609,6 +1645,9 @@ class ModuleBayTypeTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['color', 'description', 'display', 'id', 'manufacturer', 'name', 'slug', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'color': 'not-a-color',
     }
 
     @classmethod
@@ -1650,6 +1689,9 @@ class ConsolePortTemplateTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'type': 'not-a-valid-type',
     }
 
     @classmethod
@@ -1695,6 +1737,9 @@ class ConsoleServerPortTemplateTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'type': 'not-a-valid-type',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -1739,6 +1784,9 @@ class PowerPortTemplateTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'type': 'not-a-valid-type',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -1782,6 +1830,9 @@ class PowerOutletTemplateTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'type': 'not-a-valid-type',
     }
     user_permissions = ('dcim.view_devicetype', )
 
@@ -1840,6 +1891,9 @@ class InterfaceTemplateTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'poe_mode': 'not-a-valid-poe-mode',
     }
 
     @classmethod
@@ -1905,6 +1959,9 @@ class FrontPortTemplateTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'color': 'not-a-color',
     }
     user_permissions = ('dcim.view_rearporttemplate', )
 
@@ -2023,6 +2080,9 @@ class RearPortTemplateTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'color': 'not-a-color',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -2139,6 +2199,9 @@ class ModuleBayTemplateTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'device_type': 99999,
+    }
     user_permissions = ('dcim.view_devicetype', )
 
     @classmethod
@@ -2191,6 +2254,9 @@ class DeviceBayTemplateTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'device_type': 99999,
+    }
     user_permissions = ('dcim.view_devicetype', )
 
     @classmethod
@@ -2232,6 +2298,9 @@ class InventoryItemTemplateTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['_depth', 'description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'role': 99999,
     }
     user_permissions = ('dcim.view_devicetype', 'dcim.view_manufacturer',)
 
@@ -2312,6 +2381,9 @@ class DeviceRoleTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'color': 'not-a-color',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -2343,6 +2415,9 @@ class PlatformTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -2361,6 +2436,9 @@ class DeviceTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'failed',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
     user_permissions = (
         'dcim.view_site', 'dcim.view_rack', 'dcim.view_location', 'dcim.view_devicerole', 'dcim.view_devicetype',
@@ -2820,6 +2898,9 @@ class ModuleTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'device', 'display', 'id', 'module_bay', 'module_type', 'url']
     bulk_update_data = {
         'serial': '1234ABCD',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
     user_permissions = (
         'dcim.view_modulebay', 'dcim.view_moduletype', 'dcim.view_moduletypeprofile', 'dcim.view_device'
@@ -3317,6 +3398,9 @@ class ConsolePortTestCase(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTe
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'type': 'not-a-valid-type',
+    }
     peer_termination_type = ConsoleServerPort
     user_permissions = ('dcim.view_device', )
 
@@ -3359,6 +3443,9 @@ class ConsoleServerPortTestCase(Mixins.ComponentTraceMixin, APIViewTestCases.API
     brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'type': 'not-a-valid-type',
     }
     peer_termination_type = ConsolePort
     user_permissions = ('dcim.view_device', )
@@ -3403,6 +3490,9 @@ class PowerPortTestCase(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTest
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'type': 'not-a-valid-type',
+    }
     peer_termination_type = PowerOutlet
     user_permissions = ('dcim.view_device', )
 
@@ -3442,6 +3532,9 @@ class PowerOutletTestCase(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTe
     brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
     peer_termination_type = PowerPort
     user_permissions = ('dcim.view_device', )
@@ -3491,6 +3584,9 @@ class InterfaceTestCase(Mixins.ComponentTraceMixin, APIViewTestCases.APIViewTest
     brief_fields = ['_occupied', 'cable', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'poe_mode': 'not-a-valid-poe-mode',
     }
     peer_termination_type = Interface
     user_permissions = ('dcim.view_device', )
@@ -4051,6 +4147,9 @@ class FrontPortTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'color': 'not-a-color',
+    }
     peer_termination_type = Interface
     user_permissions = ('dcim.view_device', 'dcim.view_rearport')
 
@@ -4170,6 +4269,9 @@ class RearPortTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'color': 'not-a-color',
+    }
     peer_termination_type = Interface
     user_permissions = ('dcim.view_device', )
 
@@ -4285,6 +4387,9 @@ class ModuleBayTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['_occupied', 'description', 'display', 'enabled', 'id', 'installed_module', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'owner': 99999,
     }
     user_permissions = ('dcim.view_device', )
 
@@ -4417,6 +4522,9 @@ class DeviceBayTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
     user_permissions = ('dcim.view_device', )
 
     @classmethod
@@ -4480,6 +4588,9 @@ class InventoryItemTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['_depth', 'description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
     user_permissions = ('dcim.view_device', 'dcim.view_manufacturer')
 
@@ -4565,6 +4676,9 @@ class InventoryItemRoleTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'color': 'not-a-color',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -4587,6 +4701,9 @@ class CableBundleTestCase(APIViewTestCases.APIViewTestCase):
     ]
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'owner': 99999,
     }
 
     @classmethod
@@ -4637,6 +4754,9 @@ class CableTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'length': 100,
         'length_unit': 'm',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
 
     # TODO: Allow updating cable terminations
@@ -5094,6 +5214,9 @@ class VirtualChassisTestCase(APIViewTestCases.APIViewTestCase):
             'domain': 'newdomain',
             'master': None
         }
+        cls.bulk_update_invalid_data = {
+            'owner': 99999,
+        }
 
 
 class PowerPanelTestCase(APIViewTestCases.APIViewTestCase):
@@ -5144,6 +5267,9 @@ class PowerPanelTestCase(APIViewTestCases.APIViewTestCase):
             'site': sites[1].pk,
             'location': locations[3].pk
         }
+        cls.bulk_update_invalid_data = {
+            'owner': 99999,
+        }
 
 
 class PowerFeedTestCase(APIViewTestCases.APIViewTestCase):
@@ -5151,6 +5277,9 @@ class PowerFeedTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['_occupied', 'cable', 'description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'planned',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
     user_permissions = ('dcim.view_powerpanel', )
 
@@ -5208,6 +5337,9 @@ class CoolingIntakeTemplateTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'type': 'not-a-valid-type',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -5252,6 +5384,9 @@ class CoolingOutflowTemplateTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'type': 'not-a-valid-type',
     }
     user_permissions = ('dcim.view_devicetype', )
 
@@ -5312,6 +5447,9 @@ class CoolingIntakeTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'type': 'not-a-valid-type',
+    }
     user_permissions = ('dcim.view_device', )
 
     @classmethod
@@ -5355,6 +5493,9 @@ class CoolingOutflowTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'device', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'type': 'not-a-valid-type',
     }
     user_permissions = ('dcim.view_device', )
 
@@ -5459,6 +5600,9 @@ class CoolingSourceTestCase(APIViewTestCases.APIViewTestCase):
             'site': sites[1].pk,
             'location': locations[3].pk
         }
+        cls.bulk_update_invalid_data = {
+            'status': 'not-a-valid-status',
+        }
 
 
 class CoolingFeedTestCase(APIViewTestCases.APIViewTestCase):
@@ -5466,6 +5610,9 @@ class CoolingFeedTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'planned',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
     user_permissions = ('dcim.view_coolingsource', )
 
@@ -5527,6 +5674,9 @@ class VirtualDeviceContextTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'device', 'display', 'id', 'identifier', 'name', 'url']
     bulk_update_data = {
         'status': 'planned',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
 
     @classmethod
@@ -5650,6 +5800,9 @@ class MACAddressTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'mac_address', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'owner': 99999,
     }
 
     @classmethod

--- a/netbox/extras/tests/test_api.py
+++ b/netbox/extras/tests/test_api.py
@@ -62,6 +62,9 @@ class WebhookTestCase(APIViewTestCases.APIViewTestCase):
         'description': 'New description',
         'ssl_verification': False,
     }
+    bulk_update_invalid_data = {
+        'http_method': 'not-a-valid-http-method',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -89,6 +92,9 @@ class EventRuleTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'enabled': False,
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'action_type': 'not-a-valid-action-type',
     }
     update_data = {
         'name': 'Event Rule X',
@@ -308,6 +314,9 @@ class CustomFieldTestCase(APIViewTestCases.APIViewTestCase):
         'description': 'New description',
         'nulls_first': False,
     }
+    bulk_update_invalid_data = {
+        'filter_logic': 'not-a-valid-filter-logic',
+    }
     update_data = {
         'object_types': ['dcim.device'],
         'name': 'New_Name',
@@ -376,6 +385,9 @@ class CustomFieldChoiceSetTestCase(APIViewTestCases.APIViewTestCase):
     ]
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'base_choices': 'not-a-valid-base-choices',
     }
     update_data = {
         'name': 'Choice Set X',
@@ -577,6 +589,9 @@ class CustomLinkTestCase(APIViewTestCases.APIViewTestCase):
         'new_window': True,
         'enabled': False,
     }
+    bulk_update_invalid_data = {
+        'button_class': 'not-a-valid-button-class',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -660,6 +675,9 @@ class SavedFilterTestCase(SharedObjectAPITestMixin, APIViewTestCases.APIViewTest
         'weight': 1000,
         'enabled': False,
         'shared': False,
+    }
+    bulk_update_invalid_data = {
+        'object_types': ['dcim.notamodel'],
     }
 
     @classmethod
@@ -752,6 +770,9 @@ class TableConfigTestCase(SharedObjectAPITestMixin, APIViewTestCases.APIViewTest
         'weight': 999,
         'enabled': False,
         'shared': False,
+    }
+    bulk_update_invalid_data = {
+        'object_type': 'dcim.notamodel',
     }
 
     @classmethod
@@ -942,6 +963,9 @@ class ExportTemplateTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'object_types': ['dcim.notamodel'],
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -988,6 +1012,9 @@ class TagTestCase(APIViewTestCases.APIViewTestCase):
     ]
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'color': 'not-a-color',
     }
 
     @classmethod
@@ -1083,6 +1110,9 @@ class JournalEntryTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'comments': 'Overwritten',
     }
+    bulk_update_invalid_data = {
+        'kind': 'not-a-valid-kind',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -1168,6 +1198,9 @@ class ConfigContextProfileTestCase(APIViewTestCases.APIViewTestCase):
     ]
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'data_source': 99999,
     }
 
     @classmethod
@@ -1280,6 +1313,9 @@ class ConfigContextTestCase(APIViewTestCases.APIViewTestCase):
     ]
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'data_source': 99999,
     }
 
     @classmethod
@@ -1410,6 +1446,9 @@ class ConfigTemplateTestCase(APIViewTestCases.APIViewTestCase):
     ]
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'data_source': 99999,
     }
 
     @classmethod
@@ -2226,6 +2265,9 @@ class SubscriptionTestCase(APIViewTestCases.APIViewTestCase):
         cls.bulk_update_data = {
             'user': users[3].pk,
         }
+        cls.bulk_update_invalid_data = {
+            'object_type': 'dcim.notamodel',
+        }
 
 
 class NotificationGroupTestCase(APIViewTestCases.APIViewTestCase):
@@ -2256,6 +2298,9 @@ class NotificationGroupTestCase(APIViewTestCases.APIViewTestCase):
     ]
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'users': [99999],
     }
 
     @classmethod
@@ -2310,6 +2355,9 @@ class NotificationTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['display', 'event_type', 'id', 'object_id', 'object_type', 'read', 'url', 'user']
     bulk_update_data = {
         'read': now(),
+    }
+    bulk_update_invalid_data = {
+        'event_type': 'not-a-valid-event-type',
     }
     graphql_filter = {
         'event_type': {'lookup': 'exact', 'value': OBJECT_CREATED},

--- a/netbox/ipam/tests/test_api.py
+++ b/netbox/ipam/tests/test_api.py
@@ -30,6 +30,9 @@ class ASNRangeTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -142,6 +145,9 @@ class ASNTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -220,6 +226,9 @@ class VRFTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -263,6 +272,9 @@ class RouteTargetTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -295,6 +307,9 @@ class RIRTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -312,6 +327,9 @@ class AggregateTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'family', 'id', 'prefix', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'rir': 99999,
     }
 
     @classmethod
@@ -415,6 +433,9 @@ class RoleTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -454,6 +475,9 @@ class PrefixTestCase(APIViewTestCases.APIViewTestCase):
     ]
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
 
     @classmethod
@@ -754,6 +778,9 @@ class IPRangeTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -908,6 +935,9 @@ class IPAddressTestCase(APIViewTestCases.APIViewTestCase):
     ]
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
     graphql_filter = {
         'address': {'lookup': 'i_exact', 'value': '192.168.0.1/24'},
@@ -1071,6 +1101,9 @@ class FHRPGroupTestCase(APIViewTestCases.APIViewTestCase):
         'name': 'foobar-999',
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'protocol': 'not-a-valid-protocol',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -1116,6 +1149,9 @@ class FHRPGroupAssignmentTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['display', 'group', 'id', 'interface_id', 'interface_type', 'priority', 'url']
     bulk_update_data = {
         'priority': 100,
+    }
+    bulk_update_invalid_data = {
+        'group': 99999,
     }
     user_permissions = ('ipam.view_fhrpgroup', )
 
@@ -1213,6 +1249,9 @@ class VLANGroupTestCase(APIViewTestCases.APIViewTestCase):
     ]
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'owner': 99999,
     }
 
     @classmethod
@@ -1320,6 +1359,9 @@ class VLANTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -1386,6 +1428,9 @@ class VLANTranslationPolicyTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'name', 'url',]
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'owner': 99999,
     }
 
     @classmethod
@@ -1523,6 +1568,9 @@ class VLANTranslationRuleTestCase(APIViewTestCases.APIViewTestCase):
             'policy': vlan_translation_policies[2].pk,
             'description': 'New description',
         }
+        cls.bulk_update_invalid_data = {
+            'policy': 99999,
+        }
 
     def test_standard_fields_in_representation(self):
         """The standard URL, tag, custom-field and change-tracking names appear in the representation."""
@@ -1553,6 +1601,9 @@ class ServiceTemplateTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'name', 'port_mappings', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'owner': 99999,
     }
     graphql_base_name = 'service_template'
 
@@ -1837,6 +1888,9 @@ class ServiceTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'name', 'port_mappings', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'owner': 99999,
     }
     graphql_base_name = 'service'
 

--- a/netbox/tenancy/tests/test_api.py
+++ b/netbox/tenancy/tests/test_api.py
@@ -28,6 +28,9 @@ class TenantGroupTestCase(APIViewTestCases.APIViewTestCase):
         'description': 'New description',
         'comments': 'New Comment',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -119,6 +122,9 @@ class TenantTestCase(APIViewTestCases.APIViewTestCase):
         'group': None,
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -159,6 +165,9 @@ class ContactGroupTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['_depth', 'contact_count', 'description', 'display', 'id', 'name', 'slug', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'owner': 99999,
     }
 
     @classmethod
@@ -219,6 +228,9 @@ class ContactRoleTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -237,6 +249,9 @@ class ContactTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'groups': [],
         'comments': 'New comments',
+    }
+    bulk_update_invalid_data = {
+        'owner': 99999,
     }
 
     @classmethod
@@ -276,6 +291,9 @@ class ContactAssignmentTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['contact', 'display', 'id', 'priority', 'role', 'url']
     bulk_update_data = {
         'priority': ContactPriorityChoices.PRIORITY_INACTIVE,
+    }
+    bulk_update_invalid_data = {
+        'priority': 'not-a-valid-priority',
     }
     user_permissions = ('tenancy.view_contact', )
 

--- a/netbox/users/tests/test_api.py
+++ b/netbox/users/tests/test_api.py
@@ -24,6 +24,9 @@ class UserTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'email': 'test@example.com',
     }
+    bulk_update_invalid_data = {
+        'email': 'not-an-email',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -201,6 +204,9 @@ class TokenTestCase(
     brief_fields = ['description', 'display', 'enabled', 'id', 'key', 'url', 'version', 'write_enabled']
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'expires': 'not-a-date',
     }
 
     def setUp(self):
@@ -588,6 +594,9 @@ class ObjectPermissionTestCase(
         cls.bulk_update_data = {
             'description': 'New description',
         }
+        cls.bulk_update_invalid_data = {
+            'users': [99999],
+        }
 
 
 class UserConfigTestCase(APITestCase):
@@ -648,6 +657,11 @@ class OwnerGroupTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'description': 'New description',
+    }
+    # OwnerGroupSerializer exposes only name, description, and a read-only member_count, so an
+    # over-length description is the only value available to trigger a validation error.
+    bulk_update_invalid_data = {
+        'description': 'a' * 201,
     }
 
     @classmethod
@@ -749,4 +763,8 @@ class OwnerTestCase(APIViewTestCases.APIViewTestCase):
             'user_groups': [groups[3].pk],
             'users': [users[3].pk],
             'description': 'New description',
+        }
+
+        cls.bulk_update_invalid_data = {
+            'group': 99999,
         }

--- a/netbox/virtualization/tests/test_api.py
+++ b/netbox/virtualization/tests/test_api.py
@@ -56,6 +56,9 @@ class ClusterTypeTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -88,6 +91,9 @@ class ClusterGroupTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -106,6 +112,9 @@ class ClusterTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'status': 'offline',
         'comments': 'New comment',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
 
     @classmethod
@@ -235,6 +244,9 @@ class VirtualMachineTypeTestCase(APIViewTestCases.APIViewTestCase):
             'default_memory': 8192,
             'description': 'New description',
         }
+        cls.bulk_update_invalid_data = {
+            'owner': 99999,
+        }
 
 
 class VirtualMachineTestCase(APIViewTestCases.APIViewTestCase):
@@ -242,6 +254,9 @@ class VirtualMachineTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'name', 'url']
     bulk_update_data = {
         'status': 'staged',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
     user_permissions = ('dcim.view_platform', 'virtualization.view_virtualmachinetype')
 
@@ -624,6 +639,9 @@ class VMInterfaceTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'mode': 'not-a-valid-mode',
+    }
     graphql_base_name = 'vm_interface'
     user_permissions = ('virtualization.view_virtualmachine', )
 
@@ -914,6 +932,9 @@ class VirtualDiskTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['description', 'display', 'id', 'name', 'size', 'url', 'virtual_machine']
     bulk_update_data = {
         'size': 888,
+    }
+    bulk_update_invalid_data = {
+        'virtual_machine': 99999,
     }
     graphql_base_name = 'virtual_disk'
     user_permissions = ('virtualization.view_virtualmachine', )

--- a/netbox/vpn/tests/test_api.py
+++ b/netbox/vpn/tests/test_api.py
@@ -38,6 +38,9 @@ class TunnelGroupTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -57,6 +60,9 @@ class TunnelTestCase(APIViewTestCases.APIViewTestCase):
         'status': TunnelStatusChoices.STATUS_PLANNED,
         'encapsulation': TunnelEncapsulationChoices.ENCAP_GRE,
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
 
     @classmethod
@@ -116,6 +122,9 @@ class TunnelTerminationTestCase(APIViewTestCases.APIViewTestCase):
     brief_fields = ['display', 'id', 'url']
     bulk_update_data = {
         'role': TunnelTerminationRoleChoices.ROLE_PEER,
+    }
+    bulk_update_invalid_data = {
+        'role': 'not-a-valid-role',
     }
     user_permissions = ('vpn.view_tunnel', )
 
@@ -189,6 +198,9 @@ class IKEProposalTestCase(APIViewTestCases.APIViewTestCase):
         'group': DHGroupChoices.GROUP_19,
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'authentication_algorithm': 'not-a-valid-authentication-algorithm',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -251,6 +263,9 @@ class IKEPolicyTestCase(APIViewTestCases.APIViewTestCase):
         'mode': IKEModeChoices.AGGRESSIVE,
         'description': 'New description',
         'preshared_key': 'New key',
+    }
+    bulk_update_invalid_data = {
+        'version': 'not-a-valid-version',
     }
 
     @classmethod
@@ -325,6 +340,9 @@ class IPSecProposalTestCase(APIViewTestCases.APIViewTestCase):
         'authentication_algorithm': AuthenticationAlgorithmChoices.AUTH_HMAC_MD5,
         'description': 'New description',
     }
+    bulk_update_invalid_data = {
+        'encryption_algorithm': 'not-a-valid-encryption-algorithm',
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -373,6 +391,9 @@ class IPSecPolicyTestCase(APIViewTestCases.APIViewTestCase):
     bulk_update_data = {
         'pfs_group': DHGroupChoices.GROUP_5,
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'pfs_group': 'not-a-valid-pfs-group',
     }
 
     @classmethod
@@ -519,6 +540,10 @@ class IPSecProfileTestCase(APIViewTestCases.APIViewTestCase):
             'description': 'New description',
         }
 
+        cls.bulk_update_invalid_data = {
+            'mode': 'not-a-valid-mode',
+        }
+
 
 class L2VPNTestCase(APIViewTestCases.APIViewTestCase):
     model = L2VPN
@@ -548,6 +573,9 @@ class L2VPNTestCase(APIViewTestCases.APIViewTestCase):
     ]
     bulk_update_data = {
         'description': 'New description',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
 
     @classmethod
@@ -655,4 +683,8 @@ class L2VPNTerminationTestCase(APIViewTestCases.APIViewTestCase):
 
         cls.bulk_update_data = {
             'l2vpn': l2vpns[2].pk
+        }
+
+        cls.bulk_update_invalid_data = {
+            'l2vpn': 99999,
         }

--- a/netbox/wireless/tests/test_api.py
+++ b/netbox/wireless/tests/test_api.py
@@ -40,6 +40,9 @@ class WirelessLANGroupTestCase(APIViewTestCases.APIViewTestCase):
         'description': 'New description',
         'comments': 'New comment',
     }
+    bulk_update_invalid_data = {
+        'owner': 99999,
+    }
 
     @classmethod
     def setUpTestData(cls):
@@ -118,6 +121,10 @@ class WirelessLANTestCase(APIViewTestCases.APIViewTestCase):
             'auth_psk': 'abc123def456',
         }
 
+        cls.bulk_update_invalid_data = {
+            'auth_type': 'not-a-valid-auth-type',
+        }
+
 
 class WirelessLinkTestCase(APIViewTestCases.APIViewTestCase):
     model = WirelessLink
@@ -126,6 +133,9 @@ class WirelessLinkTestCase(APIViewTestCases.APIViewTestCase):
         'status': 'planned',
         'distance': 100,
         'distance_unit': 'm',
+    }
+    bulk_update_invalid_data = {
+        'status': 'not-a-valid-status',
     }
     user_permissions = ('dcim.view_interface', )
 


### PR DESCRIPTION
### Closes: #23046

`main` currently runs the suite with 150 tests skipped. This brings that down to 18, all of which are deliberate.

- The bulk of it (129 tests) was one attribute. `test_bulk_update_objects_validation_error` skips unless a test class sets `bulk_update_invalid_data`, and only `SiteTestCase` ever did, so the test has been skipping for every other model since #20054 added it. Each class now sets an invalid payload, one commit per app so the diff stays reviewable.

    Choosing those values needed a per-model look rather than a blanket rule. Where the model has a real choice field, that is what the invalid payload uses, since it exercises NetBox's own validation. Failing that: a `ColorField`, then a nonexistent FK pk, then `owner`. A few cases needed more care and are worth calling out:

    - `owner` comes from `OwnerMixin` and is not on every serializer. It is absent from `ComponentTemplateSerializer`, `CircuitTerminationSerializer`, `FHRPGroupAssignmentSerializer` and several others, where it would have been accepted without a 400 and left the test passing for the wrong reason.
    - `Aggregate.family` (`ipam/api/serializers_/ip.py:33`) and `DataSource.status` (`core/api/serializers_/data.py:17`) are `read_only=True`, so a bogus value there is ignored rather than rejected.
    - `CustomField` uses `filter_logic` rather than `type`, because `validate_type` rejects any type change on an existing instance and would 400 for the wrong reason.
    - `OwnerGroupSerializer` exposes only `name`, `description` and a read-only `member_count`, so an over-length `description` is the only value that can fail validation. That one carries a comment explaining why.

- The other change installs `dulwich` in CI. It is the optional `git` extra and so is absent from `requirements.txt`, which means CI has never had it and the four `GitBackendCredentialIntegrationTestCase` tests have been skipping since #21252 added them. They mock `dulwich.porcelain.clone`, so they only need the module importable: no network, no service, no system libraries. `dulwich` stays optional at runtime, per #12906.

The remaining 18 break down as
- 8 `Model does not support ETags`,
- 4 `Model does not have a label field`,
- 5 on `users.tests.test_api.GroupTestCase` (which overrides `test_bulk_update_objects` with "There's no attribute we can set in bulk for Groups"),
- and 1 `@skip("Test applicability TBD")` on `test_217_interface_to_interface_via_rear_ports`. The first three are the shared test mixins correctly skipping tests that do not apply to those models.

That last one is a question rather than a defect. It was added in 875e3e79 alongside the FR #20788 work and asks whether a breakout through paired pass-through ports is a topology we intend to support. My view is that it belongs with that feature rather than here, so I have left it alone.