### PR TITLE
Closes #22999: Add a default module profile for transceivers

### DIFF
--- a/docs/best-practices/modeling-pluggable-transceivers.md
+++ b/docs/best-practices/modeling-pluggable-transceivers.md
@@ -21,14 +21,14 @@ flowchart BT
     modulebay1 & modulebay2 & modulebay3 --> device[Device]
 ```
 
-### 1. Create an SFP Module Type Profile
+### 1. Select an SFP Module Type Profile
 
-If one has not already been defined, create a [module type profile](../models/dcim/moduletypeprofile.md) for SFPs. This profile will be assigned for all module types which represent a pluggable transceiver. Typically, you will need only one profile for all pluggable transceivers.
+New NetBox installations include a "Transceiver" [module type profile](../models/dcim/moduletypeprofile.md), which you can select for all module types which represent a pluggable transceiver. Typically, you will need only one profile for all pluggable transceivers. If this profile is not present, or if you prefer a different set of attributes, create your own profile for SFPs instead.
 
-You might opt to define custom attributes for the profile by defining a custom [JSON schema](https://json-schema.org/). Profile attributes might be used to define characteristics unique to transceivers, such as optical wavelength and power ranges. Adding profile attributes is optional, and can be done at a later point.
+The default profile defines attributes for form factor, media, PHY, data rate, reach, and connector type. You might opt to add or replace these by editing the profile's [JSON schema](https://json-schema.org/). Profile attributes might be used to define characteristics unique to transceivers, such as optical wavelength and power ranges. Adding profile attributes is optional, and can be done at a later point.
 
 !!! note
-    Creating a module type profile is optional, but recommended as it allows for defining custom module attributes.
+    Assigning a module type profile is optional, but recommended as it allows for defining custom module attributes.
 
 ### 2. Create a Module Type for Each SFP Model in Inventory
 

--- a/netbox/dcim/migrations/0206_load_module_type_profiles.py
+++ b/netbox/dcim/migrations/0206_load_module_type_profiles.py
@@ -20,7 +20,8 @@ def load_initial_data(apps, schema_editor):
         'hard_disk',
         'memory',
         'power_supply',
-        'expansion_card'
+        'expansion_card',
+        'transceiver'
     )
     profile_objects = []
 

--- a/netbox/dcim/migrations/initial_data/module_type_profiles/transceiver.json
+++ b/netbox/dcim/migrations/initial_data/module_type_profiles/transceiver.json
@@ -1,0 +1,38 @@
+{
+    "name": "Transceiver",
+    "schema": {
+        "properties": {
+            "form_factor": {
+                "type": "string",
+                "title": "Form factor",
+                "description": "Physical form factor e.g. SFP+, QSFP28, OSFP"
+            },
+            "media": {
+                "type": "string",
+                "title": "Media",
+                "description": "Physical media e.g. single-mode fiber, multimode fiber, DAC"
+            },
+            "phy": {
+                "type": "string",
+                "title": "PHY",
+                "description": "Physical layer standard e.g. 10GBASE-LR, 400ZR"
+            },
+            "data_rate": {
+                "type": "string",
+                "title": "Data rate",
+                "description": "Nominal line rate e.g. 10G, 400G"
+            },
+            "reach": {
+                "type": "number",
+                "title": "Maximum reach (m)",
+                "description": "Maximum supported cable or fiber run",
+                "minimum": 1
+            },
+            "connector_type": {
+                "type": "string",
+                "title": "Connector type",
+                "description": "Connector type e.g. LC/UPC, MPO-12, 8P8C"
+            }
+        }
+    }
+}

--- a/netbox/dcim/migrations/initial_data/module_type_profiles/transceiver.json
+++ b/netbox/dcim/migrations/initial_data/module_type_profiles/transceiver.json
@@ -25,8 +25,7 @@
             "reach": {
                 "type": "number",
                 "title": "Maximum reach (m)",
-                "description": "Maximum supported cable or fiber run",
-                "minimum": 1
+                "description": "Maximum supported cable or fiber run, in meters"
             },
             "connector_type": {
                 "type": "string",

--- a/netbox/dcim/migrations/initial_data/module_type_profiles/transceiver.json
+++ b/netbox/dcim/migrations/initial_data/module_type_profiles/transceiver.json
@@ -25,7 +25,7 @@
             "reach": {
                 "type": "number",
                 "title": "Maximum reach (m)",
-                "description": "Maximum supported cable or fiber run, in meters"
+                "description": "Maximum supported distance in meters, or fixed assembly length for DAC and AOC cables"
             },
             "connector_type": {
                 "type": "string",


### PR DESCRIPTION
### Closes: #22999

Adds a `Transceiver` profile to the set seeded by `dcim.0206_load_module_type_profiles`.

Five free-text attributes and one numeric attribute: `form_factor`, `media`, `phy`, `data_rate`, `connector_type`, and `reach` (numeric).

Existing installs don't get this profile, matching `Expansion card` in v4.3.4 (#19571). 
